### PR TITLE
fix(dwn-sdk-js): serialize IndexedDB filter queries to fix Firefox cursor races

### DIFF
--- a/packages/dwn-sdk-js/src/store/index-level.ts
+++ b/packages/dwn-sdk-js/src/store/index-level.ts
@@ -477,9 +477,12 @@ export class IndexLevel {
     }
 
     try {
-      await Promise.all(filters.map(filter => {
-        return this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, options );
-      }));
+      // Execute filters sequentially rather than in parallel.
+      // Concurrent IndexedDB iterators (opened by Promise.all) intermittently
+      // miss results in Firefox due to cursor/transaction scheduling races.
+      for (const filter of filters) {
+        await this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, options);
+      }
     } catch (error) {
       if ((error as DwnError).code === DwnErrorCode.IndexInvalidSortPropertyInMemory) {
         // return empty results if the sort property is invalid.


### PR DESCRIPTION
## Summary

Fixes the remaining flaky Firefox browser test failure (`aggregator.spec.ts: expected 2 to be 3`) that occurs in ~4% of CI runs.

## Problem

`queryWithInMemoryPaging` in `IndexLevel` used `Promise.all` to execute multiple filter queries concurrently. Each filter opens an IndexedDB iterator (cursor) via the `level` library's async iterator. Firefox's IndexedDB implementation intermittently closes cursors early when multiple concurrent read transactions are active, causing some results to be missed.

In the aggregator test, Alice queries for notes authored by `[bob, carol]`. The query handler builds two OR'd filters:
1. **Published records** — matches Bob's public note and Carol's public note
2. **Unpublished where recipient=Alice** — should match Bob's private note to Alice

When both filters open concurrent IndexedDB cursors, Firefox occasionally terminates Filter 2's cursor before it finds all matching entries, dropping Bob's private note from the results.

## Fix

Execute filters sequentially with a `for...of` loop instead of `Promise.all`:

```typescript
// Before (races in Firefox):
await Promise.all(filters.map(filter => {
  return this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, options);
}));

// After (safe sequential execution):
for (const filter of filters) {
  await this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, options);
}
```

The performance impact is negligible — the filters scan disjoint index partitions and results are collected into an in-memory Map regardless.

## Verification

- **Firefox**: 4 consecutive local runs, 44/44 files, 341/341 tests — aggregator passes every time
- **Chromium**: 44/44 files, 341/341 tests — no regressions
- **Node tests**: 1007 pass, 0 fail
- **Lint**: passes