### PR TITLE
feat(dwn-sdk-js): warn when encryptionRequired combined with anyone-can-read

### DIFF
--- a/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
@@ -1,7 +1,10 @@
 import type { DataEncodedRecordsWriteMessage } from '../types/records-types.js';
 import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types/message-store.js';
-import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureDescriptor, ProtocolsConfigureMessage, ProtocolUses } from '../types/protocols-types.js';
+import type {
+  ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureDescriptor,
+  ProtocolsConfigureMessage, ProtocolTypes, ProtocolUses
+} from '../types/protocols-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
 import Ajv from 'ajv/dist/2020.js';
@@ -151,7 +154,8 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
       ruleSetProtocolPath : '',
       recordTypes,
       roles,
-      uses
+      uses,
+      types               : definition.types,
     });
   }
 
@@ -196,9 +200,12 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
    * Validates the given rule set structure then recursively validates its nested child rule sets.
    */
   private static validateRuleSetRecursively(
-    input: { ruleSet: ProtocolRuleSet, ruleSetProtocolPath: string, recordTypes: string[], roles: string[], uses?: ProtocolUses }
+    input: {
+      ruleSet: ProtocolRuleSet, ruleSetProtocolPath: string, recordTypes: string[],
+      roles: string[], uses?: ProtocolUses, types: ProtocolTypes
+    }
   ): void {
-    const { ruleSet, ruleSetProtocolPath, recordTypes, roles, uses } = input;
+    const { ruleSet, ruleSetProtocolPath, recordTypes, roles, uses, types } = input;
 
     // Validate $ref constraints: $ref is only supported at root level (no `/` in protocol path),
     // and a $ref node is a pure attachment point with no other directives.
@@ -370,6 +377,26 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
       }
     }
 
+    // Warn when `encryptionRequired: true` is combined with `{ who: 'anyone', can: ['read'] }`.
+    // Authorization allows anyone to read the record, but encryption prevents them from
+    // decrypting the data — almost certainly unintentional. (issue #115)
+    if (ruleSetProtocolPath !== '') {
+      const typeName = ruleSetProtocolPath.split('/').pop()!;
+      const protocolType = types[typeName];
+      if (protocolType?.encryptionRequired === true) {
+        const anyoneCanRead = actionRules.some(
+          (rule: ProtocolActionRule): boolean => rule.who === ProtocolActor.Anyone && rule.can.includes(ProtocolAction.Read)
+        );
+        if (anyoneCanRead) {
+          console.warn(
+            `ProtocolsConfigure: type '${typeName}' at path '${ruleSetProtocolPath}' has ` +
+            `encryptionRequired: true but allows { who: 'anyone', can: ['read'] }. ` +
+            `Anyone can read the record but no one outside the key holders can decrypt it.`
+          );
+        }
+      }
+    }
+
     // Validate nested rule sets
     for (const recordType in ruleSet) {
       if (recordType.startsWith('$')) {
@@ -399,7 +426,8 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
         ruleSetProtocolPath : childRuleSetProtocolPath,
         recordTypes,
         roles,
-        uses
+        uses,
+        types,
       });
     }
   }

