### PR TITLE
fix(dwn): unskip critical tests — add JSON schema validation to RecordsWrite.parse() and fix MessagesSubscribe grant-scope test

### DIFF
--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -291,6 +291,14 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     // Make a copy so that the stored copy is not subject to external, unexpected modification.
     const message = JSON.parse(JSON.stringify(recordsWriteMessage)) as RecordsWriteMessage;
 
+    // Validate the message against the JSON schema.
+    // We strip internal properties that the MessageStore may attach to stored messages
+    // but are not part of the RecordsWrite JSON schema:
+    //   - `encodedData`:  base64url-encoded payload for small records
+    //   - `initialWrite`: the initial RecordsWrite when this message is an update
+    const { encodedData: _, initialWrite: __, ...messageToValidate } = message as RecordsWriteMessage & Record<string, unknown>;
+    Message.validateJsonSchema(messageToValidate);
+
     // asynchronous checks that are required by the constructor to initialize members properly
 
     await Message.validateSignatureStructure(message.authorization.signature, message.descriptor, 'RecordsWriteSignaturePayload');

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -308,12 +308,12 @@ export function testMessagesSubscribeHandler(): void {
           expect(bobReply.status.detail).toContain(DwnErrorCode.GrantAuthorizationInterfaceMismatch);
         });
 
-        it.skip('rejects subscribe of messages with mismatching method grant scopes', async () => {
+        it('rejects subscribe of messages with mismatching method grant scopes', async () => {
           const alice = await TestDataGenerator.generateDidKeyPersona();
           const bob = await TestDataGenerator.generateDidKeyPersona();
 
           // create grant that is scoped to `MessagesSync` for bob
-          const { recordsWrite: grantWrite, dataStream } = await TestDataGenerator.generateGrantCreate({
+          const { message: grantMessage, dataStream } = await TestDataGenerator.generateGrantCreate({
             author    : alice,
             grantedTo : bob,
             scope     : {
@@ -321,14 +321,13 @@ export function testMessagesSubscribeHandler(): void {
               method    : DwnMethodName.Sync,
             }
           });
-          const grantWriteReply = await dwn.processMessage(alice.did, grantWrite.message, { dataStream });
-          expect(grantWriteReply.status.code).toBe(204);
-
+          const grantReply = await dwn.processMessage(alice.did, grantMessage, { dataStream });
+          expect(grantReply.status.code).toBe(202);
 
           // bob attempts to use the `MessagesSync` grant on an `MessagesSubscribe` message
           const { message: bobSubscribe } = await TestDataGenerator.generateMessagesSubscribe({
             author            : bob,
-            permissionGrantId : grantWrite.message.recordId
+            permissionGrantId : grantMessage.recordId
           });
           const bobReply = await dwn.processMessage(alice.did, bobSubscribe);
           expect(bobReply.status.code).toBe(401);

--- a/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
@@ -364,7 +364,7 @@ describe('RecordsWrite', () => {
   });
 
   describe('parse()', () => {
-    it.skip('should invoke JSON schema validation when parsing a RecordsWrite', async () => {
+    it('should invoke JSON schema validation when parsing a RecordsWrite', async () => {
       const alice = await TestDataGenerator.generatePersona();
 
       const recordsWrite = await RecordsWrite.create({


### PR DESCRIPTION
## Summary

- Add `Message.validateJsonSchema()` to `RecordsWrite.parse()` — it was the **only** DWN interface lacking schema validation in both `parse()` and `create()`
- Fix and unskip the `MessagesSubscribe` method-mismatch grant authorization test, which had been skipped since the upstream import with two bugs

Closes #121

## Changes

### 1. `RecordsWrite.parse()` — add JSON schema validation

`RecordsWrite` was the only DWN interface class that called `Message.validateJsonSchema()` in neither `parse()` nor `create()`. This meant the 9 internal callsites to `RecordsWrite.parse()` (in `createFrom()`, `auth.ts`, `storage-controller.ts`, `protocol-authorization.ts`, handlers, etc.) had no schema validation — they relied on the DWN entry-point validation in `Dwn.validateMessageIntegrity()` having already run.

The fix adds `Message.validateJsonSchema()` to `parse()`, stripping internal store-only properties (`encodedData` and `initialWrite`) before validation since those are added by the MessageStore after the message is created but are not part of the RecordsWrite JSON schema.

**File:** `packages/dwn-sdk-js/src/interfaces/records-write.ts`
**Test unskipped:** `packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts:367`

### 2. `MessagesSubscribe` method-mismatch grant test — fix bugs and unskip

This test was imported from the upstream project with `xit` (Mocha skip) and has been skipped since day one. It had two bugs:
1. Wrong destructuring: `{ recordsWrite: grantWrite, dataStream }` → `{ message: grantMessage, dataStream }`
2. Wrong status code: `204` → `202` (RecordsWrite handler returns 202 Accepted)

The underlying `GrantAuthorization.verifyGrantScopeInterfaceAndMethod()` logic is fully implemented and works correctly — the mirror test in `messages-sync.spec.ts` (method mismatch in the opposite direction) already passes.

**File:** `packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts:311`

## Verification

- `bun run test:node` in `packages/dwn-sdk-js/`: **927 pass, 0 fail** (5 remaining skips are known future-work placeholders tracked in #122)
- `bun run lint`: all 9 packages pass