### PR TITLE
fix(agent,api): filter revoked grants in fetchGrants with batch revocation check

### DIFF
--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -76,7 +76,8 @@ export class AgentPermissionsApi implements PermissionsApi {
     grantee,
     grantor,
     protocol,
-    remote = false
+    remote = false,
+    checkRevoked = true,
   }: FetchPermissionsParams): Promise<PermissionGrantEntry[]> {
 
     // filter by a protocol using tags if provided
@@ -102,14 +103,65 @@ export class AgentPermissionsApi implements PermissionsApi {
       throw new Error(`PermissionsApi: Failed to fetch grants: ${reply.status.detail}`);
     }
 
+    // Build a set of revoked grant IDs so that revoked grants can be filtered out.
+    // Uses a single batch query for all revocations rather than N individual reads.
+    const revokedGrantIds = checkRevoked
+      ? await this.fetchRevokedGrantIds({ author, target, grantor, remote, tags })
+      : new Set<string>();
+
     const grants:PermissionGrantEntry[] = [];
     for (const entry of reply.entries! as DwnDataEncodedRecordsWriteMessage[]) {
-      // TODO: Check for revocation status based on a request parameter and filter out revoked grants
+      if (revokedGrantIds.has(entry.recordId)) {
+        continue;
+      }
       const grant = await DwnPermissionGrant.parse(entry);
       grants.push({ grant, message: entry });
     }
 
     return grants;
+  }
+
+  /**
+   * Fetch all revocation record IDs for grants, returned as a Set of parent grant record IDs.
+   * Issues a single RecordsQuery for all revocation records, optionally scoped to a grantor and protocol.
+   */
+  private async fetchRevokedGrantIds({ author, target, grantor, remote, tags }: {
+    author: string;
+    target: string;
+    grantor?: string;
+    remote: boolean;
+    tags?: { protocol: string };
+  }): Promise<Set<string>> {
+    const revocationParams: ProcessDwnRequest<DwnInterface.RecordsQuery> = {
+      author,
+      target,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: {
+          author       : grantor, // revocations are authored by the same grantor
+          protocol     : PermissionsProtocol.uri,
+          protocolPath : PermissionsProtocol.revocationPath,
+          tags,
+        }
+      }
+    };
+
+    const { reply: revocationReply } = remote
+      ? await this.agent.sendDwnRequest(revocationParams)
+      : await this.agent.processDwnRequest(revocationParams);
+
+    if (revocationReply.status.code !== 200) {
+      throw new Error(`PermissionsApi: Failed to fetch revocations: ${revocationReply.status.detail}`);
+    }
+
+    const revokedGrantIds = new Set<string>();
+    for (const entry of revocationReply.entries! as DwnDataEncodedRecordsWriteMessage[]) {
+      if (entry.descriptor.parentId !== undefined) {
+        revokedGrantIds.add(entry.descriptor.parentId);
+      }
+    }
+
+    return revokedGrantIds;
   }
 
   async fetchRequests({

--- a/packages/agent/src/types/permissions.ts
+++ b/packages/agent/src/types/permissions.ts
@@ -7,6 +7,8 @@ export type FetchPermissionsParams = {
   grantor?: string;
   protocol?: string;
   remote?: boolean;
+  /** Whether to filter out revoked grants. Defaults to `true`. */
+  checkRevoked?: boolean;
 };
 
 export type FetchPermissionRequestParams = {

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -316,6 +316,116 @@ describe('AgentPermissionsApi', () => {
         expect(error.message).toBe('PermissionsApi: Failed to fetch grants: Bad Request');
       }
     });
+
+    it('should filter out revoked grants by default', async () => {
+      // create two grants
+      const grant1 = await testHarness.agent.permissions.createGrant({
+        store       : true,
+        author      : aliceDid.uri,
+        grantedTo   : aliceDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Write,
+          protocol  : 'http://example.com/revocation-test'
+        }
+      });
+
+      const grant2 = await testHarness.agent.permissions.createGrant({
+        store       : true,
+        author      : aliceDid.uri,
+        grantedTo   : aliceDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Read,
+          protocol  : 'http://example.com/revocation-test'
+        }
+      });
+
+      // both grants should be returned before revocation
+      let grants = await testHarness.agent.permissions.fetchGrants({
+        author   : aliceDid.uri,
+        target   : aliceDid.uri,
+        protocol : 'http://example.com/revocation-test',
+      });
+      expect(grants.length).toBe(2);
+
+      // revoke grant1
+      await testHarness.agent.permissions.createRevocation({
+        author : aliceDid.uri,
+        store  : true,
+        grant  : grant1.grant,
+      });
+
+      // default (checkRevoked: true) should only return the non-revoked grant
+      grants = await testHarness.agent.permissions.fetchGrants({
+        author   : aliceDid.uri,
+        target   : aliceDid.uri,
+        protocol : 'http://example.com/revocation-test',
+      });
+      expect(grants.length).toBe(1);
+      expect(grants[0].grant.id).toBe(grant2.grant.id);
+    });
+
+    it('should include revoked grants when checkRevoked is false', async () => {
+      // create a grant and revoke it
+      const grant = await testHarness.agent.permissions.createGrant({
+        store       : true,
+        author      : aliceDid.uri,
+        grantedTo   : aliceDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Write,
+          protocol  : 'http://example.com/revocation-test-2'
+        }
+      });
+
+      // revoke the grant
+      await testHarness.agent.permissions.createRevocation({
+        author : aliceDid.uri,
+        store  : true,
+        grant  : grant.grant,
+      });
+
+      // with checkRevoked: false, the revoked grant should still be returned
+      const grants = await testHarness.agent.permissions.fetchGrants({
+        author       : aliceDid.uri,
+        target       : aliceDid.uri,
+        protocol     : 'http://example.com/revocation-test-2',
+        checkRevoked : false,
+      });
+      expect(grants.length).toBe(1);
+      expect(grants[0].grant.id).toBe(grant.grant.id);
+    });
+
+    it('should use only 2 DWN roundtrips when checking revocations', async () => {
+      const processDwnRequestSpy = spyOn(testHarness.agent, 'processDwnRequest');
+
+      // fetch grants with revocation check (default)
+      await testHarness.agent.permissions.fetchGrants({
+        author : aliceDid.uri,
+        target : aliceDid.uri,
+      });
+
+      // expect exactly 2 calls: one for grants query, one for revocations query
+      expect(processDwnRequestSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use only 1 DWN roundtrip when checkRevoked is false', async () => {
+      const processDwnRequestSpy = spyOn(testHarness.agent, 'processDwnRequest');
+
+      // fetch grants without revocation check
+      await testHarness.agent.permissions.fetchGrants({
+        author       : aliceDid.uri,
+        target       : aliceDid.uri,
+        checkRevoked : false,
+      });
+
+      // expect exactly 1 call: only the grants query
+      expect(processDwnRequestSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('fetchRequests', () => {

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -44,13 +44,11 @@ export type FetchRequestsRequest = Omit<FetchPermissionRequestParams, 'author' |
  * Represents the request payload for fetching permission grants from a Decentralized Web Node (DWN).
  *
  * Optionally, specify a remote DWN target in the `from` property to fetch requests from.
- * Optionally, specify whether to check if the grant is revoked in the `checkRevoked` property.
+ * Revoked grants are filtered out by default; set `checkRevoked: false` to include them.
  */
 export type FetchGrantsRequest = Omit<FetchPermissionsParams, 'author' | 'target' | 'remote'> & {
   /** Optional DID specifying the remote target DWN tenant to be queried. */
   from?: string;
-  /** Optionally check if the grant has been revoked. */
-  checkRevoked?: boolean;
 };
 
 /**
@@ -334,7 +332,7 @@ export class DwnApi {
        * Query permission grants. You can filter by grantee, grantor, protocol and specify if you want to query a remote DWN.
        */
       queryGrants: async(request: FetchGrantsRequest = {}): Promise<PermissionGrant[]> => {
-        const { checkRevoked, from, ...params } = request;
+        const { from, ...params } = request;
         const remote = from !== undefined;
         const author = this.delegateDid ?? this.connectedDid;
         const target = from ?? this.delegateDid ?? this.connectedDid;
@@ -353,12 +351,6 @@ export class DwnApi {
             message      : permission.message,
           };
 
-          if (checkRevoked) {
-            const grantRecordId = permission.grant.id;
-            if (await this.permissionsApi.isGrantRevoked({ author, target, grantRecordId, remote })) {
-              continue;
-            }
-          }
           grants.push(await PermissionGrant.parse(grantParams));
         }
 

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -3269,7 +3269,7 @@ describe('DwnApi', () => {
       expect(fetchedGrantsCarol[0].id).toBe(grantFromCarol.id);
     });
 
-    it('should check revocation status if option is set', async () => {
+    it('should filter out revoked grants by default', async () => {
       // alice creates a grant for bob and stores it
       const bobGrant = await dwnAlice.permissions.grant({
         store       : true,
@@ -3282,26 +3282,20 @@ describe('DwnApi', () => {
         }
       });
 
-      // query for the grants
-      let fetchedGrants = await dwnAlice.permissions.queryGrants({
-        checkRevoked: true
-      });
-
-      // expect to have the 1 grant created
+      // query for the grants — should include the grant
+      let fetchedGrants = await dwnAlice.permissions.queryGrants();
       expect(fetchedGrants.length).toBe(1);
       expect(fetchedGrants[0].id).toBe(bobGrant.id);
 
-      // stub the isRevoked method to return true
-      sinon.stub(AgentPermissionsApi.prototype, 'isGrantRevoked').resolves(true);
+      // revoke the grant
+      await bobGrant.revoke();
 
-      // query for the grants
-      fetchedGrants = await dwnAlice.permissions.queryGrants({
-        checkRevoked: true
-      });
+      // default query should now exclude the revoked grant
+      fetchedGrants = await dwnAlice.permissions.queryGrants();
       expect(fetchedGrants.length).toBe(0);
 
-      // return without checking revoked status
-      fetchedGrants = await dwnAlice.permissions.queryGrants();
+      // with checkRevoked: false, the revoked grant should still be returned
+      fetchedGrants = await dwnAlice.permissions.queryGrants({ checkRevoked: false });
       expect(fetchedGrants.length).toBe(1);
       expect(fetchedGrants[0].id).toBe(bobGrant.id);
     });


### PR DESCRIPTION
## Summary

Fixes #60 — `fetchGrants()` now filters out revoked grants by default using a single batch query, reducing the cost from **1+N DWN roundtrips to 2**.

## Problem

When listing permission grants, revoked grants were not filtered out at the agent layer (`fetchGrants()`). The only way to filter was via the API layer's `queryGrants({ checkRevoked: true })`, which called `isGrantRevoked()` **individually per grant** — O(1+N) roundtrips. For a user with 50 grants, that's 51 DWN roundtrips.

Additionally, `getPermissionForRequest()` (called on every delegated DWN operation, 12+ call sites) never checked revocation, meaning the agent could attempt to use a revoked grant for up to 60 seconds (the cache TTL).

## Solution

Add a `checkRevoked` parameter to `fetchGrants()` (default: `true`). When enabled:

1. Fetch grants via `RecordsQuery` (1 roundtrip) — same as before
2. Fetch all revocation records via a single `RecordsQuery` scoped to the same grantor/protocol (1 roundtrip)
3. Build a `Set<string>` of revoked grant IDs from the revocations' `parentId` fields
4. Filter grants client-side

The revocations query mirrors the grants query scope (same `author`/`tags`) so it only fetches relevant revocations.

### Performance

| Scenario | Before | After |
|---|---|---|
| `fetchGrants()` | 1 roundtrip (no revocation check) | 2 roundtrips (with batch check) |
| `fetchGrants({ checkRevoked: false })` | N/A | 1 roundtrip |
| `queryGrants({ checkRevoked: true })` | 1 + N roundtrips | 2 roundtrips |
| `getPermissionForRequest()` | 1 roundtrip (no check, could use revoked grants) | 2 roundtrips (correct, cached for 60s) |

## Changes

| File | Change |
|---|---|
| `packages/agent/src/types/permissions.ts` | Add `checkRevoked?: boolean` to `FetchPermissionsParams` |
| `packages/agent/src/permissions-api.ts` | Implement `fetchRevokedGrantIds()` batch query; update `fetchGrants()` to filter revoked grants |
| `packages/api/src/dwn-api.ts` | Remove manual per-grant `isGrantRevoked()` loop; `checkRevoked` now flows through to agent layer |
| `packages/agent/tests/permissions-api.spec.ts` | Add 4 tests: revocation filtering, opt-out, roundtrip counts |
| `packages/api/tests/dwn-api.spec.ts` | Rewrite revocation test to use actual revocation instead of stubs |

## Verification

- **Agent tests**: 713 pass, 0 fail
- **API tests**: 267 pass, 0 fail
- **Lint**: all 11 packages pass