### PR TITLE
refactor(crypto,dids,agent): remove getKeyUri from DsaApi, use KeyManager for KMS consumers

### DIFF
--- a/packages/agent/src/crypto-api.ts
+++ b/packages/agent/src/crypto-api.ts
@@ -19,7 +19,6 @@ import type {
   KeyBytesDeriver,
   KeyConverter,
   KeyWrapper,
-  KmsGetKeyUriParams,
   Pbkdf2Params,
   PrivateKeyToBytesParams,
   PublicKeyToBytesParams,
@@ -414,11 +413,6 @@ export class AgentCryptoApi implements CryptoApi<
     privateKey.kid ??= await computeJwkThumbprint({ jwk: privateKey });
 
     return privateKey;
-  }
-
-  // ! TODO: Remove this once the `Dsa` interface is updated in @enbox/crypto to remove KMS-specific methods.
-  public async getKeyUri(_params: KmsGetKeyUriParams): Promise<string> {
-    throw new Error('Method not implemented.');
   }
 
   public async getPublicKey({ key }:

--- a/packages/crypto/src/local-key-manager.ts
+++ b/packages/crypto/src/local-key-manager.ts
@@ -2,11 +2,11 @@ import type { KeyValueStore } from '@enbox/common';
 import { MemoryStore } from '@enbox/common';
 
 import type { CryptoAlgorithm } from './algorithms/crypto-algorithm.js';
-import type { DsaApi } from './types/crypto-api.js';
 import type { Hasher } from './types/hasher.js';
 import type { Jwk } from './jose/jwk.js';
 import type { KeyIdentifier } from './types/identifier.js';
 import type { KeyImporterExporter } from './types/key-io.js';
+import type { KeyManager } from './types/crypto-api.js';
 import type { Signer } from './types/signer.js';
 import type { AsymmetricKeyGenerator, KeyGenerator } from './types/key-generator.js';
 import type { GetPublicKeyParams, SignParams, VerifyParams } from './types/params-direct.js';
@@ -108,7 +108,7 @@ export interface LocalKeyManagerGenerateKeyParams extends KmsGenerateKeyParams {
 }
 
 export class LocalKeyManager implements
-    DsaApi,
+    KeyManager,
     KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams> {
 
   /**
@@ -242,7 +242,7 @@ export class LocalKeyManager implements
    * @remarks
    * This method generates a {@link https://datatracker.ietf.org/doc/html/rfc3986 | URI}
    * (Uniform Resource Identifier) for the given JWK, which uniquely identifies the key across all
-   * `DsaApi` implementations. The key URI is constructed by appending the
+   * `KeyManager` implementations. The key URI is constructed by appending the
    * {@link https://datatracker.ietf.org/doc/html/rfc7638 | JWK thumbprint} to the prefix
    * `urn:jwk:`. The JWK thumbprint is deterministically computed from the JWK and is consistent
    * regardless of property order or optional property inclusion in the JWK. This ensures that the

--- a/packages/crypto/src/types/crypto-api.ts
+++ b/packages/crypto/src/types/crypto-api.ts
@@ -65,17 +65,9 @@ export interface DsaApi<
   DigestInput = KmsDigestParams,
   SignInput = KmsSignParams,
   VerifyInput = KmsVerifyParams
-> extends AsymmetricKeyGenerator<GenerateKeyInput, GenerateKeyOutput, GetPublicKeyInput>,
+ > extends AsymmetricKeyGenerator<GenerateKeyInput, GenerateKeyOutput, GetPublicKeyInput>,
           Hasher<DigestInput>,
-          Signer<SignInput, VerifyInput> {
-  /**
-   *
-   * @param params - The parameters for getting the key URI.
-   * @param params.key - The key to get the URI for.
-   * @returns The key URI.
-   */
-  getKeyUri(params: KmsGetKeyUriParams): Promise<KeyIdentifier>;
-}
+          Signer<SignInput, VerifyInput> {}
 
 /**
  * The `CryptoApi` interface extends {@link DsaApi} with encryption, key conversion,

--- a/packages/dids/src/bearer-did.ts
+++ b/packages/dids/src/bearer-did.ts
@@ -1,10 +1,10 @@
 import type {
-  DsaApi,
   EnclosedSignParams,
   EnclosedVerifyParams,
   Jwk,
   KeyIdentifier,
   KeyImporterExporter,
+  KeyManager,
   KmsExportKeyParams,
   KmsImportKeyParams,
   Signer,
@@ -77,13 +77,13 @@ export class BearerDid {
    *
    * Each DID method requires at least one key be present in the provided `keyManager`.
    */
-  keyManager: DsaApi;
+  keyManager: KeyManager;
 
   constructor({ uri, document, metadata, keyManager }: {
     uri: string,
     document: DidDocument,
     metadata: DidMetadata,
-    keyManager: DsaApi
+    keyManager: KeyManager
   }) {
     this.uri = uri;
     this.document = document;
@@ -238,7 +238,7 @@ export class BearerDid {
    *         keys for any verification method are missing in the key manager.
    */
   public static async import({ portableDid, keyManager = new LocalKeyManager() }: {
-    keyManager?: DsaApi & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
+    keyManager?: KeyManager & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
     portableDid: PortableDid;
   }): Promise<BearerDid> {
 

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -1,9 +1,9 @@
 import type {
   AsymmetricKeyConverter,
-  DsaApi,
   Jwk,
   KeyIdentifier,
   KeyImporterExporter,
+  KeyManager,
   KmsExportKeyParams,
   KmsImportKeyParams,
   Signer,
@@ -506,7 +506,7 @@ export class DidDht extends DidMethod {
    * @param params.options - Optional parameters that can be specified when creating a new DID.
    * @returns A Promise resolving to a {@link BearerDid} object representing the new DID.
    */
-  public static async create<TKms extends DsaApi | undefined = undefined>({
+  public static async create<TKms extends KeyManager | undefined = undefined>({
     keyManager = new LocalKeyManager(),
     options = {}
   }: {
@@ -648,7 +648,7 @@ export class DidDht extends DidMethod {
    *         manager.
    */
   public static async import({ portableDid, keyManager = new LocalKeyManager() }: {
-    keyManager?: DsaApi & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
+    keyManager?: KeyManager & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
     portableDid: PortableDid;
   }): Promise<BearerDid> {
     // Verify the DID method is supported.

--- a/packages/dids/src/methods/did-ion.ts
+++ b/packages/dids/src/methods/did-ion.ts
@@ -1,10 +1,17 @@
-import type { DsaApi, Jwk, KeyIdentifier, KeyImporterExporter, KmsExportKeyParams, KmsImportKeyParams } from '@enbox/crypto';
 import type {
   IonDocumentModel,
   IonPublicKeyModel,
   IonPublicKeyPurpose,
   JwkEs256k,
 } from '@decentralized-identity/ion-sdk';
+import type {
+  Jwk,
+  KeyIdentifier,
+  KeyImporterExporter,
+  KeyManager,
+  KmsExportKeyParams,
+  KmsImportKeyParams,
+} from '@enbox/crypto';
 
 import { computeJwkThumbprint, LocalKeyManager } from '@enbox/crypto';
 import { IonDid, IonRequest } from '@decentralized-identity/ion-sdk';
@@ -364,7 +371,7 @@ export class DidIon extends DidMethod {
    * @param params.options - Optional parameters that can be specified when creating a new DID.
    * @returns A Promise resolving to a {@link BearerDid} object representing the new DID.
    */
-  public static async create<TKms extends DsaApi | undefined = undefined>({
+  public static async create<TKms extends KeyManager | undefined = undefined>({
     keyManager = new LocalKeyManager(),
     options = {}
   }: {
@@ -517,7 +524,7 @@ export class DidIon extends DidMethod {
    *         any verification method are missing in the key manager.
    */
   public static async import({ portableDid, keyManager = new LocalKeyManager() }: {
-    keyManager?: DsaApi & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
+    keyManager?: KeyManager & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
     portableDid: PortableDid;
   }): Promise<BearerDid> {
     // Verify the DID method is supported.

--- a/packages/dids/src/methods/did-jwk.ts
+++ b/packages/dids/src/methods/did-jwk.ts
@@ -1,9 +1,9 @@
 import type {
-  DsaApi,
   InferKeyGeneratorAlgorithm,
   Jwk,
   KeyIdentifier,
   KeyImporterExporter,
+  KeyManager,
   KmsExportKeyParams,
   KmsImportKeyParams,
 } from '@enbox/crypto';
@@ -76,7 +76,7 @@ export interface DidJwkCreateOptions<TKms> extends DidCreateOptions<TKms> {
   /**
    * Optionally specify the algorithm to be used for key generation.
    */
-  algorithm?: TKms extends DsaApi
+  algorithm?: TKms extends KeyManager
     ? InferKeyGeneratorAlgorithm<TKms>
     : InferKeyGeneratorAlgorithm<LocalKeyManager>;
 
@@ -193,7 +193,7 @@ export class DidJwk extends DidMethod {
    * @param params.options - Optional parameters that can be specified when creating a new DID.
    * @returns A Promise resolving to a {@link BearerDid} object representing the new DID.
    */
-  public static async create<TKms extends DsaApi | undefined = undefined>({
+  public static async create<TKms extends KeyManager | undefined = undefined>({
     keyManager = new LocalKeyManager(),
     options = {}
   }: {
@@ -305,7 +305,7 @@ export class DidJwk extends DidMethod {
    * @throws An error if the DID document does not contain exactly one verification method.
    */
   public static async import({ portableDid, keyManager = new LocalKeyManager() }: {
-    keyManager?: DsaApi & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
+    keyManager?: KeyManager & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
     portableDid: PortableDid;
   }): Promise<BearerDid> {
     // Verify the DID method is supported.

--- a/packages/dids/src/methods/did-key.ts
+++ b/packages/dids/src/methods/did-key.ts
@@ -1,11 +1,11 @@
 import type {
   AsymmetricKeyConverter,
-  DsaApi,
   InferKeyGeneratorAlgorithm,
   Jwk,
   KeyCompressor,
   KeyIdentifier,
   KeyImporterExporter,
+  KeyManager,
   KmsExportKeyParams,
   KmsImportKeyParams,
 } from '@enbox/crypto';
@@ -88,7 +88,7 @@ export interface DidKeyCreateOptions<TKms> extends DidCreateOptions<TKms> {
   /**
    * Optionally specify the algorithm to be used for key generation.
    */
-  algorithm?: TKms extends DsaApi
+  algorithm?: TKms extends KeyManager
     ? InferKeyGeneratorAlgorithm<TKms>
     : InferKeyGeneratorAlgorithm<LocalKeyManager>;
 
@@ -295,7 +295,7 @@ export class DidKey extends DidMethod {
    * @param params.options - Optional parameters that can be specified when creating a new DID.
    * @returns A Promise resolving to a {@link BearerDid} object representing the new DID.
    */
-  public static async create<TKms extends DsaApi | undefined = undefined>({
+  public static async create<TKms extends KeyManager | undefined = undefined>({
     keyManager = new LocalKeyManager(),
     options = {}
   }: {
@@ -408,7 +408,7 @@ export class DidKey extends DidMethod {
    * @throws An error if the DID document does not contain exactly one verification method.
    */
   public static async import({ portableDid, keyManager = new LocalKeyManager() }: {
-    keyManager?: DsaApi & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
+    keyManager?: KeyManager & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
     portableDid: PortableDid;
   }): Promise<BearerDid> {
     // Verify the DID method is supported.
@@ -473,7 +473,7 @@ export class DidKey extends DidMethod {
    */
   private static async createDocument({ didUri, options = {} }: {
     didUri: string;
-    options?: Exclude<DidKeyCreateOptions<DsaApi>, 'algorithm' | 'verificationMethods'> | DidResolutionOptions;
+    options?: Exclude<DidKeyCreateOptions<KeyManager>, 'algorithm' | 'verificationMethods'> | DidResolutionOptions;
   }): Promise<DidDocument> {
     const {
       defaultContext = 'https://www.w3.org/ns/did/v1',
@@ -582,7 +582,7 @@ export class DidKey extends DidMethod {
   private static async createSignatureMethod({ didUri, multibaseValue, options }: {
     didUri: string;
     multibaseValue: string;
-    options: Required<Pick<DidKeyCreateOptions<DsaApi>, 'enableExperimentalPublicKeyTypes' | 'publicKeyFormat'>>
+    options: Required<Pick<DidKeyCreateOptions<KeyManager>, 'enableExperimentalPublicKeyTypes' | 'publicKeyFormat'>>
   }): Promise<DidVerificationMethod> {
     const { enableExperimentalPublicKeyTypes, publicKeyFormat } = options;
 

--- a/packages/dids/src/methods/did-method.ts
+++ b/packages/dids/src/methods/did-method.ts
@@ -1,6 +1,6 @@
 import type {
-  DsaApi,
   InferKeyGeneratorAlgorithm,
+  KeyManager,
   LocalKeyManager,
 } from '@enbox/crypto';
 
@@ -47,7 +47,7 @@ export interface DidCreateVerificationMethod<TKms> extends Pick<Partial<DidVerif
    * };
    * ```
    */
-  algorithm: TKms extends DsaApi
+  algorithm: TKms extends KeyManager
     ? InferKeyGeneratorAlgorithm<TKms>
     : InferKeyGeneratorAlgorithm<LocalKeyManager>;
 
@@ -82,7 +82,7 @@ export interface DidCreateVerificationMethod<TKms> extends Pick<Partial<DidVerif
  * @typeparam O - The type of the options used for creating the DID.
  */
 export interface DidMethodApi<
-    TKms extends DsaApi | undefined = DsaApi,
+    TKms extends KeyManager | undefined = KeyManager,
     TDid extends BearerDid = BearerDid,
     TOptions extends DidCreateOptions<TKms> = DidCreateOptions<TKms>
   > extends DidMethodResolver {

--- a/packages/dids/tests/bearer-did.test.ts
+++ b/packages/dids/tests/bearer-did.test.ts
@@ -1,4 +1,4 @@
-import type { DsaApi } from '@enbox/crypto';
+import type { KeyManager } from '@enbox/crypto';
 
 import { LocalKeyManager } from '@enbox/crypto';
 import { afterAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
@@ -86,7 +86,7 @@ describe('BearerDid', () => {
 
     it('exported PortableDid does not include private keys  if the key manager does not support exporting keys', async () => {
       // Create a key manager that does not support exporting keys.
-      const keyManagerWithoutExport: DsaApi = {
+      const keyManagerWithoutExport: KeyManager = {
         digest       : mock(async () => undefined) as any,
         generateKey  : mock(async () => undefined) as any,
         getKeyUri    : mock(async () => undefined) as any,
@@ -136,7 +136,7 @@ describe('BearerDid', () => {
     let keyManagerMock: any;
 
     beforeEach(() => {
-      // Mock for DsaApi
+      // Mock for KeyManager
       keyManagerMock = {
         digest       : mock(async () => undefined),
         generateKey  : mock(async () => undefined),


### PR DESCRIPTION
## Summary

Closes #69

- **Remove `getKeyUri` from `DsaApi`** — the method is KMS-specific and doesn't belong on the base Digital Signature Algorithm interface. `DsaApi` now purely covers key generation, hashing, signing, and verification.
- **Retype all KMS consumers to `KeyManager`** — `BearerDid.keyManager`, DID method `create()` generic constraints (`TKms extends DsaApi` → `TKms extends KeyManager`), and `import()` key manager params all now use `KeyManager`, which inherits `DsaApi` and adds `getKeyUri`.
- **Remove dead `getKeyUri` stub from `AgentCryptoApi`** — the agent's `CryptoApi` implementation had a throwing stub (`'Method not implemented.'`) solely to satisfy the old `DsaApi` contract. This is no longer needed.

## Changed files

| Package | File | Change |
|---|---|---|
| `@enbox/crypto` | `src/types/crypto-api.ts` | Remove `getKeyUri` from `DsaApi` interface |
| `@enbox/crypto` | `src/local-key-manager.ts` | `implements DsaApi` → `implements KeyManager` |
| `@enbox/dids` | `src/bearer-did.ts` | `keyManager: DsaApi` → `keyManager: KeyManager` |
| `@enbox/dids` | `src/methods/did-method.ts` | `TKms extends DsaApi` → `TKms extends KeyManager` |
| `@enbox/dids` | `src/methods/did-dht.ts` | Same constraint + import update |
| `@enbox/dids` | `src/methods/did-key.ts` | Same constraint + import update |
| `@enbox/dids` | `src/methods/did-jwk.ts` | Same constraint + import update |
| `@enbox/dids` | `src/methods/did-ion.ts` | Same constraint + import update |
| `@enbox/dids` | `tests/bearer-did.test.ts` | Mock type `DsaApi` → `KeyManager` |
| `@enbox/agent` | `src/crypto-api.ts` | Remove `getKeyUri` stub + unused import |

## Verification

- All packages build successfully
- Lint passes across all packages
- **crypto**: 561 tests pass
- **dids**: 302 tests pass
- **agent**: 693 tests pass (4 skipped)
- **api**: 229 tests pass