### PR TITLE
fix(dwn-server): include build/ directory in Dockerfile for browser-bundle.js

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
           filters: |
             dwn-server:
               - 'packages/dwn-server/**'
+              - 'build/**'
               - 'fly.toml'
 
   deploy-dwn-server:

--- a/packages/dwn-server/Dockerfile
+++ b/packages/dwn-server/Dockerfile
@@ -12,6 +12,9 @@ COPY tsconfig.json ./
 # Copy scripts directory (needed for build)
 COPY scripts/ ./scripts/
 
+# Copy build directory (browser-bundle.js is referenced by package build scripts)
+COPY build/ ./build/
+
 # Copy all packages (since dwn-server depends on other packages in the monorepo)
 COPY packages/ ./packages/
 


### PR DESCRIPTION
## Summary

- **Fix Fly.io deploy failure** caused by missing `build/` directory in the Docker image. The `bun run --filter '*' build` command builds all packages, including those with `build:browser` scripts that reference `../../build/browser-bundle.js` — but the Dockerfile never copied the repo-root `build/` directory into the image.
- **Add `COPY build/ ./build/`** to `packages/dwn-server/Dockerfile` so `browser-bundle.js` and `esbuild-browser-config.cjs` are available during the Docker build.
- **Add `build/**` to deploy workflow change detection** so changes to the build scripts also trigger a redeploy.

## Error before fix

```
> [builder 10/10] RUN bun run --filter '*' build:
@enbox/agent build: error: Module not found "../../build/browser-bundle.js"
@enbox/api build: error: Module not found "../../build/browser-bundle.js"
```

## Changes

| File | Change |
|---|---|
| `packages/dwn-server/Dockerfile` | Add `COPY build/ ./build/` before the packages copy step |
| `.github/workflows/deploy.yml` | Add `build/**` to the `dwn-server` change detection filter |