### PR TITLE
fix(agent): cross-DWN participant decryption + E2E encryption test coverage

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -1495,6 +1495,7 @@ export class AgentDwnApi {
   private async resolveKeyDecrypter(
     authorDid: string,
     recordsWrite: RecordsWriteMessage,
+    targetDid?: string,
   ): Promise<KeyDecrypter> {
     const { encryption } = recordsWrite;
 
@@ -1553,9 +1554,12 @@ export class AgentDwnApi {
       sourceContextId : rootContextId,
     });
 
-    // Try remote: query the context owner's DWN for my contextKey record
+    // Try remote: query the DWN owner's DWN for my contextKey record.
+    // For cross-DWN records, targetDid is the DWN owner (e.g., Alice) where the
+    // contextKey was written. For same-DWN records, fall back to the record's
+    // authorization signer.
     if (!contextDerivedPrivateKey) {
-      const contextOwnerDid = Jws.getSignerDid(
+      const contextOwnerDid = targetDid ?? Jws.getSignerDid(
         recordsWrite.authorization.signature.signatures[0]
       );
       contextDerivedPrivateKey = await this.fetchContextKeyRecord({
@@ -1624,7 +1628,7 @@ export class AgentDwnApi {
           && readReply.entry?.recordsWrite?.encryption
           && readReply.entry?.data) {
         const keyDecrypter = await this.resolveKeyDecrypter(
-          request.author, readReply.entry.recordsWrite,
+          request.author, readReply.entry.recordsWrite, request.target,
         );
 
         try {
@@ -1650,7 +1654,7 @@ export class AgentDwnApi {
         for (const entry of queryReply.entries) {
           if (entry.encryption && entry.encodedData) {
             const keyDecrypter = await this.resolveKeyDecrypter(
-              request.author, entry as RecordsWriteMessage,
+              request.author, entry as RecordsWriteMessage, request.target,
             );
 
             try {

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -4258,7 +4258,7 @@ describe('Cross-DWN Encryption — External Author Support (PR E)', () => {
     },
   };
 
-  // Chat protocol with $role records
+  // Chat protocol with $role records — participants can read/write chats
   const chatProtocol: ProtocolDefinition = {
     published : true,
     protocol  : 'https://protocol.xyz/chat-pre',
@@ -4270,7 +4270,11 @@ describe('Cross-DWN Encryption — External Author Support (PR E)', () => {
     structure: {
       thread: {
         participant : { $role: true },
-        chat        : {},
+        chat        : {
+          $actions: [
+            { role: 'thread/participant', can: ['create', 'read', 'query', 'subscribe'] },
+          ],
+        },
       },
     },
   };
@@ -4572,4 +4576,377 @@ describe('Cross-DWN Encryption — External Author Support (PR E)', () => {
     });
     expect(ckQueryCarol.entries).to.have.length.greaterThanOrEqual(1);
   }).timeout(15000);
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // E2E Gap Tests: verify that participants can actually DECRYPT records,
+  // not just that keys are delivered with the right shape.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('E2E: participant (Bob) should decrypt a record via contextKey in multi-party $role protocol', async () => {
+    // Configure chat protocol for Alice with encryption
+    await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.ProtocolsConfigure,
+      messageParams : { definition: chatProtocol },
+      encryption    : true,
+    });
+
+    // Alice creates a root thread
+    const threadText = '{"title":"Secret Thread for Bob"}';
+    const { message: threadMessage } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : chatProtocol.protocol,
+        protocolPath : 'thread',
+        dataFormat   : 'application/json',
+        schema       : 'https://schemas.xyz/thread',
+      },
+      dataStream : new Blob([new TextEncoder().encode(threadText)]),
+      encryption : true,
+    });
+    const threadContextId = (threadMessage as RecordsWriteMessage).contextId!;
+    const rootContextId = threadContextId.split('/')[0];
+
+    // Alice writes a chat message in the thread
+    const chatText = 'Top secret chat message';
+    const { message: chatMessage } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol        : chatProtocol.protocol,
+        protocolPath    : 'thread/chat',
+        parentContextId : threadContextId,
+        dataFormat      : 'text/plain',
+        schema          : 'https://schemas.xyz/chat',
+      },
+      dataStream : new Blob([new TextEncoder().encode(chatText)]),
+      encryption : true,
+    });
+    const chatRecordId = (chatMessage as RecordsWriteMessage).recordId;
+
+    // Alice adds Bob as participant — triggers contextKey delivery to Bob
+    await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol        : chatProtocol.protocol,
+        protocolPath    : 'thread/participant',
+        parentContextId : threadContextId,
+        dataFormat      : 'application/json',
+        schema          : 'https://schemas.xyz/participant',
+        recipient       : bob.did.uri,
+      },
+      dataStream : new Blob([new TextEncoder().encode('{"name":"Bob"}')]),
+      encryption : true,
+    });
+
+    // Read the contextKey that was written for Bob on Alice's DWN
+    const { reply: ckQuery } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: {
+          protocol     : KeyDeliveryProtocolDefinition.protocol,
+          protocolPath : 'contextKey',
+          recipient    : bob.did.uri,
+        }
+      }
+    });
+    expect(ckQuery.entries).to.have.length(1);
+
+    // Decrypt the contextKey record to get the DerivedPrivateJwk
+    const ckRecordId = ckQuery.entries![0].recordId;
+    const { reply: ckRead } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId: ckRecordId } },
+      encryption    : true,
+    });
+    const ckDataBytes = await DataStream.toBytes((ckRead as any).entry.data);
+    const contextKeyPayload = JSON.parse(new TextDecoder().decode(ckDataBytes));
+
+    // Simulate sync: copy the contextKey to Bob's local DWN
+    await testHarness.agent.dwn.ensureKeyDeliveryProtocol(bob.did.uri);
+    await testHarness.agent.dwn.writeContextKeyRecord({
+      tenantDid       : bob.did.uri,
+      recipientDid    : bob.did.uri,
+      contextKeyData  : contextKeyPayload,
+      sourceProtocol  : chatProtocol.protocol,
+      sourceContextId : rootContextId,
+    });
+
+    // Bob reads Alice's chat message with encryption — should auto-decrypt.
+    // Bob must invoke his participant role to be authorized for the read.
+    const { reply: bobReadReply } = await testHarness.agent.dwn.processRequest({
+      author        : bob.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : {
+        filter       : { recordId: chatRecordId },
+        protocolRole : 'thread/participant',
+      },
+      encryption: true,
+    });
+
+    const bobReadResult = bobReadReply as any;
+    expect(bobReadResult.status.code).to.equal(200);
+    const decryptedBytes = await DataStream.toBytes(bobReadResult.entry.data);
+    const decryptedText = new TextDecoder().decode(decryptedBytes);
+    expect(decryptedText).to.equal(chatText);
+  }).timeout(30000);
+
+  it('E2E: cross-DWN full round-trip — Bob writes, Alice upgrades, Bob decrypts via contextKey', async () => {
+    // Configure email protocol for Alice with encryption
+    await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.ProtocolsConfigure,
+      messageParams : { definition: emailProtocol },
+      encryption    : true,
+    });
+
+    // Bob writes a root thread to Alice's DWN (cross-DWN)
+    const threadText = 'Cross-DWN secret from Bob';
+    const { message: threadMessage } = await testHarness.agent.dwn.processRequest({
+      author        : bob.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : emailProtocol.protocol,
+        protocolPath : 'thread',
+        dataFormat   : 'text/plain',
+        schema       : 'http://email-protocol.xyz/schema/thread',
+        recipient    : alice.did.uri,
+      },
+      dataStream : new Blob([new TextEncoder().encode(threadText)]),
+      encryption : true,
+    });
+    const threadRecordId = (threadMessage as RecordsWriteMessage).recordId;
+    const threadContextId = (threadMessage as RecordsWriteMessage).contextId!;
+    const rootContextId = threadContextId.split('/')[0];
+
+    // Verify reactive upgrade occurred (ProtocolContext entry was appended)
+    const { reply: aliceRead } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId: threadRecordId } },
+    });
+    const aliceReadResult = aliceRead as any;
+    expect(aliceReadResult.status.code).to.equal(200);
+    const keyEncryption = aliceReadResult.entry.recordsWrite.encryption.keyEncryption;
+    expect(keyEncryption.some(
+      (k: { derivationScheme: string }) => k.derivationScheme === 'protocolContext'
+    )).to.be.true;
+
+    // Verify contextKey was delivered for Bob
+    const { reply: ckQuery } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: {
+          protocol     : KeyDeliveryProtocolDefinition.protocol,
+          protocolPath : 'contextKey',
+          recipient    : bob.did.uri,
+        }
+      }
+    });
+    expect(ckQuery.entries).to.have.length.greaterThanOrEqual(1);
+
+    // Read the contextKey and copy to Bob's local DWN (simulating sync)
+    const ckRecordId = ckQuery.entries![0].recordId;
+    const { reply: ckRead } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId: ckRecordId } },
+      encryption    : true,
+    });
+    const ckDataBytes = await DataStream.toBytes((ckRead as any).entry.data);
+    const contextKeyPayload = JSON.parse(new TextDecoder().decode(ckDataBytes));
+
+    await testHarness.agent.dwn.ensureKeyDeliveryProtocol(bob.did.uri);
+    await testHarness.agent.dwn.writeContextKeyRecord({
+      tenantDid       : bob.did.uri,
+      recipientDid    : bob.did.uri,
+      contextKeyData  : contextKeyPayload,
+      sourceProtocol  : emailProtocol.protocol,
+      sourceContextId : rootContextId,
+    });
+
+    // Bob reads the thread from Alice's DWN with encryption — should auto-decrypt
+    const { reply: bobRead } = await testHarness.agent.dwn.processRequest({
+      author        : bob.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId: threadRecordId } },
+      encryption    : true,
+    });
+    const bobReadResult = bobRead as any;
+    expect(bobReadResult.status.code).to.equal(200);
+    const decryptedBytes = await DataStream.toBytes(bobReadResult.entry.data);
+    const decryptedText = new TextDecoder().decode(decryptedBytes);
+    expect(decryptedText).to.equal(threadText);
+  }).timeout(30000);
+
+  it('E2E: cross-DWN non-root child record via extractDerivedPublicKey', async () => {
+    // Configure email protocol for Alice with encryption
+    await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.ProtocolsConfigure,
+      messageParams : { definition: emailProtocol },
+      encryption    : true,
+    });
+
+    // Bob writes a root thread to Alice's DWN (triggers reactive upgrade)
+    const threadText = 'Thread for child record test';
+    const { message: threadMessage } = await testHarness.agent.dwn.processRequest({
+      author        : bob.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : emailProtocol.protocol,
+        protocolPath : 'thread',
+        dataFormat   : 'text/plain',
+        schema       : 'http://email-protocol.xyz/schema/thread',
+        recipient    : alice.did.uri,
+      },
+      dataStream : new Blob([new TextEncoder().encode(threadText)]),
+      encryption : true,
+    });
+    const threadContextId = (threadMessage as RecordsWriteMessage).contextId!;
+
+    // Alice writes a reply (child email) in the same context, establishing
+    // a record with derivedPublicKey in the context
+    const aliceReplyText = 'Alice reply in thread';
+    await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol        : emailProtocol.protocol,
+        protocolPath    : 'thread/email',
+        parentContextId : threadContextId,
+        dataFormat      : 'text/plain',
+        schema          : 'http://email-protocol.xyz/schema/email',
+        recipient       : bob.did.uri,
+      },
+      dataStream : new Blob([new TextEncoder().encode(aliceReplyText)]),
+      encryption : true,
+    });
+
+    // Bob writes a child email to Alice's DWN (non-root cross-DWN write).
+    // This should use extractDerivedPublicKey to find the context key.
+    const bobReplyText = 'Bob reply in Alice thread';
+    const { message: bobReplyMessage } = await testHarness.agent.dwn.processRequest({
+      author        : bob.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol        : emailProtocol.protocol,
+        protocolPath    : 'thread/email',
+        parentContextId : threadContextId,
+        dataFormat      : 'text/plain',
+        schema          : 'http://email-protocol.xyz/schema/email',
+        recipient       : alice.did.uri,
+      },
+      dataStream : new Blob([new TextEncoder().encode(bobReplyText)]),
+      encryption : true,
+    });
+    const bobReplyRecordId = (bobReplyMessage as RecordsWriteMessage).recordId;
+
+    // Verify the child record uses ProtocolContext encryption
+    const { reply: childRead } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId: bobReplyRecordId } },
+    });
+    const childReadResult = childRead as any;
+    expect(childReadResult.status.code).to.equal(200);
+    const childKeyEncryption = childReadResult.entry.recordsWrite.encryption.keyEncryption;
+    expect(childKeyEncryption.some(
+      (k: { derivationScheme: string }) => k.derivationScheme === 'protocolContext'
+    )).to.be.true;
+
+    // Alice should be able to decrypt the child record
+    const { reply: aliceDecrypt } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId: bobReplyRecordId } },
+      encryption    : true,
+    });
+    const aliceDecryptResult = aliceDecrypt as any;
+    expect(aliceDecryptResult.status.code).to.equal(200);
+    const aliceDecryptedBytes = await DataStream.toBytes(aliceDecryptResult.entry.data);
+    expect(new TextDecoder().decode(aliceDecryptedBytes)).to.equal(bobReplyText);
+  }).timeout(30000);
+
+  it('E2E: large payload (>30KB) through reactive upgrade path', async () => {
+    // Configure email protocol for Alice with encryption
+    await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.ProtocolsConfigure,
+      messageParams : { definition: emailProtocol },
+      encryption    : true,
+    });
+
+    // Generate a payload larger than the encodedData threshold (30KB)
+    const largePayload = 'X'.repeat(40_000);
+
+    // Bob writes a root thread with large payload to Alice's DWN (cross-DWN)
+    const { message: threadMessage } = await testHarness.agent.dwn.processRequest({
+      author        : bob.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : emailProtocol.protocol,
+        protocolPath : 'thread',
+        dataFormat   : 'text/plain',
+        schema       : 'http://email-protocol.xyz/schema/thread',
+        recipient    : alice.did.uri,
+      },
+      dataStream : new Blob([new TextEncoder().encode(largePayload)]),
+      encryption : true,
+    });
+    const threadRecordId = (threadMessage as RecordsWriteMessage).recordId;
+
+    // Verify reactive upgrade occurred
+    const { reply: rawRead } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId: threadRecordId } },
+    });
+    const rawReadResult = rawRead as any;
+    expect(rawReadResult.status.code).to.equal(200);
+    expect(rawReadResult.entry.recordsWrite.encryption.keyEncryption.some(
+      (k: { derivationScheme: string }) => k.derivationScheme === 'protocolContext'
+    )).to.be.true;
+
+    // Alice should be able to decrypt the large record
+    const { reply: decryptRead } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId: threadRecordId } },
+      encryption    : true,
+    });
+    const decryptResult = decryptRead as any;
+    expect(decryptResult.status.code).to.equal(200);
+    const decryptedBytes = await DataStream.toBytes(decryptResult.entry.data);
+    const decryptedText = new TextDecoder().decode(decryptedBytes);
+    expect(decryptedText).to.equal(largePayload);
+  }).timeout(30000);
 });

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -3335,6 +3335,68 @@ describe('Record', () => {
       expect(readText).to.equal('Still not encrypted');
       expect(readRecord!.encryption).to.be.undefined;
     });
