### PR TITLE
fix(dwn-sdk-js): enforce encryptionRequired at DWN protocol authorization layer

### DIFF
--- a/packages/agent/tests/store-key.spec.ts
+++ b/packages/agent/tests/store-key.spec.ts
@@ -4,6 +4,7 @@ import type { Jwk } from '@enbox/crypto';
 import { Convert } from '@enbox/common';
 import { DidJwk } from '@enbox/dids';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { Encoder, Message, PrivateKeySigner, RecordsWrite } from '@enbox/dwn-sdk-js';
 
 import type { AgentDataStore, DwnDataStore } from '../src/store-data.js';
 
@@ -231,29 +232,35 @@ describe('KeyStore', () => {
       });
 
       it('throws an error if legacy unencrypted records exceed DWN max data size for query results', async () => {
-        // Write an oversized unencrypted record directly to the DWN (bypassing
-        // the encrypted store path) to simulate a legacy record whose encodedData
-        // is missing from query results.
+        // Inject an oversized unencrypted record directly into the message store
+        // (bypassing the handler which now enforces encryptionRequired) to simulate
+        // a legacy record whose encodedData is missing from query results.
         const keyBytes = Convert.string(new Array(102400 + 1).join('0')).toUint8Array();
 
         // Initialize the storage protocol (which now includes $encryption keys).
         await (keyStore as DwnDataStore<Jwk>)['initialize']({ agent: testHarness.agent });
 
-        // Write directly without encryption: true — the record is unencrypted.
-        const response = await testHarness.agent.dwn.processRequest({
-          author        : testHarness.agent.agentDid.uri,
-          target        : testHarness.agent.agentDid.uri,
-          messageType   : DwnInterface.RecordsWrite,
-          messageParams : {
-            dataFormat   : 'application/json',
-            protocol     : JwkProtocolDefinition.protocol,
-            protocolPath : 'privateJwk',
-            schema       : JwkProtocolDefinition.types.privateJwk.schema,
-          },
-          dataStream: new Blob([keyBytes], { type: 'application/json' })
+        // Build an unencrypted RecordsWrite and inject it directly into the
+        // message store to simulate a pre-existing legacy record. The oversized
+        // payload means encodedData will be absent from query results.
+        const tenant = testHarness.agent.agentDid.uri;
+        const portableDid = await testHarness.agent.agentDid.export();
+        const signer = new PrivateKeySigner({
+          privateJwk : portableDid.privateKeys![0] as any,
+          keyId      : portableDid.document.verificationMethod![0].id,
         });
-
-        expect(response.reply.status.code).toBe(202);
+        const recordsWrite = await RecordsWrite.create({
+          dataFormat   : 'application/json',
+          protocol     : JwkProtocolDefinition.protocol,
+          protocolPath : 'privateJwk',
+          schema       : JwkProtocolDefinition.types.privateJwk.schema,
+          signer,
+          data         : keyBytes,
+        });
+        const { messageStore, stateIndex } = testHarness.agent.dwn.node.storage;
+        const indexes = await recordsWrite.constructIndexes(true);
+        await messageStore.put(tenant, recordsWrite.message, indexes);
+        await stateIndex.insert(tenant, await Message.getCid(recordsWrite.message), indexes);
 
         try {
           await keyStore.list({ agent: testHarness.agent });
@@ -550,7 +557,9 @@ describe('KeyStore', () => {
       });
 
       it('should handle mixed encrypted and unencrypted records', async () => {
-        // Step 1: Write an unencrypted record directly (simulating a legacy record).
+        // Step 1: Inject an unencrypted record directly into the message store
+        // (bypassing the handler which now enforces encryptionRequired) to
+        // simulate a pre-existing legacy record.
         await (keyStore as DwnDataStore<Jwk>)['initialize']({ agent: testHarness.agent });
         const legacyKey: Jwk = {
           kid : 'legacy-key-1',
@@ -561,18 +570,27 @@ describe('KeyStore', () => {
           d   : 'testd',
         };
         const legacyBytes = Convert.object(legacyKey).toUint8Array();
-        await testHarness.agent.dwn.processRequest({
-          author        : testHarness.agent.agentDid.uri,
-          target        : testHarness.agent.agentDid.uri,
-          messageType   : DwnInterface.RecordsWrite,
-          messageParams : {
-            dataFormat   : 'application/json',
-            protocol     : JwkProtocolDefinition.protocol,
-            protocolPath : 'privateJwk',
-            schema       : JwkProtocolDefinition.types.privateJwk.schema,
-          },
-          dataStream: new Blob([legacyBytes], { type: 'application/json' })
+        const tenant = testHarness.agent.agentDid.uri;
+        const portableDid = await testHarness.agent.agentDid.export();
+        const signer = new PrivateKeySigner({
+          privateJwk : portableDid.privateKeys![0] as any,
+          keyId      : portableDid.document.verificationMethod![0].id,
         });
+        const legacyWrite = await RecordsWrite.create({
+          dataFormat   : 'application/json',
+          protocol     : JwkProtocolDefinition.protocol,
+          protocolPath : 'privateJwk',
+          schema       : JwkProtocolDefinition.types.privateJwk.schema,
+          signer,
+          data         : legacyBytes,
+        });
+        const { messageStore, stateIndex } = testHarness.agent.dwn.node.storage;
+        const legacyIndexes = await legacyWrite.constructIndexes(true);
+        // Inline encodedData so the record is returned with data in query results.
+        const legacyMessage = legacyWrite.message as any;
+        legacyMessage.encodedData = Encoder.bytesToBase64Url(legacyBytes);
+        await messageStore.put(tenant, legacyMessage, legacyIndexes);
+        await stateIndex.insert(tenant, await Message.getCid(legacyWrite.message), legacyIndexes);
 
         // Step 2: Write an encrypted record through the store API.
         const encryptedKeyUri = await testHarness.agent.keyManager.generateKey({

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -75,6 +75,7 @@ export enum DwnErrorCode {
   ProtocolAuthorizationIncorrectContextId = 'ProtocolAuthorizationIncorrectContextId',
   ProtocolAuthorizationIncorrectProtocolPath = 'ProtocolAuthorizationIncorrectProtocolPath',
   ProtocolAuthorizationDuplicateRoleRecipient = 'ProtocolAuthorizationDuplicateRoleRecipient',
+  ProtocolAuthorizationEncryptionRequired = 'ProtocolAuthorizationEncryptionRequired',
   ProtocolAuthorizationInvalidSchema = 'ProtocolAuthorizationInvalidSchema',
   ProtocolAuthorizationInvalidType = 'ProtocolAuthorizationInvalidType',
   ProtocolAuthorizationMatchingRoleRecordNotFound = 'ProtocolAuthorizationMatchingRoleRecordNotFound',

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -674,6 +674,14 @@ export class ProtocolAuthorization {
         instead has '${dataFormat}'`
       );
     }
+
+    // enforce encryption when the protocol type requires it
+    if (protocolType.encryptionRequired === true && inboundMessage.encryption === undefined) {
+      throw new DwnError(
+        DwnErrorCode.ProtocolAuthorizationEncryptionRequired,
+        `type '${declaredTypeName}' requires encryption but message has no encryption metadata`
+      );
+    }
   }
 
   /**

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -35,6 +35,7 @@ import { PermissionConditionPublication } from '../../src/types/permission-types
 import { RecordsRead } from '../../src/interfaces/records-read.js';
 import { RecordsWrite } from '../../src/interfaces/records-write.js';
 import { RecordsWriteHandler } from '../../src/handlers/records-write.js';
+import { Secp256k1 } from '../../src/utils/secp256k1.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventStream } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
@@ -2553,6 +2554,139 @@ export function testRecordsWriteHandler(): void {
           const recordsReadReply = await dwn.processMessage(alice.did, recordsRead.message);
           expect(recordsReadReply.status.code).toBe(200);
           expect(recordsReadReply.entry!.recordsWrite?.descriptor.dataFormat).toBe(newDataFormat);
+        });
+
+        it('should reject a plaintext RecordsWrite when the protocol type has encryptionRequired: true', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://encryption-required-test.xyz',
+            published : false,
+            types     : {
+              secret: {
+                schema             : 'http://secret-schema',
+                encryptionRequired : true,
+              }
+            },
+            structure: {
+              secret: {}
+            }
+          };
+
+          // Alice installs the protocol
+          const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinition,
+          });
+          const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+          expect(configReply.status.code).toBe(202);
+
+          // Alice writes a record WITHOUT encryption — should be rejected
+          const data = Encoder.stringToBytes('plaintext secret');
+          const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'secret',
+            schema       : 'http://secret-schema',
+            data,
+          });
+
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: recordsWrite.dataStream });
+          expect(writeReply.status.code).toBe(400);
+          expect(writeReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationEncryptionRequired);
+        });
+
+        it('should accept an encrypted RecordsWrite when the protocol type has encryptionRequired: true', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://encryption-required-test.xyz',
+            published : false,
+            types     : {
+              secret: {
+                schema             : 'http://secret-schema',
+                encryptionRequired : true,
+              }
+            },
+            structure: {
+              secret: {}
+            }
+          };
+
+          // Alice installs the protocol
+          const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinition,
+          });
+          const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+          expect(configReply.status.code).toBe(202);
+
+          // Generate a secp256k1 key pair for encryption (did:key personas use Ed25519 for signing)
+          const encryptionKeyPair = await Secp256k1.generateKeyPair();
+          const data = Encoder.stringToBytes('encrypted secret');
+          const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+          const dataEncryptionInitializationVector = TestDataGenerator.randomBytes(16);
+
+          const encryptionInput: EncryptionInput = {
+            algorithm            : EncryptionAlgorithm.Aes256Ctr,
+            initializationVector : dataEncryptionInitializationVector,
+            key                  : dataEncryptionKey,
+            keyEncryptionInputs  : [{
+              publicKeyId      : alice.keyId,
+              publicKey        : encryptionKeyPair.publicJwk,
+              algorithm        : EncryptionAlgorithm.EciesSecp256k1,
+              derivationScheme : KeyDerivationScheme.ProtocolPath
+            }]
+          };
+
+          const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'secret',
+            schema       : 'http://secret-schema',
+            data,
+            encryptionInput,
+          });
+
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: recordsWrite.dataStream });
+          expect(writeReply.status.code).toBe(202);
+        });
+
+        it('should allow plaintext writes for protocol types without encryptionRequired', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://mixed-encryption-test.xyz',
+            published : false,
+            types     : {
+              public : {},
+              secret : { encryptionRequired: true },
+            },
+            structure: {
+              public : {},
+              secret : {},
+            }
+          };
+
+          // Alice installs the protocol
+          const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : protocolDefinition,
+          });
+          const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+          expect(configReply.status.code).toBe(202);
+
+          // Plaintext write to the non-encrypted type — should succeed
+          const data = Encoder.stringToBytes('public data');
+          const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'public',
+            data,
+          });
+
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: recordsWrite.dataStream });
+          expect(writeReply.status.code).toBe(202);
         });
 
         it('should fail authorization if record schema is not allowed at the hierarchical level attempted for the RecordsWrite', async () => {


### PR DESCRIPTION
## Summary

Fixes #107. **Security fix** — closes a plaintext bypass vulnerability.

### Problem

`encryptionRequired` is declared as a field on `ProtocolType` (`protocols-types.ts:57`) and accepted in the JSON schema for protocol definitions, but was **only enforced at the agent layer** (`store-data.ts`, `dwn-api.ts`). The DWN node's `ProtocolAuthorization` never checked it.

This means a client sending raw DWN messages (bypassing the agent SDK) could write **plaintext data** to a protocol type that declares `encryptionRequired: true`, and the DWN would accept it with status 202.

### Fix

Added an enforcement check in `ProtocolAuthorization.verifyType()` — the same method that validates `schema` and `dataFormats` constraints. When `protocolType.encryptionRequired === true` and `inboundMessage.encryption === undefined`, the DWN now returns HTTP 400 with `DwnErrorCode.ProtocolAuthorizationEncryptionRequired`.

### Changes

**`packages/dwn-sdk-js/src/core/dwn-error.ts`**
- Added `ProtocolAuthorizationEncryptionRequired` to the `DwnErrorCode` enum

**`packages/dwn-sdk-js/src/core/protocol-authorization.ts`**
- Added encryption enforcement check at end of `verifyType()` (+6 lines)

**`packages/dwn-sdk-js/tests/handlers/records-write.spec.ts`**
- Added 3 new tests:
  - Plaintext write rejected when `encryptionRequired: true`
  - Encrypted write accepted when `encryptionRequired: true`
  - Plaintext write allowed for types without `encryptionRequired`

**`packages/agent/tests/store-key.spec.ts`**
- Updated 2 existing legacy-record tests to inject directly into the message store (bypassing the handler) since the handler now correctly rejects plaintext writes to `encryptionRequired` protocol types

### Test results

- **DWN SDK**: 984 pass, 0 fail (includes 3 new tests)
- **Agent**: 693 pass, 0 fail
- **Lint**: All 10 packages pass