### PR TITLE
fix(dwn-sdk-js): fix flaky MemoryCache TTL expiry test

### DIFF
--- a/packages/dwn-sdk-js/tests/utils/memory-cache.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/memory-cache.spec.ts
@@ -5,13 +5,13 @@ import sinon from 'sinon';
 
 describe('MemoryCache', () => {
   it('should return `undefined` when value expires', async () => {
-    const memoryCache = new MemoryCache(0.01); // 0.01 second = 10 millisecond time-to-live
+    const memoryCache = new MemoryCache(0.05); // 0.05 second = 50 millisecond time-to-live
 
     await memoryCache.set('key', 'aValue');
     let valueInCache = await memoryCache.get('key');
     expect(valueInCache).toBe('aValue');
 
-    await new Promise(resolve => setTimeout(resolve, 11)); // wait for 11 millisecond for value to expire
+    await new Promise(resolve => setTimeout(resolve, 100)); // wait for 100 milliseconds for value to expire
     valueInCache = await memoryCache.get('key');
     expect(valueInCache).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- `MemoryCache > should return undefined when value expires` was failing in CI due to insufficient timing margins
- The test used a **10ms TTL** with an **11ms wait** (only 1ms margin), which is unreliable under CI load — especially with coverage instrumentation adding overhead
- Increased to **50ms TTL** with **100ms wait**, giving 50ms of margin while still being a fast test

This was causing the `Test: dwn-sdk-js` failure in the latest main CI run ([#22192698282](https://github.com/enboxorg/enbox/actions/runs/22192698282)).