### PR TITLE
feat: add coverage badges to all package READMEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_call:
@@ -447,7 +449,7 @@ jobs:
     name: Coverage Check
     runs-on: ubuntu-latest
     needs: [test-lightweight, test-dwn-sdk, test-agent-api, test-sql-store, test-dwn-server]
-    if: always() && github.event_name == 'pull_request' && !cancelled()
+    if: always() && !cancelled()
 
     steps:
       - name: Download coverage artifacts
@@ -495,6 +497,23 @@ jobs:
               coverage="0.0"
             fi
 
+            # Determine badge color
+            if [ "$(echo "$coverage >= 90" | bc -l)" = "1" ]; then
+              badge_color="brightgreen"
+            elif [ "$(echo "$coverage >= 80" | bc -l)" = "1" ]; then
+              badge_color="green"
+            elif [ "$(echo "$coverage >= 70" | bc -l)" = "1" ]; then
+              badge_color="yellowgreen"
+            elif [ "$(echo "$coverage >= 60" | bc -l)" = "1" ]; then
+              badge_color="yellow"
+            else
+              badge_color="red"
+            fi
+
+            # Write shields.io endpoint JSON for this package
+            mkdir -p coverage-badges
+            printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}\n' "$coverage" "$badge_color" > "coverage-badges/${pkg}.json"
+
             if [ "$(echo "$coverage < $threshold" | bc -l)" = "1" ]; then
               echo "| $pkg | ${coverage}% | :x: Below ${threshold}% |" >> coverage-report.md
               echo "::error::Coverage for $pkg is ${coverage}%, below ${threshold}% threshold"
@@ -525,7 +544,7 @@ jobs:
           fi
 
       - name: Comment PR with coverage
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -557,6 +576,36 @@ jobs:
                 body,
               });
             }
