### PR TITLE
chore(dwn-sdk-js): rename identity.foundation to enbox.org in JSON schema $id and $ref URLs

### DIFF
--- a/packages/dwn-sdk-js/json-schemas/authorization-delegated-grant.json
+++ b/packages/dwn-sdk-js/json-schemas/authorization-delegated-grant.json
@@ -1,14 +1,14 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/authorization-delegated-grant.json",
+  "$id": "https://enbox.org/dwn/json-schemas/authorization-delegated-grant.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "signature": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/general-jws.json"
     },
     "authorDelegatedGrant": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/records-write-data-encoded.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/records-write-data-encoded.json"
     }
   }
 }

--- a/packages/dwn-sdk-js/json-schemas/authorization-owner.json
+++ b/packages/dwn-sdk-js/json-schemas/authorization-owner.json
@@ -1,20 +1,20 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/authorization-owner.json",
+  "$id": "https://enbox.org/dwn/json-schemas/authorization-owner.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "signature": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/general-jws.json"
     },
     "authorDelegatedGrant": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/records-write-data-encoded.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/records-write-data-encoded.json"
     },
     "ownerSignature": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/general-jws.json"
     },
     "ownerDelegatedGrant": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/records-write-data-encoded.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/records-write-data-encoded.json"
     },
     "authorKeyDeliveryPublicKey": {
       "type": "object",
@@ -25,7 +25,7 @@
           "type": "string"
         },
         "publicKeyJwk": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/public-jwk.json"
+          "$ref": "https://enbox.org/dwn/json-schemas/public-jwk.json"
         }
       }
     }

--- a/packages/dwn-sdk-js/json-schemas/authorization.json
+++ b/packages/dwn-sdk-js/json-schemas/authorization.json
@@ -1,11 +1,11 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/authorization.json",
+  "$id": "https://enbox.org/dwn/json-schemas/authorization.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "signature": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/general-jws.json"
     }
   }
 }

--- a/packages/dwn-sdk-js/json-schemas/definitions.json
+++ b/packages/dwn-sdk-js/json-schemas/definitions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/defs.json",
+  "$id": "https://enbox.org/dwn/json-schemas/defs.json",
   "type": "object",
   "$defs": {
     "base64url": {

--- a/packages/dwn-sdk-js/json-schemas/general-jws.json
+++ b/packages/dwn-sdk-js/json-schemas/general-jws.json
@@ -1,11 +1,11 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/general-jws.json",
+  "$id": "https://enbox.org/dwn/json-schemas/general-jws.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "payload": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
+      "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/base64url"
     },
     "signatures": {
       "type": "array",
@@ -14,10 +14,10 @@
         "type": "object",
         "properties": {
           "protected": {
-            "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
+            "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/base64url"
           },
           "signature": {
-            "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
+            "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/base64url"
           }
         }
       }

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/messages-filter.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/messages-filter.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/messages-filter.json",
+  "$id": "https://enbox.org/dwn/json-schemas/messages-filter.json",
   "type": "object",
   "additionalProperties": false,
   "minProperties": 1,
@@ -30,10 +30,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     }

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/messages-read.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/messages-read.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/messages-read.json",
+  "$id": "https://enbox.org/dwn/json-schemas/messages-read.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",
@@ -34,7 +34,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "messageCid": {
           "type": "string"

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/messages-subscribe.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/messages-subscribe.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/messages-subscribe.json",
+  "$id": "https://enbox.org/dwn/json-schemas/messages-subscribe.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",
@@ -39,7 +39,7 @@
         "filters": {
           "type": "array",
           "items": {
-            "$ref": "https://identity.foundation/dwn/json-schemas/messages-filter.json"
+            "$ref": "https://enbox.org/dwn/json-schemas/messages-filter.json"
           }
         },
         "permissionGrantId": {

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/messages-sync.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/messages-sync.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/messages-sync.json",
+  "$id": "https://enbox.org/dwn/json-schemas/messages-sync.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",
@@ -30,7 +30,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "action": {
           "enum": ["root", "subtree", "leaves"],

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/number-range-filter.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/number-range-filter.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/number-range-filter.json",
+  "$id": "https://enbox.org/dwn/json-schemas/number-range-filter.json",
   "type": "object",
   "minProperties": 1,
   "additionalProperties": false,

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/pagination-cursor.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/pagination-cursor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/pagination-cursor.json",
+  "$id": "https://enbox.org/dwn/json-schemas/pagination-cursor.json",
   "type": "object",
   "minProperties": 1,
   "additionalProperties": false,

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/protocol-definition.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/protocol-definition.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/protocol-definition.json",
+  "$id": "https://enbox.org/dwn/json-schemas/protocol-definition.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
@@ -55,7 +55,7 @@
       "type": "object",
       "patternProperties": {
         ".*": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/protocol-rule-set.json"
+          "$ref": "https://enbox.org/dwn/json-schemas/protocol-rule-set.json"
         }
       }
     }

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/protocol-rule-set.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/protocol-rule-set.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/protocol-rule-set.json",
+  "$id": "https://enbox.org/dwn/json-schemas/protocol-rule-set.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
@@ -12,7 +12,7 @@
           "type": "string"
         },
         "publicKeyJwk": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/public-jwk.json"
