### PR TITLE
fix(dwn): implement temporal protocol versioning to prevent definition overwrites

### DIFF
--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -12,6 +12,7 @@ import { FilterUtility } from '../utils/filter.js';
 import { PermissionsProtocol } from '../protocols/permissions.js';
 import { Records } from '../utils/records.js';
 import { RecordsWrite } from '../interfaces/records-write.js';
+import { SortDirection } from '../types/query-types.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
@@ -27,11 +28,19 @@ export class ProtocolAuthorization {
     incomingMessage: RecordsWrite,
     messageStore: MessageStore,
   ): Promise<void> {
-    // fetch the protocol definition
+    // Determine the governing timestamp for protocol definition lookup.
+    // For an initial write, this is the message's own timestamp.
+    // For an update, this is the initial write's timestamp (the protocol version is locked at creation time).
+    const governingTimestamp = await ProtocolAuthorization.getGoverningTimestamp(
+      tenant, incomingMessage, messageStore
+    );
+
+    // fetch the protocol definition that was active at the governing timestamp
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
       tenant,
       incomingMessage.message.descriptor.protocol!,
       messageStore,
+      governingTimestamp,
     );
 
     // verify declared protocol type exists in protocol and that it conforms to type specification
@@ -89,11 +98,17 @@ export class ProtocolAuthorization {
       recordChain = await ProtocolAuthorization.constructRecordChain(tenant, incomingMessage.message.recordId, messageStore);
     }
 
-    // fetch the protocol definition
+    // Determine the governing timestamp for protocol definition lookup.
+    const governingTimestamp = await ProtocolAuthorization.getGoverningTimestamp(
+      tenant, incomingMessage, messageStore
+    );
+
+    // fetch the protocol definition that was active at the governing timestamp
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
       tenant,
       incomingMessage.message.descriptor.protocol!,
       messageStore,
+      governingTimestamp,
     );
 
     // get the rule set for the inbound message
@@ -137,11 +152,21 @@ export class ProtocolAuthorization {
     const recordChain: RecordsWriteMessage[] =
       await ProtocolAuthorization.constructRecordChain(tenant, newestRecordsWrite.message.recordId, messageStore);
 
-    // fetch the protocol definition
+    // Use the initial write's timestamp to determine the governing protocol definition.
+    // The protocol version is locked at the time the record was first created.
+    const initialWrite = await ProtocolAuthorization.fetchInitialWrite(
+      tenant, newestRecordsWrite.message.recordId, messageStore
+    );
+    const governingTimestamp = initialWrite !== undefined
+      ? initialWrite.descriptor.messageTimestamp
+      : newestRecordsWrite.message.descriptor.messageTimestamp;
+
+    // fetch the protocol definition that was active when the record was created
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
       tenant,
       newestRecordsWrite.message.descriptor.protocol!,
       messageStore,
+      governingTimestamp,
     );
 
     // get the rule set for the inbound message
@@ -225,11 +250,20 @@ export class ProtocolAuthorization {
     const recordChain: RecordsWriteMessage[] =
       await ProtocolAuthorization.constructRecordChain(tenant, incomingMessage.message.descriptor.recordId, messageStore);
 
-    // fetch the protocol definition
+    // Use the initial write's timestamp to determine the governing protocol definition.
+    const initialWrite = await ProtocolAuthorization.fetchInitialWrite(
+      tenant, incomingMessage.message.descriptor.recordId, messageStore
+    );
+    const governingTimestamp = initialWrite !== undefined
+      ? initialWrite.descriptor.messageTimestamp
+      : recordsWrite.message.descriptor.messageTimestamp;
+
+    // fetch the protocol definition that was active when the record was created
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
       tenant,
       recordsWrite.message.descriptor.protocol!,
       messageStore,
+      governingTimestamp,
     );
 
     // get the rule set for the inbound message
