### PR TITLE
fix(dwn-sdk-js): pre-bundle missing CJS deps to fix flaky Firefox browser tests

### DIFF
--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
     // from this package's node_modules. Entries that can't be resolved produce
     // "Failed to resolve dependency" warnings and are silently skipped.
     include: [
-      // noble — CJS format, direct deps of @enbox/dwn-sdk-js
+      // noble — CJS/dual-format, direct deps of @enbox/dwn-sdk-js
       '@noble/ciphers/aes',
       '@noble/ciphers/chacha',
       '@noble/ciphers/crypto',
@@ -40,9 +40,15 @@ export default defineConfig({
       '@noble/curves/secp256k1',
       '@noble/ed25519',
       '@noble/secp256k1',
-      // CJS / mixed-format packages
+      // @js-temporal/polyfill — mixed CJS/ESM; its ESM entry imports jsbi (CJS).
+      // Pre-bundling lets Vite convert both to ESM before Firefox loads them.
+      '@js-temporal/polyfill',
+      // ajv — CJS; the precompiled validators import a deep runtime subpath
+      // that must also be pre-bundled (discovered mid-run otherwise).
       'ajv',
       'ajv/dist/2020.js',
+      'ajv/dist/runtime/ucs2length.js',
+      // CJS / mixed-format packages
       'eventemitter3',
       'level',
       'lodash',


### PR DESCRIPTION
## Summary

Fixes flaky Firefox browser test failures (`records-query.spec.ts` and other interface tests) caused by Vite discovering CJS dependencies mid-test-run and triggering `optimizeDeps` restarts that crash Firefox's strict ESM loader.

## Root Cause

Two CJS/mixed-format packages were missing from `optimizeDeps.include` in `vitest.browser.config.ts`:

1. **`ajv/dist/runtime/ucs2length.js`** — CJS deep import used by the precompiled JSON schema validators (`generated/precompiled-validators.js`). While `ajv` and `ajv/dist/2020.js` were already pre-bundled, this specific deep runtime subpath was not, causing Vite to discover it mid-run.

2. **`@js-temporal/polyfill`** — mixed CJS/ESM package (direct dep of `dwn-sdk-js`, used by `Time`). Its ESM entry (`dist/index.esm.js`) imports `jsbi` which is a CJS-primary package. Pre-bundling `@js-temporal/polyfill` lets Vite convert both it and `jsbi` to ESM before Firefox loads them.

## Changes

- Added `@js-temporal/polyfill` and `ajv/dist/runtime/ucs2length.js` to `optimizeDeps.include`
- Improved comments to group deps by purpose