### PR TITLE
fix(dwn-sdk-js,agent): align encryption with spec — dataFormats path and IV size

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -647,9 +647,10 @@ export class AgentDwnApi {
           throw new Error('AgentDwnApi: Data must be provided for encrypted records.');
         }
 
-        // 5. Generate random DEK and IV
+        // 5. Generate random DEK and IV (IV size depends on content encryption algorithm)
+        const contentEncryptionAlgorithm = ContentEncryptionAlgorithm.A256GCM;
         const dataEncryptionKey = crypto.getRandomValues(new Uint8Array(32));
-        const dataEncryptionIV = crypto.getRandomValues(new Uint8Array(12));
+        const dataEncryptionIV = crypto.getRandomValues(new Uint8Array(AgentDwnApi.ivLength(contentEncryptionAlgorithm)));
 
         // 6. Build partial EncryptionInput (authenticationTag added after AEAD encryption)
         let encryptionInput: (Omit<EncryptionInput, 'authenticationTag'> & { authenticationTag?: Uint8Array }) | undefined;
@@ -731,9 +732,9 @@ export class AgentDwnApi {
           encryptionInput = buildProtocolPathInput();
         }
 
-        // 7. Encrypt data with AEAD (AES-256-GCM) and compute CID
+        // 7. Encrypt data with AEAD and compute CID
         const { encryptedBytes, dataCid, dataSize, authenticationTag } =
-          await this.encryptAndComputeCid(plaintextBytes, dataEncryptionKey, dataEncryptionIV);
+          await this.encryptAndComputeCid(plaintextBytes, dataEncryptionKey, dataEncryptionIV, contentEncryptionAlgorithm);
 
         // 8. Replace plaintext with encrypted data
         messageParams.dataCid = dataCid;
