### PR TITLE
feat(dwn-sdk-js): add cursor-based subscribe with EOSE support (Phase 2)

### DIFF
--- a/packages/dwn-sdk-js/json-schemas/interface-methods/messages-subscribe.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/messages-subscribe.json
@@ -44,6 +44,10 @@
         },
         "permissionGrantId": {
           "type": "string"
+        },
+        "cursor": {
+          "type": "number",
+          "minimum": 0
         }
       }
     }

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-subscribe.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-subscribe.json
@@ -61,6 +61,10 @@
             "updatedDescending"
           ],
           "type": "string"
+        },
+        "cursor": {
+          "type": "number",
+          "minimum": 0
         }
       }
     }

--- a/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
@@ -1,12 +1,13 @@
 import type { KeyValues } from '../types/query-types.js';
 import type {
-  EventListener,
   EventLog,
   EventLogEntry,
   EventLogReadOptions,
   EventLogReadResult,
+  EventLogSubscribeOptions,
   EventSubscription,
   MessageEvent,
+  SubscriptionListener,
 } from '../types/subscriptions.js';
 
 import mitt from 'mitt';
@@ -20,7 +21,7 @@ const EVENTS_LISTENER_CHANNEL = 'events';
  * Payload shape used internally by mitt. We bundle the three EventListener
  * arguments into a single object because mitt emits one value per event.
  */
