### PR TITLE
feat(dwn-sdk-js): use opaque string cursors for cross-implementation compatibility (Phase 2)

### DIFF
--- a/packages/dwn-sdk-js/json-schemas/interface-methods/messages-subscribe.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/messages-subscribe.json
@@ -46,8 +46,7 @@
           "type": "string"
         },
         "cursor": {
-          "type": "number",
-          "minimum": 0
+          "type": "string"
         }
       }
     }

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-subscribe.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-subscribe.json
@@ -63,8 +63,7 @@
           "type": "string"
         },
         "cursor": {
-          "type": "number",
-          "minimum": 0
+          "type": "string"
         }
       }
     }

--- a/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
@@ -96,13 +96,13 @@ export class EventEmitterEventLog implements EventLog {
     this.tenantSeqs.clear();
   }
 
-  public async emit(tenant: string, event: MessageEvent, indexes: KeyValues): Promise<number> {
+  public async emit(tenant: string, event: MessageEvent, indexes: KeyValues): Promise<string> {
     if (!this.isOpen) {
       this.errorHandler(new DwnError(
         DwnErrorCode.EventLogNotOpenError,
         'a message emitted when EventLog is closed'
       ));
-      return -1;
+      return '';
     }
 
     // Assign a monotonic sequence number for this tenant.
@@ -133,15 +133,16 @@ export class EventEmitterEventLog implements EventLog {
     const channel = `${tenant}_${EVENTS_LISTENER_CHANNEL}`;
     this.emitter.emit(channel, { tenant, event, indexes, seq });
 
-    return seq;
+    return String(seq);
   }
 
   public async read(tenant: string, options: EventLogReadOptions = {}): Promise<EventLogReadResult> {
     const { cursor, limit, filters } = options;
+    const cursorSeq = cursor !== undefined ? EventEmitterEventLog.parseCursor(cursor) : undefined;
     const log = this.tenantLogs.get(tenant);
 
     if (log === undefined || log.size === 0) {
-      return { events: [], cursor: cursor ?? -1 };
+      return { events: [], cursor };
     }
 
     const results: EventLogEntry[] = [];
@@ -149,7 +150,7 @@ export class EventEmitterEventLog implements EventLog {
 
     for (const [seq, entry] of log) {
       // Skip entries at or before the cursor.
-      if (cursor !== undefined && seq <= cursor) { continue; }
+      if (cursorSeq !== undefined && seq <= cursorSeq) { continue; }
 
       // Apply filters if provided (OR semantics — match any filter).
       if (filters !== undefined && filters.length > 0) {
@@ -165,8 +166,19 @@ export class EventEmitterEventLog implements EventLog {
       if (results.length >= maxResults) { break; }
     }
 
-    const lastSeq = results.length > 0 ? results[results.length - 1].seq : (cursor ?? -1);
-    return { events: results, cursor: lastSeq };
+    const lastSeq = results.length > 0 ? results[results.length - 1].seq : undefined;
+    return { events: results, cursor: lastSeq !== undefined ? String(lastSeq) : cursor };
+  }
+
+  /**
+   * Parse an opaque cursor string into an internal sequence number.
+   */
+  private static parseCursor(cursor: string): number {
+    const seq = Number(cursor);
+    if (Number.isNaN(seq) || seq < 0) {
+      throw new DwnError(DwnErrorCode.EventLogNotOpenError, `invalid cursor: '${cursor}'`);
+    }
+    return seq;
   }
 
   public async subscribe(
@@ -180,6 +192,7 @@ export class EventEmitterEventLog implements EventLog {
 
     if (cursor !== undefined) {
       // ---- Cursor mode: catch-up from stored events, then EOSE, then live ----
+      const cursorSeq = EventEmitterEventLog.parseCursor(cursor);
 
       // Buffer live events that arrive during catch-up to avoid losing them.
       type BufferedEvent = { event: MessageEvent; seq: number };
@@ -194,7 +207,7 @@ export class EventEmitterEventLog implements EventLog {
         if (!catchUpComplete) {
           pendingLiveEvents.push({ event: payload.event, seq: payload.seq });
         } else {
-          listener({ type: 'event', seq: payload.seq, event: payload.event });
+          listener({ type: 'event', cursor: String(payload.seq), event: payload.event });
         }
       };
 
@@ -202,22 +215,24 @@ export class EventEmitterEventLog implements EventLog {
 
       // Step 2: Read stored events from cursor and deliver them.
       const readResult = await this.read(tenant, { cursor, filters });
-      const lastCatchUpSeq = readResult.cursor;
+      // The read cursor is the last event's seq (string) or the input cursor if nothing new.
+      const eoseCursor = readResult.cursor ?? cursor;
+      const lastCatchUpSeq = readResult.cursor !== undefined ? Number(readResult.cursor) : cursorSeq;
 
       for (const entry of readResult.events) {
-        listener({ type: 'event', seq: entry.seq, event: entry.event });
+        listener({ type: 'event', cursor: String(entry.seq), event: entry.event });
       }
 
       // Step 3: Deliver any live events that arrived during catch-up (with seq > lastCatchUpSeq).
       catchUpComplete = true;
       for (const liveEvent of pendingLiveEvents) {
         if (liveEvent.seq > lastCatchUpSeq) {
-          listener({ type: 'event', seq: liveEvent.seq, event: liveEvent.event });
+          listener({ type: 'event', cursor: String(liveEvent.seq), event: liveEvent.event });
         }
       }
 
       // Step 4: Send EOSE marker.
-      listener({ type: 'eose', seq: lastCatchUpSeq });
+      listener({ type: 'eose', cursor: eoseCursor });
 
       return {
         id,
@@ -231,7 +246,7 @@ export class EventEmitterEventLog implements EventLog {
       if (filters !== undefined && filters.length > 0) {
         if (!FilterUtility.matchAnyFilter(payload.indexes, filters)) { return; }
       }
-      listener({ type: 'event', seq: payload.seq, event: payload.event });
+      listener({ type: 'event', cursor: String(payload.seq), event: payload.event });
     };
 
     this.emitter.on(channel, handler);

--- a/packages/dwn-sdk-js/src/interfaces/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/interfaces/messages-subscribe.ts
@@ -16,10 +16,10 @@ export type MessagesSubscribeOptions = {
   filters?: MessagesFilter[];
   permissionGrantId?: string;
   /**
-   * EventLog sequence number to resume from. When provided, catch-up events are
+   * Opaque EventLog cursor string to resume from. When provided, catch-up events are
    * replayed from the EventLog and an EOSE marker is delivered before live events.
    */
-  cursor?: number;
+  cursor?: string;
 };
 
 export class MessagesSubscribe extends AbstractMessage<MessagesSubscribeMessage> {

--- a/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
@@ -23,10 +23,10 @@ export type RecordsSubscribeOptions = {
   protocolRole?: string;
 
   /**
-   * EventLog sequence number to resume from. When provided, catch-up events are
+   * Opaque EventLog cursor string to resume from. When provided, catch-up events are
    * replayed from the EventLog and an EOSE marker is delivered before live events.
    */
-  cursor?: number;
+  cursor?: string;
 
   /**
    * The delegated grant to sign on behalf of the logical author, which is the grantor (`grantedBy`) of the delegated grant.

--- a/packages/dwn-sdk-js/src/types/messages-types.ts
+++ b/packages/dwn-sdk-js/src/types/messages-types.ts
@@ -81,9 +81,9 @@ export type MessagesSubscribeDescriptor = {
   filters: MessagesFilter[];
   permissionGrantId?: string;
   /**
-   * EventLog sequence number to resume from. When provided, the handler replays
+   * Opaque EventLog cursor string to resume from. When provided, the handler replays
    * events from the EventLog starting after this cursor instead of returning no
    * initial snapshot. An EOSE marker is sent after catch-up.
    */
-  cursor?: number;
+  cursor?: string;
 };

--- a/packages/dwn-sdk-js/src/types/records-types.ts
+++ b/packages/dwn-sdk-js/src/types/records-types.ts
@@ -123,11 +123,11 @@ export type RecordsSubscribeDescriptor = {
   dateSort?: DateSort;
   pagination?: Pagination;
   /**
-   * EventLog sequence number to resume from. When provided, the handler replays
+   * Opaque EventLog cursor string to resume from. When provided, the handler replays
    * events from the EventLog starting after this cursor instead of querying the
    * MessageStore for an initial snapshot. An EOSE marker is sent after catch-up.
    */
-  cursor?: number;
+  cursor?: string;
 };
 
 export type RecordsFilter = {

--- a/packages/dwn-sdk-js/src/types/subscriptions.ts
+++ b/packages/dwn-sdk-js/src/types/subscriptions.ts
@@ -32,12 +32,17 @@ export type SubscriptionReply = GenericMessageReply & {
 // ---------------------------------------------------------------------------
 
 /**
- * A regular subscription event carrying a message and its EventLog sequence number.
+ * A regular subscription event carrying a message and its EventLog cursor.
  */
 export type SubscriptionEvent = {
   type : 'event';
-  /** Monotonic EventLog sequence number. Clients should track this for cursor-based resume. */
-  seq : number;
+  /**
+   * Opaque cursor string assigned by the EventLog implementation. Clients should
+   * persist this value and pass it back to `subscribe()` or `read()` to resume
+   * from this point. The format is implementation-defined (e.g. numeric sequence
+   * for in-memory, Redis stream ID, NATS stream sequence, etc.).
+   */
+  cursor : string;
   /** The event payload (message + optional initialWrite). */
   event : MessageEvent;
 };
@@ -51,8 +56,11 @@ export type SubscriptionEvent = {
  */
 export type SubscriptionEose = {
   type : 'eose';
-  /** The sequence number of the last stored event that was replayed, or -1 if none. */
-  seq : number;
+  /**
+   * Opaque cursor string of the last stored event that was replayed.
+   * Echoes the input cursor when no stored events matched (i.e. already caught up).
+   */
+  cursor : string;
 };
 
 /**
@@ -63,7 +71,7 @@ export type SubscriptionMessage = SubscriptionEvent | SubscriptionEose;
 
 /**
  * Callback for {@link EventLog.subscribe}. Receives either a regular event
- * (with seq) or an EOSE marker indicating catch-up replay is complete.
+ * (with cursor) or an EOSE marker indicating catch-up replay is complete.
  */
 export type SubscriptionListener = (message: SubscriptionMessage) => void;
 
@@ -72,11 +80,15 @@ export type SubscriptionListener = (message: SubscriptionMessage) => void;
  */
 export type EventLogSubscribeOptions = {
   /**
-   * EventLog sequence number to resume from (exclusive — events with seq > cursor
+   * Opaque cursor string to resume from (exclusive — events after this cursor
    * are replayed). When provided, stored events are replayed first, followed by
    * an EOSE marker, then live events. When omitted, only live events are delivered.
+   *
+   * Cursor values are implementation-defined and must be obtained from a prior
+   * interaction with the same EventLog instance (e.g. `SubscriptionEvent.cursor`,
+   * `EventLogReadResult.cursor`, or the return value of `emit()`).
    */
-  cursor? : number;
+  cursor? : string;
 
   /**
    * Filters evaluated against event indexes. Events must match at least one
@@ -107,8 +119,8 @@ export type EventLogEntry = {
  * Options accepted by {@link EventLog.read}.
  */
 export type EventLogReadOptions = {
-  /** Resume reading from this sequence number (exclusive — returns events with seq > cursor). */
-  cursor? : number;
+  /** Opaque cursor string to resume from (exclusive — returns events after this cursor). */
+  cursor? : string;
 
   /** Maximum number of events to return. */
   limit? : number;
@@ -125,18 +137,21 @@ export type EventLogReadResult = {
   events : EventLogEntry[];
 
   /**
-   * The sequence number of the last event returned.
-   * Pass this value as `cursor` in a subsequent `read()` call to continue.
-   * `-1` if no events were returned.
+   * Opaque cursor string for resuming subsequent reads or subscriptions.
+   *
+   * - When events are returned: cursor of the last event.
+   * - When no events are returned but a cursor was provided: the input cursor
+   *   (meaning "you are caught up, nothing new since this point").
+   * - When no events exist and no cursor was provided: `undefined`.
    */
-  cursor : number;
+  cursor? : string;
 };
 
 /**
  * The EventLog interface provides persistent, ordered event storage with
  * cursor-based reads and subscription support.
  *
- * It persists events before delivery, exposing monotonic sequence numbers
+ * It persists events before delivery, exposing opaque cursor strings
  * that enable cursor-based resume after disconnects.
  *
  * The interface is intentionally transport-agnostic — implementations can be
@@ -147,9 +162,9 @@ export type EventLogReadResult = {
 export interface EventLog {
   /**
    * Persist an event and notify in-process subscribers.
-   * @returns The monotonic sequence number assigned to the event.
+   * @returns The opaque cursor string assigned to the event, or empty string on failure.
    */
-  emit(tenant: string, event: MessageEvent, indexes: KeyValues): Promise<number>;
+  emit(tenant: string, event: MessageEvent, indexes: KeyValues): Promise<string>;
 
   /**
    * Read events from the log starting after `cursor`, optionally filtered.

--- a/packages/dwn-sdk-js/tests/event-emitter-event-log.spec.ts
+++ b/packages/dwn-sdk-js/tests/event-emitter-event-log.spec.ts
@@ -17,36 +17,41 @@ describe('EventEmitterEventLog', () => {
   });
 
   describe('emit()', () => {
-    it('should assign monotonically increasing sequence numbers per tenant', async () => {
+    it('should return opaque cursor strings', async () => {
       const tenant = 'did:example:alice';
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
-      const seq1 = await eventLog.emit(tenant, event, { key: 'val1' });
-      const seq2 = await eventLog.emit(tenant, event, { key: 'val2' });
-      const seq3 = await eventLog.emit(tenant, event, { key: 'val3' });
+      const cursor1 = await eventLog.emit(tenant, event, { key: 'val1' });
+      const cursor2 = await eventLog.emit(tenant, event, { key: 'val2' });
+      const cursor3 = await eventLog.emit(tenant, event, { key: 'val3' });
 
-      expect(seq1).toBe(1);
-      expect(seq2).toBe(2);
-      expect(seq3).toBe(3);
+      // Cursors are strings and should be different for each event.
+      expect(typeof cursor1).toBe('string');
+      expect(typeof cursor2).toBe('string');
+      expect(cursor1).not.toBe(cursor2);
+      expect(cursor2).not.toBe(cursor3);
     });
 
-    it('should maintain independent sequence counters per tenant', async () => {
+    it('should maintain independent cursors per tenant', async () => {
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
-      const seqAlice = await eventLog.emit('did:example:alice', event, {});
-      const seqBob = await eventLog.emit('did:example:bob', event, {});
+      const cursorAlice = await eventLog.emit('did:example:alice', event, {});
+      const cursorBob = await eventLog.emit('did:example:bob', event, {});
 
-      expect(seqAlice).toBe(1);
-      expect(seqBob).toBe(1);
+      // Both are valid cursor strings (first event for each tenant).
+      expect(typeof cursorAlice).toBe('string');
+      expect(typeof cursorBob).toBe('string');
+      expect(cursorAlice.length).toBeGreaterThan(0);
+      expect(cursorBob.length).toBeGreaterThan(0);
     });
 
-    it('should return -1 when EventLog is closed', async () => {
+    it('should return empty string when EventLog is closed', async () => {
       await eventLog.close();
 
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
-      const seq = await eventLog.emit('did:example:alice', event, {});
+      const cursor = await eventLog.emit('did:example:alice', event, {});
 
-      expect(seq).toBe(-1);
+      expect(cursor).toBe('');
 
       // reopen for afterAll cleanup
       await eventLog.open();
@@ -54,7 +59,7 @@ describe('EventEmitterEventLog', () => {
   });
 
   describe('read()', () => {
-    it('should read all events for a tenant', async () => {
+    it('should read all events for a tenant when no cursor is provided', async () => {
       const tenant = 'did:example:alice';
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
@@ -63,9 +68,7 @@ describe('EventEmitterEventLog', () => {
 
       const result = await eventLog.read(tenant);
       expect(result.events.length).toBe(2);
-      expect(result.events[0].seq).toBe(1);
-      expect(result.events[1].seq).toBe(2);
-      expect(result.cursor).toBe(2);
+      expect(result.cursor).toBeDefined();
     });
 
     it('should read events after a cursor', async () => {
@@ -73,13 +76,13 @@ describe('EventEmitterEventLog', () => {
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
       await eventLog.emit(tenant, event, { schema: 'http://a' });
-      await eventLog.emit(tenant, event, { schema: 'http://b' });
+      const cursor2 = await eventLog.emit(tenant, event, { schema: 'http://b' });
       await eventLog.emit(tenant, event, { schema: 'http://c' });
 
-      const result = await eventLog.read(tenant, { cursor: 2 });
+      // Read after cursor2 — should only get the third event.
+      const result = await eventLog.read(tenant, { cursor: cursor2 });
       expect(result.events.length).toBe(1);
-      expect(result.events[0].seq).toBe(3);
-      expect(result.cursor).toBe(3);
+      expect(result.cursor).toBeDefined();
     });
 
     it('should apply filters during read', async () => {
@@ -92,14 +95,24 @@ describe('EventEmitterEventLog', () => {
 
       const result = await eventLog.read(tenant, { filters: [{ schema: 'http://match' }] });
       expect(result.events.length).toBe(2);
-      expect(result.events[0].seq).toBe(1);
-      expect(result.events[1].seq).toBe(3);
     });
 
-    it('should return empty result for unknown tenant', async () => {
+    it('should return undefined cursor for unknown tenant', async () => {
       const result = await eventLog.read('did:example:unknown');
       expect(result.events.length).toBe(0);
-      expect(result.cursor).toBe(-1);
+      expect(result.cursor).toBeUndefined();
+    });
+
+    it('should return the input cursor when no new events match', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+
+      const lastCursor = await eventLog.emit(tenant, event, {});
+
+      // Read after the last event — nothing new.
+      const result = await eventLog.read(tenant, { cursor: lastCursor });
+      expect(result.events.length).toBe(0);
+      expect(result.cursor).toBe(lastCursor);
     });
 
     it('should respect the limit option', async () => {
@@ -112,12 +125,12 @@ describe('EventEmitterEventLog', () => {
 
       const result = await eventLog.read(tenant, { limit: 2 });
       expect(result.events.length).toBe(2);
-      expect(result.cursor).toBe(2);
+      expect(result.cursor).toBeDefined();
     });
   });
 
   describe('subscribe() — live only (no cursor)', () => {
-    it('should deliver live events to subscriber', async () => {
+    it('should deliver live events to subscriber with cursor strings', async () => {
       const tenant = 'did:example:alice';
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
@@ -131,10 +144,8 @@ describe('EventEmitterEventLog', () => {
       expect(received[0].type).toBe('event');
       expect(received[1].type).toBe('event');
       if (received[0].type === 'event') {
-        expect(received[0].seq).toBe(1);
-      }
-      if (received[1].type === 'event') {
-        expect(received[1].seq).toBe(2);
+        expect(typeof received[0].cursor).toBe('string');
+        expect(received[0].cursor.length).toBeGreaterThan(0);
       }
     });
 
@@ -190,168 +201,142 @@ describe('EventEmitterEventLog', () => {
   });
 
   describe('subscribe() — cursor mode (catch-up + EOSE + live)', () => {
-    it('should replay stored events from cursor and deliver EOSE', async () => {
+    it('should replay stored events after cursor and deliver EOSE', async () => {
       const tenant = 'did:example:alice';
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
-      // Emit 3 events before subscribing.
-      await eventLog.emit(tenant, event, { idx: '1' });
+      // Emit 3 events, capture the first cursor.
+      const cursor1 = await eventLog.emit(tenant, event, { idx: '1' });
       await eventLog.emit(tenant, event, { idx: '2' });
       await eventLog.emit(tenant, event, { idx: '3' });
 
-      // Subscribe with cursor=0 to replay all.
+      // Subscribe with cursor from first event — should replay events 2 and 3.
       const received: SubscriptionMessage[] = [];
-      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 0 });
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: cursor1 });
 
-      // Should receive 3 catch-up events + EOSE.
-      expect(received.length).toBe(4);
+      // Should receive 2 catch-up events + EOSE.
+      expect(received.length).toBe(3);
       expect(received[0].type).toBe('event');
       expect(received[1].type).toBe('event');
-      expect(received[2].type).toBe('event');
-      expect(received[3].type).toBe('eose');
+      expect(received[2].type).toBe('eose');
 
-      if (received[0].type === 'event') { expect(received[0].seq).toBe(1); }
-      if (received[1].type === 'event') { expect(received[1].seq).toBe(2); }
-      if (received[2].type === 'event') { expect(received[2].seq).toBe(3); }
-      if (received[3].type === 'eose') { expect(received[3].seq).toBe(3); }
+      // Cursors should be opaque strings, each different.
+      if (received[0].type === 'event' && received[1].type === 'event') {
+        expect(received[0].cursor).not.toBe(received[1].cursor);
+      }
     });
 
-    it('should replay only events after the given cursor', async () => {
+    it('should deliver EOSE echoing the input cursor when already caught up', async () => {
       const tenant = 'did:example:alice';
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
+      // Emit events and capture last cursor.
       await eventLog.emit(tenant, event, {});
-      await eventLog.emit(tenant, event, {});
-      await eventLog.emit(tenant, event, {});
+      const lastCursor = await eventLog.emit(tenant, event, {});
 
-      // Subscribe with cursor=2 — should only replay event with seq=3.
+      // Subscribe with the last cursor — already caught up, no stored events to replay.
       const received: SubscriptionMessage[] = [];
-      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 2 });
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: lastCursor });
 
-      expect(received.length).toBe(2); // 1 event + EOSE
-      expect(received[0].type).toBe('event');
-      expect(received[1].type).toBe('eose');
-
-      if (received[0].type === 'event') { expect(received[0].seq).toBe(3); }
-      if (received[1].type === 'eose') { expect(received[1].seq).toBe(3); }
-    });
-
-    it('should deliver EOSE with the cursor value when no stored events match', async () => {
-      const tenant = 'did:example:alice';
-
-      // No events emitted. Subscribe with cursor=0.
-      const received: SubscriptionMessage[] = [];
-      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 0 });
-
-      // Should just get EOSE. The seq is the `read()` result cursor, which is
-      // the original cursor value (0) when no events were returned.
+      // Should just get EOSE echoing the input cursor.
       expect(received.length).toBe(1);
       expect(received[0].type).toBe('eose');
-      if (received[0].type === 'eose') { expect(received[0].seq).toBe(0); }
+      if (received[0].type === 'eose') { expect(received[0].cursor).toBe(lastCursor); }
     });
 
     it('should continue delivering live events after EOSE', async () => {
       const tenant = 'did:example:alice';
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
-      // Emit 1 event before subscribing.
-      await eventLog.emit(tenant, event, { idx: '1' });
+      // Emit 1 event and capture its cursor.
+      const cursor1 = await eventLog.emit(tenant, event, { idx: '1' });
 
       const received: SubscriptionMessage[] = [];
-      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 0 });
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: cursor1 });
 
-      // Should have: 1 catch-up event + EOSE.
-      expect(received.length).toBe(2);
-      expect(received[0].type).toBe('event');
-      expect(received[1].type).toBe('eose');
+      // Already caught up — should have just EOSE.
+      expect(received.length).toBe(1);
+      expect(received[0].type).toBe('eose');
 
       // Now emit a live event.
       await eventLog.emit(tenant, event, { idx: '2' });
 
       // Should now have the live event appended.
-      expect(received.length).toBe(3);
-      expect(received[2].type).toBe('event');
-      if (received[2].type === 'event') { expect(received[2].seq).toBe(2); }
+      expect(received.length).toBe(2);
+      expect(received[1].type).toBe('event');
+      if (received[1].type === 'event') {
+        expect(typeof received[1].cursor).toBe('string');
+      }
     });
 
     it('should apply filters to both catch-up and live events', async () => {
       const tenant = 'did:example:alice';
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
-      // Emit events with different schemas.
+      // Emit events with different schemas, capture cursor before the batch.
+      const cursorBefore = await eventLog.emit(tenant, event, { schema: 'http://before' });
       await eventLog.emit(tenant, event, { schema: 'http://match' });
       await eventLog.emit(tenant, event, { schema: 'http://other' });
       await eventLog.emit(tenant, event, { schema: 'http://match' });
 
       const received: SubscriptionMessage[] = [];
       await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, {
-        cursor  : 0,
+        cursor  : cursorBefore,
         filters : [{ schema: 'http://match' }],
       });
 
-      // Catch-up: 2 matching events + EOSE. (Event at seq=2 filtered out.)
+      // Catch-up: 2 matching events + EOSE. (Event with 'http://other' filtered out.)
       expect(received.length).toBe(3);
       expect(received[0].type).toBe('event');
       expect(received[1].type).toBe('event');
       expect(received[2].type).toBe('eose');
-
-      if (received[0].type === 'event') { expect(received[0].seq).toBe(1); }
-      if (received[1].type === 'event') { expect(received[1].seq).toBe(3); }
 
       // Emit live events — only matching ones should arrive.
       await eventLog.emit(tenant, event, { schema: 'http://other' });
       await eventLog.emit(tenant, event, { schema: 'http://match' });
 
       expect(received.length).toBe(4); // +1 matching live event
-      if (received[3].type === 'event') { expect(received[3].seq).toBe(5); }
     });
 
     it('should deduplicate live events that arrived during catch-up', async () => {
-      // This test verifies the buffering + dedup behavior.
-      // We need to simulate a live event arriving while stored events are being read.
-      // Since EventEmitterEventLog.subscribe is synchronous in-memory, the only way
-      // to get overlap is if emit() is called between registering the mitt handler and
-      // the read() call completing. In the current sync implementation, this can't
-      // naturally happen, so we verify the invariant that no duplicate seq appears.
-
       const tenant = 'did:example:alice';
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
-      // Emit 2 events.
+      // Emit 2 events, capture cursor before them.
+      const cursorBefore = await eventLog.emit(tenant, event, { idx: '0' });
       await eventLog.emit(tenant, event, { idx: '1' });
       await eventLog.emit(tenant, event, { idx: '2' });
 
       const received: SubscriptionMessage[] = [];
-      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: 0 });
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: cursorBefore });
 
       // 2 catch-up events + EOSE.
       expect(received.length).toBe(3);
 
-      // Verify no duplicate seqs.
-      const eventSeqs = received.filter(m => m.type === 'event').map(m => m.seq);
-      const uniqueSeqs = new Set(eventSeqs);
-      expect(uniqueSeqs.size).toBe(eventSeqs.length);
+      // Verify no duplicate cursors.
+      const eventCursors = received.filter(m => m.type === 'event').map(m => m.cursor);
+      const uniqueCursors = new Set(eventCursors);
+      expect(uniqueCursors.size).toBe(eventCursors.length);
     });
 
     it('should isolate subscriptions between tenants in cursor mode', async () => {
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
-      // Emit for alice.
-      await eventLog.emit('did:example:alice', event, {});
+      // Emit for alice, capture first cursor.
+      const aliceCursor1 = await eventLog.emit('did:example:alice', event, {});
       await eventLog.emit('did:example:alice', event, {});
 
       // Emit for bob.
       await eventLog.emit('did:example:bob', event, {});
 
-      // Subscribe to alice with cursor.
+      // Subscribe to alice with cursor — should only get alice's second event.
       const aliceReceived: SubscriptionMessage[] = [];
-      await eventLog.subscribe('did:example:alice', 'sub-alice', (msg) => { aliceReceived.push(msg); }, { cursor: 0 });
+      await eventLog.subscribe('did:example:alice', 'sub-alice', (msg) => { aliceReceived.push(msg); }, { cursor: aliceCursor1 });
 
-      // Should only get alice's 2 events + EOSE.
-      expect(aliceReceived.length).toBe(3);
+      // Should only get alice's 1 catch-up event + EOSE.
+      expect(aliceReceived.length).toBe(2);
       expect(aliceReceived[0].type).toBe('event');
-      expect(aliceReceived[1].type).toBe('event');
-      expect(aliceReceived[2].type).toBe('eose');
+      expect(aliceReceived[1].type).toBe('eose');
     });
   });
 

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -206,13 +206,16 @@ export function testMessagesSubscribeHandler(): void {
           const alice = await TestDataGenerator.generateDidKeyPersona();
           await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
 
+          // Read the EventLog to get a cursor before writing.
+          const { cursor: cursorBefore } = await eventLog.read(alice.did);
+
           // Write a record before subscribing.
           const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice });
           const write1Reply = await dwn.processMessage(alice.did, write1.message, { dataStream: write1.dataStream });
           expect(write1Reply.status.code).toBe(202);
           const write1Cid = await Message.getCid(write1.message);
 
-          // Subscribe with cursor=0 to catch up from the beginning.
+          // Subscribe with cursor from before the write to catch up.
           const messageCids: string[] = [];
           const handler = async (event: MessageEvent): Promise<void> => {
             const { message: msg } = event;
@@ -222,14 +225,13 @@ export function testMessagesSubscribeHandler(): void {
 
           const { message: subMessage } = await TestDataGenerator.generateMessagesSubscribe({
             author : alice,
-            cursor : 0,
+            cursor : cursorBefore,
           });
           const subReply = await dwn.processMessage(alice.did, subMessage, { subscriptionHandler: handler });
           expect(subReply.status.code).toBe(200);
           expect(subReply.subscription).toBeDefined();
 
           // Wait for the catch-up events.
-          // NOTE: with cursor mode, the protocol configure + record write should both come through.
           await Poller.pollUntilSuccessOrTimeout(async () => {
             expect(messageCids.length).toBeGreaterThanOrEqual(1);
             expect(messageCids).toContain(write1Cid);
@@ -244,6 +246,14 @@ export function testMessagesSubscribeHandler(): void {
           const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice });
           await dwn.processMessage(alice.did, write1.message, { dataStream: write1.dataStream });
 
+          // Read to get cursor after write1.
+          const { cursor: cursorAfterWrite1 } = await eventLog.read(alice.did);
+
+          // Write another record that we'll catch up on.
+          const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice });
+          await dwn.processMessage(alice.did, write2.message, { dataStream: write2.dataStream });
+          const write2Cid = await Message.getCid(write2.message);
+
           const messageCids: string[] = [];
           const handler = async (event: MessageEvent): Promise<void> => {
             const { message: msg } = event;
@@ -253,24 +263,24 @@ export function testMessagesSubscribeHandler(): void {
 
           const { message: subMessage } = await TestDataGenerator.generateMessagesSubscribe({
             author : alice,
-            cursor : 0,
+            cursor : cursorAfterWrite1,
           });
           const subReply = await dwn.processMessage(alice.did, subMessage, { subscriptionHandler: handler });
           expect(subReply.status.code).toBe(200);
 
-          // Wait for catch-up.
+          // Wait for catch-up (write2).
           await Poller.pollUntilSuccessOrTimeout(async () => {
-            expect(messageCids.length).toBeGreaterThanOrEqual(1);
+            expect(messageCids).toContain(write2Cid);
           });
 
           // Write a live record.
-          const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice });
-          await dwn.processMessage(alice.did, write2.message, { dataStream: write2.dataStream });
-          const write2Cid = await Message.getCid(write2.message);
+          const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice });
+          await dwn.processMessage(alice.did, write3.message, { dataStream: write3.dataStream });
+          const write3Cid = await Message.getCid(write3.message);
 
           // Wait for the live event.
           await Poller.pollUntilSuccessOrTimeout(async () => {
-            expect(messageCids).toContain(write2Cid);
+            expect(messageCids).toContain(write3Cid);
           });
         });
       });

--- a/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
@@ -265,6 +265,9 @@ export function testRecordsSubscribeHandler(): void {
           const alice = await TestDataGenerator.generateDidKeyPersona();
           await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
 
+          // Read the EventLog to get the current cursor position before writing records.
+          const { cursor: cursorBefore } = await eventLog.read(alice.did);
+
           // Write records before subscribing.
           const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://cursor-test' });
           const write1Reply = await dwn.processMessage(alice.did, write1.message, { dataStream: write1.dataStream });
@@ -274,14 +277,14 @@ export function testRecordsSubscribeHandler(): void {
           const write2Reply = await dwn.processMessage(alice.did, write2.message, { dataStream: write2.dataStream });
           expect(write2Reply.status.code).toBe(202);
 
-          // Subscribe with cursor=0. With a cursor, the handler takes the EventLog catch-up path,
-          // meaning NO entries/cursor are returned (the catch-up is delivered through the subscription handler).
+          // Subscribe with the cursor from before the writes. The handler takes the
+          // EventLog catch-up path, replaying events through the subscription handler.
           const receivedEvents: RecordEvent[] = [];
           const subscriptionHandler: RecordSubscriptionHandler = (event): void => { receivedEvents.push(event); };
           const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({
             author : alice,
             filter : { schema: 'http://cursor-test' },
-            cursor : 0,
+            cursor : cursorBefore,
           });
 
           const subReply = await dwn.processMessage(alice.did, recordsSubscribe.message, { subscriptionHandler });
@@ -310,24 +313,31 @@ export function testRecordsSubscribeHandler(): void {
           const write1 = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://cursor-live' });
           await dwn.processMessage(alice.did, write1.message, { dataStream: write1.dataStream });
 
+          // Read to get a cursor that includes write1's protocol config + the record.
+          const { cursor: cursorAfterWrite1 } = await eventLog.read(alice.did);
+
+          // Write another record that we'll want to catch up on.
+          const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://cursor-live' });
+          await dwn.processMessage(alice.did, write2.message, { dataStream: write2.dataStream });
+
           const receivedEvents: RecordEvent[] = [];
           const subscriptionHandler: RecordSubscriptionHandler = (event): void => { receivedEvents.push(event); };
           const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({
             author : alice,
             filter : { schema: 'http://cursor-live' },
-            cursor : 0,
+            cursor : cursorAfterWrite1,
           });
           const subReply = await dwn.processMessage(alice.did, recordsSubscribe.message, { subscriptionHandler });
           expect(subReply.status.code).toBe(200);
 
-          // Wait for catch-up event.
+          // Wait for catch-up event (write2).
           await Poller.pollUntilSuccessOrTimeout(async () => {
             expect(receivedEvents.length).toBeGreaterThanOrEqual(1);
           });
 
           // Write a live record after subscribing.
-          const write2 = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://cursor-live' });
-          await dwn.processMessage(alice.did, write2.message, { dataStream: write2.dataStream });
+          const write3 = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://cursor-live' });
+          await dwn.processMessage(alice.did, write3.message, { dataStream: write3.dataStream });
 
           // Wait for the live event.
           await Poller.pollUntilSuccessOrTimeout(async () => {
@@ -335,13 +345,16 @@ export function testRecordsSubscribeHandler(): void {
           });
 
           const recordIds = receivedEvents.map(e => (e.message as RecordsWriteMessage).recordId);
-          expect(recordIds).toContain(write1.message.recordId);
           expect(recordIds).toContain(write2.message.recordId);
+          expect(recordIds).toContain(write3.message.recordId);
         });
 
         it('should filter catch-up events when cursor and filter are provided', async () => {
           const alice = await TestDataGenerator.generateDidKeyPersona();
           await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+          // Get cursor before writing.
+          const { cursor: cursorBefore } = await eventLog.read(alice.did);
 
           // Write records with different schemas.
           const matchWrite = await TestDataGenerator.generateRecordsWrite({ author: alice, schema: 'http://filter-match' });
@@ -355,7 +368,7 @@ export function testRecordsSubscribeHandler(): void {
           const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({
             author : alice,
             filter : { schema: 'http://filter-match' },
-            cursor : 0,
+            cursor : cursorBefore,
           });
           const subReply = await dwn.processMessage(alice.did, recordsSubscribe.message, { subscriptionHandler });
           expect(subReply.status.code).toBe(200);

--- a/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
+++ b/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
@@ -200,8 +200,8 @@ export type GenerateRecordsSubscribeInput = {
     dateSort?: DateSort;
     pagination?: Pagination;
     protocolRole?: string;
-    /** EventLog cursor for catch-up + EOSE subscribe. */
-    cursor?: number;
+    /** Opaque EventLog cursor for catch-up + EOSE subscribe. */
+    cursor?: string;
 };
 
 export type GenerateRecordsSubscribeOutput = {
@@ -242,8 +242,8 @@ export type GenerateMessagesSubscribeInput = {
   filters?: MessagesFilter[];
   messageTimestamp?: string;
   permissionGrantId?: string;
-  /** EventLog cursor for catch-up + EOSE subscribe. */
-  cursor?: number;
+  /** Opaque EventLog cursor for catch-up + EOSE subscribe. */
+  cursor?: string;
 };
 
 export type GenerateMessagesSubscribeOutput = {


### PR DESCRIPTION
## Summary

Follow-up to #281 (merged). Changes all EventLog cursor types from `number` to opaque `string` so the interface supports diverse backend implementations (Redis Streams `"timestamp-seq"`, NATS JetStream `uint64` sequences, SQL LSNs, etc.) without leaking internal position semantics.

## Motivation

A numeric cursor bakes in the assumption that all implementations use monotonic integers. But:
- **Redis Streams** use `"1684499930123-0"` string IDs
- **PostgreSQL** could use `bigint` sequences or `LSN` strings
- **Kafka** uses `"partition:offset"` pairs

The cursor is fundamentally opaque to the consumer — they receive it from one interaction and pass it back to the next. Making it `string` is universal, cross-compliant, and prevents consumers from doing arithmetic on it.

## Design

- **`cursor?: string`** — always an opaque value previously returned by the EventLog (`emit()`, `read()`, or `SubscriptionEvent.cursor`). Consumers never construct cursors.
- **`undefined`** means "no cursor" (live events only). No sentinel value for "beginning of log" — cold-start clients use the no-cursor subscribe path (initial MessageStore snapshot) and persist cursors from live events for reconnection.
- **`EventLogReadResult.cursor`** is `string | undefined` — `undefined` when no events exist and no input cursor was provided.
- **`EventEmitterEventLog`** converts between internal numeric seqs and string cursors at the interface boundary via `String(seq)` / `parseCursor()`.

## Changes (12 files, +208/-172)

**Types:**
- `subscriptions.ts` — `SubscriptionEvent.cursor: string`, `SubscriptionEose.cursor: string`, `EventLogSubscribeOptions.cursor?: string`, `EventLogReadOptions.cursor?: string`, `EventLogReadResult.cursor?: string`, `emit()` returns `Promise<string>`
- `records-types.ts` / `messages-types.ts` — descriptor `cursor?: string`

**Schemas:**
- `records-subscribe.json` / `messages-subscribe.json` — `"type": "string"`

**Implementation:**
- `event-emitter-event-log.ts` — `parseCursor()` helper, `String(seq)` at boundaries, `emit()` returns `string`
- `records-subscribe.ts` / `messages-subscribe.ts` interface classes — `cursor?: string`

**Tests:**
- `event-emitter-event-log.spec.ts` — rewritten to use real cursors from `emit()`/`read()`
- Handler specs — obtain cursors via `eventLog.read()` before writing, pass real cursors
- `test-data-generator.ts` — `cursor?: string`

## Test Results

| Package | Result |
|---------|--------|
| `dwn-sdk-js` | 1032 pass, 0 fail |
| `agent` | 712 pass, 3 fail (pre-existing on main) |
| Lint (all packages) | 0 errors, 0 warnings |