### PR TITLE
docs: update root and @enbox/api READMEs with accurate content and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enbox
 
-> **Research Preview** — Enbox is under active development. APIs may change without notice.
+> **Research Preview** -- Enbox is under active development. APIs may change without notice.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/ci.yml?branch=main&label=ci)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
 
@@ -18,17 +18,68 @@
 
 A toolkit for decentralized identity and encrypted personal data storage.
 
+## Quick Start (for app developers)
+
+Most applications only need the `@enbox/api` package:
+
+```bash
+bun add @enbox/api
+```
+
+```ts
+import { defineProtocol, Web5 } from '@enbox/api';
+
+// Connect -- creates a local agent, identity vault, and DID
+const { web5, did: myDid } = await Web5.connect({
+  password: 'user-chosen-password',
+});
+
+// Define a protocol with typed data shapes
+const NotesProtocol = defineProtocol({
+  protocol  : 'https://example.com/notes',
+  published : true,
+  types     : {
+    note: {
+      schema      : 'https://example.com/schemas/note',
+      dataFormats : ['application/json'],
+    },
+  },
+  structure: {
+    note: {},
+  },
+} as const, {} as {
+  note: { title: string; body: string };
+});
+
+// Scope all operations to the protocol
+const notes = web5.using(NotesProtocol);
+await notes.configure();
+
+// Write a record (path, data, and schema are type-checked)
+const { record } = await notes.records.write('note', {
+  data: { title: 'Hello', body: 'World' },
+});
+
+// Query records back
+const { records } = await notes.records.query('note');
+for (const r of records) {
+  console.log(r.id, await r.data.json());
+}
+```
+
+See the full [`@enbox/api` README](./packages/api/README.md) for detailed documentation, examples, and API reference.
+
 ## How It Works
 
-Enbox gives each user an **agent** — a local software component that manages their decentralized identity (DID), cryptographic keys, and personal data. Data is stored in **Decentralized Web Nodes (DWNs)**: protocol-driven datastores that the user controls.
+Enbox gives each user an **agent** -- a local software component that manages their decentralized identity (DID), cryptographic keys, and personal data. Data is stored in **Decentralized Web Nodes (DWNs)**: protocol-driven datastores that the user controls.
 
-### The Key Components
+### Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  Your Application                                           │
 │  ┌───────────────────────────────────────────────────────┐  │
-│  │  @enbox/api  (Enbox.connect() → enbox.dwn.records.*)  │  │
+│  │  @enbox/api  (Web5.connect() → web5.using().records)  │  │
 │  └──────────────────────┬────────────────────────────────┘  │
 │                         │                                   │
 │  ┌──────────────────────▼────────────────────────────────┐  │
@@ -70,7 +121,7 @@ Enbox gives each user an **agent** — a local software component that manages t
 
 ### Protocols
 
-DWN records are organized by **protocols** — declarative schemas that define what record types exist, who can read/write them, and whether they require encryption. For example:
+DWN records are organized by **protocols** -- declarative schemas that define what record types exist, who can read/write them, and whether they require encryption. For example:
 
 ```typescript
 {
@@ -89,7 +140,7 @@ DWN records are organized by **protocols** — declarative schemas that define w
 }
 ```
 
-Protocols are installed on a DWN via `ProtocolsConfigure` messages and enforced by the DWN engine.
+Protocols are installed on a DWN via `ProtocolsConfigure` messages and enforced by the DWN engine. At the API level, use `defineProtocol()` to create typed definitions and `web5.using(protocol).configure()` to install them.
 
 ### Two-Layer Encryption
 
@@ -97,9 +148,9 @@ All sensitive data is encrypted at rest through two independent layers:
 
 1. **Vault encryption** (Layer 1): A 12-word BIP-39 seed phrase deterministically derives the agent's DID and keys. A user-chosen password encrypts the agent's portable DID as a compact JWE (AES-256-GCM via PBKDF2).
 
-2. **DWN record-level encryption** (Layer 2): Protocol types with `encryptionRequired: true` are encrypted using ECIES with the tenant's secp256k1 `#enc` key. Encryption keys are derived and injected into the protocol definition at install time.
+2. **DWN record-level encryption** (Layer 2): Protocol types with `encryptionRequired: true` are encrypted using JWE with the tenant's X25519 `#enc` key (ECDH-ES+A256KW key agreement, AES-256-GCM or XChaCha20-Poly1305 content encryption). Encryption keys are derived and injected into the protocol definition at install time.
 
