### PR TITLE
fix: resolve workspace:* from package.json instead of stale lockfile

### DIFF
--- a/.changeset/fix-api-agent-dep-v2.md
+++ b/.changeset/fix-api-agent-dep-v2.md
@@ -1,0 +1,9 @@
+---
+"@enbox/api": patch
+---
+
+fix: republish with correct @enbox/agent@0.1.1 dependency
+
+Previous attempts resolved workspace:* to @enbox/agent@0.1.0 because bun
+kept the stale lockfile resolution. This release regenerates the lockfile
+from scratch so workspace:* correctly resolves to @enbox/agent@0.1.1.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -8,8 +8,12 @@ set -e
 # in broken packages on npm with literal "workspace:*" strings.
 #
 # This script uses a two-step approach:
-# 1. `bun pm pack` — creates a tarball with workspace:* resolved to real versions
+# 1. Resolve workspace:* deps to real versions, then `bun pm pack`
 # 2. `npm publish <tarball>` — publishes the tarball (npm handles auth via .npmrc)
+#
+# We resolve workspace:* ourselves because `bun pm pack` reads versions from the
+# lockfile, and Bun's lockfile caches stale workspace versions that `bun install`
+# won't refresh (the specifier workspace:* doesn't change when a version bumps).
 #
 # We use npm for the publish step because `bun publish` has an authentication bug
 # in v1.3.x where it fails to read credentials from .npmrc in CI environments:
@@ -26,6 +30,72 @@ PACKAGES=(
   "packages/browser"
   "packages/dwn-sql-store"
 )
+
+# resolve_workspace_deps <package.json path>
+#
+# Replaces "workspace:*" dependency values with the actual version from the
+# corresponding workspace package's package.json. Backs up the original file
+# to <path>.bak before modifying.
+resolve_workspace_deps() {
+  local pkg_json="$1"
+  cp "$pkg_json" "$pkg_json.bak"
+
+  node -e "
+    const fs = require('fs');
+    const path = require('path');
+
+    // Build a map of workspace package names to their actual versions
+    const workspaceDirs = $(printf "'%s'," "${PACKAGES[@]}" | sed 's/,$//; s/^/[/; s/$/]/')
+    const versions = {};
+    for (const dir of workspaceDirs) {
+      try {
+        const wp = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+        versions[wp.name] = wp.version;
+      } catch {}
+    }
+
+    // Resolve workspace:* references in the target package.json
+    const pkg = JSON.parse(fs.readFileSync('$pkg_json', 'utf8'));
+    let changed = false;
+    for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      const deps = pkg[depType];
+      if (!deps) continue;
+      for (const [name, value] of Object.entries(deps)) {
+        if (typeof value === 'string' && value.startsWith('workspace:')) {
+          const resolved = versions[name];
+          if (resolved) {
+            deps[name] = resolved;
+            changed = true;
+          }
+        }
+      }
+    }
+    if (changed) {
+      fs.writeFileSync('$pkg_json', JSON.stringify(pkg, null, 2) + '\n');
+    }
+  "
+}
+
+# restore_package_json <package.json path>
+#
+# Restores the original package.json from the .bak copy.
+restore_package_json() {
+  local pkg_json="$1"
+  if [ -f "$pkg_json.bak" ]; then
+    mv "$pkg_json.bak" "$pkg_json"
+  fi
+}
+
+# Restore any .bak files on exit (in case the script is interrupted between
+# resolve_workspace_deps and restore_package_json).
+cleanup() {
+  for pkg_dir in "${PACKAGES[@]}"; do
+    if [ -f "$pkg_dir/package.json.bak" ]; then
+      mv "$pkg_dir/package.json.bak" "$pkg_dir/package.json"
+    fi
+  done
+}
+trap cleanup EXIT
 
 published=0
 failed=0
@@ -54,8 +124,11 @@ for pkg_dir in "${PACKAGES[@]}"; do
 
   echo "Publishing $name@$version from $pkg_dir..."
 
-  # Step 1: Pack with bun (resolves workspace:* to actual versions)
-  tarball=$(cd "$pkg_dir" && bun pm pack 2>&1 | grep '\.tgz$' | tr -d '[:space:]')
+  # Step 1: Resolve workspace:* to real versions and pack
+  resolve_workspace_deps "$pkg_dir/package.json"
+  tarball=$(cd "$pkg_dir" && bun pm pack 2>&1 | grep '\.tgz$' | tr -d '[:space:]') || true
+  restore_package_json "$pkg_dir/package.json"
+
   if [ -z "$tarball" ] || [ ! -f "$pkg_dir/$tarball" ]; then
     echo "Failed to pack $name@$version"
     failed=$((failed + 1))


### PR DESCRIPTION
## Summary

- **Resolve `workspace:*` deps ourselves** in `scripts/publish.sh` instead of relying on `bun pm pack`'s stale lockfile resolution
- **Add changeset** to bump `@enbox/api` to 0.0.6 so it publishes with correct `@enbox/agent@0.1.1` dependency

## Problem

`bun pm pack` reads workspace versions from `bun.lock`, but Bun never refreshes those cached versions when a workspace package's version field changes — the dep specifier `workspace:*` stays the same, so `bun install` reports "no changes." This caused `@enbox/api@0.0.4` and `0.0.5` to ship with `@enbox/agent@0.1.0` (broken) instead of `0.1.1`.

## Fix

Before packing each package, the publish script now:
1. Backs up the original `package.json`
2. Reads the actual version from each workspace package's `package.json`
3. Replaces `workspace:*` references with real version numbers
4. Runs `bun pm pack` (which now sees the correct versions)
5. Restores the original `package.json` (with a trap for cleanup on interruption)

This avoids the previous approaches of either:
- Deleting `bun.lock` (risks upgrading all transitive deps)
- Putting `rm -f bun.lock` in the version script (same problem, plus pollutes committed lockfile)

## Changes

| File | Change |
|---|---|
| `scripts/publish.sh` | Add `resolve_workspace_deps` / `restore_package_json` functions, cleanup trap |
| `.changeset/fix-api-agent-dep-v2.md` | Patch bump for `@enbox/api` to trigger republish |