### PR TITLE
fix(dwn-sdk-js,agent): resolve flaky Firefox browser test failures

### DIFF
--- a/packages/agent/vitest.browser.config.ts
+++ b/packages/agent/vitest.browser.config.ts
@@ -18,24 +18,11 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
+    // Pre-bundle CJS deps to avoid mid-run optimizeDeps restarts that crash Firefox.
     include: [
-      '@noble/hashes/crypto',
-      '@noble/hashes/utils',
-      '@noble/hashes/sha256',
-      '@noble/ciphers/webcrypto',
-      '@noble/ciphers/crypto',
-      '@noble/ciphers/chacha',
-      '@noble/curves/abstract/utils',
-      '@noble/curves/p256',
-      '@noble/curves/ed25519',
-      '@noble/curves/secp256k1',
-      'multiformats',
-      'multiformats/bases/base32',
-      'multiformats/bases/base58',
-      'multiformats/bases/base64',
-      '@isaacs/ttlcache',
       'ms',
     ],
+    holdUntilCrawlEnd: true,
   },
   test: {
     // Only include browser-safe tests (no LevelDB, no PlatformAgentTestHarness).

--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -18,46 +18,44 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
+    // Pre-bundle CJS dependencies so Vite converts them to ESM upfront.
+    // Without explicit inclusion, Vite may discover these mid-test-run and
+    // trigger an optimizeDeps restart. Chromium and WebKit handle restarts
+    // gracefully, but Firefox's strict ESM loader crashes with
+    // "error loading dynamically imported module" — causing flaky CI failures.
+    //
+    // Only list packages that are (a) CJS or mixed-format AND (b) resolvable
+    // from this package's node_modules. Entries that can't be resolved produce
+    // "Failed to resolve dependency" warnings and are silently skipped.
     include: [
-      '@noble/hashes/crypto',
-      '@noble/hashes/utils',
-      '@noble/hashes/sha256',
-      '@noble/hashes/hkdf',
+      // noble — CJS format, direct deps of @enbox/dwn-sdk-js
       '@noble/ciphers/aes',
+      '@noble/ciphers/chacha',
+      '@noble/ciphers/crypto',
       '@noble/ciphers/utils',
       '@noble/ciphers/webcrypto',
-      '@noble/ciphers/crypto',
-      '@noble/ciphers/chacha',
       '@noble/curves/abstract/utils',
-      '@noble/curves/p256',
       '@noble/curves/ed25519',
+      '@noble/curves/p256',
       '@noble/curves/secp256k1',
-      '@noble/secp256k1',
       '@noble/ed25519',
-      'multiformats',
-      'multiformats/block',
-      'multiformats/cid',
-      'multiformats/codecs/raw',
-      'multiformats/bases/base32',
-      'multiformats/bases/base58',
-      'multiformats/bases/base64',
-      'multiformats/hashes/sha2',
-      '@ipld/dag-cbor',
-      'sinon',
-      'eventemitter3',
-      'lodash',
-      'lru-cache',
-      'ulidx',
+      '@noble/secp256k1',
+      // CJS / mixed-format packages
       'ajv',
       'ajv/dist/2020.js',
-      'ipfs-unixfs-importer',
-      'ipfs-unixfs',
-      '@ipld/dag-pb',
-      // level ecosystem: pre-bundle to prevent mid-run CJS discovery restarts
-      // that crash Firefox. Vite resolves level -> browser.js (via the "browser"
-      // field in level/package.json) -> browser-level (IndexedDB-based).
+      'eventemitter3',
       'level',
+      'lodash',
+      'lodash/isPlainObject.js',
+      'lru-cache',
+      'ms',
+      'sinon',
+      'ulidx',
     ],
+    // Force Vite to hold the first optimization pass until ALL static imports
+    // from test entry points have been crawled. This prevents the mid-run
+    // discovery restarts that crash Firefox.
+    holdUntilCrawlEnd: true,
   },
   test: {
     // Pure-logic and utility tests that do not depend on LevelDB stores.


### PR DESCRIPTION
## Summary

- Fix flaky Firefox browser test failures in CI by cleaning up Vite `optimizeDeps` configuration
- Remove unresolvable entries that generated warnings, add missing CJS deps discovered mid-run, and explicitly set `holdUntilCrawlEnd: true`

## Problem

~14% of CI runs failed on the `test-browser` job with Firefox-only errors like:

```
Error: Failed to import test file .../tests/core/message.spec.ts
Caused by: TypeError: error loading dynamically imported module
```

The failing test files were random each run (filters.spec.ts, time.spec.ts, message.spec.ts, etc.), confirming flakiness rather than a real test bug.

## Root Cause

When Vite discovers a CJS dependency during test execution that wasn't pre-bundled in the initial crawl, it restarts its optimizer. Chromium and WebKit handle these restarts gracefully, but Firefox's strict ESM loader crashes on the module reimport.

Two issues in the existing `optimizeDeps.include` lists:

1. **Unresolvable entries** — `@noble/hashes/*`, `multiformats/*`, `@ipld/dag-cbor`, `ipfs-unixfs`, `@ipld/dag-pb` (in dwn-sdk-js) and `@noble/*`, `multiformats/*`, `@isaacs/ttlcache` (in agent) are not direct dependencies and can't be resolved from those packages, generating "Failed to resolve dependency" warnings
2. **Missing CJS deps** — `ms` (CJS, transitively loaded via `@enbox/dids`) and `lodash/isPlainObject.js` (CJS subpath import from `src/utils/jws.ts`) were not pre-bundled, making them candidates for mid-run discovery that triggers the optimizer restart

## Changes

**`packages/dwn-sdk-js/vitest.browser.config.ts`:**
- Removed 13 unresolvable `optimizeDeps.include` entries
- Added `ms` and `lodash/isPlainObject.js` (missing CJS deps)
- Added `holdUntilCrawlEnd: true` to ensure initial crawl completes before serving
- Added documentation explaining the Firefox-specific behavior

**`packages/agent/vitest.browser.config.ts`:**
- Removed 15 unresolvable `optimizeDeps.include` entries  
- Added `holdUntilCrawlEnd: true`