### PR TITLE
fix: move lockfile regeneration into version script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,9 @@ jobs:
           # raw package dir, which does NOT resolve Bun's workspace:* protocol.
           # See: https://github.com/oven-sh/bun/issues/24124
           publish: bun run release
-          # After changeset version bumps package.json files, regenerate the
-          # lockfile so bun pm pack resolves workspace:* to the new versions.
-          version: bun run version && bun install
+          # The version script runs changeset version then bun install to
+          # regenerate the lockfile so workspace:* resolves to new versions.
+          version: bun run version
           commit: "chore: version packages"
           title: "chore: version packages"
         env:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "bun run --filter '*' lint",
     "lint:fix": "bun run --filter '*' lint:fix",
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "changeset version && bun install",
     "release": "bun run build && ./scripts/publish.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

The previous attempt (#135) to regenerate the lockfile after versioning failed because the changesets/action passed `bun run version && bun install` directly to bun's script runner, which treated `&&` as arguments to `changeset` instead of a shell operator:

```
$ changeset version "&&" bun install
error: Too many arguments passed to changesets
```

## Fix

Move `&& bun install` into the `version` script in `package.json`:
```json
"version": "changeset version && bun install"
```

When `bun run version` executes this, it runs through a shell that correctly interprets `&&`. The workflow just calls `bun run version`.