### PR TITLE
docs: validate and correct documentation against actual codebase state

### DIFF
--- a/BRANCH_PROTECTION_SETUP.md
+++ b/BRANCH_PROTECTION_SETUP.md
@@ -23,7 +23,7 @@ To ensure that all tests pass and coverage doesn't decrease before merging to ma
 
 #### Required Status Checks
 Add these checks (they must run at least once before appearing in the list):
-1. `CI / Test and Coverage (20.x)`
+1. `CI / Test and Coverage`
 2. `CI / CI Success`
 3. `Coverage Comparison / Compare Coverage` (for PRs only)
 
@@ -80,8 +80,8 @@ To modify coverage requirements:
 - Ensure workflow files are in `.github/workflows/`
 
 ### Coverage reports not generating
-- Verify `c8` is installed in package devDependencies
-- Check `.c8rc.json` configuration in each package
+- For packages using `bun test`: coverage is built-in (`bun test --coverage`)
+- For packages using Mocha (`agent`, `api`): verify `c8` is configured if coverage is needed
 - Ensure test commands include coverage generation
 
 ### False coverage decreases

--- a/BUN_MIGRATION_PLAN.md
+++ b/BUN_MIGRATION_PLAN.md
@@ -75,12 +75,25 @@ Full migration from Node.js/npm/pnpm to Bun as runtime, package manager, bundler
 - [x] 9.4 Fixed `process.env.npm_package_*` refs in dwn-server config.ts
 - [x] 9.5 Added `@types/bun` to dwn-sql-store devDeps
 
+## Phase 10: Test Framework Migration -- IN PROGRESS
+
+Migrating from Mocha/Chai to `bun:test` across packages.
+
+- [x] 10.1 `@enbox/common` — migrated to `bun test`
+- [x] 10.2 `@enbox/crypto` — migrated to `bun test`
+- [x] 10.3 `@enbox/dids` — migrated to `bun test`
+- [x] 10.4 `@enbox/dwn-sdk-js` — migrated to `bun test`
+- [x] 10.5 `@enbox/dwn-server` — migrated to `bun test`
+- [x] 10.6 `@enbox/dwn-sql-store` — migrated to `bun test`
+- [ ] 10.7 `@enbox/agent` — still uses Mocha + Chai + Sinon
+- [ ] 10.8 `@enbox/api` — still uses Mocha + Chai
+
 ## Risk Register
 
 | Risk | Severity | Status |
 |------|----------|--------|
 | classic-level N-API compat | HIGH | Test at runtime; fallback plan ready |
 | bun:sqlite API diffs from better-sqlite3 | MEDIUM | Resolved via adapter |
-| Mocha/Chai ESM loader under Bun | MEDIUM | Test at runtime |
+| Mocha/Chai ESM loader under Bun | MEDIUM | Works; agent/api still on Mocha |
 | npm publish provenance support | LOW | Kept npm for publish workflows |
 | esbuild browser plugin compat | LOW | Kept esbuild for now |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,30 +46,56 @@ Before any commits get pushed and PRs opened, ALL of the following MUST pass:
 
 1. **Lint** — `bun run lint` (use `bun run lint:fix` to auto-fix issues)
 2. **Build** — `bun run --filter @enbox/agent build` (rebuild `dwn-sdk-js` first if changed)
-3. **Tests** — `bun run build:tests:node && bunx c8 mocha` from `packages/agent/`
+3. **Tests** — `bun run test:node` from `packages/agent/`
 
 Do not push or open a PR until all three checks pass locally.
 
 ### Running Tests
 
