### PR TITLE
fix: bump dwn-sdk-js, agent, and api to fix MessagesSync export chain

### DIFF
--- a/.changeset/fix-messages-sync-export.md
+++ b/.changeset/fix-messages-sync-export.md
@@ -1,0 +1,12 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+"@enbox/api": patch
+---
+
+fix: publish new versions to fix MessagesSync export chain
+
+@enbox/agent@0.1.1 imports MessagesSync from @enbox/dwn-sdk-js, but
+@enbox/dwn-sdk-js@0.0.2 was published before that export was added.
+This bumps all three packages so downstream consumers (demo apps) can
+resolve the full dependency chain.


### PR DESCRIPTION
## Summary

- Bump `@enbox/dwn-sdk-js`, `@enbox/agent`, and `@enbox/api` to fix a broken export chain that prevents demo apps from building

## Problem

`@enbox/agent@0.1.1` imports `MessagesSync` from `@enbox/dwn-sdk-js`, but `@enbox/dwn-sdk-js@0.0.2` was published before that export existed (it was added in commit 040e1ea). Both demo apps fail to build with:

```
"MessagesSync" is not exported by "node_modules/@enbox/dwn-sdk-js/dist/esm/src/index.js"
```

## Fix

A changeset that bumps all three packages:
- `@enbox/dwn-sdk-js` 0.0.2 -> 0.0.3 (adds `MessagesSync` export)
- `@enbox/agent` 0.1.1 -> 0.1.2 (depends on dwn-sdk-js 0.0.3)
- `@enbox/api` 0.0.6 -> 0.0.7 (depends on agent 0.1.2)

After merge, Changesets will create a version PR, and after that merges, the release workflow publishes all three.