### PR TITLE
perf(dwn-sdk-js): restore concurrent IndexedDB query execution

### DIFF
--- a/packages/dwn-sdk-js/src/store/index-level.ts
+++ b/packages/dwn-sdk-js/src/store/index-level.ts
@@ -477,13 +477,9 @@ export class IndexLevel {
     }
 
     try {
-      // Execute filters sequentially rather than in parallel.
-      // Concurrent IndexedDB iterators (opened by Promise.all) intermittently
-      // miss results in Firefox due to cursor/transaction scheduling races.
-      // TODO: restore concurrency once Firefox IndexedDB race is resolved (https://github.com/enboxorg/enbox/issues/264)
-      for (const filter of filters) {
-        await this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, options);
-      }
+      await Promise.all(filters.map((filter: Filter): Promise<void> => {
+        return this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, options);
+      }));
     } catch (error) {
       if ((error as DwnError).code === DwnErrorCode.IndexInvalidSortPropertyInMemory) {
         // return empty results if the sort property is invalid.
@@ -505,9 +501,6 @@ export class IndexLevel {
 
   /**
    * Execute a filtered query against a single filter and return all results.
-   * Queries are executed sequentially to avoid opening multiple IndexedDB cursors
-   * concurrently, which causes intermittent failures in Firefox.
-   * TODO: restore concurrency once Firefox IndexedDB race is resolved (https://github.com/enboxorg/enbox/issues/264)
    */
   private async executeSingleFilterQuery(
     tenant: string,
@@ -517,8 +510,42 @@ export class IndexLevel {
     levelOptions?: IndexLevelOptions
   ): Promise<void> {
 
-    // Collects results from each sub-query sequentially to avoid concurrent IndexedDB cursor races.
-    const processResults = (indexItems: IndexedItem[]): void => {
+    // Note: We have an array of Promises in order to support OR (anyOf) matches when given a list of accepted values for a property
+    const filterPromises: Promise<IndexedItem[]>[] = [];
+
+    // If the filter is empty, then we just iterate over one of the indexes that contains all the records and return all items.
+    if (isEmptyObject(filter)) {
+      const getAllItemsPromise = this.getAllItems(tenant, sortProperty);
+      filterPromises.push(getAllItemsPromise);
+    }
+
+    // else the filter is not empty
+    const searchFilter = FilterSelector.reduceFilter(filter);
+    for (const propertyName in searchFilter) {
+      const propertyFilter = searchFilter[propertyName];
+      // We will find the union of these many individual queries later.
+      if (FilterUtility.isEqualFilter(propertyFilter)) {
+        // propertyFilter is an EqualFilter, meaning it is a non-object primitive type
+        const exactMatchesPromise = this.filterExactMatches(tenant, propertyName, propertyFilter, levelOptions);
+        filterPromises.push(exactMatchesPromise);
+      } else if (FilterUtility.isOneOfFilter(propertyFilter)) {
+        // `propertyFilter` is a OneOfFilter
+        // Support OR matches by querying for each values separately, then adding them to the promises array.
+        for (const propertyValue of new Set(propertyFilter)) {
+          const exactMatchesPromise = this.filterExactMatches(tenant, propertyName, propertyValue, levelOptions);
+          filterPromises.push(exactMatchesPromise);
+        }
+      } else if (FilterUtility.isRangeFilter(propertyFilter)) {
+        // `propertyFilter` is a `RangeFilter`
+        const rangeMatchesPromise = this.filterRangeMatches(tenant, propertyName, propertyFilter, levelOptions);
+        filterPromises.push(rangeMatchesPromise);
+      }
+    }
+
+    // acting as an OR match for the property, any of the promises returning a match will be treated as a property match
+    for (const promise of filterPromises) {
+      const indexItems = await promise;
+      // reminder: the promise returns a list of IndexedItem satisfying a particular property match
       for (const indexedItem of indexItems) {
         // short circuit: if a data is already included to the final matched key set (by a different `Filter`),
         // no need to evaluate if the data satisfies this current filter being evaluated
@@ -533,36 +560,6 @@ export class IndexLevel {
         }
 
         matches.set(indexedItem.messageCid, indexedItem);
-      }
-    };
-
-    // If the filter is empty, then we just iterate over one of the indexes that contains all the records and return all items.
-    if (isEmptyObject(filter)) {
-      const allItems = await this.getAllItems(tenant, sortProperty);
-      processResults(allItems);
-      return;
-    }
-
-    // else the filter is not empty
-    const searchFilter = FilterSelector.reduceFilter(filter);
-    for (const propertyName in searchFilter) {
-      const propertyFilter = searchFilter[propertyName];
-      // We will find the union of these many individual queries later.
-      if (FilterUtility.isEqualFilter(propertyFilter)) {
-        // propertyFilter is an EqualFilter, meaning it is a non-object primitive type
-        const exactMatches = await this.filterExactMatches(tenant, propertyName, propertyFilter, levelOptions);
-        processResults(exactMatches);
-      } else if (FilterUtility.isOneOfFilter(propertyFilter)) {
-        // `propertyFilter` is a OneOfFilter
-        // Support OR matches by querying for each value separately and sequentially.
-        for (const propertyValue of new Set(propertyFilter)) {
-          const exactMatches = await this.filterExactMatches(tenant, propertyName, propertyValue, levelOptions);
-          processResults(exactMatches);
-        }
-      } else if (FilterUtility.isRangeFilter(propertyFilter)) {
-        // `propertyFilter` is a `RangeFilter`
-        const rangeMatches = await this.filterRangeMatches(tenant, propertyName, propertyFilter, levelOptions);
-        processResults(rangeMatches);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Restores `Promise.all` in `queryWithInMemoryPaging` (reverts #257)
- Restores eager promise collection in `executeSingleFilterQuery` (reverts #262)
- Removes the TODO comments referencing #264

## Why this is safe

#266 identified the **actual root cause** of the Firefox browser test flakes: multiple test files running in parallel against a shared `TestStores` singleton, with `clear()` calls in one file wiping IndexedDB state mid-test in another. With `fileParallelism: false` now in place, test files run sequentially and can no longer corrupt each other's state.

The concurrent cursor pattern within a single query was never the real problem — it was misattributed because the symptoms (missing results, unexpected status codes) looked similar. The `400 to be 202` failure in the latest CI run proved it was store-level corruption, not cursor-level.

## What changed

**`packages/dwn-sdk-js/src/store/index-level.ts`**:

- `queryWithInMemoryPaging`: sequential `for...of` loop -> `Promise.all(filters.map(...))`
- `executeSingleFilterQuery`: sequential `await` + `processResults` helper -> eager promise collection + sequential await loop (the original pattern)
- Removed TODO comments referencing #264

## Testing

- `bun run --filter @enbox/dwn-sdk-js lint` — pass
- `bun run --filter @enbox/dwn-sdk-js test:node` — 1007 pass, 0 fail
- `bun run --filter @enbox/agent test:node` — 713 pass, 0 fail

**The real validation is CI** — specifically `Test: Browser (dwn-sdk-js / firefox)`. If it passes, this confirms the concurrent cursor pattern is not a problem when test files are properly isolated.

Closes #264