### PR TITLE
fix(dwn-sdk-js): pre-bundle @isaacs/ttlcache to fix flaky Firefox browser tests

### DIFF
--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -48,6 +48,10 @@ export default defineConfig({
       'ajv',
       'ajv/dist/2020.js',
       'ajv/dist/runtime/ucs2length.js',
+      // @isaacs/ttlcache — CJS; transitive dep via @enbox/crypto -> @enbox/common.
+      // Use Vite's nested-dep `>` syntax so Vite resolves it through the
+      // workspace symlink chain rather than from this package's node_modules.
+      '@enbox/crypto > @enbox/common > @isaacs/ttlcache',
       // CJS / mixed-format packages
       'eventemitter3',
       'level',


### PR DESCRIPTION
## Summary

- Pre-bundles `@isaacs/ttlcache` (CJS) in the Vitest browser config to eliminate flaky Firefox test failures

## Problem

The `Test: Browser (dwn-sdk-js)` CI job has been intermittently failing on Firefox with:

```
FAIL firefox tests/interfaces/protocols-configure.spec.ts
Error: Failed to import test file
Caused by: TypeError: error loading dynamically imported module
```

`@isaacs/ttlcache` is a CJS package pulled in transitively via `@enbox/crypto` -> `@enbox/common`. Without explicit pre-bundling, Vite discovers it mid-test-run and triggers an `optimizeDeps` restart. Chromium and WebKit handle this gracefully, but Firefox's strict ESM loader crashes — the same class of issue documented in the existing config comments.

The failure became more frequent after #237 re-sorted the test include list, changing the module load order and making Firefox more likely to hit the restart at the wrong time.

## Fix

Adds `'@enbox/crypto > @enbox/common > @isaacs/ttlcache'` to `optimizeDeps.include` using Vite's nested-dep `>` syntax, which resolves the package through the workspace symlink chain since `@isaacs/ttlcache` isn't a direct dependency of `dwn-sdk-js`.