### PR TITLE
fix(dwn-sdk-js): re-serialize IndexedDB queries and harden Firefox browser tests

### DIFF
--- a/packages/dwn-sdk-js/src/store/index-level.ts
+++ b/packages/dwn-sdk-js/src/store/index-level.ts
@@ -477,9 +477,18 @@ export class IndexLevel {
     }
 
     try {
-      await Promise.all(filters.map((filter: Filter): Promise<void> => {
-        return this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, options);
-      }));
+      // Execute filters sequentially rather than with Promise.all.
+      // Firefox's IndexedDB implementation has two related async issues that cause flaky failures:
+      //   1. Concurrent cursors/transactions can silently miss recently-committed data
+      //   2. A read transaction opened immediately after a write transaction's oncomplete event
+      //      can fail to see the written data (write-read race)
+      // Serializing eliminates both races. Performance impact is negligible: only 3 call sites
+      // (non-owner RecordsQuery/Subscribe/Count) ever pass multiple filters, and each filter
+      // reduces to a single bounded LevelDB range scan completing in single-digit ms.
+      // See: https://github.com/enboxorg/enbox/issues/264
+      for (const filter of filters) {
+        await this.executeSingleFilterQuery(tenant, filter, sortProperty, matches, options);
+      }
     } catch (error) {
       if ((error as DwnError).code === DwnErrorCode.IndexInvalidSortPropertyInMemory) {
         // return empty results if the sort property is invalid.
@@ -501,6 +510,10 @@ export class IndexLevel {
 
   /**
    * Execute a filtered query against a single filter and return all results.
+   *
+   * Sub-queries (exact match, range, OneOf) are executed sequentially to avoid opening
+   * multiple concurrent IndexedDB cursors. Firefox's IDB implementation intermittently
+   * drops results when cursors overlap — see https://github.com/enboxorg/enbox/issues/264
    */
   private async executeSingleFilterQuery(
     tenant: string,
@@ -510,42 +523,8 @@ export class IndexLevel {
     levelOptions?: IndexLevelOptions
   ): Promise<void> {
 
-    // Note: We have an array of Promises in order to support OR (anyOf) matches when given a list of accepted values for a property
-    const filterPromises: Promise<IndexedItem[]>[] = [];
-
-    // If the filter is empty, then we just iterate over one of the indexes that contains all the records and return all items.
-    if (isEmptyObject(filter)) {
-      const getAllItemsPromise = this.getAllItems(tenant, sortProperty);
-      filterPromises.push(getAllItemsPromise);
-    }
-
-    // else the filter is not empty
-    const searchFilter = FilterSelector.reduceFilter(filter);
-    for (const propertyName in searchFilter) {
-      const propertyFilter = searchFilter[propertyName];
-      // We will find the union of these many individual queries later.
-      if (FilterUtility.isEqualFilter(propertyFilter)) {
-        // propertyFilter is an EqualFilter, meaning it is a non-object primitive type
-        const exactMatchesPromise = this.filterExactMatches(tenant, propertyName, propertyFilter, levelOptions);
-        filterPromises.push(exactMatchesPromise);
-      } else if (FilterUtility.isOneOfFilter(propertyFilter)) {
-        // `propertyFilter` is a OneOfFilter
-        // Support OR matches by querying for each values separately, then adding them to the promises array.
-        for (const propertyValue of new Set(propertyFilter)) {
-          const exactMatchesPromise = this.filterExactMatches(tenant, propertyName, propertyValue, levelOptions);
-          filterPromises.push(exactMatchesPromise);
-        }
-      } else if (FilterUtility.isRangeFilter(propertyFilter)) {
-        // `propertyFilter` is a `RangeFilter`
-        const rangeMatchesPromise = this.filterRangeMatches(tenant, propertyName, propertyFilter, levelOptions);
-        filterPromises.push(rangeMatchesPromise);
-      }
-    }
-
-    // acting as an OR match for the property, any of the promises returning a match will be treated as a property match
-    for (const promise of filterPromises) {
-      const indexItems = await promise;
-      // reminder: the promise returns a list of IndexedItem satisfying a particular property match
+    // Collects results from each sub-query sequentially to avoid concurrent IndexedDB cursor races in Firefox.
+    const processResults = (indexItems: IndexedItem[]): void => {
       for (const indexedItem of indexItems) {
         // short circuit: if a data is already included to the final matched key set (by a different `Filter`),
         // no need to evaluate if the data satisfies this current filter being evaluated
@@ -560,6 +539,36 @@ export class IndexLevel {
         }
 
         matches.set(indexedItem.messageCid, indexedItem);
+      }
+    };
+
+    // If the filter is empty, then we just iterate over one of the indexes that contains all the records and return all items.
+    if (isEmptyObject(filter)) {
+      const allItems = await this.getAllItems(tenant, sortProperty);
+      processResults(allItems);
+      return;
+    }
+
+    // else the filter is not empty
+    const searchFilter = FilterSelector.reduceFilter(filter);
+    for (const propertyName in searchFilter) {
+      const propertyFilter = searchFilter[propertyName];
+      // We will find the union of these many individual queries later.
+      if (FilterUtility.isEqualFilter(propertyFilter)) {
+        // propertyFilter is an EqualFilter, meaning it is a non-object primitive type
+        const exactMatches = await this.filterExactMatches(tenant, propertyName, propertyFilter, levelOptions);
+        processResults(exactMatches);
+      } else if (FilterUtility.isOneOfFilter(propertyFilter)) {
+        // `propertyFilter` is a OneOfFilter
+        // Support OR matches by querying for each value separately and sequentially.
+        for (const propertyValue of new Set(propertyFilter)) {
+          const exactMatches = await this.filterExactMatches(tenant, propertyName, propertyValue, levelOptions);
+          processResults(exactMatches);
+        }
+      } else if (FilterUtility.isRangeFilter(propertyFilter)) {
+        // `propertyFilter` is a `RangeFilter`
+        const rangeMatches = await this.filterRangeMatches(tenant, propertyName, propertyFilter, levelOptions);
+        processResults(rangeMatches);
       }
     }
   }

--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -76,6 +76,7 @@ export default defineConfig({
 
       // --- Dual-format packages (CJS default, ESM via exports) ---
       // Pre-bundling these avoids edge cases where Vite picks the CJS entry.
+      'mitt',
       '@js-temporal/polyfill',
       '@noble/ciphers/aes',
       '@noble/ciphers/chacha',
@@ -148,6 +149,11 @@ export default defineConfig({
       'tests/scenarios/aggregator.spec.ts',
     ],
     testTimeout : 15_000,
+    // Retry failed tests once in CI. Firefox's ESM loader can occasionally
+    // crash on dynamic module imports even with noDiscovery enabled — a
+    // single retry is enough to recover from transient loader failures
+    // without masking real bugs (real failures are deterministic and fail both times).
+    retry: isCI ? 1 : 0,
     coverage: {
       provider         : 'istanbul',
       reporter         : ['text', 'lcov'],


### PR DESCRIPTION
## Summary

- Re-serialize IndexedDB queries in `queryWithInMemoryPaging` and `executeSingleFilterQuery` to fix Firefox CI flakes caused by concurrent cursor/transaction races
- Add `mitt` to `optimizeDeps.include` — dual-format package (CJS default) reachable via barrel export, was missing from the explicit pre-bundle list
- Add `retry: 1` in CI to recover from transient Firefox ESM loader crashes that persist even with `noDiscovery`

## Context

PR #268 restored concurrent `Promise.all` query execution, believing the root cause was solely inter-file test parallelism (fixed by `fileParallelism: false` in #266). This was incorrect — there are two independent Firefox IndexedDB issues:

1. **Concurrent cursors** silently miss recently-committed data (intra-query race)
2. **Write-read visibility race** — a read transaction opened immediately after a write's `oncomplete` can fail to see the written data

#268 only fixed the inter-file issue; re-serializing fixes the intra-query issue. Both fixes are needed.

Firefox CI failures returned immediately after #268 merged, hitting different tests each run:
- `permissions.spec.ts` — `GrantAuthorizationGrantMissing` (put-then-query race)
- `aggregator.spec.ts` — wrong result count (concurrent cursor miss)
- `records-write.spec.ts` — dynamic import error (Failure Mode 1, addressed by `mitt` + `retry`)

## Performance Impact

Negligible. Only 3 of 26 `messageStore.query()` call sites ever pass multiple filters (non-owner RecordsQuery/Subscribe/Count). Each filter reduces to a single bounded LevelDB range scan completing in single-digit ms. Estimated ~5ms additional latency per affected query, browser-only.

See #264 for the full investigation, Option D (single-transaction) infeasibility analysis, and detailed call-site breakdown.

Closes #264