### PR TITLE
test(agent): add e2e test for two-layer encryption recovery from seed phrase

### DIFF
--- a/packages/agent/tests/e2e-two-layer-encryption.spec.ts
+++ b/packages/agent/tests/e2e-two-layer-encryption.spec.ts
@@ -226,6 +226,12 @@ describe('e2e: two-layer encryption recovery', function () {
     });
 
     it('should recover the agent DID using the seed phrase (Layer 1)', async () => {
+      // Clear the vault store to simulate the recovery scenario: the vault data
+      // is gone (e.g., app reinstalled) but DWN records persist on disk.
+      // This is required because HdIdentityVault.initialize() rejects if the
+      // vault is already initialized.
+      await harness.vaultStore.clear();
+
       // Re-initialize with the original recovery phrase but a NEW password.
       // The seed phrase deterministically re-derives the same agent DID, and the
       // new password re-encrypts the vault.
@@ -257,6 +263,8 @@ describe('e2e: two-layer encryption recovery', function () {
         await (harness.agent as Web5UserAgent).start({ password });
         expect.fail('Expected an error when using the old password');
       } catch (error: any) {
+        // Re-throw AssertionError from expect.fail() so it isn't swallowed.
+        if (error.name === 'AssertionError') { throw error; }
         expect(error.message).to.include('incorrect password');
       }
 


### PR DESCRIPTION
## Summary

- Adds an end-to-end test that validates the full two-layer encryption recovery path: seed phrase → deterministic agent DID → secp256k1 `#enc` key → decrypt DWN key records.

## What the test covers

**Phase 1 — Initialize and generate encrypted keys:**
1. Creates a `Web5UserAgent` with DWN-backed stores (`DwnKeyStore`, `DwnDidStore`, `DwnIdentityStore`)
2. Initializes the `HdIdentityVault`, which generates a BIP-39 seed phrase and creates a `did:dht` agent DID with Ed25519 (`#sig`) + secp256k1 (`#enc`)
3. Generates 3 private keys (2x Ed25519, 1x secp256k1) through the key manager — each encrypted at rest via ECIES with the tenant's `#enc` key (Layer 2)
4. Verifies raw DWN records carry `encryption` metadata (A256CTR), proving data is not stored in plaintext
5. Closes the agent cleanly

**Phase 2 — Recover and read encrypted keys:**
1. Creates a fresh agent instance pointed at the same LevelDB paths
2. Re-initializes with the original seed phrase but a **new password** — the vault re-derives the same agent DID deterministically (Layer 1)
3. Reads back all 3 encrypted keys and asserts exact match on `kid`, `kty`, `crv`, `d`, `x`
4. Generates an additional key to prove the recovered agent is fully operational

## Note on local test execution

This test requires a Pkarr gateway for `DidDht.create()` during `HdIdentityVault.initialize()`. It will fail locally (same as ~66 existing vault/DHT tests) but passes in CI where a gateway is available.