### PR TITLE
chore(dwn-sdk-js): fix broken TODO issue links

### DIFF
--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -62,7 +62,7 @@ export class RecordsReadHandler implements MethodHandler {
     const matchedMessage = existingMessages[0];
 
     // if the matched message is a RecordsDelete, we mark the record as not-found and return both the RecordsDelete and the initial RecordsWrite
-    // TODO: https://github.com/enboxorg/enbox/issues/819:
+    // TODO: https://github.com/enboxorg/enbox/issues/222
     // Consider performing authorization checks like when records exists before returning RecordsDelete and initial RecordsWrite of a deleted record
     if (matchedMessage.descriptor.method === DwnMethodName.Delete) {
       const recordsDeleteMessage = matchedMessage as RecordsDeleteMessage;

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -219,7 +219,7 @@ export class RecordsWriteHandler implements MethodHandler {
    */
   private async postProcessingForCoreRecordsWrite(tenant: string, recordsWrite: RecordsWrite): Promise<void> {
     // If this message is a Permission revocation, we need to delete all grant-authorized messages with timestamp after revocation
-    // TODO: https://github.com/enboxorg/enbox/issues/716
+    // TODO: https://github.com/enboxorg/enbox/issues/221
     // This code is a direct copy and paste from the original PermissionsRevokeHandler (no longer exists),
     // but it appears that there was no test for it and it does not look like the code worked:
     // - not seeing `permissionGrantId` being an index

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -713,7 +713,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       return;
     }
 
-    // TODO: multi-attesters to be unblocked by #205 - Revisit database interfaces (https://github.com/enboxorg/enbox/issues/205)
+    // TODO: support multiple attesters (https://github.com/enboxorg/enbox/issues/223)
     if (message.attestation.signatures.length !== 1) {
       throw new DwnError(
         DwnErrorCode.RecordsWriteAttestationIntegrityMoreThanOneSignature,
@@ -799,7 +799,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     }
 
     // add additional indexes to optional values if given
-    // TODO: index multi-attesters to be unblocked by #205 - Revisit database interfaces (https://github.com/enboxorg/enbox/issues/205)
+    // TODO: index multiple attesters (https://github.com/enboxorg/enbox/issues/223)
     if (this.attesters.length > 0) { indexes.attester = this.attesters[0]; }
     if (message.contextId !== undefined) { indexes.contextId = message.contextId; }
 

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -211,7 +211,7 @@ export class Records {
       );
     }
 
-    // TODO: issue #683 -Extend key derivation support to include the full contextId (https://github.com/enboxorg/enbox/issues/683)
+    // TODO: Extend key derivation support to include the full contextId (https://github.com/enboxorg/enbox/issues/99)
     const firstContextSegment = contextId.split('/')[0];
 
     const fullDerivationPath = [


### PR DESCRIPTION
## Summary

- Update 5 TODO comments in `dwn-sdk-js` that referenced pre-fork issue numbers or a merged PR that don't exist as tracking issues in `enboxorg/enbox`
- Filed 3 new issues to properly track the work described by these TODOs

## Changes

| File | Old ref | New ref | Issue title |
|---|---|---|---|
| `src/utils/records.ts:214` | #683 (doesn't exist) | #99 | Encryption improvements — full context derivation |
| `src/handlers/records-write.ts:222` | #716 (doesn't exist) | #221 | Permission revocation cleanup is broken and untested |
| `src/handlers/records-read.ts:65` | #819 (doesn't exist) | #222 | Add authorization checks for deleted record reads |
| `src/interfaces/records-write.ts:716` | #205 (merged PR) | #223 | Support multiple attesters in RecordsWrite |
| `src/interfaces/records-write.ts:802` | #205 (merged PR) | #223 | (same as above — indexing side) |

## New issues filed

- #221 — `fix(dwn-sdk-js): permission revocation cleanup is broken and untested`
- #222 — `feat(dwn-sdk-js): add authorization checks for deleted record reads`
- #223 — `feat(dwn-sdk-js): support multiple attesters in RecordsWrite`

## Context

These TODOs were inherited from the original `TBD54566975/dwn-sdk-js` fork. The issue numbers (#683, #716, #819) existed in the upstream repo but were not migrated. #205 exists in this repo but is a merged refactor PR, not a feature tracking issue.