### PR TITLE
fix: bump all packages to sync published exports with source

### DIFF
--- a/.changeset/bump-all-packages.md
+++ b/.changeset/bump-all-packages.md
@@ -1,0 +1,17 @@
+---
+"@enbox/common": patch
+"@enbox/crypto": patch
+"@enbox/dids": patch
+"@enbox/browser": patch
+"@enbox/dwn-sql-store": patch
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+"@enbox/api": patch
+---
+
+fix: publish all packages so exported symbols match cross-package imports
+
+The agent package ships prototyping code that imports symbols (AesKw,
+Secp256r1, Hkdf, etc.) from @enbox/crypto and other packages. These
+symbols exist in the source but were not in the published versions.
+Bumping all packages ensures the published dist matches the current source.


### PR DESCRIPTION
## Summary

- Bump all workspace packages so published dist matches current source exports

## Problem

The demo apps fail to build because `@enbox/agent` ships prototyping code that imports symbols (`AesKw`, `Secp256r1`, `Hkdf`, `CryptoAlgorithm`, etc.) from `@enbox/crypto` and other packages. These symbols exist in the current source but were not present in the published versions (e.g. `@enbox/crypto@0.0.2`).

```
"AesKw" is not exported by "node_modules/@enbox/crypto/dist/esm/index.js"
```

## Fix

A changeset bumping all 8 publishable packages. After merge -> version PR -> publish, all packages will have their current source exported.

| Package | Current | New |
|---|---|---|
| `@enbox/common` | 0.0.2 | 0.0.3 |
| `@enbox/crypto` | 0.0.2 | 0.0.3 |
| `@enbox/dids` | 0.0.2 | 0.0.3 |
| `@enbox/dwn-sdk-js` | 0.0.3 | 0.0.4 |
| `@enbox/agent` | 0.1.2 | 0.1.3 |
| `@enbox/api` | 0.0.7 | 0.0.8 |
| `@enbox/browser` | 0.0.2 | 0.0.3 |
| `@enbox/dwn-sql-store` | 0.0.2 | 0.0.3 |