### PR TITLE
fix(dids,dwn-sdk-js): resolve Firefox browser test failures caused by level imports

### DIFF
--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -50,10 +50,12 @@
   ],
   "exports": {
     ".": {
+      "browser": "./dist/browser.mjs",
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js"
     },
     "./utils": {
+      "browser": "./dist/utils.js",
       "types": "./dist/types/utils.d.ts",
       "import": "./dist/esm/utils.js"
     }

--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -53,6 +53,10 @@ export default defineConfig({
       'ipfs-unixfs-importer',
       'ipfs-unixfs',
       '@ipld/dag-pb',
+      // level ecosystem: pre-bundle to prevent mid-run CJS discovery restarts
+      // that crash Firefox. Vite resolves level -> browser.js (via the "browser"
+      // field in level/package.json) -> browser-level (IndexedDB-based).
+      'level',
     ],
   },
   test: {


### PR DESCRIPTION
## Summary

Fixes Firefox browser test failures in `dwn-sdk-js` caused by the `level` Node-native module being transitively imported into the browser test bundle.

## Root Cause

Firefox's strict ESM loader crashes when Vite discovers CJS dependencies mid-run and triggers an optimization restart. Two import chains pull `level` into browser tests:

1. **`@enbox/dids` barrel** — `resolver-cache-level.ts` eagerly imports `{ Level } from 'level'`, and any `import { ... } from '@enbox/dids'` (used by 22 of 33 browser test files) triggers this chain
2. **`dwn-sdk-js` barrel** — directly exports Level-backed stores (`BlockstoreLevel`, `DataStoreLevel`, etc.) that import `level`

Chromium handles Vite's optimization restarts gracefully; Firefox throws `TypeError: error loading dynamically imported module`.

## Fix (two layers)

### Layer 1: Browser conditional export for `@enbox/dids`

Added `"browser"` condition to the `exports` field in `@enbox/dids/package.json`, pointing to the existing `dist/browser.mjs` bundle (already built by `build:browser` but never exposed). This is the [Node.js-standard approach](https://nodejs.org/api/packages.html#conditional-exports) for providing browser-safe entry points. Vitest browser mode automatically resolves the `browser` condition, so all `import { ... } from '@enbox/dids'` now get the self-contained browser bundle (no external `level` dependency).

### Layer 2: Pre-bundle `level` in `dwn-sdk-js` browser config

Added `'level'` to `optimizeDeps.include` in `dwn-sdk-js/vitest.browser.config.ts`. This ensures Vite pre-bundles `level` **before** test execution starts, using `level`'s `"browser"` package.json field to correctly resolve to `browser-level` (IndexedDB-based, browser-safe). This eliminates the mid-run CJS discovery restart that crashes Firefox.

## Verification

- All 66 `dwn-sdk-js` browser test files pass (33 Chromium + 33 Firefox), 474 tests total
- All 302 `dids` node tests pass
- All 984 `dwn-sdk-js` node tests pass
- All 693 `agent` node tests pass (validates the `@enbox/dids` export change doesn't break downstream)
- Lint passes across the monorepo