### PR TITLE
feat(api): expose pagination cursor on LiveQuery

### DIFF
--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -942,7 +942,7 @@ export class DwnApi {
         }
 
         const reply = agentResponse.reply;
-        const { status, subscription, entries = [] } = reply;
+        const { status, subscription, entries = [], cursor } = reply;
 
         if (subscription) {
           liveQuery = new LiveQuery({
@@ -953,6 +953,7 @@ export class DwnApi {
             remoteOrigin,
             permissionsApi : this.permissionsApi,
             initialEntries : entries,
+            cursor,
             subscription,
           });
         }

--- a/packages/api/src/live-query.ts
+++ b/packages/api/src/live-query.ts
@@ -1,5 +1,5 @@
-import type { RecordsQueryReplyEntry } from '@enbox/dwn-sdk-js';
 import type { DwnMessageSubscription, PermissionsApi, Web5Agent } from '@enbox/agent';
+import type { PaginationCursor, RecordsQueryReplyEntry } from '@enbox/dwn-sdk-js';
 
 import { getRecordAuthor } from '@enbox/agent';
 
@@ -60,6 +60,9 @@ export type LiveQueryOptions = {
   /** The initial snapshot entries from the subscribe reply. */
   initialEntries: RecordsQueryReplyEntry[];
 
+  /** Pagination cursor for fetching the next page of initial results. */
+  cursor?: PaginationCursor;
+
   /** The underlying DWN subscription handle. */
   subscription: DwnMessageSubscription;
 };
@@ -116,6 +119,17 @@ export class LiveQuery extends EventTarget {
   /** The initial snapshot of matching records. */
   readonly records: Record[];
 
+  /**
+   * Pagination cursor for fetching the next page of initial results.
+   *
+   * When the initial snapshot was limited (via `pagination.limit`), this
+   * cursor can be passed in a subsequent `records.subscribe()` call to
+   * continue from where the previous snapshot left off.
+   *
+   * `undefined` when there are no more results.
+   */
+  readonly cursor?: PaginationCursor;
+
   /** The underlying DWN subscription handle. */
   private _subscription: DwnMessageSubscription;
 
@@ -131,6 +145,7 @@ export class LiveQuery extends EventTarget {
     const {
       agent,
       connectedDid,
+      cursor,
       delegateDid,
       protocolRole,
       remoteOrigin,
@@ -140,6 +155,7 @@ export class LiveQuery extends EventTarget {
     } = options;
 
     this._subscription = subscription;
+    this.cursor = cursor;
 
     // Build Record objects from the initial snapshot entries (same logic as records.query()).
     this.records = initialEntries.map((entry) => new Record(agent, {

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -2639,6 +2639,60 @@ describe('DwnApi', () => {
 
         await live!.close();
       });
+
+      it('should return a pagination cursor when the initial snapshot is limited', async () => {
+        const protocolConfigure = await dwnAlice.protocols.configure({
+          message: { definition: { ...emailProtocolDefinition, published: true } }
+        });
+        expect(protocolConfigure.status.code).toBe(202);
+
+        // write 3 records
+        for (let i = 0; i < 3; i++) {
+          const writeResult = await dwnAlice.records.write({
+            data    : `Message ${i}`,
+            message : {
+              recipient    : bobDid.uri,
+              protocol     : emailProtocolDefinition.protocol,
+              protocolPath : 'thread',
+              schema       : emailProtocolDefinition.types.thread.schema,
+              dataFormat   : 'text/plain'
+            }
+          });
+          expect(writeResult.status.code).toBe(202);
+        }
+
+        // subscribe with a limit of 2
+        const { liveQuery: live } = await dwnAlice.records.subscribe({
+          message: {
+            filter     : { protocol: emailProtocolDefinition.protocol },
+            pagination : { limit: 2 }
+          }
+        });
+        expect(live).toBeDefined();
+
+        // should have 2 initial records and a cursor for the next page
+        expect(live!.records.length).toBe(2);
+        expect(live!.cursor).toBeDefined();
+        expect(live!.cursor!.messageCid).toBeDefined();
+        expect(live!.cursor!.value).toBeDefined();
+
+        await live!.close();
+
+        // subscribe again using the cursor to get the remaining records
+        const { liveQuery: live2 } = await dwnAlice.records.subscribe({
+          message: {
+            filter     : { protocol: emailProtocolDefinition.protocol },
+            pagination : { limit: 2, cursor: live!.cursor }
+          }
+        });
+        expect(live2).toBeDefined();
+
+        // should have 1 remaining record and no cursor (end of results)
+        expect(live2!.records.length).toBe(1);
+        expect(live2!.cursor).toBeUndefined();
+
+        await live2!.close();
+      });
     });
 
     describe('from: did', () => {


### PR DESCRIPTION
## Summary

- Expose the `PaginationCursor` from the DWN subscribe reply as a readonly `cursor` property on `LiveQuery`
- Enables paginated initial snapshots: pass `pagination.limit` to cap the initial result set, then use the returned `cursor` in a subsequent `records.subscribe()` to fetch the next page

### Example

```ts
const { liveQuery } = await dwn.records.subscribe({
  message: {
    filter     : { protocol: chatProtocol.protocol },
    pagination : { limit: 50 }
  }
});

// First 50 records
console.log(liveQuery.records.length); // 50
console.log(liveQuery.cursor);         // { messageCid: '...', value: '...' }

// Fetch next page
const { liveQuery: page2 } = await dwn.records.subscribe({
  message: {
    filter     : { protocol: chatProtocol.protocol },
    pagination : { limit: 50, cursor: liveQuery.cursor }
  }
});
```

### Files changed

| File | Change |
|---|---|
| `packages/api/src/live-query.ts` | Added `cursor` to `LiveQueryOptions` and as readonly property on `LiveQuery` |
| `packages/api/src/dwn-api.ts` | Pass `cursor` from subscribe reply into `LiveQuery` constructor |
| `packages/api/tests/dwn-api.spec.ts` | New test: pagination cursor with limited initial snapshot |