-Agent tests use **Mocha + Chai**, NOT `bun test`. The test pipeline is:
+Most packages use **`bun test`** (Bun's native test runner). The **agent** and **api** packages still use **Mocha + Chai** and require a TypeScript compilation step before running tests.
+
+#### Test framework by package
+
+| Package | Runner | Command (from package dir) |
+|---|---|---|
+| `@enbox/agent` | Mocha + Chai + Sinon | `bun run test:node` |
+| `@enbox/api` | Mocha + Chai | `bun run test:node` |
+| `@enbox/dwn-sdk-js` | `bun test` | `bun run test:node` |
+| `@enbox/dwn-server` | `bun test` | `bun run test` |
+| `@enbox/dwn-sql-store` | `bun test` | `bun run test` |
+| `@enbox/common` | `bun test` | `bun run test:node` |
+| `@enbox/crypto` | `bun test` | `bun run test:node` |
+| `@enbox/dids` | `bun test` | `bun run test:node` |
+
+#### Agent / API tests (Mocha)
 
 ```bash
 # Full agent test suite (from packages/agent/):
 bun run test:node
-# Which runs: rimraf tests/compiled && bun tsc -p tests/tsconfig.json && bunx c8 mocha
+# Which runs: bun run build:tests:node && bunx --bun mocha
 
 # Single test file (from packages/agent/):
-bun run build:tests:node && bunx mocha --spec 'tests/compiled/tests/store-key.spec.js' --timeout 30000 --exit
+bun run build:tests:node && bunx --bun mocha --spec 'tests/compiled/tests/store-key.spec.js' --timeout 30000 --exit
+```
 
-# DWN SDK tests with grep (from packages/dwn-sdk-js/):
+Mocha config is at `packages/agent/.mocharc.json` (10s timeout, `tests/compiled/**/*.spec.js`).
+
+#### DWN SDK / other packages (bun test)
+
+```bash
+# Full DWN SDK test suite (from packages/dwn-sdk-js/):
+bun run test:node
+
+# DWN SDK tests with name filter:
 GREP="ProtocolsConfigure" bun run test:node-grep
+# Which runs: bun test .spec.ts -t $GREP
+
+# Run all tests across the monorepo (from repo root):
+bun run test:node
 
 # Lint all packages (from repo root):
 bun run lint
 ```
-
-Mocha config is at `packages/agent/.mocharc.json` (10s timeout, `tests/compiled/**/*.spec.js`).
 
 **Expect ~66 DHT failures locally** — tests requiring `did:dht` publishing fail without a local Pkarr gateway. CI has one; these pass there.
 
@@ -178,13 +204,18 @@ private async installProtocol(tenant: string, agent: Web5PlatformAgent): Promise
 - Object properties align colons when multiple keys
 - Max line length: 150 characters (strings exempted)
 - Semicolons required, single quotes, trailing commas in multi-line
-- `TODO` comments must reference a GitHub issue
+- `TODO` comments must reference a GitHub issue (enforced in `dwn-sdk-js` and `dwn-server` via `eslint-plugin-todo-plz`)
 
 ## Test Style
 
-### Framework
+### Frameworks
 
-Mocha (`describe`/`it`) + Chai (`expect`) + Sinon (mocks/stubs). Files use `.spec.ts` suffix.
+Two test frameworks are in use:
+
+- **`bun test`** — most packages (common, crypto, dids, dwn-sdk-js, dwn-server, dwn-sql-store). Uses `import { describe, expect, it } from 'bun:test'`. Assertions use `expect(...).toBe(...)`, `expect(...).toThrow(...)`, etc.
+- **Mocha + Chai + Sinon** — `agent` and `api` packages only. Uses `describe`/`it` from Mocha, `expect` from Chai, and Sinon for mocks/stubs.
+
+Files use `.spec.ts` suffix in all packages.
 
 ### Test Structure
 
@@ -202,7 +233,31 @@ describe('DwnKeyStore', () => {
 });
 ```
 
-### Test Harness Pattern
+### bun:test Patterns (dwn-sdk-js, common, crypto, dids, etc.)
+
+```typescript
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import sinon from 'sinon';
+
+describe('ComponentName', () => {
+  beforeEach(() => { /* setup */ });
+  afterAll(() => { /* cleanup */ });
+
+  it('should do something', async () => {
+    expect(result).toBe(expected);
+  });
+
+  it('should throw on invalid input', () => {
+    expect(() => doSomething()).toThrow(DwnErrorCode.SomeErrorCode);
+  });
+
+  it('should reject async errors', async () => {
+    await expect(asyncOperation()).rejects.toThrow('error message');
+  });
+});
+```
+
+### Agent Test Harness Pattern (Mocha — agent/api only)
 
 Agent tests use `PlatformAgentTestHarness` with `TestAgent`:
 
@@ -253,7 +308,13 @@ await harness.agent.start({ password: 'test' });
 
 ### Error Assertions
 
-For async errors, prefer `chai-as-promised`:
+**bun:test** (dwn-sdk-js and most packages):
+```typescript
+expect(() => syncOperation()).toThrow(DwnErrorCode.SomeErrorCode);
+await expect(asyncOperation()).rejects.toThrow('error message');
+```
+
+**Chai** (agent/api only) — prefer `chai-as-promised`:
 ```typescript
 await expect(promise).to.be.rejectedWith(DwnErrorCode.SomeErrorCode);
 ```
@@ -271,7 +332,7 @@ try {
 ### Test Isolation
 
 - Use unique `testDataLocation` per describe block to avoid LevelDB lock conflicts
-- Clean up in `afterEach`/`after` hooks — always close LevelDB handles
+- Clean up in `afterEach`/`after` (Mocha) or `afterAll` (bun:test) hooks — always close LevelDB handles
 - Test data via helper functions and inline construction, not fixture files
 
 ## Architecture Notes

--- a/FLY.md
+++ b/FLY.md
@@ -94,7 +94,7 @@ curl https://enbox-dwn.fly.dev/health
 | `DWN_TTL_CACHE_URL` | PostgreSQL URL for TTL cache |
 | `DWN_STORAGE_MESSAGES` | PostgreSQL URL for message storage |
 | `DWN_STORAGE_DATA` | PostgreSQL URL for data storage |
-| `DWN_STORAGE_STATE_INDEX` | PostgreSQL URL for event storage |
+| `DWN_STORAGE_STATE_INDEX` | PostgreSQL URL for state index (sync state) |
 | `DWN_STORAGE_RESUMABLE_TASKS` | PostgreSQL URL for resumable task storage |
 
 ### Fly.io Auto-Provided Variables

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ For detailed architecture notes, coding style, test patterns, and build instruct
 
 ## Contributing
 
-See the [contribution guide](https://github.com/enboxorg/enbox/blob/main/CONTRIBUTING.md).
+See the contribution guides in individual packages (e.g., [dwn-server](./packages/dwn-server/CONTRIBUTING.md), [dwn-sdk-js](./packages/dwn-sdk-js/CONTRIBUTING.md)).
 
 ## License
 

--- a/WEB_STREAMS_MIGRATION_PLAN.md
+++ b/WEB_STREAMS_MIGRATION_PLAN.md
@@ -48,8 +48,8 @@ support and reducing the dependency footprint.
 │  - DataStoreSql uses Readable from readable-stream              │
 ├─────────────────────────────────────────────────────────────────┤
 │  @enbox/dwn-server                                              │
-│  - HTTP handler passes Express req (Node Readable) as stream    │
-│  - Uses Readable from node:stream in json-rpc-router.ts         │
+│  - HTTP handler uses Bun.serve() (Request body is ReadableStream│
+│    natively — no Express, no Node Readable)                     │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -59,8 +59,7 @@ support and reducing the dependency footprint.
 | dwn-sdk-js        | `readable-stream` 4.5.2     | Core stream primitive          |
 | common            | `readable-stream` 4.5.2     | NodeStream utilities           |
 | dwn-sql-store     | `readable-stream` 4.4.2     | DataStoreSql                   |
-| dwn-server        | `readable-stream` 4.4.2     | HTTP handler                   |
-| dwn-server        | `stream-browserify` (dev)    | Browser test bundling          |
+| dwn-server        | N/A (uses `Bun.serve()`)    | HTTP handler uses native Web Request/Response |
 | agent             | `readable-web-to-node-stream`| Web->Node conversion (REDUNDANT)|
 
 ---
@@ -302,11 +301,7 @@ const bytes = await Stream.consumeToBytes({ readableStream: dataStream });
 
 ### 2.9 Update `@enbox/dwn-server`
 
-The HTTP API currently passes Express `req` (a Node `Readable`) directly. After migration:
-```ts
-// Convert Node request to Web ReadableStream
-const dataStream = NodeStream.toWebReadable({ readable: req });
-```
+> **Note:** The HTTP API has already been migrated from Express to `Bun.serve()`. The `Request` object in Bun's fetch handler natively provides `request.body` as a `ReadableStream`. No conversion is needed at the server boundary.
 
 ### 2.10 Update `@enbox/agent` (inner layer)
 
@@ -343,7 +338,7 @@ Once all usages are migrated:
 | `crypto.createCipheriv` is Node-only | Keep using it wrapped in TransformStream; browser crypto is a separate concern |
 | Breaking change for external DataStore implementations | Bump major version; provide migration guide |
 | `readable-stream` v4 Readable is used as AsyncIterable in for-await-of loops | ReadableStream supports this in modern runtimes; use `Stream.asAsyncIterator()` polyfill |
-| dwn-server Express req is a Node Readable | Convert at HTTP boundary with `NodeStream.toWebReadable()` |
+| dwn-server HTTP boundary | Already resolved — `Bun.serve()` provides Web `Request` with native `ReadableStream` body |
 
 ---
 

--- a/packages/dwn-sql-store/README.md
+++ b/packages/dwn-sql-store/README.md
@@ -19,10 +19,10 @@ SQL backed implementations of DWN `MessageStore`, `DataStore`, and `StateIndex`.
   - [PostgreSQL](#postgresql)
 - [Development](#development)
   - [Prerequisites](#prerequisites)
-    - [`node` and `npm`](#node-and-npm)
+    - [Bun](#bun)
     - [Docker](#docker)
   - [Running Tests](#running-tests)
-  - [`npm` scripts](#npm-scripts)
+  - [Scripts](#scripts)
 
 
 # Supported DBs
@@ -44,15 +44,11 @@ bun add @enbox/dwn-sql-store
 ## SQLite
 
 ```typescript
-import Database from 'better-sqlite3';
-
 import { Dwn } from '@enbox/dwn-sdk-js'
-import { SqliteDialect, MessageStoreSql, DataStoreSql, StateIndexSql } from '@enbox/dwn-sql-store';
+import { createBunSqliteDatabase, SqliteDialect, MessageStoreSql, DataStoreSql, StateIndexSql } from '@enbox/dwn-sql-store';
 
 const sqliteDialect = new SqliteDialect({
-  database: async () => new Database('dwn.sqlite', {
-    fileMustExist: true,
-  })
+  database: async () => createBunSqliteDatabase('dwn.sqlite'),
 });
 
 const messageStore = new MessageStoreSql(sqliteDialect);


### PR DESCRIPTION
## Summary

- Audited all documentation files against the actual codebase and fixed 10 inaccuracies across 7 files that accumulated as the codebase evolved (bun:test migration, better-sqlite3 removal, Express-to-Bun.serve migration)
- Significantly improved CLAUDE.md with accurate per-package test framework table, bun:test patterns, and corrected commands
- Fixed stale references in dwn-sql-store README, FLY.md, BUN_MIGRATION_PLAN.md, BRANCH_PROTECTION_SETUP.md, WEB_STREAMS_MIGRATION_PLAN.md, and root README

## Changes by file

### CLAUDE.md
- Correct test command (`bunx c8 mocha` -> `bunx --bun mocha`)
- Add per-package test framework table showing 6/9 packages now use `bun:test`
- Add `bun:test` patterns section with import/assertion/lifecycle examples
- Separate DWN SDK (`bun test`) and agent (Mocha) test instructions
- Scope `TODO`-must-reference-issue ESLint rule to `dwn-sdk-js` and `dwn-server` only
- Add `bun:test` error assertion patterns alongside existing Chai patterns

### dwn-sql-store/README.md
- Replace stale `better-sqlite3` import with `createBunSqliteDatabase` from `bun:sqlite` adapter
- Fix `node`/`npm` references to `bun` in table of contents

### FLY.md
- Correct `DWN_STORAGE_STATE_INDEX` description from "event storage" to "state index (sync state)"

### README.md
- Fix broken `CONTRIBUTING.md` link (root file doesn't exist) — point to package-level guides

### BUN_MIGRATION_PLAN.md
- Add Phase 10 tracking `bun:test` migration status per package

### BRANCH_PROTECTION_SETUP.md
- Remove stale `(20.x)` Node version from CI check name
- Update coverage troubleshooting for `bun test --coverage` vs Mocha/c8

### WEB_STREAMS_MIGRATION_PLAN.md
- Update architecture diagram, dependency table, plan section, and risk matrix to reflect `Bun.serve()` (not Express)