### PR TITLE
refactor(dids): extract DidKeyUtils and DidIonUtils into dedicated modules

### DIFF
--- a/packages/dids/src/methods/did-ion-utils.ts
+++ b/packages/dids/src/methods/did-ion-utils.ts
@@ -1,0 +1,186 @@
+import type { Jwk } from '@enbox/crypto';
+import type {
+  IonDocumentModel,
+  IonPublicKeyModel,
+  IonPublicKeyPurpose,
+  JwkEs256k,
+} from '@decentralized-identity/ion-sdk';
+
+import type { DidService } from '../types/did-core.js';
+import type { DidIonCreateRequest, DidIonVerificationMethod } from './did-ion.js';
+
+import { computeJwkThumbprint } from '@enbox/crypto';
+import { IonDid, IonRequest } from '@decentralized-identity/ion-sdk';
+
+/**
+ * The `DidIonUtils` class provides utility functions to support operations in the DID ION method.
+ */
+export class DidIonUtils {
+  /**
+   * Appends a specified path to a base URL, ensuring proper formatting of the resulting URL.
+   *
+   * This method is useful for constructing URLs for accessing various endpoints, such as Sidetree
+   * nodes in the ION network. It handles the nuances of URL path concatenation, including the
+   * addition or removal of leading/trailing slashes, to create a well-formed URL.
+   *
+   * @param params - The parameters for URL construction.
+   * @param params.baseUrl - The base URL to which the path will be appended.
+   * @param params.path - The path to append to the base URL.
+   * @returns The fully constructed URL string with the path appended to the base URL.
+   */
+  public static appendPathToUrl({ baseUrl, path }: {
+    baseUrl: string;
+    path: string;
+  }): string {
+    const url = new URL(baseUrl);
+    url.pathname = url.pathname.endsWith('/') ? url.pathname : url.pathname + '/';
+    url.pathname += path.startsWith('/') ? path.substring(1) : path;
+
+    return url.toString();
+  }
+
+  /**
+   * Computes the Long Form DID URI given an ION DID's recovery key, update key, services, and
+   * verification methods.
+   *
+   * @param params - The parameters for computing the Long Form DID URI.
+   * @param params.recoveryKey - The ION Recovery Key.
+   * @param params.updateKey - The ION Update Key.
+   * @param params.services - An array of services associated with the DID.
+   * @param params.verificationMethods - An array of verification methods associated with the DID.
+   * @returns A Promise resolving to the Long Form DID URI.
+   */
+  public static async computeLongFormDidUri({ recoveryKey, updateKey, services, verificationMethods }: {
+    recoveryKey: Jwk;
+    updateKey: Jwk;
+    services: DidService[];
+    verificationMethods: DidIonVerificationMethod[];
+  }): Promise<string> {
+    // Create the ION document.
+    const ionDocument = await DidIonUtils.createIonDocument({ services, verificationMethods });
+
+    // Normalize JWK to onnly include specific members and in lexicographic order.
+    const normalizedRecoveryKey = DidIonUtils.normalizeJwk(recoveryKey);
+    const normalizedUpdateKey = DidIonUtils.normalizeJwk(updateKey);
+
+    // Compute the Long Form DID URI.
+    const longFormDidUri = await IonDid.createLongFormDid({
+      document    : ionDocument,
+      recoveryKey : normalizedRecoveryKey as JwkEs256k,
+      updateKey   : normalizedUpdateKey as JwkEs256k
+    });
+
+    return longFormDidUri;
+  }
+
+  /**
+   * Constructs a Sidetree Create Operation request for a DID document within the ION network.
+   *
+   * This method prepares the necessary payload for submitting a Create Operation to a Sidetree
+   * node, encapsulating the details of the DID document, recovery key, and update key.
+   *
+   * @param params - Parameters required to construct the Create Operation request.
+   * @param params.ionDocument - The DID document model containing public keys and service endpoints.
+   * @param params.recoveryKey - The recovery public key in JWK format.
+   * @param params.updateKey - The update public key in JWK format.
+   * @returns A promise resolving to the ION Create Operation request model, ready for submission to a Sidetree node.
+   */
+  public static async constructCreateRequest({ ionDocument, recoveryKey, updateKey }: {
+    ionDocument: IonDocumentModel,
+    recoveryKey: Jwk,
+    updateKey: Jwk
+  }): Promise<DidIonCreateRequest> {
+    // Create an ION DID create request operation.
+    const createRequest = await IonRequest.createCreateRequest({
+      document    : ionDocument,
+      recoveryKey : DidIonUtils.normalizeJwk(recoveryKey) as JwkEs256k,
+      updateKey   : DidIonUtils.normalizeJwk(updateKey) as JwkEs256k
+    }) as DidIonCreateRequest;
+
+    return createRequest;
+  }
+
+  /**
+   * Assembles an ION document model from provided services and verification methods
+   *
+   * This model serves as the foundation for a DID document in the ION network, facilitating the
+   * creation and management of decentralized identities. It translates service endpoints and
+   * public keys into a format compatible with the Sidetree protocol, ensuring the resulting DID
+   * document adheres to the required specifications for ION DIDs. This method is essential for
+   * constructing the payload needed to register or update DIDs within the ION network.
+   *
+   * @param params - The parameters containing the services and verification methods to include in the ION document.
+   * @param params.services - A list of service endpoints to be included in the DID document, specifying ways to interact with the DID subject.
+   * @param params.verificationMethods - A list of verification methods to be included, detailing the
+   * cryptographic keys and their intended uses within the DID document.
+   * @returns A Promise resolving to an `IonDocumentModel`, ready for use in Sidetree operations like DID creation and updates.
+   */
+  public static async createIonDocument({ services, verificationMethods }: {
+    services: DidService[];
+    verificationMethods: DidIonVerificationMethod[]
+  }): Promise<IonDocumentModel> {
+    /**
+     * STEP 1: Convert verification methods to ION SDK format.
+     */
+    const ionPublicKeys: IonPublicKeyModel[] = [];
+
+    for (const vm of verificationMethods) {
+      // Use the given ID, the key's ID, or the key's thumbprint as the verification method ID.
+      let methodId = vm.id ?? vm.publicKeyJwk.kid ?? await computeJwkThumbprint({ jwk: vm.publicKeyJwk });
+      methodId = `${methodId.split('#').pop()}`; // Remove fragment prefix, if any.
+
+      // Convert public key JWK to ION format.
+      const publicKey: IonPublicKeyModel = {
+        id           : methodId,
+        publicKeyJwk : DidIonUtils.normalizeJwk(vm.publicKeyJwk),
+        purposes     : vm.purposes as IonPublicKeyPurpose[],
+        type         : 'JsonWebKey2020'
+      };
+
+      ionPublicKeys.push(publicKey);
+    }
+
+    /**
+     * STEP 2: Convert service entries, if any, to ION SDK format.
+     */
+    const ionServices = services.map(service => ({
+      ...service,
+      id: `${service.id.split('#').pop()}` // Remove fragment prefix, if any.
+    }));
+
+    /**
+     * STEP 3: Format as ION document.
+     */
+    const ionDocumentModel: IonDocumentModel = {
+      publicKeys : ionPublicKeys,
+      services   : ionServices
+    };
+
+    return ionDocumentModel;
+  }
+
+  /**
+   * Normalize the given JWK to include only specific members and in lexicographic order.
+   *
+   * @param jwk - The JWK to normalize.
+   * @returns The normalized JWK.
+   */
+  private static normalizeJwk(jwk: Jwk): Jwk {
+    const keyType = jwk.kty;
+    let normalizedJwk: Jwk;
+
+    if (keyType === 'EC') {
+      normalizedJwk = { crv: jwk.crv, kty: jwk.kty, x: jwk.x, y: jwk.y };
+    } else if (keyType === 'oct') {
+      normalizedJwk = { k: jwk.k, kty: jwk.kty };
+    } else if (keyType === 'OKP') {
+      normalizedJwk = { crv: jwk.crv, kty: jwk.kty, x: jwk.x };
+    } else if (keyType === 'RSA') {
+      normalizedJwk = { e: jwk.e, kty: jwk.kty, n: jwk.n };
+    } else {
+      throw new Error(`Unsupported key type: ${keyType}`);
+    }
+
+    return normalizedJwk;
+  }
+}