@@ -260,11 +294,15 @@ export class ProtocolAuthorization {
 
   /**
    * Fetches the protocol definition based on the protocol specified in the given message.
+   * When `messageTimestamp` is provided, returns the protocol definition that was active at that
+   * point in time — i.e. the ProtocolsConfigure with the greatest `messageTimestamp` that is <= the
+   * given timestamp. When not provided, returns the latest (current) protocol definition.
    */
   private static async fetchProtocolDefinition(
     tenant: string,
     protocolUri: string,
-    messageStore: MessageStore
+    messageStore: MessageStore,
+    messageTimestamp?: string,
   ): Promise<ProtocolDefinition> {
     // if first-class protocol, return the definition from const object directly without going to data store
     if (protocolUri === PermissionsProtocol.uri) {
@@ -275,9 +313,23 @@ export class ProtocolAuthorization {
     const query: Filter = {
       interface : DwnInterfaceName.Protocols,
       method    : DwnMethodName.Configure,
-      protocol  : protocolUri
+      protocol  : protocolUri,
     };
-    const { messages: protocols } = await messageStore.query(tenant, [query]);
+
+    if (messageTimestamp !== undefined) {
+      // temporal lookup: find the protocol definition active at the given timestamp
+      query.messageTimestamp = { lte: messageTimestamp };
+    } else {
+      // default: return only the latest protocol definition
+      query.isLatestBaseState = true;
+    }
+
+    const { messages: protocols } = await messageStore.query(
+      tenant,
+      [query],
+      { messageTimestamp: SortDirection.Descending },
+      { limit: 1 },
+    );
 
     if (protocols.length === 0) {
       throw new DwnError(DwnErrorCode.ProtocolAuthorizationProtocolNotFound, `unable to find protocol definition for ${protocolUri}`);
@@ -895,6 +947,30 @@ export class ProtocolAuthorization {
       const ancestorAuthor = (await RecordsWrite.parse(ancestorRecordsWrite)).author;
       return author === ancestorAuthor;
     }
+  }
+
+  /**
+   * Determines the timestamp that governs which protocol definition version applies to the given RecordsWrite.
+   * For an update, this is the initial write's `messageTimestamp` (the protocol version is locked at creation time).
+   * For a new initial write, returns `undefined` — the latest protocol definition should be used because the
+   * record is being created now and must conform to the current protocol rules.
+   */
+  private static async getGoverningTimestamp(
+    tenant: string,
+    incomingMessage: RecordsWrite,
+    messageStore: MessageStore,
+  ): Promise<string | undefined> {
+    const existingInitialWrite = await ProtocolAuthorization.fetchInitialWrite(
+      tenant, incomingMessage.message.recordId, messageStore
+    );
+
+    if (existingInitialWrite !== undefined) {
+      // update case: use the initial write's timestamp
+      return existingInitialWrite.descriptor.messageTimestamp;
+    }
+
+    // initial write case: validate against the latest protocol definition
+    return undefined;
   }
 
   private static getTypeName(protocolPath: string): string {

--- a/packages/dwn-sdk-js/src/handlers/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/handlers/protocols-configure.ts
@@ -62,7 +62,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
     // write the incoming message to DB if incoming message is newest
     let messageReply: GenericMessageReply;
     if (incomingMessageIsNewest) {
-      const indexes = ProtocolsConfigureHandler.constructIndexes(protocolsConfigure);
+      const indexes = ProtocolsConfigureHandler.constructIndexes(protocolsConfigure, true);
 
       await this.messageStore.put(tenant, message, indexes);
       const messageCid = await Message.getCid(message);
@@ -77,28 +77,35 @@ export class ProtocolsConfigureHandler implements MethodHandler {
         status: { code: 202, detail: 'Accepted' }
       };
     } else {
+      // incoming message is older — still store it as a historical version (not the latest)
+      const indexes = ProtocolsConfigureHandler.constructIndexes(protocolsConfigure, false);
+
+      await this.messageStore.put(tenant, message, indexes);
+      const messageCid = await Message.getCid(message);
+      await this.stateIndex.insert(tenant, messageCid, indexes);
+
       messageReply = {
-        status: { code: 409, detail: 'Conflict' }
+        status: { code: 202, detail: 'Accepted' }
       };
     }
 
-    // delete all existing records that are smaller
-    const deletedMessageCids: string[] = [];
-    for (const message of existingMessages) {
-      if (await Message.isNewer(newestMessage, message)) {
-        const messageCid = await Message.getCid(message);
-        deletedMessageCids.push(messageCid);
+    // re-index previously-latest messages as no longer the latest base state.
+    // We must delete and re-put (not just put) to properly replace old index entries.
+    for (const existingMessage of existingMessages) {
+      if (existingMessage !== newestMessage) {
+        const existingProtocolsConfigure = await ProtocolsConfigure.parse(existingMessage as ProtocolsConfigureMessage);
+        const updatedIndexes = ProtocolsConfigureHandler.constructIndexes(existingProtocolsConfigure, false);
+        const existingCid = await Message.getCid(existingMessage);
 
-        await this.messageStore.delete(tenant, messageCid);
+        await this.messageStore.delete(tenant, existingCid);
+        await this.messageStore.put(tenant, existingMessage, updatedIndexes);
       }
     }
-
-    await this.stateIndex.delete(tenant, deletedMessageCids);
 
     return messageReply;
   };
 
-  static constructIndexes(protocolsConfigure: ProtocolsConfigure): { [key: string]: string | boolean } {
+  static constructIndexes(protocolsConfigure: ProtocolsConfigure, isLatestBaseState: boolean): { [key: string]: string | boolean } {
     // strip out `definition` as it is not indexable
     const { definition, ...propertiesToIndex } = protocolsConfigure.message.descriptor;
     const { author } = protocolsConfigure;
@@ -107,7 +114,8 @@ export class ProtocolsConfigureHandler implements MethodHandler {
       ...propertiesToIndex,
       author    : author!,
       protocol  : definition.protocol, // retain protocol url from `definition`,
-      published : definition.published // retain published state from definition
+      published : definition.published, // retain published state from definition
+      isLatestBaseState,
     };
 
     return indexes;

--- a/packages/dwn-sdk-js/src/handlers/protocols-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/protocols-query.ts
@@ -52,8 +52,9 @@ export class ProtocolsQueryHandler implements MethodHandler {
 
     const query = {
       ...message.descriptor.filter,
-      interface : DwnInterfaceName.Protocols,
-      method    : DwnMethodName.Configure
+      interface         : DwnInterfaceName.Protocols,
+      method            : DwnMethodName.Configure,
+      isLatestBaseState : true,
     };
     removeUndefinedProperties(query);
 
@@ -72,9 +73,10 @@ export class ProtocolsQueryHandler implements MethodHandler {
     // fetch all published `ProtocolConfigure` matching the query
     const filter = {
       ...protocolsQuery.message.descriptor.filter,
-      interface : DwnInterfaceName.Protocols,
-      method    : DwnMethodName.Configure,
-      published : true
+      interface         : DwnInterfaceName.Protocols,
+      method            : DwnMethodName.Configure,
+      published         : true,
+      isLatestBaseState : true,
     };
     const { messages: publishedProtocolsConfigure } = await this.messageStore.query(tenant, [ filter ]);
     return publishedProtocolsConfigure as ProtocolsConfigureMessage[];

--- a/packages/dwn-sdk-js/tests/handlers/protocols-configure.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/protocols-configure.spec.ts
@@ -27,7 +27,7 @@ import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { Time } from '../../src/utils/time.js';
 
-import { DataStream, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, Jws, PermissionGrant, PermissionsProtocol } from '../../src/index.js';
+import { DataStream, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, Jws, PermissionGrant, PermissionsProtocol, RecordsDelete, RecordsRead, RecordsWrite } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 
 chai.use(chaiAsPromised);
@@ -121,7 +121,7 @@ export function testProtocolsConfigureHandler(): void {
         expect(reply.status.detail).to.contain(DwnErrorCode.GeneralJwsVerifierInvalidSignature);
       });
 
-      it('should be able to overwrite existing protocol if timestamp is newer', async () => {
+      it('should store all protocol versions and query should only return the latest', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
         const protocolDefinition = minimalProtocolDefinition;
@@ -140,11 +140,11 @@ export function testProtocolsConfigureHandler(): void {
         const reply1 = await dwn.processMessage(alice.did, middleProtocolsConfigure.message);
         expect(reply1.status.code).to.equal(202);
 
-        // older messages will not overwrite the existing
+        // older messages are also accepted (stored as historical versions)
         const reply2 = await dwn.processMessage(alice.did, oldProtocolsConfigure.message);
-        expect(reply2.status.code).to.equal(409);
+        expect(reply2.status.code).to.equal(202);
 
-        // newer message can overwrite the existing message
+        // newer message is also accepted and becomes the latest
         const newProtocolsConfigure = await TestDataGenerator.generateProtocolsConfigure({
           author: alice,
           protocolDefinition,
@@ -152,7 +152,7 @@ export function testProtocolsConfigureHandler(): void {
         const reply3 = await dwn.processMessage(alice.did, newProtocolsConfigure.message);
         expect(reply3.status.code).to.equal(202);
 
-        // only the newest protocol should remain
+        // only the newest protocol should be returned by query (ProtocolsQuery returns only latest)
         const queryMessageData = await TestDataGenerator.generateProtocolsQuery({
           author : alice,
           filter : { protocol: protocolDefinition.protocol }
@@ -163,7 +163,7 @@ export function testProtocolsConfigureHandler(): void {
         expect(queryReply.entries?.length).to.equal(1);
       });
 
-      it('should only be able to overwrite existing protocol if new protocol is lexicographically larger and timestamps are identical', async () => {
+      it('should store all protocol versions with identical timestamps and query should only return the newest (by CID tiebreak)', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
         // Alter each protocol slightly to create lexicographic difference between them
@@ -214,15 +214,15 @@ export function testProtocolsConfigureHandler(): void {
         const reply1 = await dwn.processMessage(alice.did, middleProtocolsConfigure.message);
         expect(reply1.status.code).to.equal(202);
 
-        // test that the protocol with the smallest lexicographic value cannot be written
+        // all versions are accepted (stored as historical versions)
         const reply2 = await dwn.processMessage(alice.did, lowestProtocolsConfigure.message);
-        expect(reply2.status.code).to.equal(409);
+        expect(reply2.status.code).to.equal(202);
 
-        // test that the protocol with the largest lexicographic value can be written
+        // highest lexicographic value is also accepted and becomes the latest
         const reply3 = await dwn.processMessage(alice.did, highestProtocolsConfigure.message);
         expect(reply3.status.code).to.equal(202);
 
-        // test that lower lexicographic protocol message is removed from DB and only the newer protocol message remains
+        // query should only return the latest protocol definition (highest by CID tiebreak)
         const queryMessageData = await TestDataGenerator.generateProtocolsQuery({
           author : alice,
           filter : { protocol: protocolDefinition1.protocol }
@@ -723,7 +723,7 @@ export function testProtocolsConfigureHandler(): void {
           expect(events[0]).to.equal(messageCid);
         });
 
-        it('should delete older ProtocolsConfigure events when one is overwritten', async () => {
+        it('should retain all ProtocolsConfigure events for protocol versioning', async () => {
           const alice = await TestDataGenerator.generateDidKeyPersona();
           const oldestWrite = await TestDataGenerator.generateProtocolsConfigure({ author: alice, protocolDefinition: minimalProtocolDefinition });
           await Time.minimalSleep();
@@ -736,10 +736,436 @@ export function testProtocolsConfigureHandler(): void {
           expect(reply.status.code).to.equal(202);
 
           const events = await stateIndex.getLeaves(alice.did, []);
-          expect(events.length).to.equal(1);
+          expect(events.length).to.equal(2);
 
+          const oldestMessageCid = await Message.getCid(oldestWrite.message);
           const newestMessageCid = await Message.getCid(newestWrite.message);
-          expect(events[0]).to.equal(newestMessageCid);
+          expect(events).to.include(oldestMessageCid);
+          expect(events).to.include(newestMessageCid);
+        });
+      });
+
+      describe('temporal protocol versioning', () => {
+        it('should authorize records created under v1 even after re-configuring to v2 that removes the type', async () => {
+          // scenario:
+          // 1. Alice installs protocol v1 with types `post` and `comment`
+          // 2. Alice writes a `post` record under v1
+          // 3. Alice re-configures the protocol to v2 which removes the `comment` type
+          // 4. Alice should still be able to read the v1 `post` record
+          // 5. Alice should still be able to update the v1 `post` record (governed by v1 definition)
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+
+          // v1: has `post` and `comment` types
+          const protocolUri = 'https://example.com/versioned-protocol';
+          const protocolDefinitionV1: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post    : { schema: 'https://example.com/post', dataFormats: ['application/json'] },
+              comment : { schema: 'https://example.com/comment', dataFormats: ['application/json'] },
+            },
+            structure: {
+              post: {
+                $actions : [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read, ProtocolAction.Update] }],
+                comment  : {
+                  $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read] }],
+                }
+              }
+            }
+          };
+
+          const configureV1 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV1,
+          });
+          const configureV1Reply = await dwn.processMessage(alice.did, configureV1.message);
+          expect(configureV1Reply.status.code).to.equal(202);
+
+          // write a `post` record under v1
+          const postRecord = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolUri,
+            protocolPath : 'post',
+            schema       : 'https://example.com/post',
+            dataFormat   : 'application/json',
+          });
+          const postReply = await dwn.processMessage(alice.did, postRecord.message, { dataStream: postRecord.dataStream });
+          expect(postReply.status.code).to.equal(202);
+
+          // write a `comment` record under v1
+          const commentRecord = await TestDataGenerator.generateRecordsWrite({
+            author          : alice,
+            protocol        : protocolUri,
+            protocolPath    : 'post/comment',
+            schema          : 'https://example.com/comment',
+            dataFormat      : 'application/json',
+            parentContextId : postRecord.message.contextId,
+          });
+          const commentReply = await dwn.processMessage(alice.did, commentRecord.message, { dataStream: commentRecord.dataStream });
+          expect(commentReply.status.code).to.equal(202);
+
+          await Time.minimalSleep();
+
+          // v2: removes the `comment` type entirely, changes `post` schema
+          const protocolDefinitionV2: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post: { schema: 'https://example.com/post-v2', dataFormats: ['application/json'] },
+            },
+            structure: {
+              post: {
+                $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read, ProtocolAction.Update] }],
+              }
+            }
+          };
+
+          const configureV2 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV2,
+          });
+          const configureV2Reply = await dwn.processMessage(alice.did, configureV2.message);
+          expect(configureV2Reply.status.code).to.equal(202);
+
+          // read the v1 `post` record — should succeed because read authorization uses v1 definition
+          const readPost = await RecordsRead.create({
+            filter : { recordId: postRecord.message.recordId },
+            signer : Jws.createSigner(alice),
+          });
+          const readPostReply = await dwn.processMessage(alice.did, readPost.message);
+          expect(readPostReply.status.code).to.equal(200);
+
+          // read the v1 `comment` record — should succeed (governed by v1 definition where `comment` exists)
+          const readComment = await RecordsRead.create({
+            filter : { recordId: commentRecord.message.recordId },
+            signer : Jws.createSigner(alice),
+          });
+          const readCommentReply = await dwn.processMessage(alice.did, readComment.message);
+          expect(readCommentReply.status.code).to.equal(200);
+
+          // update the v1 `post` record — should succeed (governed by v1 definition)
+          const updatedData = new TextEncoder().encode('{"title":"updated post"}');
+          const updatePost = await RecordsWrite.createFrom({
+            recordsWriteMessage : postRecord.message,
+            data                : updatedData,
+            signer              : Jws.createSigner(alice),
+          });
+          const updatePostReply = await dwn.processMessage(
+            alice.did, updatePost.message, { dataStream: DataStream.fromBytes(updatedData) }
+          );
+          expect(updatePostReply.status.code).to.equal(202);
+        });
+
+        it('should authorize new records against the latest protocol definition, not an older one', async () => {
+          // scenario:
+          // 1. Alice installs protocol v1 with type `post`
+          // 2. Alice re-configures to v2 that changes `post` schema to 'https://example.com/post-v2'
+          // 3. A new record with v1 schema should be rejected (not matching the latest definition)
+          // 4. A new record with v2 schema should be accepted
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolUri = 'https://example.com/versioned-protocol-2';
+          const protocolDefinitionV1: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post: { schema: 'https://example.com/post-v1', dataFormats: ['application/json'] },
+            },
+            structure: {
+              post: {
+                $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read] }],
+              }
+            }
+          };
+
+          const configureV1 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV1,
+          });
+          const configureV1Reply = await dwn.processMessage(alice.did, configureV1.message);
+          expect(configureV1Reply.status.code).to.equal(202);
+
+          await Time.minimalSleep();
+
+          // v2: changes `post` schema
+          const protocolDefinitionV2: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post: { schema: 'https://example.com/post-v2', dataFormats: ['application/json'] },
+            },
+            structure: {
+              post: {
+                $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read] }],
+              }
+            }
+          };
+
+          const configureV2 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV2,
+          });
+          const configureV2Reply = await dwn.processMessage(alice.did, configureV2.message);
+          expect(configureV2Reply.status.code).to.equal(202);
+
+          // write a new record with v1 schema — should fail (latest definition requires v2 schema)
+          const postV1 = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolUri,
+            protocolPath : 'post',
+            schema       : 'https://example.com/post-v1',
+            dataFormat   : 'application/json',
+          });
+          const postV1Reply = await dwn.processMessage(alice.did, postV1.message, { dataStream: postV1.dataStream });
+          expect(postV1Reply.status.code).to.equal(400);
+          expect(postV1Reply.status.detail).to.contain(DwnErrorCode.ProtocolAuthorizationInvalidSchema);
+
+          // write a new record with v2 schema — should succeed
+          const postV2 = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolUri,
+            protocolPath : 'post',
+            schema       : 'https://example.com/post-v2',
+            dataFormat   : 'application/json',
+          });
+          const postV2Reply = await dwn.processMessage(alice.did, postV2.message, { dataStream: postV2.dataStream });
+          expect(postV2Reply.status.code).to.equal(202);
+        });
+
+        it('should authorize deletes of v1 records after re-configuring to v2 that removes the type', async () => {
+          // scenario:
+          // 1. Alice installs protocol v1 with types `post` (with delete action) and `comment`
+          // 2. Alice writes a `post/comment` record
+          // 3. Alice re-configures to v2 which removes the `comment` type
+          // 4. Alice should still be able to delete the v1 `comment` record (governed by v1 definition)
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolUri = 'https://example.com/versioned-protocol-3';
+          const protocolDefinitionV1: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post    : {},
+              comment : {},
+            },
+            structure: {
+              post: {
+                $actions : [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read] }],
+                comment  : {
+                  $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read, ProtocolAction.Delete] }],
+                }
+              }
+            }
+          };
+
+          const configureV1 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV1,
+          });
+          const configureV1Reply = await dwn.processMessage(alice.did, configureV1.message);
+          expect(configureV1Reply.status.code).to.equal(202);
+
+          // write a `post` record
+          const postRecord = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolUri,
+            protocolPath : 'post',
+          });
+          const postReply = await dwn.processMessage(alice.did, postRecord.message, { dataStream: postRecord.dataStream });
+          expect(postReply.status.code).to.equal(202);
+
+          // write a `comment` record under the post
+          const commentRecord = await TestDataGenerator.generateRecordsWrite({
+            author          : alice,
+            protocol        : protocolUri,
+            protocolPath    : 'post/comment',
+            parentContextId : postRecord.message.contextId,
+          });
+          const commentReply = await dwn.processMessage(alice.did, commentRecord.message, { dataStream: commentRecord.dataStream });
+          expect(commentReply.status.code).to.equal(202);
+
+          await Time.minimalSleep();
+
+          // v2: removes the `comment` type
+          const protocolDefinitionV2: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post: {},
+            },
+            structure: {
+              post: {
+                $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read] }],
+              }
+            }
+          };
+
+          const configureV2 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV2,
+          });
+          const configureV2Reply = await dwn.processMessage(alice.did, configureV2.message);
+          expect(configureV2Reply.status.code).to.equal(202);
+
+          // delete the v1 `comment` record — should succeed (governed by v1 definition)
+          const deleteComment = await RecordsDelete.create({
+            signer   : Jws.createSigner(alice),
+            recordId : commentRecord.message.recordId,
+          });
+          const deleteReply = await dwn.processMessage(alice.did, deleteComment.message);
+          expect(deleteReply.status.code).to.equal(202);
+        });
+
+        it('should not retroactively apply v2 action rules to records created under v1', async () => {
+          // scenario:
+          // 1. Alice installs protocol v1 where anyone can create and update `post` records
+          // 2. Bob writes a `post` to Alice's DWN
+          // 3. Alice re-configures to v2 that restricts `post` updates to author-only (removes co-update)
+          // 4. Bob should still be able to update his own record (governed by v1 definition which had update)
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolUri = 'https://example.com/versioned-protocol-4';
+          const protocolDefinitionV1: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post: {},
+            },
+            structure: {
+              post: {
+                $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read, ProtocolAction.Update] }],
+              }
+            }
+          };
+
+          const configureV1 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV1,
+          });
+          const configureV1Reply = await dwn.processMessage(alice.did, configureV1.message);
+          expect(configureV1Reply.status.code).to.equal(202);
+
+          // Bob writes a `post` record to Alice's DWN under v1
+          const postRecord = await TestDataGenerator.generateRecordsWrite({
+            author       : bob,
+            protocol     : protocolUri,
+            protocolPath : 'post',
+          });
+          const postReply = await dwn.processMessage(alice.did, postRecord.message, { dataStream: postRecord.dataStream });
+          expect(postReply.status.code).to.equal(202);
+
+          await Time.minimalSleep();
+
+          // v2: restricts actions (only create, no update for anyone)
+          const protocolDefinitionV2: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post: {},
+            },
+            structure: {
+              post: {
+                $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read] }],
+              }
+            }
+          };
+
+          const configureV2 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV2,
+          });
+          const configureV2Reply = await dwn.processMessage(alice.did, configureV2.message);
+          expect(configureV2Reply.status.code).to.equal(202);
+
+          // Bob updates his v1 record — should succeed because v1 definition (which governs this record) allowed update
+          const updatedData = new TextEncoder().encode('updated-post-data');
+          const updatePost = await RecordsWrite.createFrom({
+            recordsWriteMessage : postRecord.message,
+            data                : updatedData,
+            signer              : Jws.createSigner(bob),
+          });
+          const updateReply = await dwn.processMessage(
+            alice.did, updatePost.message, { dataStream: DataStream.fromBytes(updatedData) }
+          );
+          expect(updateReply.status.code).to.equal(202);
+        });
+
+        it('should handle out-of-order protocol configure processing correctly', async () => {
+          // scenario:
+          // 1. Create v1 and v2 ProtocolsConfigure messages (v2 has a newer timestamp)
+          // 2. Process v2 first, then v1
+          // 3. Both should be stored; query should return only v2 (the latest)
+          // 4. A record written under v2 schema should succeed
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolUri = 'https://example.com/versioned-protocol-5';
+          const protocolDefinitionV1: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post: { schema: 'https://example.com/post-v1', dataFormats: ['application/json'] },
+            },
+            structure: {
+              post: {
+                $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read] }],
+              }
+            }
+          };
+
+          const configureV1 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV1,
+          });
+
+          await Time.minimalSleep();
+
+          const protocolDefinitionV2: ProtocolDefinition = {
+            protocol  : protocolUri,
+            published : true,
+            types     : {
+              post: { schema: 'https://example.com/post-v2', dataFormats: ['application/json'] },
+            },
+            structure: {
+              post: {
+                $actions: [{ who: 'anyone', can: [ProtocolAction.Create, ProtocolAction.Read] }],
+              }
+            }
+          };
+
+          const configureV2 = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinitionV2,
+          });
+
+          // process v2 first (out of order)
+          const configureV2Reply = await dwn.processMessage(alice.did, configureV2.message);
+          expect(configureV2Reply.status.code).to.equal(202);
+
+          // process v1 second (older, arrives later)
+          const configureV1Reply = await dwn.processMessage(alice.did, configureV1.message);
+          expect(configureV1Reply.status.code).to.equal(202);
+
+          // query should return only v2 (the latest)
+          const queryMessageData = await TestDataGenerator.generateProtocolsQuery({
+            author : alice,
+            filter : { protocol: protocolUri }
+          });
+          const queryReply = await dwn.processMessage(alice.did, queryMessageData.message);
+          expect(queryReply.status.code).to.equal(200);
+          expect(queryReply.entries?.length).to.equal(1);
+          expect(queryReply.entries![0].descriptor.definition.types.post.schema).to.equal('https://example.com/post-v2');
+
+          // writing a new record with v2 schema should succeed (latest definition)
+          const postV2 = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolUri,
+            protocolPath : 'post',
+            schema       : 'https://example.com/post-v2',
+            dataFormat   : 'application/json',
+          });
+          const postV2Reply = await dwn.processMessage(alice.did, postV2.message, { dataStream: postV2.dataStream });
+          expect(postV2Reply.status.code).to.equal(202);
         });
       });
     });


