### PR TITLE
fix: add duplex: 'half' to streaming fetch requests for browser compat

### DIFF
--- a/.changeset/fix-fetch-duplex-streaming.md
+++ b/.changeset/fix-fetch-duplex-streaming.md
@@ -1,0 +1,10 @@
+---
+'@enbox/dwn-clients': patch
+---
+
+fix: add `duplex: 'half'` to streaming fetch requests for browser compatibility
+
+Browsers require `duplex: 'half'` in the `RequestInit` options when the request
+body is a `ReadableStream`. Without it, the sync-push path (which sends record
+data as a raw stream) fails with:
+"The `duplex` member must be specified for a request with a streaming body".

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -37,6 +37,11 @@ export class HttpDwnRpcClient implements DwnRpc {
     if (request.data) {
       requestHeaders['content-type'] = 'application/octet-stream';
       fetchOpts.body = request.data;
+
+      // Browsers require `duplex: 'half'` when the fetch body is a ReadableStream.
+      // The sync-push path sends record data as a raw stream (see sync-messages.ts).
+      // TypeScript's built-in RequestInit does not include `duplex` yet.
+      (fetchOpts as Record<string, unknown>).duplex = 'half';
     }
 
     const resp = await fetch(request.dwnUrl, fetchOpts);


### PR DESCRIPTION
## Summary

- Adds `duplex: 'half'` to the `RequestInit` options in `HttpDwnRpcClient.sendDwnRequest()` when the request body is a `ReadableStream`
- Browsers require this flag for streaming request bodies per the Fetch spec; without it, sync-push fails with: `Failed to execute 'fetch' on 'Window': The duplex member must be specified for a request with a streaming body`
- The sync-push path in `sync-messages.ts` sends record data as a raw `ReadableStream`, which hits this code path

## Test

Existing `http-dwn-rpc-client.spec.ts` tests all pass (9/9). The `duplex` property is harmless in non-browser environments (Bun/Node ignore it).