--- a/packages/dids/src/methods/did-ion.ts
+++ b/packages/dids/src/methods/did-ion.ts
@@ -1,21 +1,4 @@
-import type {
-  IonDocumentModel,
-  IonPublicKeyModel,
-  IonPublicKeyPurpose,
-  JwkEs256k,
-} from '@decentralized-identity/ion-sdk';
-import type {
-  Jwk,
-  KeyIdentifier,
-  KeyImporterExporter,
-  KeyManager,
-  KmsExportKeyParams,
-  KmsImportKeyParams,
-} from '@enbox/crypto';
-
-import { computeJwkThumbprint, LocalKeyManager } from '@enbox/crypto';
-import { IonDid, IonRequest } from '@decentralized-identity/ion-sdk';
-
+import type { IonDocumentModel } from '@decentralized-identity/ion-sdk';
 import type { PortableDid } from '../types/portable-did.js';
 import type { DidCreateOptions, DidCreateVerificationMethod, DidRegistrationResult } from '../methods/did-method.js';
 import type {
@@ -26,9 +9,20 @@ import type {
   DidVerificationMethod,
   DidVerificationRelationship,
 } from '../types/did-core.js';
+import type {
+  Jwk,
+  KeyIdentifier,
+  KeyImporterExporter,
+  KeyManager,
+  KmsExportKeyParams,
+  KmsImportKeyParams,
+} from '@enbox/crypto';
+
+import { LocalKeyManager } from '@enbox/crypto';
 
 import { BearerDid } from '../bearer-did.js';
 import { Did } from '../did.js';
+import { DidIonUtils } from './did-ion-utils.js';
 import { DidMethod } from '../methods/did-method.js';
 import { EMPTY_DID_RESOLUTION_RESULT } from '../types/did-resolution.js';
 import { getVerificationRelationshipsById } from '../utils.js';
@@ -721,175 +715,5 @@ export class DidIon extends DidMethod {
   }
 }
 
