### PR TITLE
feat(agent): key delivery protocol infrastructure (PR A)

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -56,6 +56,7 @@ import type {
   SendDwnRequest
 } from './types/dwn.js';
 
+import { KeyDeliveryProtocolDefinition } from './store-data-protocols.js';
 import { DwnInterface, dwnMessageConstructors } from './types/dwn.js';
 import { getDwnServiceEndpointUrls, isRecordsWrite } from './utils.js';
 
@@ -1317,5 +1318,237 @@ export class AgentDwnApi {
     }
 
     return dwnMessageWithBlob;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Key Delivery Protocol
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Cache for key delivery protocol installation status per tenant.
+   * Once confirmed installed, we skip re-checking for 21 days.
+   */
+  private _keyDeliveryProtocolInstalledCache = new TtlCache<string, boolean>({
+    ttl : 21 * 24 * 60 * 60 * 1000,
+    max : 1000,
+  });
+
+  /**
+   * Ensures the key delivery protocol is installed on the given tenant's DWN,
+   * with `$encryption` keys injected. Uses the same lazy initialization pattern
+   * as `DwnDataStore.initialize()`.
+   *
+   * @param tenantDid - The DID of the DWN owner
+   */
+  async ensureKeyDeliveryProtocol(tenantDid: string): Promise<void> {
+    if (this._keyDeliveryProtocolInstalledCache.get(tenantDid)) {
+      return;
+    }
+
+    const protocolUri = KeyDeliveryProtocolDefinition.protocol;
+    const existing = await this.getProtocolDefinition(tenantDid, protocolUri);
+
+    if (!existing) {
+      // Derive and inject $encryption keys for each type path
+      const keyDeriver = await this.getEncryptionKeyDeriver(tenantDid);
+      const definitionWithKeys = await Protocols.deriveAndInjectPublicEncryptionKeys(
+        KeyDeliveryProtocolDefinition,
+        keyDeriver,
+      );
+
+      const { reply: { status } } = await this.processRequest({
+        author        : tenantDid,
+        target        : tenantDid,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: definitionWithKeys },
+      });
+
+      if (status.code !== 202) {
+        throw new Error(`AgentDwnApi: Failed to install key delivery protocol: ${status.code} - ${status.detail}`);
+      }
+
+      // Invalidate protocol definition cache so subsequent reads pick up the new definition
+      this._protocolDefinitionCache.delete(`${tenantDid}~${protocolUri}`);
+    }
+
+    this._keyDeliveryProtocolInstalledCache.set(tenantDid, true);
+  }
+
+  /**
+   * Writes a `contextKey` record to the owner's DWN, delivering an encrypted
+   * context key to a participant.
+   *
+   * The `contextKey` record contains a `DerivedPrivateJwk` payload encrypted to
+   * the recipient's ProtocolPath-derived key on the key-delivery protocol.
+   *
+   * @param params.tenantDid      - The DWN owner's DID (who is delivering the key)
+   * @param params.recipientDid   - The participant's DID (who will receive the key)
+   * @param params.contextKeyData - The `DerivedPrivateJwk` to deliver (will be encrypted automatically)
+   * @param params.sourceProtocol - The URI of the source protocol (tag)
+   * @param params.sourceContextId - The root context ID (tag)
+   * @returns The recordId of the written contextKey record
+   */
+  async writeContextKeyRecord({ tenantDid, recipientDid, contextKeyData, sourceProtocol, sourceContextId }: {
+    tenantDid: string;
+    recipientDid: string;
+    contextKeyData: DerivedPrivateJwk;
+    sourceProtocol: string;
+    sourceContextId: string;
+  }): Promise<string> {
+    // Ensure the key delivery protocol is installed on the owner's DWN
+    await this.ensureKeyDeliveryProtocol(tenantDid);
+
+    const protocolUri = KeyDeliveryProtocolDefinition.protocol;
+
+    // Serialize the payload to JSON bytes
+    const dataBytes = new TextEncoder().encode(JSON.stringify(contextKeyData));
+    const dataBlob = new Blob([dataBytes], { type: 'application/json' });
+
+    // Write the contextKey record — encryption is handled by processRequest
+    // because the key-delivery protocol has $encryption keys injected.
+    const { message, reply: { status } } = await this.processRequest({
+      author        : tenantDid,
+      target        : tenantDid,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : protocolUri,
+        protocolPath : 'contextKey',
+        dataFormat   : 'application/json',
+        recipient    : recipientDid,
+        tags         : { protocol: sourceProtocol, contextId: sourceContextId },
+      },
+      dataStream : dataBlob,
+      encryption : true,
+    });
+
+    if (!(message && status.code === 202)) {
+      throw new Error(
+        `AgentDwnApi: Failed to write contextKey record for ${recipientDid}: ${status.code} - ${status.detail}`
+      );
+    }
+
+    return message.recordId;
+  }
+
+  /**
+   * Fetches and decrypts a `contextKey` record from a DWN, returning the
+   * `DerivedPrivateJwk` payload.
+   *
+   * Supports both local reads (tenant queries own DWN) and remote reads
+   * (participant queries the context owner's DWN).
+   *
+   * @param params.ownerDid       - The DWN owner's DID (where contextKey records live)
+   * @param params.requesterDid   - The DID of the requester (used for signing and decryption)
+   * @param params.sourceProtocol - The URI of the source protocol (tag filter)
+   * @param params.sourceContextId - The root context ID (tag filter)
+   * @returns The decrypted `DerivedPrivateJwk`, or `undefined` if no matching record found
+   */
+  async fetchContextKeyRecord({ ownerDid, requesterDid, sourceProtocol, sourceContextId }: {
+    ownerDid: string;
+    requesterDid: string;
+    sourceProtocol: string;
+    sourceContextId: string;
+  }): Promise<DerivedPrivateJwk | undefined> {
+    const protocolUri = KeyDeliveryProtocolDefinition.protocol;
+    const isLocal = ownerDid === requesterDid;
+
+    if (isLocal) {
+      // Local query: owner queries their own DWN
+      const { reply } = await this.processRequest({
+        author        : requesterDid,
+        target        : ownerDid,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : {
+          filter: {
+            protocol     : protocolUri,
+            protocolPath : 'contextKey',
+            recipient    : requesterDid,
+            tags         : { protocol: sourceProtocol, contextId: sourceContextId },
+          },
+        },
+      });
+
+      if (reply.status.code !== 200 || !reply.entries?.length) {
+        return undefined;
+      }
+
+      // Read the full record to get the data
+      const recordId = reply.entries[0].recordId;
+      const { reply: readReply } = await this.processRequest({
+        author        : requesterDid,
+        target        : ownerDid,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : { filter: { recordId } },
+        encryption    : true,
+      });
+
+      const readResult = readReply as RecordsReadReply;
+      if (!readResult.entry?.data) {
+        return undefined;
+      }
+
+      const dataBytes = await DataStream.toBytes(readResult.entry.data);
+      const payload = JSON.parse(new TextDecoder().decode(dataBytes));
+      return payload as DerivedPrivateJwk;
+    } else {
+      // Remote query: participant queries the context owner's DWN
+      const signer = await this.getSigner(requesterDid);
+
+      const recordsQuery = await dwnMessageConstructors[DwnInterface.RecordsQuery].create({
+        signer,
+        filter: {
+          protocol     : protocolUri,
+          protocolPath : 'contextKey',
+          recipient    : requesterDid,
+          tags         : { protocol: sourceProtocol, contextId: sourceContextId },
+        },
+      });
+
+      const dwnEndpointUrls = await getDwnServiceEndpointUrls(ownerDid, this.agent.did);
+      const queryReply = await this.sendDwnRpcRequest<DwnInterface.RecordsQuery>({
+        targetDid : ownerDid,
+        dwnEndpointUrls,
+        message   : recordsQuery.message,
+      }) as RecordsQueryReply;
+
+      if (queryReply.status.code !== 200 || !queryReply.entries?.length) {
+        return undefined;
+      }
+
+      // Read the full record remotely
+      const recordId = queryReply.entries[0].recordId;
+      const recordsRead = await dwnMessageConstructors[DwnInterface.RecordsRead].create({
+        signer,
+        filter: { recordId },
+      });
+
+      const readReply = await this.sendDwnRpcRequest<DwnInterface.RecordsRead>({
+        targetDid : ownerDid,
+        dwnEndpointUrls,
+        message   : recordsRead.message,
+      }) as RecordsReadReply;
+
+      if (!readReply.entry?.data) {
+        return undefined;
+      }
+
+      // Decrypt the contextKey payload using the requester's key-delivery protocol path key
+      const readResult = readReply.entry;
+      if (!readResult.recordsWrite) {
+        return undefined;
+      }
+
+      // The record is encrypted with the recipient's ProtocolPath key on the key-delivery protocol.
+      // Use the requester's KeyDecrypter to decrypt it.
+      const keyDecrypter = await this.getKeyDecrypter(requesterDid);
+      const decryptedStream = await Records.decrypt(
+        readResult.recordsWrite,
+        keyDecrypter,
+        readResult.data as ReadableStream<Uint8Array>,
+      );
+      const decryptedBytes = await DataStream.toBytes(decryptedStream);
+      const payload = JSON.parse(new TextDecoder().decode(decryptedBytes));
+      return payload as DerivedPrivateJwk;
+    }
   }
 }

