### PR TITLE
fix(crypto): publish updated barrel with algorithm class exports

### DIFF
--- a/.changeset/fix-crypto-missing-exports.md
+++ b/.changeset/fix-crypto-missing-exports.md
@@ -1,0 +1,14 @@
+---
+"@enbox/crypto": patch
+---
+
+fix(crypto): publish updated barrel with algorithm class exports
+
+The `@enbox/crypto@0.0.3` dist was built before the algorithm barrel
+exports (`AesKwAlgorithm`, `HkdfAlgorithm`, `Pbkdf2Algorithm`,
+`X25519Algorithm`, `EciesSecp256k1`) were added to `index.ts`.
+`@enbox/agent@0.1.4` imports these symbols, causing Vite/Rollup build
+failures in downstream apps (`"AesKwAlgorithm" is not exported`).
+
+The source was already correct — this bump triggers a fresh publish so
+the dist matches the source.


### PR DESCRIPTION
## Summary

- Adds a changeset to trigger a patch publish of `@enbox/crypto` (0.0.3 -> 0.0.4)
- No source changes — the barrel (`index.ts`) was already fixed in earlier PRs, but `0.0.3` was published from a stale build

## CI Note

This PR only adds a `.changeset/*.md` file. The CI `changes` filter ([ci.yml line 42](https://github.com/enboxorg/enbox/blob/main/.github/workflows/ci.yml#L42)) excludes `.changeset/**`, so all test jobs are correctly skipped and the `ci-passed` gate reports success.

## Problem

`@enbox/crypto@0.0.3` was published before these algorithm barrel exports were added to `index.ts`:

| Symbol | Module |
|---|---|
| `AesKwAlgorithm` | `./algorithms/aes-kw.js` |
| `HkdfAlgorithm` | `./algorithms/hkdf.js` |
| `Pbkdf2Algorithm` | `./algorithms/pbkdf2.js` |
| `X25519Algorithm` | `./algorithms/x25519.js` |
| `EciesSecp256k1` | `./primitives/ecies-secp256k1.js` |

`@enbox/agent@0.1.4` imports `AesKwAlgorithm`, `HkdfAlgorithm`, `Pbkdf2Algorithm`, and `X25519Algorithm` from `@enbox/crypto`. When a downstream app (e.g. the web wallet) installs these from npm, Vite/Rollup fails with:

```
"AesKwAlgorithm" is not exported by "node_modules/@enbox/crypto/dist/esm/index.js"
```

## Fix

The source is already correct on `main`. This changeset triggers a fresh publish so the dist matches the source. With `updateInternalDependencies: "patch"` in changeset config, all dependent packages will also get patch bumps.

## Merge order

1. **Merge this PR** — adds crypto changeset to main
2. The release workflow will auto-update PR #203 (`chore: version packages`) to include both the protocols minor bump AND the crypto patch bump with cascading deps
3. **Merge PR #203** — triggers publish of all bumped packages

## Local validation

```
@enbox/crypto  — 561 tests pass, lint clean
@enbox/agent   — 695 tests pass (4 skip), build clean
```
