### PR TITLE
fix(agent,dwn-sdk-js): fix flaky sync timeout and Firefox browser test import failure

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -15,6 +15,7 @@ import {
   Message,
   PermissionsProtocol,
 } from '@enbox/dwn-sdk-js';
+import { hashToHex, initDefaultHashes } from '@enbox/dwn-sdk-js';
 
 import type { PermissionsApi } from './types/permissions.js';
 import type { SyncEngine, SyncIdentityOptions } from './types/sync.js';
@@ -54,6 +55,13 @@ export class SyncEngineLevel implements SyncEngine {
   private _db: AbstractLevel<string | Buffer | Uint8Array>;
   private _syncIntervalId?: ReturnType<typeof setInterval>;
   private _syncLock = false;
+
+  /**
+   * Hex-encoded default hashes for empty subtrees at each depth, keyed by depth.
+   * Lazily initialized on first use. Used by `walkTreeDiff` to detect empty subtrees
+   * and short-circuit the recursive walk instead of descending all the way to MAX_DIFF_DEPTH.
+   */
+  private _defaultHashHex?: Map<number, string>;
 
   constructor({ agent, dataPath, db }: SyncEngineLevelParams) {
     this._agent = agent;
@@ -256,6 +264,27 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   // ---------------------------------------------------------------------------
+  // Default Hash Cache
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the hex-encoded default (empty-subtree) hash for a given depth.
+   * Lazily initializes the cache on first call.
+   */
+  private async getDefaultHashHex(depth: number): Promise<string> {
+    if (this._defaultHashHex === undefined) {
+      const defaults = await initDefaultHashes();
+      const map = new Map<number, string>();
+      // Pre-compute hex strings for depths 0 through MAX_DIFF_DEPTH (inclusive).
+      for (let d = 0; d <= MAX_DIFF_DEPTH; d++) {
+        map.set(d, hashToHex(defaults[d]));
+      }
+      this._defaultHashHex = map;
+    }
+    return this._defaultHashHex.get(depth) ?? '';
+  }
+
+  // ---------------------------------------------------------------------------
   // SMT Root Comparison
   // ---------------------------------------------------------------------------
 
@@ -345,16 +374,17 @@ export class SyncEngineLevel implements SyncEngine {
         return;
       }
 
-      // Short-circuit: if one side is entirely empty, all entries on the other
-      // side are unique.  Enumerate leaves directly instead of recursing further
-      // into the tree — this avoids the exponential walk when the remote DWN
-      // returns empty responses (e.g. auth failure or truly empty tree).
-      if (!remoteHash && localHash) {
+      // Short-circuit: if one side is the default (empty-subtree) hash, all entries
+      // on the other side are unique.  Enumerate leaves directly instead of recursing
+      // further into the tree — this avoids an exponential walk when one DWN has
+      // entries that the other lacks entirely in this subtree.
+      const emptyHash = await this.getDefaultHashHex(prefix.length);
+      if (remoteHash === emptyHash && localHash !== emptyHash) {
         const localLeaves = await this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantId);
         onlyLocal.push(...localLeaves);
         return;
       }
-      if (!localHash && remoteHash) {
+      if (localHash === emptyHash && remoteHash !== emptyHash) {
         const remoteLeaves = await this.getRemoteLeaves(did, dwnUrl, prefix, delegateDid, protocol, permissionGrantId);
         onlyRemote.push(...remoteLeaves);
         return;

--- a/packages/dwn-sdk-js/tests/interfaces/messages-get.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/messages-get.spec.ts
@@ -1,10 +1,11 @@
-import type { MessagesReadMessage } from '../../src/index.js';
+import type { MessagesReadMessage } from '../../src/types/messages-types.js';
 
+import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { Jws } from '../../src/utils/jws.js';
 import { Message } from '../../src/core/message.js';
-import { MessagesRead } from '../../src/index.js';
+import { MessagesRead } from '../../src/interfaces/messages-read.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { describe, expect, it } from 'bun:test';
-import { DwnErrorCode, Jws } from '../../src/index.js';
 
 describe('MessagesRead Message', () => {
   describe('create', () => {

--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -49,6 +49,10 @@ export default defineConfig({
       'lru-cache',
       'ulidx',
       'ajv',
+      'ajv/dist/2020.js',
+      'ipfs-unixfs-importer',
+      'ipfs-unixfs',
+      '@ipld/dag-pb',
     ],
   },
   test: {


### PR DESCRIPTION
## Summary

- **agent**: Fix broken short-circuit optimization in `SyncEngineLevel.walkTreeDiff` that caused the sync engine to make ~32 sequential HTTP round trips instead of ~4-6, intermittently exceeding the 10s test timeout
- **dwn-sdk-js**: Fix intermittent Firefox browser test import failure in `messages-get.spec.ts` by using direct path imports and adding missing CJS transitive dependencies to Vitest `optimizeDeps`

## Details

### Sync engine short-circuit fix (`sync-engine-level.ts`)

The `walkTreeDiff` method had a short-circuit optimization that checked `!remoteHash` to detect empty subtrees. However, the DWN `MessagesSyncHandler` always returns `hashToHex(hash)` — a 64-character hex string even for empty subtrees (the default hash at that depth). This meant `!remoteHash` was always `false`, making the optimization dead code.

Without the short-circuit, every differing subtree descended all 16 levels to `MAX_DIFF_DEPTH`, resulting in dozens of sequential remote HTTP calls. Under CI resource contention this caused the `"syncs RecordsDelete messages from local to remote"` test to exceed its 10-second timeout.

**Fix**: Import `hashToHex` and `initDefaultHashes` from `@enbox/dwn-sdk-js`, lazily build a cache of hex-encoded default hashes, and compare subtree hashes against the actual default hash instead of checking for falsiness.

### Browser test fix (`messages-get.spec.ts` + `vitest.browser.config.ts`)

`messages-get.spec.ts` was the only interface test importing its tested class from the barrel (`../../src/index.js`), pulling in the entire DWN module graph including CJS dependencies not listed in `optimizeDeps.include`. When Vite discovered these un-optimized deps mid-run, it triggered optimization restarts that Firefox handled poorly, causing `TypeError: error loading dynamically imported module`.

**Fix**: Switch to direct path imports and add missing CJS transitive dependencies (`ajv/dist/2020.js`, `ipfs-unixfs-importer`, `ipfs-unixfs`, `@ipld/dag-pb`) to `optimizeDeps.include`.

## Verification

- `bun run lint` — all packages pass
- `bun test tests/sync-engine-level.spec.ts` — 50 pass, 0 fail (11s)
- `GREP="MessagesRead" bun run test:node-grep` — 21 pass, 0 fail
- Full agent test suite — 693 pass, 0 fail (90s)
- Full dwn-sdk-js test suite — 984 pass, 0 fail