### PR TITLE
fix(dwn-clients): add error handling for JSON parsing in HTTP DWN RPC client

### DIFF
--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -62,7 +62,13 @@ export class HttpDwnRpcClient implements DwnRpc {
       dwnRpcResponse = jsonRpcResponse;
     } else {
       const responseBody = await resp.text();
-      dwnRpcResponse = JSON.parse(responseBody);
+      const jsonRpcResponse = parseJson(responseBody) as JsonRpcResponse;
+
+      if (jsonRpcResponse == null) {
+        throw new Error(`failed to parse json rpc response. dwn url: ${request.dwnUrl}, status: ${resp.status}`);
+      }
+
+      dwnRpcResponse = jsonRpcResponse;
     }
 
     if (dwnRpcResponse.error) {

--- a/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
+++ b/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
@@ -113,6 +113,44 @@ describe('HttpDwnRpcClient', () => {
       expect(readResponse.entry?.recordsWrite?.recordId).toBe(writeMessage.recordId);
     });
 
+    it('throws error if response body is not valid JSON', async () => {
+      sinon.stub(globalThis, 'fetch').resolves({
+        headers : new Headers(),
+        status  : 200,
+        text    : async (): Promise<string> => 'not json',
+      } as any);
+
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      await expect(client.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      })).rejects.toThrow('failed to parse json rpc response.');
+    });
+
+    it('throws error if response body is empty', async () => {
+      sinon.stub(globalThis, 'fetch').resolves({
+        headers : new Headers(),
+        status  : 502,
+        text    : async (): Promise<string> => '',
+      } as any);
+
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      await expect(client.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      })).rejects.toThrow('failed to parse json rpc response.');
+    });
+
     it('throws error if invalid response exists in the header', async () => {
       const headers = sinon.createStubInstance(Headers, { has: true });
       sinon.stub(globalThis, 'fetch').resolves({ headers } as any);


### PR DESCRIPTION
## Summary

- Wraps the response body JSON parse in `sendDwnRequest` with the existing `parseJson` helper, matching the pattern already used for the `dwn-response` header path
- Throws a descriptive error including DWN URL and HTTP status on malformed responses
- Adds tests for non-JSON and empty response bodies

## Problem

Line 65 of `http-dwn-rpc-client.ts` used raw `JSON.parse(responseBody)` without error handling. When a DWN server returns a non-JSON response (e.g. an HTML error page from a reverse proxy, an empty 502 from a load balancer), the caller gets an unreadable `SyntaxError: Unexpected token...` with no context about which server or what HTTP status was returned.

The header path (line 56) already used `parseJson` with a null-check and descriptive error. The body path just needed the same treatment.

## Changes

**`packages/dwn-clients/src/http-dwn-rpc-client.ts`**: Replace `JSON.parse(responseBody)` with `parseJson(responseBody)` + null-check that throws with URL and status.

**`packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts`**: Add two tests — non-JSON body and empty body — verifying the error message.

## Testing

- `bun run lint` — all 11 packages pass
- `bun run --filter @enbox/dwn-clients test:node` — 89 pass, 0 fail
- `bun run --filter @enbox/agent test:node` — 713 pass, 0 fail

Closes #70