-/**
- * The `DidIonUtils` class provides utility functions to support operations in the DID ION method.
- */
-export class DidIonUtils {
-  /**
-   * Appends a specified path to a base URL, ensuring proper formatting of the resulting URL.
-   *
-   * This method is useful for constructing URLs for accessing various endpoints, such as Sidetree
-   * nodes in the ION network. It handles the nuances of URL path concatenation, including the
-   * addition or removal of leading/trailing slashes, to create a well-formed URL.
-   *
-   * @param params - The parameters for URL construction.
-   * @param params.baseUrl - The base URL to which the path will be appended.
-   * @param params.path - The path to append to the base URL.
-   * @returns The fully constructed URL string with the path appended to the base URL.
-   */
-  public static appendPathToUrl({ baseUrl, path }: {
-    baseUrl: string;
-    path: string;
-  }): string {
-    const url = new URL(baseUrl);
-    url.pathname = url.pathname.endsWith('/') ? url.pathname : url.pathname + '/';
-    url.pathname += path.startsWith('/') ? path.substring(1) : path;
-
-    return url.toString();
-  }
-
-  /**
-   * Computes the Long Form DID URI given an ION DID's recovery key, update key, services, and
-   * verification methods.
-   *
-   * @param params - The parameters for computing the Long Form DID URI.
-   * @param params.recoveryKey - The ION Recovery Key.
-   * @param params.updateKey - The ION Update Key.
-   * @param params.services - An array of services associated with the DID.
-   * @param params.verificationMethods - An array of verification methods associated with the DID.
-   * @returns A Promise resolving to the Long Form DID URI.
-   */
-  public static async computeLongFormDidUri({ recoveryKey, updateKey, services, verificationMethods }: {
-    recoveryKey: Jwk;
-    updateKey: Jwk;
-    services: DidService[];
-    verificationMethods: DidIonVerificationMethod[];
-  }): Promise<string> {
-    // Create the ION document.
-    const ionDocument = await DidIonUtils.createIonDocument({ services, verificationMethods });
-
-    // Normalize JWK to onnly include specific members and in lexicographic order.
-    const normalizedRecoveryKey = DidIonUtils.normalizeJwk(recoveryKey);
-    const normalizedUpdateKey = DidIonUtils.normalizeJwk(updateKey);
-
-    // Compute the Long Form DID URI.
-    const longFormDidUri = await IonDid.createLongFormDid({
-      document    : ionDocument,
-      recoveryKey : normalizedRecoveryKey as JwkEs256k,
-      updateKey   : normalizedUpdateKey as JwkEs256k
-    });
-
-    return longFormDidUri;
-  }
-
-  /**
-   * Constructs a Sidetree Create Operation request for a DID document within the ION network.
-   *
-   * This method prepares the necessary payload for submitting a Create Operation to a Sidetree
-   * node, encapsulating the details of the DID document, recovery key, and update key.
-   *
-   * @param params - Parameters required to construct the Create Operation request.
-   * @param params.ionDocument - The DID document model containing public keys and service endpoints.
-   * @param params.recoveryKey - The recovery public key in JWK format.
-   * @param params.updateKey - The update public key in JWK format.
-   * @returns A promise resolving to the ION Create Operation request model, ready for submission to a Sidetree node.
-   */
-  public static async constructCreateRequest({ ionDocument, recoveryKey, updateKey }: {
-    ionDocument: IonDocumentModel,
-    recoveryKey: Jwk,
-    updateKey: Jwk
-  }): Promise<DidIonCreateRequest> {
-    // Create an ION DID create request operation.
-    const createRequest = await IonRequest.createCreateRequest({
-      document    : ionDocument,
-      recoveryKey : DidIonUtils.normalizeJwk(recoveryKey) as JwkEs256k,
-      updateKey   : DidIonUtils.normalizeJwk(updateKey) as JwkEs256k
-    }) as DidIonCreateRequest;
-
-    return createRequest;
-  }
-
-  /**
-   * Assembles an ION document model from provided services and verification methods
-   *
-   * This model serves as the foundation for a DID document in the ION network, facilitating the
-   * creation and management of decentralized identities. It translates service endpoints and
-   * public keys into a format compatible with the Sidetree protocol, ensuring the resulting DID
-   * document adheres to the required specifications for ION DIDs. This method is essential for
-   * constructing the payload needed to register or update DIDs within the ION network.
-   *
-   * @param params - The parameters containing the services and verification methods to include in the ION document.
-   * @param params.services - A list of service endpoints to be included in the DID document, specifying ways to interact with the DID subject.
-   * @param params.verificationMethods - A list of verification methods to be included, detailing the
-   * cryptographic keys and their intended uses within the DID document.
-   * @returns A Promise resolving to an `IonDocumentModel`, ready for use in Sidetree operations like DID creation and updates.
-   */
-  public static async createIonDocument({ services, verificationMethods }: {
-    services: DidService[];
-    verificationMethods: DidIonVerificationMethod[]
-  }): Promise<IonDocumentModel> {
-    /**
-     * STEP 1: Convert verification methods to ION SDK format.
-     */
-    const ionPublicKeys: IonPublicKeyModel[] = [];
-
-    for (const vm of verificationMethods) {
-      // Use the given ID, the key's ID, or the key's thumbprint as the verification method ID.
-      let methodId = vm.id ?? vm.publicKeyJwk.kid ?? await computeJwkThumbprint({ jwk: vm.publicKeyJwk });
-      methodId = `${methodId.split('#').pop()}`; // Remove fragment prefix, if any.
-
-      // Convert public key JWK to ION format.
-      const publicKey: IonPublicKeyModel = {
-        id           : methodId,
-        publicKeyJwk : DidIonUtils.normalizeJwk(vm.publicKeyJwk),
-        purposes     : vm.purposes as IonPublicKeyPurpose[],
-        type         : 'JsonWebKey2020'
-      };
-
-      ionPublicKeys.push(publicKey);
-    }
-
-    /**
-     * STEP 2: Convert service entries, if any, to ION SDK format.
-     */
-    const ionServices = services.map(service => ({
-      ...service,
-      id: `${service.id.split('#').pop()}` // Remove fragment prefix, if any.
-    }));
-
-    /**
-     * STEP 3: Format as ION document.
-     */
-    const ionDocumentModel: IonDocumentModel = {
-      publicKeys : ionPublicKeys,
-      services   : ionServices
-    };
-
-    return ionDocumentModel;
-  }
-
-  /**
-   * Normalize the given JWK to include only specific members and in lexicographic order.
-   *
-   * @param jwk - The JWK to normalize.
-   * @returns The normalized JWK.
-   */
-  private static normalizeJwk(jwk: Jwk): Jwk {
-    const keyType = jwk.kty;
-    let normalizedJwk: Jwk;
-
-    if (keyType === 'EC') {
-      normalizedJwk = { crv: jwk.crv, kty: jwk.kty, x: jwk.x, y: jwk.y };
-    } else if (keyType === 'oct') {
-      normalizedJwk = { k: jwk.k, kty: jwk.kty };
-    } else if (keyType === 'OKP') {
-      normalizedJwk = { crv: jwk.crv, kty: jwk.kty, x: jwk.x };
-    } else if (keyType === 'RSA') {
-      normalizedJwk = { e: jwk.e, kty: jwk.kty, n: jwk.n };
-    } else {
-      throw new Error(`Unsupported key type: ${keyType}`);
-    }
-
-    return normalizedJwk;
-  }
-}
+// Re-export DidIonUtils from its dedicated module for backward compatibility.
+export { DidIonUtils } from './did-ion-utils.js';