+
+    it('E2E: should encrypt on write and decrypt on read via API layer', async () => {
+      // Define a simple protocol for encrypted notes
+      const encProtocol: DwnProtocolDefinition = {
+        published : true,
+        protocol  : `http://encrypted-notes.xyz/${TestDataGenerator.randomString(15)}`,
+        types     : {
+          note: {
+            schema      : 'https://schemas.xyz/note',
+            dataFormats : ['text/plain']
+          }
+        },
+        structure: {
+          note: {}
+        }
+      };
+
+      // Configure with encryption
+      const { status: configStatus } = await dwnAlice.protocols.configure({
+        message    : { definition: encProtocol },
+        encryption : true,
+      });
+      expect(configStatus.code).to.equal(202);
+
+      // Write an encrypted record
+      const secretText = 'This is a secret note for E2E test';
+      const { status: writeStatus, record } = await dwnAlice.records.write({
+        data    : secretText,
+        message : {
+          protocol     : encProtocol.protocol,
+          protocolPath : 'note',
+          dataFormat   : 'text/plain',
+          schema       : 'https://schemas.xyz/note',
+        },
+        encryption: true,
+      });
+      expect(writeStatus.code).to.equal(202);
+      expect(record).to.exist;
+      expect(record!.encryption).to.exist;
+
+      // Read back with decryption
+      const { status: readStatus, record: readRecord } = await dwnAlice.records.read({
+        message    : { filter: { recordId: record!.id } },
+        encryption : true,
+      });
+      expect(readStatus.code).to.equal(200);
+      expect(readRecord).to.exist;
+
+      const decryptedText = await readRecord!.data.text();
+      expect(decryptedText).to.equal(secretText);
+
+      // Query back with decryption
+      const { status: queryStatus, records: queryRecords } = await dwnAlice.records.query({
+        message    : { filter: { protocol: encProtocol.protocol } },
+        encryption : true,
+      });
+      expect(queryStatus.code).to.equal(200);
+      expect(queryRecords).to.have.length(1);
+
+      const queryDecryptedText = await queryRecords![0].data.text();
+      expect(queryDecryptedText).to.equal(secretText);
+    });
   });
 
   describe('delete()', () => {


### PR DESCRIPTION
## Summary

Fixes a bug in cross-DWN participant decryption and adds comprehensive E2E tests that verify participants can actually **decrypt** records, not just that keys are delivered.

## Bug Fix

`resolveKeyDecrypter` used the record's authorization signer to determine where to fetch the contextKey in the remote fallback path. For cross-DWN records (Bob writes to Alice's DWN), the signer is Bob (the author), but the contextKey lives on Alice's DWN. This caused the remote contextKey fetch to query the wrong DWN, making participant decryption fail in cross-DWN scenarios.

**Fix**: Accept `targetDid` parameter from the caller (who knows the DWN being queried) and use it as the context owner for the remote fetch, falling back to the record author for same-DWN cases.

## New E2E Tests (agent layer — 4 tests)

| Test | What It Verifies |
|------|-----------------|
| Participant (Bob) decrypts via contextKey | Full `$role` flow: Alice creates context, writes chat, adds Bob as participant, Bob uses delivered contextKey to **decrypt** the chat message |
| Cross-DWN full round-trip | Bob writes to Alice's DWN → reactive upgrade → contextKey delivered to Bob → Bob **decrypts** using the contextKey |
| Cross-DWN non-root child record | Bob writes a child email to Alice's DWN using `extractDerivedPublicKey` → verifies ProtocolContext scheme used → Alice **decrypts** |
| Large payload (>30KB) through upgrade | Verifies the reactive upgrade path handles payloads above the `encodedData` threshold (stored in data store, not inline) |

## New E2E Test (API layer — 1 test)

| Test | What It Verifies |
|------|-----------------|
| API write→read→query encryption round-trip | `dwnAlice.records.write({ encryption: true })` → `dwnAlice.records.read({ encryption: true })` → `dwnAlice.records.query({ encryption: true })` with plaintext verification at each step |

## Verification

- 12/12 agent PR E tests pass (8 original + 4 new)
- SDK tests pass (9/9 encryption-related)
- Lint clean across all packages
- Build clean
- API test is correctly written but requires DHT gateway infrastructure to run (same as all existing API tests)