--- a/packages/dwn-sdk-js/tests/interfaces/protocols-configure.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/protocols-configure.spec.ts
@@ -6,7 +6,7 @@ import { ProtocolAction } from '../../src/types/protocols-types.js';
 import { ProtocolsConfigure } from '../../src/interfaces/protocols-configure.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { Time } from '../../src/utils/time.js';
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
 import { DwnErrorCode, DwnInterfaceName, DwnMethodName, Message } from '../../src/index.js';
 
 describe('ProtocolsConfigure', () => {
@@ -475,6 +475,158 @@ describe('ProtocolsConfigure', () => {
         });
 
         await expect(createProtocolsConfigurePromise).rejects.toThrow(DwnErrorCode.ProtocolsConfigureInvalidSize);
+      });
+
+      describe('encryptionRequired + anyone-can-read warning', () => {
+        const capturedWarnings: string[] = [];
+        let originalWarn: typeof console.warn;
+
+        afterEach(() => {
+          console.warn = originalWarn;
+          capturedWarnings.length = 0;
+        });
+
+        it('should warn when encryptionRequired: true and anyone can read at the same path', async () => {
+          originalWarn = console.warn;
+          console.warn = (...args: unknown[]): void => { capturedWarnings.push(String(args[0])); };
+
+          const definition = {
+            published : true,
+            protocol  : 'http://example.com/encryption-warning',
+            types     : {
+              secret: {
+                dataFormats        : ['application/json'],
+                encryptionRequired : true,
+              },
+            },
+            structure: {
+              secret: {
+                $actions: [
+                  { who: 'anyone', can: ['read'] },
+                ],
+              },
+            },
+          };
+
+          const alice = await TestDataGenerator.generatePersona();
+          const result = await ProtocolsConfigure.create({
+            signer: Jws.createSigner(alice),
+            definition,
+          });
+
+          // The protocol is still valid — the warning is non-fatal
+          expect(result).toBeDefined();
+
+          // A warning should have been emitted
+          expect(capturedWarnings.length).toBe(1);
+          expect(capturedWarnings[0]).toContain('encryptionRequired: true');
+          expect(capturedWarnings[0]).toContain('anyone');
+          expect(capturedWarnings[0]).toContain('secret');
+        });
+
+        it('should warn for nested types with encryptionRequired + anyone-can-read', async () => {
+          originalWarn = console.warn;
+          console.warn = (...args: unknown[]): void => { capturedWarnings.push(String(args[0])); };
+
+          const definition = {
+            published : true,
+            protocol  : 'http://example.com/nested-warning',
+            types     : {
+              thread  : { dataFormats: ['application/json'] },
+              message : {
+                dataFormats        : ['application/json'],
+                encryptionRequired : true,
+              },
+            },
+            structure: {
+              thread: {
+                $actions : [{ who: 'anyone', can: ['create'] }],
+                message  : {
+                  $actions: [{ who: 'anyone', can: ['create', 'read'] }],
+                },
+              },
+            },
+          };
+
+          const alice = await TestDataGenerator.generatePersona();
+          const result = await ProtocolsConfigure.create({
+            signer: Jws.createSigner(alice),
+            definition,
+          });
+
+          expect(result).toBeDefined();
+          expect(capturedWarnings.length).toBe(1);
+          expect(capturedWarnings[0]).toContain('message');
+          expect(capturedWarnings[0]).toContain('thread/message');
+        });
+
+        it('should not warn when encryptionRequired is absent', async () => {
+          originalWarn = console.warn;
+          console.warn = (...args: unknown[]): void => { capturedWarnings.push(String(args[0])); };
+
+          const definition = {
+            published : true,
+            protocol  : 'http://example.com/no-encryption',
+            types     : {
+              post: { dataFormats: ['application/json'] },
+            },
+            structure: {
+              post: {
+                $actions: [{ who: 'anyone', can: ['create', 'read'] }],
+              },
+            },
+          };
+
+          const alice = await TestDataGenerator.generatePersona();
+          const result = await ProtocolsConfigure.create({
+            signer: Jws.createSigner(alice),
+            definition,
+          });
+
+          expect(result).toBeDefined();
+          expect(capturedWarnings.length).toBe(0);
+        });
+
+        it('should not warn when encryptionRequired is true but no anyone-can-read rule', async () => {
+          originalWarn = console.warn;
+          console.warn = (...args: unknown[]): void => { capturedWarnings.push(String(args[0])); };
+
+          const definition = {
+            published : true,
+            protocol  : 'http://example.com/encryption-no-anyone',
+            types     : {
+              secret: {
+                dataFormats        : ['application/json'],
+                encryptionRequired : true,
+              },
+              participant: {
+                dataFormats: ['application/json'],
+              },
+            },
+            structure: {
+              secret: {
+                $actions: [
+                  { who: 'author', of: 'secret', can: ['create', 'read'] },
+                ],
+                participant: {
+                  $role    : true,
+                  $actions : [
+                    { who: 'author', of: 'secret', can: ['create', 'delete'] },
+                  ],
+                },
+              },
+            },
+          };
+
+          const alice = await TestDataGenerator.generatePersona();
+          const result = await ProtocolsConfigure.create({
+            signer: Jws.createSigner(alice),
+            definition,
+          });
+
+          expect(result).toBeDefined();
+          expect(capturedWarnings.length).toBe(0);
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes #115. Adds a definition-time warning when a protocol type has `encryptionRequired: true` and an action rule grants `{ who: 'anyone', can: ['read'] }` at the same protocol path.

This combination is a protocol designer footgun: authorization allows anyone to read the record, but encryption prevents them from decrypting the data — the reader gets an opaque encrypted blob.

### Behavior

- **Non-fatal**: The warning is emitted via `console.warn`, not an error. Existing protocols with this combination still install successfully.
- **Definition-time**: The check runs during `ProtocolsConfigure.create()` and `ProtocolsConfigure.parse()`, before the message is processed.
- **Recursive**: Works for nested types (e.g., `thread/message` where `message` has `encryptionRequired: true`).

### Example warning

```
ProtocolsConfigure: type 'secret' at path 'secret' has encryptionRequired: true
but allows { who: 'anyone', can: ['read'] }. Anyone can read the record but no
one outside the key holders can decrypt it.
```

### Implementation

- `validateRuleSetRecursively()` now receives the `types` map
- After the `$actions` validation loop, checks if the current type has `encryptionRequired: true` and any action rule has `who: 'anyone'` with `read` in `can`

### Tests (4 new)

| Test | Asserts |
|---|---|
| Warns when `encryptionRequired` + anyone-can-read at root path | Warning emitted with correct message |
| Warns for nested types (`thread/message`) | Warning includes nested path |
| No warn when `encryptionRequired` is absent | No warning emitted |
| No warn when `encryptionRequired` but no anyone-can-read | No warning emitted |

### Files changed
- `packages/dwn-sdk-js/src/interfaces/protocols-configure.ts` — warning logic
- `packages/dwn-sdk-js/tests/interfaces/protocols-configure.spec.ts` — 4 new tests