--- a/packages/dids/src/methods/did-key-utils.ts
+++ b/packages/dids/src/methods/did-key-utils.ts
@@ -1,0 +1,258 @@
+import type { AsymmetricKeyConverter, Jwk, KeyCompressor } from '@enbox/crypto';
+import type { MulticodecCode, MulticodecDefinition } from '@enbox/common';
+
+import { Multicodec } from '@enbox/common';
+import { Ed25519, Secp256k1, Secp256r1 } from '@enbox/crypto';
+
+import { keyBytesToMultibaseId } from '../utils.js';
+import { DidError, DidErrorCode } from '../did-error.js';
+
+/**
+ * Private helper that maps algorithm identifiers to their corresponding DID Key
+ * {@link DidKeyRegisteredKeyType | registered key type}.
+ *
+ * Note: This is also used by `DidKeyUtils.publicKeyToMultibaseId()` to validate key types.
+ */
+export const AlgorithmToKeyTypeMap = {
+  Ed25519   : 'Ed25519',
+  ES256K    : 'secp256k1',
+  ES256     : 'secp256r1',
+  'P-256'   : 'secp256r1',
+  secp256k1 : 'secp256k1',
+  secp256r1 : 'secp256r1',
+} as const;
+
+/**
+ * The `DidKeyUtils` class provides utility functions to support operations in the DID Key method.
+ */
+export class DidKeyUtils {
+  /**
+   * A mapping from JSON Web Key (JWK) property descriptors to multicodec names.
+   *
+   * This mapping is used to convert keys in JWK (JSON Web Key) format to multicodec format.
+   *
+   * @remarks
+   * The keys of this object are strings that describe the JOSE key type and usage,
+   * such as 'Ed25519:public', 'Ed25519:private', etc. The values are the corresponding multicodec
+   * names used to represent these key types.
+   *
+   * @example
+   * ```ts
+   * const multicodecName = JWK_TO_MULTICODEC['Ed25519:public'];
+   * // Returns 'ed25519-pub', the multicodec name for an Ed25519 public key
+   * ```
+   */
+  private static JWK_TO_MULTICODEC: { [key: string]: string } = {
+    'Ed25519:public'    : 'ed25519-pub',
+    'Ed25519:private'   : 'ed25519-priv',
+    'secp256k1:public'  : 'secp256k1-pub',
+    'secp256k1:private' : 'secp256k1-priv',
+  };
+
+  /**
+   * Defines the expected byte lengths for public keys associated with different cryptographic
+   * algorithms, indexed by their multicodec code values.
+   */
+  public static MULTICODEC_PUBLIC_KEY_LENGTH: Record<number, number> = {
+    // secp256k1-pub - Secp256k1 public key (compressed) - 33 bytes
+    0xe7: 33,
+
+    // ed25519-pub - Ed25519 public key - 32 bytes
+    0xed: 32
+  };
+
+  /**
+   * A mapping from multicodec names to their corresponding JOSE (JSON Object Signing and Encryption)
+   * representations. This mapping facilitates the conversion of multicodec key formats to
+   * JWK (JSON Web Key) formats.
+   *
+   * @remarks
+   * The keys of this object are multicodec names, such as 'ed25519-pub', 'ed25519-priv', etc.
+   * The values are objects representing the corresponding JWK properties for that key type.
+   *
+   * @example
+   * ```ts
+   * const joseKey = MULTICODEC_TO_JWK['ed25519-pub'];
+   * // Returns a partial JWK for an Ed25519 public key
+   * ```
+   */
+  private static MULTICODEC_TO_JWK: { [key: string]: Jwk } = {
+    'ed25519-pub'    : { crv: 'Ed25519', kty: 'OKP', x: '' },
+    'ed25519-priv'   : { crv: 'Ed25519', kty: 'OKP', x: '', d: '' },
+    'secp256k1-pub'  : { crv: 'secp256k1', kty: 'EC', x: '', y: '' },
+    'secp256k1-priv' : { crv: 'secp256k1', kty: 'EC', x: '', y: '', d: '' },
+  };
+
+  /**
+   * Converts a JWK (JSON Web Key) to a Multicodec code and name.
+   *
+   * @example
+   * ```ts
+   * const jwk: Jwk = { crv: 'Ed25519', kty: 'OKP', x: '...' };
+   * const { code, name } = await DidKeyUtils.jwkToMulticodec({ jwk });
+   * ```
+   *
+   * @param params - The parameters for the conversion.
+   * @param params.jwk - The JSON Web Key to be converted.
+   * @returns A promise that resolves to a Multicodec definition.
+   */
+  public static async jwkToMulticodec({ jwk }: {
+    jwk: Jwk
+  }): Promise<MulticodecDefinition<MulticodecCode>> {
+    const params: string[] = [];
+
+    if (jwk.crv) {
+      params.push(jwk.crv);
+      if (jwk.d) {
+        params.push('private');
+      } else {
+        params.push('public');
+      }
+    }
+
+    const lookupKey = params.join(':');
+    const name = DidKeyUtils.JWK_TO_MULTICODEC[lookupKey];
+
+    if (name === undefined) {
+      throw new Error(`Unsupported JWK to Multicodec conversion: '${lookupKey}'`);
+    }
+
+    const code = Multicodec.getCodeFromName({ name });
+
+    return { code, name };
+  }
+
+  /**
+   * Returns the appropriate public key compressor for the specified cryptographic curve.
+   *
+   * @param curve - The cryptographic curve to use for the key conversion.
+   * @returns A public key compressor for the specified curve.
+   */
+  public static keyCompressor(
+    curve: string
+  ): KeyCompressor['compressPublicKey'] {
+  // ): ({ publicKeyBytes }: { publicKeyBytes: Uint8Array }) => Promise<Uint8Array> {
+    const compressors = {
+      'P-256'     : Secp256r1.compressPublicKey,
+      'secp256k1' : Secp256k1.compressPublicKey
+    } as Record<string, KeyCompressor['compressPublicKey']>;
+
+    const compressor = compressors[curve];
+
+    if (!compressor) {throw new DidError(DidErrorCode.InvalidPublicKeyType, `Unsupported curve: ${curve}`);}
+
+    return compressor;
+  }
+
+  /**
+   * Returns the appropriate key converter for the specified cryptographic curve.
+   *
+   * @param curve - The cryptographic curve to use for the key conversion.
+   * @returns An `AsymmetricKeyConverter` for the specified curve.
+   */
+  public static keyConverter(curve: string): AsymmetricKeyConverter {
+    const converters: Record<string, AsymmetricKeyConverter> = {
+      'Ed25519'   : Ed25519,
+      'P-256'     : Secp256r1,
+      'secp256k1' : Secp256k1,
+    };
+
+    const converter = converters[curve];
+
+    if (!converter) {throw new DidError(DidErrorCode.InvalidPublicKeyType, `Unsupported curve: ${curve}`);}
+
+    return converter;
+  }
+
+  /**
+   * Converts a Multicodec code or name to parial JWK (JSON Web Key).
+   *
+   * @example
+   * ```ts
+   * const partialJwk = await DidKeyUtils.multicodecToJwk({ name: 'ed25519-pub' });
+   * ```
+   *
+   * @param params - The parameters for the conversion.
+   * @param params.code - Optional Multicodec code to convert.
+   * @param params.name - Optional Multicodec name to convert.
+   * @returns A promise that resolves to a JOSE format key.
+   */
+  public static async multicodecToJwk({ code, name }: {
+    code?: MulticodecCode,
+    name?: string
+  }): Promise<Jwk> {
+    // Either code or name must be specified, but not both.
+    if (!(name ? !code : code)) {
+      throw new Error(`Either 'name' or 'code' must be defined, but not both.`);
+    }
+
+    // If name is undefined, lookup by code.
+    name = (name === undefined ) ? Multicodec.getNameFromCode({ code: code! }) : name;
+
+    const lookupKey = name;
+    const jose = DidKeyUtils.MULTICODEC_TO_JWK[lookupKey];
+
+    if (jose === undefined) {
+      throw new Error(`Unsupported Multicodec to JWK conversion`);
+    }
+
+    return { ...jose };
+  }
+
+  /**
+   * Converts a public key in JWK (JSON Web Key) format to a multibase identifier.
+   *
+   * @remarks
+   * Note: All secp public keys are converted to compressed point encoding
+   *       before the multibase identifier is computed.
+   *
+   * Per {@link https://github.com/multiformats/multicodec/blob/master/table.csv | Multicodec table}:
+   *    Public keys for Elliptic Curve cryptography algorithms (e.g., secp256k1,
+   *    secp256k1r1, secp384r1, etc.) are always represented with compressed point
+   *    encoding (e.g., secp256k1-pub, p256-pub, p384-pub, etc.).
+   *
+   * Per {@link https://datatracker.ietf.org/doc/html/rfc8812#name-jose-and-cose-secp256k1-cur | RFC 8812}:
+   *    "As a compressed point encoding representation is not defined for JWK
+   *    elliptic curve points, the uncompressed point encoding defined there
+   *    MUST be used. The x and y values represented MUST both be exactly
+   *    256 bits, with any leading zeros preserved."
+   *
+   * @example
+   * ```ts
+   * const publicKey = { crv: 'Ed25519', kty: 'OKP', x: '...' };
+   * const multibaseId = await DidKeyUtils.publicKeyToMultibaseId({ publicKey });
+   * ```
+   *
+   * @param params - The parameters for the conversion.
+   * @param params.publicKey - The public key in JWK format.
+   * @returns A promise that resolves to the multibase identifier.
+   */
+  public static async publicKeyToMultibaseId({ publicKey }: {
+    publicKey: Jwk
+  }): Promise<string> {
+    if (!(publicKey?.crv && publicKey.crv in AlgorithmToKeyTypeMap)) {
+      throw new DidError(DidErrorCode.InvalidPublicKeyType, `Public key contains an unsupported key type: ${publicKey?.crv ?? 'undefined'}`);
+    }
+
+    // Convert the public key from JWK format to a byte array.
+    let publicKeyBytes = await DidKeyUtils.keyConverter(publicKey.crv).publicKeyToBytes({ publicKey });
+
+    // Compress the public key if it is an elliptic curve key.
+    if (/^(secp256k1|P-256|P-384|P-521)$/.test(publicKey.crv)) {
+      publicKeyBytes = await DidKeyUtils.keyCompressor(publicKey.crv)({ publicKeyBytes });
+    }
+
+    // Convert the JSON Web Key (JWK) parameters to a Multicodec name.
+    const { name: multicodecName } = await DidKeyUtils.jwkToMulticodec({ jwk: publicKey });
+
+    // Compute the multibase identifier based on the provided key.
+    const multibaseId = keyBytesToMultibaseId({
+      keyBytes: publicKeyBytes,
+      multicodecName
+    });
+
+    return multibaseId;
+  }
+}
+
+