-**Recovery**: Given only the seed phrase, the agent DID is deterministically regenerated, yielding the secp256k1 `#enc` key needed to decrypt all DWN key records.
+**Recovery**: Given only the seed phrase, the agent DID is deterministically regenerated, yielding the X25519 `#enc` key needed to decrypt all DWN key records.
 
 ## Packages
 
@@ -121,24 +172,24 @@ All sensitive data is encrypted at rest through two independent layers:
 
 | Package | Description |
 |---|---|
-| `@enbox/common` | Shared utilities, `TtlCache`, `LevelStore` |
-| `@enbox/crypto` | Ed25519, secp256k1, AES, PBKDF2, JWE |
-| `@enbox/dids` | DID methods (`did:dht`, `did:jwk`), resolution |
-| `@enbox/dwn-sdk-js` | DWN protocol engine, message handlers, stores |
-| `@enbox/dwn-clients` | DWN client libraries, shared types, JSON-RPC transport |
-| `@enbox/agent` | Agent framework: identity vault, key management, DWN stores, sync |
-| `@enbox/api` | High-level SDK for applications (`Enbox.connect()`) |
-| `@enbox/dwn-sql-store` | SQL-backed DWN storage (PostgreSQL, SQLite, MySQL) |
-| `@enbox/dwn-server` | Multi-tenant remote DWN server (HTTP/WS via Bun.serve) |
-| `@enbox/browser` | Browser-specific DID tools |
+| [`@enbox/api`](./packages/api) | **High-level SDK for applications** -- `Web5.connect()`, typed protocols, records, subscriptions |
+| [`@enbox/agent`](./packages/agent) | Agent framework: identity vault, key management, DWN stores, sync engine |
+| [`@enbox/dwn-sdk-js`](./packages/dwn-sdk-js) | DWN protocol engine, message handlers, storage interfaces |
+| [`@enbox/dwn-clients`](./packages/dwn-clients) | DWN client libraries, shared types, JSON-RPC transport |
+| [`@enbox/dwn-server`](./packages/dwn-server) | Multi-tenant remote DWN server (HTTP/WS via Bun.serve) |
+| [`@enbox/dwn-sql-store`](./packages/dwn-sql-store) | SQL-backed DWN storage (PostgreSQL, SQLite, MySQL) |
+| [`@enbox/dids`](./packages/dids) | DID methods (`did:dht`, `did:jwk`), resolution |
+| [`@enbox/crypto`](./packages/crypto) | Ed25519, X25519, secp256k1, AES, PBKDF2, JWE |
+| [`@enbox/common`](./packages/common) | Shared utilities: `TtlCache`, `LevelStore`, data conversion |
+| [`@enbox/browser`](./packages/browser) | Browser-specific helpers and DRL polyfills |
 
-## Quick Start
+## Development
 
 ### Prerequisites
 
 - [Bun](https://bun.sh) >= 1.0
 
-### Installation
+### Setup
 
 ```bash
 git clone https://github.com/enboxorg/enbox.git
@@ -147,7 +198,7 @@ bun install
 bun run build
 ```
 
-### Development
+### Common Commands
 
 ```bash
 # Run all tests
@@ -164,7 +215,23 @@ bun run --filter @enbox/agent build
 bun run clean
 ```
 
-## Docker Setup
+### Test Infrastructure
+
+Several packages require external services (Pkarr relay, PostgreSQL, MySQL) for their full test suites. Start them with Docker Compose:
+
+```bash
+# Start test services
+docker compose -f docker-compose.test.yaml up -d --wait
+
+# Required env var for did:dht tests
+export DID_DHT_GATEWAY_URI=http://localhost:7527
+```
+
+A local DWN server on `localhost:3000` is also required for `agent` and `api` tests. See [`CLAUDE.md`](./CLAUDE.md) for full instructions.
+
+## Hosting a DWN Server
+
+### Docker Compose
 
 The easiest way to run a remote DWN server is with Docker Compose, which sets up both the DWN server and PostgreSQL.
 
@@ -201,11 +268,9 @@ cp docker.env.example .env
 4. Configure backup strategies
 5. Set resource limits for containers
 
-## Fly.io Deployment
+### Fly.io Deployment
 
 Deploy the DWN server to Fly.io with managed PostgreSQL. See the complete [Fly.io Deployment Guide](./FLY.md).
-
-**Quick summary**: Fork repo, create Fly app + Postgres cluster, attach Postgres, configure secrets, `fly deploy`.
 
 ## AI / LLM Agent Context
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -4,7 +4,32 @@
 
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/api.json)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
 
