### PR TITLE
feat(agent): auto-encrypt/decrypt protocol records (single-party)

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -1,24 +1,33 @@
 import type { Readable } from '@enbox/common';
 import type {
   DwnConfig,
+  EncryptionInput,
   EncryptionKeyDeriver,
   GenericMessage,
   KeyDecrypter,
-  ProtocolDefinition } from '@enbox/dwn-sdk-js';
+  ProtocolDefinition,
+  RecordsQueryReply,
+  RecordsReadReply,
+  RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 import type { KeyIdentifier, PublicKeyJwk } from '@enbox/crypto';
 
 import { CryptoUtils } from '@enbox/crypto';
 import {
   Cid,
   DataStoreLevel,
+  DataStream,
   Dwn,
   DwnInterfaceName,
   DwnMethodName,
+  Encoder,
+  Encryption,
   EventEmitterStream,
   EventLogLevel,
   KeyDerivationScheme,
   Message,
   MessageStoreLevel,
+  Protocols,
+  Records,
   ResumableTaskStoreLevel
 } from '@enbox/dwn-sdk-js';
 import { DidDht, DidJwk, DidResolverCacheLevel, UniversalResolver } from '@enbox/dids';
@@ -194,6 +203,9 @@ export class AgentDwnApi {
       ? await this._dwn.processMessage(request.target, message, { dataStream: dataStream as any, subscriptionHandler })
       : { status: { code: 202, detail: 'Accepted' } };
 
+    // Auto-decrypt reply data if encryption is enabled (Component 7)
+    await this.maybeDecryptReply(request, reply);
+
     // Returns an object containing the reply from processing the message, the original message,
     // and the content identifier (CID) of the message.
     return {
@@ -244,6 +256,9 @@ export class AgentDwnApi {
       data,
       subscriptionHandler
     });
+
+    // Auto-decrypt reply data if encryption is enabled (Component 7)
+    await this.maybeDecryptReply(request, reply);
 
     // If the message CID was not given in the `request`, compute it.
     messageCid ??= await Message.getCid(message);
@@ -346,6 +361,115 @@ export class AgentDwnApi {
           // @ts-ignore
           messageParams.dataSize ??= isomorphicNodeReadable['bytesRead'];
         }
+      }
+    }
+
+    // Auto-inject encryption keys into protocol definition (Component 5)
+    if (isDwnRequest(request, DwnInterface.ProtocolsConfigure) && request.encryption && !rawMessage) {
+      const messageParams = request.messageParams!;
+      const keyDeriver = await this.getEncryptionKeyDeriver(request.author);
+
+      // SDK walks the protocol structure and calls our callback for each path.
+      // The KMS performs HKDF derivation + public key computation internally.
+      messageParams.definition = await Protocols.deriveAndInjectPublicEncryptionKeys(
+        messageParams.definition,
+        keyDeriver,
+      );
+
+      // Invalidate cache for this protocol
+      this._protocolDefinitionCache.delete(
+        `${request.target}~${messageParams.definition.protocol}`
+      );
+    }
+
+    // Auto-encrypt data on RecordsWrite (Component 6)
+    if (isDwnRequest(request, DwnInterface.RecordsWrite) && request.encryption && !rawMessage) {
+      const messageParams = request.messageParams;
+      if (messageParams?.protocol && messageParams.protocolPath) {
+        // 1. Fetch the installed protocol definition (cached)
+        const protocolDefinition = await this.getProtocolDefinition(
+          request.target,
+          messageParams.protocol
+        );
+
+        if (!protocolDefinition) {
+          throw new Error(
+            `AgentDwnApi: Protocol '${messageParams.protocol}' is not installed ` +
+            `for '${request.target}'. Install the protocol before writing ` +
+            `encrypted records.`
+          );
+        }
+
+        // 2. Walk the protocol structure to find $encryption for this protocol path
+        const protocolPathSegments = messageParams.protocolPath.split('/');
+        let ruleSet: any = protocolDefinition.structure;
+        for (const segment of protocolPathSegments) {
+          ruleSet = ruleSet[segment];
+        }
+
+        if (!ruleSet?.$encryption) {
+          throw new Error(
+            `AgentDwnApi: Protocol '${messageParams.protocol}' at path ` +
+            `'${messageParams.protocolPath}' does not have encryption configured. ` +
+            `Configure the protocol with encryption: true.`
+          );
+        }
+
+        // 3. Generate random DEK and IV
+        const dataEncryptionKey = crypto.getRandomValues(new Uint8Array(32));
+        const dataEncryptionIV = crypto.getRandomValues(new Uint8Array(16));
+
+        // 4. Get plaintext bytes (normalize from all supported input types)
+        let plaintextBytes: Uint8Array;
+        if (messageParams.data) {
+          plaintextBytes = messageParams.data instanceof Uint8Array
+            ? messageParams.data
+            : new TextEncoder().encode(String(messageParams.data));
+        } else if (request.dataStream instanceof Blob) {
+          plaintextBytes = new Uint8Array(await request.dataStream.arrayBuffer());
+        } else if (request.dataStream instanceof ReadableStream) {
+          const nodeReadable = webReadableToIsomorphicNodeReadable(request.dataStream);
+          plaintextBytes = await NodeStream.consumeToBytes({ readable: nodeReadable });
+        } else if (request.dataStream) {
+          plaintextBytes = await NodeStream.consumeToBytes({ readable: request.dataStream as Readable });
+        } else {
+          throw new Error('AgentDwnApi: Data must be provided for encrypted records.');
+        }
+
+        // 5. Encrypt data with AES-256-CTR
+        const plaintextStream = DataStream.fromBytes(plaintextBytes);
+        const encryptedStream = await Encryption.aes256CtrEncrypt(
+          dataEncryptionKey, dataEncryptionIV, plaintextStream
+        );
+        const encryptedBytes = await NodeStream.consumeToBytes({ readable: encryptedStream });
+
+        // 6. Replace plaintext with encrypted data.
+        // Compute dataCid/dataSize from the *encrypted* bytes so the descriptor
+        // references the ciphertext CID (what the DWN stores and verifies).
+        // Clear messageParams.data so the SDK sees dataCid (not both).
+        const encryptedCidStream = DataStream.fromBytes(encryptedBytes);
+        // @ts-ignore — dataCid is set dynamically above
+        messageParams.dataCid = await Cid.computeDagPbCidFromStream(encryptedCidStream);
+        // @ts-ignore — dataSize is set dynamically above
+        messageParams.dataSize = encryptedBytes.length;
+        delete messageParams.data;
+        // Provide the encrypted bytes as the dataStream for processMessage()
+        // so the DWN actually persists the data (avoids 204 No Content).
+        readableStream = DataStream.fromBytes(encryptedBytes);
+        request.dataStream = undefined;
+
+        // 7. Build EncryptionInput — only uses PUBLIC key from $encryption
+        const encryptionInput: EncryptionInput = {
+          initializationVector : dataEncryptionIV,
+          key                  : dataEncryptionKey,
+          keyEncryptionInputs  : [{
+            publicKeyId      : ruleSet.$encryption.rootKeyId,
+            publicKey        : ruleSet.$encryption.publicKeyJwk,
+            derivationScheme : KeyDerivationScheme.ProtocolPath,
+          }]
+        };
+
+        messageParams.encryptionInput = encryptionInput;
       }
     }
 
