### PR TITLE
feat(dwn-sdk): add append mode to encryptSymmetricEncryptionKey (PR 0b)

### DIFF
--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -142,6 +142,7 @@ export enum DwnErrorCode {
   RecordsWriteMissingSigner = 'RecordsWriteMissingSigner',
   RecordsWriteMissingDataInPrevious = 'RecordsWriteMissingDataInPrevious',
   RecordsWriteMissingEncodedDataInPrevious = 'RecordsWriteMissingEncodedDataInPrevious',
+  RecordsWriteMissingEncryption = 'RecordsWriteMissingEncryption',
   RecordsWriteMissingProtocol = 'RecordsWriteMissingProtocol',
   RecordsWriteMissingSchema = 'RecordsWriteMissingSchema',
   RecordsWriteNotAllowedAfterDelete = 'RecordsWriteNotAllowedAfterDelete',

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -477,9 +477,33 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
 
   /**
    * Encrypts the symmetric encryption key using the public keys given and attach the resulting `encryption` property to the RecordsWrite.
+   *
+   * @param options.append - When `true`, appends new `keyEncryption` entries to the existing
+   *   `encryption` property instead of replacing it. Requires `this._message.encryption` to
+   *   already exist (i.e., the record must already be encrypted). This is used for the reactive
+   *   root-record upgrade: adding a ProtocolContext `keyEncryption` entry alongside an existing
+   *   ProtocolPath entry so both the owner and context key holders can decrypt.
    */
-  public async encryptSymmetricEncryptionKey(encryptionInput: EncryptionInput): Promise<void> {
-    this._message.encryption = await RecordsWrite.createEncryptionProperty(this._message.descriptor, encryptionInput);
+  public async encryptSymmetricEncryptionKey(
+    encryptionInput: EncryptionInput,
+    options?: { append?: boolean },
+  ): Promise<void> {
+    if (options?.append) {
+      if (!this._message.encryption) {
+        throw new DwnError(
+          DwnErrorCode.RecordsWriteMissingEncryption,
+          'Cannot append keyEncryption entries: record does not have an existing `encryption` property.'
+        );
+      }
+
+      // Build only the new keyEncryption entries (reuses createEncryptionProperty for ECIES logic)
+      const newEncryption = await RecordsWrite.createEncryptionProperty(this._message.descriptor, encryptionInput);
+      if (newEncryption) {
+        this._message.encryption.keyEncryption.push(...newEncryption.keyEncryption);
+      }
+    } else {
+      this._message.encryption = await RecordsWrite.createEncryptionProperty(this._message.descriptor, encryptionInput);
+    }
 
     // opportunity here to re-sign instead of remove
     delete this._message.authorization;

--- a/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
@@ -492,4 +492,139 @@ describe('RecordsWrite', () => {
       expect(() => recordsWrite.message).to.throw(DwnErrorCode.RecordsWriteMissingSigner);
     });
   });
+
+  describe('encryptSymmetricEncryptionKey()', () => {
+    it('should replace encryption property by default', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+      const dataEncryptionIV = TestDataGenerator.randomBytes(16);
+
+      const recordsWrite = await RecordsWrite.create({
+        signer       : Jws.createSigner(alice),
+        protocol     : 'https://example.com/protocol',
+        protocolPath : 'test',
+        schema       : 'https://example.com/schema',
+        dataFormat   : 'application/octet-stream',
+        data         : TestDataGenerator.randomBytes(100),
+      });
+
+      // First encryption — ProtocolPath
+      const encryptionInput1: EncryptionInput = {
+        initializationVector : dataEncryptionIV,
+        key                  : dataEncryptionKey,
+        keyEncryptionInputs  : [{
+          publicKeyId      : alice.keyId,
+          publicKey        : alice.keyPair.publicJwk,
+          derivationScheme : KeyDerivationScheme.ProtocolPath,
+        }],
+      };
+      await recordsWrite.encryptSymmetricEncryptionKey(encryptionInput1);
+
+      expect(recordsWrite['_message'].encryption).to.exist;
+      expect(recordsWrite['_message'].encryption!.keyEncryption).to.have.length(1);
+      expect(recordsWrite['_message'].encryption!.keyEncryption[0].derivationScheme).to.equal('protocolPath');
+
+      // Second encryption (replace mode) — should overwrite
+      const encryptionInput2: EncryptionInput = {
+        initializationVector : dataEncryptionIV,
+        key                  : dataEncryptionKey,
+        keyEncryptionInputs  : [{
+          publicKeyId      : alice.keyId,
+          publicKey        : alice.keyPair.publicJwk,
+          derivationScheme : KeyDerivationScheme.Schemas,
+        }],
+      };
+      await recordsWrite.encryptSymmetricEncryptionKey(encryptionInput2);
+
+      // Should have replaced — only 1 entry with Schemas scheme
+      expect(recordsWrite['_message'].encryption!.keyEncryption).to.have.length(1);
+      expect(recordsWrite['_message'].encryption!.keyEncryption[0].derivationScheme).to.equal('schemas');
+    });
+
+    it('should append keyEncryption entries when append option is true', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+      const dataEncryptionIV = TestDataGenerator.randomBytes(16);
+
+      const recordsWrite = await RecordsWrite.create({
+        signer       : Jws.createSigner(alice),
+        protocol     : 'https://example.com/protocol',
+        protocolPath : 'test',
+        schema       : 'https://example.com/schema',
+        dataFormat   : 'application/octet-stream',
+        data         : TestDataGenerator.randomBytes(100),
+      });
+
+      // First encryption — ProtocolPath
+      const encryptionInput1: EncryptionInput = {
+        initializationVector : dataEncryptionIV,
+        key                  : dataEncryptionKey,
+        keyEncryptionInputs  : [{
+          publicKeyId      : alice.keyId,
+          publicKey        : alice.keyPair.publicJwk,
+          derivationScheme : KeyDerivationScheme.ProtocolPath,
+        }],
+      };
+      await recordsWrite.encryptSymmetricEncryptionKey(encryptionInput1);
+
+      const originalIV = recordsWrite['_message'].encryption!.initializationVector;
+      const originalAlgorithm = recordsWrite['_message'].encryption!.algorithm;
+
+      // Second encryption with append — ProtocolContext
+      const encryptionInput2: EncryptionInput = {
+        initializationVector : dataEncryptionIV,
+        key                  : dataEncryptionKey,
+        keyEncryptionInputs  : [{
+          publicKeyId      : alice.keyId,
+          publicKey        : alice.keyPair.publicJwk,
+          derivationScheme : KeyDerivationScheme.ProtocolContext,
+        }],
+      };
+      await recordsWrite.encryptSymmetricEncryptionKey(encryptionInput2, { append: true });
+
+      // Should have both entries
+      const encryption = recordsWrite['_message'].encryption!;
+      expect(encryption.keyEncryption).to.have.length(2);
+      expect(encryption.keyEncryption[0].derivationScheme).to.equal('protocolPath');
+      expect(encryption.keyEncryption[1].derivationScheme).to.equal('protocolContext');
+
+      // Original IV and algorithm should be preserved
+      expect(encryption.initializationVector).to.equal(originalIV);
+      expect(encryption.algorithm).to.equal(originalAlgorithm);
+
+      // ProtocolContext entry should have derivedPublicKey
+      expect(encryption.keyEncryption[1].derivedPublicKey).to.exist;
+
+      // Authorization should be stripped (needs re-signing)
+      expect(recordsWrite['_message'].authorization).to.not.exist;
+    });
+
+    it('should throw when append is true but encryption does not exist', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+      const dataEncryptionIV = TestDataGenerator.randomBytes(16);
+
+      const recordsWrite = await RecordsWrite.create({
+        signer       : Jws.createSigner(alice),
+        protocol     : 'https://example.com/protocol',
+        protocolPath : 'test',
+        dataFormat   : 'application/octet-stream',
+        data         : TestDataGenerator.randomBytes(100),
+      });
+
+      const encryptionInput: EncryptionInput = {
+        initializationVector : dataEncryptionIV,
+        key                  : dataEncryptionKey,
+        keyEncryptionInputs  : [{
+          publicKeyId      : alice.keyId,
+          publicKey        : alice.keyPair.publicJwk,
+          derivationScheme : KeyDerivationScheme.ProtocolPath,
+        }],
+      };
+
+      await expect(
+        recordsWrite.encryptSymmetricEncryptionKey(encryptionInput, { append: true })
+      ).to.be.rejectedWith(DwnErrorCode.RecordsWriteMissingEncryption);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add optional `{ append: true }` parameter to `RecordsWrite.encryptSymmetricEncryptionKey()` that appends new `keyEncryption` entries to the existing `encryption` property instead of replacing it
- Add `DwnErrorCode.RecordsWriteMissingEncryption` error code for when append is attempted on an unencrypted record
- Add 3 unit tests covering replace mode, append mode, and the error case

## Context

This is **PR 0b** in the [Key Delivery Protocol Plan](./KEY_DELIVERY_PROTOCOL_PLAN.md) — a DWN SDK prerequisite for PR E (Cross-DWN Encryption).

### Why this is needed

The current `encryptSymmetricEncryptionKey()` **replaces** the entire `encryption` property every time it's called. PR E's reactive root-record upgrade needs to **append** a ProtocolContext `keyEncryption` entry alongside an existing ProtocolPath entry on the same record, so that both the owner (ProtocolPath) and context key holders (ProtocolContext) can decrypt.

### How it works

```ts
// First pass: encrypt with ProtocolPath (external author's initial write)
await recordsWrite.encryptSymmetricEncryptionKey(protocolPathInput);

// Second pass: owner appends ProtocolContext entry (reactive upgrade)
await recordsWrite.encryptSymmetricEncryptionKey(protocolContextInput, { append: true });

// Result: encryption.keyEncryption has 2 entries — both schemes can decrypt
```

When `append: true`:
- Existing `encryption.algorithm` and `encryption.initializationVector` are preserved
- New `keyEncryption` entries are ECIES-encrypted and appended to the array
- Authorization is stripped (caller must re-sign, same as replace mode)
- Throws `RecordsWriteMissingEncryption` if the record isn't already encrypted

## Remaining PRs
- **PR E**: Cross-DWN Encryption (External Author Support) — uses this append mode