### PR TITLE
refactor: split record.ts and dwn-api.ts into focused modules

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -5,8 +5,6 @@ import type {
   EncryptionKeyDeriver,
   KeyDecrypter,
   ProtocolDefinition,
-  ProtocolsQueryReply,
-  RecordsQueryReply,
   RecordsWrite,
   RecordsWriteMessage,
 } from '@enbox/dwn-sdk-js';
@@ -72,7 +70,6 @@ import {
 // Import extracted protocol utilities
 import {
   detectNewParticipants as detectNewParticipantsFn,
-  hasRelationalReadAccess as hasRelationalReadAccessFn,
   isMultiPartyContext as isMultiPartyContextFn,
 } from './protocol-utils.js';
 
@@ -86,6 +83,13 @@ import {
 
 // Import extracted record upgrade function
 import { upgradeExternalRootRecord as upgradeExternalRootRecordFn } from './dwn-record-upgrade.js';
+
+// Import extracted protocol definition fetching functions
+import {
+  extractDerivedPublicKey as extractDerivedPublicKeyFn,
+  fetchRemoteProtocolDefinition as fetchRemoteProtocolDefinitionFn,
+  getProtocolDefinition as getProtocolDefinitionFn,
+} from './dwn-protocol-cache.js';
 
 type DwnMessageWithBlob<T extends DwnInterface> = {
   message: DwnMessage[T];
@@ -229,122 +233,8 @@ export class AgentDwnApi {
 
 
     // Post-write key delivery: detect new participants and write contextKey records.
-    // This replaces the old roleRecordAutoPush mechanism with the unified key delivery protocol.
-    if (
-      isDwnRequest(request, DwnInterface.RecordsWrite) &&
-      request.encryption &&
-      reply.status.code === 202
-    ) {
-      const writeParams = request.messageParams as DwnMessageParams[DwnInterface.RecordsWrite];
-      // Skip key-delivery protocol writes to avoid infinite recursion (contextKey records are themselves encrypted)
-      if (writeParams.protocol !== KeyDeliveryProtocolDefinition.protocol) {
-        try {
-          const protocolDefinition = await this.getProtocolDefinition(
-            request.target, writeParams.protocol,
-          );
-          if (protocolDefinition) {
-            const recordsWriteMessage = message as unknown as RecordsWriteMessage;
+    await this.postWriteKeyDelivery(request, message, reply);
 
-            // Reactive root-record upgrade (PR E): if this is an externally-authored
-            // root record with only ProtocolPath encryption, the owner upgrades it by
-            // appending a ProtocolContext recipient entry so that context key
-            // holders (including the external author) can also decrypt.
-            const authorDid = Jws.getSignerDid(
-              recordsWriteMessage.authorization.signature.signatures[0]
-            );
-            const isExternallyAuthored = authorDid !== request.target;
-            const isRootRecord = !writeParams.parentContextId;
-            const rootPathSegment = writeParams.protocolPath.split('/')[0];
-            const isMultiParty = isMultiPartyContextFn(protocolDefinition, rootPathSegment);
-
-            if (isExternallyAuthored && isRootRecord && isMultiParty) {
-              try {
-                await upgradeExternalRootRecordFn(
-                  this.agent, request.target, recordsWriteMessage,
-                  this._dwn, this.getSigner.bind(this), this._contextKeyCache,
-                );
-              } catch (upgradeError: any) {
-                console.warn(
-                  `AgentDwnApi: Reactive root-record upgrade failed for ` +
-                  `'${recordsWriteMessage.recordId}': ${upgradeError.message}`
-                );
-              }
-            }
-
-            const newParticipants = detectNewParticipantsFn({
-              protocolDefinition,
-              protocolPath : writeParams.protocolPath,
-              recipient    : writeParams.recipient,
-              tenantDid    : request.target,
-              authorDid    : isExternallyAuthored ? authorDid : undefined,
-            });
-
-            if (newParticipants.size > 0) {
-              // Derive the context key to deliver to participants
-              const rootContextId = recordsWriteMessage.contextId?.split('/')[0]
-                || recordsWriteMessage.contextId
-                || recordsWriteMessage.recordId;
-
-              const { keyId, keyUri } = await getEncryptionKeyInfoFn(this.agent, request.target);
-              const contextDerivationPath = [
-                KeyDerivationScheme.ProtocolContext,
-                rootContextId,
-              ];
-              const contextDerivedPrivateKeyBytes =
-                await this.agent.keyManager.derivePrivateKeyBytes({
-                  keyUri,
-                  derivationPath: contextDerivationPath,
-                });
-              const contextDerivedPrivateJwk =
-                await X25519.bytesToPrivateKey({ privateKeyBytes: contextDerivedPrivateKeyBytes });
-              const contextKeyPayload: DerivedPrivateJwk = {
-                rootKeyId         : keyId,
-                derivationScheme  : KeyDerivationScheme.ProtocolContext,
-                derivationPath    : contextDerivationPath,
-                derivedPrivateKey : contextDerivedPrivateJwk as PrivateKeyJwk,
-              };
-
-              // Extract the author's key delivery public key from the record
-              // so we can encrypt the contextKey directly to the external author.
-              const authorKeyDeliveryPubKey =
-                recordsWriteMessage.authorization?.authorKeyDeliveryPublicKey;
-
-              for (const participantDid of newParticipants) {
-                try {
-                  // Use the author's key delivery public key when delivering
-                  // to the external author; for other participants (e.g.
-                  // recipient, role holders) fall back to owner-key encryption.
-                  const recipientKey = (participantDid === authorDid && authorKeyDeliveryPubKey)
-                    ? authorKeyDeliveryPubKey
-                    : undefined;
-
-                  await this.writeContextKeyRecord({
-                    tenantDid                     : request.target,
-                    recipientDid                  : participantDid,
-                    contextKeyData                : contextKeyPayload,
-                    sourceProtocol                : writeParams.protocol,
-                    sourceContextId               : rootContextId,
-                    recipientKeyDeliveryPublicKey : recipientKey,
-                  });
-                } catch (keyDeliveryError: any) {
-                  console.warn(
-                    `AgentDwnApi: Key delivery to '${participantDid}' for context ` +
-                    `'${rootContextId}' failed: ${keyDeliveryError.message}. ` +
-                    `The participant may not be able to decrypt records in this context.`
-                  );
-                }
-              }
-            }
-          }
-        } catch (detectionError: any) {
-          // Participant detection failure is non-fatal — the record is still stored.
-          console.warn(
-            `AgentDwnApi: Post-write participant detection failed: ` +
-            `${detectionError.message}`
-          );
-        }
-      }
-    }
     // Auto-decrypt reply data if encryption is enabled (Component 7)
     await this.maybeDecryptReply(request, reply);
 
@@ -408,6 +298,142 @@ export class AgentDwnApi {
     // Returns an object containing the reply from processing the message, the original message,
     // and the content identifier (CID) of the message.
     return { reply, message, messageCid };
+  }
+
+  /**
+   * Post-write key delivery: after a successful encrypted `RecordsWrite`,
+   * detect new participants and write `contextKey` records so they can
+   * decrypt records in the context.
+   *
+   * This is a non-fatal operation — if participant detection or key delivery
+   * fails, the record is still stored and a warning is logged.
+   */
+  private async postWriteKeyDelivery<T extends DwnInterface>(
+    request: ProcessDwnRequest<T>,
+    message: DwnMessage[T],
+    reply: DwnMessageReply[T],
+  ): Promise<void> {
+    if (
+      !isDwnRequest(request, DwnInterface.RecordsWrite) ||
+      !request.encryption ||
+      reply.status.code !== 202
+    ) {
+      return;
+    }
+
+    const writeParams = request.messageParams as DwnMessageParams[DwnInterface.RecordsWrite];
+    // Skip key-delivery protocol writes to avoid infinite recursion (contextKey records are themselves encrypted)
+    if (writeParams.protocol === KeyDeliveryProtocolDefinition.protocol) {
+      return;
+    }
+
+    try {
+      const protocolDefinition = await this.getProtocolDefinition(
+        request.target, writeParams.protocol,
+      );
+      if (!protocolDefinition) {
+        return;
+      }
+
+      const recordsWriteMessage = message as unknown as RecordsWriteMessage;
+
+      // Reactive root-record upgrade (PR E): if this is an externally-authored
+      // root record with only ProtocolPath encryption, the owner upgrades it by
+      // appending a ProtocolContext recipient entry so that context key
+      // holders (including the external author) can also decrypt.
+      const authorDid = Jws.getSignerDid(
+        recordsWriteMessage.authorization.signature.signatures[0]
+      );
+      const isExternallyAuthored = authorDid !== request.target;
+      const isRootRecord = !writeParams.parentContextId;
+      const rootPathSegment = writeParams.protocolPath.split('/')[0];
+      const isMultiParty = isMultiPartyContextFn(protocolDefinition, rootPathSegment);
+
+      if (isExternallyAuthored && isRootRecord && isMultiParty) {
+        try {
+          await upgradeExternalRootRecordFn(
+            this.agent, request.target, recordsWriteMessage,
+            this._dwn, this.getSigner.bind(this), this._contextKeyCache,
+          );
+        } catch (upgradeError: any) {
+          console.warn(
+            `AgentDwnApi: Reactive root-record upgrade failed for ` +
+            `'${recordsWriteMessage.recordId}': ${upgradeError.message}`
+          );
+        }
+      }
+
+      const newParticipants = detectNewParticipantsFn({
+        protocolDefinition,
+        protocolPath : writeParams.protocolPath,
+        recipient    : writeParams.recipient,
+        tenantDid    : request.target,
+        authorDid    : isExternallyAuthored ? authorDid : undefined,
+      });
+
+      if (newParticipants.size > 0) {
+        // Derive the context key to deliver to participants
+        const rootContextId = recordsWriteMessage.contextId?.split('/')[0]
+          || recordsWriteMessage.contextId
+          || recordsWriteMessage.recordId;
+
+        const { keyId, keyUri } = await getEncryptionKeyInfoFn(this.agent, request.target);
+        const contextDerivationPath = [
+          KeyDerivationScheme.ProtocolContext,
+          rootContextId,
+        ];
+        const contextDerivedPrivateKeyBytes =
+          await this.agent.keyManager.derivePrivateKeyBytes({
+            keyUri,
+            derivationPath: contextDerivationPath,
+          });
+        const contextDerivedPrivateJwk =
+          await X25519.bytesToPrivateKey({ privateKeyBytes: contextDerivedPrivateKeyBytes });
+        const contextKeyPayload: DerivedPrivateJwk = {
+          rootKeyId         : keyId,
+          derivationScheme  : KeyDerivationScheme.ProtocolContext,
+          derivationPath    : contextDerivationPath,
+          derivedPrivateKey : contextDerivedPrivateJwk as PrivateKeyJwk,
+        };
+
+        // Extract the author's key delivery public key from the record
+        // so we can encrypt the contextKey directly to the external author.
+        const authorKeyDeliveryPubKey =
+          recordsWriteMessage.authorization?.authorKeyDeliveryPublicKey;
+
+        for (const participantDid of newParticipants) {
+          try {
+            // Use the author's key delivery public key when delivering
+            // to the external author; for other participants (e.g.
+            // recipient, role holders) fall back to owner-key encryption.
+            const recipientKey = (participantDid === authorDid && authorKeyDeliveryPubKey)
+              ? authorKeyDeliveryPubKey
+              : undefined;
+
+            await this.writeContextKeyRecord({
+              tenantDid                     : request.target,
+              recipientDid                  : participantDid,
+              contextKeyData                : contextKeyPayload,
+              sourceProtocol                : writeParams.protocol,
+              sourceContextId               : rootContextId,
+              recipientKeyDeliveryPublicKey : recipientKey,
+            });
+          } catch (keyDeliveryError: any) {
+            console.warn(
+              `AgentDwnApi: Key delivery to '${participantDid}' for context ` +
+              `'${rootContextId}' failed: ${keyDeliveryError.message}. ` +
+              `The participant may not be able to decrypt records in this context.`
+            );
+          }
+        }
+      }
+    } catch (detectionError: any) {
+      // Participant detection failure is non-fatal — the record is still stored.
+      console.warn(
+        `AgentDwnApi: Post-write participant detection failed: ` +
+        `${detectionError.message}`
+      );
+    }
   }
 
   private async sendDwnRpcRequest<T extends DwnInterface>({
@@ -904,35 +930,6 @@ export class AgentDwnApi {
   }
 
   /**
-   * Checks if a protocol path represents a multi-party context.
-   *
-   * @param protocolDefinition - The full protocol definition
-   * @param rootProtocolPath - The root protocol path to check
-   */
-  private isMultiPartyContext(
-    protocolDefinition: ProtocolDefinition,
-    rootProtocolPath: string,
-  ): boolean {
-    return isMultiPartyContextFn(protocolDefinition, rootProtocolPath);
-  }
-
-  /**
-   * Checks if any `$actions` rule in the protocol grants read access
-   * via `who: '<actorType>'` and `of: '<path>'`.
-   *
-   * @param actorType - The actor type to check ('author', 'recipient', or undefined for any)
-   * @param ofPath - The protocol path to check
-   * @param protocolDefinition - The protocol definition
-   */
-  private hasRelationalReadAccess(
-    actorType: 'author' | 'recipient' | undefined,
-    ofPath: string,
-    protocolDefinition: ProtocolDefinition,
-  ): boolean {
-    return hasRelationalReadAccessFn(actorType, ofPath, protocolDefinition);
-  }
-
-  /**
    * Analyses a record write to determine which DIDs need context key delivery.
    *
    * @param params - Parameters for participant detection
@@ -949,7 +946,7 @@ export class AgentDwnApi {
   }
 
   /**
-    * Fetches a protocol definition from the local DWN, with caching.
+   * Fetches a protocol definition from the local DWN, with caching.
    * Returns undefined if the protocol is not installed.
    *
    * @param tenantDid - The tenant DID to query
@@ -958,33 +955,12 @@ export class AgentDwnApi {
    */
   private async getProtocolDefinition(
     tenantDid: string,
-    protocolUri: string
+    protocolUri: string,
   ): Promise<ProtocolDefinition | undefined> {
-    const cacheKey = `${tenantDid}~${protocolUri}`;
-
-    const cached = this._protocolDefinitionCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-
-    const signer = await this.getSigner(tenantDid);
-    const protocolsQuery = await dwnMessageConstructors[
-      DwnInterface.ProtocolsQuery
-    ].create({
-      filter: { protocol: protocolUri },
-      signer,
-    });
-
-    const reply = await this._dwn.processMessage(
-      tenantDid, protocolsQuery.message,
+    return getProtocolDefinitionFn(
+      tenantDid, protocolUri, this._dwn,
+      this.getSigner.bind(this), this._protocolDefinitionCache,
     );
-    if (reply.status.code !== 200 || !reply.entries?.length) {
-      return undefined;
-    }
-
-    const definition = reply.entries[0].descriptor.definition;
-    this._protocolDefinitionCache.set(cacheKey, definition);
-    return definition;
   }
 
   /**
@@ -995,34 +971,10 @@ export class AgentDwnApi {
     targetDid: string,
     protocolUri: string,
   ): Promise<ProtocolDefinition> {
-    const cacheKey = `remote~${targetDid}~${protocolUri}`;
-    const cached = this._protocolDefinitionCache.get(cacheKey);
-    if (cached) { return cached; }
-
-    const protocolsQuery = await dwnMessageConstructors[
-      DwnInterface.ProtocolsQuery
-    ].create({
-      filter: { protocol: protocolUri },
-    });
-
-    const reply = await this.sendDwnRpcRequest({
-      targetDid,
-      dwnEndpointUrls: await getDwnServiceEndpointUrls(
-        targetDid, this.agent.did,
-      ),
-      message: protocolsQuery.message,
-    }) as ProtocolsQueryReply;
-
-    if (reply.status.code !== 200 || !reply.entries?.length) {
-      throw new Error(
-        `AgentDwnApi: Failed to fetch protocol '${protocolUri}' from ` +
-        `'${targetDid}'. The recipient may not have the protocol installed.`
-      );
-    }
-
-    const definition = reply.entries[0].descriptor.definition;
-    this._protocolDefinitionCache.set(cacheKey, definition);
-    return definition;
+    return fetchRemoteProtocolDefinitionFn(
+      targetDid, protocolUri, this.agent.did,
+      this.sendDwnRpcRequest.bind(this), this._protocolDefinitionCache,
+    );
   }
 
   /**
@@ -1043,46 +995,11 @@ export class AgentDwnApi {
     rootContextId: string,
     requesterDid: string,
   ): Promise<{ rootKeyId: string; derivedPublicKey: PublicKeyJwk } | undefined> {
-    const signer = await this.getSigner(requesterDid);
-
-    // Query the target's DWN for any record in this context
-    const recordsQuery = await dwnMessageConstructors[DwnInterface.RecordsQuery].create({
-      signer,
-      filter: {
-        protocol  : protocolUri,
-        contextId : rootContextId,
-      },
-    });
-
-    const dwnEndpointUrls = await getDwnServiceEndpointUrls(targetDid, this.agent.did);
-    const queryReply = await this.sendDwnRpcRequest<DwnInterface.RecordsQuery>({
-      targetDid,
-      dwnEndpointUrls,
-      message: recordsQuery.message,
-    }) as RecordsQueryReply;
-
-    if (queryReply.status.code !== 200 || !queryReply.entries?.length) {
-      return undefined;
-    }
-
-    // Search entries for one with a ProtocolContext recipient entry
-    // that includes derivedPublicKey
-    for (const entry of queryReply.entries) {
-      if (entry.encryption?.recipients) {
-        const contextEntry = entry.encryption.recipients.find(
-          (r: { header: { derivationScheme: string; derivedPublicKey?: PublicKeyJwk } }) =>
-            r.header.derivationScheme === KeyDerivationScheme.ProtocolContext && r.header.derivedPublicKey
-        );
-        if (contextEntry?.header.derivedPublicKey) {
-          return {
-            rootKeyId        : contextEntry.header.kid,
-            derivedPublicKey : contextEntry.header.derivedPublicKey,
-          };
-        }
-      }
-    }
-
-    return undefined;
+    return extractDerivedPublicKeyFn(
+      targetDid, protocolUri, rootContextId, requesterDid,
+      this.agent.did, this.getSigner.bind(this),
+      this.sendDwnRpcRequest.bind(this),
+    );
   }
 
   /**

--- a/packages/agent/src/dwn-protocol-cache.ts
+++ b/packages/agent/src/dwn-protocol-cache.ts
@@ -1,0 +1,216 @@
+/**
+ * Protocol definition fetching and caching utilities for {@link AgentDwnApi}.
+ *
+ * Extracted from `dwn-api.ts` to keep protocol-resolution logic in its own
+ * module.
+ *
+ * @module
+ */
+
+import type { DidUrlDereferencer } from '@enbox/dids';
+import type { PublicKeyJwk } from '@enbox/crypto';
+import type { TtlCache } from '@enbox/common';
+import type {
+  ProtocolDefinition,
+  ProtocolsQueryReply,
+  RecordsQueryReply,
+} from '@enbox/dwn-sdk-js';
+
+import type {
+  DwnInterface,
+  DwnMessage,
+  DwnMessageReply,
+  DwnSigner,
+  MessageHandler,
+} from './types/dwn.js';
+
+import { KeyDerivationScheme } from '@enbox/dwn-sdk-js';
+
+import { getDwnServiceEndpointUrls } from './utils.js';
+import { DwnInterface as DwnInterfaceEnum, dwnMessageConstructors } from './types/dwn.js';
+
+// ---------------------------------------------------------------------------
+// Dependency signatures — keep the extracted code free of `this` references.
+// ---------------------------------------------------------------------------
+
+/** Callback to obtain a DWN signer for a given DID. */
+type GetSignerFn = (author: string) => Promise<DwnSigner>;
+
+/** Callback to send a raw DWN request to a remote endpoint. */
+type SendDwnRpcRequestFn = <T extends DwnInterface>(params: {
+  targetDid: string;
+  dwnEndpointUrls: string[];
+  message: DwnMessage[T];
+  data?: Blob;
+  subscriptionHandler?: MessageHandler[T];
+}) => Promise<DwnMessageReply[T]>;
+
+/** Minimal DWN interface needed for local `processMessage` calls. */
+interface DwnNode {
+  processMessage(tenant: string, message: unknown, options?: unknown): Promise<any>;
+}
+
+// ---------------------------------------------------------------------------
+// Exported functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches a protocol definition from the **local** DWN, backed by a TTL cache.
+ *
+ * @param tenantDid - The DID whose DWN to query
+ * @param protocolUri - The protocol URI to look up
+ * @param dwn - The local DWN instance
+ * @param getSigner - Callback to obtain the signer for `tenantDid`
+ * @param cache - The shared protocol definition cache
+ * @returns The protocol definition, or `undefined` if not installed
+ */
+export async function getProtocolDefinition(
+  tenantDid: string,
+  protocolUri: string,
+  dwn: DwnNode,
+  getSigner: GetSignerFn,
+  cache: TtlCache<string, ProtocolDefinition>,
+): Promise<ProtocolDefinition | undefined> {
+  const cacheKey = `${tenantDid}~${protocolUri}`;
+
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const signer = await getSigner(tenantDid);
+  const protocolsQuery = await dwnMessageConstructors[
+    DwnInterfaceEnum.ProtocolsQuery
+  ].create({
+    filter: { protocol: protocolUri },
+    signer,
+  });
+
+  const reply = await dwn.processMessage(
+    tenantDid, protocolsQuery.message,
+  );
+  if (reply.status.code !== 200 || !reply.entries?.length) {
+    return undefined;
+  }
+
+  const definition = reply.entries[0].descriptor.definition;
+  cache.set(cacheKey, definition);
+  return definition;
+}
+
+/**
+ * Fetches a protocol definition from a **remote** DWN.
+ *
+ * Uses an unsigned `ProtocolsQuery` since public protocols can be queried
+ * anonymously.
+ *
+ * @param targetDid - The remote DWN owner
+ * @param protocolUri - The protocol URI to look up
+ * @param didDereferencer - A DID URL dereferencer for resolving service endpoints
+ * @param sendDwnRpcRequest - Callback to send the RPC query
+ * @param cache - The shared protocol definition cache
+ * @returns The protocol definition
+ * @throws If the protocol cannot be fetched
+ */
+export async function fetchRemoteProtocolDefinition(
+  targetDid: string,
+  protocolUri: string,
+  didDereferencer: DidUrlDereferencer,
+  sendDwnRpcRequest: SendDwnRpcRequestFn,
+  cache: TtlCache<string, ProtocolDefinition>,
+): Promise<ProtocolDefinition> {
+  const cacheKey = `remote~${targetDid}~${protocolUri}`;
+  const cached = cache.get(cacheKey);
+  if (cached) { return cached; }
+
+  const protocolsQuery = await dwnMessageConstructors[
+    DwnInterfaceEnum.ProtocolsQuery
+  ].create({
+    filter: { protocol: protocolUri },
+  });
+
+  const reply = await sendDwnRpcRequest({
+    targetDid,
+    dwnEndpointUrls : await getDwnServiceEndpointUrls(targetDid, didDereferencer),
+    message         : protocolsQuery.message,
+  }) as ProtocolsQueryReply;
+
+  if (reply.status.code !== 200 || !reply.entries?.length) {
+    throw new Error(
+      `AgentDwnApi: Failed to fetch protocol '${protocolUri}' from ` +
+      `'${targetDid}'. The recipient may not have the protocol installed.`
+    );
+  }
+
+  const definition = reply.entries[0].descriptor.definition;
+  cache.set(cacheKey, definition);
+  return definition;
+}
+
+/**
+ * Extracts the `derivedPublicKey` from an existing `ProtocolContext`-encrypted
+ * record in a context on a remote DWN.
+ *
+ * This key allows an external author to encrypt new records in the same
+ * context without knowing the context private key.
+ *
+ * @param targetDid      - The DWN owner's DID
+ * @param protocolUri    - The protocol URI to search
+ * @param rootContextId  - The root context ID
+ * @param requesterDid   - The DID of the requester (used for signing the query)
+ * @param didDereferencer - A DID URL dereferencer for resolving service endpoints
+ * @param getSigner      - Callback to obtain the signer for `requesterDid`
+ * @param sendDwnRpcRequest - Callback to send the RPC query
+ * @returns The rootKeyId and derivedPublicKey, or `undefined` if no
+ *          `ProtocolContext` record exists yet
+ */
+export async function extractDerivedPublicKey(
+  targetDid: string,
+  protocolUri: string,
+  rootContextId: string,
+  requesterDid: string,
+  didDereferencer: DidUrlDereferencer,
+  getSigner: GetSignerFn,
+  sendDwnRpcRequest: SendDwnRpcRequestFn,
+): Promise<{ rootKeyId: string; derivedPublicKey: PublicKeyJwk } | undefined> {
+  const signer = await getSigner(requesterDid);
+
+  // Query the target's DWN for any record in this context
+  const recordsQuery = await dwnMessageConstructors[DwnInterfaceEnum.RecordsQuery].create({
+    signer,
+    filter: {
+      protocol  : protocolUri,
+      contextId : rootContextId,
+    },
+  });
+
+  const dwnEndpointUrls = await getDwnServiceEndpointUrls(targetDid, didDereferencer);
+  const queryReply = await sendDwnRpcRequest<DwnInterfaceEnum.RecordsQuery>({
+    targetDid,
+    dwnEndpointUrls,
+    message: recordsQuery.message,
+  }) as RecordsQueryReply;
+
+  if (queryReply.status.code !== 200 || !queryReply.entries?.length) {
+    return undefined;
+  }
+
+  // Search entries for one with a ProtocolContext recipient entry
+  // that includes derivedPublicKey
+  for (const entry of queryReply.entries) {
+    if (entry.encryption?.recipients) {
+      const contextEntry = entry.encryption.recipients.find(
+        (r: { header: { derivationScheme: string; derivedPublicKey?: PublicKeyJwk } }) =>
+          r.header.derivationScheme === KeyDerivationScheme.ProtocolContext && r.header.derivedPublicKey
+      );
+      if (contextEntry?.header.derivedPublicKey) {
+        return {
+          rootKeyId        : contextEntry.header.kid,
+          derivedPublicKey : contextEntry.header.derivedPublicKey,
+        };
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -22,6 +22,7 @@ import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
 import { AgentDwnApi, isDwnMessage, isMessagesPermissionScope, isRecordPermissionScope } from '../src/dwn-api.js';
+import { hasRelationalReadAccess, isMultiPartyContext } from '../src/protocol-utils.js';
 
 const testDwnUrls: string[] = [testDwnUrl];
 
@@ -2866,16 +2867,11 @@ describe('Encryption Callback Factories', () => {
     };
 
     it('should detect multi-party protocols via isMultiPartyContext()', () => {
-      // Access private method via bracket notation
-      const isMultiParty = testHarness.agent.dwn['isMultiPartyContext'].bind(
-        testHarness.agent.dwn
-      );
-
       // Multi-party: thread has participant with $role: true
-      expect(isMultiParty(multiPartyProtocolDefinition, 'thread')).toBe(true);
+      expect(isMultiPartyContext(multiPartyProtocolDefinition, 'thread')).toBe(true);
 
       // Single-party: note has no $role children
-      expect(isMultiParty(singlePartyProtocolDefinition, 'note')).toBe(false);
+      expect(isMultiPartyContext(singlePartyProtocolDefinition, 'note')).toBe(false);
     });
 
     it('should encrypt root record with ProtocolContext for multi-party protocol', async () => {
@@ -3818,83 +3814,50 @@ describe('Participant Detection (PR B)', () => {
 
   describe('isMultiPartyContext()', () => {
     it('should return true for role-based protocols', () => {
-      const isMultiParty = testHarness.agent.dwn['isMultiPartyContext'].bind(
-        testHarness.agent.dwn
-      );
-      expect(isMultiParty(roleProtocol, 'thread')).toBe(true);
+      expect(isMultiPartyContext(roleProtocol, 'thread')).toBe(true);
     });
 
     it('should return true for relational-only protocols with read rules', () => {
-      const isMultiParty = testHarness.agent.dwn['isMultiPartyContext'].bind(
-        testHarness.agent.dwn
-      );
-      expect(isMultiParty(relationalProtocol, 'email')).toBe(true);
+      expect(isMultiPartyContext(relationalProtocol, 'email')).toBe(true);
     });
 
     it('should return true for mixed role + relational protocols', () => {
-      const isMultiParty = testHarness.agent.dwn['isMultiPartyContext'].bind(
-        testHarness.agent.dwn
-      );
-      expect(isMultiParty(mixedProtocol, 'community')).toBe(true);
+      expect(isMultiPartyContext(mixedProtocol, 'community')).toBe(true);
     });
 
     it('should return false for single-party protocols', () => {
-      const isMultiParty = testHarness.agent.dwn['isMultiPartyContext'].bind(
-        testHarness.agent.dwn
-      );
-      expect(isMultiParty(singlePartyProtocol, 'note')).toBe(false);
+      expect(isMultiPartyContext(singlePartyProtocol, 'note')).toBe(false);
     });
 
     it('should return false when relational rules only grant create, not read', () => {
-      const isMultiParty = testHarness.agent.dwn['isMultiPartyContext'].bind(
-        testHarness.agent.dwn
-      );
-      expect(isMultiParty(createOnlyProtocol, 'form')).toBe(false);
+      expect(isMultiPartyContext(createOnlyProtocol, 'form')).toBe(false);
     });
   });
 
   describe('hasRelationalReadAccess()', () => {
     it('should find recipient-of read rules', () => {
-      const hasAccess = testHarness.agent.dwn['hasRelationalReadAccess'].bind(
-        testHarness.agent.dwn
-      );
-      expect(hasAccess('recipient', 'email', relationalProtocol)).toBe(true);
+      expect(hasRelationalReadAccess('recipient', 'email', relationalProtocol)).toBe(true);
     });
 
     it('should find author-of read rules', () => {
-      const hasAccess = testHarness.agent.dwn['hasRelationalReadAccess'].bind(
-        testHarness.agent.dwn
-      );
-      expect(hasAccess('author', 'email', relationalProtocol)).toBe(true);
+      expect(hasRelationalReadAccess('author', 'email', relationalProtocol)).toBe(true);
     });
 
     it('should return false when no matching rule exists', () => {
-      const hasAccess = testHarness.agent.dwn['hasRelationalReadAccess'].bind(
-        testHarness.agent.dwn
-      );
-      expect(hasAccess('recipient', 'note', singlePartyProtocol)).toBe(false);
+      expect(hasRelationalReadAccess('recipient', 'note', singlePartyProtocol)).toBe(false);
     });
 
     it('should return false when rules exist but do not grant read', () => {
-      const hasAccess = testHarness.agent.dwn['hasRelationalReadAccess'].bind(
-        testHarness.agent.dwn
-      );
-      expect(hasAccess('recipient', 'form/submission', createOnlyProtocol)).toBe(false);
+      expect(hasRelationalReadAccess('recipient', 'form/submission', createOnlyProtocol)).toBe(false);
     });
 
     it('should find rules with undefined actorType (any who)', () => {
-      const hasAccess = testHarness.agent.dwn['hasRelationalReadAccess'].bind(
-        testHarness.agent.dwn
-      );
-      expect(hasAccess(undefined, 'email', relationalProtocol)).toBe(true);
+      expect(hasRelationalReadAccess(undefined, 'email', relationalProtocol)).toBe(true);
     });
 
     it('should find deeply nested relational rules', () => {
-      const hasAccess = testHarness.agent.dwn['hasRelationalReadAccess'].bind(
-        testHarness.agent.dwn
-      );
       // The mixed protocol has { who: 'recipient', of: 'community/channel/message', can: ['read'...] }
-      expect(hasAccess('recipient', 'community/channel/message', mixedProtocol)).toBe(true);
+      expect(hasRelationalReadAccess('recipient', 'community/channel/message', mixedProtocol)).toBe(true);
     });
   });
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -32,6 +32,8 @@ export * from './protocol.js';
 export * from './protocol-types.js';
 export * from './read-only-record.js';
 export * from './record.js';
+export * from './record-data.js';
+export * from './record-types.js';
 export * from './typed-web5.js';
 export * from './vc-api.js';
 export * from './web5.js';

--- a/packages/api/src/record-data.ts
+++ b/packages/api/src/record-data.ts
@@ -1,0 +1,155 @@
+/**
+ * Data-access helpers for the {@link Record} class.
+ *
+ * `RecordData` is the object returned by `Record.data`. It wraps a lazily
+ * evaluated `stream()` function with convenience accessors that mirror the
+ * Fetch `Response` API (`blob()`, `bytes()`, `json()`, `text()`).
+ *
+ * Extracted from `record.ts` so the convenience-method boilerplate lives in
+ * its own module while the stream-resolution logic (which is tightly coupled
+ * to `Record` internals) stays inside the `Record` class.
+ *
+ * @module
+ */
+
+import { Stream } from '@enbox/common';
+
+/**
+ * A thenable data accessor returned by {@link Record.data}.
+ *
+ * Provides convenience methods for consuming the record's data in various
+ * formats, plus `then`/`catch` so the object can be awaited directly to
+ * obtain the underlying `ReadableStream`.
+ *
+ * @beta
+ */
+export type RecordData = {
+  /** Consume the data as a `Blob`. */
+  blob: () => Promise<Blob>;
+  /** Consume the data as raw bytes. */
+  bytes: () => Promise<Uint8Array>;
+  /** Parse the data as JSON. */
+  json: <T = unknown>() => Promise<T>;
+  /** Consume the data as a UTF-8 string. */
+  text: () => Promise<string>;
+  /** Obtain the underlying Web `ReadableStream`. */
+  stream: () => Promise<ReadableStream>;
+  /** Proxy for `stream().then(...)` so the object is directly awaitable. */
+  then: (
+    onFulfilled?: (value: ReadableStream) => ReadableStream | PromiseLike<ReadableStream>,
+    onRejected?: (reason: any) => PromiseLike<never>,
+  ) => Promise<ReadableStream>;
+  /** Proxy for `stream().catch(...)`. */
+  catch: (onRejected?: (reason: any) => PromiseLike<never>) => Promise<ReadableStream>;
+};
+
+/**
+ * Create a {@link RecordData} wrapper around a `stream` provider function.
+ *
+ * @param streamFn   - A function that returns a `Promise<ReadableStream>` for the record data.
+ * @param dataFormat - The MIME type used when constructing Blobs.
+ * @returns A {@link RecordData} object with convenience accessors.
+ *
+ * @beta
+ */
+export function createRecordData(streamFn: () => Promise<ReadableStream>, dataFormat: string | undefined): RecordData {
+  const dataObj: RecordData = {
+
+    /**
+     * Returns the data of the current record as a `Blob`.
+     *
+     * @returns A promise that resolves to a Blob containing the record's data.
+     * @throws If the record data is not available or cannot be converted to a `Blob`.
+     *
+     * @beta
+     */
+    async blob(): Promise<Blob> {
+      return new Blob([await Stream.consumeToBytes({ readableStream: await this.stream() })], { type: dataFormat });
+    },
+
+    /**
+     * Returns the data of the current record as a `Uint8Array`.
+     *
+     * @returns A Promise that resolves to a `Uint8Array` containing the record's data bytes.
+     * @throws If the record data is not available or cannot be converted to a byte array.
+     *
+     * @beta
+     */
+    async bytes(): Promise<Uint8Array> {
+      return await Stream.consumeToBytes({ readableStream: await this.stream() });
+    },
+
+    /**
+     * Parses the data of the current record as JSON and returns it as a JavaScript object.
+     *
+     * @returns A Promise that resolves to a JavaScript object parsed from the record's JSON data.
+     * @throws If the record data is not available, not in JSON format, or cannot be parsed.
+     *
+     * @beta
+     */
+    async json<T = unknown>(): Promise<T> {
+      return await Stream.consumeToJson({ readableStream: await this.stream() }) as T;
+    },
+
+    /**
+     * Returns the data of the current record as a `string`.
+     *
+     * @returns A promise that resolves to a `string` containing the record's text data.
+     * @throws If the record data is not available or cannot be converted to text.
+     *
+     * @beta
+     */
+    async text(): Promise<string> {
+      return await Stream.consumeToText({ readableStream: await this.stream() });
+    },
+
+    /**
+     * Provides a Web `ReadableStream` containing the record's data.
+     *
+     * Uses the standard Web Streams API for cross-platform compatibility across
+     * browsers, Node.js, Bun, and Deno.
+     *
+     * @returns A promise that resolves to a Web `ReadableStream` of the record's data.
+     * @throws If the record data is not available in-memory and cannot be fetched.
+     *
+     * @beta
+     */
+    stream: streamFn,
+
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the `Promise` returned by
+     * `stream()`.
+     *
+     * This method is a proxy to the `then` method of the `Promise` returned by `stream()`,
+     * allowing for a seamless integration with promise-based workflows.
+     * @param onFulfilled - A function to asynchronously execute when the `stream()` promise
+     *                      becomes fulfilled.
+     * @param onRejected - A function to asynchronously execute when the `stream()` promise
+     *                     becomes rejected.
+     * @returns A `Promise` for the completion of which ever callback is executed.
+     */
+    then(
+      onFulfilled?: (value: ReadableStream) => ReadableStream | PromiseLike<ReadableStream>,
+      onRejected?: (reason: any) => PromiseLike<never>,
+    ): Promise<ReadableStream> {
+      return this.stream().then(onFulfilled, onRejected);
+    },
+
+    /**
+     * Attaches a rejection handler callback to the `Promise` returned by the `stream()` method.
+     * This method is a shorthand for `.then(undefined, onRejected)`, specifically designed for handling
+     * rejection cases in the promise chain initiated by accessing the record's data. It ensures that
+     * errors during data retrieval or processing can be caught and handled appropriately.
+     *
+     * @param onRejected - A function to asynchronously execute when the `stream()` promise
+     *                     becomes rejected.
+     * @returns A `Promise` that resolves to the value of the callback if it is called, or to its
+     *          original fulfillment value if the promise is instead fulfilled.
+     */
+    catch(onRejected?: (reason: any) => PromiseLike<never>): Promise<ReadableStream> {
+      return this.stream().catch(onRejected);
+    }
+  };
+
+  return dataObj;
+}

--- a/packages/api/src/record-types.ts
+++ b/packages/api/src/record-types.ts
@@ -1,0 +1,188 @@
+/**
+ * Type definitions for the {@link Record} class.
+ *
+ * Extracted from `record.ts` to keep the main module focused on behaviour.
+ *
+ * @module
+ */
+
+import type {
+  DwnMessage,
+  DwnMessageDescriptor,
+} from '@enbox/agent';
+
+import type { DwnInterface } from '@enbox/agent';
+
+/**
+ * Represents Immutable Record properties that cannot be changed after the record is created.
+ *
+ * @beta
+ * */
+export type ImmutableRecordProperties =
+  Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dateCreated' | 'parentId' | 'protocol' | 'protocolPath' | 'recipient' | 'schema'>;
+
+/**
+ * Represents Optional Record properties that depend on the Record's current state.
+ *
+ * @beta
+*/
+export type OptionalRecordProperties =
+  Pick<DwnMessage[DwnInterface.RecordsWrite], 'authorization' | 'attestation' | 'encryption' | 'contextId' > &
+  Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dataFormat' | 'dataCid' | 'dataSize' | 'datePublished' | 'published' | 'tags'>;
+
+/**
+ * Represents the structured data model of a record, encapsulating the essential fields that define
+ * the record's metadata and payload within a Decentralized Web Node (DWN).
+ *
+ * @beta
+ */
+export type RecordModel = ImmutableRecordProperties & OptionalRecordProperties & {
+
+  /** The logical author of the record. */
+  author: string;
+
+  /** The unique identifier of the record. */
+  recordId?: string;
+
+  /** The message timestamp (time of creation, most recent update, or deletion). */
+  timestamp?: string;
+
+  /** The protocol role under which this record is written. */
+  protocolRole?: RecordOptions['protocolRole'];
+};
+
+/**
+ * Options for configuring a {@link Record} instance, extending the base `RecordsWriteMessage` with
+ * additional properties.
+ *
+ * This type combines the standard fields required for writing DWN records with additional metadata
+ * and configuration options used specifically in the {@link Record} class.
+ *
+ * @beta
+ */
+export type RecordOptions = DwnMessage[DwnInterface.RecordsWrite | DwnInterface.RecordsDelete] & {
+  /** The DID that signed the record. */
+  author: string;
+
+  /** The attestation signature(s) for the record. */
+  attestation?: DwnMessage[DwnInterface.RecordsWrite]['attestation'];
+
+  /** The encryption information for the record. */
+  encryption?: DwnMessage[DwnInterface.RecordsWrite]['encryption'];
+
+  /** The contextId associated with the record. */
+  contextId?: string;
+
+  /** The unique identifier of the record */
+  recordId?: string;
+
+  /** The DID of the DWN tenant under which record operations are being performed. */
+  connectedDid: string;
+
+  /** The optional DID that will sign the records on behalf of the connectedDid  */
+  delegateDid?: string;
+
+  /** The data of the record, either as a Base64 URL encoded string or a Blob. */
+  encodedData?: string | Blob;
+
+  /**
+   * A stream of data, conforming to the Web `ReadableStream` interface, providing a mechanism
+   * to read the record's data sequentially. This is particularly useful for handling large
+   * datasets that should not be loaded entirely in memory, allowing for efficient, chunked
+   * processing of the record's data.
+   *
+   * The DWN SDK now returns Web `ReadableStream` natively, so no conversion is needed.
+   */
+  data?: ReadableStream;
+
+  /** The initial `RecordsWriteMessage` that represents the initial state/version of the record. */
+  initialWrite?: DwnMessage[DwnInterface.RecordsWrite];
+
+  /** The protocol role under which this record is written. */
+  protocolRole?: string;
+
+  /** The remote tenant DID if the record was queried or read from a remote DWN. */
+  remoteOrigin?: string;
+};
+
+/**
+ * Parameters for updating a DWN record.
+ *
+ * This type specifies the set of properties that can be updated on an existing record. It is used
+ * to convey the new state or changes to be applied to the record.
+ *
+ * @beta
+ */
+export type RecordUpdateParams = {
+  /**
+   * The new data for the record, which can be of any type. This data will replace the existing
+   * data of the record. It's essential to ensure that this data is compatible with the record's
+   * schema or data format expectations.
+   */
+  data?: unknown;
+
+  /**
+   * The Content Identifier (CID) of the data. Updating this value changes the reference to the data
+   * associated with the record.
+   */
+  dataCid?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['dataCid'];
+
+  /** Whether or not to store the updated message. */
+  store?: boolean;
+
+  /** The data format/MIME type of the supplied data */
+  dataFormat?: string;
+
+  /** The size of the data in bytes. */
+  dataSize?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['dataSize'];
+
+  /** The timestamp of the update message. */
+  timestamp?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['messageTimestamp'];
+
+  /** The timestamp indicating when the record was published. */
+  datePublished?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['datePublished'];
+
+  /** The protocol role under which this record is written. */
+  protocolRole?: RecordOptions['protocolRole'];
+
+  /** The published status of the record. */
+  published?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['published'];
+
+
+  /** The tags associated with the updated record */
+  tags?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['tags'];
+
+  /**
+   * Controls whether the updated record should be auto-encrypted.
+   *
+   * If omitted, auto-detected from the original record: if the record was
+   * originally encrypted, the update is automatically re-encrypted with a
+   * fresh DEK. Set to `false` explicitly to skip encryption on the update.
+   */
+  encryption?: boolean;
+};
+
+/**
+ * Parameters for deleting a DWN record.
+ *
+ * This type specifies the set of properties that are used when deleting an existing record. It is used
+ * to convey the new state or changes to be applied to the record.
+ *
+ * @beta
+ */
+export type RecordDeleteParams = {
+  /** Whether or not to store the message. */
+  store?: boolean;
+
+  /** Whether or not to sign the delete as an owner in order to import it. */
+  signAsOwner?: boolean;
+
+  /** Whether or not to prune any children this record may have. */
+  prune?: DwnMessageDescriptor[DwnInterface.RecordsDelete]['prune'];
+
+  /** The timestamp of the delete message. */
+  timestamp?: DwnMessageDescriptor[DwnInterface.RecordsDelete]['messageTimestamp'];
+
+  /** The protocol role under which this record will be deleted. */
+  protocolRole?: string;
+};

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -17,6 +17,13 @@ import type {
   Web5Agent,
 } from '@enbox/agent';
 
+import type {
+  RecordDeleteParams,
+  RecordModel,
+  RecordOptions,
+  RecordUpdateParams,
+} from './record-types.js';
+
 import {
   AgentPermissionsApi,
   DwnInterface,
@@ -27,181 +34,23 @@ import {
 } from '@enbox/agent';
 import { Convert, isEmptyObject, removeUndefinedProperties, Stream } from '@enbox/common';
 
+import type { RecordData } from './record-data.js';
+
+import { createRecordData } from './record-data.js';
 import { dataToBlob, SendCache } from './utils.js';
 
-/**
- * Represents Immutable Record properties that cannot be changed after the record is created.
- *
- * @beta
- * */
-export type ImmutableRecordProperties =
-  Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dateCreated' | 'parentId' | 'protocol' | 'protocolPath' | 'recipient' | 'schema'>;
+// Re-export types for backward compatibility — consumers that import from
+// `./record.js` will continue to resolve every type without changes.
+export type {
+  ImmutableRecordProperties,
+  OptionalRecordProperties,
+  RecordDeleteParams,
+  RecordModel,
+  RecordOptions,
+  RecordUpdateParams,
+} from './record-types.js';
 
-/**
- * Represents Optional Record properties that depend on the Record's current state.
- *
- * @beta
-*/
-export type OptionalRecordProperties =
-  Pick<DwnMessage[DwnInterface.RecordsWrite], 'authorization' | 'attestation' | 'encryption' | 'contextId' > &
-  Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dataFormat' | 'dataCid' | 'dataSize' | 'datePublished' | 'published' | 'tags'>;
-
-/**
- * Represents the structured data model of a record, encapsulating the essential fields that define
- * the record's metadata and payload within a Decentralized Web Node (DWN).
- *
- * @beta
- */
-export type RecordModel = ImmutableRecordProperties & OptionalRecordProperties & {
-
-  /** The logical author of the record. */
-  author: string;
-
-  /** The unique identifier of the record. */
-  recordId?: string;
-
-  /** The message timestamp (time of creation, most recent update, or deletion). */
-  timestamp?: string;
-
-  /** The protocol role under which this record is written. */
-  protocolRole?: RecordOptions['protocolRole'];
-};
-
-/**
- * Options for configuring a {@link Record} instance, extending the base `RecordsWriteMessage` with
- * additional properties.
- *
- * This type combines the standard fields required for writing DWN records with additional metadata
- * and configuration options used specifically in the {@link Record} class.
- *
- * @beta
- */
-export type RecordOptions = DwnMessage[DwnInterface.RecordsWrite | DwnInterface.RecordsDelete] & {
-  /** The DID that signed the record. */
-  author: string;
-
-  /** The attestation signature(s) for the record. */
-  attestation?: DwnMessage[DwnInterface.RecordsWrite]['attestation'];
-
-  /** The encryption information for the record. */
-  encryption?: DwnMessage[DwnInterface.RecordsWrite]['encryption'];
-
-  /** The contextId associated with the record. */
-  contextId?: string;
-
-  /** The unique identifier of the record */
-  recordId?: string;
-
-  /** The DID of the DWN tenant under which record operations are being performed. */
-  connectedDid: string;
-
-  /** The optional DID that will sign the records on behalf of the connectedDid  */
-  delegateDid?: string;
-
-  /** The data of the record, either as a Base64 URL encoded string or a Blob. */
-  encodedData?: string | Blob;
-
-  /**
-   * A stream of data, conforming to the Web `ReadableStream` interface, providing a mechanism
-   * to read the record's data sequentially. This is particularly useful for handling large
-   * datasets that should not be loaded entirely in memory, allowing for efficient, chunked
-   * processing of the record's data.
-   *
-   * The DWN SDK now returns Web `ReadableStream` natively, so no conversion is needed.
-   */
-  data?: ReadableStream;
-
-  /** The initial `RecordsWriteMessage` that represents the initial state/version of the record. */
-  initialWrite?: DwnMessage[DwnInterface.RecordsWrite];
-
-  /** The protocol role under which this record is written. */
-  protocolRole?: string;
-
-  /** The remote tenant DID if the record was queried or read from a remote DWN. */
-  remoteOrigin?: string;
-};
-
-/**
- * Parameters for updating a DWN record.
- *
- * This type specifies the set of properties that can be updated on an existing record. It is used
- * to convey the new state or changes to be applied to the record.
- *
- * @beta
- */
-export type RecordUpdateParams = {
-  /**
-   * The new data for the record, which can be of any type. This data will replace the existing
-   * data of the record. It's essential to ensure that this data is compatible with the record's
-   * schema or data format expectations.
-   */
-  data?: unknown;
-
-  /**
-   * The Content Identifier (CID) of the data. Updating this value changes the reference to the data
-   * associated with the record.
-   */
-  dataCid?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['dataCid'];
-
-  /** Whether or not to store the updated message. */
-  store?: boolean;
-
-  /** The data format/MIME type of the supplied data */
-  dataFormat?: string;
-
-  /** The size of the data in bytes. */
-  dataSize?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['dataSize'];
-
-  /** The timestamp of the update message. */
-  timestamp?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['messageTimestamp'];
-
-  /** The timestamp indicating when the record was published. */
-  datePublished?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['datePublished'];
-
-  /** The protocol role under which this record is written. */
-  protocolRole?: RecordOptions['protocolRole'];
-
-  /** The published status of the record. */
-  published?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['published'];
-
-
-  /** The tags associated with the updated record */
-  tags?: DwnMessageDescriptor[DwnInterface.RecordsWrite]['tags'];
-
-  /**
-   * Controls whether the updated record should be auto-encrypted.
-   *
-   * If omitted, auto-detected from the original record: if the record was
-   * originally encrypted, the update is automatically re-encrypted with a
-   * fresh DEK. Set to `false` explicitly to skip encryption on the update.
-   */
-  encryption?: boolean;
-};
-
-/**
- * Parameters for deleting a DWN record.
- *
- * This type specifies the set of properties that are used when deleting an existing record. It is used
- * to convey the new state or changes to be applied to the record.
- *
- * @beta
- */
-export type RecordDeleteParams = {
-  /** Whether or not to store the message. */
-  store?: boolean;
-
-  /** Whether or not to sign the delete as an owner in order to import it. */
-  signAsOwner?: boolean;
-
-  /** Whether or not to prune any children this record may have. */
-  prune?: DwnMessageDescriptor[DwnInterface.RecordsDelete]['prune'];
-
-  /** The timestamp of the delete message. */
-  timestamp?: DwnMessageDescriptor[DwnInterface.RecordsDelete]['messageTimestamp'];
-
-  /** The protocol role under which this record will be deleted. */
-  protocolRole?: string;
-};
+export type { RecordData } from './record-data.js';
 
 /**
  * The result of a {@link Record.update} operation.
@@ -472,147 +321,37 @@ export class Record implements RecordModel {
    *
    * @beta
    */
-  get data(): {
-      blob: () => Promise<Blob>;
-      bytes: () => Promise<Uint8Array>;
-      json: <T = unknown>() => Promise<T>;
-      text: () => Promise<string>;
-      stream: () => Promise<ReadableStream>;
-      then: (
-        onFulfilled?: (value: ReadableStream) => ReadableStream | PromiseLike<ReadableStream>,
-        onRejected?: (reason: any) => PromiseLike<never>,
-      ) => Promise<ReadableStream>;
-      catch: (onRejected?: (reason: any) => PromiseLike<never>) => Promise<ReadableStream>;
-      } {
-    const self = this; // Capture the context of the `Record` instance.
-    const dataObj = {
-
-      /**
-       * Returns the data of the current record as a `Blob`.
-       *
-       * @returns A promise that resolves to a Blob containing the record's data.
-       * @throws If the record data is not available or cannot be converted to a `Blob`.
-       *
-       * @beta
-       */
-      async blob(): Promise<Blob> {
-        return new Blob([await Stream.consumeToBytes({ readableStream: await this.stream() })], { type: self.dataFormat });
-      },
-
-      /**
-       * Returns the data of the current record as a `Uint8Array`.
-       *
-       * @returns A Promise that resolves to a `Uint8Array` containing the record's data bytes.
-       * @throws If the record data is not available or cannot be converted to a byte array.
-       *
-       * @beta
-       */
-      async bytes(): Promise<Uint8Array> {
-        return await Stream.consumeToBytes({ readableStream: await this.stream() });
-      },
-
-      /**
-       * Parses the data of the current record as JSON and returns it as a JavaScript object.
-       *
-       * @returns A Promise that resolves to a JavaScript object parsed from the record's JSON data.
-       * @throws If the record data is not available, not in JSON format, or cannot be parsed.
-       *
-       * @beta
-       */
-      async json<T = unknown>(): Promise<T> {
-        return await Stream.consumeToJson({ readableStream: await this.stream() }) as T;
-      },
-
-      /**
-       * Returns the data of the current record as a `string`.
-       *
-       * @returns A promise that resolves to a `string` containing the record's text data.
-       * @throws If the record data is not available or cannot be converted to text.
-       *
-       * @beta
-       */
-      async text(): Promise<string> {
-        return await Stream.consumeToText({ readableStream: await this.stream() });
-      },
-
-      /**
-       * Provides a Web `ReadableStream` containing the record's data.
-       *
-       * Uses the standard Web Streams API for cross-platform compatibility across
-       * browsers, Node.js, Bun, and Deno.
-       *
-       * @returns A promise that resolves to a Web `ReadableStream` of the record's data.
-       * @throws If the record data is not available in-memory and cannot be fetched.
-       *
-       * @beta
-       */
-      async stream(): Promise<ReadableStream> {
-        if (self.deleted) {
-          throw new Error('404: Not Found');
-        }
-
-        if (self._encodedData) {
-          /** If `encodedData` is set, it indicates that the Record was instantiated by
-           * `dwn.records.create()`/`dwn.records.write()` or the record's data payload was small
-           * enough to be returned in `dwn.records.query()` results. In either case, the data is
-           * already available in-memory and can be returned as a Web `ReadableStream`. */
-          return Stream.fromBlob(self._encodedData);
-
-        } else if (self._readableStream) {
-          /** If a data stream is available, return it and clear the reference so subsequent
-           * calls will re-fetch. Unlike Node Readable streams, a consumed Web ReadableStream
-           * still appears "readable" (unlocked), so we cannot rely on `isReadable()` to
-           * detect exhaustion. Clearing the reference ensures the next call re-fetches. */
-          const currentStream = self._readableStream;
-          self._readableStream = undefined;
-          return currentStream;
-
-        } else {
-          /** The data stream has been consumed or was never set. Re-fetch from either: */
-          return self._remoteOrigin ?
-            // A. ...a remote DWN if the record was originally queried from a remote DWN.
-            await self.readRecordData({ target: self._remoteOrigin, isRemote: true }) :
-            // B. ...a local DWN if the record was originally queried from the local DWN.
-            await self.readRecordData({ target: self._connectedDid, isRemote: false });
-        }
-      },
-
-      /**
-       * Attaches callbacks for the resolution and/or rejection of the `Promise` returned by
-       * `stream()`.
-       *
-       * This method is a proxy to the `then` method of the `Promise` returned by `stream()`,
-       * allowing for a seamless integration with promise-based workflows.
-       * @param onFulfilled - A function to asynchronously execute when the `stream()` promise
-       *                      becomes fulfilled.
-       * @param onRejected - A function to asynchronously execute when the `stream()` promise
-       *                     becomes rejected.
-       * @returns A `Promise` for the completion of which ever callback is executed.
-       */
-      then(
-        onFulfilled?: (value: ReadableStream) => ReadableStream | PromiseLike<ReadableStream>,
-        onRejected?: (reason: any) => PromiseLike<never>,
-      ): Promise<ReadableStream> {
-        return this.stream().then(onFulfilled, onRejected);
-      },
-
-      /**
-       * Attaches a rejection handler callback to the `Promise` returned by the `stream()` method.
-       * This method is a shorthand for `.then(undefined, onRejected)`, specifically designed for handling
-       * rejection cases in the promise chain initiated by accessing the record's data. It ensures that
-       * errors during data retrieval or processing can be caught and handled appropriately.
-       *
-       * @param onRejected - A function to asynchronously execute when the `stream()` promise
-       *                     becomes rejected.
-       * @returns A `Promise` that resolves to the value of the callback if it is called, or to its
-       *          original fulfillment value if the promise is instead fulfilled.
-       */
-      catch(onRejected?: (reason: any) => PromiseLike<never>): Promise<ReadableStream> {
-        return this.stream().catch(onRejected);
+  get data(): RecordData {
+    return createRecordData(async (): Promise<ReadableStream> => {
+      if (this.deleted) {
+        throw new Error('404: Not Found');
       }
-    };
 
-    return dataObj;
+      if (this._encodedData) {
+        /** If `encodedData` is set, it indicates that the Record was instantiated by
+         * `dwn.records.create()`/`dwn.records.write()` or the record's data payload was small
+         * enough to be returned in `dwn.records.query()` results. In either case, the data is
+         * already available in-memory and can be returned as a Web `ReadableStream`. */
+        return Stream.fromBlob(this._encodedData);
+
+      } else if (this._readableStream) {
+        /** If a data stream is available, return it and clear the reference so subsequent
+         * calls will re-fetch. Unlike Node Readable streams, a consumed Web ReadableStream
+         * still appears "readable" (unlocked), so we cannot rely on `isReadable()` to
+         * detect exhaustion. Clearing the reference ensures the next call re-fetches. */
+        const currentStream = this._readableStream;
+        this._readableStream = undefined;
+        return currentStream;
+
+      } else {
+        /** The data stream has been consumed or was never set. Re-fetch from either: */
+        return this._remoteOrigin ?
+          // A. ...a remote DWN if the record was originally queried from a remote DWN.
+          await this.readRecordData({ target: this._remoteOrigin, isRemote: true }) :
+          // B. ...a local DWN if the record was originally queried from the local DWN.
+          await this.readRecordData({ target: this._connectedDid, isRemote: false });
+      }
+    }, this.dataFormat);
   }
 
   /**
@@ -835,18 +574,7 @@ export class Record implements RecordModel {
       encryption    : shouldEncrypt || undefined,
     };
 
-    if (this._delegateDid) {
-      const { message: delegatedGrant } = await this._permissionsApi.getPermissionForRequest({
-        connectedDid : this._connectedDid,
-        delegateDid  : this._delegateDid,
-        protocol     : this.protocol,
-        delegate     : true,
-        cached       : true,
-        messageType  : requestOptions.messageType
-      });
-      requestOptions.messageParams.delegatedGrant = delegatedGrant;
-      requestOptions.granteeDid = this._delegateDid;
-    }
+    await this.applyDelegateGrant(requestOptions);
 
     const agentResponse = await this._agent.processDwnRequest(requestOptions);
 
@@ -925,23 +653,7 @@ export class Record implements RecordModel {
       };
     }
 
-    if (this._delegateDid) {
-      const { message: delegatedGrant } = await this._permissionsApi.getPermissionForRequest({
-        connectedDid : this._connectedDid,
-        delegateDid  : this._delegateDid,
-        protocol     : this.protocol,
-        delegate     : true,
-        cached       : true,
-        messageType  : deleteOptions.messageType
-      });
-
-      deleteOptions.messageParams = {
-        ...deleteOptions.messageParams,
-        delegatedGrant
-      };
-
-      deleteOptions.granteeDid = this._delegateDid;
-    }
+    await this.applyDelegateGrant(deleteOptions);
 
     const agentResponse = await this._agent.processDwnRequest(deleteOptions);
     const { message, reply: { status } } = agentResponse;
@@ -984,23 +696,7 @@ export class Record implements RecordModel {
         store,
       };
 
-      if (this._delegateDid) {
-        const { message: delegatedGrant } = await this._permissionsApi.getPermissionForRequest({
-          connectedDid : this._connectedDid,
-          delegateDid  : this._delegateDid,
-          protocol     : this.protocol,
-          delegate     : true,
-          cached       : true,
-          messageType  : initialWriteRequest.messageType
-        });
-
-        initialWriteRequest.messageParams = {
-          ...initialWriteRequest.messageParams,
-          delegatedGrant
-        };
-
-        initialWriteRequest.granteeDid = this._delegateDid;
-      }
+      await this.applyDelegateGrant(initialWriteRequest);
 
       // Process the prepared initial write, with the options set for storing and/or signing as the owner.
       const agentResponse = await this._agent.processDwnRequest(initialWriteRequest);
@@ -1054,23 +750,7 @@ export class Record implements RecordModel {
       };
     }
 
-    if (this._delegateDid) {
-      const { message: delegatedGrant } = await this._permissionsApi.getPermissionForRequest({
-        connectedDid : this._connectedDid,
-        delegateDid  : this._delegateDid,
-        protocol     : this.protocol,
-        delegate     : true,
-        cached       : true,
-        messageType  : requestOptions.messageType
-      });
-
-      requestOptions.messageParams = {
-        ...requestOptions.messageParams,
-        delegatedGrant
-      };
-
-      requestOptions.granteeDid = this._delegateDid;
-    }
+    await this.applyDelegateGrant(requestOptions);
 
     const agentResponse = await this._agent.processDwnRequest(requestOptions);
     const { message, reply: { status } } = agentResponse;
@@ -1122,21 +802,7 @@ export class Record implements RecordModel {
       // NOTE: For anonymous/public record data access, callers can use `ReadOnlyRecord` via `Web5.anonymous()`.
       // See: https://github.com/enboxorg/enbox/issues/898
       try {
-        const { message: delegatedGrant } = await this._permissionsApi.getPermissionForRequest({
-          connectedDid : this._connectedDid,
-          delegateDid  : this._delegateDid,
-          protocol     : this.protocol,
-          delegate     : true,
-          cached       : true,
-          messageType  : readRequest.messageType
-        });
-
-        readRequest.messageParams = {
-          ...readRequest.messageParams,
-          delegatedGrant
-        };
-
-        readRequest.granteeDid = this._delegateDid;
+        await this.applyDelegateGrant(readRequest);
       } catch {
         // If there is an error fetching the grant, we will attempt to read the data as the delegate.
         readRequest.author = this._delegateDid;
@@ -1159,6 +825,37 @@ export class Record implements RecordModel {
     } catch (error) {
       throw new Error(`Error encountered while attempting to read data: ${error.message}`);
     }
+  }
+
+  /**
+   * If the record is operating as a delegate, fetches the appropriate permission grant
+   * and applies it to the given DWN request options. This centralises the repeated
+   * pattern of looking up a delegated grant and attaching it to a request.
+   *
+   * @param requestOptions - The DWN request options to augment with the delegate grant.
+   */
+  private async applyDelegateGrant<T extends DwnInterface>(
+    requestOptions: ProcessDwnRequest<T>,
+  ): Promise<void> {
+    if (!this._delegateDid) {
+      return;
+    }
+
+    const { message: delegatedGrant } = await this._permissionsApi.getPermissionForRequest({
+      connectedDid : this._connectedDid,
+      delegateDid  : this._delegateDid,
+      protocol     : this.protocol,
+      delegate     : true,
+      cached       : true,
+      messageType  : requestOptions.messageType
+    });
+
+    requestOptions.messageParams = {
+      ...requestOptions.messageParams,
+      delegatedGrant
+    };
+
+    requestOptions.granteeDid = this._delegateDid;
   }
 
   /**


### PR DESCRIPTION
## Summary

Split two large files (`record.ts` at 1197 lines, `dwn-api.ts` at 1223 lines) into smaller, focused modules to improve maintainability. No public API changes — all exports are preserved via re-exports for backward compatibility.

## Changes

### `packages/api` — `record.ts` refactoring

- **`record-types.ts`** (new, 189 lines) — Extract 6 type definitions (`ImmutableRecordProperties`, `OptionalRecordProperties`, `RecordModel`, `RecordOptions`, `RecordUpdateParams`, `RecordDeleteParams`). `record.ts` re-exports for backward compat.
- **`record-data.ts`** (new, 155 lines) — Extract `RecordData` type and `createRecordData()` factory function. The `data` getter delegates convenience methods (`blob`, `bytes`, `json`, `text`, `then`, `catch`) to this module while keeping stream-resolution logic in `Record` via a closure.
- **`applyDelegateGrant()` helper** — Consolidate 5 repeated delegate grant blocks (~15 lines each) into a single private method.
- **`record.ts`** reduced from 1197 → 893 lines (**-25%**)

### `packages/agent` — `dwn-api.ts` refactoring

- **`dwn-protocol-cache.ts`** (new, 217 lines) — Extract `getProtocolDefinition()`, `fetchRemoteProtocolDefinition()`, `extractDerivedPublicKey()` as standalone functions with explicit dependency injection.
- **Remove 2 dead private wrappers** — `isMultiPartyContext()` and `hasRelationalReadAccess()` were never called; call sites use the `*Fn` standalone functions directly.
- **`postWriteKeyDelivery()` method** — Extract the 117-line post-write key delivery block from `processRequest()` into its own method. `processRequest` reduced from 149 → 35 lines.
- **`dwn-api.ts`** reduced from 1223 → 1140 lines (**-7%**)
- **Test updates** — 12 tests updated to call standalone functions from `protocol-utils.ts` instead of accessing removed private methods via bracket notation.

## Verification

| Check | Agent | API |
|-------|-------|-----|
| Lint | ✅ clean | ✅ clean |
| Build | ✅ passes | ✅ passes |
| Tests | ✅ 712 pass, 3 fail (pre-existing) | ✅ 237 pass, 31 fail (pre-existing) |

All test failures are pre-existing infrastructure issues (permissions protocol URI mismatch on local DWN server, Pkarr relay). No new failures introduced.