### PR TITLE
chore: eliminate 21 unnecessary `as any` casts across 7 packages

### DIFF
--- a/packages/agent/src/prototyping/crypto/primitives/aes-gcm.ts
+++ b/packages/agent/src/prototyping/crypto/primitives/aes-gcm.ts
@@ -191,7 +191,7 @@ export class AesGcm {
     }
 
     // Validate the tag length.
-    if (tagLength && !AES_GCM_TAG_LENGTHS.includes(tagLength as any)) {
+    if (tagLength && !(AES_GCM_TAG_LENGTHS as readonly number[]).includes(tagLength)) {
       throw new RangeError(`The tag length is invalid: Must be ${AES_GCM_TAG_LENGTHS.join(', ')} bits`);
     }
 
@@ -263,7 +263,7 @@ export class AesGcm {
     }
 
     // Validate the tag length.
-    if (tagLength && !AES_GCM_TAG_LENGTHS.includes(tagLength as any)) {
+    if (tagLength && !(AES_GCM_TAG_LENGTHS as readonly number[]).includes(tagLength)) {
       throw new RangeError(`The tag length is invalid: Must be ${AES_GCM_TAG_LENGTHS.join(', ')} bits`);
     }
 
@@ -317,7 +317,7 @@ export class AesGcm {
     length: typeof AES_KEY_LENGTHS[number];
   }): Promise<Jwk> {
     // Validate the key length.
-    if (!AES_KEY_LENGTHS.includes(length as any)) {
+    if (!(AES_KEY_LENGTHS as readonly number[]).includes(length)) {
       throw new RangeError(`The key length is invalid: Must be ${AES_KEY_LENGTHS.join(', ')} bits`);
     }
 

--- a/packages/agent/src/prototyping/crypto/primitives/aes-kw.ts
+++ b/packages/agent/src/prototyping/crypto/primitives/aes-kw.ts
@@ -101,7 +101,7 @@ export class AesKw {
     length: typeof AES_KEY_LENGTHS[number];
   }): Promise<Jwk> {
     // Validate the key length.
-    if (!AES_KEY_LENGTHS.includes(length as any)) {
+    if (!(AES_KEY_LENGTHS as readonly number[]).includes(length)) {
       throw new RangeError(`The key length is invalid: Must be ${AES_KEY_LENGTHS.join(', ')} bits`);
     }
 

--- a/packages/browser/src/web-features.ts
+++ b/packages/browser/src/web-features.ts
@@ -119,14 +119,14 @@ async function cacheResponse(drl: any, url: any, response: any, cache: any): Pro
 /* Service Worker-based features */
 
 async function installWorker(options: any = {}): Promise<void> {
-  const workerSelf = self as any;
   try {
     // Check to see if we are in a Service Worker already, if so, proceed
     // You can call the activatePolyfills() function in your own worker, or standalone as a root worker
     if (
       typeof ServiceWorkerGlobalScope !== 'undefined' &&
-      workerSelf instanceof ServiceWorkerGlobalScope
+      self instanceof ServiceWorkerGlobalScope
     ) {
+      const workerSelf = self as ServiceWorkerGlobalScope;
       workerSelf.skipWaiting();
       workerSelf.addEventListener('activate', (event) => {
         // Claim clients to make the service worker take control immediately

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -65,6 +65,10 @@ export const logger = new Web5Logger();
 
 // Attach logger to the global window object in browser environment for easy access to the logger instance.
 // e.g. can call `web5logger.setLogLevel('debug');` directly in browser console.
+declare global {
+  interface Window { web5logger?: Web5Logger }
+}
+
 if (typeof window !== 'undefined') {
-  (window as any).web5logger = logger; // Makes `web5Logger` accessible globally in browser
+  window.web5logger = logger;
 }

--- a/packages/crypto/src/primitives/aes-ctr.ts
+++ b/packages/crypto/src/primitives/aes-ctr.ts
@@ -296,7 +296,7 @@ export class AesCtr {
     length: typeof AES_KEY_LENGTHS[number];
   }): Promise<Jwk> {
     // Validate the key length.
-    if (!AES_KEY_LENGTHS.includes(length as any)) {
+    if (!(AES_KEY_LENGTHS as readonly number[]).includes(length)) {
       throw new RangeError(`The key length is invalid: Must be ${AES_KEY_LENGTHS.join(', ')} bits`);
     }
 

--- a/packages/crypto/src/primitives/aes-gcm.ts
+++ b/packages/crypto/src/primitives/aes-gcm.ts
@@ -187,7 +187,7 @@ export class AesGcm {
     }
 
     // Validate the tag length.
-    if (tagLength && !AES_GCM_TAG_LENGTHS.includes(tagLength as any)) {
+    if (tagLength && !(AES_GCM_TAG_LENGTHS as readonly number[]).includes(tagLength)) {
       throw new RangeError(`The tag length is invalid: Must be ${AES_GCM_TAG_LENGTHS.join(', ')} bits`);
     }
 
@@ -263,7 +263,7 @@ export class AesGcm {
     }
 
     // Validate the tag length.
-    if (tagLength && !AES_GCM_TAG_LENGTHS.includes(tagLength as any)) {
+    if (tagLength && !(AES_GCM_TAG_LENGTHS as readonly number[]).includes(tagLength)) {
       throw new RangeError(`The tag length is invalid: Must be ${AES_GCM_TAG_LENGTHS.join(', ')} bits`);
     }
 
@@ -321,7 +321,7 @@ export class AesGcm {
     length: typeof AES_KEY_LENGTHS[number];
   }): Promise<Jwk> {
     // Validate the key length.
-    if (!AES_KEY_LENGTHS.includes(length as any)) {
+    if (!(AES_KEY_LENGTHS as readonly number[]).includes(length)) {
       throw new RangeError(`The key length is invalid: Must be ${AES_KEY_LENGTHS.join(', ')} bits`);
     }
 

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -552,7 +552,7 @@ export class DidDht extends DidMethod {
     if (!verificationMethodsToAdd?.some(vm => vm.id?.split('#').pop() === '0')) {
       // Add the Identity Key to the beginning of the key set.
       verificationMethodsToAdd.unshift({
-        algorithm : 'Ed25519' as any,
+        algorithm : 'Ed25519' as DidCreateVerificationMethod<TKms>['algorithm'],
         id        : '0',
         purposes  : ['authentication', 'assertionMethod', 'capabilityDelegation', 'capabilityInvocation']
       });
@@ -1298,8 +1298,8 @@ export class DidDhtDocument {
     // Add verification relationships to the root record.
     Object.keys(DidVerificationRelationship).forEach(relationship => {
       // Collect the verification method IDs for the given relationship.
-      const dnsRecordIds = (didDocument[relationship as keyof DidDocument] as any[])
-        ?.map(id => idLookup.get(id.split('#').pop()));
+      const dnsRecordIds = (didDocument[relationship as keyof DidDocument] as string[] | undefined)
+        ?.map((id: string): string | undefined => idLookup.get(id.split('#').pop()!));
 
       // If the relationship includes verification methods, add them to the root record.
       if (dnsRecordIds) {

--- a/packages/dids/src/methods/did-ion.ts
+++ b/packages/dids/src/methods/did-ion.ts
@@ -393,7 +393,7 @@ export class DidIon extends DidMethod {
 
     // If no verification methods were specified, generate a default Ed25519 verification method.
     const defaultVerificationMethod: DidCreateVerificationMethod<TKms> = {
-      algorithm : 'Ed25519' as any,
+      algorithm : 'Ed25519' as DidCreateVerificationMethod<TKms>['algorithm'],
       purposes  : ['authentication', 'assertionMethod', 'capabilityDelegation', 'capabilityInvocation']
     };
 

--- a/packages/dwn-sdk-js/src/core/message.ts
+++ b/packages/dwn-sdk-js/src/core/message.ts
@@ -70,12 +70,12 @@ export class Message {
     // but we can remove this method entirely if the code becomes stable and it is apparent that the wrapper is not needed
 
     // ^--- seems like we might need to keep this around for now.
-    const rawMessage = { ...message } as any;
+    const rawMessage = { ...message };
     if (rawMessage.encodedData) {
       delete rawMessage.encodedData;
     }
 
-    const cid = await Cid.computeCid(rawMessage as GenericMessage);
+    const cid = await Cid.computeCid(rawMessage);
     return cid;
   }
 

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -742,8 +742,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       throw new DwnError(DwnErrorCode.RecordsWriteGetEntryIdUndefinedAuthor, 'Property `author` is needed to compute entry ID.');
     }
 
-    const entryIdInput = { ...descriptor };
-    (entryIdInput as any).author = author;
+    const entryIdInput: Record<string, unknown> = { ...descriptor, author };
 
     const cid = await Cid.computeCid(entryIdInput);
     return cid;
@@ -988,8 +987,8 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     for (const descriptorPropertyName of descriptorPropertyNames) {
       // if property is supposed to be immutable
       if (mutableDescriptorProperties.indexOf(descriptorPropertyName) === -1) {
-        const valueInExistingWrite = (existingWriteMessage.descriptor as any)[descriptorPropertyName];
-        const valueInNewMessage = (newMessage.descriptor as any)[descriptorPropertyName];
+        const valueInExistingWrite = (existingWriteMessage.descriptor as Record<string, unknown>)[descriptorPropertyName];
+        const valueInNewMessage = (newMessage.descriptor as Record<string, unknown>)[descriptorPropertyName];
         if (valueInNewMessage !== valueInExistingWrite) {
           throw new DwnError(
             DwnErrorCode.RecordsWriteImmutablePropertyChanged,

--- a/packages/dwn-sdk-js/src/schema-validator.ts
+++ b/packages/dwn-sdk-js/src/schema-validator.ts
@@ -1,15 +1,23 @@
 import * as precompiledValidators from '../generated/precompiled-validators.js';
 import { DwnError, DwnErrorCode } from './core/dwn-error.js';
 
+/** AJV-style validate function with an optional `errors` array after invocation. */
+interface ValidateError {
+  instancePath: string;
+  message: string;
+  keyword: string;
+  params: Record<string, unknown>;
+}
+type ValidateFn = ((payload: unknown) => boolean) & { errors?: ValidateError[] };
+
 /**
  * Validates the given payload using JSON schema keyed by the given schema name. Throws if the given payload fails validation.
  * @param schemaName the schema name use to look up the JSON schema to be used for schema validation.
  *                   The list of schema names can be found in compile-validators.js
  * @param payload javascript object to be validated
  */
-export function validateJsonSchema(schemaName: string, payload: any): void {
-  // const validateFn = validator.getSchema(schemaName);
-  const validateFn = (precompiledValidators as any)[schemaName];
+export function validateJsonSchema(schemaName: string, payload: unknown): void {
+  const validateFn = (precompiledValidators as Record<string, ValidateFn>)[schemaName];
 
   if (!validateFn) {
     throw new DwnError(DwnErrorCode.SchemaValidatorSchemaNotFound, `schema for ${schemaName} not found.`);

--- a/packages/dwn-sdk-js/src/types/message-types.ts
+++ b/packages/dwn-sdk-js/src/types/message-types.ts
@@ -8,6 +8,13 @@ import type { PaginationCursor, SortDirection } from './query-types.js';
 export type GenericMessage = {
   descriptor: Descriptor;
   authorization?: AuthorizationModel;
+
+  /**
+   * Base64url-encoded data that the message store may attach to small RecordsWrite messages.
+   * This is a runtime-only property — it is stripped before CID computation and not part of the
+   * canonical message schema, but it flows through the store layer for performance optimisation.
+   */
+  encodedData?: string;
 };
 
 /**

--- a/packages/dwn-sql-store/src/message-store-sql.ts
+++ b/packages/dwn-sql-store/src/message-store-sql.ts
@@ -171,9 +171,9 @@ export class MessageStoreSql implements MessageStore {
     const getEncodedData = (message: GenericMessage): { message: GenericMessage, encodedData: string|null} => {
       let encodedData: string|null = null;
       if (message.descriptor.interface === DwnInterfaceName.Records && message.descriptor.method === DwnMethodName.Write) {
-        const data = (message as any).encodedData as string|undefined;
+        const data = message.encodedData;
         if (data) {
-          delete (message as any).encodedData;
+          delete message.encodedData;
           encodedData = data;
         }
       }
@@ -386,7 +386,7 @@ export class MessageStoreSql implements MessageStore {
     // We store encodedData when the data is below a certain threshold.
     // https://github.com/enboxorg/enbox/pull/456
     if (message !== undefined && encodedData !== undefined && encodedData !== null) {
-      (message as any).encodedData = encodedData;
+      message.encodedData = encodedData;
     }
     return message;
   }


### PR DESCRIPTION
## Summary

- Eliminate **21 `as any` casts** from source files across 7 packages, replacing each with a precise type
- No test file changes — only production source code
- No behavioral changes

## Changes by category

### `Array.includes()` on const tuples (8 casts)
Widen `AES_KEY_LENGTHS` and `AES_GCM_TAG_LENGTHS` to `readonly number[]` before calling `.includes()`. TypeScript's `Array<128|192|256>.includes()` only accepts the narrow literal union, rejecting the broader `number` type even though it's semantically correct.

**Files:** `crypto/aes-gcm.ts` (3), `crypto/aes-ctr.ts` (1), `agent/aes-gcm.ts` (3), `agent/aes-kw.ts` (1)

### `encodedData` runtime property (4 casts)
Add optional `encodedData?: string` to the `GenericMessage` type in dwn-sdk-js, reflecting the well-known runtime property that the message/SQL store layers attach to small `RecordsWrite` messages. This removes `as any` casts in `message-store-sql.ts` (3) and `core/message.ts` (1).

### `'Ed25519'` algorithm literal (2 casts)
Cast to `DidCreateVerificationMethod<TKms>['algorithm']` instead of `any` in `did-dht.ts` and `did-ion.ts`, preserving the generic constraint while satisfying the conditional type.

### Global type augmentation (2 casts)
- `common/logger.ts`: Add `declare global { interface Window { web5logger?: Web5Logger } }` instead of `window as any`
- `browser/web-features.ts`: Cast `self` to `ServiceWorkerGlobalScope` inside the `instanceof` guard instead of `self as any` at the top

### Schema validator (1 cast)
Type `precompiledValidators` as `Record<string, ValidateFn>` with a proper `ValidateFn` interface matching AJV's validate signature. Also narrow the `payload` parameter from `any` to `unknown`.

### Dynamic property access (2 casts)
- `records-write.ts` `getEntryId`: Use `Record<string, unknown>` spread to add `author` to descriptor
- `records-write.ts` `verifyEqualityOfImmutableProperties`: Cast descriptors to `Record<string, unknown>` for dynamic key indexing

### DID document relationship array (1 cast)
Cast to `string[] | undefined` instead of `any[]` in `did-dht.ts` since verification relationship values are string arrays.

## What's left

The remaining ~19 source `as any` casts are all genuinely untyped at the boundary:
- DWN message constructor mapped-type table (10) — unified generic lookup
- LevelDB wrapper internal APIs (5) — untyped upstream `level` library
- Bun SQLite adapter parameter spreading (2) — `ReadonlyArray<unknown>` bridge
- Dynamic query-string building (2) — truly dynamic object construction