-type EmitterPayload = { tenant: string; event: MessageEvent; indexes: KeyValues };
+type EmitterPayload = { tenant: string; event: MessageEvent; indexes: KeyValues; seq: number };
 
 /**
  * mitt event map — every channel name maps to an `EmitterPayload`.
@@ -130,7 +131,7 @@ export class EventEmitterEventLog implements EventLog {
 
     // Notify in-process subscribers.
     const channel = `${tenant}_${EVENTS_LISTENER_CHANNEL}`;
-    this.emitter.emit(channel, { tenant, event, indexes });
+    this.emitter.emit(channel, { tenant, event, indexes, seq });
 
     return seq;
   }
@@ -168,12 +169,69 @@ export class EventEmitterEventLog implements EventLog {
     return { events: results, cursor: lastSeq };
   }
 
-  public async subscribe(tenant: string, id: string, listener: EventListener): Promise<EventSubscription> {
+  public async subscribe(
+    tenant: string,
+    id: string,
+    listener: SubscriptionListener,
+    options?: EventLogSubscribeOptions,
+  ): Promise<EventSubscription> {
     const channel = `${tenant}_${EVENTS_LISTENER_CHANNEL}`;
+    const { cursor, filters } = options ?? {};
 
-    // Wrap the three-arg EventListener into a single-arg mitt handler.
+    if (cursor !== undefined) {
+      // ---- Cursor mode: catch-up from stored events, then EOSE, then live ----
+
+      // Buffer live events that arrive during catch-up to avoid losing them.
+      type BufferedEvent = { event: MessageEvent; seq: number };
+      const pendingLiveEvents: BufferedEvent[] = [];
+      let catchUpComplete = false;
+
+      // Step 1: Register live listener FIRST so no events are missed during read.
+      const handler = (payload: EmitterPayload): void => {
+        if (filters !== undefined && filters.length > 0) {
+          if (!FilterUtility.matchAnyFilter(payload.indexes, filters)) { return; }
+        }
+        if (!catchUpComplete) {
+          pendingLiveEvents.push({ event: payload.event, seq: payload.seq });
+        } else {
+          listener({ type: 'event', seq: payload.seq, event: payload.event });
+        }
+      };
+
+      this.emitter.on(channel, handler);
+
+      // Step 2: Read stored events from cursor and deliver them.
+      const readResult = await this.read(tenant, { cursor, filters });
+      const lastCatchUpSeq = readResult.cursor;
+
+      for (const entry of readResult.events) {
+        listener({ type: 'event', seq: entry.seq, event: entry.event });
+      }
+
+      // Step 3: Deliver any live events that arrived during catch-up (with seq > lastCatchUpSeq).
+      catchUpComplete = true;
+      for (const liveEvent of pendingLiveEvents) {
+        if (liveEvent.seq > lastCatchUpSeq) {
+          listener({ type: 'event', seq: liveEvent.seq, event: liveEvent.event });
+        }
+      }
+
+      // Step 4: Send EOSE marker.
+      listener({ type: 'eose', seq: lastCatchUpSeq });
+
+      return {
+        id,
+        close: async (): Promise<void> => { this.emitter.off(channel, handler); }
+      };
+    }
+
+    // ---- No cursor: live events only ----
+
     const handler = (payload: EmitterPayload): void => {
-      listener(payload.tenant, payload.event, payload.indexes);
+      if (filters !== undefined && filters.length > 0) {
+        if (!FilterUtility.matchAnyFilter(payload.indexes, filters)) { return; }
+      }
+      listener({ type: 'event', seq: payload.seq, event: payload.event });
     };
 
     this.emitter.on(channel, handler);

--- a/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
@@ -1,11 +1,10 @@
 import type { DidResolver } from '@enbox/dids';
 import type { MessageStore } from '../types/message-store.js';
 import type { MethodHandler } from '../types/method-handler.js';
-import type { EventListener, EventLog } from '../types/subscriptions.js';
+import type { EventLog, SubscriptionListener } from '../types/subscriptions.js';
 import type { MessagesSubscribeMessage, MessagesSubscribeReply, MessageSubscriptionHandler } from '../types/messages-types.js';
 
 import { authenticate } from '../core/auth.js';
-import { FilterUtility } from '../utils/filter.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { Messages } from '../utils/messages.js';
@@ -51,22 +50,31 @@ export class MessagesSubscribeHandler implements MethodHandler {
       return messageReplyFromError(error, 401);
     }
 
-    const { filters } = message.descriptor;
+    const { filters, cursor: eventLogCursor } = message.descriptor;
     const messagesFilters = Messages.convertFilters(filters);
     const messageCid = await Message.getCid(message);
 
-    const listener: EventListener = (eventTenant, event, eventIndexes):void => {
-      if (tenant === eventTenant && FilterUtility.matchAnyFilter(eventIndexes, messagesFilters)) {
-        subscriptionHandler(event);
+    // Wrap SubscriptionListener → MessageSubscriptionHandler.
+    // The handler callback receives plain MessageEvents; seq/EOSE are EventLog concerns.
+    const listener: SubscriptionListener = (msg):void => {
+      if (msg.type === 'event') {
+        subscriptionHandler(msg.event);
       }
     };
 
-    const subscription = await this.eventLog.subscribe(tenant, messageCid, listener);
+    try {
+      const subscription = await this.eventLog.subscribe(tenant, messageCid, listener, {
+        cursor  : eventLogCursor,
+        filters : messagesFilters,
+      });
 
-    return {
-      status: { code: 200, detail: 'OK' },
-      subscription,
-    };
+      return {
+        status: { code: 200, detail: 'OK' },
+        subscription,
+      };
+    } catch (error) {
+      return messageReplyFromError(error, 500);
+    }
   }
 
   private static async authorizeMessagesSubscribe(tenant: string, messagesSubscribe: MessagesSubscribe, messageStore: MessageStore): Promise<void> {

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -2,13 +2,12 @@ import type { DidResolver } from '@enbox/dids';
 import type { MessageSort } from '../types/message-types.js';
 import type { MessageStore } from '../types//message-store.js';
 import type { MethodHandler } from '../types/method-handler.js';
-import type { EventListener, EventLog } from '../types/subscriptions.js';
+import type { EventLog, SubscriptionListener } from '../types/subscriptions.js';
 import type { Filter, PaginationCursor } from '../types/query-types.js';
 import type { RecordEvent, RecordsQueryReplyEntry, RecordsSubscribeMessage, RecordsSubscribeReply, RecordSubscriptionHandler } from '../types/records-types.js';
 
 import { authenticate } from '../core/auth.js';
 import { DateSort } from '../types/records-types.js';
-import { FilterUtility } from '../utils/filter.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
@@ -74,25 +73,56 @@ export class RecordsSubscribeHandler implements MethodHandler {
       }
     }
 
-    // Step 1: Register event listener FIRST to ensure no events are missed between query and subscribe
-    const listener: EventListener = (eventTenant, event, eventIndexes):void => {
-      if (tenant === eventTenant && FilterUtility.matchAnyFilter(eventIndexes, eventFilters)) {
-        subscriptionHandler(event as RecordEvent);
+    const messageCid = await Message.getCid(message);
+    const { cursor: eventLogCursor } = recordsSubscribe.message.descriptor;
+
+    // Wrap the SubscriptionListener → RecordSubscriptionHandler.
+    // The handler callback receives plain RecordEvents; seq/EOSE are EventLog concerns.
+    const listener: SubscriptionListener = (msg):void => {
+      if (msg.type === 'event') {
+        subscriptionHandler(msg.event as RecordEvent);
       }
+      // EOSE is silently consumed here — it's meaningful to the EventLog consumer
+      // (server, agent) who registered via eventLog.subscribe() directly, not to the
+      // DWN handler's subscription callback.
     };
 
-    const messageCid = await Message.getCid(message);
-    const subscription = await this.eventLog.subscribe(tenant, messageCid, listener);
+    if (eventLogCursor !== undefined) {
+      // ---- Cursor mode: catch-up from EventLog + EOSE + live ----
+      // All catch-up, buffering, dedup, and EOSE delivery are handled by the
+      // EventLog implementation. The handler just passes the cursor and filters.
+
+      try {
+        const subscription = await this.eventLog!.subscribe(tenant, messageCid, listener, {
+          cursor  : eventLogCursor,
+          filters : eventFilters,
+        });
+
+        return {
+          status: { code: 200, detail: 'OK' },
+          subscription,
+        };
+      } catch (error) {
+        return messageReplyFromError(error, 500);
+      }
+    }
+
+    // ---- No cursor: existing behavior (initial snapshot from MessageStore) ----
+
+    // Step 1: Register event listener FIRST to ensure no events are missed between query and subscribe
+    const subscription = await this.eventLog!.subscribe(tenant, messageCid, listener, {
+      filters: eventFilters,
+    });
 
     // Step 2: Query for initial snapshot of matching records
     let entries: RecordsQueryReplyEntry[];
-    let cursor: PaginationCursor | undefined;
+    let paginationCursor: PaginationCursor | undefined;
     try {
       const { dateSort, pagination } = recordsSubscribe.message.descriptor;
       const messageSort = RecordsSubscribeHandler.convertDateSort(dateSort);
       const queryResult = await this.messageStore.query(tenant, queryFilters, messageSort, pagination);
       entries = queryResult.messages as RecordsQueryReplyEntry[];
-      cursor = queryResult.cursor;
+      paginationCursor = queryResult.cursor;
 
       // attach initialWrite for non-initial writes
       for (const entry of entries) {
@@ -114,10 +144,10 @@ export class RecordsSubscribeHandler implements MethodHandler {
 
     // Step 3: Return subscription + initial entries + cursor
     return {
-      status: { code: 200, detail: 'OK' },
+      status : { code: 200, detail: 'OK' },
       subscription,
       entries,
-      cursor
+      cursor : paginationCursor,
     };
   }
 

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -1,6 +1,6 @@
 // export everything that we want to be consumable
 export type { DwnConfig } from './dwn.js';
-export type { EventListener, EventLog, EventLogEntry, EventLogReadOptions, EventLogReadResult, EventSubscription, MessageEvent, SubscriptionReply } from './types/subscriptions.js';
+export type { EventListener, EventLog, EventLogEntry, EventLogReadOptions, EventLogReadResult, EventLogSubscribeOptions, EventSubscription, MessageEvent, SubscriptionEose, SubscriptionEvent, SubscriptionListener, SubscriptionMessage, SubscriptionReply } from './types/subscriptions.js';
 export type { AuthorizationModel, Descriptor, DelegatedGrantRecordsWriteMessage, GenericMessage, GenericMessageReply, GenericSignaturePayload, MessageSort, MessageSubscription, Pagination, QueryResultEntry, Status } from './types/message-types.js';
 export type { MessagesFilter, MessagesReadMessage as MessagesReadMessage, MessagesReadReply as MessagesReadReply, MessagesReadReplyEntry as MessagesReadReplyEntry, MessagesReadDescriptor, MessagesSubscribeDescriptor, MessagesSubscribeMessage, MessagesSubscribeReply, MessageSubscriptionHandler, MessagesSubscribeMessageOptions, MessagesSyncAction, MessagesSyncDescriptor, MessagesSyncMessage, MessagesSyncReply } from './types/messages-types.js';
 export type { GT, LT, Filter, FilterValue, KeyValues, EqualFilter, OneOfFilter, RangeFilter, RangeCriterion, PaginationCursor, QueryOptions, RangeValue, StartsWithFilter } from './types/query-types.js';

--- a/packages/dwn-sdk-js/src/interfaces/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/interfaces/messages-subscribe.ts
@@ -13,8 +13,13 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 export type MessagesSubscribeOptions = {
   signer: MessageSigner;
   messageTimestamp?: string;
-  filters?: MessagesFilter[]
+  filters?: MessagesFilter[];
   permissionGrantId?: string;
+  /**
+   * EventLog sequence number to resume from. When provided, catch-up events are
+   * replayed from the EventLog and an EOSE marker is delivered before live events.
+   */
+  cursor?: number;
 };
 
 export class MessagesSubscribe extends AbstractMessage<MessagesSubscribeMessage> {
@@ -48,6 +53,7 @@ export class MessagesSubscribe extends AbstractMessage<MessagesSubscribeMessage>
       filters           : options.filters ?? [],
       messageTimestamp  : options.messageTimestamp ?? currentTime,
       permissionGrantId : options.permissionGrantId,
+      cursor            : options.cursor,
     };
 
     removeUndefinedProperties(descriptor);

