### PR TITLE
fix: migrate permissions protocol URI to identity.foundation namespace

### DIFF
--- a/packages/agent/src/store-data-protocols.ts
+++ b/packages/agent/src/store-data-protocols.ts
@@ -1,7 +1,7 @@
 import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
 
 export const IdentityProtocolDefinition: ProtocolDefinition = {
-  protocol  : 'http://identity.foundation/protocols/web5/identity-store',
+  protocol  : 'https://identity.foundation/protocols/web5/identity-store',
   published : false,
   types     : {
     portableDid: {
@@ -47,7 +47,7 @@ export const KeyDeliveryProtocolDefinition: ProtocolDefinition = {
 };
 
 export const JwkProtocolDefinition: ProtocolDefinition = {
-  protocol  : 'http://identity.foundation/protocols/web5/jwk-store',
+  protocol  : 'https://identity.foundation/protocols/web5/jwk-store',
   published : false,
   types     : {
     privateJwk: {

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -90,7 +90,7 @@ describe('web5 connect', () => {
         descriptor : {
           interface    : 'Records',
           method       : 'Write',
-          protocol     : 'https://tbd.website/dwn/permissions',
+          protocol     : 'https://identity.foundation/dwn/permissions',
           protocolPath : 'grant',
           recipient:
             'did:dht:pfm8f6w57srtci1k3spp73dqgk5eo3afkimtyi4zcqc5hg1ui5mo',

--- a/packages/dwn-sdk-js/src/protocols/permissions.ts
+++ b/packages/dwn-sdk-js/src/protocols/permissions.ts
@@ -84,7 +84,7 @@ export class PermissionsProtocol {
   /**
    * The URI of the DWN Permissions protocol.
    */
-  public static readonly uri = 'https://tbd.website/dwn/permissions';
+  public static readonly uri = 'https://identity.foundation/dwn/permissions';
 
   /**
    * The protocol path of the `request` record.


### PR DESCRIPTION
## Summary

Moves the DWN permissions protocol URI from the legacy `tbd.website` domain to the `identity.foundation` namespace, and fixes an `http://` vs `https://` inconsistency in agent store protocol URIs.

Closes #277.

## Changes

### `packages/dwn-sdk-js/src/protocols/permissions.ts`
- `PermissionsProtocol.uri`: `https://tbd.website/dwn/permissions` → `https://identity.foundation/dwn/permissions`

### `packages/agent/src/store-data-protocols.ts`
- `IdentityProtocolDefinition.protocol`: `http://` → `https://identity.foundation/protocols/web5/identity-store`
- `JwkProtocolDefinition.protocol`: `http://` → `https://identity.foundation/protocols/web5/jwk-store`

### `packages/agent/tests/connect.spec.ts`
- Updated hard-coded permissions protocol URI string in test fixture

## Migration notes

- This is a **breaking change** for existing DWN data: records written under the old `https://tbd.website/dwn/permissions` protocol URI will not be found when querying with the new URI. A data migration strategy may be needed for production deployments.
- The `http://` → `https://` fix for `identity-store` and `jwk-store` similarly affects existing agent store data.
- All 63 existing `identity.foundation` URIs (JSON schemas, other protocols, schema identifiers) were already correct and remain unchanged.