### PR TITLE
fix(dwn): validate that action rule `of` path is an ancestor at protocol definition time

### DIFF
--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -84,6 +84,7 @@ export enum DwnErrorCode {
   ProtocolsConfigureDuplicateRoleInRuleSet = 'ProtocolsConfigureDuplicateRoleInRuleSet',
   ProtocolsConfigureInvalidSize = 'ProtocolsConfigureInvalidSize',
   ProtocolsConfigureInvalidActionMissingOf = 'ProtocolsConfigureInvalidActionMissingOf',
+  ProtocolsConfigureInvalidActionOfNotAnAncestor = 'ProtocolsConfigureInvalidActionOfNotAnAncestor',
   ProtocolsConfigureInvalidActionOfNotAllowed = 'ProtocolsConfigureInvalidActionOfNotAllowed',
   ProtocolsConfigureInvalidActionDeleteWithoutCreate = 'ProtocolsConfigureInvalidActionDeleteWithoutCreate',
   ProtocolsConfigureInvalidActionUpdateWithoutCreate = 'ProtocolsConfigureInvalidActionUpdateWithoutCreate',

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -933,10 +933,13 @@ export class ProtocolAuthorization {
     );
 
     if (ancestorRecordsWrite === undefined) {
-      // If this is reached, there is likely an issue with the protocol definition.
-      // The protocolPath to the actionRule should start with actionRule.of
-      // consider moving this check to ProtocolsConfigure message ingestion
-      return false;
+      // This should be unreachable for valid protocol definitions because `ProtocolsConfigure.validateRuleSetRecursively()`
+      // now validates that `actionRule.of` is an ancestor of the current protocol path at definition time.
+      throw new DwnError(
+        DwnErrorCode.ProtocolAuthorizationActionNotAllowed,
+        `No ancestor record found with protocol path '${actionRule.of!}' in the record chain. ` +
+        `This indicates an invalid protocol definition that should have been rejected at configuration time.`
+      );
     }
 
     if (actionRule.who === ProtocolActor.Recipient) {

--- a/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
@@ -247,6 +247,20 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
         );
       }
 
+      // Validate that `of` points to the current protocol path or an ancestor of it.
+      // At runtime, `checkActor()` searches the record chain for a matching `protocolPath` equal to `actionRule.of`.
+      // If `of` is not the current path or one of its ancestors, the action rule would silently never authorize anyone.
+      if (actionRule.of !== undefined && ruleSetProtocolPath !== '') {
+        const isSelfOrAncestor = ruleSetProtocolPath === actionRule.of
+          || ruleSetProtocolPath.startsWith(actionRule.of + '/');
+        if (!isSelfOrAncestor) {
+          throw new DwnError(
+            DwnErrorCode.ProtocolsConfigureInvalidActionOfNotAnAncestor,
+            `'of' value '${actionRule.of}' is not an ancestor of protocol path '${ruleSetProtocolPath}' in action rule ${JSON.stringify(actionRule)}.`
+          );
+        }
+      }
+
       // For `who`-based rules with `of`, enforce that read-type actions (read, query, subscribe)
       // are all-or-nothing, same as the role-based rule constraint above.
       if (actionRule.who !== undefined && actionRule.of !== undefined) {

--- a/packages/dwn-sdk-js/tests/handlers/protocols-configure.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/protocols-configure.spec.ts
@@ -592,6 +592,179 @@ export function testProtocolsConfigureHandler(): void {
         expect(withAllReadActionsResponse.status.code).to.equal(202);
       });
 