+          "$ref": "https://enbox.org/dwn/json-schemas/public-jwk.json"
         }
       },
       "required": [
@@ -174,7 +174,7 @@
   },
   "patternProperties": {
     "^[^$].*$": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/protocol-rule-set.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/protocol-rule-set.json"
     }
   }
 }

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/protocols-configure.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/protocols-configure.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/protocols-configure.json",
+  "$id": "https://enbox.org/dwn/json-schemas/protocols-configure.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization-delegated-grant.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization-delegated-grant.json"
     },
     "descriptor": {
       "type": "object",
@@ -34,10 +34,10 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "definition": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/protocol-definition.json"
+          "$ref": "https://enbox.org/dwn/json-schemas/protocol-definition.json"
         },
         "permissionGrantId": {
           "type": "string"

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/protocols-query.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/protocols-query.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/protocols-query.json",
+  "$id": "https://enbox.org/dwn/json-schemas/protocols-query.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -8,7 +8,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization.json"
     },
     "descriptor": {
       "type": "object",
@@ -32,7 +32,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filter": {
           "type": "object",
@@ -43,7 +43,7 @@
               "type": "string"
             },
             "recipient": {
-              "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
+              "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/did"
             }
           }
         },

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-count.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-count.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/records-count.json",
+  "$id": "https://enbox.org/dwn/json-schemas/records-count.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -8,7 +8,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization-delegated-grant.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization-delegated-grant.json"
     },
     "descriptor": {
       "type": "object",
@@ -33,10 +33,10 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filter": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/records-filter.json"
+          "$ref": "https://enbox.org/dwn/json-schemas/records-filter.json"
         }
       }
     }

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-delete.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-delete.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/records-delete.json",
+  "$id": "https://enbox.org/dwn/json-schemas/records-delete.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization-delegated-grant.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization-delegated-grant.json"
     },
     "descriptor": {
       "type": "object",
@@ -35,7 +35,7 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "recordId": {
           "type": "string"

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-filter.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-filter.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/records-filter.json",
+  "$id": "https://enbox.org/dwn/json-schemas/records-filter.json",
   "type": "object",
   "minProperties": 1,
   "additionalProperties": false,
@@ -13,24 +13,24 @@
     },
     "author": {
       "oneOf": [{
-        "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
+        "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/did"
       },{
         "type": "array",
         "items": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/did"
         }
       }]
     },
     "attester": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
+      "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/did"
     },
     "recipient": {
       "oneOf": [{
-        "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
+        "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/did"
       },{
         "type": "array",
         "items": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/did"
         }
       }]
     },
@@ -66,9 +66,9 @@
             }
           },
           {
-            "$ref": "https://identity.foundation/dwn/json-schemas/string-range-filter.json"
+            "$ref": "https://enbox.org/dwn/json-schemas/string-range-filter.json"
           }, {
-            "$ref": "https://identity.foundation/dwn/json-schemas/number-range-filter.json"
+            "$ref": "https://enbox.org/dwn/json-schemas/number-range-filter.json"
           }
         ]
       }
