### PR TITLE
chore: gitignore CLAUDE.local.md for local AI agent instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ __screenshots__/
 
 .notes/
 TEST-COMPOUND-INDEX/
+
+# Local AI agent instructions (not committed)
+CLAUDE.local.md


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.local.md` to `.gitignore` so that user-local AI agent instruction files are not committed to the repo.
- This allows individual contributors to maintain personal workflow rules (e.g. worktree policies, PR conventions) that are picked up by tools like Claude Code, OpenCode, and Crush without polluting the shared repository.