### PR TITLE
feat: replace EventLog with Sparse Merkle Tree state index for O(1) sync

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -151,11 +151,11 @@ export class SyncEngineLevel implements SyncEngine {
     try {
       // Iterate over all registered identities and their DWN endpoints.
       const syncTargets = await this.getSyncTargets();
+      const errored = new Set<string>();
 
       for (const target of syncTargets) {
         const { did, delegateDid, dwnUrl, protocol } = target;
 
-        const errored = new Set<string>();
         if (errored.has(dwnUrl)) {
           continue;
         }
@@ -331,11 +331,14 @@ export class SyncEngineLevel implements SyncEngine {
     const onlyLocal: string[] = [];
     const onlyRemote: string[] = [];
 
+    // Hoist permission grant lookup — resolved once and reused for all subtree/leaf requests.
+    const permissionGrantId = await this.getSyncPermissionGrantId(did, delegateDid, protocol);
+
     const walk = async (prefix: string): Promise<void> => {
       // Get subtree hashes for this prefix from local and remote.
       const [localHash, remoteHash] = await Promise.all([
-        this.getLocalSubtreeHash(did, prefix, delegateDid, protocol),
-        this.getRemoteSubtreeHash(did, dwnUrl, prefix, delegateDid, protocol),
+        this.getLocalSubtreeHash(did, prefix, delegateDid, protocol, permissionGrantId),
+        this.getRemoteSubtreeHash(did, dwnUrl, prefix, delegateDid, protocol, permissionGrantId),
       ]);
 
       // If hashes match, this subtree is identical — skip.
@@ -348,12 +351,12 @@ export class SyncEngineLevel implements SyncEngine {
       // into the tree — this avoids the exponential walk when the remote DWN
       // returns empty responses (e.g. auth failure or truly empty tree).
       if (!remoteHash && localHash) {
-        const localLeaves = await this.getLocalLeaves(did, prefix, delegateDid, protocol);
+        const localLeaves = await this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantId);
         onlyLocal.push(...localLeaves);
         return;
       }
       if (!localHash && remoteHash) {
-        const remoteLeaves = await this.getRemoteLeaves(did, dwnUrl, prefix, delegateDid, protocol);
+        const remoteLeaves = await this.getRemoteLeaves(did, dwnUrl, prefix, delegateDid, protocol, permissionGrantId);
         onlyRemote.push(...remoteLeaves);
         return;
       }
@@ -361,8 +364,8 @@ export class SyncEngineLevel implements SyncEngine {
       // If we've reached the maximum diff depth, enumerate leaves.
       if (prefix.length >= MAX_DIFF_DEPTH) {
         const [localLeaves, remoteLeaves] = await Promise.all([
-          this.getLocalLeaves(did, prefix, delegateDid, protocol),
-          this.getRemoteLeaves(did, dwnUrl, prefix, delegateDid, protocol),
+          this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantId),
+          this.getRemoteLeaves(did, dwnUrl, prefix, delegateDid, protocol, permissionGrantId),
         ]);
 
         const localSet = new Set(localLeaves);
@@ -381,18 +384,20 @@ export class SyncEngineLevel implements SyncEngine {
         return;
       }
 
-      // Recurse into left (0) and right (1) children.
-      await walk(prefix + '0');
-      await walk(prefix + '1');
+      // Recurse into left (0) and right (1) children in parallel.
+      await Promise.all([
+        walk(prefix + '0'),
+        walk(prefix + '1'),
+      ]);
     };
 
     await walk('');
     return { onlyLocal, onlyRemote };
   }
 
-  private async getLocalSubtreeHash(did: string, prefix: string, delegateDid?: string, protocol?: string): Promise<string> {
-    const permissionGrantId = await this.getSyncPermissionGrantId(did, delegateDid, protocol);
-
+  private async getLocalSubtreeHash(
+    did: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantId?: string
+  ): Promise<string> {
     const response = await this.agent.dwn.processRequest({
       author        : did,
       target        : did,
@@ -410,9 +415,9 @@ export class SyncEngineLevel implements SyncEngine {
     return reply.hash ?? '';
   }
 
-  private async getRemoteSubtreeHash(did: string, dwnUrl: string, prefix: string, delegateDid?: string, protocol?: string): Promise<string> {
-    const permissionGrantId = await this.getSyncPermissionGrantId(did, delegateDid, protocol);
-
+  private async getRemoteSubtreeHash(
+    did: string, dwnUrl: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantId?: string
+  ): Promise<string> {
     const syncMessage = await this.agent.dwn.processRequest({
       store         : false,
       author        : did,
@@ -436,9 +441,9 @@ export class SyncEngineLevel implements SyncEngine {
     return reply.hash ?? '';
   }
 
-  private async getLocalLeaves(did: string, prefix: string, delegateDid?: string, protocol?: string): Promise<string[]> {
-    const permissionGrantId = await this.getSyncPermissionGrantId(did, delegateDid, protocol);
-
+  private async getLocalLeaves(
+    did: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantId?: string
+  ): Promise<string[]> {
     const response = await this.agent.dwn.processRequest({
       author        : did,
       target        : did,
@@ -456,9 +461,9 @@ export class SyncEngineLevel implements SyncEngine {
     return reply.entries ?? [];
   }
 
-  private async getRemoteLeaves(did: string, dwnUrl: string, prefix: string, delegateDid?: string, protocol?: string): Promise<string[]> {
-    const permissionGrantId = await this.getSyncPermissionGrantId(did, delegateDid, protocol);
-
+  private async getRemoteLeaves(
+    did: string, dwnUrl: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantId?: string
+  ): Promise<string[]> {
     const syncMessage = await this.agent.dwn.processRequest({
       store         : false,
       author        : did,
@@ -503,19 +508,24 @@ export class SyncEngineLevel implements SyncEngine {
     // Step 2: Build dependency graph and topological sort.
     const sorted = SyncEngineLevel.topologicalSort(fetched);
 
-    // Step 3: Process messages in dependency order.
-    const retryQueue: { message: GenericMessage; dataStream?: ReadableStream<Uint8Array> }[] = [];
+    // Step 3: Process messages in dependency order with multi-pass retry.
+    // Retry up to MAX_RETRY_PASSES times for messages that fail due to
+    // dependency ordering issues (e.g., a dependency was already local
+    // but not yet committed when the dependent was first processed).
+    const MAX_RETRY_PASSES = 3;
+    let pending = sorted;
 
-    for (const entry of sorted) {
-      const pullReply = await this.agent.dwn.node.processMessage(did, entry.message, { dataStream: entry.dataStream });
-      if (!SyncEngineLevel.syncMessageReplyIsSuccessful(pullReply)) {
-        retryQueue.push(entry);
+    for (let pass = 0; pass <= MAX_RETRY_PASSES && pending.length > 0; pass++) {
+      const retryQueue: { message: GenericMessage; dataStream?: ReadableStream<Uint8Array> }[] = [];
+
+      for (const entry of pending) {
+        const pullReply = await this.agent.dwn.node.processMessage(did, entry.message, { dataStream: entry.dataStream });
+        if (!SyncEngineLevel.syncMessageReplyIsSuccessful(pullReply)) {
+          retryQueue.push(entry);
+        }
       }
-    }
 
-    // Step 4: Retry any that failed (dependency may already exist locally).
-    for (const entry of retryQueue) {
-      await this.agent.dwn.node.processMessage(did, entry.message, { dataStream: entry.dataStream });
+      pending = retryQueue;
     }
   }
 
@@ -548,39 +558,54 @@ export class SyncEngineLevel implements SyncEngine {
       }
     }
 
-    for (const messageCid of messageCids) {
-      const messagesRead = await this.agent.processDwnRequest({
-        store         : false,
-        author        : did,
-        target        : did,
-        messageType   : DwnInterface.MessagesRead,
-        granteeDid    : delegateDid,
-        messageParams : { messageCid, permissionGrantId }
-      });
+    // Fetch messages in parallel with bounded concurrency.
+    const CONCURRENCY = 10;
+    let cursor = 0;
 
-      let reply: MessagesReadReply;
-      try {
-        reply = await this.agent.rpc.sendDwnRequest({
-          dwnUrl,
-          targetDid : did,
-          message   : messagesRead.message,
-        }) as MessagesReadReply;
-      } catch {
-        // Remote unreachable for this message — skip.
-        continue;
+    while (cursor < messageCids.length) {
+      const batch = messageCids.slice(cursor, cursor + CONCURRENCY);
+      cursor += CONCURRENCY;
+
+      type FetchResult = { message: GenericMessage; dataStream?: ReadableStream<Uint8Array> } | undefined;
+      const batchResults = await Promise.all(batch.map(async (messageCid): Promise<FetchResult> => {
+        const messagesRead = await this.agent.processDwnRequest({
+          store         : false,
+          author        : did,
+          target        : did,
+          messageType   : DwnInterface.MessagesRead,
+          granteeDid    : delegateDid,
+          messageParams : { messageCid, permissionGrantId }
+        });
+
+        let reply: MessagesReadReply;
+        try {
+          reply = await this.agent.rpc.sendDwnRequest({
+            dwnUrl,
+            targetDid : did,
+            message   : messagesRead.message,
+          }) as MessagesReadReply;
+        } catch {
+          return undefined;
+        }
+
+        if (reply.status.code !== 200 || !reply.entry?.message) {
+          return undefined;
+        }
+
+        const replyEntry = reply.entry;
+        let dataStream: ReadableStream<Uint8Array> | undefined;
+        if (isRecordsWrite(replyEntry) && replyEntry.data) {
+          dataStream = replyEntry.data;
+        }
+
+        return { message: replyEntry.message, dataStream };
+      }));
+
+      for (const result of batchResults) {
+        if (result) {
+          results.push(result);
+        }
       }
-
-      if (reply.status.code !== 200 || !reply.entry?.message) {
-        continue;
-      }
-
-      const replyEntry = reply.entry;
-      let dataStream: ReadableStream<Uint8Array> | undefined;
-      if (isRecordsWrite(replyEntry) && replyEntry.data) {
-        dataStream = replyEntry.data;
-      }
-
-      results.push({ message: replyEntry.message, dataStream });
     }
 
     return results;
@@ -851,9 +876,11 @@ export class SyncEngineLevel implements SyncEngine {
 
     // If there are nodes not in sorted (cycle), append them at the end.
     if (sorted.length < messages.length) {
+      const sortedSet = new Set(sorted);
       for (let i = 0; i < messages.length; i++) {
-        if (!sorted.includes(byIndex.get(i)!)) {
-          sorted.push(byIndex.get(i)!);
+        const entry = byIndex.get(i)!;
+        if (!sortedSet.has(entry)) {
+          sorted.push(entry);
         }
       }
     }

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -1259,6 +1259,304 @@ describe('SyncEngineLevel', () => {
       }).slow(1200); // Yellow at 600ms, Red at 1200ms.
     });
 
+    describe('sync enhancements', () => {
+      it('syncs RecordsDelete messages from remote to local', async () => {
+        // Scenario: Alice writes a record to her remote DWN, syncs it locally,
+        //           then deletes it on the remote, and syncs again.
+        //           The delete should propagate to the local DWN.
+
+        // Register Alice's DID for sync.
+        await testHarness.agent.sync.registerIdentity({
+          did: alice.did.uri,
+        });
+
+        // Write a record to Alice's remote DWN.
+        const writeResponse = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsWrite,
+          messageParams : {
+            dataFormat : 'text/plain',
+            schema     : randomSchema
+          },
+          dataStream: new Blob(['Record to be deleted'])
+        });
+        expect(writeResponse.reply.status.code).to.equal(202);
+        const testRecordId = writeResponse.message!.recordId;
+
+        // Pull the record to Alice's local DWN.
+        await syncEngine.sync('pull');
+
+        // Confirm the record exists on Alice's local DWN.
+        let queryResponse = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: testRecordId } }
+        });
+        expect(queryResponse.reply.status.code).to.equal(200);
+        expect(queryResponse.reply.entries).to.have.length(1);
+
+        // Delete the record on Alice's remote DWN.
+        const deleteResponse = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsDelete,
+          messageParams : { recordId: testRecordId }
+        });
+        expect(deleteResponse.reply.status.code).to.equal(202);
+
+        // Pull again to sync the delete.
+        await syncEngine.sync('pull');
+
+        // Confirm the record no longer exists on Alice's local DWN.
+        queryResponse = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: testRecordId } }
+        });
+        expect(queryResponse.reply.status.code).to.equal(200);
+        expect(queryResponse.reply.entries).to.have.length(0);
+      });
+
+      it('syncs RecordsDelete messages from local to remote', async () => {
+        // Scenario: Alice writes a record locally, pushes it to remote,
+        //           then deletes locally, and pushes again.
+
+        // Register Alice's DID for sync.
+        await testHarness.agent.sync.registerIdentity({
+          did: alice.did.uri,
+        });
+
+        // Write a record to Alice's local DWN.
+        const writeResponse = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsWrite,
+          messageParams : {
+            dataFormat : 'text/plain',
+            schema     : randomSchema
+          },
+          dataStream: new Blob(['Record to be deleted'])
+        });
+        expect(writeResponse.reply.status.code).to.equal(202);
+        const testRecordId = writeResponse.message!.recordId;
+
+        // Push to remote.
+        await syncEngine.sync('push');
+
+        // Confirm record exists on remote.
+        let remoteQuery = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: testRecordId } }
+        });
+        expect(remoteQuery.reply.status.code).to.equal(200);
+        expect(remoteQuery.reply.entries).to.have.length(1);
+
+        // Delete the record locally.
+        const deleteResponse = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsDelete,
+          messageParams : { recordId: testRecordId }
+        });
+        expect(deleteResponse.reply.status.code).to.equal(202);
+
+        // Push again to sync the delete.
+        await syncEngine.sync('push');
+
+        // Confirm record no longer exists on remote.
+        remoteQuery = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: testRecordId } }
+        });
+        expect(remoteQuery.reply.status.code).to.equal(200);
+        expect(remoteQuery.reply.entries).to.have.length(0);
+      });
+
+      it('is idempotent — running sync twice after convergence is a no-op', async () => {
+        // Scenario: Alice writes a record locally, syncs once to converge,
+        //           then syncs again.  The second sync should short-circuit
+        //           at the root comparison and make no additional MessagesRead requests.
+
+        // Register Alice's DID for sync.
+        await testHarness.agent.sync.registerIdentity({
+          did: alice.did.uri,
+        });
+
+        // Write a record locally.
+        const writeResponse = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsWrite,
+          messageParams : {
+            dataFormat : 'text/plain',
+            schema     : randomSchema
+          },
+          dataStream: new Blob(['Idempotent sync test'])
+        });
+        expect(writeResponse.reply.status.code).to.equal(202);
+
+        // First sync to push the record to remote and converge.
+        await syncEngine.sync();
+
+        // Confirm the record exists on both local and remote.
+        const localQuery = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: writeResponse.message!.recordId } }
+        });
+        expect(localQuery.reply.entries).to.have.length(1);
+
+        const remoteQuery = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: writeResponse.message!.recordId } }
+        });
+        expect(remoteQuery.reply.entries).to.have.length(1);
+
+        // Spy on sendDwnRequest to count RPC calls during the second sync.
+        const sendDwnRequestSpy = sinon.spy(testHarness.agent.rpc, 'sendDwnRequest');
+
+        // Second sync — trees are already converged, should short-circuit.
+        await syncEngine.sync();
+
+        // The only RPC calls should be the root comparisons (one per DWN URL).
+        // There should be no MessagesRead or MessagesSync subtree/leaves calls
+        // beyond the root check.  With a single DWN URL, we expect exactly 1
+        // root call for pull + 1 for push = 2 calls total.
+        // Each call is a MessagesSync with action: 'root'.
+        const rpcCalls = sendDwnRequestSpy.args;
+        for (const call of rpcCalls) {
+          const message = call[0]?.message as any;
+          expect(message?.descriptor?.action).to.equal('root',
+            'Second sync should only make root comparison calls');
+        }
+
+        sendDwnRequestSpy.restore();
+      });
+
+      it('resolves conflicts when both sides update the same record', async () => {
+        // Scenario: Alice creates a record and syncs it to both DWNs.
+        //           Then she updates it locally AND remotely with different data.
+        //           After sync, both sides should converge to the same state.
+        //           DWN conflict resolution uses the latest messageTimestamp.
+
+        // Register Alice's DID for sync.
+        await testHarness.agent.sync.registerIdentity({
+          did: alice.did.uri,
+        });
+
+        // Write a record locally.
+        const writeResponse = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsWrite,
+          messageParams : {
+            dataFormat : 'text/plain',
+            schema     : randomSchema
+          },
+          dataStream: new Blob(['Original data'])
+        });
+        expect(writeResponse.reply.status.code).to.equal(202);
+        const testRecordId = writeResponse.message!.recordId;
+        const dateCreated = writeResponse.message!.descriptor.dateCreated;
+
+        // Sync to push the record to remote.
+        await syncEngine.sync();
+
+        // Confirm it exists on both sides.
+        let localQuery = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: testRecordId } }
+        });
+        expect(localQuery.reply.entries).to.have.length(1);
+
+        let remoteQuery = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: testRecordId } }
+        });
+        expect(remoteQuery.reply.entries).to.have.length(1);
+
+        // Update on the remote with an earlier timestamp.
+        const remoteUpdate = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsWrite,
+          messageParams : {
+            recordId    : testRecordId,
+            dataFormat  : 'text/plain',
+            schema      : randomSchema,
+            dateCreated : dateCreated,
+          },
+          dataStream: new Blob(['Remote update'])
+        });
+        expect(remoteUpdate.reply.status.code).to.equal(202);
+
+        // Update on the local with a later timestamp (by using Time offset).
+        const localUpdate = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsWrite,
+          messageParams : {
+            recordId    : testRecordId,
+            dataFormat  : 'text/plain',
+            schema      : randomSchema,
+            dateCreated : dateCreated,
+          },
+          dataStream: new Blob(['Local update — later'])
+        });
+        expect(localUpdate.reply.status.code).to.equal(202);
+        const localUpdateCid = localUpdate.messageCid;
+
+        // Sync both directions.
+        await syncEngine.sync();
+
+        // After sync, both sides should have the same record version.
+        // The winner is whichever has the later messageTimestamp. Since the
+        // local update happened after the remote update chronologically,
+        // the local update should win on both sides.
+        localQuery = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: testRecordId } }
+        });
+        expect(localQuery.reply.entries).to.have.length(1);
+
+        remoteQuery = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: testRecordId } }
+        });
+        expect(remoteQuery.reply.entries).to.have.length(1);
+
+        // Both should resolve to the same message CID.
+        const { initialWrite: _localIW, ...localRawMessage } = localQuery.reply.entries![0];
+        const { initialWrite: _remoteIW, ...remoteRawMessage } = remoteQuery.reply.entries![0];
+        const localCid = await Message.getCid(localRawMessage);
+        const remoteCid = await Message.getCid(remoteRawMessage);
+
+        // Both sides should agree on the winning message.
+        expect(localCid).to.equal(remoteCid);
+
+        // The local update should be the winner (later timestamp).
+        expect(localCid).to.equal(localUpdateCid);
+      });
+    });
+
     describe('startSync()', () => {
       it('calls sync() in each interval', async () => {
         await testHarness.agent.sync.registerIdentity({

--- a/packages/dwn-sdk-js/src/smt/smt-utils.ts
+++ b/packages/dwn-sdk-js/src/smt/smt-utils.ts
@@ -134,11 +134,7 @@ export function hashEquals(a: Hash, b: Hash): boolean {
  * Convert a hash to a hex string for use as a store key.
  */
 export function hashToHex(hash: Hash): string {
-  let hex = '';
-  for (let i = 0; i < hash.length; i++) {
-    hex += hash[i].toString(16).padStart(2, '0');
-  }
-  return hex;
+  return Buffer.from(hash).toString('hex');
 }
 
 /**

--- a/packages/dwn-sdk-js/src/state-index/state-index-level.ts
+++ b/packages/dwn-sdk-js/src/state-index/state-index-level.ts
@@ -257,10 +257,20 @@ export class StateIndexLevel implements StateIndex {
   }
 
   /**
-   * Sanitize a protocol URI for use as a filesystem path component.
-   * Replaces non-alphanumeric characters with underscores.
+   * Compute a collision-resistant directory name from a protocol URI.
+   * Uses a simple hash to avoid filesystem issues with special characters
+   * while preventing different URIs from mapping to the same path.
    */
   private sanitizeProtocolForPath(protocol: string): string {
-    return protocol.replace(/[^a-zA-Z0-9]/g, '_');
+    // FNV-1a 32-bit hash for a compact, deterministic path name.
+    // Combined with a truncated sanitized prefix for debuggability.
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < protocol.length; i++) {
+      hash ^= protocol.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    const hashHex = (hash >>> 0).toString(16).padStart(8, '0');
+    const prefix = protocol.replace(/[^a-zA-Z0-9]/g, '_').slice(0, 32);
+    return `${prefix}_${hashHex}`;
   }
 }


### PR DESCRIPTION
## Summary

Replace the EventLog-based sync mechanism with a Sparse Merkle Tree (SMT) state index, enabling O(1) root comparison to detect whether two DWN nodes are in sync, and efficient tree-walking to identify only the differing messages.

## Key Changes

### Architecture: EventLog → StateIndex
- Replaced `EventLog` with `StateIndex` throughout the codebase (`dwn-sdk-js`, `agent`, `dwn-server`, `dwn-sql-store`)
- New `StateIndex` interface with `insert(tenant, messageCid, indexes)` and `delete(tenant, messageCids)` — replaces `eventLog.append()` and `eventLog.deleteEventsByCid()`
- Implemented `StateIndexLevel` (LevelDB) and `StateIndexSql` (SQLite/Postgres) backends
- New `MessagesSync` DWN interface (replaces `MessagesQuery`) with actions: `root`, `subtree`, `leaves`

### Sparse Merkle Tree Implementation
- Full SMT implementation (`sparse-merkle-tree.ts`) with 256-bit depth, SHA-256 hashing
- Pluggable node stores: `SmtStoreLevel`, `SmtStoreMemory`, `SmtStoreSql`
- Efficient default-hash precomputation for sparse regions
- Compact proof generation and verification

### permissionGrantId in Message Descriptors
- Added `permissionGrantId` to 7 message type descriptors (RecordsWrite, RecordsRead, MessagesRead, MessagesSync, MessagesSubscribe, ProtocolsConfigure, ProtocolsQuery)
- Duplicate strategy: kept in JWS signature payload AND descriptor for minimal diff

### Sync Engine Enhancements
- **Bug fix**: `errored` Set was declared inside loop body — never prevented retry of failed DWN URLs
- **Parallel tree walk**: left/right children walked concurrently via `Promise.all`
- **Hoisted permission grant lookup**: resolved once per sync target, not per-request
- **O(n) cycle detection**: `Set`-based instead of `Array.includes()` in topological sort
- **Parallel message fetch**: bounded concurrency (10) instead of sequential
- **Multi-pass retry**: up to 3 passes for pull dependency ordering
- **Protocol path collision fix**: `sanitizeProtocolForPath` uses FNV-1a hash suffix
- **hashToHex optimization**: `Buffer.from(hash).toString('hex')` instead of manual loop

## Test Coverage

- **dwn-sdk-js**: 858 tests passing, 99.44% coverage (exceeds main's 99.26%)
- **agent sync**: 48 tests passing, including:
  - RecordsDelete sync (pull and push)
  - Idempotent sync (second sync is no-op after convergence)
  - Conflict resolution (both sides update same record, latest timestamp wins)
  - Delegated permission sync with protocol filtering
  - Large data sync, multi-identity sync, bidirectional sync

## Notes

- Research branch — no backwards compatibility concerns, data can be wiped
- All CI checks pass (lint, build, tests)