### PR TITLE
fix(deploy): update Dockerfiles to use bun.lock instead of pnpm-lock.yaml

### DIFF
--- a/deploy/dapp-demo/Dockerfile
+++ b/deploy/dapp-demo/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 
 # Copy package manifest and lockfile first for better layer caching
 COPY examples/dapp-demo/package.json ./
-COPY examples/dapp-demo/pnpm-lock.yaml ./
+COPY examples/dapp-demo/bun.lock ./
 
-# Install dependencies with Bun (reads pnpm lockfile)
+# Install dependencies with Bun
 RUN bun install --frozen-lockfile
 
 # Copy the rest of the app source

--- a/deploy/web-wallet/Dockerfile
+++ b/deploy/web-wallet/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 
 # Copy package manifest and lockfile first for better layer caching
 COPY examples/web-wallet/package.json ./
-COPY examples/web-wallet/pnpm-lock.yaml ./
+COPY examples/web-wallet/bun.lock ./
 
-# Install dependencies with Bun (reads pnpm lockfile)
+# Install dependencies with Bun
 RUN bun install --frozen-lockfile
 
 # Copy the rest of the app source


### PR DESCRIPTION
## Summary

- Updates `deploy/dapp-demo/Dockerfile` to copy `bun.lock` instead of `pnpm-lock.yaml`
- Updates `deploy/web-wallet/Dockerfile` to copy `bun.lock` instead of `pnpm-lock.yaml`
- Fixes stale comment referencing pnpm lockfile

## Problem

Both Dockerfiles for the dapp-demo and web-wallet Fly.io deployments were copying `pnpm-lock.yaml` into the build container, but then running `bun install --frozen-lockfile`. Bun's `--frozen-lockfile` flag requires an existing Bun lockfile (`bun.lock`) to validate against — it cannot use a pnpm lockfile. This caused both deployments to fail.

## Dependencies

The corresponding `bun.lock` files need to be merged in the submodule repos first:

- https://github.com/enboxorg/dapp-demo/pull/3
- https://github.com/enboxorg/web-wallet/pull/15

After those are merged, update the submodule references in this repo before merging this PR.