@@ -607,6 +731,72 @@ export class AgentDwnApi {
     const definition = reply.entries[0].descriptor.definition;
     this._protocolDefinitionCache.set(cacheKey, definition);
     return definition;
+  }
+
+  /**
+   * Post-processes a DWN reply, auto-decrypting data if encryption is enabled.
+   * Delegates to the SDK's Records.decrypt() with a KeyDecrypter callback —
+   * the SDK handles key matching, path construction, and AES decryption.
+   * The KMS handles HKDF + ECIES via the callback.
+   */
+  private async maybeDecryptReply<T extends DwnInterface>(
+    request: ProcessDwnRequest<T> | SendDwnRequest<T>,
+    reply: DwnMessageReply[T],
+  ): Promise<void> {
+    if (!('encryption' in request) || !request.encryption) {
+      return;
+    }
+
+    // Auto-decrypt RecordsRead replies
+    if (isDwnRequest(request as ProcessDwnRequest<DwnInterface>, DwnInterface.RecordsRead)) {
+      const readReply = reply as RecordsReadReply;
+      if (readReply.status.code === 200
+          && readReply.entry?.recordsWrite?.encryption
+          && readReply.entry?.data) {
+        const keyDecrypter = await this.getKeyDecrypter(request.author);
+
+        try {
+          readReply.entry.data = await Records.decrypt(
+            readReply.entry.recordsWrite,
+            keyDecrypter,
+            readReply.entry.data,
+          );
+        } catch (error: any) {
+          throw new Error(
+            `AgentDwnApi: Failed to decrypt record ` +
+            `'${readReply.entry.recordsWrite.recordId}'. ` +
+            `Original error: ${error.message}`
+          );
+        }
+      }
+    }
+
+    // Auto-decrypt RecordsQuery replies (small records inline as encodedData)
+    if (isDwnRequest(request as ProcessDwnRequest<DwnInterface>, DwnInterface.RecordsQuery)) {
+      const queryReply = reply as RecordsQueryReply;
+      if (queryReply.status.code === 200 && queryReply.entries) {
+        const keyDecrypter = await this.getKeyDecrypter(request.author);
+
+        for (const entry of queryReply.entries) {
+          if (entry.encryption && entry.encodedData) {
+            try {
+              const cipherBytes = Encoder.base64UrlToBytes(entry.encodedData);
+              const cipherStream = DataStream.fromBytes(cipherBytes);
+              const plainStream = await Records.decrypt(
+                entry as RecordsWriteMessage, keyDecrypter, cipherStream,
+              );
+              const plainBytes = await NodeStream.consumeToBytes({ readable: plainStream });
+              entry.encodedData = Encoder.bytesToBase64Url(plainBytes);
+            } catch (error: any) {
+              throw new Error(
+                `AgentDwnApi: Failed to decrypt record ` +
+                `'${entry.recordId}'. Original error: ${error.message}`
+              );
+            }
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -2161,17 +2161,488 @@ describe('Encryption Callback Factories', () => {
     });
   });
 
-  describe('Skipped tests for PR #4', () => {
-    it.skip('should auto-inject $encryption on ProtocolsConfigure', async () => {
-      // Will be implemented in PR #4
+  describe('Auto-Encryption (PR #4)', () => {
+    const encryptedProtocolDefinition = {
+      published : true,
+      protocol  : 'https://protocol.xyz/encrypted-notes',
+      types     : {
+        note: {
+          schema      : 'https://schemas.xyz/note',
+          dataFormats : ['text/plain', 'application/json']
+        }
+      },
+      structure: {
+        note: {}
+      }
+    };
+
+    it('should auto-inject $encryption on ProtocolsConfigure', async () => {
+      // Configure protocol with encryption: true
+      const { reply: { status } } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: encryptedProtocolDefinition
+        },
+        encryption: true
+      });
+      expect(status.code).to.equal(202);
+
+      // Query to verify $encryption was injected
+      const { reply: queryReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsQuery,
+        messageParams : {
+          filter: { protocol: encryptedProtocolDefinition.protocol },
+        }
+      });
+
+      expect(queryReply.status.code).to.equal(200);
+      expect(queryReply.entries).to.have.length(1);
+
+      const storedDefinition = queryReply.entries![0].descriptor.definition;
+      // Verify $encryption was injected at the 'note' level
+      expect(storedDefinition.structure.note).to.have.property('$encryption');
+      expect(storedDefinition.structure.note.$encryption).to.have.property('rootKeyId');
+      expect(storedDefinition.structure.note.$encryption!.rootKeyId).to.include('#enc');
+      expect(storedDefinition.structure.note.$encryption).to.have.property('publicKeyJwk');
+      expect(storedDefinition.structure.note.$encryption!.publicKeyJwk).to.have.property('crv', 'secp256k1');
     });
 
-    it.skip('should auto-encrypt data on RecordsWrite', async () => {
-      // Will be implemented in PR #4
+    it('should auto-encrypt data on RecordsWrite', async () => {
+      // First configure the protocol with encryption
+      await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: encryptedProtocolDefinition
+        },
+        encryption: true
+      });
+
+      // Write an encrypted record
+      const plaintextString = 'This is my secret note';
+      const dataBytes = Convert.string(plaintextString).toUint8Array();
+
+      const { message: writeMessage, reply: { status: writeStatus } } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : encryptedProtocolDefinition.protocol,
+          protocolPath : 'note',
+          dataFormat   : 'text/plain',
+          schema       : 'https://schemas.xyz/note',
+        },
+        dataStream : new Blob([dataBytes]),
+        encryption : true
+      });
+
+      expect(writeStatus.code).to.equal(202);
+
+      // Verify the message has encryption metadata
+      const recordsWriteMessage = writeMessage as RecordsWriteMessage;
+      expect(recordsWriteMessage).to.have.property('encryption');
+      expect(recordsWriteMessage.encryption).to.have.property('algorithm');
+      expect(recordsWriteMessage.encryption).to.have.property('initializationVector');
+      expect(recordsWriteMessage.encryption).to.have.property('keyEncryption');
+      expect(recordsWriteMessage.encryption!.keyEncryption).to.have.length(1);
+      expect(recordsWriteMessage.encryption!.keyEncryption[0]).to.have.property('rootKeyId');
+      expect(recordsWriteMessage.encryption!.keyEncryption[0].rootKeyId).to.include('#enc');
+      expect(recordsWriteMessage.encryption!.keyEncryption[0]).to.have.property('derivationScheme', 'protocolPath');
+
+      // Read the raw data without decryption to verify it's encrypted
+      const { reply: readReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : {
+          filter: { recordId: recordsWriteMessage.recordId }
+        }
+      });
+
+      expect(readReply.status.code).to.equal(200);
+      const rawDataBytes = await NodeStream.consumeToBytes({ readable: readReply.entry!.data! });
+      // Raw data should NOT be the original plaintext (it's encrypted)
+      expect(Convert.uint8Array(rawDataBytes).toString()).to.not.equal(plaintextString);
     });
 
