### PR TITLE
fix(api,crypto,dwn-sdk-js): update stale secp256k1 encryption references to X25519

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Bun workspace monorepo for decentralized web infrastructure. Runtime is **Bun** 
 
 ```
 @enbox/common          (shared utilities, TtlCache, LevelStore)
-  @enbox/crypto        (Ed25519, secp256k1, AES, JWE)
+  @enbox/crypto        (Ed25519, X25519, secp256k1, AES, JWE)
     @enbox/dids        (did:dht, did:jwk, resolution)
       @enbox/dwn-sdk-js  (DWN protocol engine, message handlers, stores)
         @enbox/agent     (agent framework: identity, key management, DWN stores, sync)
@@ -361,7 +361,7 @@ describe('ComponentName', () => {
 
   beforeEach(async () => {
     await testHarness.clearStorage();
-    await testHarness.createAgentDid();  // creates secp256k1 did:jwk
+    await testHarness.createAgentDid();  // creates did:jwk with Ed25519 + X25519
   });
 
   afterAll(async () => {
@@ -409,7 +409,7 @@ await expect(asyncOperation()).rejects.toThrow('error message');
 
 1. **Layer 1 — Vault** (`HdIdentityVault`): 12-word BIP-39 seed phrase derives HD keys. Password encrypts the agent's `PortableDid` as CompactJWE (AES-256-GCM via PBKDF2). Stored in `VAULT_STORE` LevelDB.
 
-2. **Layer 2 — DWN record-level** (`DwnKeyStore`): Records with `encryptionRequired: true` in their protocol type definition are encrypted using ECIES-ES256K with the tenant's secp256k1 `#enc` key. The `$encryption` block is derived and injected into the protocol definition at install time.
+2. **Layer 2 — DWN record-level** (`DwnKeyStore`): Records with `encryptionRequired: true` in their protocol type definition are encrypted using JWE (ECDH-ES+A256KW key agreement with the tenant's X25519 `#enc` key, AES-256-GCM or XChaCha20-Poly1305 content encryption). The `$encryption` block is derived and injected into the protocol definition at install time.
 
 Recovery path: seed phrase -> agent DID (deterministic) -> `#enc` key -> decrypt DWN key records.
 
@@ -435,6 +435,6 @@ The **agent DID** (`agent.agentDid`) is the agent's own identity. The **tenant D
 
 ### DWN Encryption
 
-Strictly secp256k1. The entire pipeline (ECIES, HdKey derivation, protocol key injection) is hardcoded to secp256k1. In production, `HdIdentityVault.initialize()` always creates the agent DID as `did:dht` with both Ed25519 (`#sig`) and secp256k1 (`#enc`).
+Uses X25519 for key agreement (ECDH-ES+A256KW) with AEAD content encryption (AES-256-GCM or XChaCha20-Poly1305). The JWE General JSON Serialization format stores recipients, IV, and authentication tag alongside the encrypted data. In production, `HdIdentityVault.initialize()` always creates the agent DID as `did:dht` with both Ed25519 (`#sig`) and X25519 (`#enc`).
 
-Encryption is declared in the protocol definition via `ProtocolType.encryptionRequired: true`. When set, `DwnDataStore.installProtocol()` derives and injects `$encryption` keys. If the tenant DID lacks a secp256k1 keyAgreement key, installation fails — no plaintext fallback.
+Encryption is declared in the protocol definition via `ProtocolType.encryptionRequired: true`. When set, `DwnDataStore.installProtocol()` derives and injects `$encryption` keys. If the tenant DID lacks an X25519 keyAgreement key, installation fails — no plaintext fallback.

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -381,7 +381,7 @@ export class Web5 {
                   purposes  : ['assertionMethod', 'authentication']
                 },
                 {
-                  algorithm : 'secp256k1',
+                  algorithm : 'X25519',
                   id        : 'enc',
                   purposes  : ['keyAgreement']
                 }

--- a/packages/crypto/src/primitives/x25519.ts
+++ b/packages/crypto/src/primitives/x25519.ts
@@ -345,32 +345,25 @@ export class X25519 {
   }
 
   /**
-   * Computes an RFC6090-compliant Elliptic Curve Diffie-Hellman (ECDH) shared secret
-   * using secp256k1 private and public keys in JSON Web Key (JWK) format.
+   * Computes an X25519 Elliptic Curve Diffie-Hellman (ECDH) shared secret
+   * using X25519 private and public keys in JSON Web Key (JWK) format.
    *
    * @remarks
    * This method facilitates the ECDH key agreement protocol, which is a method of securely
    * deriving a shared secret between two parties based on their private and public keys.
    * It takes the private key of one party (privateKeyA) and the public key of another
-   * party (publicKeyB) to compute a shared secret. The shared secret is derived from the
-   * x-coordinate of the elliptic curve point resulting from the multiplication of the
-   * public key with the private key.
+   * party (publicKeyB) to compute a shared secret. The shared secret is the raw output
+   * of the X25519 function as defined in RFC 7748.
    *
-   * Note: When performing Elliptic Curve Diffie-Hellman (ECDH) key agreement,
-   * the resulting shared secret is a point on the elliptic curve, which
-   * consists of an x-coordinate and a y-coordinate. With a 256-bit curve like
-   * secp256k1, each of these coordinates is 32 bytes (256 bits) long. However,
-   * in the ECDH process, it's standard practice to use only the x-coordinate
-   * of the shared secret point as the resulting shared key. This is because
-   * the y-coordinate does not add to the entropy of the key, and both parties
-   * can independently compute the x-coordinate.  Consquently, this implementation
-   * omits the y-coordinate for simplicity and standard compliance.
+   * Note: Unlike Weierstrass curves (e.g., secp256k1), X25519 is a Montgomery curve
+   * where the ECDH output is a single 32-byte scalar value, not an (x, y) point.
+   * The result is used directly as the shared secret.
    *
    * @example
    * ```ts
    * const privateKeyA = { ... }; // A Jwk object for party A
    * const publicKeyB = { ... }; // A PublicKeyJwk object for party B
-   * const sharedSecret = await Secp256k1.sharedSecret({
+   * const sharedSecret = await X25519.sharedSecret({
    *   privateKeyA,
    *   publicKeyB
    * });

--- a/packages/dwn-sdk-js/src/types/protocols-types.ts
+++ b/packages/dwn-sdk-js/src/types/protocols-types.ts
@@ -49,7 +49,7 @@ export type ProtocolType = {
   /**
    * When `true`, records of this type **must** be encrypted at the DWN record
    * level using the tenant's ProtocolPath-derived encryption key. The tenant
-   * DID must have a secp256k1 keyAgreement key; protocol installation will
+   * DID must have an X25519 keyAgreement key; protocol installation will
    * fail if it does not.
    *
    * When `false` or omitted, encryption is not required for this type.


### PR DESCRIPTION
## Summary

Followup to #191 — fixes stale secp256k1 references that were missed during the JWE encryption rewrite.

- **`packages/api/src/web5.ts`**: `Web5.connect()` was creating agent DIDs with `algorithm: 'secp256k1'` for the `#enc` keyAgreement key. Changed to `'X25519'`. Without this fix, new agent DIDs created in production would have secp256k1 encryption keys incompatible with the JWE pipeline.
- **`packages/crypto/src/primitives/x25519.ts`**: `sharedSecret()` JSDoc was copy-pasted from `Secp256k1` and referenced the wrong curve, algorithm, and example code.
- **`packages/dwn-sdk-js/src/types/protocols-types.ts`**: JSDoc still said "secp256k1 keyAgreement key" — updated to "X25519".
- **`CLAUDE.md`**: Updated architecture docs — DWN encryption section, Layer 2 description, test harness comment, and crypto package description.

## Verification

- `bun run lint` — all 10 packages pass
- `@enbox/crypto` build + 561 tests pass
- `@enbox/dwn-sdk-js` build + 985 tests pass

Closes #185