### PR TITLE
fix(protocols): increase profile image size limits + add changesets for publish

### DIFF
--- a/.changeset/profile-image-limits.md
+++ b/.changeset/profile-image-limits.md
@@ -1,0 +1,5 @@
+---
+'@enbox/protocols': patch
+---
+
+fix(protocols): increase avatar size limit to 12 MB and hero banner to 24 MB

--- a/.changeset/sync-error-logging.md
+++ b/.changeset/sync-error-logging.md
@@ -1,0 +1,5 @@
+---
+'@enbox/agent': patch
+---
+
+fix(agent): preserve original error in sync catch blocks instead of generic 'unreachable'

--- a/packages/protocols/src/profile.ts
+++ b/packages/protocols/src/profile.ts
@@ -95,13 +95,13 @@ export const ProfileDefinition = {
         { who: 'anyone', can: ['read'] },
       ],
       avatar: {
-        $size    : { max: 1048576 },
+        $size    : { max: 12582912 },
         $actions : [
           { who: 'anyone', can: ['read'] },
         ],
       },
       hero: {
-        $size    : { max: 2097152 },
+        $size    : { max: 25165824 },
         $actions : [
           { who: 'anyone', can: ['read'] },
         ],

--- a/packages/protocols/tests/protocols.spec.ts
+++ b/packages/protocols/tests/protocols.spec.ts
@@ -82,8 +82,8 @@ describe('@enbox/protocols', () => {
     });
 
     it('should enforce size limits on avatar and hero', () => {
-      expect(ProfileDefinition.structure.profile.avatar.$size?.max).toBe(1048576);
-      expect(ProfileDefinition.structure.profile.hero.$size?.max).toBe(2097152);
+      expect(ProfileDefinition.structure.profile.avatar.$size?.max).toBe(12582912);
+      expect(ProfileDefinition.structure.profile.hero.$size?.max).toBe(25165824);
     });
 
     it('should use cross-protocol friend role for privateNote', () => {


### PR DESCRIPTION
## Summary

- **Avatar** size limit: 1 MB -> **12 MB**
- **Hero banner** size limit: 2 MB -> **24 MB**
- Adds changeset for `@enbox/protocols` (patch bump)
- Adds changeset for `@enbox/agent` (patch bump) — the sync error logging fix from #258 was merged without a changeset so it was never published

## After merge

CI will publish:
- `@enbox/agent@0.1.7` — includes the sync error fix from #258
- `@enbox/protocols@0.2.3` — includes the image limit increase

Then the wallet and dapp-demo can update to the new versions.