+      it('should reject ProtocolsConfigure with action rule `of` pointing to a sibling type (not an ancestor)', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        // `bar` and `baz` are siblings under `foo`, so `baz` action rule cannot reference `of: 'foo/bar'`
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://example.com/sibling-of-test',
+          published : true,
+          types     : {
+            foo : {},
+            bar : {},
+            baz : {},
+          },
+          structure: {
+            foo: {
+              bar : {},
+              baz : {
+                $actions: [
+                  {
+                    who : 'author',
+                    of  : 'foo/bar', // sibling, not ancestor
+                    can : [ProtocolAction.Create]
+                  }
+                ]
+              }
+            }
+          }
+        };
+
+        // manually craft the invalid ProtocolsConfigure message because our library will not let you create an invalid definition
+        const descriptor: ProtocolsConfigureDescriptor = {
+          interface        : DwnInterfaceName.Protocols,
+          method           : DwnMethodName.Configure,
+          messageTimestamp : Time.getCurrentTimestamp(),
+          definition       : protocolDefinition
+        };
+
+        const authorization = await Message.createAuthorization({
+          descriptor,
+          signer: Jws.createSigner(alice)
+        });
+        const protocolsConfigureMessage = { descriptor, authorization };
+
+        const reply = await dwn.processMessage(alice.did, protocolsConfigureMessage);
+        expect(reply.status.code).to.equal(400);
+        expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolsConfigureInvalidActionOfNotAnAncestor);
+      });
+
+      it('should reject ProtocolsConfigure with action rule `of` pointing to an unrelated type', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        // `comment` is a top-level type unrelated to the nested `thread/reply` path
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://example.com/unrelated-of-test',
+          published : true,
+          types     : {
+            thread  : {},
+            reply   : {},
+            comment : {},
+          },
+          structure: {
+            thread: {
+              reply: {
+                $actions: [
+                  {
+                    who : 'author',
+                    of  : 'comment', // unrelated type, not an ancestor of 'thread/reply'
+                    can : [ProtocolAction.Create]
+                  }
+                ]
+              }
+            },
+            comment: {}
+          }
+        };
+
+        const descriptor: ProtocolsConfigureDescriptor = {
+          interface        : DwnInterfaceName.Protocols,
+          method           : DwnMethodName.Configure,
+          messageTimestamp : Time.getCurrentTimestamp(),
+          definition       : protocolDefinition
+        };
+
+        const authorization = await Message.createAuthorization({
+          descriptor,
+          signer: Jws.createSigner(alice)
+        });
+        const protocolsConfigureMessage = { descriptor, authorization };
+
+        const reply = await dwn.processMessage(alice.did, protocolsConfigureMessage);
+        expect(reply.status.code).to.equal(400);
+        expect(reply.status.detail).to.contain(DwnErrorCode.ProtocolsConfigureInvalidActionOfNotAnAncestor);
+      });
+
+      it('should accept ProtocolsConfigure with action rule `of` pointing to itself (same protocol path)', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        // `of` pointing to the same protocol path is valid: "the author of this record can update it"
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://example.com/self-of-test',
+          published : true,
+          types     : {
+            foo : {},
+            bar : {},
+          },
+          structure: {
+            foo: {
+              bar: {
+                $actions: [
+                  {
+                    who : 'author',
+                    of  : 'foo/bar', // same as current protocol path — valid self-reference
+                    can : [ProtocolAction.Create]
+                  }
+                ]
+              }
+            }
+          }
+        };
+
+        const protocolsConfigure = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+
+        const reply = await dwn.processMessage(alice.did, protocolsConfigure.message);
+        expect(reply.status.code).to.equal(202);
+      });
+
+      it('should accept ProtocolsConfigure with action rule `of` pointing to a valid ancestor', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        // `of: 'thread'` is a valid ancestor of `thread/reply/reaction`
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://example.com/valid-ancestor-of-test',
+          published : true,
+          types     : {
+            thread   : {},
+            reply    : {},
+            reaction : {},
+          },
+          structure: {
+            thread: {
+              reply: {
+                $actions: [
+                  {
+                    who : 'author',
+                    of  : 'thread', // valid ancestor
+                    can : [ProtocolAction.Create]
+                  }
+                ],
+                reaction: {
+                  $actions: [
+                    {
+                      who : 'author',
+                      of  : 'thread/reply', // valid immediate parent ancestor
+                      can : [ProtocolAction.Create]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        };
+
+        const protocolsConfigure = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+
+        const reply = await dwn.processMessage(alice.did, protocolsConfigure.message);
+        expect(reply.status.code).to.equal(202);
+      });
+
       describe('Grant authorization', () => {
         it('allows an external party to ProtocolsConfigure only if they have a valid grant', async () => {
           // scenario:


### PR DESCRIPTION
## Summary

Closes #96.

- Adds validation in `validateRuleSetRecursively()` that rejects protocol definitions where an action rule's `of` value points to a sibling or unrelated protocol path, rather than the current path or one of its ancestors
- Converts the silent `return false` in `checkActor()` to a defensive throw, since that code path is now unreachable for valid protocols
- Adds 4 new test cases covering sibling rejection, unrelated path rejection, self-reference acceptance, and ancestor acceptance

## Details

When a protocol action rule specifies `who: 'author', of: 'someType'` or `who: 'recipient', of: 'someType'`, the `of` value must refer to the current protocol path or an ancestor in the hierarchy. Previously, an invalid `of` (e.g., pointing to a sibling or unrelated type) would be silently accepted at definition time and then never authorize anyone at runtime — a usability trap where the protocol appears valid but the action rule is dead code.

The validation allows:
- **Self-reference** (`of` equals current path): e.g., `who: 'author', of: 'email'` at path `email` — "the author of this record can read it"
- **Ancestor reference** (`of` is a prefix of current path): e.g., `of: 'thread'` at path `thread/reply` — "the author of the parent thread can create replies"

The validation rejects:
- **Sibling paths**: e.g., `of: 'foo/bar'` at path `foo/baz`
- **Unrelated paths**: e.g., `of: 'comment'` at path `thread/reply`

New error code: `ProtocolsConfigureInvalidActionOfNotAnAncestor`

## Test results

- 894 tests passing, 0 failures
- Lint clean