### PR TITLE
test(api): implement Protocol.toJSON() test and delete stale encryption callback stubs

### DIFF
--- a/packages/api/tests/protocol.spec.ts
+++ b/packages/api/tests/protocol.spec.ts
@@ -94,6 +94,29 @@ describe('Protocol', () => {
   });
 
   describe('toJSON()', () => {
-    it.skip('should return all defined properties');
+    it('should return all defined properties', async () => {
+      const protocolUri = `http://example.com/protocol/${TestDataGenerator.randomString(15)}`;
+      const { status, protocol: aliceProtocol } = await dwnAlice.protocols.configure({
+        message: {
+          definition: {
+            ...emailProtocolDefinition,
+            protocol: protocolUri
+          }
+        }
+      });
+      expect(status.code).toBe(202);
+
+      const protocolJson = aliceProtocol.toJSON();
+
+      expect(protocolJson.descriptor).toBeDefined();
+      expect(protocolJson.descriptor.interface).toBe('Protocols');
+      expect(protocolJson.descriptor.method).toBe('Configure');
+      expect(protocolJson.descriptor.messageTimestamp).toBeDefined();
+      expect(protocolJson.descriptor.definition).toEqual({
+        ...emailProtocolDefinition,
+        protocol: protocolUri
+      });
+      expect(protocolJson.authorization).toBeDefined();
+    });
   });
 });

--- a/packages/dwn-sdk-js/tests/utils/encryption-callbacks.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/encryption-callbacks.spec.ts
@@ -294,10 +294,4 @@ describe('Encryption Callback Interfaces', () => {
       ).rejects.toThrow('Unable to find a symmetric key encrypted using key');
     });
   });
-
-  // Skipped tests — these will be implemented in future PRs
-  describe.skip('Agent callback factories (PR 3)', () => {
-    it.skip('getEncryptionKeyDeriver() constructs valid EncryptionKeyDeriver', async () => {});
-    it.skip('getKeyDecrypter() constructs valid KeyDecrypter', async () => {});
-  });
 });


### PR DESCRIPTION
## Summary

Two small cleanup items from the skipped test audit:

### 1. Protocol.toJSON() test

Replaces `xit('should return all defined properties')` in `packages/api/tests/protocol.spec.ts` with a real test that:
- Configures a protocol via `dwnAlice.protocols.configure()`
- Calls `protocol.toJSON()` and verifies the returned `ProtocolsConfigureMessage` has correct `descriptor.interface`, `descriptor.method`, `descriptor.messageTimestamp`, `descriptor.definition`, and `authorization`

This was the only `toJSON()` method in the API layer without test coverage — `Record`, `PermissionGrant`, and `PermissionRequest` all had theirs tested.

### 2. Delete stale encryption callback placeholders

Removes the `describe.skip('Agent callback factories (PR 3)')` block from `packages/dwn-sdk-js/tests/utils/encryption-callbacks.spec.ts`. These were stale placeholders from PR 1/7 of a phased series. The actual factories (`getEncryptionKeyDeriver()`, `getKeyDecrypter()`) were implemented in PR 3/7 with full tests in `packages/agent/tests/dwn-api.spec.ts` (6 test cases at lines 1956-2033). The stubs were never cleaned up and cannot be tested from `dwn-sdk-js` since they require agent infrastructure.

## Testing

- **dwn-sdk-js**: 975 pass, 3 skip (-2 stale skips removed), 0 fail
- **Lint**: all packages pass

Closes #134