### PR TITLE
fix: use bun publish to resolve workspace:* deps on npm publish

### DIFF
--- a/.changeset/fix-workspace-deps.md
+++ b/.changeset/fix-workspace-deps.md
@@ -1,0 +1,11 @@
+---
+"@enbox/agent": patch
+"@enbox/api": patch
+---
+
+fix: republish with resolved workspace dependencies
+
+The previous releases of @enbox/agent@0.1.0 and @enbox/api@0.0.3 contained
+literal `workspace:*` strings in their published dependencies, making them
+uninstallable outside the monorepo. This patch release uses `bun publish`
+which correctly resolves workspace references to actual version numbers.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,9 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          # Uses bun publish (via scripts/publish.sh) instead of changeset publish
+          # because changeset publish calls npm publish, which does NOT resolve
+          # Bun's workspace:* protocol — resulting in broken packages on npm.
           publish: bun run release
           version: bun run version
           commit: "chore: version packages"
@@ -62,3 +65,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # bun publish reads the npm token from bunfig or NPM_CONFIG_TOKEN
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "bun run --filter '*' lint:fix",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "bun run build && changeset publish"
+    "release": "bun run build && ./scripts/publish.sh"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+# Custom publish script that uses `bun publish` instead of `changeset publish`.
+#
+# Changesets' built-in publish uses `npm publish` which does NOT resolve Bun's
+# `workspace:*` protocol in dependencies. This results in broken packages on npm
+# that contain literal "workspace:*" strings. Bun's publish command resolves
+# workspace references to actual version numbers before publishing.
+#
+# This script:
+# 1. Checks each public package to see if its current version is already on npm
+# 2. If not published yet, runs `bun publish` (which resolves workspace:*)
+# 3. Creates git tags in the format expected by Changesets
+
+PACKAGES=(
+  "packages/common"
+  "packages/crypto"
+  "packages/dids"
+  "packages/dwn-sdk-js"
+  "packages/agent"
+  "packages/api"
+  "packages/browser"
+  "packages/dwn-sql-store"
+)
+
+published=0
+failed=0
+
+for pkg_dir in "${PACKAGES[@]}"; do
+  if [ ! -f "$pkg_dir/package.json" ]; then
+    echo "Skipping $pkg_dir (no package.json)"
+    continue
+  fi
+
+  name=$(bun -e "console.log(require('./$pkg_dir/package.json').name)")
+  version=$(bun -e "console.log(require('./$pkg_dir/package.json').version)")
+  private=$(bun -e "console.log(require('./$pkg_dir/package.json').private || false)")
+
+  if [ "$private" = "true" ]; then
+    echo "Skipping $name (private)"
+    continue
+  fi
+
+  # Check if this version is already published
+  existing=$(npm view "$name@$version" version 2>/dev/null || echo "")
+  if [ "$existing" = "$version" ]; then
+    echo "Skipping $name@$version (already published)"
+    continue
+  fi
+
+  echo "Publishing $name@$version from $pkg_dir..."
+  if (cd "$pkg_dir" && bun publish --access public); then
+    echo "Published $name@$version"
+    published=$((published + 1))
+
+    # Create a git tag matching Changesets convention
+    tag="$name@$version"
+    git tag -a "$tag" -m "$tag" 2>/dev/null || echo "Tag $tag already exists"
+  else
+    echo "Failed to publish $name@$version"
+    failed=$((failed + 1))
+  fi
+done
+
+echo ""
+echo "Published: $published, Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

The previous release published `@enbox/agent@0.1.0` and `@enbox/api@0.0.3` with literal `workspace:*` in their npm dependencies, making them **uninstallable** outside the monorepo. This happened because `changeset publish` calls `npm publish`, which does not resolve Bun's `workspace:` protocol.

## Changes

- **`scripts/publish.sh`** — custom publish script that iterates over each public package and uses `bun publish` (which resolves `workspace:*` to actual version numbers). Also creates git tags in the Changesets convention.
- **`package.json`** — updated `release` script to use `./scripts/publish.sh` instead of `changeset publish`
- **`.github/workflows/release.yml`** — added `NPM_CONFIG_TOKEN` env var so `bun publish` can authenticate, plus comments explaining the approach
- **`.changeset/fix-workspace-deps.md`** — patch bump for `@enbox/agent` (0.1.0 -> 0.1.1) and `@enbox/api` (0.0.3 -> 0.0.4) so corrected packages can be published (npm does not allow overwriting)

## Sequence after merge

1. Changesets action detects the changeset and creates a "version packages" PR
2. Merging that PR triggers the release job, which now uses `bun publish`
3. `@enbox/agent@0.1.1` and `@enbox/api@0.0.4` are published with correct resolved dependencies
4. Demo apps (`dapp-demo`, `web-wallet`) can then be updated to use the fixed versions