### PR TITLE
fix(dwn-sdk-js,agent): add direct grant auth for RecordsDelete and harden upgrade atomicity

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -3,10 +3,8 @@ import type {
   DwnConfig,
   EncryptionInput,
   EncryptionKeyDeriver,
-  EventStream,
   GenericMessage,
   KeyDecrypter,
-  MessageStore,
   ProtocolDefinition,
   ProtocolRuleSet,
   ProtocolsQueryReply,
@@ -14,8 +12,7 @@ import type {
   RecordsQueryReplyEntry,
   RecordsReadReply,
   RecordsWrite,
-  RecordsWriteMessage,
-  StateIndex } from '@enbox/dwn-sdk-js';
+  RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 import type { KeyIdentifier, PrivateKeyJwk, PublicKeyJwk } from '@enbox/crypto';
 
 import { CryptoUtils } from '@enbox/crypto';
@@ -1505,18 +1502,22 @@ export class AgentDwnApi {
     // We must also update the state index and event stream to keep sync and
     // real-time subscribers consistent — without this, the upgraded record
     // would never propagate to remote DWNs or notify subscribers.
-    const dwnInternal = this._dwn as any;
-    const messageStore = dwnInternal.messageStore as MessageStore;
-    const stateIndex = dwnInternal.stateIndex as StateIndex;
-    const eventStream = dwnInternal.eventStream as EventStream | undefined;
+    const { messageStore, stateIndex, eventStream } = this._dwn.storage;
+
+    // Validate the upgrade only changed encryption and authorization fields.
+    // The descriptor, recordId, contextId, and data must remain identical.
+    // Note: parse() may produce a new descriptor object, so we compare by value.
+    const upgradedMessage = recordsWriteInstance.message as RecordsQueryReplyEntry;
+    if (JSON.stringify(upgradedMessage.descriptor) !== JSON.stringify(recordsWrite.descriptor)) {
+      throw new Error('AgentDwnApi: upgradeExternalRootRecord() must not modify the descriptor.');
+    }
+    if (upgradedMessage.recordId !== recordsWrite.recordId) {
+      throw new Error('AgentDwnApi: upgradeExternalRootRecord() must not modify the recordId.');
+    }
 
     // Fetch the stored original (which carries encodedData for small payloads)
     const originalCid = await Message.getCid(recordsWrite);
     const storedOriginal = await messageStore.get(tenantDid, originalCid) as RecordsQueryReplyEntry | undefined;
-
-    // Remove the original message and its state index entry
-    await messageStore.delete(tenantDid, originalCid);
-    await stateIndex.delete(tenantDid, [originalCid]);
 
     // Build indexes for the upgraded message (mark as latest base state)
     const isLatestBaseState = true;
@@ -1524,15 +1525,20 @@ export class AgentDwnApi {
 
     // Carry over the encoded data from the stored original (the handler
     // base64url-encodes small payloads into encodedData during processMessage)
-    const upgradedMessage = recordsWriteInstance.message as RecordsQueryReplyEntry;
     if (storedOriginal?.encodedData) {
       upgradedMessage.encodedData = storedOriginal.encodedData;
     }
 
-    // Store the upgraded message and insert into state index
-    await messageStore.put(tenantDid, upgradedMessage, upgradedIndexes);
+    // Use put-before-delete ordering: if a crash occurs after the put but
+    // before the delete, we end up with a duplicate (recoverable via the
+    // isLatestBaseState index) rather than data loss (unrecoverable).
     const upgradedCid = await Message.getCid(upgradedMessage);
+    await messageStore.put(tenantDid, upgradedMessage, upgradedIndexes);
     await stateIndex.insert(tenantDid, upgradedCid, upgradedIndexes);
+
+    // Now remove the original message and its state index entry.
+    await messageStore.delete(tenantDid, originalCid);
+    await stateIndex.delete(tenantDid, [originalCid]);
 
     // Notify real-time subscribers (mirrors handler behavior)
     if (eventStream !== undefined) {

--- a/packages/dwn-sdk-js/src/dwn.ts
+++ b/packages/dwn-sdk-js/src/dwn.ts
@@ -162,6 +162,21 @@ export class Dwn {
   }
 
   /**
+   * Returns the internal storage components for advanced operations that
+   * cannot be expressed through the standard `processMessage()` pipeline
+   * (e.g., owner-upgrade of externally authored encrypted records).
+   *
+   * Callers are responsible for maintaining consistency across stores.
+   */
+  public get storage(): { messageStore: MessageStore; stateIndex: StateIndex; eventStream: EventStream | undefined } {
+    return {
+      messageStore : this.messageStore,
+      stateIndex   : this.stateIndex,
+      eventStream  : this.eventStream,
+    };
+  }
+
+  /**
    * Processes the given DWN message and returns with a reply.
    * @param tenant The tenant DID to route the given message to.
    */

--- a/packages/dwn-sdk-js/src/handlers/records-delete.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-delete.ts
@@ -9,9 +9,11 @@ import { authenticate } from '../core/auth.js';
 import { DwnInterfaceName } from '../enums/dwn-interface-method.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
+import { PermissionsProtocol } from '../protocols/permissions.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
 import { Records } from '../utils/records.js';
 import { RecordsDelete } from '../interfaces/records-delete.js';
+import { RecordsGrantAuthorization } from '../core/records-grant-authorization.js';
 import { RecordsWrite } from '../interfaces/records-write.js';
 import { ResumableTaskName } from '../core/resumable-task-manager.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
@@ -112,6 +114,16 @@ export class RecordsDeleteHandler implements MethodHandler {
 
     if (recordsDelete.author === tenant) {
       return;
+    } else if (recordsDelete.author !== undefined && recordsDelete.signaturePayload!.permissionGrantId !== undefined) {
+      const permissionGrant = await PermissionsProtocol.fetchGrant(tenant, messageStore, recordsDelete.signaturePayload!.permissionGrantId);
+      await RecordsGrantAuthorization.authorizeDelete({
+        recordsDeleteMessage : recordsDelete.message,
+        recordsWriteToDelete : recordsWrite.message,
+        expectedGrantor      : tenant,
+        expectedGrantee      : recordsDelete.author,
+        permissionGrant,
+        messageStore,
+      });
     } else if (recordsWrite.message.descriptor.protocol !== undefined) {
       await ProtocolAuthorization.authorizeDelete(tenant, recordsDelete, recordsWrite, messageStore);
     } else {

--- a/packages/dwn-sdk-js/src/interfaces/records-delete.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-delete.ts
@@ -24,6 +24,11 @@ export type RecordsDeleteOptions = {
   prune?: boolean
 
   /**
+   * The ID of the permission grant authorizing this delete.
+   */
+  permissionGrantId?: string;
+
+  /**
    * The delegated grant to sign on behalf of the logical author, which is the grantor (`grantedBy`) of the delegated grant.
    */
   delegatedGrant?: DataEncodedRecordsWriteMessage;
@@ -64,9 +69,10 @@ export class RecordsDelete extends AbstractMessage<RecordsDeleteMessage> {
 
     const authorization = await Message.createAuthorization({
       descriptor,
-      signer         : options.signer,
-      protocolRole   : options.protocolRole,
-      delegatedGrant : options.delegatedGrant
+      signer            : options.signer,
+      protocolRole      : options.protocolRole,
+      permissionGrantId : options.permissionGrantId,
+      delegatedGrant    : options.delegatedGrant
     });
     const message: RecordsDeleteMessage = { descriptor, authorization };
 

--- a/packages/dwn-sdk-js/tests/handlers/records-delete.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-delete.spec.ts
@@ -21,7 +21,6 @@ import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread
 
 import { ArrayUtility } from '../../src/utils/array.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
-import { DwnMethodName } from '../../src/enums/dwn-interface-method.js';
 import { Message } from '../../src/core/message.js';
 import { normalizeSchemaUrl } from '../../src/utils/url.js';
 import { RecordsDeleteHandler } from '../../src/handlers/records-delete.js';
@@ -30,8 +29,9 @@ import { TestEventStream } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { Time } from '../../src/utils/time.js';
-import { DataStream, Dwn, Encoder, Jws, MessageStoreLevel, RecordsDelete, RecordsRead, RecordsWrite } from '../../src/index.js';
+import { DataStream, Dwn, Encoder, Jws, MessageStoreLevel, PermissionsProtocol, RecordsDelete, RecordsRead, RecordsWrite } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
+import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
 
 export function testRecordsDeleteHandler(): void {
   describe('RecordsDeleteHandler.handle()', () => {
@@ -659,6 +659,146 @@ export function testRecordsDeleteHandler(): void {
         const recordsDeleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
         expect(recordsDeleteReply.status.code).toBe(401);
         expect(recordsDeleteReply.status.detail).toContain(DwnErrorCode.RecordsDeleteAuthorizationFailed);
+      });
+
+      describe('grant based deletes', () => {
+        it('should allow delete with a matching protocol grant scope', async () => {
+          // scenario: Alice writes a protocol record, grants Bob delete permission, Bob deletes it.
+
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://grant-delete-test.xyz',
+            published : false,
+            types     : { foo: {} },
+            structure : { foo: {} }
+          };
+
+          // Alice installs the protocol
+          const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author: alice,
+            protocolDefinition
+          });
+          const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
+          expect(protocolsConfigureReply.status.code).toBe(202);
+
+          // Alice writes a record
+          const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'foo',
+          });
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
+          expect(writeReply.status.code).toBe(202);
+
+          // Alice grants Bob delete permission scoped to the protocol
+          const permissionGrant = await PermissionsProtocol.createGrant({
+            signer      : Jws.createSigner(alice),
+            grantedTo   : bob.did,
+            dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }),
+            scope       : {
+              interface : DwnInterfaceName.Records,
+              method    : DwnMethodName.Delete,
+              protocol  : protocolDefinition.protocol,
+            }
+          });
+          const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
+          const grantWriteReply = await dwn.processMessage(
+            alice.did,
+            permissionGrant.recordsWrite.message,
+            { dataStream: grantDataStream }
+          );
+          expect(grantWriteReply.status.code).toBe(202);
+
+          // Bob deletes the record using the grant
+          const recordsDelete = await RecordsDelete.create({
+            recordId          : recordsWrite.message.recordId,
+            signer            : Jws.createSigner(bob),
+            permissionGrantId : permissionGrant.recordsWrite.message.recordId,
+          });
+          const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+          expect(deleteReply.status.code).toBe(202);
+        });
+
+        it('should reject delete when grant has mismatching protocol scope', async () => {
+          // scenario: Alice grants Bob delete permission for protocol A,
+          //           Bob tries to delete a record in protocol B.
+
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolA: ProtocolDefinition = {
+            protocol  : 'http://protocol-a.xyz',
+            published : false,
+            types     : { foo: {} },
+            structure : { foo: {} }
+          };
+          const protocolB: ProtocolDefinition = {
+            protocol  : 'http://protocol-b.xyz',
+            published : false,
+            types     : { foo: {} },
+            structure : { foo: {} }
+          };
+
+          // Alice installs both protocols
+          const configA = await TestDataGenerator.generateProtocolsConfigure({ author: alice, protocolDefinition: protocolA });
+          expect((await dwn.processMessage(alice.did, configA.message)).status.code).toBe(202);
+          const configB = await TestDataGenerator.generateProtocolsConfigure({ author: alice, protocolDefinition: protocolB });
+          expect((await dwn.processMessage(alice.did, configB.message)).status.code).toBe(202);
+
+          // Alice writes a record in protocol B
+          const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolB.protocol,
+            protocolPath : 'foo',
+          });
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream });
+          expect(writeReply.status.code).toBe(202);
+
+          // Alice grants Bob delete permission scoped to protocol A (not B)
+          const permissionGrant = await PermissionsProtocol.createGrant({
+            signer      : Jws.createSigner(alice),
+            grantedTo   : bob.did,
+            dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 }),
+            scope       : {
+              interface : DwnInterfaceName.Records,
+              method    : DwnMethodName.Delete,
+              protocol  : protocolA.protocol,
+            }
+          });
+          const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
+          expect((await dwn.processMessage(alice.did, permissionGrant.recordsWrite.message, { dataStream: grantDataStream })).status.code).toBe(202);
+
+          // Bob tries to delete the protocol B record with the protocol A grant — should fail
+          const recordsDelete = await RecordsDelete.create({
+            recordId          : recordsWrite.message.recordId,
+            signer            : Jws.createSigner(bob),
+            permissionGrantId : permissionGrant.recordsWrite.message.recordId,
+          });
+          const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+          expect(deleteReply.status.code).toBe(401);
+          expect(deleteReply.status.detail).toContain(DwnErrorCode.RecordsGrantAuthorizationDeleteProtocolScopeMismatch);
+        });
+
+        it('should reject delete without a grant when non-owner tries to delete a non-protocol record', async () => {
+          // scenario: Alice writes a non-protocol record, Bob tries to delete it without any grant.
+          //           This test verifies the fallback error path is unchanged.
+
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+
+          const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
+          expect((await dwn.processMessage(alice.did, recordsWrite.message, { dataStream })).status.code).toBe(202);
+
+          const recordsDelete = await RecordsDelete.create({
+            recordId : recordsWrite.message.recordId,
+            signer   : Jws.createSigner(bob),
+          });
+          const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+          expect(deleteReply.status.code).toBe(401);
+          expect(deleteReply.status.detail).toContain(DwnErrorCode.RecordsDeleteAuthorizationFailed);
+        });
       });
 
       it('should index additional properties from the RecordsWrite being deleted', async () => {


### PR DESCRIPTION
## Summary

Fixes #108 and #109.

### Issue #108 — RecordsDelete missing direct grant authorization

`RecordsDeleteHandler.authorizeRecordsDelete()` had only three auth paths: owner, delegated grant, and protocol-based. The direct `permissionGrantId` path — which RecordsWrite and RecordsRead both support — was missing. Non-owner actors with a valid grant could not delete records without going through protocol-based auth.

**Changes:**
- Added `permissionGrantId` option to `RecordsDeleteOptions` and wired it through `RecordsDelete.create()` → `Message.createAuthorization()`
- Added the direct grant authorization branch in `RecordsDeleteHandler.authorizeRecordsDelete()`, following the same pattern as RecordsWrite (line 388) and RecordsRead (line 167)
- Added 3 new tests: happy path grant delete, mismatching protocol scope rejection, non-owner non-grant rejection

### Issue #109 — Non-atomic upgrade in `upgradeExternalRootRecord()`

`upgradeExternalRootRecord()` in `AgentDwnApi` used `(this._dwn as any)` to access private stores and performed delete-before-put ordering, risking data loss on crash.

**Changes:**
- Added `public get storage()` accessor to `Dwn` class, eliminating the `as any` cast
- Reordered to put-before-delete: crash after put but before delete leaves a recoverable duplicate rather than unrecoverable data loss
- Added validation guard ensuring only encryption/authorization fields change (descriptor and recordId must remain identical)
- Removed unused type imports (`EventStream`, `StateIndex`) from `dwn-api.ts`

### Test results

- **DWN SDK**: 981 pass, 0 fail (includes 3 new grant-based delete tests)
- **Agent**: 701 pass, 0 fail
- **Lint**: All packages pass