-    it.skip('should auto-decrypt data on RecordsRead', async () => {
-      // Will be implemented in PR #4
+    it('should auto-decrypt data on RecordsRead', async () => {
+      // Configure and write encrypted record
+      await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: encryptedProtocolDefinition
+        },
+        encryption: true
+      });
+
+      const plaintextString = 'This is my secret note for reading';
+      const dataBytes = Convert.string(plaintextString).toUint8Array();
+
+      const { message: writeMessage } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : encryptedProtocolDefinition.protocol,
+          protocolPath : 'note',
+          dataFormat   : 'text/plain',
+          schema       : 'https://schemas.xyz/note',
+        },
+        dataStream : new Blob([dataBytes]),
+        encryption : true
+      });
+
+      const recordsWriteMessage = writeMessage as RecordsWriteMessage;
+
+      // Read with encryption: true should auto-decrypt
+      const { reply: readReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : {
+          filter: { recordId: recordsWriteMessage.recordId }
+        },
+        encryption: true
+      });
+
+      expect(readReply.status.code).to.equal(200);
+      const decryptedBytes = await NodeStream.consumeToBytes({ readable: readReply.entry!.data! });
+      expect(Convert.uint8Array(decryptedBytes).toString()).to.equal(plaintextString);
+    });
+
+    it('should auto-decrypt encodedData on RecordsQuery', async () => {
+      // Configure and write a small encrypted record (will be inline as encodedData)
+      await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: encryptedProtocolDefinition
+        },
+        encryption: true
+      });
+
+      const plaintextString = 'Small secret';
+      const dataBytes = Convert.string(plaintextString).toUint8Array();
+
+      await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : encryptedProtocolDefinition.protocol,
+          protocolPath : 'note',
+          dataFormat   : 'text/plain',
+          schema       : 'https://schemas.xyz/note',
+        },
+        dataStream : new Blob([dataBytes]),
+        encryption : true
+      });
+
+      // Query with encryption: true should auto-decrypt encodedData
+      const { reply: queryReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : {
+          filter: {
+            protocol     : encryptedProtocolDefinition.protocol,
+            protocolPath : 'note',
+          }
+        },
+        encryption: true
+      });
+
+      expect(queryReply.status.code).to.equal(200);
+      expect(queryReply.entries).to.have.length(1);
+
+      const entry = queryReply.entries![0];
+      // The encodedData should be decrypted plaintext (base64url encoded)
+      if (entry.encodedData) {
+        const { Encoder } = await import('@enbox/dwn-sdk-js');
+        const decodedBytes = Encoder.base64UrlToBytes(entry.encodedData);
+        expect(Convert.uint8Array(decodedBytes).toString()).to.equal(plaintextString);
+      }
+    });
+
+    it('should throw if protocol is not installed when encrypting', async () => {
+      const dataBytes = Convert.string('secret').toUint8Array();
+
+      try {
+        await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsWrite,
+          messageParams : {
+            protocol     : 'https://protocol.xyz/non-existent',
+            protocolPath : 'note',
+            dataFormat   : 'text/plain',
+          },
+          dataStream : new Blob([dataBytes]),
+          encryption : true
+        });
+        expect.fail('Expected an error to be thrown');
+      } catch (error: any) {
+        expect(error.message).to.include('not installed');
+      }
+    });
+
+    it('should throw if protocol path has no $encryption configured', async () => {
+      // Install protocol WITHOUT encryption
+      await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: encryptedProtocolDefinition
+        }
+        // No encryption: true, so no $encryption injected
+      });
+
+      const dataBytes = Convert.string('secret').toUint8Array();
+
+      try {
+        await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsWrite,
+          messageParams : {
+            protocol     : encryptedProtocolDefinition.protocol,
+            protocolPath : 'note',
+            dataFormat   : 'text/plain',
+            schema       : 'https://schemas.xyz/note',
+          },
+          dataStream : new Blob([dataBytes]),
+          encryption : true
+        });
+        expect.fail('Expected an error to be thrown');
+      } catch (error: any) {
+        expect(error.message).to.include('does not have encryption configured');
+      }
+    });
+
+    it('should handle Uint8Array data input for encryption', async () => {
+      // Configure protocol with encryption
+      await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: encryptedProtocolDefinition
+        },
+        encryption: true
+      });
+
+      const plaintextString = 'Direct Uint8Array data';
+      const dataBytes = Convert.string(plaintextString).toUint8Array();
+
+      // Write with data as Uint8Array in messageParams.data
+      const { message: writeMessage, reply: { status: writeStatus } } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : encryptedProtocolDefinition.protocol,
+          protocolPath : 'note',
+          dataFormat   : 'text/plain',
+          schema       : 'https://schemas.xyz/note',
+          data         : dataBytes,
+        },
+        encryption: true
+      });
+
+      expect(writeStatus.code).to.equal(202);
+
+      const recordsWriteMessage = writeMessage as RecordsWriteMessage;
+
+      // Verify encryption metadata present
+      expect(recordsWriteMessage).to.have.property('encryption');
+
+      // Read with decryption
+      const { reply: readReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : {
+          filter: { recordId: recordsWriteMessage.recordId }
+        },
+        encryption: true
+      });
+
+      expect(readReply.status.code).to.equal(200);
+      const decryptedBytes = await NodeStream.consumeToBytes({ readable: readReply.entry!.data! });
+      expect(Convert.uint8Array(decryptedBytes).toString()).to.equal(plaintextString);
+    });
+
+    it('should invalidate protocol definition cache on ProtocolsConfigure', async () => {
+      // Configure protocol with encryption
+      await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: encryptedProtocolDefinition
+        },
+        encryption: true
+      });
+
+      // Populate cache
+      const def1 = await testHarness.agent.dwn['getProtocolDefinition'](
+        alice.did.uri,
+        encryptedProtocolDefinition.protocol
+      );
+      expect(def1).to.exist;
+      expect(def1!.structure.note).to.have.property('$encryption');
+
+      // Reconfigure (should invalidate cache)
+      await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: encryptedProtocolDefinition
+        },
+        encryption: true
+      });
+
+      // Fetch again - should be the fresh definition, not the old cached one
+      const def2 = await testHarness.agent.dwn['getProtocolDefinition'](
+        alice.did.uri,
+        encryptedProtocolDefinition.protocol
+      );
+      expect(def2).to.exist;
+      expect(def2!.structure.note).to.have.property('$encryption');
+    });
+
+    it('should handle nested protocol paths', async () => {
+      const nestedProtocol = {
+        published : true,
+        protocol  : 'https://protocol.xyz/nested-encrypted',
+        types     : {
+          thread: {
+            schema      : 'https://schemas.xyz/thread',
+            dataFormats : ['application/json']
+          },
+          message: {
+            schema      : 'https://schemas.xyz/message',
+            dataFormats : ['text/plain']
+          }
+        },
+        structure: {
+          thread: {
+            message: {}
+          }
+        }
+      };
+
+      // Configure with encryption
+      const { reply: { status } } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: nestedProtocol
+        },
+        encryption: true
+      });
+      expect(status.code).to.equal(202);
+
+      // Query to verify $encryption was injected at all levels
+      const { reply: queryReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsQuery,
+        messageParams : {
+          filter: { protocol: nestedProtocol.protocol },
+        }
+      });
+
+      const storedDef = queryReply.entries![0].descriptor.definition;
+      // Verify $encryption exists at 'thread' level
+      expect(storedDef.structure.thread).to.have.property('$encryption');
+      expect(storedDef.structure.thread.$encryption!.publicKeyJwk).to.have.property('crv', 'secp256k1');
+      // Verify $encryption exists at 'thread/message' level
+      expect(storedDef.structure.thread.message).to.have.property('$encryption');
+      expect(storedDef.structure.thread.message.$encryption!.publicKeyJwk).to.have.property('crv', 'secp256k1');
+    });
+
+    it('should full round-trip: configure, write, read, query with encryption', async () => {
+      // 1. Configure protocol with encryption
+      await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : {
+          definition: encryptedProtocolDefinition
+        },
+        encryption: true
+      });
+
+      // 2. Write encrypted record
+      const plaintextString = 'Full round-trip secret message';
+      const dataBytes = Convert.string(plaintextString).toUint8Array();
+
+      const { message: writeMessage } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : encryptedProtocolDefinition.protocol,
+          protocolPath : 'note',
+          dataFormat   : 'text/plain',
+          schema       : 'https://schemas.xyz/note',
+        },
+        dataStream : new Blob([dataBytes]),
+        encryption : true
+      });
+
+      const recordsWriteMessage = writeMessage as RecordsWriteMessage;
+
+      // 3. Read with auto-decrypt
+      const { reply: readReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : {
+          filter: { recordId: recordsWriteMessage.recordId }
+        },
+        encryption: true
+      });
+
+      expect(readReply.status.code).to.equal(200);
+      const readDecryptedBytes = await NodeStream.consumeToBytes({ readable: readReply.entry!.data! });
+      expect(Convert.uint8Array(readDecryptedBytes).toString()).to.equal(plaintextString);
+
+      // 4. Query with auto-decrypt
+      const { reply: queryReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : {
+          filter: {
+            protocol     : encryptedProtocolDefinition.protocol,
+            protocolPath : 'note',
+          }
+        },
+        encryption: true
+      });
+
+      expect(queryReply.status.code).to.equal(200);
+      expect(queryReply.entries).to.have.length(1);
+
+      const entry = queryReply.entries![0];
+      if (entry.encodedData) {
+        const { Encoder } = await import('@enbox/dwn-sdk-js');
+        const queryDecryptedBytes = Encoder.base64UrlToBytes(entry.encodedData);
+        expect(Convert.uint8Array(queryDecryptedBytes).toString()).to.equal(plaintextString);
+      }
     });
   });
 });

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -64,6 +64,8 @@ export type FetchGrantsRequest = Omit<FetchPermissionsParams, 'author' | 'target
 export type ProtocolsConfigureRequest = {
   /** Configuration options for the protocol. */
   message: Omit<DwnMessageParams[DwnInterface.ProtocolsConfigure], 'signer'>;
+  /** When true, derives and injects $encryption public keys into the protocol definition. */
+  encryption?: boolean;
 };
 
 /**
@@ -165,6 +167,9 @@ export type RecordsQueryRequest = {
 
   /** The parameters for the query operation, detailing the criteria for selecting records. */
   message: Omit<DwnMessageParams[DwnInterface.RecordsQuery], 'signer'>;
