### PR TITLE
fix(dwn-server): replace flaky setTimeout delays with condition-based polling in WebSocket tests

### DIFF
--- a/packages/dwn-server/tests/utils.ts
+++ b/packages/dwn-server/tests/utils.ts
@@ -153,6 +153,21 @@ export async function sendHttpMessage(options: {
   return reply as UnionMessageReply;
 }
 
+/**
+ * Polls until the predicate returns true, or rejects after `timeoutMs`.
+ * Use this instead of fixed `setTimeout` delays when waiting for async events
+ * (e.g. WebSocket subscription messages) to avoid timing-dependent flakiness.
+ */
+export async function waitUntil(predicate: () => boolean, timeoutMs = 2000, intervalMs = 10): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitUntil timed out after ${timeoutMs}ms`);
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+}
+
 export async function sendWsMessage(
   address: string,
   message: any,

--- a/packages/dwn-server/tests/ws-api.spec.ts
+++ b/packages/dwn-server/tests/ws-api.spec.ts
@@ -17,7 +17,7 @@ import {
   createJsonRpcSubscriptionRequest,
   JsonRpcErrorCodes,
 } from '../src/lib/json-rpc.js';
-import { createRecordsWriteMessage, sendHttpMessage, sendWsMessage } from './utils.js';
+import { createRecordsWriteMessage, sendHttpMessage, sendWsMessage, waitUntil } from './utils.js';
 
 
 describe('websocket api', function () {
@@ -155,7 +155,7 @@ describe('websocket api', function () {
     });
     expect(writeResult2.status.code).to.equal(202);
 
-    await new Promise(resolve => setTimeout(resolve, 5)); // wait for records to be processed
+    await waitUntil(() => records.length >= 2);
 
     // close the subscription
     await close();
@@ -214,7 +214,7 @@ describe('websocket api', function () {
     expect(writeResult1.status.code).to.equal(202);
 
     // wait for the subscription event to arrive via WebSocket before closing
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await waitUntil(() => records.length >= 1);
 
     // close the subscription after only 1 message
     await close();
@@ -326,7 +326,7 @@ describe('websocket api', function () {
     });
     expect(writeResult2.status.code).to.equal(202);
 
-    await new Promise(resolve => setTimeout(resolve, 5)); // wait for records to be processed
+    await waitUntil(() => records.length >= 2);
 
     // close the subscription
     await close();
@@ -403,7 +403,7 @@ describe('websocket api', function () {
     });
     expect(updateResult.status.code).to.equal(202);
 
-    await new Promise(resolve => setTimeout(resolve, 5)); // wait for records to be processed
+    await waitUntil(() => records.length >= 2);
 
     // close the subscription
     await close();


### PR DESCRIPTION
## Summary

- Add a `waitUntil()` test utility that polls a predicate until it returns true (or times out), replacing brittle fixed-delay `setTimeout` calls
- Replace 4 pre-event `setTimeout` delays with `waitUntil(() => records.length >= N)` — these were the source of flakiness since WebSocket events could arrive after the delay expired
- Keep 2 post-close `setTimeout` delays that intentionally prove no further events arrive after subscription close (valid use of fixed delay for asserting negatives)

## Before / After

```typescript
// Before: guessing how long async events take — flaky
await new Promise(resolve => setTimeout(resolve, 5));
expect(records).to.have.members([...]);

// After: deterministic — waits exactly until events arrive
await waitUntil(() => records.length >= 2);
expect(records).to.have.members([...]);
```

## Why the old approach was flaky

The test suite uses Sinon fake timers (`useFakeTimers({ shouldAdvanceTime: true })`), which interacts unpredictably with real async WebSocket event delivery. A 5-10ms `setTimeout` through a fake timer was not reliably long enough for WebSocket events to propagate through the DWN server processing pipeline.