### PR TITLE
fix(agent): conditionally skip DWN-specific DidStore tests for InMemoryDidStore only

### DIFF
--- a/packages/agent/tests/store-did.spec.ts
+++ b/packages/agent/tests/store-did.spec.ts
@@ -36,6 +36,9 @@ describe('DidStore', () => {
   [DwnDidStore, InMemoryDidStore].forEach((DidStore) => {
     describe(DidStore.name, () => {
       let didStore: AgentDataStore<PortableDid>;
+      const isDwnStore = DidStore === DwnDidStore;
+      // Tests that assert DWN-specific signing behavior are not relevant for InMemoryDidStore.
+      const dwnIt = isDwnStore ? it : it.skip;
 
       beforeEach(async () => {
         didStore = new DidStore();
@@ -80,10 +83,7 @@ describe('DidStore', () => {
           expect(deleteResult).toBe(false);
         });
 
-        it.skip('throws an error if no keys exist for specified DID', async () => {
-          // Skip this test for InMemoryDidStore, as checking for keys to sign DWN messages is not
-          // relevant given that the store is in-memory.
-
+        dwnIt('throws an error if no keys exist for specified DID', async () => {
           try {
             await didStore.delete({
               id     : 'did:jwk:eyJrdHkiOiJFQyIsInVzZSI6InNpZyIsImNydiI6InNlY3AyNTZrMSIsImtpZCI6ImkzU1BSQnRKS292SEZzQmFxTTkydGk2eFFDSkxYM0U3WUNld2lIVjJDU2ciLCJ4IjoidmRyYnoyRU96dmJMRFZfLWtMNGVKdDdWSS04VEZaTm1BOVlnV3p2aGg3VSIsInkiOiJWTEZxUU1aUF9Bc3B1Y1hvV1gyLWJHWHBBTzFmUTVMbjE5VjVSQXhyZ3ZVIiwiYWxnIjoiRVMyNTZLIn0',
@@ -122,10 +122,7 @@ describe('DidStore', () => {
           expect(storedDid).toBeUndefined();
         });
 
-        it.skip('throws an error if no keys exist for specified DID', async () => {
-          // Skip this test for InMemoryDidStore, as checking for keys to sign DWN messages is not
-          // relevant given that the store is in-memory.
-
+        dwnIt('throws an error if no keys exist for specified DID', async () => {
           try {
             await didStore.get({
               id     : 'did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IjNFQmFfRUxvczJhbHZMb2pxSVZjcmJLcGlyVlhqNmNqVkQ1djJWaHdMejgifQ',
@@ -204,10 +201,7 @@ describe('DidStore', () => {
           expect(storedDids).toHaveLength(0);
         });
 
-        it.skip('throws an error if the DID records exceed the DWN maximum data size for query results', async () => {
-          // Skip this test for InMemoryDidStore, as the in-memory store returns all records
-          // regardless of the size of the data.
-
+        dwnIt('throws an error if the DID records exceed the DWN maximum data size for query results', async () => {
           const didBytes = Convert.string(new Array(102400 + 1).join('0')).toUint8Array();
 
           // since we are writing directly to the dwn we first initialize the storage protocol
@@ -339,10 +333,7 @@ describe('DidStore', () => {
           }
         });
 
-        it.skip('throws an error if no keys exist for specified DID', async () => {
-          // Skip this test for InMemoryDidStore, as checking for keys to sign DWN messages is not
-          // relevant given that the store is in-memory.
-
+        dwnIt('throws an error if no keys exist for specified DID', async () => {
           // Generate a new DID.
           const bearerDid = await DidJwk.create();
 


### PR DESCRIPTION
## Summary

- Restore 4 `DwnDidStore` tests that were unconditionally `it.skip`'d due to shared test loop structure
- Tests now run for `DwnDidStore` and skip only for `InMemoryDidStore` where DWN signing behavior is irrelevant

Closes #124

## Problem

`store-did.spec.ts` iterates over `[DwnDidStore, InMemoryDidStore]` and runs the same test block for both. Four tests that assert DWN-specific signing behavior (e.g., "throws when no keys exist for specified DID") were marked `it.skip` with comments saying they should be skipped for `InMemoryDidStore` — but the skip was unconditional, so the `DwnDidStore` path never ran either.

## Solution

Introduce a `dwnIt` helper at the top of the loop:

```typescript
const isDwnStore = DidStore === DwnDidStore;
const dwnIt = isDwnStore ? it : it.skip;
```

Replace the 4 `it.skip` calls with `dwnIt`, so the tests execute for `DwnDidStore` and are properly skipped for `InMemoryDidStore`.

## Verification

- `bun test tests/store-did.spec.ts`: **28 pass, 4 skip, 0 fail** (previously 24 pass, 8 skip)
- The 4 skips are correctly the `InMemoryDidStore` variants only
- `bun run lint`: all 9 packages pass