### PR TITLE
chore: rename enbox.org protocol/schema URIs to identity.foundation

### DIFF
--- a/TYPED_PROTOCOLS_PLAN.md
+++ b/TYPED_PROTOCOLS_PLAN.md
@@ -92,11 +92,11 @@ assertions where needed. Key files:
 
 | Protocol | URI | Types | Key Features |
 |----------|-----|-------|-------------|
-| Social Graph | `https://enbox.org/protocols/social-graph` | friend, block, group, member | `$role`, `$tags`, nested list, owner-only |
-| Profile | `https://enbox.org/protocols/profile` | profile, avatar, link, privateNote | `uses` Social Graph, cross-protocol role, `$size`, binary formats, mixed visibility |
-| Preferences | `https://enbox.org/protocols/preferences` | theme, locale, privacy, notification | `encryptionRequired`, `$tags`, flat, owner-only |
-| Status | `https://enbox.org/protocols/status` | status, reaction | `uses` Social Graph, cross-protocol role, `$size`, published flag |
-| Lists | `https://enbox.org/protocols/lists` | list, item, folder, collaborator, comment | Both nesting patterns, `$role`, `uses` Social Graph, `$tags` with `enum`, deep paths |
+| Social Graph | `https://identity.foundation/protocols/social-graph` | friend, block, group, member | `$role`, `$tags`, nested list, owner-only |
+| Profile | `https://identity.foundation/protocols/profile` | profile, avatar, link, privateNote | `uses` Social Graph, cross-protocol role, `$size`, binary formats, mixed visibility |
+| Preferences | `https://identity.foundation/protocols/preferences` | theme, locale, privacy, notification | `encryptionRequired`, `$tags`, flat, owner-only |
+| Status | `https://identity.foundation/protocols/status` | status, reaction | `uses` Social Graph, cross-protocol role, `$size`, published flag |
+| Lists | `https://identity.foundation/protocols/lists` | list, item, folder, collaborator, comment | Both nesting patterns, `$role`, `uses` Social Graph, `$tags` with `enum`, deep paths |
 
 ### Composition graph:
 