--- a/packages/dids/src/methods/did-key.ts
+++ b/packages/dids/src/methods/did-key.ts
@@ -1,24 +1,3 @@
-import type {
-  AsymmetricKeyConverter,
-  InferKeyGeneratorAlgorithm,
-  Jwk,
-  KeyCompressor,
-  KeyIdentifier,
-  KeyImporterExporter,
-  KeyManager,
-  KmsExportKeyParams,
-  KmsImportKeyParams,
-} from '@enbox/crypto';
-import type { MulticodecCode, MulticodecDefinition } from '@enbox/common';
-
-import {
-  Ed25519,
-  LocalKeyManager,
-  Secp256k1,
-  Secp256r1,
-} from '@enbox/crypto';
-import { Multicodec, universalTypeOf } from '@enbox/common';
-
 import type { PortableDid } from '../types/portable-did.js';
 import type { DidCreateOptions, DidCreateVerificationMethod } from './did-method.js';
 import type {
@@ -27,13 +6,25 @@ import type {
   DidResolutionResult,
   DidVerificationMethod,
 } from '../types/did-core.js';
+import type {
+  InferKeyGeneratorAlgorithm,
+  KeyIdentifier,
+  KeyImporterExporter,
+  KeyManager,
+  KmsExportKeyParams,
+  KmsImportKeyParams,
+} from '@enbox/crypto';
+
+import { universalTypeOf } from '@enbox/common';
+import { Ed25519, LocalKeyManager, Secp256k1 } from '@enbox/crypto';
 
 import { BearerDid } from '../bearer-did.js';
 import { Did } from '../did.js';
+import { DidKeyUtils } from './did-key-utils.js';
 import { DidMethod } from './did-method.js';
 import { EMPTY_DID_RESOLUTION_RESULT } from '../types/did-resolution.js';
 import { DidError, DidErrorCode } from '../did-error.js';
-import { getVerificationMethodTypes, keyBytesToMultibaseId, multibaseIdToKeyBytes } from '../utils.js';
+import { getVerificationMethodTypes, multibaseIdToKeyBytes } from '../utils.js';
 
 /**
  * Defines the set of options available when creating a new Decentralized Identifier (DID) with the
@@ -163,19 +154,6 @@ export const DidKeyVerificationMethodType = {
 
   /** Represents a JSON Web Key (JWK) used for digital signatures and key agreement protocols. */
   JsonWebKey2020: 'https://w3id.org/security/suites/jws-2020/v1',
-} as const;
-
-/**
- * Private helper that maps algorithm identifiers to their corresponding DID Key
- * {@link DidKeyRegisteredKeyType | registered key type}.
- */
-const AlgorithmToKeyTypeMap = {
-  Ed25519   : DidKeyRegisteredKeyType.Ed25519,
-  ES256K    : DidKeyRegisteredKeyType.secp256k1,
-  ES256     : DidKeyRegisteredKeyType.secp256r1,
-  'P-256'   : DidKeyRegisteredKeyType.secp256r1,
-  secp256k1 : DidKeyRegisteredKeyType.secp256k1,
-  secp256r1 : DidKeyRegisteredKeyType.secp256r1,
 } as const;
 
 /**
@@ -733,235 +711,5 @@ export class DidKey extends DidMethod {
   }
 }
 
-/**
- * The `DidKeyUtils` class provides utility functions to support operations in the DID Key method.
- */
-export class DidKeyUtils {
-  /**
-   * A mapping from JSON Web Key (JWK) property descriptors to multicodec names.
-   *
-   * This mapping is used to convert keys in JWK (JSON Web Key) format to multicodec format.
-   *
-   * @remarks
-   * The keys of this object are strings that describe the JOSE key type and usage,
-   * such as 'Ed25519:public', 'Ed25519:private', etc. The values are the corresponding multicodec
-   * names used to represent these key types.
-   *
-   * @example
-   * ```ts
-   * const multicodecName = JWK_TO_MULTICODEC['Ed25519:public'];
-   * // Returns 'ed25519-pub', the multicodec name for an Ed25519 public key
-   * ```
-   */
-  private static JWK_TO_MULTICODEC: { [key: string]: string } = {
-    'Ed25519:public'    : 'ed25519-pub',
-    'Ed25519:private'   : 'ed25519-priv',
-    'secp256k1:public'  : 'secp256k1-pub',
-    'secp256k1:private' : 'secp256k1-priv',
-  };
-
-  /**
-   * Defines the expected byte lengths for public keys associated with different cryptographic
-   * algorithms, indexed by their multicodec code values.
-   */
-  public static MULTICODEC_PUBLIC_KEY_LENGTH: Record<number, number> = {
-    // secp256k1-pub - Secp256k1 public key (compressed) - 33 bytes
-    0xe7: 33,
-
-    // ed25519-pub - Ed25519 public key - 32 bytes
-    0xed: 32
-  };
-
-  /**
-   * A mapping from multicodec names to their corresponding JOSE (JSON Object Signing and Encryption)
-   * representations. This mapping facilitates the conversion of multicodec key formats to
-   * JWK (JSON Web Key) formats.
-   *
-   * @remarks
-   * The keys of this object are multicodec names, such as 'ed25519-pub', 'ed25519-priv', etc.
-   * The values are objects representing the corresponding JWK properties for that key type.
-   *
-   * @example
-   * ```ts
-   * const joseKey = MULTICODEC_TO_JWK['ed25519-pub'];
-   * // Returns a partial JWK for an Ed25519 public key
-   * ```
-   */
-  private static MULTICODEC_TO_JWK: { [key: string]: Jwk } = {
-    'ed25519-pub'    : { crv: 'Ed25519', kty: 'OKP', x: '' },
-    'ed25519-priv'   : { crv: 'Ed25519', kty: 'OKP', x: '', d: '' },
-    'secp256k1-pub'  : { crv: 'secp256k1', kty: 'EC', x: '', y: '' },
-    'secp256k1-priv' : { crv: 'secp256k1', kty: 'EC', x: '', y: '', d: '' },
-  };
-
-  /**
-   * Converts a JWK (JSON Web Key) to a Multicodec code and name.
-   *
-   * @example
-   * ```ts
-   * const jwk: Jwk = { crv: 'Ed25519', kty: 'OKP', x: '...' };
-   * const { code, name } = await DidKeyUtils.jwkToMulticodec({ jwk });
-   * ```
-   *
-   * @param params - The parameters for the conversion.
-   * @param params.jwk - The JSON Web Key to be converted.
-   * @returns A promise that resolves to a Multicodec definition.
-   */
-  public static async jwkToMulticodec({ jwk }: {
-    jwk: Jwk
-  }): Promise<MulticodecDefinition<MulticodecCode>> {
-    const params: string[] = [];
-
-    if (jwk.crv) {
-      params.push(jwk.crv);
-      if (jwk.d) {
-        params.push('private');
-      } else {
-        params.push('public');
-      }
-    }
-
-    const lookupKey = params.join(':');
-    const name = DidKeyUtils.JWK_TO_MULTICODEC[lookupKey];
-
-    if (name === undefined) {
-      throw new Error(`Unsupported JWK to Multicodec conversion: '${lookupKey}'`);
-    }
-
-    const code = Multicodec.getCodeFromName({ name });
-
-    return { code, name };
-  }
-
-  /**
-   * Returns the appropriate public key compressor for the specified cryptographic curve.
-   *
-   * @param curve - The cryptographic curve to use for the key conversion.
-   * @returns A public key compressor for the specified curve.
-   */
-  public static keyCompressor(
-    curve: string
-  ): KeyCompressor['compressPublicKey'] {
-  // ): ({ publicKeyBytes }: { publicKeyBytes: Uint8Array }) => Promise<Uint8Array> {
-    const compressors = {
-      'P-256'     : Secp256r1.compressPublicKey,
-      'secp256k1' : Secp256k1.compressPublicKey
-    } as Record<string, KeyCompressor['compressPublicKey']>;
-
-    const compressor = compressors[curve];
-
-    if (!compressor) {throw new DidError(DidErrorCode.InvalidPublicKeyType, `Unsupported curve: ${curve}`);}
-
-    return compressor;
-  }
-
-  /**
-   * Returns the appropriate key converter for the specified cryptographic curve.
-   *
-   * @param curve - The cryptographic curve to use for the key conversion.
-   * @returns An `AsymmetricKeyConverter` for the specified curve.
-   */
-  public static keyConverter(curve: string): AsymmetricKeyConverter {
-    const converters: Record<string, AsymmetricKeyConverter> = {
-      'Ed25519'   : Ed25519,
-      'P-256'     : Secp256r1,
-      'secp256k1' : Secp256k1,
-    };
-
-    const converter = converters[curve];
-
-    if (!converter) {throw new DidError(DidErrorCode.InvalidPublicKeyType, `Unsupported curve: ${curve}`);}
-
-    return converter;
-  }
-
-  /**
-   * Converts a Multicodec code or name to parial JWK (JSON Web Key).
-   *
-   * @example
-   * ```ts
-   * const partialJwk = await DidKeyUtils.multicodecToJwk({ name: 'ed25519-pub' });
-   * ```
-   *
-   * @param params - The parameters for the conversion.
-   * @param params.code - Optional Multicodec code to convert.
-   * @param params.name - Optional Multicodec name to convert.
-   * @returns A promise that resolves to a JOSE format key.
-   */
-  public static async multicodecToJwk({ code, name }: {
-    code?: MulticodecCode,
-    name?: string
-  }): Promise<Jwk> {
-    // Either code or name must be specified, but not both.
-    if (!(name ? !code : code)) {
-      throw new Error(`Either 'name' or 'code' must be defined, but not both.`);
-    }
-
-    // If name is undefined, lookup by code.
-    name = (name === undefined ) ? Multicodec.getNameFromCode({ code: code! }) : name;
-
-    const lookupKey = name;
-    const jose = DidKeyUtils.MULTICODEC_TO_JWK[lookupKey];
-
-    if (jose === undefined) {
-      throw new Error(`Unsupported Multicodec to JWK conversion`);
-    }
-
-    return { ...jose };
-  }
-
-  /**
-   * Converts a public key in JWK (JSON Web Key) format to a multibase identifier.
-   *
-   * @remarks
-   * Note: All secp public keys are converted to compressed point encoding
-   *       before the multibase identifier is computed.
-   *
-   * Per {@link https://github.com/multiformats/multicodec/blob/master/table.csv | Multicodec table}:
-   *    Public keys for Elliptic Curve cryptography algorithms (e.g., secp256k1,
-   *    secp256k1r1, secp384r1, etc.) are always represented with compressed point
-   *    encoding (e.g., secp256k1-pub, p256-pub, p384-pub, etc.).
-   *
-   * Per {@link https://datatracker.ietf.org/doc/html/rfc8812#name-jose-and-cose-secp256k1-cur | RFC 8812}:
-   *    "As a compressed point encoding representation is not defined for JWK
-   *    elliptic curve points, the uncompressed point encoding defined there
-   *    MUST be used. The x and y values represented MUST both be exactly
-   *    256 bits, with any leading zeros preserved."
-   *
-   * @example
-   * ```ts
-   * const publicKey = { crv: 'Ed25519', kty: 'OKP', x: '...' };
-   * const multibaseId = await DidKeyUtils.publicKeyToMultibaseId({ publicKey });
-   * ```
-   *
-   * @param params - The parameters for the conversion.
-   * @param params.publicKey - The public key in JWK format.
-   * @returns A promise that resolves to the multibase identifier.
-   */
-  public static async publicKeyToMultibaseId({ publicKey }: {
-    publicKey: Jwk
-  }): Promise<string> {
-    if (!(publicKey?.crv && publicKey.crv in AlgorithmToKeyTypeMap)) {
-      throw new DidError(DidErrorCode.InvalidPublicKeyType, `Public key contains an unsupported key type: ${publicKey?.crv ?? 'undefined'}`);
-    }
-
-    // Convert the public key from JWK format to a byte array.
-    let publicKeyBytes = await DidKeyUtils.keyConverter(publicKey.crv).publicKeyToBytes({ publicKey });
-
-    // Compress the public key if it is an elliptic curve key.
-    if (/^(secp256k1|P-256|P-384|P-521)$/.test(publicKey.crv)) {
-      publicKeyBytes = await DidKeyUtils.keyCompressor(publicKey.crv)({ publicKeyBytes });
-    }
-
-    // Convert the JSON Web Key (JWK) parameters to a Multicodec name.
-    const { name: multicodecName } = await DidKeyUtils.jwkToMulticodec({ jwk: publicKey });
-
-    // Compute the multibase identifier based on the provided key.
-    const multibaseId = keyBytesToMultibaseId({
-      keyBytes: publicKeyBytes,
-      multicodecName
-    });
-
-    return multibaseId;
-  }
-}
+// Re-export DidKeyUtils from its dedicated module for backward compatibility.
+export { DidKeyUtils } from './did-key-utils.js';