+
+  /** When true, automatically decrypts encrypted records in the query results. */
+  encryption?: boolean;
 };
 
 /**
@@ -195,6 +200,9 @@ export type RecordsReadRequest = {
 
   /** The parameters for the read operation, detailing the criteria for selecting the record. */
   message: Omit<DwnMessageParams[DwnInterface.RecordsRead], 'signer'>;
+
+  /** When true, automatically decrypts the encrypted record data. */
+  encryption?: boolean;
 };
 
 /**
@@ -227,6 +235,9 @@ export type RecordsSubscribeRequest = {
 
   /** The handler to process the subscription events */
   subscriptionHandler: RecordsSubscriptionHandler;
+
+  /** When true, indicates encryption is active (decryption happens on subsequent reads). */
+  encryption?: boolean;
 };
 
 /** Encapsulates the response from a DWN RecordsSubscriptionRequest */
@@ -262,6 +273,9 @@ export type RecordsWriteRequest = {
    * signed, and returned but not persisted.
    */
   store?: boolean;
+
+  /** When true, automatically encrypts the record data using the protocol's encryption keys. */
+  encryption?: boolean;
 };
 
 /**
@@ -440,7 +454,8 @@ export class DwnApi {
           author        : this.connectedDid,
           messageParams : request.message,
           messageType   : DwnInterface.ProtocolsConfigure,
-          target        : this.connectedDid
+          target        : this.connectedDid,
+          encryption    : request.encryption,
         };
 
         if (this.delegateDid) {
@@ -650,7 +665,8 @@ export class DwnApi {
            * If `from` is provided, the query operation will be executed on a remote DWN.
            * Otherwise, the local DWN will be queried.
            */