@@ -964,6 +965,14 @@ export class AgentDwnApi {
    * The `authenticationTag` is NOT set here — the caller must set it after
    * AEAD encryption produces the tag.
    */
+  /**
+   * Returns the correct nonce/IV byte length for the given content encryption algorithm.
+   * A256GCM uses 96-bit (12-byte) nonces; XC20P uses 192-bit (24-byte) nonces.
+   */
+  private static ivLength(algorithm: ContentEncryptionAlgorithm): number {
+    return algorithm === ContentEncryptionAlgorithm.XC20P ? 24 : 12;
+  }
+
   private buildEncryptionInput(
     dek: Uint8Array,
     iv: Uint8Array,
@@ -983,17 +992,18 @@ export class AgentDwnApi {
   }
 
   /**
-   * Encrypts plaintext bytes with AEAD (AES-256-GCM by default) and computes
-   * the CID of the resulting ciphertext. Returns everything needed to attach
-   * the encrypted data to a DWN message, including the authentication tag.
+   * Encrypts plaintext bytes with AEAD and computes the CID of the resulting ciphertext.
+   * Returns everything needed to attach the encrypted data to a DWN message, including
+   * the authentication tag.
    */
   private async encryptAndComputeCid(
     plaintextBytes: Uint8Array,
     dek: Uint8Array,
     iv: Uint8Array,
+    algorithm: ContentEncryptionAlgorithm = ContentEncryptionAlgorithm.A256GCM,
   ): Promise<{ encryptedBytes: Uint8Array; dataCid: string; dataSize: number; authenticationTag: Uint8Array }> {
     const { ciphertextStream, tag: authenticationTag } = await Encryption.aeadEncryptStream(
-      ContentEncryptionAlgorithm.A256GCM, dek, iv, DataStream.fromBytes(plaintextBytes),
+      algorithm, dek, iv, DataStream.fromBytes(plaintextBytes),
     );
     const encryptedBytes = await DataStream.toBytes(ciphertextStream);
     const cidStream = DataStream.fromBytes(encryptedBytes);
@@ -1873,11 +1883,12 @@ export class AgentDwnApi {
       // --- Encrypt to the recipient's ProtocolPath key (cross-DWN delivery) ---
       // Manually build encryption input targeting the recipient's key so the
       // record is decryptable only by the recipient.
+      const algorithm = ContentEncryptionAlgorithm.A256GCM;
       const dataEncryptionKey = crypto.getRandomValues(new Uint8Array(32));
-      const dataEncryptionIV = crypto.getRandomValues(new Uint8Array(12));
+      const dataEncryptionIV = crypto.getRandomValues(new Uint8Array(AgentDwnApi.ivLength(algorithm)));
 
       const { encryptedBytes, dataCid, dataSize, authenticationTag } =
-        await this.encryptAndComputeCid(plaintextBytes, dataEncryptionKey, dataEncryptionIV);
+        await this.encryptAndComputeCid(plaintextBytes, dataEncryptionKey, dataEncryptionIV, algorithm);
 
       const encryptionInput = {
         ...this.buildEncryptionInput(

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -140,7 +140,7 @@ export class Records {
 
     let fullDerivationPath;
     if (keyDerivationScheme === KeyDerivationScheme.DataFormats) {
-      fullDerivationPath = Records.constructKeyDerivationPathUsingDataFormatsScheme(descriptor.schema, descriptor.dataFormat);
+      fullDerivationPath = Records.constructKeyDerivationPathUsingDataFormatsScheme(descriptor.dataFormat);
     } else if (keyDerivationScheme === KeyDerivationScheme.ProtocolPath) {
       fullDerivationPath = Records.constructKeyDerivationPathUsingProtocolPathScheme(descriptor);
     } else if (keyDerivationScheme === KeyDerivationScheme.ProtocolContext) {
@@ -155,20 +155,14 @@ export class Records {
 
   /**
    * Constructs the full key derivation path using `dataFormats` scheme.
+   * The derivation path is always `["dataFormats", "<mime-type>"]` regardless of whether
+   * a schema is present. This matches the spec: keys are derived purely from the MIME type.
    */
-  public static constructKeyDerivationPathUsingDataFormatsScheme(schema: string | undefined, dataFormat: string ): string[] {
-    if (schema !== undefined) {
-      return [
-        KeyDerivationScheme.DataFormats,
-        schema, // this is as spec-ed on TP27, the intent is to support sharing the key for just a specific data type under a schema
-        dataFormat
-      ];
-    } else {
-      return [
-        KeyDerivationScheme.DataFormats,
-        dataFormat
-      ];
-    }
+  public static constructKeyDerivationPathUsingDataFormatsScheme(dataFormat: string): string[] {
+    return [
+      KeyDerivationScheme.DataFormats,
+      dataFormat
+    ];
   }
 
   /**

--- a/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
@@ -1864,7 +1864,7 @@ export function testRecordsReadHandler(): void {
           };
 
           const dataFormat = 'some/format';
-          const dataFormatDerivationPath = Records.constructKeyDerivationPathUsingDataFormatsScheme(schema, dataFormat);
+          const dataFormatDerivationPath = Records.constructKeyDerivationPathUsingDataFormatsScheme(dataFormat);
           const dataFormatDerivedPublicKey = await HdKey.derivePublicKey(rootPrivateKeyWithDataFormatsScheme, dataFormatDerivationPath);
 
           const encryptionInput: EncryptionInput = {
@@ -1920,12 +1920,12 @@ export function testRecordsReadHandler(): void {
           const plaintextBytes2 = await DataStream.toBytes(plaintextDataStream2);
           expect(ArrayUtility.byteArraysEqual(plaintextBytes2, originalData)).toBe(true);
 
-          // test unable to decrypt the message if dataFormat-derived key is derived without taking `schema` as input to derivation path
+          // test unable to decrypt the message if dataFormat-derived key uses an incorrect data format in derivation path
           const readReply3 = await dwn.processMessage(alice.did, recordsRead.message); // process the same read message to get a new cipher stream
           expect(readReply3.status.code).toBe(200);
           const cipherStream3 = readReply3.entry!.data!;
 
-          const invalidDerivationPath = [KeyDerivationScheme.DataFormats, message.descriptor.dataFormat];
+          const invalidDerivationPath = [KeyDerivationScheme.DataFormats, 'wrong/format'];
           const inValidDescendantPrivateKey: DerivedPrivateJwk
             = await HdKey.derivePrivateKey(rootPrivateKeyWithDataFormatsScheme, invalidDerivationPath);
 
@@ -1956,7 +1956,7 @@ export function testRecordsReadHandler(): void {
           };
 
           const dataFormat = `image/jpg`;
-          const dataFormatDerivationPath = Records.constructKeyDerivationPathUsingDataFormatsScheme(undefined, dataFormat);
+          const dataFormatDerivationPath = Records.constructKeyDerivationPathUsingDataFormatsScheme(dataFormat);
           const dataFormatDerivedPublicKey = await HdKey.derivePublicKey(rootPrivateKeyWithDataFormatsScheme, dataFormatDerivationPath);
 
           const encryptionInput: EncryptionInput = {


### PR DESCRIPTION
## Summary

Closes two spec compliance gaps identified during the encryption spec-vs-implementation audit.

- **dataFormats derivation path**: Removed the `schema` segment from the `dataFormats` key derivation path. The spec defines this as `["dataFormats", "<mime-type>"]` (always 2 segments), but the implementation was producing `["dataFormats", "<schema>", "<mime-type>"]` when a schema was present. Keys derived by a spec-conformant implementation would have been incompatible.
- **Agent IV size**: IV generation was hardcoded to 12 bytes (correct for A256GCM but wrong for XC20P which needs 24 bytes). Added `AgentDwnApi.ivLength()` static helper that returns the correct nonce size for any `ContentEncryptionAlgorithm`.

## Verification

- `bun run lint` — all 11 packages pass
- `@enbox/dwn-sdk-js` — 989 pass, 0 fail
- `@enbox/agent` — 695 pass, 0 fail, 4 skip
- `@enbox/api` — 243 pass, 0 fail

Companion spec PR: enboxorg/dwn-spec#32
Relates to #185