--- a/packages/agent/src/store-data-protocols.ts
+++ b/packages/agent/src/store-data-protocols.ts
@@ -23,6 +23,29 @@ export const IdentityProtocolDefinition: ProtocolDefinition = {
   }
 };
 
+export const KeyDeliveryProtocolDefinition: ProtocolDefinition = {
+  protocol  : 'https://enbox.org/protocols/key-delivery',
+  published : false,
+  types     : {
+    contextKey: {
+      dataFormats: ['application/json']
+    }
+  },
+  structure: {
+    contextKey: {
+      $actions: [
+        { who: 'recipient', of: 'contextKey', can: ['read', 'query', 'subscribe'] },
+      ],
+      $tags: {
+        $requiredTags       : ['protocol', 'contextId'],
+        $allowUndefinedTags : false,
+        protocol            : { type: 'string' },
+        contextId           : { type: 'string' },
+      },
+    }
+  }
+};
+
 export const JwkProtocolDefinition: ProtocolDefinition = {
   protocol  : 'http://identity.foundation/protocols/web5/jwk-store',
   published : false,

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -16,6 +16,7 @@ import type { DwnPermissionScope } from '../src/types/dwn.js';
 
 import { DwnInterface } from '../src/types/dwn.js';
 import emailProtocolDefinition from './fixtures/protocol-definitions/email.json' with { type: 'json' };
+import { KeyDeliveryProtocolDefinition } from '../src/store-data-protocols.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
@@ -3220,6 +3221,241 @@ describe('Encryption Callback Factories', () => {
       expect(readReply.status.code).to.equal(200);
       const rawBytes = await DataStream.toBytes(readReply.entry!.data!);
       expect(Convert.uint8Array(rawBytes).toString()).to.not.equal(plaintextString);
+    });
+  });
+});
+
+describe('Key Delivery Protocol Infrastructure (PR A)', () => {
+  let testHarness: PlatformAgentTestHarness;
+  let alice: BearerIdentity;
+
+  before(async () => {
+    testHarness = await PlatformAgentTestHarness.setup({
+      agentClass  : TestAgent,
+      agentStores : 'dwn'
+    });
+  });
+
+  beforeEach(async () => {
+    await testHarness.clearStorage();
+    await testHarness.createAgentDid();
+    alice = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
+  });
+
+  after(async () => {
+    await testHarness.clearStorage();
+    await testHarness.closeStorage();
+  });
+
+  describe('ensureKeyDeliveryProtocol()', () => {
+    it('should install the key delivery protocol on first call', async () => {
+      // Before: verify protocol is not installed
+      const { reply: beforeReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsQuery,
+        messageParams : {
+          filter: { protocol: KeyDeliveryProtocolDefinition.protocol }
+        }
+      });
+      expect(beforeReply.entries).to.have.length(0);
+
+      // Act: install key delivery protocol
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(alice.did.uri);
+
+      // After: verify protocol is installed with $encryption keys
+      const { reply: afterReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.ProtocolsQuery,
+        messageParams : {
+          filter: { protocol: KeyDeliveryProtocolDefinition.protocol }
+        }
+      });
+      expect(afterReply.entries).to.have.length(1);
+
+      const definition = afterReply.entries![0].descriptor.definition;
+      expect(definition.protocol).to.equal('https://enbox.org/protocols/key-delivery');
+
+      // Verify $encryption keys were injected at the contextKey path
+      const contextKeyRuleSet = definition.structure.contextKey as any;
+      expect(contextKeyRuleSet).to.have.property('$encryption');
+      expect(contextKeyRuleSet.$encryption).to.have.property('rootKeyId');
+      expect(contextKeyRuleSet.$encryption).to.have.property('publicKeyJwk');
+      expect(contextKeyRuleSet.$encryption.rootKeyId).to.include('#enc');
+    });
+
+    it('should skip installation on subsequent calls (cache hit)', async () => {
+      // First call — installs
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(alice.did.uri);
+
+      // Spy on processRequest to detect further calls
+      const processRequestSpy = sinon.spy(testHarness.agent.dwn, 'processRequest');
+
+      // Second call — should be cached, no processRequest for ProtocolsConfigure
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(alice.did.uri);
+
+      // processRequest should not have been called at all (cache returns early)
+      expect(processRequestSpy.callCount).to.equal(0);
+
+      processRequestSpy.restore();
+    });
+  });
+
+  describe('writeContextKeyRecord()', () => {
+    it('should write an encrypted contextKey record with correct tags', async () => {
+      const bob = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
+
+      // Ensure Bob's key delivery protocol is also installed (for recipient key resolution)
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(bob.did.uri);
+
+      // Create a mock DerivedPrivateJwk payload
+      const mockContextKey = {
+        rootKeyId         : `${alice.did.uri}#enc`,
+        derivationScheme  : 'protocolContext',
+        derivationPath    : ['protocolContext', 'mock-context-id-123'],
+        derivedPrivateKey : { kty: 'EC', crv: 'secp256k1', x: 'test', d: 'test' },
+      };
+
+      const recordId = await testHarness.agent.dwn.writeContextKeyRecord({
+        tenantDid       : alice.did.uri,
+        recipientDid    : bob.did.uri,
+        contextKeyData  : mockContextKey as any,
+        sourceProtocol  : 'https://protocol.xyz/multi-party-chat',
+        sourceContextId : 'mock-context-id-123',
+      });
+
+      expect(recordId).to.be.a('string');
+      expect(recordId).to.not.be.empty;
+
+      // Verify the record was written — query as Alice (the owner)
+      const { reply: queryReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : {
+          filter: {
+            protocol     : KeyDeliveryProtocolDefinition.protocol,
+            protocolPath : 'contextKey',
+          }
+        }
+      });
+
+      expect(queryReply.entries).to.have.length(1);
+
+      const entry = queryReply.entries![0] as RecordsWriteMessage;
+      expect(entry.recordId).to.equal(recordId);
+
+      // Verify the record is encrypted
+      expect(entry).to.have.property('encryption');
+      expect(entry.encryption).to.have.property('keyEncryption');
+      expect(entry.encryption!.keyEncryption).to.have.length(1);
+
+      // Verify it uses ProtocolPath derivation (encrypted to the path key)
+      expect(entry.encryption!.keyEncryption[0].derivationScheme).to.equal('protocolPath');
+
+      // Verify recipient
+      expect(entry.descriptor).to.have.property('recipient', bob.did.uri);
+    });
+  });
+
+  describe('fetchContextKeyRecord()', () => {
+    it('should round-trip write + fetch for the local path (owner queries own DWN)', async () => {
+      const bob = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
+
+      // Install key delivery protocol for both Alice and Bob
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(alice.did.uri);
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(bob.did.uri);
+
+      // Create a realistic DerivedPrivateJwk payload
+      const mockContextKey = {
+        rootKeyId         : `${alice.did.uri}#enc`,
+        derivationScheme  : 'protocolContext',
+        derivationPath    : ['protocolContext', 'test-context-id-456'],
+        derivedPrivateKey : { kty: 'EC', crv: 'secp256k1', x: 'AAAA', d: 'BBBB' },
+      };
+
+      // Write the contextKey record (encrypted)
+      await testHarness.agent.dwn.writeContextKeyRecord({
+        tenantDid       : alice.did.uri,
+        recipientDid    : alice.did.uri, // Alice is the recipient for local test
+        contextKeyData  : mockContextKey as any,
+        sourceProtocol  : 'https://protocol.xyz/chat',
+        sourceContextId : 'test-context-id-456',
+      });
+
+      // Fetch it back — local path (ownerDid === requesterDid)
+      const result = await testHarness.agent.dwn.fetchContextKeyRecord({
+        ownerDid        : alice.did.uri,
+        requesterDid    : alice.did.uri,
+        sourceProtocol  : 'https://protocol.xyz/chat',
+        sourceContextId : 'test-context-id-456',
+      });
+
+      expect(result).to.not.be.undefined;
+      expect(result!.rootKeyId).to.equal(mockContextKey.rootKeyId);
+      expect(result!.derivationScheme).to.equal(mockContextKey.derivationScheme);
+      expect(result!.derivationPath).to.deep.equal(mockContextKey.derivationPath);
+      expect(result!.derivedPrivateKey).to.deep.equal(mockContextKey.derivedPrivateKey);
+    });
+
+    it('should return undefined when no matching contextKey record exists', async () => {
+      const result = await testHarness.agent.dwn.fetchContextKeyRecord({
+        ownerDid        : alice.did.uri,
+        requesterDid    : alice.did.uri,
+        sourceProtocol  : 'https://protocol.xyz/nonexistent',
+        sourceContextId : 'nonexistent-context-id',
+      });
+
+      expect(result).to.be.undefined;
+    });
+
+    it('should find contextKey by specific tag filters (protocol + contextId)', async () => {
+      const bob = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(alice.did.uri);
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(bob.did.uri);
+
+      // Write two contextKey records for different contexts
+      const contextKey1 = {
+        rootKeyId         : `${alice.did.uri}#enc`,
+        derivationScheme  : 'protocolContext',
+        derivationPath    : ['protocolContext', 'context-aaa'],
+        derivedPrivateKey : { kty: 'EC', crv: 'secp256k1', x: 'key1x', d: 'key1d' },
+      };
+      const contextKey2 = {
+        rootKeyId         : `${alice.did.uri}#enc`,
+        derivationScheme  : 'protocolContext',
+        derivationPath    : ['protocolContext', 'context-bbb'],
+        derivedPrivateKey : { kty: 'EC', crv: 'secp256k1', x: 'key2x', d: 'key2d' },
+      };
+
+      await testHarness.agent.dwn.writeContextKeyRecord({
+        tenantDid       : alice.did.uri,
+        recipientDid    : alice.did.uri,
+        contextKeyData  : contextKey1 as any,
+        sourceProtocol  : 'https://protocol.xyz/chat',
+        sourceContextId : 'context-aaa',
+      });
+
+      await testHarness.agent.dwn.writeContextKeyRecord({
+        tenantDid       : alice.did.uri,
+        recipientDid    : alice.did.uri,
+        contextKeyData  : contextKey2 as any,
+        sourceProtocol  : 'https://protocol.xyz/chat',
+        sourceContextId : 'context-bbb',
+      });
+
+      // Fetch context-bbb specifically
+      const result = await testHarness.agent.dwn.fetchContextKeyRecord({
+        ownerDid        : alice.did.uri,
+        requesterDid    : alice.did.uri,
+        sourceProtocol  : 'https://protocol.xyz/chat',
+        sourceContextId : 'context-bbb',
+      });
+
+      expect(result).to.not.be.undefined;
+      expect(result!.derivationPath).to.deep.equal(['protocolContext', 'context-bbb']);
+      expect(result!.derivedPrivateKey).to.deep.equal(contextKey2.derivedPrivateKey);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds the key delivery system protocol infrastructure for unified context key distribution, as specified in the [Key Delivery Protocol Plan](./KEY_DELIVERY_PROTOCOL_PLAN.md) (PR A).

This separates encryption key delivery from `$role` authorization, enabling support for both role-based and relational (`who`/`of`) access patterns through a dedicated system protocol.

## Changes

### `packages/agent/src/store-data-protocols.ts`
- Added `KeyDeliveryProtocolDefinition` — system protocol at `https://enbox.org/protocols/key-delivery` with `contextKey` type, `who: recipient` read/query/subscribe rules, and required `protocol` + `contextId` tags

### `packages/agent/src/dwn-api.ts`
- `ensureKeyDeliveryProtocol(tenantDid)` — Lazy installation with 21-day TTL cache, derives and injects `$encryption` keys via `Protocols.deriveAndInjectPublicEncryptionKeys()`
- `writeContextKeyRecord({ tenantDid, recipientDid, contextKeyData, sourceProtocol, sourceContextId })` — Writes an encrypted `contextKey` record with tag filters for protocol + contextId
- `fetchContextKeyRecord({ ownerDid, requesterDid, sourceProtocol, sourceContextId })` — Queries and decrypts contextKey records, supporting both local (owner queries own DWN) and remote (participant queries owner's DWN) paths

### `packages/agent/tests/dwn-api.spec.ts`
- Tests for protocol auto-installation (first call installs, second call uses cache)
- Tests for `writeContextKeyRecord` (encrypted record with correct tags)
- Tests for `fetchContextKeyRecord` (local round-trip, missing record, tag-based filtering with multiple contexts)

## Depends On
- PR 0a (#32, merged) — `query`/`subscribe` in `who`-based action rules