### PR TITLE
refactor(dwn-sdk-js): upgrade ES target to ES2022 and improve stream workaround comments (#90)

### DIFF
--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -66,9 +66,10 @@ export class HttpDwnRpcClient implements DwnRpc {
     }
 
     // Materialise the response body before attaching to the reply.
-    // Bun (<=1.3.9) has a bug where resp.body.getReader() can intermittently
-    // return undefined, crashing DataStream.toBytes() in its finally block.
-    // Buffering via arrayBuffer() is a safe workaround.
+    // Bun has a bug where ReadableStream from fetch resp.body crashes in
+    // DataStream.toBytes() (reader.releaseLock() is undefined) when the
+    // stream is later consumed by the local DWN node (e.g. during sync).
+    // Buffering via arrayBuffer() avoids the broken getReader() path.
     // TODO: https://github.com/enboxorg/enbox/issues/90 — remove once Bun ships fix
     const { reply } = dwnRpcResponse.result;
     if (hasDataStream) {

--- a/packages/dwn-sdk-js/tsconfig.json
+++ b/packages/dwn-sdk-js/tsconfig.json
@@ -4,10 +4,10 @@
     "noImplicitAny": true,
     "lib": [
       "DOM",
-      "ES6"
+      "ES2022"
     ],
     "allowJs": true,
-    "target": "ES6",
+    "target": "ES2022",
     "module": "NodeNext",
     "declaration": true,
     "declarationMap": true,

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -328,10 +328,11 @@ export class HttpApi {
     }
 
     // Materialise the request body before passing to DWN.
-    // Bun (<=1.3.9) has a bug where req.body.getReader() can return undefined
-    // when the stream hasn't been fully received yet, causing DataStream.toBytes()
-    // to crash in its finally block.  Buffering via arrayBuffer() is a safe
-    // workaround until Bun fixes this.
+    // Bun's Bun.serve() returns a ReadableStream for req.body that is
+    // incompatible with the ReadableStream consumer code in dwn-sdk-js,
+    // causing DataStream.toBytes() to crash with "undefined is not a
+    // function" at reader.releaseLock().  Buffering via arrayBuffer()
+    // converts it into a well-behaved stream that dwn-sdk-js can consume.
     // TODO: https://github.com/enboxorg/enbox/issues/90 — remove once Bun ships fix
     const contentLength = req.headers.get('content-length');
     const transferEncoding = req.headers.get('transfer-encoding');


### PR DESCRIPTION
## Summary

Investigates [#90](https://github.com/enboxorg/enbox/issues/90) — the `arrayBuffer()` workarounds for Bun's broken `ReadableStream`.

### Findings

Extensive root-cause analysis confirmed the Bun stream bug is **real and still present** in Bun 1.3.9:

- **`req.body` from `Bun.serve()`** — crashes deterministically when passed through `DataStream.toBytes()` (`reader.releaseLock()` is `undefined`)
- **`resp.body` from `fetch()`** — also crashes when the stream is later consumed by `DataStream.toBytes()` (e.g., during sync when records are written to the local DWN node)
- The ES6→ES2022 target change eliminates `__awaiter` wrappers but does **not** fix the stream bug
- Both the server-side (`dwn-server`) and client-side (`dwn-clients`) `arrayBuffer()` workarounds **must remain**

### Changes

- **`packages/dwn-sdk-js/tsconfig.json`** — Upgrade `target`/`lib` from `ES6` to `ES2022`, producing native `async/await` instead of `__awaiter` generators (smaller bundle, cleaner stack traces)
- **`packages/dwn-server/src/http-api.ts`** — Updated workaround comment with accurate bug description
- **`packages/dwn-clients/src/http-dwn-rpc-client.ts`** — Updated workaround comment with accurate bug description

### Test results (local)

| Package | Result |
|---|---|
| `dwn-sdk-js` | 1012 pass, 0 fail |
| `dwn-server` | 100 pass, 0 fail |
| `dwn-clients` | 87 pass, 0 fail |
| `agent` | 697 pass, 0 fail |

Closes #90 (workarounds confirmed necessary; comments improved to document root cause).
