### PR TITLE
test(dwn-sdk-js,agent): add encryption edge case tests

### DIFF
--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -3454,6 +3454,68 @@ describe('Key Delivery Protocol Infrastructure (PR A)', () => {
 
       warnStub.restore();
     }, 10000);
+
+    it('should handle concurrent contextKey writes for different recipients gracefully', async () => {
+      const bob = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
+      const carol = await testHarness.createIdentity({ name: 'Carol', testDwnUrls });
+
+      // Install key delivery protocol for all participants
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(alice.did.uri);
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(bob.did.uri);
+      await testHarness.agent.dwn.ensureKeyDeliveryProtocol(carol.did.uri);
+
+      const contextId = 'concurrent-context-id';
+      const mockContextKey = {
+        rootKeyId         : `${alice.did.uri}#enc`,
+        derivationScheme  : 'protocolContext',
+        derivationPath    : ['protocolContext', contextId],
+        derivedPrivateKey : { kty: 'OKP', crv: 'X25519', x: 'test', d: 'test' },
+      };
+
+      // Fire two contextKey writes concurrently for different recipients
+      const [bobRecordId, carolRecordId] = await Promise.all([
+        testHarness.agent.dwn.writeContextKeyRecord({
+          tenantDid       : alice.did.uri,
+          recipientDid    : bob.did.uri,
+          contextKeyData  : mockContextKey as any,
+          sourceProtocol  : 'https://protocol.xyz/concurrent-test',
+          sourceContextId : contextId,
+        }),
+        testHarness.agent.dwn.writeContextKeyRecord({
+          tenantDid       : alice.did.uri,
+          recipientDid    : carol.did.uri,
+          contextKeyData  : mockContextKey as any,
+          sourceProtocol  : 'https://protocol.xyz/concurrent-test',
+          sourceContextId : contextId,
+        }),
+      ]);
+
+      // Both writes should succeed with distinct record IDs
+      expect(typeof bobRecordId).toBe('string');
+      expect(typeof carolRecordId).toBe('string');
+      expect(bobRecordId).not.toBe(carolRecordId);
+
+      // Verify both records exist
+      const { reply: queryReply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : {
+          filter: {
+            protocol     : KeyDeliveryProtocolDefinition.protocol,
+            protocolPath : 'contextKey',
+          }
+        }
+      });
+
+      expect(queryReply.entries).toHaveLength(2);
+
+      const recipientDids = queryReply.entries!.map(
+        (entry: any) => entry.descriptor.recipient as string
+      );
+      expect(recipientDids).toContain(bob.did.uri);
+      expect(recipientDids).toContain(carol.did.uri);
+    }, 15000);
   });
 
   describe('fetchContextKeyRecord()', () => {

--- a/packages/agent/tests/store-key.spec.ts
+++ b/packages/agent/tests/store-key.spec.ts
@@ -526,6 +526,31 @@ describe('KeyStore', () => {
 
         expect((freshKeyStore as any).isEncryptionActive(tenantDid)).toBe(false);
       });
+
+      it('should still decrypt old records after re-initialization', async () => {
+        // Write an encrypted key record.
+        const keyUri = await testHarness.agent.keyManager.generateKey({
+          algorithm: 'Ed25519'
+        });
+
+        // Read it back to verify it decrypts successfully.
+        const storedKeyBefore = await keyStore.get({ id: keyUri, agent: testHarness.agent });
+        expect(storedKeyBefore).toBeDefined();
+        expect(storedKeyBefore!.kty).toBe('OKP');
+
+        // Clear the protocol initialization cache (simulating agent restart).
+        (keyStore as DwnDataStore<Jwk>)['_protocolInitializedCache']?.clear();
+        (keyStore as any)._tenantEncryptionActive?.clear();
+
+        // Re-initialize — should detect the existing protocol, not re-install.
+        await (keyStore as DwnDataStore<Jwk>)['initialize']({ agent: testHarness.agent });
+
+        // The previously written encrypted record should still be readable.
+        const storedKeyAfter = await keyStore.get({ id: keyUri, agent: testHarness.agent });
+        expect(storedKeyAfter).toBeDefined();
+        expect(storedKeyAfter!.kty).toBe(storedKeyBefore!.kty);
+        expect(storedKeyAfter!.kid).toBe(storedKeyBefore!.kid);
+      });
     });
 
     describe('getAllRecords() error handling', () => {

--- a/packages/dwn-sdk-js/tests/utils/encryption.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/encryption.spec.ts
@@ -2,10 +2,14 @@ import type { PublicKeyJwk } from '../../src/types/jose-types.js';
 
 import { ArrayUtility } from '../../src/utils/array.js';
 import { DataStream } from '../../src/index.js';
+import { Encoder } from '../../src/utils/encoder.js';
 import { TestDataGenerator } from './test-data-generator.js';
 import { X25519 } from '@enbox/crypto';
 import { ContentEncryptionAlgorithm, Encryption } from '../../src/utils/encryption.js';
 import { describe, expect, it } from 'bun:test';
+
+/** Boundary sizes that exercise edge cases in AEAD ciphers. */
+const boundarySizes = [0, 1, 15, 16, 17, 32, 256];
 
 describe('Encryption', () => {
   describe('AEAD A256GCM', () => {
@@ -43,6 +47,48 @@ describe('Encryption', () => {
       const plaintextBytes = await DataStream.toBytes(plaintextStream);
 
       expect(ArrayUtility.byteArraysEqual(inputBytes, plaintextBytes)).toBe(true);
+    });
+
+    it('should handle boundary plaintext sizes via byte API', async () => {
+      const key = TestDataGenerator.randomBytes(32);
+      const iv = TestDataGenerator.randomBytes(12);
+
+      for (const size of boundarySizes) {
+        const inputBytes = size === 0 ? new Uint8Array(0) : TestDataGenerator.randomBytes(size);
+
+        const { ciphertext, tag } = await Encryption.aeadEncrypt(
+          ContentEncryptionAlgorithm.A256GCM, key, iv, inputBytes
+        );
+
+        const plaintext = await Encryption.aeadDecrypt(
+          ContentEncryptionAlgorithm.A256GCM, key, iv, ciphertext, tag
+        );
+
+        expect(plaintext.length).toBe(size);
+        expect(ArrayUtility.byteArraysEqual(inputBytes, plaintext)).toBe(true);
+      }
+    });
+
+    it('should handle boundary plaintext sizes via stream API', async () => {
+      const key = TestDataGenerator.randomBytes(32);
+      const iv = TestDataGenerator.randomBytes(12);
+
+      for (const size of boundarySizes) {
+        const inputBytes = size === 0 ? new Uint8Array(0) : TestDataGenerator.randomBytes(size);
+        const inputStream = DataStream.fromBytes(inputBytes);
+
+        const { ciphertextStream, tag } = await Encryption.aeadEncryptStream(
+          ContentEncryptionAlgorithm.A256GCM, key, iv, inputStream
+        );
+
+        const plaintextStream = await Encryption.aeadDecryptStream(
+          ContentEncryptionAlgorithm.A256GCM, key, iv, ciphertextStream, tag
+        );
+        const plaintextBytes = await DataStream.toBytes(plaintextStream);
+
+        expect(plaintextBytes.length).toBe(size);
+        expect(ArrayUtility.byteArraysEqual(inputBytes, plaintextBytes)).toBe(true);
+      }
     });
   });
 
@@ -82,6 +128,48 @@ describe('Encryption', () => {
 
       expect(ArrayUtility.byteArraysEqual(inputBytes, plaintextBytes)).toBe(true);
     });
+
+    it('should handle boundary plaintext sizes via byte API', async () => {
+      const key = TestDataGenerator.randomBytes(32);
+      const nonce = TestDataGenerator.randomBytes(24);
+
+      for (const size of boundarySizes) {
+        const inputBytes = size === 0 ? new Uint8Array(0) : TestDataGenerator.randomBytes(size);
+
+        const { ciphertext, tag } = await Encryption.aeadEncrypt(
+          ContentEncryptionAlgorithm.XC20P, key, nonce, inputBytes
+        );
+
+        const plaintext = await Encryption.aeadDecrypt(
+          ContentEncryptionAlgorithm.XC20P, key, nonce, ciphertext, tag
+        );
+
+        expect(plaintext.length).toBe(size);
+        expect(ArrayUtility.byteArraysEqual(inputBytes, plaintext)).toBe(true);
+      }
+    });
+
+    it('should handle boundary plaintext sizes via stream API', async () => {
+      const key = TestDataGenerator.randomBytes(32);
+      const nonce = TestDataGenerator.randomBytes(24);
+
+      for (const size of boundarySizes) {
+        const inputBytes = size === 0 ? new Uint8Array(0) : TestDataGenerator.randomBytes(size);
+        const inputStream = DataStream.fromBytes(inputBytes);
+
+        const { ciphertextStream, tag } = await Encryption.aeadEncryptStream(
+          ContentEncryptionAlgorithm.XC20P, key, nonce, inputStream
+        );
+
+        const plaintextStream = await Encryption.aeadDecryptStream(
+          ContentEncryptionAlgorithm.XC20P, key, nonce, ciphertextStream, tag
+        );
+        const plaintextBytes = await DataStream.toBytes(plaintextStream);
+
+        expect(plaintextBytes.length).toBe(size);
+        expect(ArrayUtility.byteArraysEqual(inputBytes, plaintextBytes)).toBe(true);
+      }
+    });
   });
 
   describe('ECDH-ES+A256KW', () => {
@@ -102,6 +190,31 @@ describe('Encryption', () => {
       );
 
       expect(ArrayUtility.byteArraysEqual(cek, unwrappedCek)).toBe(true);
+    });
+
+    it('should produce different wrapped keys for the same CEK and recipient', async () => {
+      const recipientPrivateKey = await X25519.generateKey();
+      const recipientPublicKey = await X25519.getPublicKey({ key: recipientPrivateKey });
+      const cek = TestDataGenerator.randomBytes(32);
+
+      // Wrap the same CEK twice with different ephemeral keys
+      const ephemeralKey1 = await X25519.generateKey();
+      const ephemeralKey2 = await X25519.generateKey();
+
+      const wrappedKey1 = await Encryption.ecdhEsWrapKey(ephemeralKey1, recipientPublicKey, cek);
+      const wrappedKey2 = await Encryption.ecdhEsWrapKey(ephemeralKey2, recipientPublicKey, cek);
+
+      // Different ephemeral keys must produce different wrapped keys
+      expect(ArrayUtility.byteArraysEqual(wrappedKey1, wrappedKey2)).toBe(false);
+
+      // Both must still unwrap to the same CEK
+      const epk1 = await X25519.getPublicKey({ key: ephemeralKey1 });
+      const epk2 = await X25519.getPublicKey({ key: ephemeralKey2 });
+      const unwrapped1 = await Encryption.ecdhEsUnwrapKey(recipientPrivateKey, epk1, wrappedKey1);
+      const unwrapped2 = await Encryption.ecdhEsUnwrapKey(recipientPrivateKey, epk2, wrappedKey2);
+
+      expect(ArrayUtility.byteArraysEqual(unwrapped1, cek)).toBe(true);
+      expect(ArrayUtility.byteArraysEqual(unwrapped2, cek)).toBe(true);
     });
   });
 
@@ -140,6 +253,52 @@ describe('Encryption', () => {
       const protectedHeader = Encryption.parseProtectedHeader(jwe.protected);
       expect(protectedHeader.alg).toBe('ECDH-ES+A256KW');
       expect(protectedHeader.enc).toBe('A256GCM');
+    });
+
+    it('should produce different ephemeral keys and wrapped CEKs for identical inputs', async () => {
+      const recipientPrivateKey = await X25519.generateKey();
+      const recipientPublicKey = await X25519.getPublicKey({ key: recipientPrivateKey }) as PublicKeyJwk;
+
+      const cek = TestDataGenerator.randomBytes(32);
+      const iv = TestDataGenerator.randomBytes(12);
+      const tag = TestDataGenerator.randomBytes(16);
+
+      const encryptionInput = {
+        key                  : cek,
+        initializationVector : iv,
+        authenticationTag    : tag,
+        keyEncryptionInputs  : [{
+          publicKeyId      : 'did:example:alice#enc',
+          publicKey        : recipientPublicKey,
+          derivationScheme : 'protocolPath' as any,
+        }],
+      };
+
+      const jwe1 = await Encryption.buildJwe(encryptionInput, tag);
+      const jwe2 = await Encryption.buildJwe(encryptionInput, tag);
+
+      // Each call generates a fresh ephemeral key pair — epk values must differ
+      const epk1 = jwe1.recipients[0].header.epk;
+      const epk2 = jwe2.recipients[0].header.epk;
+      expect(JSON.stringify(epk1)).not.toBe(JSON.stringify(epk2));
+
+      // Different ephemeral keys produce different wrapped CEKs
+      expect(jwe1.recipients[0].encrypted_key).not.toBe(jwe2.recipients[0].encrypted_key);
+
+      // Both wrapped CEKs must still unwrap to the same original CEK
+      const unwrapped1 = await Encryption.ecdhEsUnwrapKey(
+        recipientPrivateKey,
+        epk1 as PublicKeyJwk,
+        Encoder.base64UrlToBytes(jwe1.recipients[0].encrypted_key),
+      );
+      const unwrapped2 = await Encryption.ecdhEsUnwrapKey(
+        recipientPrivateKey,
+        epk2 as PublicKeyJwk,
+        Encoder.base64UrlToBytes(jwe2.recipients[0].encrypted_key),
+      );
+
+      expect(ArrayUtility.byteArraysEqual(unwrapped1, cek)).toBe(true);
+      expect(ArrayUtility.byteArraysEqual(unwrapped2, cek)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #112. Adds 8 new tests covering four encryption test gaps identified in the issue.

### Gap 1: AEAD boundary plaintext sizes
- Tests 0, 1, 15, 16, 17, 32, and 256 byte plaintexts for both **A256GCM** and **XC20P**
- Covers both the byte API (`aeadEncrypt`/`aeadDecrypt`) and the stream API (`aeadEncryptStream`/`aeadDecryptStream`)
- Previously only 1 MB was tested

### Gap 2: Concurrent contextKey writes
- Fires two `writeContextKeyRecord()` calls via `Promise.all` for different recipients (Bob and Carol) in the same context
- Verifies both succeed with distinct record IDs and both records are retrievable

### Gap 3: Protocol re-initialization safety
- Writes an encrypted key record, clears the initialization and encryption caches, re-initializes, and reads the record back
- Confirms encrypted data survives protocol re-initialization without corruption

### Gap 4: ECDH-ES ephemeral key non-determinism
- Verifies `ecdhEsWrapKey()` with different ephemeral keys produces different wrapped keys for the same CEK and recipient (both unwrap correctly)
- Verifies `buildJwe()` called twice with identical inputs produces different `epk` values and different `encrypted_key` values (both unwrap to the original CEK)

### Test counts
| Package | Before | After | Delta |
|---|---|---|---|
| `@enbox/dwn-sdk-js` | 989 | 995 | +6 |
| `@enbox/agent` | 695 | 697 | +2 |

### Files changed
- `packages/dwn-sdk-js/tests/utils/encryption.spec.ts` — 6 new tests
- `packages/agent/tests/dwn-api.spec.ts` — 1 new test
- `packages/agent/tests/store-key.spec.ts` — 1 new test