### PR TITLE
fix(dwn-server): restore console spies in json-rpc-socket tests

### DIFF
--- a/packages/dwn-server/tests/json-rpc-socket.test.ts
+++ b/packages/dwn-server/tests/json-rpc-socket.test.ts
@@ -259,6 +259,7 @@ describe('JsonRpcSocket', () => {
     // extract log message from argument
     const logMessage:string = consoleInfoSpy.mock.calls[0][0]!;
     expect(logMessage).toBe('JSON RPC Socket close ws://127.0.0.1:9003');
+    consoleInfoSpy.mockRestore();
   });
 
   it('calls onerror handler', async () => {
@@ -289,5 +290,6 @@ describe('JsonRpcSocket', () => {
     // extract log message from argument
     const logMessage:string = consoleErrorSpy.mock.calls[0][0]!;
     expect(logMessage).toBe(`JSON RPC Socket error ${badUrl}`);
+    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- Adds missing `mockRestore()` calls on `console.info` and `console.error` spies in `json-rpc-socket.test.ts`

## Problem

PR #168 changed the `onclose`/`onerror` tests from spying on `log.info`/`log.error` (loglevel) to `console.info`/`console.error` (matching the new `@enbox/dwn-clients` `JsonRpcSocket` implementation), but the spies were never restored.

Bun's test file execution order is non-deterministic. On the PR branch CI run, `process-handler.test.ts` happened to run **before** `json-rpc-socket.test.ts`, so the leak didn't matter. On the merge commit to `main`, the order flipped — `json-rpc-socket.test.ts` ran first, leaking a wrapped `console.error` into `process-handler.test.ts`, which then counted `console.error` calls as 2 instead of 1.

**PR branch CI** (passed):
```
process-handler.test.ts  → ran 5th (before json-rpc-socket.test.ts)
json-rpc-socket.test.ts  → ran 8th
console.error call count 1 ✓
```

**Main CI** (failed):
```
json-rpc-socket.test.ts  → ran 1st (before process-handler.test.ts)
process-handler.test.ts  → ran 2nd
console.error call count 2 ✗
```

## Fix

Add `consoleInfoSpy.mockRestore()` and `consoleErrorSpy.mockRestore()` at the end of the two affected tests, preventing spy leakage regardless of file execution order.