### PR TITLE
fix(ci): stop cancelling main branch CI runs on new merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes CI runs on `main` being cancelled when a new commit is merged before the previous run completes

## Problem

The concurrency group was:
```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
cancel-in-progress: true
```

For pushes to main (no PR number), this resolves to `CI-refs/heads/main` — every merge shares the same group. With `cancel-in-progress: true`, each new merge cancels the previous run, meaning rapid merges skip CI validation for intermediate commits.

## Fix

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **`github.sha`** instead of `github.ref` — each main push gets a unique group, so runs never cancel each other
- **`cancel-in-progress`** only for PRs — new pushes to the same PR still cancel stale runs (desired behavior)

The `release.yml` workflow already had `cancel-in-progress: false` and is unaffected.