@@ -86,7 +86,7 @@
       "type": "string"
     },
     "dataSize": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/number-range-filter.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/number-range-filter.json"
     },
     "dataCid": {
       "type": "string"
@@ -97,10 +97,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     },
@@ -110,10 +110,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     },
@@ -123,10 +123,10 @@
       "additionalProperties": false,
       "properties": {
         "from": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "to": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         }
       }
     }

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-query.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-query.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/records-query.json",
+  "$id": "https://enbox.org/dwn/json-schemas/records-query.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -8,7 +8,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization-delegated-grant.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization-delegated-grant.json"
     },
     "descriptor": {
       "type": "object",
@@ -33,10 +33,10 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filter": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/records-filter.json"
+          "$ref": "https://enbox.org/dwn/json-schemas/records-filter.json"
         },
         "pagination": {
           "type": "object",
@@ -47,7 +47,7 @@
               "minimum": 1
             },
             "cursor": {
-              "$ref": "https://identity.foundation/dwn/json-schemas/pagination-cursor.json"
+              "$ref": "https://enbox.org/dwn/json-schemas/pagination-cursor.json"
             }
           }
         },

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-read.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-read.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/records-read.json",
+  "$id": "https://enbox.org/dwn/json-schemas/records-read.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -8,7 +8,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization-delegated-grant.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization-delegated-grant.json"
     },
     "descriptor": {
       "type": "object",
@@ -33,10 +33,10 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filter": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/records-filter.json"
+          "$ref": "https://enbox.org/dwn/json-schemas/records-filter.json"
         },
         "permissionGrantId": {
           "type": "string"

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-subscribe.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-subscribe.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/records-subscribe.json",
+  "$id": "https://enbox.org/dwn/json-schemas/records-subscribe.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -8,7 +8,7 @@
   ],
   "properties": {
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization-delegated-grant.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization-delegated-grant.json"
     },
     "descriptor": {
       "type": "object",
@@ -33,10 +33,10 @@
           "type": "string"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "filter": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/records-filter.json"
+          "$ref": "https://enbox.org/dwn/json-schemas/records-filter.json"
         },
         "pagination": {
           "type": "object",
@@ -47,7 +47,7 @@
               "minimum": 1
             },
             "cursor": {
-              "$ref": "https://identity.foundation/dwn/json-schemas/pagination-cursor.json"
+              "$ref": "https://enbox.org/dwn/json-schemas/pagination-cursor.json"
             }
           }
         },

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-data-encoded.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-data-encoded.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/records-write-data-encoded.json",
-  "$ref": "https://identity.foundation/dwn/json-schemas/records-write-unidentified.json",
+  "$id": "https://enbox.org/dwn/json-schemas/records-write-data-encoded.json",
+  "$ref": "https://enbox.org/dwn/json-schemas/records-write-unidentified.json",
   "unevaluatedProperties": false,
   "type": "object",
   "required": [

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-unidentified.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-unidentified.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/records-write-unidentified.json",
+  "$id": "https://enbox.org/dwn/json-schemas/records-write-unidentified.json",
   "type": "object",
   "required": [
     "descriptor"
@@ -15,22 +15,22 @@
       "pattern": "^[a-zA-Z0-9]+(\/[a-zA-Z0-9]+)*$"
     },
     "attestation": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/general-jws.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/general-jws.json"
     },
     "authorization": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/authorization-owner.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/authorization-owner.json"
     },
     "encryption": {
       "type": "object",
       "properties": {
         "protected": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/base64url"
         },
         "iv": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/base64url"
         },
         "tag": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/base64url"
         },
         "recipients": {
           "type": "array",
@@ -45,7 +45,7 @@
                     "type": "string"
                   },
                   "epk": {
-                    "$ref": "https://identity.foundation/dwn/json-schemas/public-jwk.json"
+                    "$ref": "https://enbox.org/dwn/json-schemas/public-jwk.json"
                   },
                   "derivationScheme": {
                     "type": "string",
@@ -57,7 +57,7 @@
                     ]
                   },
                   "derivedPublicKey": {
-                    "$ref": "https://identity.foundation/dwn/json-schemas/public-jwk.json"
+                    "$ref": "https://enbox.org/dwn/json-schemas/public-jwk.json"
                   }
                 },
                 "additionalProperties": false,