### PR DESCRIPTION
## Summary

- Extract `DidKeyUtils` class from `did-key.ts` into `did-key-utils.ts` (258 lines), reducing `did-key.ts` from 967 to 714 lines
- Extract `DidIonUtils` class from `did-ion.ts` into `did-ion-utils.ts` (186 lines), reducing `did-ion.ts` from 895 to 718 lines
- Both original files re-export the extracted classes for full backward compatibility — no consumer changes needed

## What changed

| File | Before | After | Extracted |
|---|---|---|---|
| `did-key.ts` | 967 lines | 714 lines | `did-key-utils.ts` (258 lines) |
| `did-ion.ts` | 895 lines | 718 lines | `did-ion-utils.ts` (186 lines) |

### `did-key-utils.ts`
Contains the `DidKeyUtils` class with multicodec/JWK conversion utilities (`jwkToMulticodec`, `multicodecToJwk`, `keyConverter`, `keyCompressor`, `publicKeyToMultibaseId`) and the `AlgorithmToKeyTypeMap` constant.

### `did-ion-utils.ts`
Contains the `DidIonUtils` class with ION network utilities (`appendPathToUrl`, `computeLongFormDidUri`, `constructCreateRequest`, `createIonDocument`, `normalizeJwk`).

## Verification

- **Lint**: `bun run --filter @enbox/dids lint` — 0 errors
- **Build**: `bun run --filter @enbox/dids build` — clean
- **Tests**: `bun run test:node` from `packages/dids/` — 302 pass, 0 fail

Part of the ongoing effort to decompose large source files in the monorepo (PRs #205, #216, #220, #228).