### PR TITLE
fix: unskip platform-incompatibility tests — AES-192 and ws onerror handler

### DIFF
--- a/packages/agent/tests/crypto-api.spec.ts
+++ b/packages/agent/tests/crypto-api.spec.ts
@@ -62,9 +62,7 @@ describe('AgentCryptoApi', () => {
       }
     });
 
-    it.skip('supports A192GCM in all supported runtimes except Chrome browser', async () => {
-      // Google Chrome does not support AES with 192-bit keys.
-
+    it('supports A192GCM in all supported runtimes except Chrome browser', async () => {
       for (const algorithm of ['A192GCM'] as const) {
         // Setup.
         const privateKeyInput = await cryptoApi.generateKey({ algorithm });
@@ -96,9 +94,7 @@ describe('AgentCryptoApi', () => {
       }
     });
 
-    it.skip('supports A192KW in all supported runtimes except Chrome browser', async () => {
-      // Google Chrome does not support AES with 192-bit keys.
-
+    it('supports A192KW in all supported runtimes except Chrome browser', async () => {
       for (const algorithm of ['A192KW'] as const) {
         // Setup.
         const privateKeyInput = await cryptoApi.generateKey({ algorithm });

--- a/packages/dwn-server/tests/json-rpc-socket.test.ts
+++ b/packages/dwn-server/tests/json-rpc-socket.test.ts
@@ -263,28 +263,33 @@ describe('JsonRpcSocket', () => {
     expect(logMessage).toBe('JSON RPC Socket close ws://127.0.0.1:9003');
   });
 
-  // Skip under Bun: ws EventEmitter 'error' event handling is incompatible with Bun's runtime.
-  // The `socket.emit('error', ...)` call throws "Unhandled error" before the registered handler runs.
-  it.skip('calls onerror handler', async () => {
+  it('calls onerror handler', async () => {
+    // Trigger a real connection error by connecting to a port with no server.
+    // This exercises the onerror handler through the ws library's own internal
+    // error path rather than raw EventEmitter emit(), which is incompatible with Bun.
+    const badUrl = 'ws://127.0.0.1:19999';
+
     // test injected handler
     const onErrorHandler = { onerror: ():void => {} };
     const onErrorSpy = spyOn(onErrorHandler, 'onerror');
-    const client = await JsonRpcSocket.connect('ws://127.0.0.1:9003', { onerror: onErrorHandler.onerror });
-    client['socket'].emit('error', 'some error');
-
-    await new Promise((resolve) => setTimeout(resolve, 5)); // wait for close event to arrive
+    try {
+      await JsonRpcSocket.connect(badUrl, { onerror: onErrorHandler.onerror, connectTimeout: 2000 });
+    } catch {
+      // expected — connection refused
+    }
     expect(onErrorSpy).toHaveBeenCalledTimes(1);
 
     // test default logger
-    const logInfoSpy = spyOn(log, 'error');
-    const defaultClient = await JsonRpcSocket.connect('ws://127.0.0.1:9003');
-    defaultClient['socket'].emit('error', 'some error');
-
-    await new Promise((resolve) => setTimeout(resolve, 5)); // wait for close event to arrive
-    expect(logInfoSpy).toHaveBeenCalledTimes(1);
+    const logErrorSpy = spyOn(log, 'error');
+    try {
+      await JsonRpcSocket.connect(badUrl, { connectTimeout: 2000 });
+    } catch {
+      // expected — connection refused
+    }
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
 
     // extract log message from argument
-    const logMessage:string = logInfoSpy.mock.calls[0][0]!;
-    expect(logMessage).toBe('JSON RPC Socket error ws://127.0.0.1:9003');
+    const logMessage:string = logErrorSpy.mock.calls[0][0]!;
+    expect(logMessage).toBe(`JSON RPC Socket error ${badUrl}`);
   });
 });


### PR DESCRIPTION
## Summary

- Unskip 2 AES-192 crypto tests that were unnecessarily skipped under Bun
- Rewrite the ws `onerror` handler test to work under Bun by triggering real connection errors

Closes #123

## Changes

### 1. AES-192 tests unskipped (agent)

**File:** `packages/agent/tests/crypto-api.spec.ts:65, 99`

Two tests (`supports A192GCM...` and `supports A192KW...`) were `it.skip`'d with comments about Chrome's WebCrypto API not supporting AES with 192-bit keys. Since the test runner is Bun (which fully supports AES-192), the skip was unnecessary — a leftover from when these tests may have also run in a browser context.

Simply removed the `.skip` and the stale comment. Both tests pass.

### 2. ws onerror handler test rewritten (dwn-server)

**File:** `packages/dwn-server/tests/json-rpc-socket.test.ts:268`

The original test used `client['socket'].emit('error', 'some error')` to synthetically trigger an error event. This is incompatible with Bun's EventEmitter, which throws "Unhandled error" before registered `addEventListener` wrappers run.

The fix triggers errors naturally by connecting to a port with no server (`ws://127.0.0.1:19999`). This exercises the `onerror` handler through ws's own internal error path (the same path real errors take in production), making the test both Bun-compatible and more realistic.

**Note:** The 2 CORS tests in `packages/dwn-server/tests/cors.spec.ts` that use `this.skip()` when Chrome/Puppeteer is unavailable are already correctly implemented as conditional runtime skips — no changes needed.

## Verification

- `bun test tests/crypto-api.spec.ts` (agent): **31 pass, 0 fail** (was 29 pass, 2 skip)
- `bun test tests/json-rpc-socket.test.ts` (dwn-server): **11 pass, 0 fail** (was 10 pass, 1 skip)
- `bun run lint`: all 9 packages pass