@@ -68,7 +68,7 @@
                 ]
               },
               "encrypted_key": {
-                "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
+                "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/base64url"
               }
             },
             "additionalProperties": false,
@@ -103,7 +103,7 @@
           "type": "string"
         },
         "recipient": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/did"
         },
         "protocol": {
           "type": "string"
@@ -159,16 +159,16 @@
           "type": "number"
         },
         "dateCreated": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "messageTimestamp": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "published": {
           "type": "boolean"
         },
         "datePublished": {
-          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+          "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
         },
         "dataFormat": {
           "type": "string"

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-write.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-write.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/records-write.json",
-  "$ref": "https://identity.foundation/dwn/json-schemas/records-write-unidentified.json",
+  "$id": "https://enbox.org/dwn/json-schemas/records-write.json",
+  "$ref": "https://enbox.org/dwn/json-schemas/records-write-unidentified.json",
   "unevaluatedProperties": false,
   "type": "object",
   "required": [

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/string-range-filter.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/string-range-filter.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/string-range-filter.json",
+  "$id": "https://enbox.org/dwn/json-schemas/string-range-filter.json",
   "type": "object",
   "minProperties": 1,
   "additionalProperties": false,

--- a/packages/dwn-sdk-js/json-schemas/jwk-verification-method.json
+++ b/packages/dwn-sdk-js/json-schemas/jwk-verification-method.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/jwk-verification-method.json",
+  "$id": "https://enbox.org/dwn/json-schemas/jwk-verification-method.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
@@ -20,10 +20,10 @@
       ]
     },
     "controller": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/did"
+      "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/did"
     },
     "publicKeyJwk": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/public-jwk.json"
+      "$ref": "https://enbox.org/dwn/json-schemas/public-jwk.json"
     }
   }
 }

--- a/packages/dwn-sdk-js/json-schemas/jwk/general-jwk.json
+++ b/packages/dwn-sdk-js/json-schemas/jwk/general-jwk.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/general-jwk.json",
+  "$id": "https://enbox.org/dwn/json-schemas/general-jwk.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "required": [

--- a/packages/dwn-sdk-js/json-schemas/jwk/public-jwk.json
+++ b/packages/dwn-sdk-js/json-schemas/jwk/public-jwk.json
@@ -1,7 +1,7 @@
 {
-  "$id": "https://identity.foundation/dwn/json-schemas/public-jwk.json",
+  "$id": "https://enbox.org/dwn/json-schemas/public-jwk.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$ref": "https://identity.foundation/dwn/json-schemas/general-jwk.json",
+  "$ref": "https://enbox.org/dwn/json-schemas/general-jwk.json",
   "not": {
     "anyOf": [
       {

--- a/packages/dwn-sdk-js/json-schemas/permissions/permission-grant-data.json
+++ b/packages/dwn-sdk-js/json-schemas/permissions/permission-grant-data.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/permission-grant-data.json",
+  "$id": "https://enbox.org/dwn/json-schemas/permission-grant-data.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -12,7 +12,7 @@
       "type": "string"
     },
     "dateExpires": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+      "$ref": "https://enbox.org/dwn/json-schemas/defs.json#/$defs/date-time"
     },
     "requestId": {
       "type": "string"
@@ -21,10 +21,10 @@
       "type": "boolean"
     },
     "scope": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/$defs/scope"
+      "$ref": "https://enbox.org/dwn/json-schemas/permissions/defs.json#/$defs/scope"
     },
     "conditions": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/$defs/conditions"
+      "$ref": "https://enbox.org/dwn/json-schemas/permissions/defs.json#/$defs/conditions"
     }
   }
 }

