### PR TITLE
chore: add changeset for protocol-first API release

### DIFF
--- a/.changeset/protocol-first-api.md
+++ b/.changeset/protocol-first-api.md
@@ -1,0 +1,9 @@
+---
+"@enbox/api": minor
+"@enbox/agent": patch
+"@enbox/dids": patch
+"@enbox/dwn-sdk-js": patch
+"@enbox/dwn-clients": patch
+---
+
+Protocol-first Web5 API surface: `web5.using(protocol)` replaces `web5.dwn`, `TypedWeb5` replaces `TypedDwnApi`, `DwnApi` moved to `@enbox/api/advanced` sub-path. Flat request shapes, `records.create()`/`createFrom()` removed, `Record.update()`/`delete()` return new immutable records, `dateModified` renamed to `timestamp`. Smart `configure()` skips redundant re-installation when definition is unchanged.


### PR DESCRIPTION
## Summary

Adds a changeset to trigger version bumps and npm publish for the protocol-first API reshape.

### Version bumps

| Package | Current | Next | Bump |
|---------|---------|------|------|
| `@enbox/api` | 0.1.1 | 0.2.0 | **minor** |
| `@enbox/agent` | 0.1.5 | 0.1.6 | patch |
| `@enbox/dids` | 0.0.4 | 0.0.5 | patch |
| `@enbox/dwn-sdk-js` | 0.0.6 | 0.0.7 | patch |
| `@enbox/dwn-clients` | 0.0.3 | 0.0.4 | patch |
| `@enbox/protocols` | 0.2.0 | 0.2.1 | patch (auto) |
| `@enbox/browser` | 0.0.4 | 0.0.5 | patch (auto) |
| `@enbox/dwn-sql-store` | — | — | patch (auto) |

Once merged to main, the release workflow will create a "Version Packages" PR. Merging that PR publishes all bumped packages to npm.