### PR TITLE
fix(ci): skip coverage check on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,8 +459,8 @@ jobs:
   coverage:
     name: Coverage Check
     runs-on: ubuntu-latest
-    needs: [test-lightweight, test-dwn-sdk, test-agent-api, test-sql-store, test-dwn-server, test-browser]
-    if: always() && !cancelled()
+    needs: [changes, test-lightweight, test-dwn-sdk, test-agent-api, test-sql-store, test-dwn-server, test-browser]
+    if: always() && !cancelled() && needs.changes.outputs.src == 'true'
 
     steps:
       - name: Download coverage artifacts


### PR DESCRIPTION
## Summary

- The `Coverage Check` job runs with `if: always() && !cancelled()` but didn't have `changes` in its `needs` list, so it always ran — even on docs-only PRs where all test jobs are skipped
- With no test jobs running, no coverage artifacts are uploaded, and the coverage job fails with "No coverage artifacts found"
- Fix: add `changes` to the coverage job's `needs` and gate on `needs.changes.outputs.src == 'true'` so it skips entirely for docs-only changes

This unblocks #250 (docs-only README updates) which currently has a failing Coverage Check.