-The high-level SDK for building decentralized applications with protocol-first data management.
+The high-level SDK for building decentralized applications with protocol-first data management. This is the main consumer-facing package in the Enbox ecosystem -- most applications only need `@enbox/api`.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Core Concepts](#core-concepts)
+  - [Web5.connect()](#web5connectoptions)
+  - [defineProtocol()](#defineprotocoldefinition-schemamap)
+  - [web5.using()](#web5usingprotocol)
+  - [Record Instances](#record-instances)
+  - [LiveQuery (Subscriptions)](#livequery-subscriptions)
+  - [Web5.anonymous()](#web5anonymousoptions)
+- [Cookbook](#cookbook)
+  - [Nested Records](#nested-records)
+  - [Querying with Filters and Pagination](#querying-with-filters-and-pagination)
+  - [Tags](#tags)
+  - [Publishing Records](#publishing-records)
+  - [Reading Public Data Anonymously](#reading-public-data-anonymously)
+  - [Sending Records to Remote DWNs](#sending-records-to-remote-dwns)
+- [Advanced Usage](#advanced-usage)
+  - [Unscoped DWN Access](#unscoped-dwn-access)
+  - [Permissions](#permissions)
+  - [DID Operations](#did-operations)
+- [API Reference](#api-reference)
+- [License](#license)
 
 ## Installation
 
@@ -17,7 +42,7 @@ bun add @enbox/api
 ```ts
 import { defineProtocol, Web5 } from '@enbox/api';
 
-// 1. Connect
+// 1. Connect -- creates or loads a local identity and agent
 const { web5, did: myDid } = await Web5.connect();
 
 // 2. Define a protocol with typed data shapes
@@ -40,15 +65,21 @@ const NotesProtocol = defineProtocol({
 // 3. Scope all operations to the protocol
 const notes = web5.using(NotesProtocol);
 
-// 4. Install the protocol
+// 4. Install the protocol on the local DWN
 await notes.configure();
 
-// 5. Write a record (path, data, and schema are type-checked)
+// 5. Write a record -- path, data, and schema are type-checked
 const { record } = await notes.records.write('note', {
   data: { title: 'Hello', body: 'World' },
 });
 
-// 6. Send to your remote DWN
+// 6. Query records back
+const { records } = await notes.records.query('note');
+for (const r of records) {
+  console.log(r.id, await r.data.json());
+}
+
+// 7. Send to your remote DWN
 await record.send(myDid);
 ```
 
@@ -56,25 +87,268 @@ await record.send(myDid);
 
 ### `Web5.connect(options?)`
 
-Connects to a local identity agent or generates an in-app DID.
+Connects to a local identity agent. On first launch it creates an identity vault, generates a `did:dht` DID, and starts the sync engine. On subsequent launches it unlocks the existing vault.
 
 ```ts
-const { web5, did, recoveryPhrase } = await Web5.connect();
+const { web5, did, recoveryPhrase } = await Web5.connect({
+  password: 'user-chosen-password',
+});
+
+// recoveryPhrase is returned on first launch only -- store it safely!
 ```
 
 **Options** (all optional):
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `agent` | `Web5Agent` | Custom agent instance. Defaults to a local `Web5UserAgent`. |
-| `connectedDid` | `string` | Existing DID to connect to. |
-| `password` | `string` | Password to protect the local identity vault. |
-| `recoveryPhrase` | `string` | 12-word BIP-39 phrase for vault recovery. |
-| `sync` | `string` | Sync interval (e.g. `'2m'`) or `'off'`. Default: `'2m'`. |
-| `didCreateOptions.dwnEndpoints` | `string[]` | DWN endpoints for the created DID. |
-| `walletConnectOptions` | `ConnectOptions` | Trigger external wallet connect flow. |
+| `password` | `string` | Password to protect the local identity vault. **Defaults to an insecure static value** -- always set this in production. |
+| `recoveryPhrase` | `string` | 12-word BIP-39 phrase for vault recovery. Generated automatically on first launch if not provided. |
+| `sync` | `string` | Sync interval (e.g. `'2m'`, `'30s'`) or `'off'` to disable. Default: `'2m'`. |
+| `didCreateOptions.dwnEndpoints` | `string[]` | DWN service endpoints for the created DID. Default: `['https://enbox-dwn.fly.dev']`. |
+| `connectedDid` | `string` | Use an existing DID instead of creating a new one. |
+| `agent` | `Web5Agent` | Provide a custom agent instance. Defaults to a local `Web5UserAgent`. |
+| `walletConnectOptions` | `ConnectOptions` | Trigger an external wallet connect flow for delegated identity. |
+| `registration` | `{ onSuccess, onFailure }` | Callbacks for DWN endpoint registration status. |
 
 **Returns** `{ web5, did, recoveryPhrase?, delegateDid? }`.
+
+- `web5` -- the `Web5` instance for all subsequent operations
+- `did` -- the connected DID URI (e.g. `did:dht:abc...`)
+- `recoveryPhrase` -- only returned on first initialization
+- `delegateDid` -- only present when using wallet connect
+
+---
+
+### `defineProtocol(definition, schemaMap?)`
+
+Creates a typed protocol definition that enables compile-time path autocompletion and data type checking when used with `web5.using()`.
+
+```ts
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+
+const ChatProtocol = defineProtocol({
+  protocol  : 'https://example.com/chat',
+  published : true,
+  types: {
+    thread  : { schema: 'https://example.com/schemas/thread',  dataFormats: ['application/json'] },
+    message : { schema: 'https://example.com/schemas/message', dataFormats: ['application/json'] },
+  },
+  structure: {
+    thread: {
+      message: {},   // messages are nested under threads
+    },
+  },
+} as const satisfies ProtocolDefinition, {} as {
+  thread  : { title: string; description?: string };
+  message : { text: string };
+});
+```
+
+The second argument is a **phantom type** -- it only exists at compile time. Pass `{} as YourSchemaMap` to map protocol type names to TypeScript interfaces. The runtime value is ignored.
+
+This gives you:
+- **Path autocompletion**: `'thread'`, `'thread/message'` are inferred from `structure`
+- **Typed `data` payloads**: `write('thread', { data: ... })` type-checks against the schema map
+- **Typed `dataFormat`**: restricted to the formats declared in the protocol type
+
+---
+
+### `web5.using(protocol)`
+
+The **primary interface** for all record operations. Returns a `TypedWeb5` instance scoped to the given protocol.
+
+```ts
+const chat = web5.using(ChatProtocol);
+```
+
+#### `configure()`
+
+Installs the protocol on the local DWN. If already installed with an identical definition, this is a no-op. If the definition has changed, it reconfigures with the updated version.
+
+```ts
+await chat.configure();
+```
+
+#### `records.write(path, request)`
+
+Write a record at a protocol path. The protocol URI, protocolPath, schema, and dataFormat are automatically injected.
+
+```ts
+const { record, status } = await chat.records.write('thread', {
+  data: { title: 'General', description: 'General discussion' },
+});
+
+console.log(status.code);  // 202
+console.log(record.id);    // unique record ID
+```
+
+#### `records.query(path, request?)`
+
+Query records at a protocol path. Returns matching records with optional pagination.
+
+```ts
+const { records, cursor } = await chat.records.query('thread', {
+  dateSort   : 'createdDescending',
+  pagination : { limit: 20 },
+});
+
+for (const thread of records) {
+  console.log(await thread.data.json());
+}
+
+// Fetch next page
+if (cursor) {
+  const { records: nextPage } = await chat.records.query('thread', {
+    pagination: { limit: 20, cursor },
+  });
+}
+```
+
+#### `records.read(path, request)`
+
+Read a single record by filter criteria.
+
+```ts
+const { record } = await chat.records.read('thread', {
+  filter: { recordId: 'bafyrei...' },
+});
+
+const data = await record.data.json();
+```
+
+#### `records.delete(path, request)`
+
+Delete a record by ID.
+
+```ts
+const { status } = await chat.records.delete('thread', {
+  recordId: record.id,
+});
+```
+
+#### `records.subscribe(path, request?)`
+
+Subscribe to real-time changes. Returns a `LiveQuery` with an initial snapshot plus a stream of change events.
+
+```ts
+const { liveQuery } = await chat.records.subscribe('thread/message');
+
+// Initial snapshot
+for (const msg of liveQuery.records) {
+  console.log(await msg.data.json());
+}
+
+// Real-time updates
+liveQuery.on('create', (record) => console.log('new:', record.id));
+liveQuery.on('update', (record) => console.log('updated:', record.id));
+liveQuery.on('delete', (record) => console.log('deleted:', record.id));
+```
+
+All methods also accept a `from` option to query a remote DWN:
+
+```ts
+const { records } = await chat.records.query('thread', {
+  from: 'did:dht:other-user...',
+});
+```
+
+---
+
+### Record Instances
+
+Methods like `write`, `query`, and `read` return `Record` instances.
+
+**Properties**:
+
+| Property | Description |
+|----------|-------------|
+| `id` | Unique record identifier |
+| `contextId` | Context ID (scopes nested records to a parent thread) |
+| `protocol` | Protocol URI |
+| `protocolPath` | Path within the protocol structure (e.g. `'thread/message'`) |
+| `schema` | Schema URI |
+| `dataFormat` | MIME type of the data |
+| `dataCid` | Content-addressed hash of the data |
+| `dataSize` | Size of the data in bytes |
+| `dateCreated` | ISO timestamp of creation |
+| `timestamp` | ISO timestamp of most recent write |
+| `datePublished` | ISO timestamp of publication (if published) |
+| `published` | Whether the record is publicly readable |
+| `author` | DID of the record author |
+| `recipient` | DID of the intended recipient |
+| `parentId` | Record ID of the parent record (for nested structures) |
+| `tags` | Key-value metadata tags |
+| `deleted` | Whether the record has been deleted |
+
+**Data accessors** -- read the record payload in different formats:
+
+```ts
+const text   = await record.data.text();          // string
+const obj    = await record.data.json<MyType>();  // parsed JSON (typed)
+const blob   = await record.data.blob();          // Blob
+const bytes  = await record.data.bytes();         // Uint8Array
+const stream = await record.data.stream();        // ReadableStream
+```
+
+**Mutators**:
+
+```ts
+// Update the record's data
+const { record: updated } = await record.update({
+  data: { title: 'Updated Title', body: '...' },
+});
+
+// Delete the record
+const { status } = await record.delete();
+```
+
+**Side-effect methods**:
+
+```ts
+// Send the record to a remote DWN
+await record.send(targetDid);
+
+// Persist a remote record to the local DWN
+await record.store();
+
+// Import a record from a remote DWN into the local store
+await record.import();
+```
+
+---
+
+### LiveQuery (Subscriptions)
+
+`records.subscribe()` returns a `LiveQuery` that provides an initial snapshot of existing records plus a real-time stream of deduplicated change events.
+
+```ts
+const { liveQuery } = await chat.records.subscribe('thread/message');
+
+// Initial snapshot
+for (const msg of liveQuery.records) {
+  renderMessage(msg);
+}
+
+// Real-time changes
+const offCreate = liveQuery.on('create', (record) => appendMessage(record));
+const offUpdate = liveQuery.on('update', (record) => refreshMessage(record));
+const offDelete = liveQuery.on('delete', (record) => removeMessage(record));
+
+// Catch-all event (receives { type, record })
+liveQuery.on('change', ({ type, record }) => {
+  console.log(`${type}: ${record.id}`);
+});
+
+// Unsubscribe from a specific handler
+offCreate();
+
+// Close the subscription entirely
+await liveQuery.close();
+```
+
+`LiveQuery` extends `EventTarget`, so standard `addEventListener` / `removeEventListener` also work. The `.on()` method is a convenience wrapper that returns an unsubscribe function.
+
+Events are automatically deduplicated against the initial snapshot -- you won't receive a `create` event for records already in the `records` array.
 
 ---
 
@@ -85,6 +359,7 @@ Creates a lightweight, read-only instance for querying public DWN data. No ident
 ```ts
 const { dwn } = Web5.anonymous();
 
+// Query published records from someone's DWN
 const { records } = await dwn.records.query({
   from   : 'did:dht:alice...',
   filter : { protocol: 'https://example.com/notes', protocolPath: 'note' },
@@ -93,136 +368,247 @@ const { records } = await dwn.records.query({
 for (const record of records) {
   console.log(record.id, await record.data.text());
 }
-```
 
-Returns a `{ dwn: DwnReaderApi }` with read-only `records.query()` and `records.read()`.
+// Read a specific record
+const { record } = await dwn.records.read({
+  from   : 'did:dht:alice...',
+  filter : { recordId: 'bafyrei...' },
+});
 
----
+// Count matching records
+const { count } = await dwn.records.count({
+  from   : 'did:dht:alice...',
+  filter : { protocol: 'https://example.com/notes', protocolPath: 'note' },
+});
 
-### `web5.using(protocol)`
-
-The **primary interface** for all record operations. Returns a `TypedWeb5` instance scoped to the given protocol.
-
-```ts
-const notes = web5.using(NotesProtocol);
-```
-
-The returned object provides:
-
-- **`notes.configure()`** -- Install the protocol on the local DWN.
-- **`notes.records.write(path, request)`** -- Write a record at a protocol path.
-- **`notes.records.query(path, request?)`** -- Query records at a path.
-- **`notes.records.read(path, request)`** -- Read a single record.
-- **`notes.records.delete(path, request)`** -- Delete a record by ID.
-- **`notes.records.subscribe(path, request?)`** -- Subscribe to real-time changes (returns a `LiveQuery`).
-
-Protocol URI, protocolPath, and schema are automatically injected into every operation.
-
----
-
-### `defineProtocol(definition, schemaMap?)`
-
-Creates a typed protocol definition that enables compile-time path autocompletion and data type checking.
-
-```ts
-import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
-
-const SocialProtocol = defineProtocol({
-  protocol  : 'https://social.example/protocol',
-  published : true,
-  types: {
-    profile : { schema: 'https://social.example/schemas/profile', dataFormats: ['application/json'] },
-    post    : { schema: 'https://social.example/schemas/post',    dataFormats: ['application/json'] },
-    reply   : { schema: 'https://social.example/schemas/reply',   dataFormats: ['application/json'] },
-  },
-  structure: {
-    profile : {},
-    post    : {
-      reply: {},
-    },
-  },
-} as const satisfies ProtocolDefinition, {} as {
-  profile : { displayName: string; bio?: string };
-  post    : { title: string; body: string };
-  reply   : { body: string };
+// Query published protocols
+const { protocols } = await dwn.protocols.query({
+  from: 'did:dht:alice...',
 });
 ```
 
-The `schemaMap` is a phantom type -- it exists only at compile time. Pass `{} as YourSchemaMap` as the second argument.
+Returns `ReadOnlyRecord` instances (no `update`, `delete`, `send`, or `store` methods). All calls require a `from` DID since the reader has no local DWN.
 
 ---
 
-### Record Instances
+## Cookbook
 
-Methods like `write`, `query`, and `read` return `Record` instances.
+### Nested Records
 
-**Properties**: `id`, `contextId`, `dataFormat`, `dateCreated`, `timestamp`, `datePublished`, `protocol`, `protocolPath`, `recipient`, `schema`, `dataCid`, `dataSize`, `published`.
-
-**Data accessors**:
+Protocols support hierarchical record structures. Child records reference their parent via `parentContextId`.
 
 ```ts
-await record.data.text();          // string
-await record.data.json<MyType>();  // typed JSON
-await record.data.blob();          // Blob
-await record.data.bytes();         // Uint8Array
-await record.data.stream();        // ReadableStream
+const ChatProtocol = defineProtocol({
+  protocol  : 'https://example.com/chat',
+  published : true,
+  types: {
+    thread  : { schema: 'https://example.com/schemas/thread',  dataFormats: ['application/json'] },
+    message : { schema: 'https://example.com/schemas/message', dataFormats: ['application/json'] },
+  },
+  structure: {
+    thread: {
+      message: {},
+    },
+  },
+} as const, {} as {
+  thread  : { title: string };
+  message : { text: string };
+});
+
+const chat = web5.using(ChatProtocol);
+await chat.configure();
+
+// Create a parent thread
+const { record: thread } = await chat.records.write('thread', {
+  data: { title: 'General' },
+});
+
+// Write a message nested under the thread
+const { record: msg } = await chat.records.write('thread/message', {
+  parentContextId : thread.contextId,
+  data            : { text: 'Hello, world!' },
+});
+
+// Query messages within a specific thread
+const { records: messages } = await chat.records.query('thread/message', {
+  filter: { parentId: thread.id },
+});
 ```
 
-**Mutators** (return a new `Record` instance):
+### Querying with Filters and Pagination
 
 ```ts
-const { record: updated } = await record.update({ data: { title: 'New Title', body: '...' } });
-const { status } = await record.delete();
+// Date-sorted, paginated query
+const { records, cursor } = await notes.records.query('note', {
+  dateSort   : 'createdDescending',
+  pagination : { limit: 10 },
+});
+
+// Fetch next page using the cursor
+if (cursor) {
+  const { records: page2 } = await notes.records.query('note', {
+    dateSort   : 'createdDescending',
+    pagination : { limit: 10, cursor },
+  });
+}
+
+// Filter by recipient
+const { records: shared } = await notes.records.query('note', {
+  filter: { recipient: 'did:dht:bob...' },
+});
+
+// Query from a remote DWN
+const { records: remote } = await notes.records.query('note', {
+  from: 'did:dht:alice...',
+});
 ```
 
-**Side-effect methods** (return status only):
+### Tags
+
+Tags are key-value metadata attached to records, useful for filtering without parsing record data.
 
 ```ts
-await record.send(targetDid);     // send to a remote DWN
-await record.store();             // persist locally
-await record.import();            // import from a remote DWN
+const { record } = await notes.records.write('note', {
+  data : { title: 'Meeting Notes', body: '...' },
+  tags : { category: 'work', priority: 'high' },
+});
+
+// Query by tag
+const { records } = await notes.records.query('note', {
+  filter: { tags: { category: 'work' } },
+});
 ```
 
----
+> Note: tags must be declared in your protocol's type definition for the DWN engine to index them.
 
-### LiveQuery (Subscriptions)
+### Publishing Records
 
-`records.subscribe()` returns a `LiveQuery` that provides an initial snapshot plus real-time deduplicated change events.
+Published records are publicly readable by anyone, including anonymous readers.
 
 ```ts
-const { liveQuery } = await notes.records.subscribe('post');
-
-liveQuery.on('create', (record) => { /* new record */ });
-liveQuery.on('update', (record) => { /* updated record */ });
-liveQuery.on('delete', (record) => { /* deleted record */ });
-
-// Clean up
-await liveQuery.close();
+const { record } = await notes.records.write('note', {
+  data      : { title: 'Public Note', body: 'Visible to everyone' },
+  published : true,
+});
 ```
+
+### Reading Public Data Anonymously
+
+```ts
+const { dwn } = Web5.anonymous();
+
+const { records } = await dwn.records.query({
+  from   : 'did:dht:alice...',
+  filter : {
+    protocol     : 'https://example.com/notes',
+    protocolPath : 'note',
+  },
+});
+
+for (const record of records) {
+  const note = await record.data.json();
+  console.log(note.title);
+}
+```
+
+### Sending Records to Remote DWNs
+
+Records are initially written to the local DWN. Use `send()` to push them to a remote DWN, or rely on the automatic sync engine.
+
+```ts
+// Explicitly send to your own remote DWN
+await record.send(myDid);
+
+// Send to someone else's DWN (requires protocol permissions)
+await record.send('did:dht:bob...');
+```
+
+The sync engine (enabled by default at 2-minute intervals) automatically synchronizes records between local and remote DWNs. For most use cases, you don't need to call `send()` manually.
 
 ---
 
 ## Advanced Usage
 
-For power users who need direct, unscoped DWN access (e.g. cross-protocol queries, raw permission management), import from the `@enbox/api/advanced` sub-path:
+### Unscoped DWN Access
+
+For power users who need direct DWN access without protocol scoping (e.g. cross-protocol queries, raw permission management), import from the `@enbox/api/advanced` sub-path:
 
 ```ts
 import { DwnApi } from '@enbox/api/advanced';
 ```
 
-The `DwnApi` class provides raw `records`, `protocols`, and `permissions` accessors without protocol scoping. Most applications should use `web5.using()` instead.
+The `DwnApi` class provides raw `records`, `protocols`, and `permissions` accessors without automatic protocol/path/schema injection. You must provide those fields manually in every call. Most applications should use `web5.using()` instead.
+
+### Permissions
+
+The DWN permission system supports fine-grained access control through permission requests, grants, and revocations.
+
+```ts
+import { DwnApi } from '@enbox/api/advanced';
+
+// Query existing permission grants
+const grants = await web5._dwn.permissions.queryGrants();
+
+// Request permissions from another DWN
+const request = await web5._dwn.permissions.request({
+  scope: {
+    interface : 'Records',
+    method    : 'Write',
+    protocol  : 'https://example.com/notes',
+  },
+});
+
+// Send the request to the target DWN
+await request.send('did:dht:alice...');
+```
+
+### DID Operations
+
+```ts
+// Resolve any DID
+const { didDocument } = await web5.did.resolve('did:dht:abc...');
+```
 
 ---
 
-## DID Operations
+## API Reference
 
-```ts
-// Create a DID
-const myDid = await web5.did.create('dht');
+### Main Exports (`@enbox/api`)
 
-// Resolve a DID
-const { didDocument } = await web5.did.resolve('did:dht:abc...');
-```
+| Export | Description |
+|--------|-------------|
+| `Web5` | Main entry point -- `connect()`, `anonymous()`, `using()` |
+| `defineProtocol()` | Factory for creating typed protocol definitions |
+| `TypedWeb5` | Protocol-scoped API returned by `web5.using()` |
+| `Record` | Mutable record instance with data accessors and side-effect methods |
+| `ReadOnlyRecord` | Immutable record for anonymous/read-only access |
+| `LiveQuery` | Real-time subscription with initial snapshot and change events |
+| `Protocol` | Protocol metadata wrapper |
+| `PermissionGrant` | Permission grant record |
+| `PermissionRequest` | Permission request record |
+| `PermissionGrantRevocation` | Permission revocation record |
+| `DidApi` | DID resolution |
+| `VcApi` | Verifiable Credentials (not yet implemented) |
+| `DwnReaderApi` | Read-only DWN API for anonymous access |
+
+### Advanced Export (`@enbox/api/advanced`)
+
+| Export | Description |
+|--------|-------------|
+| `DwnApi` | Full unscoped DWN API with `records`, `protocols`, `permissions` |
+
+### Key Types
+
+| Export | Description |
+|--------|-------------|
+| `TypedProtocol<D, M>` | Typed protocol wrapper with definition and schema map |
+| `ProtocolPaths<D>` | Union of valid slash-delimited paths for a protocol definition |
+| `SchemaMap` | Maps protocol type names to TypeScript interfaces |
+| `Web5ConnectOptions` | Options for `Web5.connect()` |
+| `Web5ConnectResult` | Return type of `Web5.connect()` |
+| `RecordModel` | Structured data model of a record |
+| `RecordChangeType` | `'create' \| 'update' \| 'delete'` |
+| `RecordChange` | Change event payload `{ type, record }` |
 
 ## License
 


### PR DESCRIPTION
## Summary

- **Fix factual errors in docs**: Corrected `secp256k1 #enc key` to `X25519 #enc key (ECDH-ES+A256KW)` in encryption docs; fixed `Enbox.connect()` to `Web5.connect()` in architecture diagram; added `X25519` to crypto package description
- **Root README**: Added a Quick Start code example for app developers at the top; reordered package table with `@enbox/api` first and added directory links; added test infrastructure section; renamed sections for better scannability
- **`@enbox/api` README**: Expanded from 229 to 445 lines with table of contents, per-method code examples for all `TypedWeb5` operations, a Cookbook section (nested records, pagination, tags, publishing, anonymous reading, remote sends), full Record properties table, expanded LiveQuery docs, and an API Reference section

> **Note:** The `Coverage Check` job fails on docs-only PRs because it finds no coverage artifacts. #251 fixes this — merge that first, then this PR's CI will pass cleanly.