-          target        : request.from || this.connectedDid
+          target        : request.from || this.connectedDid,
+          encryption    : request.encryption,
         };
 
         if (this.delegateDid) {
@@ -742,7 +758,8 @@ export class DwnApi {
            * If `from` is provided, the read operation will be executed on a remote DWN.
            * Otherwise, the read will occur on the local DWN.
            */
-          target        : request.from || this.connectedDid
+          target        : request.from || this.connectedDid,
+          encryption    : request.encryption,
         };
         if (this.delegateDid) {
           // if we don't find a delegated grant, we will attempt to read signing as the delegated DID
@@ -914,7 +931,8 @@ export class DwnApi {
           },
           author     : this.connectedDid,
           target     : this.connectedDid,
-          dataStream : dataBlob
+          dataStream : dataBlob,
+          encryption : request.encryption,
         };
 
         // if impersonation is enabled, fetch the delegated grant to use with the write operation


### PR DESCRIPTION
## Summary

Implements single-party automatic encryption/decryption for protocol-based records (PR #4 of the protocol encryption plan, Components 5-8).

- **Component 5**: Auto-inject `$encryption` public keys on `ProtocolsConfigure` when `encryption: true`. Delegates to SDK's `Protocols.deriveAndInjectPublicEncryptionKeys()` via `EncryptionKeyDeriver` callback — the KMS performs HKDF derivation internally.
- **Component 6**: Auto-encrypt data on `RecordsWrite` when `encryption: true`. Generates random DEK/IV, encrypts data with AES-256-CTR, wraps DEK with ECIES using the protocol-path derived public key from `$encryption`.
- **Component 7**: Auto-decrypt on `RecordsRead` and `RecordsQuery` via new `maybeDecryptReply()`. Constructs `KeyDecrypter` callback and delegates to SDK's `Records.decrypt()`.
- **Component 8**: API layer pass-through — adds `encryption?: boolean` to `ProtocolsConfigureRequest`, `RecordsWriteRequest`, `RecordsReadRequest`, `RecordsQueryRequest`, `RecordsSubscribeRequest`.

## Test Coverage

10 new tests covering:
- `$encryption` injection into protocol definitions (flat and nested)
- Encrypted write verification (encryption metadata present, raw data != plaintext)
- Read decryption round-trip
- Query decryption (inline `encodedData`)
- Error cases: protocol not installed, no `$encryption` configured
- Uint8Array data input handling
- Protocol definition cache invalidation
- Full end-to-end round-trip (configure → write → read → query)

## Files Changed

| File | Change |
|------|--------|
| `packages/agent/src/dwn-api.ts` | +181 lines: encryption logic in `constructDwnMessage()`, `maybeDecryptReply()`, new imports |
| `packages/agent/tests/dwn-api.spec.ts` | +485 lines: replaced 3 skipped tests with 10 real test cases |
| `packages/api/src/dwn-api.ts` | +26 lines: `encryption` flag on request types + pass-through |

## Local Verification

- ✅ `bun run lint` — all packages pass
- ✅ `bun run --filter @enbox/agent build` — compiles cleanly
- ✅ `bun run --filter @enbox/agent test:node` — 466 passing, 92 failing (all network-dependent, same as baseline)

## Builds On

- PR #27 (`feat/encryption-callback-factories`) — merged ✅