--- a/packages/agent/src/store-data-protocols.ts
+++ b/packages/agent/src/store-data-protocols.ts
@@ -24,7 +24,7 @@ export const IdentityProtocolDefinition: ProtocolDefinition = {
 };
 
 export const KeyDeliveryProtocolDefinition: ProtocolDefinition = {
-  protocol  : 'https://enbox.org/protocols/key-delivery',
+  protocol  : 'https://identity.foundation/protocols/key-delivery',
   published : false,
   types     : {
     contextKey: {

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -3189,7 +3189,7 @@ describe('Key Delivery Protocol Infrastructure (PR A)', () => {
       expect(afterReply.entries).toHaveLength(1);
 
       const definition = afterReply.entries![0].descriptor.definition;
-      expect(definition.protocol).toBe('https://enbox.org/protocols/key-delivery');
+      expect(definition.protocol).toBe('https://identity.foundation/protocols/key-delivery');
 
       // Verify $encryption keys were injected at the contextKey path
       const contextKeyRuleSet = definition.structure.contextKey as any;

--- a/packages/protocols/CHANGELOG.md
+++ b/packages/protocols/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [#200](https://github.com/enboxorg/enbox/pull/200) [`95781ac`](https://github.com/enboxorg/enbox/commit/95781ac7cc656bd617cdc64466ab55f4a098b7cb) Thanks [@LiranCohen](https://github.com/LiranCohen)! - feat(protocols): add hero image support to Profile and new Connect protocol
 
   - ProfileProtocol: added `hero` type (binary images nested under `profile/hero`, 2MB size limit, publicly readable) and `tagline` field to `ProfileData`
-  - New ConnectProtocol: stores wallet discovery info (`{ webWallets: string[] }`) at `https://enbox.org/protocols/connect`, publicly readable
+  - New ConnectProtocol: stores wallet discovery info (`{ webWallets: string[] }`) at `https://identity.foundation/protocols/connect`, publicly readable
 
 ### Patch Changes
 

--- a/packages/protocols/src/connect.ts
+++ b/packages/protocols/src/connect.ts
@@ -36,11 +36,11 @@ export type ConnectSchemaMap = {
 // ---------------------------------------------------------------------------
 
 export const ConnectDefinition = {
-  protocol  : 'https://enbox.org/protocols/connect',
+  protocol  : 'https://identity.foundation/protocols/connect',
   published : true,
   types     : {
     wallet: {
-      schema      : 'https://enbox.org/schemas/connect/wallet',
+      schema      : 'https://identity.foundation/schemas/connect/wallet',
       dataFormats : ['application/json'],
     },
   },

--- a/packages/protocols/src/lists.ts
+++ b/packages/protocols/src/lists.ts
@@ -72,30 +72,30 @@ export type ListsSchemaMap = {
 // ---------------------------------------------------------------------------
 
 export const ListsDefinition = {
-  protocol  : 'https://enbox.org/protocols/lists',
+  protocol  : 'https://identity.foundation/protocols/lists',
   published : false,
   uses      : {
-    social: 'https://enbox.org/protocols/social-graph',
+    social: 'https://identity.foundation/protocols/social-graph',
   },
   types: {
     list: {
-      schema      : 'https://enbox.org/schemas/lists/list',
+      schema      : 'https://identity.foundation/schemas/lists/list',
       dataFormats : ['application/json'],
     },
     item: {
-      schema      : 'https://enbox.org/schemas/lists/item',
+      schema      : 'https://identity.foundation/schemas/lists/item',
       dataFormats : ['application/json'],
     },
     folder: {
-      schema      : 'https://enbox.org/schemas/lists/folder',
+      schema      : 'https://identity.foundation/schemas/lists/folder',
       dataFormats : ['application/json'],
     },
     collaborator: {
-      schema      : 'https://enbox.org/schemas/lists/collaborator',
+      schema      : 'https://identity.foundation/schemas/lists/collaborator',
       dataFormats : ['application/json'],
     },
     comment: {
-      schema      : 'https://enbox.org/schemas/lists/comment',
+      schema      : 'https://identity.foundation/schemas/lists/comment',
       dataFormats : ['application/json'],
     },
   },

--- a/packages/protocols/src/preferences.ts
+++ b/packages/protocols/src/preferences.ts
@@ -67,24 +67,24 @@ export type PreferencesSchemaMap = {
 // ---------------------------------------------------------------------------
 
 export const PreferencesDefinition = {
-  protocol  : 'https://enbox.org/protocols/preferences',
+  protocol  : 'https://identity.foundation/protocols/preferences',
   published : false,
   types     : {
     theme: {
-      schema      : 'https://enbox.org/schemas/preferences/theme',
+      schema      : 'https://identity.foundation/schemas/preferences/theme',
       dataFormats : ['application/json'],
     },
     locale: {
-      schema      : 'https://enbox.org/schemas/preferences/locale',
+      schema      : 'https://identity.foundation/schemas/preferences/locale',
       dataFormats : ['application/json'],
     },
     privacy: {
-      schema             : 'https://enbox.org/schemas/preferences/privacy',
+      schema             : 'https://identity.foundation/schemas/preferences/privacy',
       dataFormats        : ['application/json'],
       encryptionRequired : true,
     },
     notification: {
-      schema      : 'https://enbox.org/schemas/preferences/notification',
+      schema      : 'https://identity.foundation/schemas/preferences/notification',
       dataFormats : ['application/json'],
     },
   },

--- a/packages/protocols/src/profile.ts
+++ b/packages/protocols/src/profile.ts
@@ -63,14 +63,14 @@ export type ProfileSchemaMap = {
 // ---------------------------------------------------------------------------
 
 export const ProfileDefinition = {
-  protocol  : 'https://enbox.org/protocols/profile',
+  protocol  : 'https://identity.foundation/protocols/profile',
   published : true,
   uses      : {
-    social: 'https://enbox.org/protocols/social-graph',
+    social: 'https://identity.foundation/protocols/social-graph',
   },
   types: {
     profile: {
-      schema      : 'https://enbox.org/schemas/profile/profile',
+      schema      : 'https://identity.foundation/schemas/profile/profile',
       dataFormats : ['application/json'],
     },
     avatar: {
@@ -80,11 +80,11 @@ export const ProfileDefinition = {
       dataFormats: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],
     },
     link: {
-      schema      : 'https://enbox.org/schemas/profile/link',
+      schema      : 'https://identity.foundation/schemas/profile/link',
       dataFormats : ['application/json'],
     },
     privateNote: {
-      schema      : 'https://enbox.org/schemas/profile/private-note',
+      schema      : 'https://identity.foundation/schemas/profile/private-note',
       dataFormats : ['application/json'],
     },
   },

--- a/packages/protocols/src/social-graph.ts
+++ b/packages/protocols/src/social-graph.ts
@@ -59,23 +59,23 @@ export type SocialGraphSchemaMap = {
 // ---------------------------------------------------------------------------
 
 export const SocialGraphDefinition = {
-  protocol  : 'https://enbox.org/protocols/social-graph',
+  protocol  : 'https://identity.foundation/protocols/social-graph',
   published : true,
   types     : {
     friend: {
-      schema      : 'https://enbox.org/schemas/social-graph/friend',
+      schema      : 'https://identity.foundation/schemas/social-graph/friend',
       dataFormats : ['application/json'],
     },
     block: {
-      schema      : 'https://enbox.org/schemas/social-graph/block',
+      schema      : 'https://identity.foundation/schemas/social-graph/block',
       dataFormats : ['application/json'],
     },
     group: {
-      schema      : 'https://enbox.org/schemas/social-graph/group',
+      schema      : 'https://identity.foundation/schemas/social-graph/group',
       dataFormats : ['application/json'],
     },
     member: {
-      schema      : 'https://enbox.org/schemas/social-graph/member',
+      schema      : 'https://identity.foundation/schemas/social-graph/member',
       dataFormats : ['application/json'],
     },
   },

--- a/packages/protocols/src/status.ts
+++ b/packages/protocols/src/status.ts
@@ -44,18 +44,18 @@ export type StatusSchemaMap = {
 // ---------------------------------------------------------------------------
 
 export const StatusDefinition = {
-  protocol  : 'https://enbox.org/protocols/status',
+  protocol  : 'https://identity.foundation/protocols/status',
   published : true,
   uses      : {
-    social: 'https://enbox.org/protocols/social-graph',
+    social: 'https://identity.foundation/protocols/social-graph',
   },
   types: {
     status: {
-      schema      : 'https://enbox.org/schemas/status/status',
+      schema      : 'https://identity.foundation/schemas/status/status',
       dataFormats : ['application/json'],
     },
     reaction: {
-      schema      : 'https://enbox.org/schemas/status/reaction',
+      schema      : 'https://identity.foundation/schemas/status/reaction',
       dataFormats : ['application/json'],
     },
   },

--- a/packages/protocols/tests/protocols.spec.ts
+++ b/packages/protocols/tests/protocols.spec.ts
@@ -19,7 +19,7 @@ describe('@enbox/protocols', () => {
 
   describe('SocialGraphProtocol', () => {
     it('should have the correct protocol URI', () => {
-      expect(SocialGraphDefinition.protocol).toBe('https://enbox.org/protocols/social-graph');
+      expect(SocialGraphDefinition.protocol).toBe('https://identity.foundation/protocols/social-graph');
     });
 
     it('should be a published protocol', () => {
@@ -52,12 +52,12 @@ describe('@enbox/protocols', () => {
 
   describe('ProfileProtocol', () => {
     it('should have the correct protocol URI', () => {
-      expect(ProfileDefinition.protocol).toBe('https://enbox.org/protocols/profile');
+      expect(ProfileDefinition.protocol).toBe('https://identity.foundation/protocols/profile');
     });
 
     it('should compose with Social Graph via uses', () => {
       expect(ProfileDefinition.uses).toBeDefined();
-      expect(ProfileDefinition.uses!.social).toBe('https://enbox.org/protocols/social-graph');
+      expect(ProfileDefinition.uses!.social).toBe('https://identity.foundation/protocols/social-graph');
     });
 
     it('should define profile, avatar, hero, link, and privateNote types', () => {
@@ -100,7 +100,7 @@ describe('@enbox/protocols', () => {
 
   describe('PreferencesProtocol', () => {
     it('should have the correct protocol URI', () => {
-      expect(PreferencesDefinition.protocol).toBe('https://enbox.org/protocols/preferences');
+      expect(PreferencesDefinition.protocol).toBe('https://identity.foundation/protocols/preferences');
     });
 
     it('should be a private (not published) protocol', () => {
@@ -129,12 +129,12 @@ describe('@enbox/protocols', () => {
 
   describe('StatusProtocol', () => {
     it('should have the correct protocol URI', () => {
-      expect(StatusDefinition.protocol).toBe('https://enbox.org/protocols/status');
+      expect(StatusDefinition.protocol).toBe('https://identity.foundation/protocols/status');
     });
 
     it('should compose with Social Graph via uses', () => {
       expect(StatusDefinition.uses).toBeDefined();
-      expect(StatusDefinition.uses!.social).toBe('https://enbox.org/protocols/social-graph');
+      expect(StatusDefinition.uses!.social).toBe('https://identity.foundation/protocols/social-graph');
     });
 
     it('should define status and reaction types', () => {
@@ -165,12 +165,12 @@ describe('@enbox/protocols', () => {
 
   describe('ListsProtocol', () => {
     it('should have the correct protocol URI', () => {
-      expect(ListsDefinition.protocol).toBe('https://enbox.org/protocols/lists');
+      expect(ListsDefinition.protocol).toBe('https://identity.foundation/protocols/lists');
     });
 
     it('should compose with Social Graph via uses', () => {
       expect(ListsDefinition.uses).toBeDefined();
-      expect(ListsDefinition.uses!.social).toBe('https://enbox.org/protocols/social-graph');
+      expect(ListsDefinition.uses!.social).toBe('https://identity.foundation/protocols/social-graph');
     });
 
     it('should define list, item, folder, collaborator, and comment types', () => {
@@ -222,7 +222,7 @@ describe('@enbox/protocols', () => {
 
   describe('ConnectProtocol', () => {
     it('should have the correct protocol URI', () => {
-      expect(ConnectDefinition.protocol).toBe('https://enbox.org/protocols/connect');
+      expect(ConnectDefinition.protocol).toBe('https://identity.foundation/protocols/connect');
     });
 
     it('should be a published protocol', () => {


### PR DESCRIPTION
## Summary

- Replaces all 45 `enbox.org` references in protocol and schema URIs with `identity.foundation`
- We do not own `enbox.org` — protocol/schema namespace identifiers should use a domain we control or an established spec domain

## Scope

| Category | Count | Example |
|---|---|---|
| Protocol URIs | 7 | `https://identity.foundation/protocols/profile` |
| Schema URIs | 19 | `https://identity.foundation/schemas/lists/item` |
| `uses` composition refs | 3 | `social: 'https://identity.foundation/protocols/social-graph'` |
| Test assertions | 10 | `expect(...).toBe('https://identity.foundation/protocols/...')` |
| Documentation | 6 | CHANGELOG.md, TYPED_PROTOCOLS_PLAN.md |

### Files changed (11)

- `packages/protocols/src/` — all 6 protocol definitions
- `packages/agent/src/store-data-protocols.ts` — key-delivery protocol
- `packages/protocols/tests/protocols.spec.ts` — test assertions
- `packages/agent/tests/dwn-api.spec.ts` — key-delivery test assertion
- `packages/protocols/CHANGELOG.md`, `TYPED_PROTOCOLS_PLAN.md`

**Note:** The JSON Schema `$id`/`$ref` values in `packages/dwn-sdk-js/json-schemas/` already use `identity.foundation` and are unchanged.

## Breaking changes

Protocol URIs changed — any existing DWN records written with the old `enbox.org` URIs will not match queries using the new URIs. This is acceptable for pre-release protocols.

## Verification

- `bun run build` — all packages build (agent, api, protocols, dwn-sdk-js, etc.)
- `bun run lint` — 0 warnings across all packages
- `@enbox/protocols` tests — **43 pass, 0 fail**
- `@enbox/agent` tests — **697 pass, 0 fail**
- `@enbox/api` tests — **248 pass, 0 fail**