### PR TITLE
refactor(dwn-sdk-js): unify JWK types with @enbox/crypto, rename Signer → MessageSigner

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -243,6 +243,7 @@
       "name": "@enbox/dwn-sdk-js",
       "version": "0.0.2",
       "dependencies": {
+        "@enbox/crypto": "workspace:*",
         "@enbox/dids": "workspace:*",
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",

--- a/packages/agent/src/types/dwn.ts
+++ b/packages/agent/src/types/dwn.ts
@@ -254,10 +254,10 @@ export type DwnMessageWithData<T extends DwnInterface> = {
 
 export {
   DwnConstant,
-  Signer as DwnSigner,
+  MessageSigner as DwnSigner,
   DateSort as DwnDateSort,
   DataEncodedRecordsWriteMessage as DwnDataEncodedRecordsWriteMessage,
-  PublicJwk as DwnPublicKeyJwk, // TODO: Remove once DWN SDK switches to Jwk from @enbox/crypto
+  PublicKeyJwk as DwnPublicKeyJwk,
   PaginationCursor as DwnPaginationCursor,
   MessageSubscriptionHandler as DwnMessageSubscriptionHandler,
   RecordSubscriptionHandler as DwnRecordSubscriptionHandler,

--- a/packages/dwn-sdk-js/package.json
+++ b/packages/dwn-sdk-js/package.json
@@ -70,6 +70,7 @@
     "@noble/curves": "1.4.2",
     "@noble/ed25519": "2.0.0",
     "@noble/secp256k1": "2.0.0",
+    "@enbox/crypto": "workspace:*",
     "@enbox/dids": "workspace:*",
     "abstract-level": "1.0.3",
     "ajv": "8.12.0",

--- a/packages/dwn-sdk-js/src/core/message.ts
+++ b/packages/dwn-sdk-js/src/core/message.ts
@@ -1,6 +1,6 @@
 import type { DataEncodedRecordsWriteMessage } from '../types/records-types.js';
 import type { GeneralJws } from '../types/jws-types.js';
-import type { Signer } from '../types/signer.js';
+import type { MessageSigner } from '../types/signer.js';
 import type { AuthorizationModel, Descriptor, GenericMessage, GenericSignaturePayload } from '../types/message-types.js';
 
 import { Cid } from '../utils/cid.js';
@@ -97,7 +97,7 @@ export class Message {
    */
   public static async createAuthorization(input: {
     descriptor: Descriptor,
-    signer: Signer,
+    signer: MessageSigner,
     delegatedGrant?: DataEncodedRecordsWriteMessage,
     permissionGrantId?: string,
     protocolRole?: string
@@ -128,7 +128,7 @@ export class Message {
    */
   public static async createSignature(
     descriptor: Descriptor,
-    signer: Signer,
+    signer: MessageSigner,
     additionalPayloadProperties?: { delegatedGrantId?: string, permissionGrantId?: string, protocolRole?: string }
   ): Promise<GeneralJws> {
     const descriptorCid = await Cid.computeCid(descriptor);

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -26,7 +26,7 @@ export { Encryption, EncryptionAlgorithm, EciesEncryptionOutput, EciesEncryption
 export { EncryptionInput, KeyEncryptionInput, RecordsWrite, RecordsWriteOptions, CreateFromOptions } from './interfaces/records-write.js';
 export { executeUnlessAborted } from './utils/abort.js';
 export { Jws } from './utils/jws.js';
-export { KeyMaterial, PrivateJwk, PublicJwk, Jwk } from './types/jose-types.js';
+export { KeyMaterial, PrivateKeyJwk, PublicKeyJwk, Jwk } from './types/jose-types.js';
 export { Message } from './core/message.js';
 export { MessagesRead as MessagesRead, MessagesReadOptions as MessagesReadOptions } from './interfaces/messages-read.js';
 export { MessagesQuery, MessagesQueryOptions } from './interfaces/messages-query.js';
@@ -46,7 +46,8 @@ export { RecordsRead, RecordsReadOptions } from './interfaces/records-read.js';
 export { RecordsSubscribe, RecordsSubscribeOptions } from './interfaces/records-subscribe.js';
 export { Secp256k1 } from './utils/secp256k1.js';
 export { Secp256r1 } from './utils/secp256r1.js';
-export { Signer } from './types/signer.js';
+export type { SupportedCurve } from './jose/algorithms/signing/signature-algorithms.js';
+export { MessageSigner } from './types/signer.js';
 export { SortDirection } from './types/query-types.js';
 export type { EncryptionKeyDeriver, KeyDecrypter } from './types/encryption-types.js';
 export { Time } from './utils/time.js';

--- a/packages/dwn-sdk-js/src/interfaces/messages-query.ts
+++ b/packages/dwn-sdk-js/src/interfaces/messages-query.ts
@@ -1,5 +1,5 @@
+import type { MessageSigner } from '../types/signer.js';
 import type { PaginationCursor } from '../types/query-types.js';
-import type { Signer } from '../types/signer.js';
 import type { MessagesFilter, MessagesQueryDescriptor, MessagesQueryMessage } from '../types/messages-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
@@ -11,7 +11,7 @@ import { validateProtocolUrlNormalized } from '../utils/url.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
 export type MessagesQueryOptions = {
-  signer: Signer;
+  signer: MessageSigner;
   filters?: MessagesFilter[];
   cursor?: PaginationCursor;
   messageTimestamp?: string;

--- a/packages/dwn-sdk-js/src/interfaces/messages-read.ts
+++ b/packages/dwn-sdk-js/src/interfaces/messages-read.ts
@@ -1,4 +1,4 @@
-import type { Signer } from '../types/signer.js';
+import type { MessageSigner } from '../types/signer.js';
 import type { MessagesReadDescriptor, MessagesReadMessage } from '../types/messages-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
@@ -10,7 +10,7 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export type MessagesReadOptions = {
   messageCid: string;
-  signer: Signer;
+  signer: MessageSigner;
   messageTimestamp?: string;
   permissionGrantId?: string;
 };

--- a/packages/dwn-sdk-js/src/interfaces/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/interfaces/messages-subscribe.ts
@@ -1,5 +1,5 @@
 import type { MessagesFilter } from '../types/messages-types.js';
-import type { Signer } from '../types/signer.js';
+import type { MessageSigner } from '../types/signer.js';
 import type { MessagesSubscribeDescriptor, MessagesSubscribeMessage } from '../types/messages-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
@@ -11,7 +11,7 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 
 export type MessagesSubscribeOptions = {
-  signer: Signer;
+  signer: MessageSigner;
   messageTimestamp?: string;
   filters?: MessagesFilter[]
   permissionGrantId?: string;

--- a/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
@@ -1,6 +1,6 @@
 import type { DataEncodedRecordsWriteMessage } from '../types/records-types.js';
+import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types/message-store.js';
-import type { Signer } from '../types/signer.js';
 import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureDescriptor, ProtocolsConfigureMessage } from '../types/protocols-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
@@ -17,7 +17,7 @@ import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
 export type ProtocolsConfigureOptions = {
   messageTimestamp?: string;
   definition: ProtocolDefinition;
-  signer: Signer;
+  signer: MessageSigner;
   /**
    * The delegated grant invoked to sign on behalf of the logical author, which is the grantor of the delegated grant.
    */

--- a/packages/dwn-sdk-js/src/interfaces/protocols-query.ts
+++ b/packages/dwn-sdk-js/src/interfaces/protocols-query.ts
@@ -1,6 +1,6 @@
 import type { AuthorizationModel } from '../types/message-types.js';
+import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types/message-store.js';
-import type { Signer } from '../types/signer.js';
 import type { ProtocolsQueryDescriptor, ProtocolsQueryFilter, ProtocolsQueryMessage } from '../types/protocols-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
@@ -16,7 +16,7 @@ import { normalizeProtocolUrl, validateProtocolUrlNormalized } from '../utils/ur
 export type ProtocolsQueryOptions = {
   messageTimestamp?: string;
   filter?: ProtocolsQueryFilter,
-  signer?: Signer;
+  signer?: MessageSigner;
   permissionGrantId?: string;
 };
 

--- a/packages/dwn-sdk-js/src/interfaces/records-delete.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-delete.ts
@@ -1,6 +1,6 @@
 import type { KeyValues } from '../types/query-types.js';
+import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types//message-store.js';
-import type { Signer } from '../types/signer.js';
 import type { DataEncodedRecordsWriteMessage, RecordsDeleteDescriptor, RecordsDeleteMessage, RecordsWriteMessage } from '../types/records-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
@@ -16,7 +16,7 @@ export type RecordsDeleteOptions = {
   recordId: string;
   messageTimestamp?: string;
   protocolRole?: string;
-  signer: Signer;
+  signer: MessageSigner;
 
   /**
    * Denotes if all the descendent records should be purged. Defaults to `false`.

--- a/packages/dwn-sdk-js/src/interfaces/records-query.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-query.ts
@@ -1,6 +1,6 @@
+import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types//message-store.js';
 import type { Pagination } from '../types/message-types.js';
-import type { Signer } from '../types/signer.js';
 import type { DataEncodedRecordsWriteMessage, RecordsFilter, RecordsQueryDescriptor, RecordsQueryMessage } from '../types/records-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
@@ -20,7 +20,7 @@ export type RecordsQueryOptions = {
   filter: RecordsFilter;
   dateSort?: DateSort;
   pagination?: Pagination;
-  signer?: Signer;
+  signer?: MessageSigner;
   protocolRole?: string;
 
   /**

--- a/packages/dwn-sdk-js/src/interfaces/records-read.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-read.ts
@@ -1,5 +1,5 @@
+import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types//message-store.js';
-import type { Signer } from '../types/signer.js';
 import type { DataEncodedRecordsWriteMessage, RecordsFilter , RecordsReadDescriptor, RecordsReadMessage, RecordsWriteMessage } from '../types/records-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
@@ -14,7 +14,7 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 export type RecordsReadOptions = {
   filter: RecordsFilter;
   messageTimestamp?: string;
-  signer?: Signer;
+  signer?: MessageSigner;
   permissionGrantId?: string;
   /**
    * Used when authorizing protocol records.

--- a/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
@@ -1,5 +1,5 @@
+import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types/message-store.js';
-import type { Signer } from '../types/signer.js';
 import type { DataEncodedRecordsWriteMessage, RecordsFilter, RecordsSubscribeDescriptor, RecordsSubscribeMessage } from '../types/records-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
@@ -16,7 +16,7 @@ import { validateProtocolUrlNormalized, validateSchemaUrlNormalized } from '../u
 export type RecordsSubscribeOptions = {
   messageTimestamp?: string;
   filter: RecordsFilter;
-  signer?: Signer;
+  signer?: MessageSigner;
   protocolRole?: string;
 
   /**

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -1,9 +1,9 @@
 import type { GeneralJws } from '../types/jws-types.js';
 import type { KeyValues } from '../types/query-types.js';
 import type { MessageInterface } from '../types/message-interface.js';
+import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types/message-store.js';
-import type { PublicJwk } from '../types/jose-types.js';
-import type { Signer } from '../types/signer.js';
+import type { PublicKeyJwk } from '../types/jose-types.js';
 import type {
   DataEncodedRecordsWriteMessage,
   EncryptedKey,
@@ -62,14 +62,14 @@ export type RecordsWriteOptions = {
   /**
    * The signer of the message, which is commonly the author, but can also be a delegate.
    */
-  signer?: Signer;
+  signer?: MessageSigner;
 
   /**
    * The delegated grant invoked to sign on behalf of the logical author, which is the grantor of the delegated grant.
    */
   delegatedGrant?: DataEncodedRecordsWriteMessage;
 
-  attestationSigners?: Signer[];
+  attestationSigners?: MessageSigner[];
   encryptionInput?: EncryptionInput;
   permissionGrantId?: string;
 };
@@ -118,7 +118,7 @@ export type KeyEncryptionInput = {
   /**
    * Public key to be used to encrypt the symmetric key.
    */
-  publicKey: PublicJwk;
+  publicKey: PublicKeyJwk;
 
   /**
    * Algorithm used for encrypting the symmetric key. Uses {EncryptionAlgorithm.EciesSecp256k1} if not given.
@@ -144,14 +144,14 @@ export type CreateFromOptions = {
   /**
    * The signer of the message, which is commonly the author, but can also be a delegate.
    */
-  signer?: Signer;
+  signer?: MessageSigner;
 
   /**
    * The delegated grant to sign on behalf of the logical author, which is the grantor (`grantedBy`) of the delegated grant.
    */
   delegatedGrant?: DataEncodedRecordsWriteMessage;
 
-  attestationSigners?: Signer[];
+  attestationSigners?: MessageSigner[];
   encryptionInput?: EncryptionInput;
   protocolRole?: string;
 };
@@ -491,7 +491,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
    * Signs the RecordsWrite, the signer is commonly the author, but can also be a delegate.
    */
   public async sign(options: {
-    signer: Signer,
+    signer: MessageSigner,
     delegatedGrant?: DataEncodedRecordsWriteMessage,
     permissionGrantId?: string,
     protocolRole?: string
@@ -555,7 +555,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
    * This is used when the DWN owner wants to retain a copy of a message that the owner did not author.
    * NOTE: requires the `RecordsWrite` to already have the author's signature.
    */
-  public async signAsOwner(signer: Signer): Promise<void> {
+  public async signAsOwner(signer: MessageSigner): Promise<void> {
     if (this._author === undefined) {
       throw new DwnError(
         DwnErrorCode.RecordsWriteSignAsOwnerUnknownAuthor,
@@ -577,7 +577,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
    * This is used when a DWN owner-delegate wants to retain a copy of a message that the owner did not author.
    * NOTE: requires the `RecordsWrite` to already have the author's signature.
    */
-  public async signAsOwnerDelegate(signer: Signer, delegatedGrant: DataEncodedRecordsWriteMessage): Promise<void> {
+  public async signAsOwnerDelegate(signer: MessageSigner, delegatedGrant: DataEncodedRecordsWriteMessage): Promise<void> {
     if (this._author === undefined) {
       throw new DwnError(
         DwnErrorCode.RecordsWriteSignAsOwnerDelegateUnknownAuthor,
@@ -907,7 +907,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
   /**
    * Creates the `attestation` property of a RecordsWrite message if given signature inputs; returns `undefined` otherwise.
    */
-  public static async createAttestation(descriptorCid: string, signers?: Signer[]): Promise<GeneralJws | undefined> {
+  public static async createAttestation(descriptorCid: string, signers?: MessageSigner[]): Promise<GeneralJws | undefined> {
     if (signers === undefined || signers.length === 0) {
       return undefined;
     }
@@ -928,7 +928,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     descriptorCid: string,
     attestation: GeneralJws | undefined,
     encryption: EncryptionProperty | undefined,
-    signer: Signer,
+    signer: MessageSigner,
     delegatedGrantId?: string,
     permissionGrantId?: string,
     protocolRole?: string

--- a/packages/dwn-sdk-js/src/jose/algorithms/signing/ed25519.ts
+++ b/packages/dwn-sdk-js/src/jose/algorithms/signing/ed25519.ts
@@ -1,19 +1,19 @@
 import * as Ed25519 from '@noble/ed25519';
-import type { PrivateJwk, PublicJwk, SignatureAlgorithm } from '../../../types/jose-types.js';
+import type { PrivateKeyJwk, PublicKeyJwk, SignatureAlgorithm } from '../../../types/jose-types.js';
 
 import { Encoder } from '../../../utils/encoder.js';
 import { DwnError, DwnErrorCode } from '../../../core/dwn-error.js';
 
-function validateKey(jwk: PrivateJwk | PublicJwk): void {
+function validateKey(jwk: PrivateKeyJwk | PublicKeyJwk): void {
   if (jwk.kty !== 'OKP' || jwk.crv !== 'Ed25519') {
     throw new DwnError(DwnErrorCode.Ed25519InvalidJwk, 'invalid jwk. kty MUST be OKP. crv MUST be Ed25519');
   }
 }
 
-function publicKeyToJwk(publicKeyBytes: Uint8Array): PublicJwk {
+function publicKeyToJwk(publicKeyBytes: Uint8Array): PublicKeyJwk {
   const x = Encoder.bytesToBase64Url(publicKeyBytes);
 
-  const publicJwk: PublicJwk = {
+  const publicJwk: PublicKeyJwk = {
     alg : 'EdDSA',
     kty : 'OKP',
     crv : 'Ed25519',
@@ -24,7 +24,7 @@ function publicKeyToJwk(publicKeyBytes: Uint8Array): PublicJwk {
 }
 
 export const ed25519: SignatureAlgorithm = {
-  sign: async (content: Uint8Array, privateJwk: PrivateJwk): Promise<Uint8Array> => {
+  sign: async (content: Uint8Array, privateJwk: PrivateKeyJwk): Promise<Uint8Array> => {
     validateKey(privateJwk);
 
     const privateKeyBytes = Encoder.base64UrlToBytes(privateJwk.d);
@@ -32,7 +32,7 @@ export const ed25519: SignatureAlgorithm = {
     return Ed25519.signAsync(content, privateKeyBytes);
   },
 
-  verify: async (content: Uint8Array, signature: Uint8Array, publicJwk: PublicJwk): Promise<boolean> => {
+  verify: async (content: Uint8Array, signature: Uint8Array, publicJwk: PublicKeyJwk): Promise<boolean> => {
     validateKey(publicJwk);
 
     const publicKeyBytes = Encoder.base64UrlToBytes(publicJwk.x);
@@ -40,19 +40,19 @@ export const ed25519: SignatureAlgorithm = {
     return Ed25519.verifyAsync(signature, content, publicKeyBytes);
   },
 
-  generateKeyPair: async (): Promise<{publicJwk: PublicJwk, privateJwk: PrivateJwk}> => {
+  generateKeyPair: async (): Promise<{publicJwk: PublicKeyJwk, privateJwk: PrivateKeyJwk}> => {
     const privateKeyBytes = Ed25519.utils.randomPrivateKey();
     const publicKeyBytes = await Ed25519.getPublicKeyAsync(privateKeyBytes);
 
     const d = Encoder.bytesToBase64Url(privateKeyBytes);
 
     const publicJwk = publicKeyToJwk(publicKeyBytes);
-    const privateJwk: PrivateJwk = { ...publicJwk, d };
+    const privateJwk: PrivateKeyJwk = { ...publicJwk, d };
 
     return { publicJwk, privateJwk };
   },
 
-  publicKeyToJwk: async (publicKeyBytes: Uint8Array): Promise<PublicJwk> => {
+  publicKeyToJwk: async (publicKeyBytes: Uint8Array): Promise<PublicKeyJwk> => {
     return publicKeyToJwk(publicKeyBytes);
   }
 };

--- a/packages/dwn-sdk-js/src/jose/algorithms/signing/signature-algorithms.ts
+++ b/packages/dwn-sdk-js/src/jose/algorithms/signing/signature-algorithms.ts
@@ -4,8 +4,13 @@ import { ed25519 } from './ed25519.js';
 import { Secp256k1 } from '../../../utils/secp256k1.js';
 import { Secp256r1 } from '../../../utils/secp256r1.js';
 
+/**
+ * Curves supported by the DWN for signing and verification.
+ */
+export type SupportedCurve = 'Ed25519' | 'secp256k1' | 'P-256';
+
 // the key should be the appropriate `crv` value
-export const signatureAlgorithms: Record<string, SignatureAlgorithm> = {
+export const signatureAlgorithms: Record<SupportedCurve, SignatureAlgorithm> = {
   'Ed25519'   : ed25519,
   'secp256k1' : {
     sign            : Secp256k1.sign,

--- a/packages/dwn-sdk-js/src/jose/jws/general/builder.ts
+++ b/packages/dwn-sdk-js/src/jose/jws/general/builder.ts
@@ -1,5 +1,5 @@
 import type { GeneralJws } from '../../../types/jws-types.js';
-import type { Signer } from '../../../types/signer.js';
+import type { MessageSigner } from '../../../types/signer.js';
 
 import { Encoder } from '../../../utils/encoder.js';
 
@@ -10,7 +10,7 @@ export class GeneralJwsBuilder {
     this.jws = jws;
   }
 
-  static async create(payload: Uint8Array, signers: Signer[] = []): Promise<GeneralJwsBuilder> {
+  static async create(payload: Uint8Array, signers: MessageSigner[] = []): Promise<GeneralJwsBuilder> {
     const jws: GeneralJws = {
       payload    : Encoder.bytesToBase64Url(payload),
       signatures : []
@@ -25,7 +25,7 @@ export class GeneralJwsBuilder {
     return builder;
   }
 
-  async addSignature(signer: Signer): Promise<void> {
+  async addSignature(signer: MessageSigner): Promise<void> {
     const protectedHeader = {
       kid : signer.keyId,
       alg : signer.algorithm

--- a/packages/dwn-sdk-js/src/jose/jws/general/verifier.ts
+++ b/packages/dwn-sdk-js/src/jose/jws/general/verifier.ts
@@ -1,6 +1,6 @@
 import type { Cache } from '../../../types/cache.js';
 import type { GeneralJws } from '../../../types/jws-types.js';
-import type { PublicJwk } from '../../../types/jose-types.js';
+import type { PublicKeyJwk } from '../../../types/jose-types.js';
 import type { DidResolver, DidVerificationMethod } from '@enbox/dids';
 
 import { Jws } from '../../../utils/jws.js';
@@ -80,7 +80,7 @@ export class GeneralJwsVerifier {
   /**
    * Gets the public key given a fully qualified key ID (`kid`) by resolving the DID to its DID Document.
    */
-  private static async getPublicKey(kid: string, didResolver: DidResolver): Promise<PublicJwk> {
+  private static async getPublicKey(kid: string, didResolver: DidResolver): Promise<PublicKeyJwk> {
     // `resolve` throws exception if DID is invalid, DID method is not supported,
     // or resolving DID fails
     const did = Jws.extractDid(kid);
@@ -107,6 +107,6 @@ export class GeneralJwsVerifier {
 
     const { publicKeyJwk: publicJwk } = verificationMethod;
 
-    return publicJwk as PublicJwk;
+    return publicJwk as PublicKeyJwk;
   }
 }

--- a/packages/dwn-sdk-js/src/protocols/permissions.ts
+++ b/packages/dwn-sdk-js/src/protocols/permissions.ts
@@ -1,7 +1,7 @@
 import type { GenericMessage } from '../types/message-types.js';
+import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { ProtocolDefinition } from '../types/protocols-types.js';
-import type { Signer } from '../types/signer.js';
 import type { DataEncodedRecordsWriteMessage, RecordsWriteMessage } from '../types/records-types.js';
 import type { PermissionConditions, PermissionGrantData, PermissionRequestData, PermissionRevocationData, PermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
 
@@ -22,7 +22,7 @@ export type PermissionRequestCreateOptions = {
   /**
    * The signer of the request.
    */
-  signer?: Signer;
+  signer?: MessageSigner;
 
   dateRequested?: string;
 
@@ -41,7 +41,7 @@ export type PermissionGrantCreateOptions = {
   /**
    * The signer of the grant.
    */
-  signer?: Signer;
+  signer?: MessageSigner;
   grantedTo: string;
   dateGranted?: string;
 
@@ -65,7 +65,7 @@ export type PermissionRevocationCreateOptions = {
   /**
    * The signer of the grant.
    */
-  signer?: Signer;
+  signer?: MessageSigner;
   /**
    * The PermissionGrant this revocation is for.
    */

--- a/packages/dwn-sdk-js/src/types/encryption-types.ts
+++ b/packages/dwn-sdk-js/src/types/encryption-types.ts
@@ -1,13 +1,13 @@
 import type { EciesEncryptionOutput } from '../utils/encryption.js';
 import type { KeyDerivationScheme } from '../utils/hd-key.js';
-import type { PublicJwk } from './jose-types.js';
+import type { PublicKeyJwk } from './jose-types.js';
 
 /**
  * A callback interface for deriving HD public encryption keys.
  * The implementor performs HKDF key derivation and public key computation
  * internally — the private key never leaves the implementation boundary.
  *
- * Analogous to `Signer` for signing operations.
+ * Analogous to `MessageSigner` for signing operations.
  */
 export interface EncryptionKeyDeriver {
   /** Fully qualified key ID (e.g. did:example:alice#enc) */
@@ -22,7 +22,7 @@ export interface EncryptionKeyDeriver {
    *   (e.g. ['protocolPath', 'https://chat.example', 'thread', 'message'])
    * @returns The derived child public key as a JWK
    */
-  derivePublicKey(fullDerivationPath: string[]): Promise<PublicJwk>;
+  derivePublicKey(fullDerivationPath: string[]): Promise<PublicKeyJwk>;
 }
 
 /**
@@ -30,7 +30,7 @@ export interface EncryptionKeyDeriver {
  * The implementor performs HKDF key derivation and ECIES decryption
  * internally — the private key never leaves the implementation boundary.
  *
- * Analogous to `Signer` for signing operations.
+ * Analogous to `MessageSigner` for signing operations.
  */
 export interface KeyDecrypter {
   /** Fully qualified key ID (e.g. did:example:alice#enc) */

--- a/packages/dwn-sdk-js/src/types/jose-types.ts
+++ b/packages/dwn-sdk-js/src/types/jose-types.ts
@@ -1,45 +1,31 @@
+import type {
+  Jwk,
+  JwkParamsEcPrivate,
+  JwkParamsEcPublic,
+  JwkParamsOkpPrivate,
+  JwkParamsOkpPublic,
+} from '@enbox/crypto';
+
+export type { Jwk };
+
+/**
+ * Public key types supported by DWN: EC (secp256k1, P-256) and OKP (Ed25519).
+ * Re-exported from `@enbox/crypto` for convenience.
+ */
+export type PublicKeyJwk = JwkParamsEcPublic | JwkParamsOkpPublic;
+
+/**
+ * Private key types supported by DWN: EC (secp256k1, P-256) and OKP (Ed25519).
+ * Re-exported from `@enbox/crypto` for convenience.
+ */
+export type PrivateKeyJwk = JwkParamsEcPrivate | JwkParamsOkpPrivate;
+
 /**
  * Contains a public-private key pair and the associated key ID.
  */
 export type KeyMaterial = {
   keyId: string,
-  keyPair: { publicJwk: PublicJwk, privateJwk: PrivateJwk }
-};
-
-export type Jwk = {
-  /** The "alg" (algorithm) parameter identifies the algorithm intended for use with the key. */
-  alg?: string;
-  /** The "alg" (algorithm) parameter identifies the algorithm intended for use with the key. */
-  kid?: string;
-  /** identifies the cryptographic algorithm family used with the key, such "EC". */
-  kty: string;
-};
-
-export type PublicJwk = Jwk & {
-  /** The "crv" (curve) parameter identifies the cryptographic curve used with the key.
-   * MUST be present for all EC public keys
-   */
-  crv: 'Ed25519' | 'secp256k1' | 'P-256';
-  /**
-   * the x coordinate for the Elliptic Curve point.
-   * Represented as the base64url encoding of the octet string representation of the coordinate.
-   * MUST be present for all EC public keys
-   */
-  x: string;
-  /**
-   * the y coordinate for the Elliptic Curve point.
-   * Represented as the base64url encoding of the octet string representation of the coordinate.
-   */
-  y?: string;
-};
-
-export type PrivateJwk = PublicJwk & {
-  /**
-   * the Elliptic Curve private key value.
-   * It is represented as the base64url encoding of the octet string representation of the private key value
-   * MUST be present to represent Elliptic Curve private keys.
-   */
-  d: string;
+  keyPair: { publicJwk: PublicKeyJwk, privateJwk: PrivateKeyJwk }
 };
 
 export interface SignatureAlgorithm {
@@ -49,7 +35,7 @@ export interface SignatureAlgorithm {
    * @param privateJwk - the key to sign with
    * @returns the signed content (aka signature)
    */
-  sign(content: Uint8Array, privateJwk: PrivateJwk): Promise<Uint8Array>;
+  sign(content: Uint8Array, privateJwk: PrivateKeyJwk): Promise<Uint8Array>;
 
   /**
    * Verifies a signature against the provided payload hash and public key.
@@ -58,13 +44,13 @@ export interface SignatureAlgorithm {
    * @param publicJwk - the key to verify with
    * @returns a boolean indicating whether the signature matches
    */
-  verify(content: Uint8Array, signature: Uint8Array, publicJwk: PublicJwk): Promise<boolean>;
+  verify(content: Uint8Array, signature: Uint8Array, publicJwk: PublicKeyJwk): Promise<boolean>;
 
   /**
    * generates a random key pair
    * @returns the public and private keys as JWKs
    */
-  generateKeyPair(): Promise<{ publicJwk: PublicJwk, privateJwk: PrivateJwk }>
+  generateKeyPair(): Promise<{ publicJwk: PublicKeyJwk, privateJwk: PrivateKeyJwk }>
 
 
   /**
@@ -72,5 +58,5 @@ export interface SignatureAlgorithm {
    * @param publicKeyBytes - the public key to convert into JWK
    * @returns the public key in JWK format
    */
-  publicKeyToJwk(publicKeyBytes: Uint8Array): Promise<PublicJwk>
+  publicKeyToJwk(publicKeyBytes: Uint8Array): Promise<PublicKeyJwk>
 }

--- a/packages/dwn-sdk-js/src/types/protocols-types.ts
+++ b/packages/dwn-sdk-js/src/types/protocols-types.ts
@@ -1,4 +1,4 @@
-import type { PublicJwk } from './jose-types.js';
+import type { PublicKeyJwk } from './jose-types.js';
 import type { AuthorizationModel, GenericMessage, GenericMessageReply } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
@@ -112,7 +112,7 @@ export type ProtocolPathEncryption = {
   /**
    * Public key for encrypting the symmetric key used for data encryption.
    */
-  publicKeyJwk: PublicJwk;
+  publicKeyJwk: PublicKeyJwk;
 };
 
 export type ProtocolRuleSet = {

--- a/packages/dwn-sdk-js/src/types/records-types.ts
+++ b/packages/dwn-sdk-js/src/types/records-types.ts
@@ -1,7 +1,7 @@
 import type { EncryptionAlgorithm } from '../utils/encryption.js';
 import type { GeneralJws } from './jws-types.js';
 import type { KeyDerivationScheme } from '../utils/hd-key.js';
-import type { PublicJwk } from './jose-types.js';
+import type { PublicKeyJwk } from './jose-types.js';
 import type { Readable } from 'readable-stream';
 import type { AuthorizationModel, GenericMessage, GenericMessageReply, GenericSignaturePayload, MessageSubscription, Pagination } from './message-types.js';
 import type { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
@@ -78,11 +78,11 @@ export type EncryptedKey = {
   /**
    * The actual derived public key.
    */
-  derivedPublicKey?: PublicJwk;
+  derivedPublicKey?: PublicKeyJwk;
   derivationScheme: KeyDerivationScheme;
   algorithm: EncryptionAlgorithm;
   initializationVector: string;
-  ephemeralPublicKey: PublicJwk;
+  ephemeralPublicKey: PublicKeyJwk;
   messageAuthenticationCode: string;
   encryptedKey: string;
 };

--- a/packages/dwn-sdk-js/src/types/signer.ts
+++ b/packages/dwn-sdk-js/src/types/signer.ts
@@ -1,7 +1,7 @@
 /**
  * A signer that is capable of generating a digital signature over any given bytes.
  */
-export interface Signer {
+export interface MessageSigner {
   /**
    * The ID of the key used by this signer.
    * This needs to be a fully-qualified ID (ie. prefixed with DID) so that author can be parsed out for processing such as `recordId` computation.

--- a/packages/dwn-sdk-js/src/utils/hd-key.ts
+++ b/packages/dwn-sdk-js/src/utils/hd-key.ts
@@ -1,4 +1,4 @@
-import type { PrivateJwk, PublicJwk } from '../types/jose-types.js';
+import type { PrivateKeyJwk, PublicKeyJwk } from '../types/jose-types.js';
 
 import { Encoder } from './encoder.js';
 import { getWebcryptoSubtle } from '@noble/ciphers/webcrypto';
@@ -23,7 +23,7 @@ export type DerivedPrivateJwk = {
   rootKeyId: string,
   derivationScheme: KeyDerivationScheme;
   derivationPath?: string[];
-  derivedPrivateKey: PrivateJwk,
+  derivedPrivateKey: PrivateKeyJwk,
 };
 
 /**
@@ -38,12 +38,12 @@ export class HdKey {
     const ancestorPrivateKey = Secp256k1.privateJwkToBytes(ancestorKey.derivedPrivateKey);
     const ancestorPrivateKeyDerivationPath = ancestorKey.derivationPath ?? [];
     const derivedPrivateKeyBytes = await HdKey.derivePrivateKeyBytes(ancestorPrivateKey, subDerivationPath);
-    const derivedPrivateJwk = await Secp256k1.privateKeyToJwk(derivedPrivateKeyBytes);
+    const derivedPrivateKeyJwk = await Secp256k1.privateKeyToJwk(derivedPrivateKeyBytes);
     const derivedDescendantPrivateKey: DerivedPrivateJwk = {
       rootKeyId         : ancestorKey.rootKeyId,
       derivationScheme  : ancestorKey.derivationScheme,
       derivationPath    : [...ancestorPrivateKeyDerivationPath, ...subDerivationPath],
-      derivedPrivateKey : derivedPrivateJwk
+      derivedPrivateKey : derivedPrivateKeyJwk
     };
 
     return derivedDescendantPrivateKey;
@@ -53,7 +53,7 @@ export class HdKey {
    * Derives a descendant public key from an ancestor private key.
    * NOTE: currently only supports SECP256K1 keys.
    */
-  public static async derivePublicKey(ancestorKey: DerivedPrivateJwk, subDerivationPath: string[]): Promise<PublicJwk> {
+  public static async derivePublicKey(ancestorKey: DerivedPrivateJwk, subDerivationPath: string[]): Promise<PublicKeyJwk> {
     const derivedDescendantPrivateKey = await HdKey.derivePrivateKey(ancestorKey, subDerivationPath);
     const derivedDescendantPublicKey = await Secp256k1.getPublicJwk(derivedDescendantPrivateKey.derivedPrivateKey);
 

--- a/packages/dwn-sdk-js/src/utils/jws.ts
+++ b/packages/dwn-sdk-js/src/utils/jws.ts
@@ -1,14 +1,14 @@
 import type { GeneralJws } from '../types/jws-types.js';
+import type { MessageSigner } from '../types/signer.js';
 import type { SignatureEntry } from '../types/jws-types.js';
-import type { Signer } from '../types/signer.js';
-import type { KeyMaterial, PublicJwk } from '../types/jose-types.js';
+import type { KeyMaterial, PublicKeyJwk } from '../types/jose-types.js';
 
 import isPlainObject from 'lodash/isPlainObject.js';
 
 import { Encoder } from './encoder.js';
 import { PrivateKeySigner } from './private-key-signer.js';
-import { signatureAlgorithms } from '../jose/algorithms/signing/signature-algorithms.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
+import { signatureAlgorithms, type SupportedCurve } from '../jose/algorithms/signing/signature-algorithms.js';
 
 
 /**
@@ -36,8 +36,8 @@ export class Jws {
    * Verifies the signature against the given payload.
    * @returns `true` if signature is valid; `false` otherwise
    */
-  public static async verifySignature(base64UrlPayload: string, signatureEntry: SignatureEntry, jwkPublic: PublicJwk): Promise<boolean> {
-    const signatureAlgorithm = signatureAlgorithms[jwkPublic.crv];
+  public static async verifySignature(base64UrlPayload: string, signatureEntry: SignatureEntry, jwkPublic: PublicKeyJwk): Promise<boolean> {
+    const signatureAlgorithm = signatureAlgorithms[jwkPublic.crv as SupportedCurve];
 
     if (!signatureAlgorithm) {
       throw new DwnError(DwnErrorCode.JwsVerifySignatureUnsupportedCrv, `unsupported crv. crv must be one of ${Object.keys(signatureAlgorithms)}`);
@@ -76,17 +76,17 @@ export class Jws {
   }
 
   /**
-   * Creates a Signer[] from the given Personas.
+   * Creates a MessageSigner[] from the given Personas.
    */
-  public static createSigners(keyMaterials: KeyMaterial[]): Signer[] {
+  public static createSigners(keyMaterials: KeyMaterial[]): MessageSigner[] {
     const signers = keyMaterials.map((keyMaterial) => Jws.createSigner(keyMaterial));
     return signers;
   }
 
   /**
-   * Creates a Signer from the given Persona.
+   * Creates a MessageSigner from the given Persona.
    */
-  public static createSigner(keyMaterial: KeyMaterial): Signer {
+  public static createSigner(keyMaterial: KeyMaterial): MessageSigner {
     const privateJwk = keyMaterial.keyPair.privateJwk;
     const keyId = keyMaterial.keyId;
     const signer = new PrivateKeySigner({ privateJwk, keyId });

--- a/packages/dwn-sdk-js/src/utils/private-key-signer.ts
+++ b/packages/dwn-sdk-js/src/utils/private-key-signer.ts
@@ -1,8 +1,8 @@
-import type { PrivateJwk } from '../types/jose-types.js';
-import type { Signer } from '../types/signer.js';
+import type { MessageSigner } from '../types/signer.js';
+import type { PrivateKeyJwk } from '../types/jose-types.js';
 
-import { signatureAlgorithms } from '../jose/algorithms/signing/signature-algorithms.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
+import { signatureAlgorithms, type SupportedCurve } from '../jose/algorithms/signing/signature-algorithms.js';
 
 /**
  * Input to `PrivateKeySigner` constructor.
@@ -11,7 +11,7 @@ export type PrivateKeySignerOptions = {
   /**
    * Private JWK to create the signer from.
    */
-  privateJwk: PrivateJwk;
+  privateJwk: PrivateKeyJwk;
 
   /**
    * If not specified, the constructor will attempt to default/fall back to the `kid` value in the given `privateJwk`.
@@ -27,10 +27,10 @@ export type PrivateKeySignerOptions = {
 /**
  * A signer that signs using a private key.
  */
-export class PrivateKeySigner implements Signer {
+export class PrivateKeySigner implements MessageSigner {
   public keyId;
   public algorithm;
-  private privateJwk: PrivateJwk;
+  private privateJwk: PrivateKeyJwk;
   private signatureAlgorithm;
 
   public constructor(options: PrivateKeySignerOptions) {
@@ -52,7 +52,7 @@ export class PrivateKeySigner implements Signer {
     this.keyId = options.keyId ?? options.privateJwk.kid!;
     this.algorithm = options.algorithm ?? options.privateJwk.alg!;
     this.privateJwk = options.privateJwk;
-    this.signatureAlgorithm = signatureAlgorithms[options.privateJwk.crv];
+    this.signatureAlgorithm = signatureAlgorithms[options.privateJwk.crv as SupportedCurve];
 
     if (!this.signatureAlgorithm) {
       throw new DwnError(

--- a/packages/dwn-sdk-js/src/utils/protocols.ts
+++ b/packages/dwn-sdk-js/src/utils/protocols.ts
@@ -1,6 +1,6 @@
 import type { DerivedPrivateJwk } from '../utils/hd-key.js';
 import type { EncryptionKeyDeriver } from '../types/encryption-types.js';
-import type { PrivateJwk } from '../types/jose-types.js';
+import type { PrivateKeyJwk } from '../types/jose-types.js';
 import type { ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
 
 import { Secp256k1 } from './secp256k1.js';
@@ -24,20 +24,20 @@ export class Protocols {
   ): Promise<ProtocolDefinition>;
 
   /**
-   * Overload 2 (raw-key, existing): Takes rootKeyId and raw PrivateJwk directly.
+   * Overload 2 (raw-key, existing): Takes rootKeyId and raw PrivateKeyJwk directly.
    * Preserved for backward compatibility with tests and non-KMS callers.
    */
   public static async deriveAndInjectPublicEncryptionKeys(
     protocolDefinition: ProtocolDefinition,
     rootKeyId: string,
-    privateJwk: PrivateJwk,
+    privateJwk: PrivateKeyJwk,
   ): Promise<ProtocolDefinition>;
 
   // Implementation dispatches based on argument type
   public static async deriveAndInjectPublicEncryptionKeys(
     protocolDefinition: ProtocolDefinition,
     rootKeyIdOrKeyDeriver: string | EncryptionKeyDeriver,
-    privateJwk?: PrivateJwk,
+    privateJwk?: PrivateKeyJwk,
   ): Promise<ProtocolDefinition> {
     // clone before modify
     const clone = JSON.parse(JSON.stringify(protocolDefinition)) as ProtocolDefinition;

--- a/packages/dwn-sdk-js/src/utils/secp256k1.ts
+++ b/packages/dwn-sdk-js/src/utils/secp256k1.ts
@@ -1,4 +1,5 @@
-import type { PrivateJwk, PublicJwk } from '../types/jose-types.js';
+import type { JwkParamsEcPublic } from '@enbox/crypto';
+import type { PrivateKeyJwk, PublicKeyJwk } from '../types/jose-types.js';
 
 import * as secp256k1 from '@noble/secp256k1';
 
@@ -15,7 +16,7 @@ export class Secp256k1 {
    * Validates the given JWK is a SECP256K1 key.
    * @throws {Error} if fails validation.
    */
-  public static validateKey(jwk: PrivateJwk | PublicJwk): void {
+  public static validateKey(jwk: PrivateKeyJwk | PublicKeyJwk): void {
     if (jwk.kty !== 'EC' || jwk.crv !== 'secp256k1') {
       throw new DwnError(DwnErrorCode.Secp256k1KeyNotValid, 'Invalid SECP256K1 JWK: `kty` MUST be `EC`. `crv` MUST be `secp256k1`');
     }
@@ -24,7 +25,7 @@ export class Secp256k1 {
   /**
    * Converts a public key in bytes into a JWK.
    */
-  public static async publicKeyToJwk(publicKeyBytes: Uint8Array): Promise<PublicJwk> {
+  public static async publicKeyToJwk(publicKeyBytes: Uint8Array): Promise<PublicKeyJwk> {
   // ensure public key is in uncompressed format so we can convert it into both x and y value
     let uncompressedPublicKeyBytes;
     if (publicKeyBytes.byteLength === 33) {
@@ -43,7 +44,7 @@ export class Secp256k1 {
     const x = Encoder.bytesToBase64Url(uncompressedPublicKeyBytes.subarray(1, 33));
     const y = Encoder.bytesToBase64Url(uncompressedPublicKeyBytes.subarray(33, 65));
 
-    const publicJwk: PublicJwk = {
+    const publicJwk: PublicKeyJwk = {
       alg : 'ES256K',
       kty : 'EC',
       crv : 'secp256k1',
@@ -57,21 +58,22 @@ export class Secp256k1 {
   /**
    * Converts a private key in bytes into a JWK.
    */
-  public static async privateKeyToJwk(privateKeyBytes: Uint8Array): Promise<PrivateJwk> {
+  public static async privateKeyToJwk(privateKeyBytes: Uint8Array): Promise<PrivateKeyJwk> {
     const publicKeyBytes = await Secp256k1.getPublicKey(privateKeyBytes);
 
     const jwk = await Secp256k1.publicKeyToJwk(publicKeyBytes);
-    (jwk as PrivateJwk).d = Encoder.bytesToBase64Url(privateKeyBytes);
+    (jwk as PrivateKeyJwk).d = Encoder.bytesToBase64Url(privateKeyBytes);
 
-    return jwk as PrivateJwk;
+    return jwk as PrivateKeyJwk;
   }
 
   /**
    * Creates a compressed key in raw bytes from the given SECP256K1 JWK.
    */
-  public static publicJwkToBytes(publicJwk: PublicJwk): Uint8Array {
-    const x = Encoder.base64UrlToBytes(publicJwk.x);
-    const y = Encoder.base64UrlToBytes(publicJwk.y!);
+  public static publicJwkToBytes(publicJwk: PublicKeyJwk): Uint8Array {
+    const ecJwk = publicJwk as JwkParamsEcPublic;
+    const x = Encoder.base64UrlToBytes(ecJwk.x);
+    const y = Encoder.base64UrlToBytes(ecJwk.y!);
 
     return secp256k1.ProjectivePoint.fromAffine({
       x : secp256k1.etc.bytesToNumberBE(x),
@@ -82,7 +84,7 @@ export class Secp256k1 {
   /**
    * Creates a private key in raw bytes from the given SECP256K1 JWK.
    */
-  public static privateJwkToBytes(privateJwk: PrivateJwk): Uint8Array {
+  public static privateJwkToBytes(privateJwk: PrivateKeyJwk): Uint8Array {
     const privateKey = Encoder.base64UrlToBytes(privateJwk.d);
     return privateKey;
   }
@@ -90,7 +92,7 @@ export class Secp256k1 {
   /**
    * Signs the provided content using the provided JWK.
    */
-  public static async sign(content: Uint8Array, privateJwk: PrivateJwk): Promise<Uint8Array> {
+  public static async sign(content: Uint8Array, privateJwk: PrivateKeyJwk): Promise<Uint8Array> {
     Secp256k1.validateKey(privateJwk);
 
     // the underlying lib expects us to hash the content ourselves:
@@ -105,7 +107,7 @@ export class Secp256k1 {
    * Verifies a signature against the provided payload hash and public key.
    * @returns a boolean indicating whether the signature is valid.
    */
-  public static async verify(content: Uint8Array, signature: Uint8Array, publicJwk: PublicJwk): Promise<boolean> {
+  public static async verify(content: Uint8Array, signature: Uint8Array, publicJwk: PublicKeyJwk): Promise<boolean> {
     Secp256k1.validateKey(publicJwk);
 
     const publicKeyBytes = Secp256k1.publicJwkToBytes(publicJwk);
@@ -116,13 +118,13 @@ export class Secp256k1 {
   /**
    * Generates a random key pair in JWK format.
    */
-  public static async generateKeyPair(): Promise<{publicJwk: PublicJwk, privateJwk: PrivateJwk}> {
+  public static async generateKeyPair(): Promise<{publicJwk: PublicKeyJwk, privateJwk: PrivateKeyJwk}> {
     const privateKeyBytes = secp256k1.utils.randomPrivateKey();
     const publicKeyBytes = secp256k1.getPublicKey(privateKeyBytes, false); // `false` = uncompressed
 
     const d = Encoder.bytesToBase64Url(privateKeyBytes);
-    const publicJwk: PublicJwk = await Secp256k1.publicKeyToJwk(publicKeyBytes);
-    const privateJwk: PrivateJwk = { ...publicJwk, d };
+    const publicJwk: PublicKeyJwk = await Secp256k1.publicKeyToJwk(publicKeyBytes);
+    const privateJwk: PrivateKeyJwk = { ...publicJwk, d };
 
     return { publicJwk, privateJwk };
   }
@@ -148,7 +150,7 @@ export class Secp256k1 {
   /**
    * Gets the public JWK of the given private JWK.
    */
-  public static async getPublicJwk(privateKeyJwk: PrivateJwk): Promise<PublicJwk> {
+  public static async getPublicJwk(privateKeyJwk: PrivateKeyJwk): Promise<PublicKeyJwk> {
     // strip away `d`
     const { d: _d, ...publicKey } = privateKeyJwk;
     return publicKey;

--- a/packages/dwn-sdk-js/src/utils/secp256r1.ts
+++ b/packages/dwn-sdk-js/src/utils/secp256r1.ts
@@ -1,4 +1,5 @@
-import type { PrivateJwk, PublicJwk } from '../types/jose-types.js';
+import type { JwkParamsEcPublic } from '@enbox/crypto';
+import type { PrivateKeyJwk, PublicKeyJwk } from '../types/jose-types.js';
 
 import { p256, secp256r1 } from '@noble/curves/p256';
 
@@ -17,7 +18,7 @@ export class Secp256r1 {
    * Validates the given JWK is a SECP256R1 key.
    * @throws {Error} if fails validation.
    */
-  public static validateKey(jwk: PrivateJwk | PublicJwk): void {
+  public static validateKey(jwk: PrivateKeyJwk | PublicKeyJwk): void {
     if (jwk.kty !== 'EC' || jwk.crv !== 'P-256') {
       throw new DwnError(
         DwnErrorCode.Secp256r1KeyNotValid,
@@ -31,7 +32,7 @@ export class Secp256r1 {
    */
   public static async publicKeyToJwk(
     publicKeyBytes: Uint8Array
-  ): Promise<PublicJwk> {
+  ): Promise<PublicKeyJwk> {
     // ensure public key is in uncompressed format so we can convert it into both x and y value
     let uncompressedPublicKeyBytes;
     if (publicKeyBytes.byteLength === 33) {
@@ -54,7 +55,7 @@ export class Secp256r1 {
       uncompressedPublicKeyBytes.subarray(33, 65)
     );
 
-    const publicJwk: PublicJwk = {
+    const publicJwk: PublicKeyJwk = {
       alg : 'ES256',
       kty : 'EC',
       crv : 'P-256',
@@ -68,7 +69,7 @@ export class Secp256r1 {
   /**
    * Creates a private key in raw bytes from the given SECP256R1 JWK.
    */
-  public static privateJwkToBytes(privateJwk: PrivateJwk): Uint8Array {
+  public static privateJwkToBytes(privateJwk: PrivateKeyJwk): Uint8Array {
     const privateKey = Encoder.base64UrlToBytes(privateJwk.d);
     return privateKey;
   }
@@ -79,7 +80,7 @@ export class Secp256r1 {
    */
   public static async sign(
     content: Uint8Array,
-    privateJwk: PrivateJwk
+    privateJwk: PrivateKeyJwk
   ): Promise<Uint8Array> {
     Secp256r1.validateKey(privateJwk);
 
@@ -99,7 +100,7 @@ export class Secp256r1 {
   public static async verify(
     content: Uint8Array,
     signature: Uint8Array,
-    publicJwk: PublicJwk
+    publicJwk: PublicKeyJwk
   ): Promise<boolean> {
     Secp256r1.validateKey(publicJwk);
 
@@ -111,9 +112,10 @@ export class Secp256r1 {
       sig = p256.Signature.fromDER(signature);
     }
     const hashedContent = await sha256.encode(content);
+    const ecJwk = publicJwk as JwkParamsEcPublic;
     const keyBytes = p256.ProjectivePoint.fromAffine({
-      x : Secp256r1.bytesToBigInt(Encoder.base64UrlToBytes(publicJwk.x)),
-      y : Secp256r1.bytesToBigInt(Encoder.base64UrlToBytes(publicJwk.y!)),
+      x : Secp256r1.bytesToBigInt(Encoder.base64UrlToBytes(ecJwk.x)),
+      y : Secp256r1.bytesToBigInt(Encoder.base64UrlToBytes(ecJwk.y!)),
     }).toRawBytes(false);
 
     return p256.verify(sig, hashedContent, keyBytes);
@@ -123,15 +125,15 @@ export class Secp256r1 {
    * Generates a random key pair in JWK format.
    */
   public static async generateKeyPair(): Promise<{
-    publicJwk: PublicJwk;
-    privateJwk: PrivateJwk;
+    publicJwk: PublicKeyJwk;
+    privateJwk: PrivateKeyJwk;
   }> {
     const privateKeyBytes = p256.utils.randomPrivateKey();
     const publicKeyBytes = secp256r1.getPublicKey(privateKeyBytes, false); // `false` = uncompressed
 
     const d = Encoder.bytesToBase64Url(privateKeyBytes);
-    const publicJwk: PublicJwk = await Secp256r1.publicKeyToJwk(publicKeyBytes);
-    const privateJwk: PrivateJwk = { ...publicJwk, d };
+    const publicJwk: PublicKeyJwk = await Secp256r1.publicKeyToJwk(publicKeyBytes);
+    const privateJwk: PrivateKeyJwk = { ...publicJwk, d };
 
     return { publicJwk, privateJwk };
   }

--- a/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
@@ -1874,7 +1874,7 @@ export function testRecordsReadHandler(): void {
             protocolPath                                     : 'thread/message',
             protocolParentContextId                          : fetchedRecordsWrite.contextId,
             protocolContextDerivingRootKeyId                 : protocolContextDerivingRootKeyIdReturned,
-            protocolContextDerivedPublicJwk                  : protocolContextDerivedPublicJwkReturned!,
+            protocolContextDerivedPublicKeyJwk               : protocolContextDerivedPublicJwkReturned!,
             encryptSymmetricKeyWithProtocolPathDerivedKey    : true,
             encryptSymmetricKeyWithProtocolContextDerivedKey : true
           });

--- a/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
@@ -1,5 +1,5 @@
 import type { EncryptionInput, RecordsWriteOptions } from '../../src/interfaces/records-write.js';
-import type { PermissionScope, Signer } from '../../src/index.js';
+import type { MessageSigner, PermissionScope } from '../../src/index.js';
 
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
@@ -183,7 +183,7 @@ describe('RecordsWrite', () => {
     it('should be able to create a RecordsWrite successfully using a custom signer', async () => {
       // create a custom signer
       const hardCodedSignature = Encoder.stringToBytes('some_hard_coded_signature');
-      class CustomSigner implements Signer {
+      class CustomSigner implements MessageSigner {
         public keyId = 'did:example:alice#key1';
         public algorithm = 'unused';
         public async sign (_content: Uint8Array): Promise<Uint8Array> {

--- a/packages/dwn-sdk-js/tests/scenarios/end-to-end-tests.spec.ts
+++ b/packages/dwn-sdk-js/tests/scenarios/end-to-end-tests.spec.ts
@@ -165,7 +165,7 @@ export function testEndToEndScenarios(): void {
         protocolPath                                     : 'thread/chat',
         protocolParentContextId                          : threadRecord.message.contextId,
         protocolContextDerivingRootKeyId                 : aliceRootKey.rootKeyId,
-        protocolContextDerivedPublicJwk                  : contextDerivedPublicKey,
+        protocolContextDerivedPublicKeyJwk               : contextDerivedPublicKey,
         encryptSymmetricKeyWithProtocolPathDerivedKey    : false,
         encryptSymmetricKeyWithProtocolContextDerivedKey : true
       });

--- a/packages/dwn-sdk-js/tests/utils/encryption-callbacks.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/encryption-callbacks.spec.ts
@@ -1,5 +1,5 @@
 import type { EncryptionKeyDeriver, KeyDecrypter } from '../../src/types/encryption-types.js';
-import type { PrivateJwk, PublicJwk } from '../../src/types/jose-types.js';
+import type { PrivateKeyJwk, PublicKeyJwk } from '../../src/types/jose-types.js';
 
 import { DataStream } from '../../src/utils/data-stream.js';
 import { Encoder } from '../../src/utils/encoder.js';
@@ -12,7 +12,7 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { HdKey, KeyDerivationScheme } from '../../src/utils/hd-key.js';
 
 describe('Encryption Callback Interfaces', () => {
-  let privateJwk: PrivateJwk;
+  let privateJwk: PrivateKeyJwk;
   let rootKeyId: string;
 
   beforeEach(async () => {
@@ -54,7 +54,7 @@ describe('Encryption Callback Interfaces', () => {
       const keyDeriver: EncryptionKeyDeriver = {
         rootKeyId,
         derivationScheme : KeyDerivationScheme.ProtocolPath,
-        derivePublicKey  : async (fullDerivationPath: string[]): Promise<PublicJwk> => {
+        derivePublicKey  : async (fullDerivationPath: string[]): Promise<PublicKeyJwk> => {
           const privateKeyBytes = Secp256k1.privateJwkToBytes(privateJwk);
           const derivedPrivateKeyBytes = await HdKey.derivePrivateKeyBytes(
             privateKeyBytes, fullDerivationPath
@@ -115,7 +115,7 @@ describe('Encryption Callback Interfaces', () => {
       const keyDeriver: EncryptionKeyDeriver = {
         rootKeyId,
         derivationScheme : KeyDerivationScheme.ProtocolPath,
-        derivePublicKey  : async (fullDerivationPath: string[]): Promise<PublicJwk> => {
+        derivePublicKey  : async (fullDerivationPath: string[]): Promise<PublicKeyJwk> => {
           calledPaths.push([...fullDerivationPath]);
           const privateKeyBytes = Secp256k1.privateJwkToBytes(privateJwk);
           const derivedPrivateKeyBytes = await HdKey.derivePrivateKeyBytes(

--- a/packages/dwn-sdk-js/tests/utils/secp256k1.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/secp256k1.spec.ts
@@ -1,3 +1,5 @@
+import type { JwkParamsEcPublic } from '@enbox/crypto';
+
 import { base64url } from 'multiformats/bases/base64';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { expect } from 'chai';
@@ -33,7 +35,7 @@ describe('Secp256k1', () => {
       const publicJwk2 = await Secp256k1.publicKeyToJwk(uncompressedPublicKey);
 
       expect(publicJwk1.x).to.equal(publicJwk2.x);
-      expect(publicJwk1.y).to.equal(publicJwk2.y);
+      expect((publicJwk1 as JwkParamsEcPublic).y).to.equal((publicJwk2 as JwkParamsEcPublic).y);
     });
   });
 

--- a/packages/dwn-sdk-js/tests/utils/secp256r1.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/secp256r1.spec.ts
@@ -1,3 +1,5 @@
+import type { JwkParamsEcPublic } from '@enbox/crypto';
+
 import { base64url } from 'multiformats/bases/base64';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { expect } from 'chai';
@@ -38,7 +40,7 @@ describe('Secp256r1', () => {
       const publicJwk2 = await Secp256r1.publicKeyToJwk(uncompressedPublicKey);
 
       expect(publicJwk1.x).to.equal(publicJwk2.x);
-      expect(publicJwk1.y).to.equal(publicJwk2.y);
+      expect((publicJwk1 as JwkParamsEcPublic).y).to.equal((publicJwk2 as JwkParamsEcPublic).y);
     });
   });
 

--- a/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
+++ b/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
@@ -1,6 +1,7 @@
 import type { DerivedPrivateJwk } from '../../src/utils/hd-key.js';
 import type { DidResolutionResult } from '@enbox/dids';
 import type { GeneralJws } from '../../src/types/jws-types.js';
+import type { MessageSigner } from '../../src/types/signer.js';
 import type { MessagesQueryOptions } from '../../src/interfaces/messages-query.js';
 import type { MessagesReadOptions } from '../../src/interfaces/messages-read.js';
 import type { MessagesSubscribeOptions } from '../../src/interfaces/messages-subscribe.js';
@@ -11,13 +12,12 @@ import type { ProtocolsQueryOptions } from '../../src/interfaces/protocols-query
 import type { Readable } from 'readable-stream';
 import type { RecordsQueryOptions } from '../../src/interfaces/records-query.js';
 import type { RecordsSubscribeOptions } from '../../src/interfaces/records-subscribe.js';
-import type { Signer } from '../../src/types/signer.js';
 import type { AuthorizationModel, Pagination } from '../../src/types/message-types.js';
 import type { CreateFromOptions, EncryptionInput, KeyEncryptionInput, RecordsWriteOptions } from '../../src/interfaces/records-write.js';
 import type { DataEncodedRecordsWriteMessage, DateSort, RecordsDeleteMessage, RecordsFilter, RecordsQueryMessage, RecordsWriteTags } from '../../src/types/records-types.js';
 import type { MessagesFilter, MessagesQueryMessage, MessagesReadMessage, MessagesSubscribeMessage } from '../../src/types/messages-types.js';
 import type { PermissionConditions, PermissionScope } from '../../src/types/permission-types.js';
-import type { PrivateJwk, PublicJwk } from '../../src/types/jose-types.js';
+import type { PrivateKeyJwk, PublicKeyJwk } from '../../src/types/jose-types.js';
 import type { ProtocolDefinition, ProtocolsConfigureMessage, ProtocolsQueryMessage } from '../../src/types/protocols-types.js';
 import type { RecordsSubscribeMessage, RecordsWriteMessage } from '../../src/types/records-types.js';
 
@@ -54,8 +54,8 @@ import { HdKey, KeyDerivationScheme } from '../../src/utils/hd-key.js';
 export type Persona = {
   did: string;
   keyId: string;
-  keyPair: { publicJwk: PublicJwk, privateJwk: PrivateJwk };
-  signer: Signer;
+  keyPair: { publicJwk: PublicKeyJwk, privateJwk: PrivateKeyJwk };
+  signer: MessageSigner;
 };
 
 export type GenerateProtocolsConfigureInput = {
@@ -403,7 +403,7 @@ export class TestDataGenerator {
    * @param input.attesters Attesters of the message. Will NOT be generated if not given.
    * @param input.data Data that belongs to the record. Generated when not given only if `dataCid` and `dataSize` are also not given.
    * @param input.dataFormat Format of the data. Defaults to 'application/json' if not given.
-   * @param input.signer Signer of the message. Generated if not given.
+   * @param input.signer MessageSigner of the message. Generated if not given.
    * @param input.schema Schema of the message. Randomly generated if not given.
    */
   public static async generateRecordsWrite(input?: GenerateRecordsWriteInput): Promise<GenerateRecordsWriteOutput> {
@@ -479,7 +479,7 @@ export class TestDataGenerator {
     protocolPath: string,
     protocolParentContextId?: string,
     protocolContextDerivingRootKeyId?: string,
-    protocolContextDerivedPublicJwk?: PublicJwk,
+    protocolContextDerivedPublicKeyJwk?: PublicKeyJwk,
     encryptSymmetricKeyWithProtocolPathDerivedKey: boolean,
     encryptSymmetricKeyWithProtocolContextDerivedKey: boolean,
   }): Promise<{
@@ -497,7 +497,7 @@ export class TestDataGenerator {
       protocolPath,
       protocolParentContextId,
       protocolContextDerivingRootKeyId,
-      protocolContextDerivedPublicJwk,
+      protocolContextDerivedPublicKeyJwk,
     } = input;
 
     // encrypt the plaintext data for the target with a randomly generated symmetric key
@@ -539,11 +539,11 @@ export class TestDataGenerator {
         protocolRuleSetSegment = protocolRuleSetSegment[pathSegment];
       }
 
-      const protocolPathDerivedPublicJwk = protocolRuleSetSegment.$encryption?.publicKeyJwk;
+      const protocolPathDerivedPublicKeyJwk = protocolRuleSetSegment.$encryption?.publicKeyJwk;
       const protocolPathDerivationRootKeyId = protocolRuleSetSegment.$encryption?.rootKeyId;
       const protocolPathDerivedKeyEncryptionInput: KeyEncryptionInput = {
         publicKeyId      : protocolPathDerivationRootKeyId,
-        publicKey        : protocolPathDerivedPublicJwk!,
+        publicKey        : protocolPathDerivedPublicKeyJwk!,
         derivationScheme : KeyDerivationScheme.ProtocolPath
       };
 
@@ -563,22 +563,22 @@ export class TestDataGenerator {
 
         const contextId = await RecordsWrite.getEntryId(author.did, message.descriptor);
         const contextDerivationPath = Records.constructKeyDerivationPathUsingProtocolContextScheme(contextId);
-        const authorGeneratedProtocolContextDerivedPublicJwk = await HdKey.derivePublicKey(authorRootPrivateKey, contextDerivationPath);
+        const authorGeneratedProtocolContextDerivedPublicKeyJwk = await HdKey.derivePublicKey(authorRootPrivateKey, contextDerivationPath);
 
         protocolContextDerivedKeyEncryptionInput = {
           publicKeyId      : author.keyId,
-          publicKey        : authorGeneratedProtocolContextDerivedPublicJwk,
+          publicKey        : authorGeneratedProtocolContextDerivedPublicKeyJwk,
           derivationScheme : KeyDerivationScheme.ProtocolContext
         };
       } else {
         if (protocolContextDerivingRootKeyId === undefined ||
-          protocolContextDerivedPublicJwk === undefined) {
-          throw new Error ('`protocolContextDerivingRootKeyId` and `protocolContextDerivedPublicJwk` must both be defined if `protocolContextId` is given');
+          protocolContextDerivedPublicKeyJwk === undefined) {
+          throw new Error ('`protocolContextDerivingRootKeyId` and `protocolContextDerivedPublicKeyJwk` must both be defined if `protocolContextId` is given');
         }
 
         protocolContextDerivedKeyEncryptionInput = {
           publicKeyId      : protocolContextDerivingRootKeyId!,
-          publicKey        : protocolContextDerivedPublicJwk!,
+          publicKey        : protocolContextDerivedPublicKeyJwk!,
           derivationScheme : KeyDerivationScheme.ProtocolContext
         };
       }
@@ -914,8 +914,8 @@ export class TestDataGenerator {
     const portableDid = await did.export();
     const keyPair = {
       // TODO: #672 - port and use type from @enbox/crypto - https://github.com/enboxorg/enbox/issues/672
-      publicJwk  : signingMethod.publicKeyJwk as PublicJwk,
-      privateJwk : portableDid.privateKeys![0] as PrivateJwk,
+      publicJwk  : signingMethod.publicKeyJwk as PublicKeyJwk,
+      privateJwk : portableDid.privateKeys![0] as PrivateKeyJwk,
     };
 
     return {


### PR DESCRIPTION
## Summary

- **Imports JWK types from `@enbox/crypto`** instead of maintaining duplicate definitions in `dwn-sdk-js`, making `@enbox/crypto` the canonical source for all JWK types across the monorepo
- **Renames `Signer` → `MessageSigner`** in `dwn-sdk-js` to avoid conflicts with `@enbox/crypto`'s incompatible `Signer` interface (which uses Web Crypto API semantics)
- **Renames `PublicJwk` → `PublicKeyJwk` and `PrivateJwk` → `PrivateKeyJwk`** for full alignment with `@enbox/crypto` naming conventions

## Details

### Type definitions (`jose-types.ts`)
- Rewrote to import `Jwk`, `JwkParamsEcPublic`, `JwkParamsEcPrivate`, `JwkParamsOkpPublic`, `JwkParamsOkpPrivate` from `@enbox/crypto`
- Defined narrower `PublicKeyJwk = JwkParamsEcPublic | JwkParamsOkpPublic` (EC + OKP only — no RSA, matching DWN protocol scope)
- Defined narrower `PrivateKeyJwk = JwkParamsEcPrivate | JwkParamsOkpPrivate` (same rationale)
- Added `SupportedCurve` type and narrowed `signatureAlgorithms` Record key type

### Union type safety
- Added `as JwkParamsEcPublic` casts where `.y` property is accessed (only exists on EC keys, not OKP)
- Added `as SupportedCurve` casts at `signatureAlgorithms` indexing sites with runtime guards

### Agent package
- Updated re-exports: `MessageSigner as DwnSigner`, simplified `PublicKeyJwk as DwnPublicKeyJwk`

### What is NOT changed
- JSON schemas (`general-jwk.json`, `public-jwk.json`) — these define the wire protocol and stay broad
- `DwnErrorCode` enum values (e.g., `RecordsWriteMissingSigner`) — these are error codes, not type names
- Method names (`createSigner`, `getPublicJwk`, etc.) — only type annotations were renamed

## Verification
- `bun run --filter '@enbox/dwn-sdk-js' lint` — passes
- `bun run --filter '@enbox/agent' lint` — passes
- `bun run --filter '*' build` — all packages build successfully

## Context
This is a prerequisite for protocol encryption PRs #3–#7. Unifying types now prevents cascading conflicts when those PRs land.