--- a/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
@@ -23,6 +23,12 @@ export type RecordsSubscribeOptions = {
   protocolRole?: string;
 
   /**
+   * EventLog sequence number to resume from. When provided, catch-up events are
+   * replayed from the EventLog and an EOSE marker is delivered before live events.
+   */
+  cursor?: number;
+
+  /**
    * The delegated grant to sign on behalf of the logical author, which is the grantor (`grantedBy`) of the delegated grant.
    */
   delegatedGrant?: DataEncodedRecordsWriteMessage;
@@ -68,6 +74,7 @@ export class RecordsSubscribe extends AbstractMessage<RecordsSubscribeMessage> {
       filter           : Records.normalizeFilter(options.filter),
       dateSort         : options.dateSort,
       pagination       : options.pagination,
+      cursor           : options.cursor,
     };
 
     // delete all descriptor properties that are `undefined` else the code will encounter the following IPLD issue when attempting to generate CID:

--- a/packages/dwn-sdk-js/src/types/messages-types.ts
+++ b/packages/dwn-sdk-js/src/types/messages-types.ts
@@ -80,4 +80,10 @@ export type MessagesSubscribeDescriptor = {
   messageTimestamp: string;
   filters: MessagesFilter[];
   permissionGrantId?: string;
+  /**
+   * EventLog sequence number to resume from. When provided, the handler replays
+   * events from the EventLog starting after this cursor instead of returning no
+   * initial snapshot. An EOSE marker is sent after catch-up.
+   */
+  cursor?: number;
 };

--- a/packages/dwn-sdk-js/src/types/records-types.ts
+++ b/packages/dwn-sdk-js/src/types/records-types.ts
@@ -122,6 +122,12 @@ export type RecordsSubscribeDescriptor = {
   filter: RecordsFilter;
   dateSort?: DateSort;
   pagination?: Pagination;
+  /**
+   * EventLog sequence number to resume from. When provided, the handler replays
+   * events from the EventLog starting after this cursor instead of querying the
+   * MessageStore for an initial snapshot. An EOSE marker is sent after catch-up.
+   */
+  cursor?: number;
 };
 
 export type RecordsFilter = {

--- a/packages/dwn-sdk-js/src/types/subscriptions.ts
+++ b/packages/dwn-sdk-js/src/types/subscriptions.ts
@@ -2,7 +2,12 @@ import type { RecordsWriteMessage } from './records-types.js';
 import type { Filter, KeyValues } from './query-types.js';
 import type { GenericMessage, GenericMessageReply, MessageSubscription } from './message-types.js';
 
-export type EventListener = (tenant: string, event: MessageEvent, indexes: KeyValues) => void;
+/**
+ * Internal listener type used by {@link EventLog.emit} to notify in-process
+ * subscribers. Not intended for direct consumer use — consumers should use
+ * {@link SubscriptionListener} via {@link EventLog.subscribe}.
+ */
+export type EventListener = (tenant: string, event: MessageEvent, indexes: KeyValues, seq: number) => void;
 
 /**
  * MessageEvent contains the message being emitted and an optional initial write message.
@@ -20,6 +25,64 @@ export interface EventSubscription {
 
 export type SubscriptionReply = GenericMessageReply & {
   subscription?: MessageSubscription;
+};
+
+// ---------------------------------------------------------------------------
+// Subscription events — discriminated union for event + EOSE delivery
+// ---------------------------------------------------------------------------
+
+/**
+ * A regular subscription event carrying a message and its EventLog sequence number.
+ */
+export type SubscriptionEvent = {
+  type : 'event';
+  /** Monotonic EventLog sequence number. Clients should track this for cursor-based resume. */
+  seq : number;
+  /** The event payload (message + optional initialWrite). */
+  event : MessageEvent;
+};
+
+/**
+ * End-of-Stored-Events marker. Sent after all catch-up events have been replayed
+ * from the EventLog. After EOSE, all subsequent events are live.
+ *
+ * Only delivered when a subscription is created with a `cursor`. Subscriptions
+ * without a cursor never receive EOSE.
+ */
+export type SubscriptionEose = {
+  type : 'eose';
+  /** The sequence number of the last stored event that was replayed, or -1 if none. */
+  seq : number;
+};
+
+/**
+ * Discriminated union of subscription event types delivered to
+ * {@link SubscriptionListener} callbacks.
+ */
+export type SubscriptionMessage = SubscriptionEvent | SubscriptionEose;
+
+/**
+ * Callback for {@link EventLog.subscribe}. Receives either a regular event
+ * (with seq) or an EOSE marker indicating catch-up replay is complete.
+ */
+export type SubscriptionListener = (message: SubscriptionMessage) => void;
+
+/**
+ * Options for {@link EventLog.subscribe}.
+ */
+export type EventLogSubscribeOptions = {
+  /**
+   * EventLog sequence number to resume from (exclusive — events with seq > cursor
+   * are replayed). When provided, stored events are replayed first, followed by
+   * an EOSE marker, then live events. When omitted, only live events are delivered.
+   */
+  cursor? : number;
+
+  /**
+   * Filters evaluated against event indexes. Events must match at least one
+   * filter (OR semantics). When omitted, all events are delivered.
+   */
+  filters? : Filter[];
 };
 
 // ---------------------------------------------------------------------------
@@ -71,14 +134,15 @@ export type EventLogReadResult = {
 
 /**
  * The EventLog interface provides persistent, ordered event storage with
- * cursor-based reads and in-process subscription support.
+ * cursor-based reads and subscription support.
  *
- * It persists events before delivery and
- * exposing monotonic sequence numbers that enable cursor-based resume after
- * disconnects.
+ * It persists events before delivery, exposing monotonic sequence numbers
+ * that enable cursor-based resume after disconnects.
  *
  * The interface is intentionally transport-agnostic — implementations can be
  * backed by LevelDB (embedded), SQL, NATS JetStream, Redis Streams, etc.
+ * Each implementation owns the catch-up + live transition strategy appropriate
+ * to its backend (e.g., NATS pull consumers, Redis XREAD, in-memory buffering).
  */
 export interface EventLog {
   /**
@@ -93,11 +157,21 @@ export interface EventLog {
   read(tenant: string, options?: EventLogReadOptions): Promise<EventLogReadResult>;
 
   /**
-   * Register an in-process listener for live events on a tenant.
-   * This is the real-time notification path used by embedded DWN instances.
-   * For remote delivery, the server reads from the log and pushes over WebSocket.
+   * Subscribe to events for a tenant.
+   *
+   * When `options.cursor` is provided, the implementation replays stored events
+   * from that cursor through the listener, delivers an EOSE marker, then
+   * continues with live events. The catch-up → live transition (including
+   * buffering and deduplication) is owned by the implementation.
+   *
+   * When `options.cursor` is omitted, only live events are delivered.
+   *
+   * @param tenant   The tenant DID to subscribe to.
+   * @param id       A unique subscription identifier (used for close/tracking).
+   * @param listener Callback that receives {@link SubscriptionMessage} events.
+   * @param options  Optional cursor and filters for catch-up replay.
    */
-  subscribe(tenant: string, id: string, listener: EventListener): Promise<EventSubscription>;
+  subscribe(tenant: string, id: string, listener: SubscriptionListener, options?: EventLogSubscribeOptions): Promise<EventSubscription>;
 
   /**
    * Delete events older than the given sequence number or ISO-8601 timestamp.

--- a/packages/dwn-sdk-js/tests/event-emitter-event-log.spec.ts
+++ b/packages/dwn-sdk-js/tests/event-emitter-event-log.spec.ts
@@ -1,0 +1,412 @@
+import type { SubscriptionMessage } from '../src/types/subscriptions.js';
+
+import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
+
+import { EventEmitterEventLog } from '../src/event-stream/event-emitter-event-log.js';
+
+describe('EventEmitterEventLog', () => {
+  let eventLog: EventEmitterEventLog;
+
+  beforeEach(async () => {
+    eventLog = new EventEmitterEventLog();
+    await eventLog.open();
+  });
+
+  afterAll(async () => {
+    await eventLog.close();
+  });
+
+  describe('emit()', () => {
+    it('should assign monotonically increasing sequence numbers per tenant', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      const seq1 = await eventLog.emit(tenant, event, { key: 'val1' });
+      const seq2 = await eventLog.emit(tenant, event, { key: 'val2' });
+      const seq3 = await eventLog.emit(tenant, event, { key: 'val3' });
+
+      expect(seq1).toBe(1);
+      expect(seq2).toBe(2);
+      expect(seq3).toBe(3);
+    });
+
+    it('should maintain independent sequence counters per tenant', async () => {
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      const seqAlice = await eventLog.emit('did:example:alice', event, {});
+      const seqBob = await eventLog.emit('did:example:bob', event, {});
+
+      expect(seqAlice).toBe(1);
+      expect(seqBob).toBe(1);
+    });
+
+    it('should return -1 when EventLog is closed', async () => {
+      await eventLog.close();
+
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+      const seq = await eventLog.emit('did:example:alice', event, {});
+
+      expect(seq).toBe(-1);
+
+      // reopen for afterAll cleanup
+      await eventLog.open();
+    });
+  });
+
+  describe('read()', () => {
+    it('should read all events for a tenant', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      await eventLog.emit(tenant, event, { schema: 'http://a' });
+      await eventLog.emit(tenant, event, { schema: 'http://b' });
+
+      const result = await eventLog.read(tenant);
+      expect(result.events.length).toBe(2);
+      expect(result.events[0].seq).toBe(1);
+      expect(result.events[1].seq).toBe(2);
+      expect(result.cursor).toBe(2);
+    });
+
+    it('should read events after a cursor', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      await eventLog.emit(tenant, event, { schema: 'http://a' });
+      await eventLog.emit(tenant, event, { schema: 'http://b' });
+      await eventLog.emit(tenant, event, { schema: 'http://c' });
+
+      const result = await eventLog.read(tenant, { cursor: 2 });
+      expect(result.events.length).toBe(1);
+      expect(result.events[0].seq).toBe(3);
+      expect(result.cursor).toBe(3);
+    });
+
+    it('should apply filters during read', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      await eventLog.emit(tenant, event, { schema: 'http://match' });
+      await eventLog.emit(tenant, event, { schema: 'http://other' });
+      await eventLog.emit(tenant, event, { schema: 'http://match' });
+
+      const result = await eventLog.read(tenant, { filters: [{ schema: 'http://match' }] });
+      expect(result.events.length).toBe(2);
+      expect(result.events[0].seq).toBe(1);
+      expect(result.events[1].seq).toBe(3);
+    });
+
+    it('should return empty result for unknown tenant', async () => {
+      const result = await eventLog.read('did:example:unknown');
+      expect(result.events.length).toBe(0);
+      expect(result.cursor).toBe(-1);
+    });
+
+    it('should respect the limit option', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      await eventLog.emit(tenant, event, {});
+      await eventLog.emit(tenant, event, {});
+      await eventLog.emit(tenant, event, {});
+
+      const result = await eventLog.read(tenant, { limit: 2 });
+      expect(result.events.length).toBe(2);
+      expect(result.cursor).toBe(2);
+    });
+  });
+
+  describe('subscribe() — live only (no cursor)', () => {
+    it('should deliver live events to subscriber', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      const received: SubscriptionMessage[] = [];
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); });
+
+      await eventLog.emit(tenant, event, {});
+      await eventLog.emit(tenant, event, {});
+
+      expect(received.length).toBe(2);
+      expect(received[0].type).toBe('event');
+      expect(received[1].type).toBe('event');
+      if (received[0].type === 'event') {
+        expect(received[0].seq).toBe(1);
+      }
+      if (received[1].type === 'event') {
+        expect(received[1].seq).toBe(2);
+      }
+    });
+
+    it('should NOT deliver EOSE when no cursor is provided', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      // Emit some events before subscribing.
+      await eventLog.emit(tenant, event, {});
+
+      const received: SubscriptionMessage[] = [];
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); });
+
+      // Emit after subscribing.
+      await eventLog.emit(tenant, event, {});
+
+      // Should only have the live event, no EOSE.
+      expect(received.length).toBe(1);
+      expect(received[0].type).toBe('event');
+    });
+
+    it('should filter live events', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      const received: SubscriptionMessage[] = [];
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, {
+        filters: [{ schema: 'http://match' }],
+      });
+
+      await eventLog.emit(tenant, event, { schema: 'http://match' });
+      await eventLog.emit(tenant, event, { schema: 'http://other' });
+      await eventLog.emit(tenant, event, { schema: 'http://match' });
+
+      expect(received.length).toBe(2);
+    });
+
+    it('should stop delivering events after close', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      const received: SubscriptionMessage[] = [];
+      const sub = await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); });
+
+      await eventLog.emit(tenant, event, {});
+      expect(received.length).toBe(1);
+
+      await sub.close();
+
+      await eventLog.emit(tenant, event, {});
+      expect(received.length).toBe(1); // no new events after close
+    });
+  });
+
+  describe('subscribe() — cursor mode (catch-up + EOSE + live)', () => {
+    it('should replay stored events from cursor and deliver EOSE', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      // Emit 3 events before subscribing.
+      await eventLog.emit(tenant, event, { idx: '1' });
+      await eventLog.emit(tenant, event, { idx: '2' });
+      await eventLog.emit(tenant, event, { idx: '3' });
+
+      // Subscribe with cursor=0 to replay all.
+      const received: SubscriptionMessage[] = [];
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 0 });
+
+      // Should receive 3 catch-up events + EOSE.
+      expect(received.length).toBe(4);
+      expect(received[0].type).toBe('event');
+      expect(received[1].type).toBe('event');
+      expect(received[2].type).toBe('event');
+      expect(received[3].type).toBe('eose');
+
+      if (received[0].type === 'event') { expect(received[0].seq).toBe(1); }
+      if (received[1].type === 'event') { expect(received[1].seq).toBe(2); }
+      if (received[2].type === 'event') { expect(received[2].seq).toBe(3); }
+      if (received[3].type === 'eose') { expect(received[3].seq).toBe(3); }
+    });
+
+    it('should replay only events after the given cursor', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      await eventLog.emit(tenant, event, {});
+      await eventLog.emit(tenant, event, {});
+      await eventLog.emit(tenant, event, {});
+
+      // Subscribe with cursor=2 — should only replay event with seq=3.
+      const received: SubscriptionMessage[] = [];
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 2 });
+
+      expect(received.length).toBe(2); // 1 event + EOSE
+      expect(received[0].type).toBe('event');
+      expect(received[1].type).toBe('eose');
+
+      if (received[0].type === 'event') { expect(received[0].seq).toBe(3); }
+      if (received[1].type === 'eose') { expect(received[1].seq).toBe(3); }
+    });
+
+    it('should deliver EOSE with the cursor value when no stored events match', async () => {
+      const tenant = 'did:example:alice';
+
+      // No events emitted. Subscribe with cursor=0.
+      const received: SubscriptionMessage[] = [];
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 0 });
+
+      // Should just get EOSE. The seq is the `read()` result cursor, which is
+      // the original cursor value (0) when no events were returned.
+      expect(received.length).toBe(1);
+      expect(received[0].type).toBe('eose');
+      if (received[0].type === 'eose') { expect(received[0].seq).toBe(0); }
+    });
+
+    it('should continue delivering live events after EOSE', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      // Emit 1 event before subscribing.
+      await eventLog.emit(tenant, event, { idx: '1' });
+
+      const received: SubscriptionMessage[] = [];
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 0 });
+
+      // Should have: 1 catch-up event + EOSE.
+      expect(received.length).toBe(2);
+      expect(received[0].type).toBe('event');
+      expect(received[1].type).toBe('eose');
+
+      // Now emit a live event.
+      await eventLog.emit(tenant, event, { idx: '2' });
+
+      // Should now have the live event appended.
+      expect(received.length).toBe(3);
+      expect(received[2].type).toBe('event');
+      if (received[2].type === 'event') { expect(received[2].seq).toBe(2); }
+    });
+
+    it('should apply filters to both catch-up and live events', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      // Emit events with different schemas.
+      await eventLog.emit(tenant, event, { schema: 'http://match' });
+      await eventLog.emit(tenant, event, { schema: 'http://other' });
+      await eventLog.emit(tenant, event, { schema: 'http://match' });
+
+      const received: SubscriptionMessage[] = [];
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, {
+        cursor  : 0,
+        filters : [{ schema: 'http://match' }],
+      });
+
+      // Catch-up: 2 matching events + EOSE. (Event at seq=2 filtered out.)
+      expect(received.length).toBe(3);
+      expect(received[0].type).toBe('event');
+      expect(received[1].type).toBe('event');
+      expect(received[2].type).toBe('eose');
+
+      if (received[0].type === 'event') { expect(received[0].seq).toBe(1); }
+      if (received[1].type === 'event') { expect(received[1].seq).toBe(3); }
+
+      // Emit live events — only matching ones should arrive.
+      await eventLog.emit(tenant, event, { schema: 'http://other' });
+      await eventLog.emit(tenant, event, { schema: 'http://match' });
+
+      expect(received.length).toBe(4); // +1 matching live event
+      if (received[3].type === 'event') { expect(received[3].seq).toBe(5); }
+    });
+
+    it('should deduplicate live events that arrived during catch-up', async () => {
+      // This test verifies the buffering + dedup behavior.
+      // We need to simulate a live event arriving while stored events are being read.
+      // Since EventEmitterEventLog.subscribe is synchronous in-memory, the only way
+      // to get overlap is if emit() is called between registering the mitt handler and
+      // the read() call completing. In the current sync implementation, this can't
+      // naturally happen, so we verify the invariant that no duplicate seq appears.
+
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      // Emit 2 events.
+      await eventLog.emit(tenant, event, { idx: '1' });
+      await eventLog.emit(tenant, event, { idx: '2' });
+
+      const received: SubscriptionMessage[] = [];
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 0 });
+
+      // 2 catch-up events + EOSE.
+      expect(received.length).toBe(3);
+
+      // Verify no duplicate seqs.
+      const eventSeqs = received.filter(m => m.type === 'event').map(m => m.seq);
+      const uniqueSeqs = new Set(eventSeqs);
+      expect(uniqueSeqs.size).toBe(eventSeqs.length);
+    });
+
+    it('should isolate subscriptions between tenants in cursor mode', async () => {
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      // Emit for alice.
+      await eventLog.emit('did:example:alice', event, {});
+      await eventLog.emit('did:example:alice', event, {});
+
+      // Emit for bob.
+      await eventLog.emit('did:example:bob', event, {});
+
+      // Subscribe to alice with cursor.
+      const aliceReceived: SubscriptionMessage[] = [];
+      await eventLog.subscribe('did:example:alice', 'sub-alice', (msg) => { aliceReceived.push(msg); }, { cursor: 0 });
+
+      // Should only get alice's 2 events + EOSE.
+      expect(aliceReceived.length).toBe(3);
+      expect(aliceReceived[0].type).toBe('event');
+      expect(aliceReceived[1].type).toBe('event');
+      expect(aliceReceived[2].type).toBe('eose');
+    });
+  });
+
+  describe('trim()', () => {
+    it('should trim events by sequence number', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      await eventLog.emit(tenant, event, {});
+      await eventLog.emit(tenant, event, {});
+      await eventLog.emit(tenant, event, {});
+
+      await eventLog.trim(tenant, 3); // trim events with seq < 3
+
+      const result = await eventLog.read(tenant);
+      expect(result.events.length).toBe(1);
+      expect(result.events[0].seq).toBe(3);
+    });
+
+    it('should trim events by ISO-8601 timestamp', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      const oldTime = '2020-01-01T00:00:00.000000Z';
+      const newTime = '2025-01-01T00:00:00.000000Z';
+
+      await eventLog.emit(tenant, event, { messageTimestamp: oldTime });
+      await eventLog.emit(tenant, event, { messageTimestamp: newTime });
+
+      await eventLog.trim(tenant, '2023-01-01T00:00:00.000000Z');
+
+      const result = await eventLog.read(tenant);
+      expect(result.events.length).toBe(1);
+    });
+  });
+
+  describe('maxEventsPerTenant eviction', () => {
+    it('should evict oldest events when limit is exceeded', async () => {
+      const smallLog = new EventEmitterEventLog({ maxEventsPerTenant: 3 });
+      await smallLog.open();
+
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      await smallLog.emit(tenant, event, { idx: '1' });
+      await smallLog.emit(tenant, event, { idx: '2' });
+      await smallLog.emit(tenant, event, { idx: '3' });
+      await smallLog.emit(tenant, event, { idx: '4' }); // should evict seq=1
+
+      const result = await smallLog.read(tenant);
+      expect(result.events.length).toBe(3);
+      expect(result.events[0].seq).toBe(2); // seq=1 was evicted
+      expect(result.events[2].seq).toBe(4);
+
+      await smallLog.close();
+    });
+  });
+});

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -201,6 +201,80 @@ export function testMessagesSubscribeHandler(): void {
         expect(subscriptionReply.subscription).toBeUndefined();
       });
 
+      describe('cursor-based subscriptions', () => {
+        it('should deliver catch-up events through the handler when cursor is provided', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+          // Write a record before subscribing.
+          const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice });
+          const write1Reply = await dwn.processMessage(alice.did, write1.message, { dataStream: write1.dataStream });
+          expect(write1Reply.status.code).toBe(202);
+          const write1Cid = await Message.getCid(write1.message);
+
+          // Subscribe with cursor=0 to catch up from the beginning.
+          const messageCids: string[] = [];
+          const handler = async (event: MessageEvent): Promise<void> => {
+            const { message: msg } = event;
+            const cid = await Message.getCid(msg);
+            messageCids.push(cid);
+          };
+
+          const { message: subMessage } = await TestDataGenerator.generateMessagesSubscribe({
+            author : alice,
+            cursor : 0,
+          });
+          const subReply = await dwn.processMessage(alice.did, subMessage, { subscriptionHandler: handler });
+          expect(subReply.status.code).toBe(200);
+          expect(subReply.subscription).toBeDefined();
+
+          // Wait for the catch-up events.
+          // NOTE: with cursor mode, the protocol configure + record write should both come through.
+          await Poller.pollUntilSuccessOrTimeout(async () => {
+            expect(messageCids.length).toBeGreaterThanOrEqual(1);
+            expect(messageCids).toContain(write1Cid);
+          });
+        });
+
+        it('should receive live events after cursor catch-up completes', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+          // Write before subscribing.
+          const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice });
+          await dwn.processMessage(alice.did, write1.message, { dataStream: write1.dataStream });
+
+          const messageCids: string[] = [];
+          const handler = async (event: MessageEvent): Promise<void> => {
+            const { message: msg } = event;
+            const cid = await Message.getCid(msg);
+            messageCids.push(cid);
+          };
+
+          const { message: subMessage } = await TestDataGenerator.generateMessagesSubscribe({
+            author : alice,
+            cursor : 0,
+          });
+          const subReply = await dwn.processMessage(alice.did, subMessage, { subscriptionHandler: handler });
+          expect(subReply.status.code).toBe(200);
+
+          // Wait for catch-up.
+          await Poller.pollUntilSuccessOrTimeout(async () => {
+            expect(messageCids.length).toBeGreaterThanOrEqual(1);
+          });
+
+          // Write a live record.
+          const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice });
+          await dwn.processMessage(alice.did, write2.message, { dataStream: write2.dataStream });
+          const write2Cid = await Message.getCid(write2.message);
+
+          // Wait for the live event.
+          await Poller.pollUntilSuccessOrTimeout(async () => {
+            expect(messageCids).toContain(write2Cid);
+          });
+        });
+      });
+
       describe('grant based subscribes', () => {
         it('allows subscribe of messages with matching interface and method grant scope', async () => {
           // scenario: Alice gives Bob permission to subscribe for all of her messages

--- a/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
@@ -260,6 +260,114 @@ export function testRecordsSubscribeHandler(): void {
         });
       });
 
+      describe('cursor-based subscriptions', () => {
+        it('should use EventLog catch-up when cursor is provided (no initial MessageStore query)', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+          // Write records before subscribing.
+          const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://cursor-test' });
+          const write1Reply = await dwn.processMessage(alice.did, write1.message, { dataStream: write1.dataStream });
+          expect(write1Reply.status.code).toBe(202);
+
+          const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://cursor-test' });
+          const write2Reply = await dwn.processMessage(alice.did, write2.message, { dataStream: write2.dataStream });
+          expect(write2Reply.status.code).toBe(202);
+
+          // Subscribe with cursor=0. With a cursor, the handler takes the EventLog catch-up path,
+          // meaning NO entries/cursor are returned (the catch-up is delivered through the subscription handler).
+          const receivedEvents: RecordEvent[] = [];
+          const subscriptionHandler: RecordSubscriptionHandler = (event): void => { receivedEvents.push(event); };
+          const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({
+            author : alice,
+            filter : { schema: 'http://cursor-test' },
+            cursor : 0,
+          });
+
+          const subReply = await dwn.processMessage(alice.did, recordsSubscribe.message, { subscriptionHandler });
+          expect(subReply.status.code).toBe(200);
+          expect(subReply.subscription).toBeDefined();
+
+          // In cursor mode, initial entries are NOT returned via the reply —
+          // they come through the subscription handler as catch-up events.
+          // The handler wraps SubscriptionListener→RecordSubscriptionHandler,
+          // so we get plain RecordEvents (EOSE is silently consumed).
+          await Poller.pollUntilSuccessOrTimeout(async () => {
+            expect(receivedEvents.length).toBeGreaterThanOrEqual(2);
+          });
+
+          // Verify the catch-up events are our records.
+          const recordIds = receivedEvents.map(e => (e.message as RecordsWriteMessage).recordId);
+          expect(recordIds).toContain(write1.message.recordId);
+          expect(recordIds).toContain(write2.message.recordId);
+        });
+
+        it('should receive live events after cursor catch-up', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+          // Write a record before subscribing.
+          const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://cursor-live' });
+          await dwn.processMessage(alice.did, write1.message, { dataStream: write1.dataStream });
+
+          const receivedEvents: RecordEvent[] = [];
+          const subscriptionHandler: RecordSubscriptionHandler = (event): void => { receivedEvents.push(event); };
+          const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({
+            author : alice,
+            filter : { schema: 'http://cursor-live' },
+            cursor : 0,
+          });
+          const subReply = await dwn.processMessage(alice.did, recordsSubscribe.message, { subscriptionHandler });
+          expect(subReply.status.code).toBe(200);
+
+          // Wait for catch-up event.
+          await Poller.pollUntilSuccessOrTimeout(async () => {
+            expect(receivedEvents.length).toBeGreaterThanOrEqual(1);
+          });
+
+          // Write a live record after subscribing.
+          const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://cursor-live' });
+          await dwn.processMessage(alice.did, write2.message, { dataStream: write2.dataStream });
+
+          // Wait for the live event.
+          await Poller.pollUntilSuccessOrTimeout(async () => {
+            expect(receivedEvents.length).toBeGreaterThanOrEqual(2);
+          });
+
+          const recordIds = receivedEvents.map(e => (e.message as RecordsWriteMessage).recordId);
+          expect(recordIds).toContain(write1.message.recordId);
+          expect(recordIds).toContain(write2.message.recordId);
+        });
+
+        it('should filter catch-up events when cursor and filter are provided', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+          // Write records with different schemas.
+          const matchWrite = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://filter-match' });
+          await dwn.processMessage(alice.did, matchWrite.message, { dataStream: matchWrite.dataStream });
+
+          const noMatchWrite = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://filter-other' });
+          await dwn.processMessage(alice.did, noMatchWrite.message, { dataStream: noMatchWrite.dataStream });
+
+          const receivedEvents: RecordEvent[] = [];
+          const subscriptionHandler: RecordSubscriptionHandler = (event): void => { receivedEvents.push(event); };
+          const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({
+            author : alice,
+            filter : { schema: 'http://filter-match' },
+            cursor : 0,
+          });
+          const subReply = await dwn.processMessage(alice.did, recordsSubscribe.message, { subscriptionHandler });
+          expect(subReply.status.code).toBe(200);
+
+          // Wait for catch-up events. Should only get the matching one.
+          await Poller.pollUntilSuccessOrTimeout(async () => {
+            expect(receivedEvents.length).toBe(1);
+            expect((receivedEvents[0].message as RecordsWriteMessage).recordId).toBe(matchWrite.message.recordId);
+          });
+        });
+      });
+
       it('should return 400 if protocol is not normalized', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 

--- a/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
+++ b/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
@@ -200,6 +200,8 @@ export type GenerateRecordsSubscribeInput = {
     dateSort?: DateSort;
     pagination?: Pagination;
     protocolRole?: string;
+    /** EventLog cursor for catch-up + EOSE subscribe. */
+    cursor?: number;
 };
 
 export type GenerateRecordsSubscribeOutput = {
@@ -240,6 +242,8 @@ export type GenerateMessagesSubscribeInput = {
   filters?: MessagesFilter[];
   messageTimestamp?: string;
   permissionGrantId?: string;
+  /** EventLog cursor for catch-up + EOSE subscribe. */
+  cursor?: number;
 };
 
 export type GenerateMessagesSubscribeOutput = {
@@ -747,6 +751,7 @@ export class TestDataGenerator {
       dateSort         : input?.dateSort,
       pagination       : input?.pagination,
       protocolRole     : input?.protocolRole,
+      cursor           : input?.cursor,
     };
     removeUndefinedProperties(options);
 
@@ -827,6 +832,7 @@ export class TestDataGenerator {
       filters           : input?.filters,
       messageTimestamp  : input?.messageTimestamp,
       permissionGrantId : input?.permissionGrantId,
+      cursor            : input?.cursor,
       signer,
     };
     removeUndefinedProperties(options);


### PR DESCRIPTION
## Summary

Phase 2 of the EventLog subscription revamp: adds cursor-based resumption and End-of-Stored-Events (EOSE) markers so clients can reconnect and replay missed events without data loss.

Builds on Phase 1 (#274) which replaced the fire-and-forget EventStream with the persistent EventLog interface.

## Key Changes

- **`EventLog.subscribe()` gains cursor + filters options** — when a cursor is provided, stored events are replayed through the listener, an EOSE marker is delivered, then live events continue. The catch-up → live transition (buffering, dedup) is owned by each EventLog implementation, not the DWN handlers.
- **`SubscriptionMessage` discriminated union** (`event | eose`) with monotonic `seq` numbers — this is the `EventLog.subscribe()` listener contract. Handler callbacks (`RecordSubscriptionHandler`, `MessageSubscriptionHandler`) remain simple `(event) => void`.
- **`RecordsSubscribe` / `MessagesSubscribe` descriptors** gain optional `cursor` field with JSON schema validation.
- **Handlers simplified** — `RecordsSubscribeHandler` and `MessagesSubscribeHandler` delegate filtering and catch-up entirely to `EventLog.subscribe()`, removing `FilterUtility` imports.
- **`EventEmitterEventLog.subscribe()` rewritten** — cursor mode: register live listener → read stored events → buffer live events during read → deduplicate → deliver EOSE → transition to live.

## New Tests (27 tests added, 1029 total)

- **`event-emitter-event-log.spec.ts`** (20 tests) — emit, read, subscribe (live-only & cursor modes), trim, eviction
- **`records-subscribe.spec.ts`** (+3 cursor tests) — catch-up, live-after-catch-up, filtered catch-up
- **`messages-subscribe.spec.ts`** (+2 cursor tests) — catch-up, live-after-catch-up
- Test data generators updated to support `cursor` parameter

## Test Results

| Package | Result |
|---------|--------|
| `dwn-sdk-js` | 1029 pass, 0 fail |
| `agent` | 713 pass, 0 fail |
| `api` | 267 pass, 0 fail |
| Lint (all packages) | 0 errors, 0 warnings |

## Files Changed (15 files, +843/-40)

**Source:**
- `src/types/subscriptions.ts` — `SubscriptionEvent`, `SubscriptionEose`, `SubscriptionMessage`, `SubscriptionListener`, `EventLogSubscribeOptions` types; updated `EventLog.subscribe()` signature
- `src/types/records-types.ts` / `messages-types.ts` — `cursor` field on subscribe descriptors
- `src/event-stream/event-emitter-event-log.ts` — cursor catch-up + EOSE implementation
- `src/handlers/records-subscribe.ts` / `messages-subscribe.ts` — simplified handler logic
- `src/interfaces/records-subscribe.ts` / `messages-subscribe.ts` — `cursor` in options + descriptor
- `src/index.ts` — new type exports
- `json-schemas/interface-methods/records-subscribe.json` / `messages-subscribe.json` — `cursor` property

**Tests:**
- `tests/event-emitter-event-log.spec.ts` (new)
- `tests/handlers/records-subscribe.spec.ts` (+108 lines)
- `tests/handlers/messages-subscribe.spec.ts` (+74 lines)
- `tests/utils/test-data-generator.ts` (+6 lines)