### PR TITLE
fix: resolve flaky test failures in dwn-server and dwn-sql-store

### DIFF
--- a/packages/dwn-server/tests/process-handler.test.ts
+++ b/packages/dwn-server/tests/process-handler.test.ts
@@ -13,7 +13,7 @@ describe('Process Handlers', () => {
   let processExitStub: ReturnType<typeof spyOn>;
 
   beforeEach(async () => {
-    const dwn = await getTestDwn();
+    dwn = await getTestDwn();
     dwnServer = new DwnServer({ dwn, config: { ...config, port: 0 } });
     await dwnServer.start();
     processExitStub = spyOn(process, 'exit').mockImplementation(() => {});

--- a/packages/dwn-sql-store/package.json
+++ b/packages/dwn-sql-store/package.json
@@ -52,8 +52,8 @@
     "clean": "rimraf dist compiled",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
-    "test": "bun test .spec.ts",
-    "test:node:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage .spec.ts"
+    "test": "bun test --timeout 10000 .spec.ts",
+    "test:node:coverage": "bun test --timeout 10000 --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage .spec.ts"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- **dwn-server**: Fix variable shadowing bug in `process-handler.test.ts` where `const dwn` in `beforeEach` shadowed the outer `let dwn`, leaving it `undefined` when the uncaught exception test recreated `DwnServer` — causing a hang and 5s timeout
- **dwn-sql-store**: Increase test timeout from 5s (bun default) to 10s — all three SQL dialects (MySQL, Postgres, SQLite) run concurrently in the same file and heavyweight integration tests occasionally exceed 5s under resource contention

## Verification

- `dwn-server`: 100 pass, 0 fail (was 99 pass, 1 fail)
- `dwn-sql-store`: 1581 pass, 0 fail (was 1580 pass, 1 fail)