### PR TITLE
fix(ci): don't ignore .changeset/*.md in release workflow paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - '**/*.md'
       - 'docs/**'
       - 'LICENSE'
+      - '*.md'
+      - 'packages/**/*.md'
+      # NOTE: .changeset/*.md is intentionally NOT ignored — changesets are .md
+      # files and must trigger this workflow for version PRs to be created.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Fix `paths-ignore` in the release workflow so changeset-only commits actually trigger the workflow

## Problem

The release workflow had `paths-ignore: '**/*.md'` which matched `.changeset/*.md` files. When PR #147 (which only added a changeset .md file) was merged, the release workflow was skipped entirely, so Changesets never created the version PR.

## Fix

Narrow the ignore rules to only skip non-changeset markdown:
- `*.md` (root-level README, CONTRIBUTING, etc.)
- `packages/**/*.md` (package READMEs, CHANGELOGs)
- `docs/**`, `LICENSE`

`.changeset/*.md` is intentionally NOT ignored.

**Merging this will also trigger the release workflow**, which will detect the pending changeset from PR #147 and create the version PR for dwn-sdk-js, agent, and api.