### PR TITLE
fix(ci): fix duplicated coverage numbers and docs-only path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          # With the default predicate-quantifier ('some'), a file only needs
+          # to match ONE pattern to be considered changed.  Since '**' matches
+          # everything, the negation patterns were silently ignored and the
+          # filter always returned true.
+          #
+          # With 'every', a file must match ALL patterns.  A .md file matches
+          # '**' but fails '!**/*.md', so it's excluded — which is the
+          # intended behavior.
+          predicate-quantifier: 'every'
           filters: |
             src:
               - '**'


### PR DESCRIPTION
## Summary

Two CI fixes:

1. **Fix duplicated browser coverage percentages** — the bash parameter expansion `${var:+${var}%}${var:-—}` was printing both branches when set (e.g. `81.9%81.9` instead of `81.9%`). Split into two sequential assignments.

2. **Fix path filter so docs-only PRs skip the test pipeline** — `dorny/paths-filter` with the default `predicate-quantifier: 'some'` treated each pattern as OR, so `'**'` matched everything and the `!` negations were ignored. The filter always returned `true`. Switching to `predicate-quantifier: 'every'` makes files match ALL patterns, so `.md` files now correctly fail `'!**/*.md'` and are excluded.

## Before (path filter)

Every PR ran the full pipeline (~12 min), including docs-only and changeset-only PRs.

## After (path filter)

PRs that only touch `.md` files, `docs/`, `LICENSE`, `.changeset/`, or `scripts/` skip straight to the `CI Passed` gate job (~10 seconds).