+
+      # Update coverage badge data in a public Gist (main branch only).
+      # TODO: When the repo is made public, migrate to Codecov or GitHub Pages.
+      - name: Update coverage badges
+        if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        env:
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+        run: |
+          if [ -z "$GIST_TOKEN" ]; then
+            echo "::warning::GIST_TOKEN not set — skipping badge update"
+            exit 0
+          fi
+
+          GIST_ID="02d15f39a46173a612a8862ec6d7cfcf"
+
+          for badge_file in coverage-badges/*.json; do
+            [ -f "$badge_file" ] || continue
+            filename=$(basename "$badge_file")
+            content=$(cat "$badge_file")
+
+            echo "Updating badge: $filename"
+            curl -sf -X PATCH \
+              -H "Authorization: token $GIST_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/gists/$GIST_ID" \
+              -d "$(jq -n --arg fn "$filename" --arg ct "$content" '{files: {($fn): {content: $ct}}}')" \
+              > /dev/null
+          done
+
+          echo "Coverage badges updated"
 
   # ---------------------------------------------------------------------------
   # Gate job for branch protection — always runs so required checks pass even

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 > **Research Preview** — Enbox is under active development. APIs may change without notice.
 
+[![CI](https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/ci.yml?branch=main&label=ci)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+
+| Package | Coverage |
+|---------|----------|
+| `@enbox/api` | [![api](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/api.json)](packages/api) |
+| `@enbox/agent` | [![agent](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/agent.json)](packages/agent) |
+| `@enbox/common` | [![common](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/common.json)](packages/common) |
+| `@enbox/crypto` | [![crypto](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/crypto.json)](packages/crypto) |
+| `@enbox/dids` | [![dids](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dids.json)](packages/dids) |
+| `@enbox/dwn-sdk-js` | [![dwn-sdk-js](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sdk-js.json)](packages/dwn-sdk-js) |
+| `@enbox/dwn-server` | [![dwn-server](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-server.json)](packages/dwn-server) |
+| `@enbox/dwn-sql-store` | [![dwn-sql-store](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sql-store.json)](packages/dwn-sql-store) |
+
 A toolkit for decentralized identity and encrypted personal data storage.
 
 ## How It Works

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -2,6 +2,8 @@
 
 > **Research Preview** — Enbox is under active development. APIs may change without notice.
 
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/agent.json)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+
 The agent framework for decentralized identity management — handles identities, keys, DWN storage, sync, and wallet connect.
 
 ## Overview

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2,6 +2,8 @@
 
 > **Research Preview** — Enbox is under active development. APIs may change without notice.
 
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/api.json)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+
 The high-level SDK for building decentralized applications with identity and data management.
 
 ## Installation

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -45,8 +45,8 @@ To enable this functionality import and run `activatePolyfills()` at the entrypo
 [browser-downloads-badge]: https://img.shields.io/npm/dt/@enbox/browser?&color=blue
 [browser-build-badge]: https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/tests-ci.yml?branch=main&label=build
 [browser-build-link]: https://github.com/enboxorg/enbox/actions/workflows/tests-ci.yml
-[browser-coverage-badge]: https://img.shields.io/codecov/c/gh/enboxorg/enbox/main?style=flat&token=YI87CKF1LI
-[browser-coverage-link]: https://app.codecov.io/github/enboxorg/enbox/tree/main/packages%2Fbrowser
+[browser-coverage-badge]: https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/crypto.json
+[browser-coverage-link]: https://github.com/enboxorg/enbox/actions/workflows/ci.yml
 [browser-issues-badge]: https://img.shields.io/github/issues/enboxorg/enbox/package:%20browser?label=issues
 [browser-issues-link]: https://github.com/enboxorg/enbox/issues?q=is%3Aopen+is%3Aissue+label%3A"package%3A+browser"
 [browser-repo-link]: https://github.com/enboxorg/enbox/tree/main/packages/browser

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -2,6 +2,8 @@
 
 > **Research Preview** — Enbox is under active development. APIs may change without notice.
 
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/common.json)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+
 Shared utilities used across the Enbox monorepo — data conversion, key-value stores, caching, streams, and type helpers.
 
 ## Installation

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -621,8 +621,8 @@ const decryptedData = await XChaCha20Poly1305.decrypt({
 [crypto-downloads-badge]: https://img.shields.io/npm/dt/@enbox/crypto?&color=blue
 [crypto-build-badge]: https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/tests-ci.yml?branch=main&label=build
 [crypto-build-link]: https://github.com/enboxorg/enbox/actions/workflows/tests-ci.yml
-[crypto-coverage-badge]: https://img.shields.io/codecov/c/gh/enboxorg/enbox/main?style=flat&token=YI87CKF1LI
-[crypto-coverage-link]: https://app.codecov.io/github/enboxorg/enbox/tree/main/packages%2Fcrypto
+[crypto-coverage-badge]: https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/crypto.json
+[crypto-coverage-link]: https://github.com/enboxorg/enbox/actions/workflows/ci.yml
 [crypto-issues-badge]: https://img.shields.io/github/issues/enboxorg/enbox/package:%20crypto?label=issues
 [crypto-issues-link]: https://github.com/enboxorg/enbox/issues?q=is%3Aopen+is%3Aissue+label%3A"package%3A+crypto"
 [crypto-aws-kms-repo-link]: https://github.com/enboxorg/enbox/tree/main/packages/crypto-aws-kms

--- a/packages/dids/README.md
+++ b/packages/dids/README.md
@@ -2,6 +2,8 @@
 
 > **Research Preview** — Enbox is under active development. APIs may change without notice.
 
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dids.json)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+
 A comprehensive library for working with Decentralized Identifiers (DIDs) in the Enbox ecosystem.
 
 ## Overview

--- a/packages/dwn-sdk-js/README.md
+++ b/packages/dwn-sdk-js/README.md
@@ -2,6 +2,8 @@
 
 > **Research Preview** — Enbox is under active development. APIs may change without notice.
 
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sdk-js.json)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+
 A TypeScript implementation of [Decentralized Web Nodes](https://identity.foundation/decentralized-web-node/spec/) — protocol-driven personal datastores that users control.
 
 ## Overview

--- a/packages/dwn-server/README.md
+++ b/packages/dwn-server/README.md
@@ -2,6 +2,8 @@
 
 > **Research Preview** — Enbox is under active development. APIs may change without notice.
 
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-server.json)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+
 A multi-tenant Decentralized Web Node exposed via JSON-RPC over HTTP and WebSocket, powered by `Bun.serve()`.
 
 - [Supported DBs](#supported-dbs)

--- a/packages/dwn-sql-store/README.md
+++ b/packages/dwn-sql-store/README.md
@@ -3,8 +3,8 @@
 > **Research Preview** — Enbox is under active development. APIs may change without notice.
 
 [![NPM](https://img.shields.io/npm/v/@enbox/dwn-sql-store.svg?style=flat-square&logo=npm&logoColor=FFFFFF&color=FFEC19&santize=true)](https://www.npmjs.com/package/@enbox/dwn-sql-store)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/integrity-checks.yml?branch=main&logo=github&label=ci&logoColor=FFFFFF&style=flat-square)](https://github.com/enboxorg/enbox/actions/workflows/integrity-checks.yml)
-[![Coverage](https://img.shields.io/codecov/c/gh/enboxorg/enbox/main?logo=codecov&logoColor=FFFFFF&style=flat-square&token=YI87CKF1LI)](https://codecov.io/github/enboxorg/enbox)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/ci.yml?branch=main&logo=github&label=ci&logoColor=FFFFFF&style=flat-square)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sql-store.json&style=flat-square)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/@enbox/dwn-sql-store.svg?style=flat-square&color=24f2ff&logo=apache&logoColor=FFFFFF&santize=true)](https://github.com/enboxorg/enbox/blob/main/LICENSE)
 [![Chat](https://img.shields.io/badge/chat-on%20discord-7289da.svg?style=flat-square&color=9a1aff&logo=discord&logoColor=FFFFFF&sanitize=true)](https://discord.com/channels/937858703112155166/969272658501976117)
 


### PR DESCRIPTION
## Summary

- Adds shields.io coverage badges backed by a public Gist to all package READMEs and the root README
- CI now runs coverage on push to `main` and updates per-package badge JSON in the Gist
- Migrates existing crypto, browser, and dwn-sql-store badges from dead Codecov URLs to Gist-backed badges
- Fixes dwn-sql-store build badge that pointed to a deleted workflow

### How it works

1. The coverage job generates a shields.io [endpoint JSON](https://shields.io/badges/endpoint-badge) file per package with the coverage percentage and a color (green/yellow/red)
2. On push to `main`, a new step pushes these JSON files to a **public Gist** via the GitHub API
3. README badges use `img.shields.io/endpoint?url=<gist-raw-url>` to render dynamic badges

### Setup required

A `GIST_TOKEN` repository secret with `gist` scope is needed. The Gist has been created at:
https://gist.github.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf

> **TODO:** When the repo is made public, migrate to Codecov or GitHub Pages for badge hosting.