### PR DESCRIPTION
## Summary

- **Fix**: `ProtocolsConfigureHandler` previously deleted all older protocol definitions on re-configure, causing existing records to be validated against the latest definition. Records created under an earlier protocol version would fail authorization if the protocol changed (e.g., removed types, tightened action rules, changed schemas).
- **Solution**: Retain all protocol definitions with an `isLatestBaseState` index. Records are authorized against the protocol definition active at their creation time (temporal lookup via `messageTimestamp`). Initial writes validate against the latest definition; updates/reads/deletes use the definition active when the record was first created; queries/subscribes always use the latest.
- **Tests**: 5 new temporal versioning tests covering: v1 records surviving v2 re-configuration, new records validated against latest definition, deletes of v1 records after type removal in v2, non-retroactive action rule changes, and out-of-order protocol configure processing.

## Changes

### `protocols-configure.ts` (Handler)
- Store all protocol versions instead of deleting older ones
- Add `isLatestBaseState` boolean index to track the newest definition
- Re-index existing messages via delete+put pattern (required because `IndexLevel.put()` doesn't clean old entries)
- Older-than-newest messages now return 202 (stored as historical) instead of 409

### `protocol-authorization.ts` (Authorization)
- `fetchProtocolDefinition()` accepts optional `messageTimestamp` for temporal lookup (`lte` range filter + descending sort + limit 1)
- New `getGoverningTimestamp()` helper: returns `undefined` for initial writes (use latest), initial write's timestamp for updates
- `authorizeRead()` and `authorizeDelete()` fetch the initial write's timestamp to determine the governing protocol version
- `authorizeQueryOrSubscribe()` always uses the latest definition (no timestamp parameter)

### `protocols-query.ts` (Query Handler)
- Add `isLatestBaseState: true` to both authenticated and published query filters so queries return only the latest protocol definition

### `protocols-configure.spec.ts` (Tests)
- Updated 3 existing tests for new behavior (202 instead of 409, 2 state index events instead of 1)
- Added 5 new tests under `describe('temporal protocol versioning')`