### PR TITLE
fix(agent): re-fetch failed messages during sync retry to recover consumed data streams

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -493,6 +493,11 @@ export class SyncEngineLevel implements SyncEngine {
   /**
    * Fetches missing messages from the remote DWN and processes them on the local DWN
    * in dependency order (topological sort).
+   *
+   * Messages that fail processing are re-fetched from the remote before each retry
+   * pass rather than buffered in memory. ReadableStream is single-use, so a failed
+   * message's data stream is consumed on the first attempt. Re-fetching provides a
+   * fresh stream without holding all record data in memory simultaneously.
    */
   private async pullMessages({ did, dwnUrl, delegateDid, protocol, messageCids }: {
     did: string;
@@ -509,22 +514,30 @@ export class SyncEngineLevel implements SyncEngine {
 
     // Step 3: Process messages in dependency order with multi-pass retry.
     // Retry up to MAX_RETRY_PASSES times for messages that fail due to
-    // dependency ordering issues (e.g., a dependency was already local
-    // but not yet committed when the dependent was first processed).
+    // dependency ordering issues (e.g., a RecordsWrite whose ProtocolsConfigure
+    // hasn't committed yet). Failed messages are re-fetched from the remote
+    // to obtain a fresh data stream, since ReadableStream is single-use.
     const MAX_RETRY_PASSES = 3;
     let pending = sorted;
 
     for (let pass = 0; pass <= MAX_RETRY_PASSES && pending.length > 0; pass++) {
-      const retryQueue: { message: GenericMessage; dataStream?: ReadableStream<Uint8Array> }[] = [];
+      const failedCids: string[] = [];
 
       for (const entry of pending) {
         const pullReply = await this.agent.dwn.node.processMessage(did, entry.message, { dataStream: entry.dataStream });
         if (!SyncEngineLevel.syncMessageReplyIsSuccessful(pullReply)) {
-          retryQueue.push(entry);
+          const cid = await SyncEngineLevel.getMessageCid(entry.message);
+          failedCids.push(cid);
         }
       }
 
-      pending = retryQueue;
+      // Re-fetch failed messages from the remote to get fresh data streams.
+      if (failedCids.length > 0) {
+        const reFetched = await this.fetchRemoteMessages({ did, dwnUrl, delegateDid, protocol, messageCids: failedCids });
+        pending = SyncEngineLevel.topologicalSort(reFetched);
+      } else {
+        pending = [];
+      }
     }
   }
 
@@ -735,15 +748,15 @@ export class SyncEngineLevel implements SyncEngine {
    * - Initial write must come before update writes (same recordId, not initial)
    * - Permission grant must come before records using that permissionGrantId
    */
-  static topologicalSort(
-    messages: { message: GenericMessage; dataStream?: ReadableStream<Uint8Array> }[]
-  ): { message: GenericMessage; dataStream?: ReadableStream<Uint8Array> }[] {
+  static topologicalSort<T extends { message: GenericMessage }>(
+    messages: T[]
+  ): T[] {
     if (messages.length <= 1) {
       return messages;
     }
 
     // Index messages by various keys for dependency resolution.
-    const byIndex = new Map<number, { message: GenericMessage; dataStream?: ReadableStream<Uint8Array> }>();
+    const byIndex = new Map<number, T>();
     const protocolConfigureIndex = new Map<string, number>(); // protocol URL -> index
     const initialWriteIndex = new Map<string, number>(); // recordId -> index of initial write
     const grantIndex = new Map<string, number>(); // grant recordId -> index
@@ -847,7 +860,7 @@ export class SyncEngineLevel implements SyncEngine {
       }
     }
 
-    const sorted: { message: GenericMessage; dataStream?: ReadableStream<Uint8Array> }[] = [];
+    const sorted: T[] = [];
     while (queue.length > 0) {
       const node = queue.shift()!;
       sorted.push(byIndex.get(node)!);

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -2838,5 +2838,65 @@ describe('SyncEngineLevel', () => {
       expect(parentIdx).toBeLessThan(childIdx);
       expect(grantIdx).toBeLessThan(childIdx);
     });
+
+    it('preserves extra properties on message entries through the sort', () => {
+      const protocolUrl = 'https://example.com/proto';
+      const dataBytes = new Uint8Array([1, 2, 3]);
+      const recordsWrite = {
+        ...mockMessage(
+          { protocol: protocolUrl },
+          { recordId: 'rec-1' }
+        ),
+        dataBytes,
+      };
+      const protocolsConfigure = {
+        ...mockMessage({
+          interface  : DwnInterfaceName.Protocols,
+          method     : DwnMethodName.Configure,
+          definition : { protocol: protocolUrl },
+        }),
+      };
+      // Pass in reverse order: records first, protocol second.
+      const result = SyncEngineLevel.topologicalSort([recordsWrite, protocolsConfigure]);
+      expect(result[0]).toBe(protocolsConfigure);
+      expect(result[1]).toBe(recordsWrite);
+      // Verify the dataBytes property survived the sort.
+      expect((result[1] as typeof recordsWrite).dataBytes).toBe(dataBytes);
+    });
+
+    it('sorts RecordsDelete after ProtocolsConfigure for the same protocol', () => {
+      const protocolUrl = 'https://example.com/proto';
+      const recordId = 'rec-1';
+      const ts = '2024-01-01T00:00:00.000000Z';
+      const initialWrite = mockMessage(
+        {
+          protocol         : protocolUrl,
+          dateCreated      : ts,
+          messageTimestamp : ts,
+        },
+        { recordId }
+      );
+      // RecordsDelete has recordId in the descriptor (accessed via msg.descriptor.recordId).
+      const deleteMsg = mockMessage({
+        interface        : DwnInterfaceName.Records,
+        method           : DwnMethodName.Delete,
+        protocol         : protocolUrl,
+        recordId,
+        messageTimestamp : '2024-01-02T00:00:00.000000Z',
+      });
+      // Delete depends on initial write (not directly on ProtocolsConfigure,
+      // but the initial write depends on ProtocolsConfigure).
+      const protocolsConfigure = mockMessage({
+        interface  : DwnInterfaceName.Protocols,
+        method     : DwnMethodName.Configure,
+        definition : { protocol: protocolUrl },
+      });
+      const result = SyncEngineLevel.topologicalSort([deleteMsg, initialWrite, protocolsConfigure]);
+      const configIdx = result.indexOf(protocolsConfigure);
+      const writeIdx = result.indexOf(initialWrite);
+      const deleteIdx = result.indexOf(deleteMsg);
+      expect(configIdx).toBeLessThan(writeIdx);
+      expect(writeIdx).toBeLessThan(deleteIdx);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #94 — protocol message sync ordering where a `RecordsWrite` can arrive before its `ProtocolsConfigure`.

- **Re-fetch on retry instead of buffering**: When a pulled message fails processing (e.g., a `RecordsWrite` whose `ProtocolsConfigure` dependency hasn't committed yet), its `ReadableStream` data is already consumed. The retry loop now re-fetches only the failed messages from the remote via `fetchRemoteMessages()`, providing a fresh data stream without holding all record data in memory simultaneously.
- **Generic `topologicalSort`**: Changed from a hardcoded `{ message, dataStream }` type to `T extends { message: GenericMessage }`, making it reusable for any message carrier shape without duplicating type definitions.
- **New tests**: Verifies generic property preservation through the sort, and `RecordsDelete` transitive ordering (`ProtocolsConfigure` → initial write → delete).

## Root Cause

`pullMessages()` had a multi-pass retry loop that pushed the same `{ message, dataStream }` entry back into a retry queue. Since `ReadableStream` is single-use, any data-bearing message that failed on the first pass would permanently lose its data on all subsequent retry attempts — the stream was already consumed.

## Approach

Rather than buffering all data streams into memory upfront (which could be GBs for large record batches), failed messages are re-fetched from the remote on each retry pass. This follows the same lazy re-fetch pattern used by `Record.readRecordData()` in the API layer. The tradeoff is an extra network round-trip per retry pass for the failed subset, but retries are rare since the topological sort handles the common case on the first pass.

## Verification

- Lint: all 10 packages pass
- Build: `@enbox/agent` builds cleanly
- Tests: 701 pass, 0 fail (full agent suite)