### PR TITLE
fix(agent): preserve original error in sync catch blocks instead of 'unreachable'

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -187,7 +187,7 @@ export class SyncEngineLevel implements SyncEngine {
             }
           }
         } catch (error: any) {
-          // If the remote DWN is unreachable, skip this target and continue.
+          // Skip this DWN endpoint for remaining targets and log the real cause.
           errored.add(dwnUrl);
           console.error(`SyncEngineLevel: Error syncing ${did} with ${dwnUrl}`, error);
         }

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -149,7 +149,8 @@ export async function fetchRemoteMessages({ did, dwnUrl, delegateDid, protocol, 
           targetDid : did,
           message   : messagesRead.message,
         }) as MessagesReadReply;
-      } catch {
+      } catch (error: any) {
+        console.error(`SyncEngineLevel: pull - failed to read ${messageCid} from ${dwnUrl}:`, error.message ?? error);
         return undefined;
       }
 
@@ -217,9 +218,10 @@ export async function pushMessages({ did, dwnUrl, delegateDid, protocol, message
         const cid = await getMessageCid(entry.message);
         console.error(`SyncEngineLevel: push failed for ${cid}: ${reply.status.code} ${reply.status.detail}`);
       }
-    } catch {
-      // Remote unreachable — stop pushing to this endpoint.
-      throw new Error(`SyncEngineLevel: Remote DWN at ${dwnUrl} is unreachable.`);
+    } catch (error: any) {
+      // Preserve the original error so callers can diagnose the root cause.
+      const detail = error.message ?? error;
+      throw new Error(`SyncEngineLevel: push to ${dwnUrl} failed: ${detail}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

- The `pushMessages()` catch block was replacing real errors with a generic `Remote DWN at <url> is unreachable` message, making sync failures impossible to diagnose
- The `fetchRemoteMessages()` catch block was silently swallowing errors with no logging
- Now `pushMessages()` preserves the original error message in the re-thrown error
- Now `fetchRemoteMessages()` logs the original error before returning `undefined`

## Context

When debugging wallet-connect sync failures against `enbox-dwn.fly.dev`, the only visible error was "unreachable" even though the server was up and responding to requests. The real cause (likely a permissions/authorization issue) was being discarded.