### PR TITLE
fix(dwn-sdk-js): disable browser test file parallelism to fix shared IndexedDB corruption

### DIFF
--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -94,6 +94,12 @@ export default defineConfig({
     holdUntilCrawlEnd: true,
   },
   test: {
+    // Run test files sequentially. Multiple files (aggregator.spec.ts,
+    // permissions.spec.ts) share IndexedDB state via the TestStores singleton.
+    // Parallel execution causes clear() in one file to wipe data mid-test in
+    // another, producing intermittent 400s and missing results — especially in
+    // Firefox where IndexedDB transaction scheduling differs from Chromium.
+    fileParallelism: false,
     // Browser-compatible tests. Most are pure-logic; a few use TestStores which
     // resolve to IndexedDB-backed stores in browser mode (via level's browser
     // field). The 29 function-wrapped handler/feature/scenario tests are excluded


### PR DESCRIPTION
## Summary

- Disables Vitest file parallelism (`fileParallelism: false`) in the dwn-sdk-js browser test config
- Fixes the root cause of intermittent Firefox browser test failures that have been plaguing CI

## Root Cause

Multiple browser test files share IndexedDB state via the `TestStores` singleton (static class with shared `TEST-MESSAGESTORE`, `TEST-INDEX`, etc. database names). Two files in the browser include list use `TestStores`:

- `tests/scenarios/aggregator.spec.ts` — `beforeEach` calls `clear()` on all 4 stores
- `tests/protocols/permissions.spec.ts` — `afterEach` calls `messageStore.clear()`

When Vitest runs these files in **parallel** (the default), one file's `clear()` wipes the IndexedDB databases mid-test in another file. This produces two distinct failure modes:

1. **`expected 400 to be 202`** — protocol configuration cleared during authorization, causing the DWN to reject a valid message
2. **`expected N to be M`** (missing query results) — records cleared between write and query

Firefox is disproportionately affected because its IndexedDB transaction scheduling makes the race window larger, but the bug exists on all browsers.

## What about PRs #257 and #262?

Those PRs fixed a **real, separate issue**: concurrent IndexedDB cursors within a single query dropping results. That bug is internal to `executeSingleFilterQuery` / `queryWithInMemoryPaging` and has nothing to do with test file parallelism. Both fixes should stay in place.

However, once this PR lands and CI stabilizes, it would be reasonable to try reverting #257/#262 on a branch to see if the cursor race manifests in practice without the file-parallelism confound. If it doesn't, the sequential query changes could be reverted to recover browser query performance (tracked in #264).

## Changes

**`packages/dwn-sdk-js/vitest.browser.config.ts`**: Added `fileParallelism: false` to the test config with a comment explaining why.

## Testing

- `bun run --filter @enbox/dwn-sdk-js lint` — pass
- `bun run --filter @enbox/dwn-sdk-js build` — pass
- `bun run --filter @enbox/dwn-sdk-js test:node` — 1007 pass, 0 fail

The real validation is CI — the Firefox browser job should pass consistently.

Related: #264