### PR TITLE
ci: collect and report browser test coverage alongside Node coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,8 +685,13 @@ jobs:
         run: bunx playwright install --with-deps chromium firefox webkit
 
       - name: Run browser tests with coverage
+        id: browser-tests
         env:
           CI: true
+        # Coverage is collected even when some tests fail. Use continue-on-error
+        # so the staging/upload steps always run, then re-check the exit code in
+        # the final step to fail the job if tests actually broke.
+        continue-on-error: true
         run: |
           bun run --filter @enbox/common      test:browser:coverage
           bun run --filter @enbox/crypto      test:browser:coverage
@@ -714,6 +719,12 @@ jobs:
         with:
           name: coverage-browser
           path: coverage-staging/
+
+      - name: Fail if browser tests failed
+        if: always() && steps.browser-tests.outcome == 'failure'
+        run: |
+          echo "::error::Browser tests failed (coverage was still collected)"
+          exit 1
 
   # ---------------------------------------------------------------------------
   # Gate job for branch protection — always runs so required checks pass even


### PR DESCRIPTION
## Summary

- Collect browser test coverage in CI and surface it in PR comments and badges alongside existing Node coverage
- Browser coverage is informational only (no 90% threshold enforcement) since browser test suites are intentionally smaller subsets

## Changes

### `test-browser` job
- Switched from `test:browser` to `test:browser:coverage` (runs istanbul coverage collection)
- Added artifact staging and upload steps for browser lcov data (`coverage-browser` artifact)

### `coverage` job
- Added `test-browser` to `needs` so browser artifacts are available
- Added `Environment` column to the PR comment coverage table (Node vs Browser)
- Browser rows show an :information_source: icon instead of pass/fail — they don't enforce the 90% threshold
- Browser badge JSON files are generated alongside Node badges (e.g., `common-browser.json`)
- Footer note explains browser coverage is informational

### Example PR comment table

| Package | Environment | Line Coverage | Status |
|---------|-------------|---------------|--------|
| common | Node | 95.7% | :white_check_mark: |
| common | Browser | 96.3% | :information_source: |
| crypto | Node | 98.6% | :white_check_mark: |
| crypto | Browser | 91.2% | :information_source: |
| agent | Node | 90.3% | :white_check_mark: |
| agent | Browser | 34.1% | :information_source: |

_Browser coverage is informational only (subset of tests). Node coverage enforces the 90% threshold._