### PR TITLE
refactor(dwn-sdk-js): remove flat-space remnants from schemas, dead code, and stale guards

### DIFF
--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-unidentified.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-unidentified.json
@@ -3,7 +3,8 @@
   "$id": "https://identity.foundation/dwn/json-schemas/records-write-unidentified.json",
   "type": "object",
   "required": [
-    "descriptor"
+    "descriptor",
+    "contextId"
   ],
   "properties": {
     "recordId": {
@@ -50,10 +51,8 @@
                   "derivationScheme": {
                     "type": "string",
                     "enum": [
-                      "dataFormats",
                       "protocolContext",
-                      "protocolPath",
-                      "schemas"
+                      "protocolPath"
                     ]
                   },
                   "derivedPublicKey": {
@@ -181,6 +180,8 @@
       "required": [
         "interface",
         "method",
+        "protocol",
+        "protocolPath",
         "dataCid",
         "dataSize",
         "dateCreated",
@@ -247,57 +248,5 @@
         }
       ]
     }
-  },
-  "$comment": "rule defining `protocol` and `contextId` relationship",
-  "anyOf": [
-    {
-      "properties": {
-        "descriptor": {
-          "type": "object",
-          "required": [
-            "protocol",
-            "protocolPath"
-          ]
-        }
-      },
-      "required": [
-        "contextId"
-      ]
-    },
-    {
-      "allOf": [
-        {
-          "not": {
-            "required": [
-              "contextId"
-            ]
-          }
-        },
-        {
-          "properties": {
-            "descriptor": {
-              "type": "object",
-              "not": {
-                "required": [
-                  "protocol"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "properties": {
-            "descriptor": {
-              "type": "object",
-              "not": {
-                "required": [
-                  "protocolPath"
-                ]
-              }
-            }
-          }
-        }
-      ]
-    }
-  ]
+  }
 }

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -141,8 +141,7 @@ export enum DwnErrorCode {
   RecordsOwnerDelegatedGrantCidMismatch = 'RecordsOwnerDelegatedGrantCidMismatch',
   RecordsOwnerDelegatedGrantGrantedToAndOwnerSignatureMismatch = 'RecordsOwnerDelegatedGrantGrantedToAndOwnerSignatureMismatch',
   RecordsOwnerDelegatedGrantNotADelegatedGrant = 'RecordsOwnerDelegatedGrantNotADelegatedGrant',
-  RecordsProtocolContextDerivationSchemeMissingContextId = 'RecordsProtocolContextDerivationSchemeMissingContextId',
-  RecordsProtocolPathDerivationSchemeMissingProtocol = 'RecordsProtocolPathDerivationSchemeMissingProtocol',
+
   RecordsQueryFilterMissingRequiredProperties = 'RecordsQueryFilterMissingRequiredProperties',
 
   RecordsReadCreateFilterPublishedSortInvalid = 'RecordsReadCreateFilterPublishedSortInvalid',
@@ -157,7 +156,7 @@ export enum DwnErrorCode {
   RecordsWriteCreateMissingSigner = 'RecordsWriteCreateMissingSigner',
   RecordsWriteCreateDataAndDataCidMutuallyExclusive = 'RecordsWriteCreateDataAndDataCidMutuallyExclusive',
   RecordsWriteCreateDataCidAndDataSizeMutuallyInclusive = 'RecordsWriteCreateDataCidAndDataSizeMutuallyInclusive',
-  RecordsWriteCreateProtocolAndProtocolPathMutuallyInclusive = 'RecordsWriteCreateProtocolAndProtocolPathMutuallyInclusive',
+  RecordsWriteCreateMissingProtocol = 'RecordsWriteCreateMissingProtocol',
   RecordsWriteDataCidMismatch = 'RecordsWriteDataCidMismatch',
   RecordsWriteDataSizeMismatch = 'RecordsWriteDataSizeMismatch',
   RecordsWriteGetEntryIdUndefinedAuthor = 'RecordsWriteGetEntryIdUndefinedAuthor',

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -1,6 +1,5 @@
 import type { Filter } from '../types/query-types.js';
 import type { MessageStore } from '../types/message-store.js';
-import type { ProtocolAction } from '../types/protocols-types.js';
 import type { RecordsCount } from '../interfaces/records-count.js';
 import type { RecordsDelete } from '../interfaces/records-delete.js';
 import type { RecordsQuery } from '../interfaces/records-query.js';
@@ -16,7 +15,7 @@ import { SortDirection } from '../types/query-types.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
-import { authorizeAgainstAllowedActions, getActionsSeekingARuleMatch, verifyInvokedRole } from './protocol-authorization-action.js';
+import { authorizeAgainstAllowedActions, verifyInvokedRole } from './protocol-authorization-action.js';
 import { constructRecordChain, fetchInitialWrite, getGoverningTimestamp } from './record-chain.js';
 import {
   verifyAsRoleRecordIfNeeded,
@@ -385,15 +384,4 @@ export class ProtocolAuthorization {
     return ruleSet;
   }
 
-  /**
-   * Returns all the ProtocolActions that would authorize the incoming message.
-   * Delegates to the standalone function in `protocol-authorization-action.ts`.
-   */
-  private static async getActionsSeekingARuleMatch(
-    tenant: string,
-    incomingMessage: RecordsCount | RecordsDelete | RecordsQuery | RecordsRead | RecordsSubscribe | RecordsWrite,
-    messageStore: MessageStore,
-  ): Promise<ProtocolAction[]> {
-    return getActionsSeekingARuleMatch(tenant, incomingMessage, messageStore);
-  }
 }

--- a/packages/dwn-sdk-js/src/core/records-grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/records-grant-authorization.ts
@@ -87,15 +87,14 @@ export class RecordsGrantAuthorization {
       messageStore
     });
 
-    // If the grant specifies a protocol, the subscribe or query must specify the same protocol.
+    // The grant's protocol must match the query/subscribe filter's protocol.
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
     const permissionScope = permissionGrant.scope as RecordsPermissionScope;
-    const protocolInGrant = permissionScope.protocol;
     const protocolInMessage = incomingMessage.descriptor.filter.protocol;
-    if (protocolInGrant !== undefined && protocolInMessage !== protocolInGrant) {
+    if (protocolInMessage !== permissionScope.protocol) {
       throw new DwnError(
         DwnErrorCode.RecordsGrantAuthorizationQueryOrSubscribeProtocolScopeMismatch,
-        `Grant protocol scope ${protocolInGrant} does not match protocol in message ${protocolInMessage}`
+        `Grant protocol scope ${permissionScope.protocol} does not match protocol in message ${protocolInMessage}`
       );
     }
   }
@@ -124,15 +123,14 @@ export class RecordsGrantAuthorization {
       messageStore
     });
 
-    // If the grant specifies a protocol, the delete must be deleting a record with the same protocol.
+    // The grant's protocol must match the protocol of the record being deleted.
     // NOTE: validated the invoked permission is for Records in GrantAuthorization.performBaseValidation()
     const permissionScope = permissionGrant.scope as RecordsPermissionScope;
-    const protocolInGrant = permissionScope.protocol;
     const protocolOfRecordToDelete = recordsWriteToDelete.descriptor.protocol;
-    if (protocolInGrant !== undefined && protocolOfRecordToDelete !== protocolInGrant) {
+    if (protocolOfRecordToDelete !== permissionScope.protocol) {
       throw new DwnError(
         DwnErrorCode.RecordsGrantAuthorizationDeleteProtocolScopeMismatch,
-        `Grant protocol scope ${protocolInGrant} does not match protocol in record to delete ${protocolOfRecordToDelete}`
+        `Grant protocol scope ${permissionScope.protocol} does not match protocol in record to delete ${protocolOfRecordToDelete}`
       );
     }
   }

--- a/packages/dwn-sdk-js/src/interfaces/records-write-signing.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write-signing.ts
@@ -1,7 +1,7 @@
 import type { GeneralJws } from '../types/jws-types.js';
 import type { MessageSigner } from '../types/signer.js';
 import type { EncryptionInput, JweEncryption } from '../utils/encryption.js';
-import type { RecordsWriteAttestationPayload, RecordsWriteDescriptor, RecordsWriteMessage, RecordsWriteSignaturePayload } from '../types/records-types.js';
+import type { RecordsWriteAttestationPayload, RecordsWriteMessage, RecordsWriteSignaturePayload } from '../types/records-types.js';
 
 import { Cid } from '../utils/cid.js';
 import { Encoder } from '../utils/encoder.js';
@@ -14,11 +14,9 @@ import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 /**
  * Creates the JWE `encryption` property if encryption input is given. Else `undefined` is returned.
  * Uses ECDH-ES+A256KW key agreement with X25519 and AEAD content encryption (A256GCM or XC20P).
- * @param descriptor Descriptor of the `RecordsWrite` message which contains the information needed by key path derivation schemes.
  * @param encryptionInput The encryption input containing CEK, IV, authentication tag, and recipient key encryption inputs.
  */
 export async function createEncryptionProperty(
-  descriptor: RecordsWriteDescriptor,
   encryptionInput: EncryptionInput | undefined,
 ): Promise<JweEncryption | undefined> {
   if (encryptionInput === undefined) {

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -286,7 +286,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
    */
   public static async create(options: RecordsWriteOptions): Promise<RecordsWrite> {
     if (options.protocol === undefined || options.protocolPath === undefined) {
-      throw new DwnError(DwnErrorCode.RecordsWriteCreateProtocolAndProtocolPathMutuallyInclusive, '`protocol` and `protocolPath` are required');
+      throw new DwnError(DwnErrorCode.RecordsWriteCreateMissingProtocol, '`protocol` and `protocolPath` are required');
     }
 
     if ((options.data === undefined && options.dataCid === undefined) ||
@@ -345,7 +345,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     const attestation = await createAttestation(descriptorCid, options.attestationSigners);
 
     // `encryption` generation
-    const encryption = await createEncryptionProperty(descriptor, options.encryptionInput);
+    const encryption = await createEncryptionProperty(options.encryptionInput);
 
     const message: InternalRecordsWriteMessage = {
       recordId,
@@ -473,7 +473,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       }
 
       // Build only the new recipients (reuses createEncryptionProperty for ECDH-ES+A256KW logic)
-      const newEncryption = await createEncryptionProperty(this._message.descriptor, encryptionInput);
+      const newEncryption = await createEncryptionProperty(encryptionInput);
       if (newEncryption) {
         this._message.encryption.recipients.push(...newEncryption.recipients);
       }
@@ -492,7 +492,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       // the contextKey schema. We chose the in-record approach because it keeps
       // records self-contained and the read/decrypt path unchanged.
     } else {
-      this._message.encryption = await createEncryptionProperty(this._message.descriptor, encryptionInput);
+      this._message.encryption = await createEncryptionProperty(encryptionInput);
 
       // Full replacement invalidates the authorization — caller must re-sign.
       delete this._message.authorization;
@@ -585,7 +585,6 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
 
     this._ownerSignaturePayload = Jws.decodePlainObjectPayload(ownerSignature);
     this._owner = Jws.extractDid(signer.keyId);
-    ;
   }
 
   /**
@@ -707,13 +706,6 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
   }
 
   /**
-   * Delegate to the standalone `validateAttestationIntegrity` function for backward compatibility.
-   */
-  private static async validateAttestationIntegrity(message: RecordsWriteMessage): Promise<void> {
-    return validateAttestationIntegrity(message);
-  }
-
-  /**
    * Computes the deterministic Entry ID of this message.
    */
   public async getEntryId(): Promise<string> {
@@ -820,14 +812,6 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     const author = Message.getAuthor(recordsWriteMessage);
     const entryId = await RecordsWrite.getEntryId(author, recordsWriteMessage.descriptor);
     return (entryId === recordsWriteMessage.recordId);
-  }
-
-  /** Delegate to `createEncryptionProperty` in `records-write-signing.ts`. */
-  private static async createEncryptionProperty(
-    descriptor: RecordsWriteDescriptor,
-    encryptionInput: EncryptionInput | undefined,
-  ): Promise<JweEncryption | undefined> {
-    return createEncryptionProperty(descriptor, encryptionInput);
   }
 
   /** Delegate to `createAttestation` in `records-write-signing.ts`. */

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -158,16 +158,7 @@ export class Records {
    * its children (composing protocol) use different protocol URIs and thus different key trees.
    */
   public static constructKeyDerivationPathUsingProtocolPathScheme(descriptor: RecordsWriteDescriptor): string[] {
-    // ensure `protocol` is defined
-    // NOTE: no need to check `protocolPath` and `contextId` because earlier code ensures that if `protocol` is defined, those are defined also
-    if (descriptor.protocol === undefined) {
-      throw new DwnError(
-        DwnErrorCode.RecordsProtocolPathDerivationSchemeMissingProtocol,
-        'Unable to construct key derivation path using `protocols` scheme because `protocol` is missing.'
-      );
-    }
-
-    const protocolPathSegments = descriptor.protocolPath!.split('/');
+    const protocolPathSegments = descriptor.protocolPath.split('/');
     const fullDerivationPath = [
       KeyDerivationScheme.ProtocolPath,
       descriptor.protocol,
@@ -187,14 +178,7 @@ export class Records {
    * a shared context (e.g., thread participants can decrypt messages from both the threads protocol
    * and composing protocols that attach to those threads).
    */
-  public static constructKeyDerivationPathUsingProtocolContextScheme(contextId: string | undefined): string[] {
-    if (contextId === undefined) {
-      throw new DwnError(
-        DwnErrorCode.RecordsProtocolContextDerivationSchemeMissingContextId,
-        'Unable to construct key derivation path using `protocolContext` scheme because `contextId` is missing.'
-      );
-    }
-
+  public static constructKeyDerivationPathUsingProtocolContextScheme(contextId: string): string[] {
     // TODO: Extend key derivation support to include the full contextId (https://github.com/enboxorg/enbox/issues/99)
     const firstContextSegment = contextId.split('/')[0];
 

--- a/packages/dwn-sdk-js/tests/core/protocol-authorization.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/protocol-authorization.spec.ts
@@ -1,4 +1,5 @@
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { getActionsSeekingARuleMatch } from '../../src/core/protocol-authorization-action.js';
 import { MessageStoreLevel } from '../../src/index.js';
 import { ProtocolAuthorization } from '../../src/core/protocol-authorization.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
@@ -43,7 +44,7 @@ describe('ProtocolAuthorization', () => {
       } as any;
 
       const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
-      expect(await ProtocolAuthorization['getActionsSeekingARuleMatch'](alice.did, deliberatelyCraftedInvalidMessage, messageStoreStub)).toHaveLength(0);
+      expect(await getActionsSeekingARuleMatch(alice.did, deliberatelyCraftedInvalidMessage, messageStoreStub)).toHaveLength(0);
     });
   });
 });

--- a/packages/dwn-sdk-js/tests/features/protocol-delete-action.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/protocol-delete-action.spec.ts
@@ -7,9 +7,9 @@ import sinon from 'sinon';
 
 import { DataStream } from '../../src/utils/data-stream.js';
 import { Dwn } from '../../src/dwn.js';
+import { getActionsSeekingARuleMatch } from '../../src/core/protocol-authorization-action.js';
 import { Jws } from '../../src/utils/jws.js';
 import { ProtocolAction } from '../../src/types/protocols-types.js';
-import { ProtocolAuthorization } from '../../src/core/protocol-authorization.js';
 import { RecordsRead } from '../../src/interfaces/records-read.js';
 import { RecordsWrite } from '../../src/interfaces/records-write.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
@@ -570,7 +570,7 @@ export function testProtocolDeleteAction(): void {
       expect(protocolsConfigureReply.status.detail).toContain(DwnErrorCode.ProtocolsConfigureInvalidActionDeleteWithoutCreate);
     });
 
-    describe('ProtocolAuthorization.getActionsSeekingARuleMatch()', () => {
+    describe('getActionsSeekingARuleMatch()', () => {
       it('should return empty array when given a RecordsDelete on a non-existent record', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
@@ -584,7 +584,7 @@ export function testProtocolDeleteAction(): void {
           = await dwn.processMessage(alice.did, bobUnauthorizedFooDelete.message);
         expect(bobUnauthorizedFooDeleteReply.status.code).toBe(404);
 
-        const actionsSeekingARuleMatch = await ProtocolAuthorization['getActionsSeekingARuleMatch'](alice.did, bobUnauthorizedFooDelete, messageStore);
+        const actionsSeekingARuleMatch = await getActionsSeekingARuleMatch(alice.did, bobUnauthorizedFooDelete, messageStore);
         expect(actionsSeekingARuleMatch).toHaveLength(0);
       });
     });

--- a/packages/dwn-sdk-js/tests/utils/records.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/records.spec.ts
@@ -40,9 +40,9 @@ describe('Records', () => {
   });
 
   describe('constructKeyDerivationPathUsingProtocolContextScheme()', () => {
-    it('should throw if not given contextId', async () => {
-      expect(() => Records.constructKeyDerivationPathUsingProtocolContextScheme(undefined))
-        .toThrow(DwnErrorCode.RecordsProtocolContextDerivationSchemeMissingContextId);
+    it('should construct a valid key derivation path using protocol context scheme', async () => {
+      const path = Records.constructKeyDerivationPathUsingProtocolContextScheme('rootId/childId');
+      expect(path).toEqual([KeyDerivationScheme.ProtocolContext, 'rootId']);
     });
   });
 

--- a/packages/dwn-sdk-js/tests/validation/json-schemas/records/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/validation/json-schemas/records/records-write.spec.ts
@@ -6,9 +6,12 @@ describe('RecordsWrite schema definition', () => {
   it('should allow descriptor with only required properties', async () => {
     const validMessage = {
       recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
+        protocol         : 'http://example.com/protocol',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,
@@ -22,9 +25,12 @@ describe('RecordsWrite schema definition', () => {
 
   it('should throw if `recordId` is missing', async () => {
     const message = {
-      descriptor: {
+      contextId  : 'anyContextId',
+      descriptor : {
         interface        : 'Records',
         method           : 'Write',
+        protocol         : 'http://example.com/protocol',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,
@@ -42,9 +48,12 @@ describe('RecordsWrite schema definition', () => {
   it('should throw if `authorization` is missing', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
+        protocol         : 'http://example.com/protocol',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,
@@ -61,9 +70,12 @@ describe('RecordsWrite schema definition', () => {
   it('should throw if unknown property is given in message', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
+        protocol         : 'http://example.com/protocol',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,
@@ -82,9 +94,12 @@ describe('RecordsWrite schema definition', () => {
   it('should throw if unknown property is given in the `descriptor`', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
+        protocol         : 'http://example.com/protocol',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,
@@ -186,12 +201,14 @@ describe('RecordsWrite schema definition', () => {
     }).toThrow(expectedErrorMessage);
   });
 
-  it('should pass if none of `protocol` related properties are present', () => {
+  it('should throw if `contextId` is missing', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
+        protocol         : 'http://example.com/protocol',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,
@@ -201,7 +218,9 @@ describe('RecordsWrite schema definition', () => {
       authorization: TestDataGenerator.generateAuthorization()
     };
 
-    Message.validateJsonSchema(invalidMessage);
+    expect(() => {
+      Message.validateJsonSchema(invalidMessage);
+    }).toThrow('must have required property \'contextId\'');
   });
 
   it('should throw if `contextId` is defined but `protocol` is missing', () => {
@@ -231,7 +250,8 @@ describe('RecordsWrite schema definition', () => {
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
-        protocol         : 'invalid', // must have `contextId` to exist
+        protocol         : 'invalid',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,
@@ -246,15 +266,15 @@ describe('RecordsWrite schema definition', () => {
     }).toThrow('must have required property \'contextId\'');
   });
 
-  it('#434 - should throw if `parentId` is defined without other protocol related properties', () => {
+  it('#434 - should throw if `protocol` is missing from descriptor', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
-      // contextId  : 'anyContextId', // intentionally missing
+      contextId  : 'anyContextId',
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
-        // protocol         : 'http://foo.bar', // intentionally missing
-        // protocolPath     : 'foo/bar', // intentionally missing
+        // protocol     : 'http://foo.bar', // intentionally missing
+        protocolPath     : 'foo/bar',
         parentId         : 'anyParentId',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
@@ -267,7 +287,7 @@ describe('RecordsWrite schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
-    }).toThrow('must have property protocol when property parentId is present');
+    }).toThrow('descriptor: must have required property \'protocol\'');
   });
 
   it('should throw if `protocol` is defined but `protocolPath` is missing', () => {
@@ -390,9 +410,12 @@ describe('RecordsWrite schema definition', () => {
   it('should throw if published is false but datePublished is present', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
+        protocol         : 'http://example.com/protocol',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,
@@ -412,9 +435,12 @@ describe('RecordsWrite schema definition', () => {
   it('should throw if published is true but datePublished is missing', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
+        protocol         : 'http://example.com/protocol',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,
@@ -433,9 +459,12 @@ describe('RecordsWrite schema definition', () => {
   it('should throw if published is missing and datePublished is present', () => {
     const invalidMessage = {
       recordId   : 'anyRecordId',
+      contextId  : 'anyContextId',
       descriptor : {
         interface        : 'Records',
         method           : 'Write',
+        protocol         : 'http://example.com/protocol',
+        protocolPath     : 'foo',
         dataCid          : 'anyCid',
         dataFormat       : 'application/json',
         dataSize         : 123,


### PR DESCRIPTION
## Summary

Complete the post-flat-space cleanup for `RecordsWrite` and related code in `dwn-sdk-js`. Follow-up to #248 (flat-space removal) and #256 (stale comment cleanup).

### A. JSON Schema fixes (`records-write-unidentified.json`)
- Remove `dataFormats` and `schemas` from `derivationScheme` enum (flat-space key derivation schemes already removed from TypeScript)
- Add `protocol` and `protocolPath` to descriptor's `required` array (they are required in the TypeScript types but were not enforced at the schema level)
- Add `contextId` to top-level `required` array
- Remove the dead `anyOf` block (52 lines) — the second branch allowed records *without* a protocol, which is no longer valid

### B. Dead code removal
- Remove `RecordsWrite.createEncryptionProperty` private static delegator (never called — all call sites use the direct import)
- Remove `RecordsWrite.validateAttestationIntegrity` private static delegator (never called — the only call site uses the direct import)
- Remove unused `descriptor` parameter from `createEncryptionProperty()` in `records-write-signing.ts` and update all 3 call sites
- Remove `ProtocolAuthorization.getActionsSeekingARuleMatch` private static delegator; update 2 test files to import the standalone function directly from `protocol-authorization-action.ts`
- Remove stray semicolon in `signAsOwner()`

### C. Post-flat-space stale code
- Rename `DwnErrorCode.RecordsWriteCreateProtocolAndProtocolPathMutuallyInclusive` → `RecordsWriteCreateMissingProtocol` (the old name was vestigial — "mutually inclusive" made sense when they were optional)
- Remove dead `protocol === undefined` guard + error code in `constructKeyDerivationPathUsingProtocolPathScheme` (`protocol` is now required in `RecordsWriteDescriptor`)
- Remove dead `contextId === undefined` guard + error code in `constructKeyDerivationPathUsingProtocolContextScheme`; tighten parameter type from `string | undefined` to `string`
- Remove dead `protocolInGrant !== undefined` guards in `RecordsGrantAuthorization.authorizeQueryOrSubscribe` and `authorizeDelete` (`protocol` is now required in `RecordsPermissionScope`)
- Remove 2 stale `DwnErrorCode` entries

### Testing
- All 1007 dwn-sdk-js tests pass (0 fail)
- Lint passes with 0 warnings
- Build passes (including schema validator recompilation)