--- a/packages/dwn-sdk-js/json-schemas/permissions/permission-request-data.json
+++ b/packages/dwn-sdk-js/json-schemas/permissions/permission-request-data.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/permission-request-data.json",
+  "$id": "https://enbox.org/dwn/json-schemas/permission-request-data.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -15,10 +15,10 @@
       "type": "boolean"
     },
     "scope": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/$defs/scope"
+      "$ref": "https://enbox.org/dwn/json-schemas/permissions/defs.json#/$defs/scope"
     },
     "conditions": {
-      "$ref": "https://identity.foundation/dwn/json-schemas/permissions/defs.json#/$defs/conditions"
+      "$ref": "https://enbox.org/dwn/json-schemas/permissions/defs.json#/$defs/conditions"
     }
   }
 }

--- a/packages/dwn-sdk-js/json-schemas/permissions/permission-revocation-data.json
+++ b/packages/dwn-sdk-js/json-schemas/permissions/permission-revocation-data.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/permission-revoke-data.json",
+  "$id": "https://enbox.org/dwn/json-schemas/permission-revoke-data.json",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/packages/dwn-sdk-js/json-schemas/permissions/permissions-definitions.json
+++ b/packages/dwn-sdk-js/json-schemas/permissions/permissions-definitions.json
@@ -1,42 +1,42 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/permissions/defs.json",
+  "$id": "https://enbox.org/dwn/json-schemas/permissions/defs.json",
   "type": "object",
   "$defs": {
     "scope": {
       "oneOf": [
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/messages-read-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/messages-read-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/messages-subscribe-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/messages-subscribe-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/messages-sync-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/messages-sync-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/protocols-configure-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/protocols-configure-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/protocols-query-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/protocols-query-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-read-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/records-read-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-delete-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/records-delete-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-write-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/records-write-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-query-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/records-query-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-subscribe-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/records-subscribe-scope"
         },
         {
-          "$ref": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json#/$defs/records-count-scope"
+          "$ref": "https://enbox.org/dwn/json-schemas/permissions/scopes.json#/$defs/records-count-scope"
         }
       ]
     },

--- a/packages/dwn-sdk-js/json-schemas/permissions/scopes.json
+++ b/packages/dwn-sdk-js/json-schemas/permissions/scopes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/permissions/scopes.json",
+  "$id": "https://enbox.org/dwn/json-schemas/permissions/scopes.json",
   "type": "object",
   "$defs": {
     "messages-read-scope": {

--- a/packages/dwn-sdk-js/json-schemas/signature-payloads/generic-signature-payload.json
+++ b/packages/dwn-sdk-js/json-schemas/signature-payloads/generic-signature-payload.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/signature-payloads/generic-signature-payload.json",
+  "$id": "https://enbox.org/dwn/json-schemas/signature-payloads/generic-signature-payload.json",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/packages/dwn-sdk-js/json-schemas/signature-payloads/records-write-signature-payload.json
+++ b/packages/dwn-sdk-js/json-schemas/signature-payloads/records-write-signature-payload.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://identity.foundation/dwn/json-schemas/signature-payloads/records-write-signature-payload.json",
+  "$id": "https://enbox.org/dwn/json-schemas/signature-payloads/records-write-signature-payload.json",
   "type": "object",
   "additionalProperties": false,
   "required": [


### PR DESCRIPTION
## Summary

- Replaces all 126 references to `https://identity.foundation/dwn/json-schemas/` with `https://enbox.org/dwn/json-schemas/` across 35 JSON schema files
- These are JSON Schema `$id` namespace identifiers used for internal `$ref` resolution, not fetched URLs
- The `identity.foundation` domain is a pre-fork artifact

Closes #206

## Scope

| Location | Files | References |
|---|---|---|
| `packages/dwn-sdk-js/json-schemas/` | 35 | 126 |

No TypeScript source code changes — only JSON schema `$id` and `$ref` values.

## Verification

- `bun run compile-validators` — passes (`$ref` chains resolve correctly with new `$id` values)
- `bun run build` — passes
- `bun run test:node` — **999 pass, 0 fail**
- `bun run lint` — 0 warnings