### PR TITLE
fix(protocols): remove empty $actions arrays from ListsDefinition

### DIFF
--- a/.changeset/fix-lists-empty-actions.md
+++ b/.changeset/fix-lists-empty-actions.md
@@ -1,0 +1,9 @@
+---
+'@enbox/protocols': patch
+---
+
+fix(protocols): remove empty `$actions` arrays from `ListsDefinition` folder structure
+
+The DWN JSON schema requires `$actions` arrays to have at least one item (`minItems: 1`).
+Empty `$actions: []` on the `folder` type caused `ProtocolsConfigure` to fail with
+`SchemaValidatorFailure` when installing the Lists protocol.

--- a/packages/protocols/src/lists.ts
+++ b/packages/protocols/src/lists.ts
@@ -137,16 +137,12 @@ export const ListsDefinition = {
       },
     },
     folder: {
-      $actions : [],
-      $tags    : {
+      $tags: {
         $allowUndefinedTags : true,
         sortOrder           : { type: 'number' },
       },
       folder: {
-        $actions : [],
-        folder   : {
-          $actions: [],
-        },
+        folder: {},
       },
     },
   },


### PR DESCRIPTION
## Summary

- Removes empty `$actions: []` arrays from the `folder` structure in `ListsDefinition` (3 occurrences at nested levels)
- The DWN JSON schema (`protocol-rule-set.json`) requires `$actions` to have `minItems: 1` — empty arrays cause `SchemaValidatorFailure` when installing the Lists protocol via `ProtocolsConfigure`
- All 43 protocol tests pass

## Details

The `folder` type in `ListsDefinition` had `$actions: []` at three nesting levels (lines 140, 146, 148). Since no actions were defined, the correct fix is to remove the empty arrays entirely rather than adding placeholder actions. The DWN treats the absence of `$actions` as "no action rules" which is the intended behavior for folders.

This unblocks the dapp-demo and web-wallet from installing the Lists protocol.