### PR TITLE
fix: regenerate lockfile after version bumps and republish api

### DIFF
--- a/.changeset/fix-api-agent-dep.md
+++ b/.changeset/fix-api-agent-dep.md
@@ -1,0 +1,13 @@
+---
+"@enbox/api": patch
+---
+
+fix: republish with correct @enbox/agent dependency version
+
+The previous @enbox/api@0.0.4 was published with a dependency on
+@enbox/agent@0.1.0 (which has broken workspace:* references) instead of
+@enbox/agent@0.1.1. This happened because the lockfile was stale when
+bun pm pack resolved the workspace:* reference.
+
+The release workflow now regenerates the lockfile after version bumps
+to prevent this from recurring.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,14 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          # Uses bun publish (via scripts/publish.sh) instead of changeset publish
-          # because changeset publish calls npm publish, which does NOT resolve
-          # Bun's workspace:* protocol — resulting in broken packages on npm.
+          # Uses bun pack + npm publish (via scripts/publish.sh) instead of
+          # changeset publish because changeset publish calls npm publish on the
+          # raw package dir, which does NOT resolve Bun's workspace:* protocol.
+          # See: https://github.com/oven-sh/bun/issues/24124
           publish: bun run release
-          version: bun run version
+          # After changeset version bumps package.json files, regenerate the
+          # lockfile so bun pm pack resolves workspace:* to the new versions.
+          version: bun run version && bun install
           commit: "chore: version packages"
           title: "chore: version packages"
         env:


### PR DESCRIPTION
## Summary

`@enbox/api@0.0.4` was published with a dependency on `@enbox/agent@0.1.0` (broken, has `workspace:*`) instead of `@enbox/agent@0.1.1` (clean). This happened because `changeset version` bumped `package.json` files but didn't regenerate the lockfile, so `bun pm pack` resolved `workspace:*` using the stale lock.

## Changes

1. **`.github/workflows/release.yml`** — the `version` command now runs `bun install --no-frozen-lockfile` after `changeset version` to regenerate the lockfile with correct internal dependency versions
2. **`.changeset/fix-api-agent-dep.md`** — patch bump for `@enbox/api` (0.0.4 -> 0.0.5) so it gets republished with the correct `@enbox/agent@0.1.1` dependency

## After merge

1. Changesets creates "version packages" PR bumping api to 0.0.5
2. Merging that PR triggers publish — this time with a fresh lockfile
3. `@enbox/api@0.0.5` is published with `@enbox/agent@0.1.1` (clean)
4. Demo apps can install cleanly