### PR TITLE
feat: rpc.ack backpressure flow control for WebSocket subscriptions (Phase 3B)

### DIFF
--- a/packages/dwn-clients/src/json-rpc.ts
+++ b/packages/dwn-clients/src/json-rpc.ts
@@ -119,6 +119,22 @@ export const createJsonRpcSubscriptionRequest = (
   };
 };
 
+/**
+ * Creates a JSON-RPC notification to acknowledge receipt of subscription events
+ * up to the given cursor. No `id` is set because no response is expected.
+ */
+export const createJsonRpcAck = (
+  subscriptionId: JsonRpcId,
+  cursor: string,
+): JsonRpcRequest => {
+  return {
+    jsonrpc      : '2.0',
+    method       : 'rpc.ack',
+    params       : { cursor },
+    subscription : { id: subscriptionId },
+  };
+};
+
 export const createJsonRpcSuccessResponse = (
   id: JsonRpcId,
   result?: any,

--- a/packages/dwn-clients/src/server-info-types.ts
+++ b/packages/dwn-clients/src/server-info-types.ts
@@ -4,6 +4,12 @@ export type ServerInfo = {
   /** the maximum file size the user can request to store */
   maxFileSize: number,
   /**
+   * Maximum number of unacknowledged subscription events the server will send
+   * before pausing delivery. Clients ****MUST**** send `rpc.ack` to advance the
+   * window. When absent, the server does not enforce backpressure.
+   */
+  maxInFlight?: number,
+  /**
    * an array of strings representing the server's registration requirements.
    *
    * ie. ['proof-of-work-sha256-v0', 'terms-of-service']

--- a/packages/dwn-clients/src/web-socket-clients.ts
+++ b/packages/dwn-clients/src/web-socket-clients.ts
@@ -4,7 +4,7 @@ import type { GenericMessage, MessageSubscription, SubscriptionMessage, UnionMes
 
 import { CryptoUtils } from '@enbox/crypto';
 import { JsonRpcSocket } from './json-rpc-socket.js';
-import { createJsonRpcRequest, createJsonRpcSubscriptionRequest } from './json-rpc.js';
+import { createJsonRpcAck, createJsonRpcRequest, createJsonRpcSubscriptionRequest } from './json-rpc.js';
 
 interface SocketConnection {
   socket: JsonRpcSocket;
@@ -89,6 +89,11 @@ export class WebSocketDwnRpcClient implements DwnRpc {
 
       const subscriptionMessage = result.subscription as SubscriptionMessage;
       messageHandler(subscriptionMessage);
+
+      // Send rpc.ack to advance the server's flow-control window.
+      if (subscriptionMessage.cursor) {
+        socket.send(createJsonRpcAck(subscriptionId, subscriptionMessage.cursor));
+      }
     });
 
     const { error, result } = response;

--- a/packages/dwn-server/src/config.ts
+++ b/packages/dwn-server/src/config.ts
@@ -41,6 +41,13 @@ export const config = {
   // max size of data that can be provided with a RecordsWrite
   maxRecordDataSize : bytes(process.env.MAX_RECORD_DATA_SIZE || '1gb'),
 
+  /**
+   * Maximum number of unacknowledged subscription events the server will send
+   * per subscription before pausing delivery. Clients must send `rpc.ack` to
+   * advance the window. Configurable via `DWN_MAX_IN_FLIGHT` env var.
+   */
+  maxInFlight: parseInt(process.env.DWN_MAX_IN_FLIGHT || '32'),
+
   // whether to enable 'ws:'
   webSocketSupport: { on: true, off: false }[process.env.DS_WEBSOCKET_SERVER] ?? true,
 

--- a/packages/dwn-server/src/connection/connection-manager.ts
+++ b/packages/dwn-server/src/connection/connection-manager.ts
@@ -22,14 +22,15 @@ export interface ConnectionManager {
 export class InMemoryConnectionManager implements ConnectionManager {
   constructor(
     private dwn: Dwn,
-    private connections: Map<ServerWebSocket<WsData>, SocketConnection> = new Map()
+    private connections: Map<ServerWebSocket<WsData>, SocketConnection> = new Map(),
+    private maxInFlight?: number,
   ) {}
 
   async connect(socket: ServerWebSocket<WsData>): Promise<void> {
     const connection = new SocketConnection(socket, this.dwn, () => {
       // this is the onClose handler to clean up any closed connections.
       this.connections.delete(socket);
-    });
+    }, this.maxInFlight);
 
     // Attach the connection to the ws.data so Bun's websocket handlers can delegate to it.
     socket.data.connection = connection;

--- a/packages/dwn-server/src/connection/flow-controller.ts
+++ b/packages/dwn-server/src/connection/flow-controller.ts
@@ -1,0 +1,117 @@
+import type { SubscriptionMessage } from '@enbox/dwn-sdk-js';
+import type { JsonRpcId, JsonRpcSuccessResponse } from '@enbox/dwn-clients';
+
+import log from 'loglevel';
+
+import { createJsonRpcSuccessResponse } from '@enbox/dwn-clients';
+
+/** Default maximum number of unacknowledged events before pausing delivery. */
+export const DEFAULT_MAX_IN_FLIGHT = 32;
+
+/** Maximum buffer size before the subscription is force-closed to prevent OOM. */
+export const MAX_BUFFER_SIZE = 1000;
+
+/**
+ * Per-subscription flow controller that enforces a sliding window of
+ * unacknowledged events. When the window is full, incoming events are
+ * buffered. When the client sends `rpc.ack` with a cursor, events up
+ * to that cursor are acknowledged and buffered events are flushed.
+ *
+ * If the buffer exceeds {@link MAX_BUFFER_SIZE}, the subscription is
+ * closed via the provided `onOverflow` callback to prevent unbounded
+ * memory growth.
+ */
+export class FlowController {
+  /** Ordered list of cursors for events that have been sent but not yet acknowledged. */
+  private unacked: string[] = [];
+
+  /** Buffer of events waiting to be sent once the window opens. */
+  private buffer: SubscriptionMessage[] = [];
+
+  /** Whether the controller has been closed due to overflow. */
+  private closed = false;
+
+  constructor(
+    private readonly subscriptionId: JsonRpcId,
+    private readonly maxInFlight: number,
+    private readonly send: (response: JsonRpcSuccessResponse) => void,
+    private readonly onOverflow: () => void,
+  ) {}
+
+  /**
+   * Accept an incoming {@link SubscriptionMessage} from the EventLog listener.
+   * If the window has room, send immediately. Otherwise buffer.
+   */
+  public push(message: SubscriptionMessage): void {
+    if (this.closed) {
+      return;
+    }
+
+    if (this.unacked.length < this.maxInFlight) {
+      this.sendMessage(message);
+    } else {
+      this.buffer.push(message);
+
+      if (this.buffer.length > MAX_BUFFER_SIZE) {
+        log.warn(
+          `FlowController: buffer overflow for subscription ${String(this.subscriptionId)}, ` +
+          `closing subscription (buffer=${this.buffer.length}, unacked=${this.unacked.length})`
+        );
+        this.closed = true;
+        this.buffer = [];
+        this.unacked = [];
+        this.onOverflow();
+      }
+    }
+  }
+
+  /**
+   * Process an `rpc.ack` for this subscription. Acknowledges all events up
+   * to and including the given cursor, then flushes buffered events into the
+   * newly opened window slots.
+   */
+  public ack(cursor: string): void {
+    if (this.closed) {
+      return;
+    }
+
+    const idx = this.unacked.lastIndexOf(cursor);
+    if (idx === -1) {
+      // Unknown cursor — could be a stale or duplicate ack. Ignore silently.
+      log.debug(`FlowController: unknown cursor in ack for subscription ${String(this.subscriptionId)}: ${cursor}`);
+      return;
+    }
+
+    // Remove all entries up to and including the acked cursor.
+    this.unacked.splice(0, idx + 1);
+
+    // Flush buffered messages into the freed window slots.
+    while (this.buffer.length > 0 && this.unacked.length < this.maxInFlight) {
+      const buffered = this.buffer.shift()!;
+      this.sendMessage(buffered);
+    }
+  }
+
+  /**
+   * Returns the number of events currently in flight (sent but unacknowledged).
+   */
+  public get inFlightCount(): number {
+    return this.unacked.length;
+  }
+
+  /**
+   * Returns the number of events currently buffered (waiting to be sent).
+   */
+  public get bufferCount(): number {
+    return this.buffer.length;
+  }
+
+  /**
+   * Sends a single message over the wire and tracks its cursor.
+   */
+  private sendMessage(message: SubscriptionMessage): void {
+    const response = createJsonRpcSuccessResponse(this.subscriptionId, { subscription: message });
+    this.send(response);
+    this.unacked.push(message.cursor);
+  }
+}

--- a/packages/dwn-server/src/connection/socket-connection.ts
+++ b/packages/dwn-server/src/connection/socket-connection.ts
@@ -10,7 +10,8 @@ import { DwnMethodName } from '@enbox/dwn-sdk-js';
 import { jsonRpcRouter } from '../json-rpc-api.js';
 import { requestCounter } from '../metrics.js';
 import { v4 as uuidv4 } from 'uuid';
-import { createJsonRpcErrorResponse, createJsonRpcSuccessResponse, JsonRpcErrorCodes } from '@enbox/dwn-clients';
+import { createJsonRpcErrorResponse, JsonRpcErrorCodes } from '@enbox/dwn-clients';
+import { DEFAULT_MAX_IN_FLIGHT, FlowController } from './flow-controller.js';
 import { DwnServerError, DwnServerErrorCode } from '../dwn-error.js';
 
 const HEARTBEAT_INTERVAL = 30_000;
@@ -26,12 +27,14 @@ const HEARTBEAT_INTERVAL = 30_000;
 export class SocketConnection {
   private heartbeatInterval: ReturnType<typeof setInterval>;
   private subscriptions: Map<JsonRpcId, JsonRpcSubscription> = new Map();
+  private flowControllers: Map<JsonRpcId, FlowController> = new Map();
   private isAlive: boolean;
 
   constructor(
     private socket: ServerWebSocket<WsData>,
     private dwn: Dwn,
-    private onCloseCallback?: () => void
+    private onCloseCallback?: () => void,
+    private maxInFlight: number = DEFAULT_MAX_IN_FLIGHT,
   ){
     // Bun handles ping/pong automatically at the protocol level, but we still
     // want an application-level heartbeat to detect dead connections.
@@ -91,6 +94,18 @@ export class SocketConnection {
     const connection = this.subscriptions.get(id);
     await connection.close();
     this.subscriptions.delete(id);
+    this.flowControllers.delete(id);
+  }
+
+  /**
+   * Acknowledges subscription events up to the given cursor, advancing the
+   * flow-control window for the subscription.
+   */
+  ackSubscription(id: JsonRpcId, cursor: string): void {
+    const fc = this.flowControllers.get(id);
+    if (fc) {
+      fc.ack(cursor);
+    }
   }
 
   /**
@@ -107,6 +122,9 @@ export class SocketConnection {
 
     // close all of the associated subscriptions
     await Promise.all(closePromises);
+
+    // clear all flow controllers
+    this.flowControllers.clear();
 
     // close the socket.
     this.socket.close();
@@ -173,13 +191,30 @@ export class SocketConnection {
   }
 
   /**
-   * Creates a subscription handler that forwards SubscriptionMessage (event + EOSE)
-   * over the WebSocket as JSON-RPC responses.
+   * Creates a flow-controlled subscription handler that enforces the
+   * `maxInFlight` window. Returns a `SubscriptionListener` to be passed
+   * to the EventLog, and stores the `FlowController` for later `rpc.ack`
+   * processing.
    */
   private createSubscriptionHandler(id: JsonRpcId): (message: SubscriptionMessage) => void {
+    const fc = new FlowController(
+      id,
+      this.maxInFlight,
+      (response) => {
+        this.send(response);
+      },
+      () => {
+        // overflow: close the subscription to prevent OOM
+        this.closeSubscription(id).catch((err) => {
+          log.error(`FlowController: error closing subscription ${String(id)} on overflow`, err);
+        });
+      },
+    );
+
+    this.flowControllers.set(id, fc);
+
     return (message) => {
-      const response = createJsonRpcSuccessResponse(id, { subscription: message });
-      this.send(response);
+      fc.push(message);
     };
   }
 

--- a/packages/dwn-server/src/dwn-server.ts
+++ b/packages/dwn-server/src/dwn-server.ts
@@ -124,7 +124,7 @@ export class DwnServer {
     log.info(`HttpServer listening on port ${this.config.port}`);
 
     if (this.config.webSocketSupport) {
-      this.#wsApi = new WsApi(this.#httpApi, this.dwn);
+      this.#wsApi = new WsApi(this.#httpApi, this.dwn, undefined, this.config.maxInFlight);
       this.#wsApi.start();
       log.info('WebSocketServer ready...');
     }

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -296,6 +296,7 @@ export class HttpApi {
 
     const serverInfo: ServerInfo = {
       maxFileSize              : config.maxRecordDataSize,
+      maxInFlight              : config.maxInFlight,
       registrationRequirements : registrationRequirements,
       server                   : this.#packageInfo.server,
       sdkVersion               : this.#packageInfo.sdkVersion,

--- a/packages/dwn-server/src/json-rpc-api.ts
+++ b/packages/dwn-server/src/json-rpc-api.ts
@@ -1,11 +1,12 @@
 import { JsonRpcRouter } from './lib/json-rpc-router.js';
 
 import { handleDwnProcessMessage } from './json-rpc-handlers/dwn/index.js';
-import { handleSubscriptionsClose } from './json-rpc-handlers/subscription/index.js';
+import { handleSubscriptionAck, handleSubscriptionsClose } from './json-rpc-handlers/subscription/index.js';
 
 export const jsonRpcRouter = new JsonRpcRouter();
 
 jsonRpcRouter.on('dwn.processMessage', handleDwnProcessMessage);
 jsonRpcRouter.on('rpc.subscribe.dwn.processMessage', handleDwnProcessMessage);
 
+jsonRpcRouter.on('rpc.ack', handleSubscriptionAck);
 jsonRpcRouter.on('rpc.subscribe.close', handleSubscriptionsClose);

--- a/packages/dwn-server/src/json-rpc-handlers/subscription/ack.ts
+++ b/packages/dwn-server/src/json-rpc-handlers/subscription/ack.ts
@@ -1,0 +1,63 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import type { JsonRpcId } from '@enbox/dwn-clients';
+import type {
+  HandlerResponse,
+  JsonRpcHandler,
+} from '../../lib/json-rpc-router.js';
+
+import { createJsonRpcErrorResponse, createJsonRpcSuccessResponse, JsonRpcErrorCodes } from '@enbox/dwn-clients';
+
+/**
+ * Handles `rpc.ack` — acknowledges receipt of subscription events up to the
+ * given cursor, advancing the per-subscription flow-control window.
+ *
+ * Request shape:
+ * ```json
+ * {
+ *   "jsonrpc": "2.0",
+ *   "method": "rpc.ack",
+ *   "params": { "cursor": "<opaque-cursor>" },
+ *   "subscription": { "id": "<subscription-id>" }
+ * }
+ * ```
+ *
+ * This is a notification (no `id` required), but the server sends a response
+ * if validation fails (missing params, unknown subscription, etc.).
+ */
+export const handleSubscriptionAck: JsonRpcHandler = async (
+  jsonRpcRequest,
+  context,
+) => {
+  const requestId = jsonRpcRequest.id ?? uuidv4();
+
+  if (context.socketConnection === undefined) {
+    const jsonRpcResponse = createJsonRpcErrorResponse(
+      requestId, JsonRpcErrorCodes.InvalidRequest, 'socket connection does not exist'
+    );
+    return { jsonRpcResponse };
+  }
+
+  if (jsonRpcRequest.subscription === undefined) {
+    const jsonRpcResponse = createJsonRpcErrorResponse(
+      requestId, JsonRpcErrorCodes.InvalidParams, 'subscription options are required'
+    );
+    return { jsonRpcResponse };
+  }
+
+  const { id: subscriptionId } = jsonRpcRequest.subscription as { id: JsonRpcId };
+  const { cursor } = (jsonRpcRequest.params ?? {}) as { cursor?: string };
+
+  if (cursor === undefined || typeof cursor !== 'string' || cursor === '') {
+    const jsonRpcResponse = createJsonRpcErrorResponse(
+      requestId, JsonRpcErrorCodes.InvalidParams, 'params.cursor is required and must be a non-empty string'
+    );
+    return { jsonRpcResponse };
+  }
+
+  const { socketConnection } = context;
+  socketConnection.ackSubscription(subscriptionId, cursor);
+
+  const jsonRpcResponse = createJsonRpcSuccessResponse(requestId, { reply: { status: 200, detail: 'OK' } });
+  return { jsonRpcResponse } as HandlerResponse;
+};

--- a/packages/dwn-server/src/json-rpc-handlers/subscription/index.ts
+++ b/packages/dwn-server/src/json-rpc-handlers/subscription/index.ts
@@ -1,1 +1,2 @@
+export * from './ack.js';
 export * from './close.js';

--- a/packages/dwn-server/src/ws-api.ts
+++ b/packages/dwn-server/src/ws-api.ts
@@ -10,9 +10,9 @@ export class WsApi {
   dwn: Dwn;
   #connectionManager: ConnectionManager;
 
-  constructor(httpApi: HttpApi, dwn: Dwn, connectionManager?: ConnectionManager) {
+  constructor(httpApi: HttpApi, dwn: Dwn, connectionManager?: ConnectionManager, maxInFlight?: number) {
     this.dwn = dwn;
-    this.#connectionManager = connectionManager || new InMemoryConnectionManager(dwn);
+    this.#connectionManager = connectionManager || new InMemoryConnectionManager(dwn, new Map(), maxInFlight);
 
     // Wire up the WebSocket open event from Bun.serve() to the connection manager.
     httpApi.onWebSocketConnection = (ws: ServerWebSocket<WsData>): void => {

--- a/packages/dwn-server/tests/connection/flow-controller.test.ts
+++ b/packages/dwn-server/tests/connection/flow-controller.test.ts
@@ -1,0 +1,245 @@
+import type { JsonRpcSuccessResponse } from '@enbox/dwn-clients';
+import type { SubscriptionMessage } from '@enbox/dwn-sdk-js';
+
+import { describe, expect, it } from 'bun:test';
+
+import { DEFAULT_MAX_IN_FLIGHT, FlowController, MAX_BUFFER_SIZE } from '../../src/connection/flow-controller.js';
+
+/** Helper to create a SubscriptionEvent message with a given cursor. */
+function makeEvent(cursor: string): SubscriptionMessage {
+  return {
+    type  : 'event',
+    cursor,
+    event : { message: { descriptor: { interface: 'Records', method: 'Write' } } as any },
+  };
+}
+
+/** Helper to create a SubscriptionEose message with a given cursor. */
+function makeEose(cursor: string): SubscriptionMessage {
+  return { type: 'eose', cursor };
+}
+
+/** Creates a FlowController with a collector array for sent responses. */
+function createFc(
+  maxInFlight: number,
+  sent: JsonRpcSuccessResponse[],
+  onOverflow: () => void = () => { /* no-op */ },
+  subscriptionId = 'sub-1',
+): FlowController {
+  return new FlowController(
+    subscriptionId,
+    maxInFlight,
+    (r) => {
+      sent.push(r);
+    },
+    onOverflow,
+  );
+}
+
+describe('FlowController', () => {
+  describe('defaults', () => {
+    it('should have a default maxInFlight of 32', () => {
+      expect(DEFAULT_MAX_IN_FLIGHT).toBe(32);
+    });
+
+    it('should have a max buffer size of 1000', () => {
+      expect(MAX_BUFFER_SIZE).toBe(1000);
+    });
+  });
+
+  describe('push()', () => {
+    it('should send events immediately when window has room', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      const fc = createFc(3, sent);
+
+      fc.push(makeEvent('1'));
+      fc.push(makeEvent('2'));
+
+      expect(sent).toHaveLength(2);
+      expect(sent[0].result.subscription.cursor).toBe('1');
+      expect(sent[1].result.subscription.cursor).toBe('2');
+      expect(fc.inFlightCount).toBe(2);
+      expect(fc.bufferCount).toBe(0);
+    });
+
+    it('should buffer events when window is full', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      const fc = createFc(2, sent);
+
+      fc.push(makeEvent('1'));
+      fc.push(makeEvent('2'));
+      fc.push(makeEvent('3'));
+      fc.push(makeEvent('4'));
+
+      expect(sent).toHaveLength(2);
+      expect(fc.inFlightCount).toBe(2);
+      expect(fc.bufferCount).toBe(2);
+    });
+
+    it('should handle EOSE messages the same as events', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      const fc = createFc(2, sent);
+
+      fc.push(makeEvent('1'));
+      fc.push(makeEose('2'));
+
+      expect(sent).toHaveLength(2);
+      expect(sent[1].result.subscription.type).toBe('eose');
+      expect(fc.inFlightCount).toBe(2);
+    });
+
+    it('should not send after overflow closes the controller', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      let overflowed = false;
+      const fc = createFc(1, sent, () => {
+        overflowed = true;
+      });
+
+      // Send 1 (fills window)
+      fc.push(makeEvent('1'));
+      expect(sent).toHaveLength(1);
+
+      // Buffer MAX_BUFFER_SIZE + 1 events to trigger overflow
+      for (let i = 0; i <= MAX_BUFFER_SIZE; i++) {
+        fc.push(makeEvent(String(i + 2)));
+      }
+
+      expect(overflowed).toBe(true);
+
+      // After overflow, push should be a no-op
+      const sentBefore = sent.length;
+      fc.push(makeEvent('9999'));
+      expect(sent).toHaveLength(sentBefore);
+    });
+  });
+
+  describe('ack()', () => {
+    it('should acknowledge events and flush buffered events', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      const fc = createFc(2, sent);
+
+      fc.push(makeEvent('1'));
+      fc.push(makeEvent('2'));
+      fc.push(makeEvent('3'));
+      fc.push(makeEvent('4'));
+      fc.push(makeEvent('5'));
+
+      // Window: [1, 2], Buffer: [3, 4, 5]
+      expect(sent).toHaveLength(2);
+      expect(fc.inFlightCount).toBe(2);
+      expect(fc.bufferCount).toBe(3);
+
+      // Ack cursor '2' — acknowledges both '1' and '2'
+      fc.ack('2');
+
+      // Window should now have [3, 4] from flush, Buffer: [5]
+      expect(sent).toHaveLength(4);
+      expect(sent[2].result.subscription.cursor).toBe('3');
+      expect(sent[3].result.subscription.cursor).toBe('4');
+      expect(fc.inFlightCount).toBe(2);
+      expect(fc.bufferCount).toBe(1);
+    });
+
+    it('should handle acking the first cursor only', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      const fc = createFc(2, sent);
+
+      fc.push(makeEvent('1'));
+      fc.push(makeEvent('2'));
+      fc.push(makeEvent('3'));
+
+      // Ack only cursor '1'
+      fc.ack('1');
+
+      // One slot freed, one buffered event flushed
+      expect(sent).toHaveLength(3);
+      expect(sent[2].result.subscription.cursor).toBe('3');
+      expect(fc.inFlightCount).toBe(2); // '2' and '3' still in flight
+      expect(fc.bufferCount).toBe(0);
+    });
+
+    it('should ignore unknown cursors', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      const fc = createFc(2, sent);
+
+      fc.push(makeEvent('1'));
+      fc.push(makeEvent('2'));
+      fc.push(makeEvent('3'));
+
+      fc.ack('unknown');
+
+      // Nothing should change
+      expect(sent).toHaveLength(2);
+      expect(fc.inFlightCount).toBe(2);
+      expect(fc.bufferCount).toBe(1);
+    });
+
+    it('should handle acking all cursors at once', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      const fc = createFc(3, sent);
+
+      fc.push(makeEvent('1'));
+      fc.push(makeEvent('2'));
+      fc.push(makeEvent('3'));
+
+      // Ack the last cursor
+      fc.ack('3');
+
+      expect(fc.inFlightCount).toBe(0);
+      expect(fc.bufferCount).toBe(0);
+    });
+
+    it('should be a no-op after overflow', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      let overflowed = false;
+      const fc = createFc(1, sent, () => {
+        overflowed = true;
+      });
+
+      fc.push(makeEvent('1'));
+      for (let i = 0; i <= MAX_BUFFER_SIZE; i++) {
+        fc.push(makeEvent(String(i + 2)));
+      }
+
+      expect(overflowed).toBe(true);
+
+      const sentBefore = sent.length;
+      fc.ack('1');
+      expect(sent).toHaveLength(sentBefore);
+    });
+
+    it('should handle cumulative acks (ack last cursor in batch)', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      const fc = createFc(3, sent);
+
+      // Push 6 events. Window: [1,2,3], Buffer: [4,5,6]
+      for (let i = 1; i <= 6; i++) {
+        fc.push(makeEvent(String(i)));
+      }
+
+      expect(sent).toHaveLength(3);
+      expect(fc.bufferCount).toBe(3);
+
+      // Cumulative ack up to cursor '3' — frees all 3 slots, flushes 3 buffered
+      fc.ack('3');
+      expect(sent).toHaveLength(6);
+      expect(fc.inFlightCount).toBe(3);
+      expect(fc.bufferCount).toBe(0);
+    });
+  });
+
+  describe('JSON-RPC framing', () => {
+    it('should wrap messages in JSON-RPC success responses with subscription id', () => {
+      const sent: JsonRpcSuccessResponse[] = [];
+      const fc = createFc(10, sent, undefined, 'sub-42');
+
+      fc.push(makeEvent('abc'));
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0].jsonrpc).toBe('2.0');
+      expect(sent[0].id).toBe('sub-42');
+      expect(sent[0].result.subscription.type).toBe('event');
+      expect(sent[0].result.subscription.cursor).toBe('abc');
+    });
+  });
+});

--- a/packages/dwn-server/tests/ws-api.test.ts
+++ b/packages/dwn-server/tests/ws-api.test.ts
@@ -1,9 +1,10 @@
 import type { SinonFakeTimers } from 'sinon';
-import type { Dwn, MessageEvent } from '@enbox/dwn-sdk-js';
+import type { Dwn, MessageEvent, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
 import { base64url } from 'multiformats/bases/base64';
 import { useFakeTimers } from 'sinon';
 import { v4 as uuidv4 } from 'uuid';
+import { WebSocket } from 'ws';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { DataStream, Message, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
@@ -11,7 +12,7 @@ import { config } from '../src/config.js';
 import { getTestDwn } from './test-dwn.js';
 import { HttpApi } from '../src/http-api.js';
 import { WsApi } from '../src/ws-api.js';
-import { createJsonRpcRequest, createJsonRpcSubscriptionRequest, JsonRpcErrorCodes, JsonRpcSocket } from '@enbox/dwn-clients';
+import { createJsonRpcAck, createJsonRpcRequest, createJsonRpcSubscriptionRequest, JsonRpcErrorCodes, JsonRpcSocket } from '@enbox/dwn-clients';
 import { createRecordsWriteMessage, sendHttpMessage, sendWsMessage, waitUntil } from './utils.js';
 
 
@@ -432,5 +433,344 @@ describe('websocket api', function () {
       await Message.getCid(updatedMessage.message)
     ].sort();
     expect([...records].sort()).toEqual(expectedMembers);
+  });
+});
+
+describe('websocket backpressure (rpc.ack)', function () {
+  let httpApi: HttpApi;
+  let wsApi: WsApi;
+  let dwn: Dwn;
+  let clock: SinonFakeTimers;
+  let wsUrl: string;
+  let httpUrl: string;
+
+  beforeAll(() => {
+    clock = useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterAll(() => {
+    clock.restore();
+  });
+
+  afterEach(async function () {
+    await wsApi.close();
+    await httpApi.close();
+    await dwn.close();
+  });
+
+  /**
+   * Helper: creates the DWN + HTTP + WS stack with a custom maxInFlight.
+   */
+  async function setupServer(maxInFlight: number): Promise<void> {
+    dwn = await getTestDwn({ withEvents: true });
+    httpApi = await HttpApi.create(config, dwn);
+    await httpApi.start(0);
+    const port = httpApi.server.port;
+    wsUrl = `ws://127.0.0.1:${port}`;
+    httpUrl = `http://localhost:${port}`;
+    wsApi = new WsApi(httpApi, dwn, undefined, maxInFlight);
+    wsApi.start();
+  }
+
+  /**
+   * Helper: opens a raw WebSocket (from `ws` package) and subscribes to foo/bar records.
+   * Returns tools to observe events, send acks, and close.
+   *
+   * This bypasses JsonRpcSocket to avoid auto-ack behavior, giving full control
+   * over the flow-control window for testing.
+   */
+  async function rawSubscribe(
+    alice: { did: string; signer: any },
+    subscribeMessage: any,
+  ): Promise<{
+    receivedMessages: SubscriptionMessage[];
+    subscriptionId: string;
+    socket: WebSocket;
+    sendAck: (cursor: string) => void;
+    waitForMessages: (count: number, timeoutMs?: number) => Promise<void>;
+    close: () => Promise<void>;
+  }> {
+    const receivedMessages: SubscriptionMessage[] = [];
+    const requestId = uuidv4();
+    const subscriptionId = uuidv4();
+
+    const socket = new WebSocket(wsUrl);
+
+    await new Promise<void>((resolve, reject) => {
+      socket.onopen = (): void => resolve();
+      socket.onerror = (err): void => reject(err);
+      setTimeout(() => reject(new Error('raw WS connect timeout')), 3000);
+    });
+
+    // Send the subscribe request
+    const subscribeRequest = createJsonRpcSubscriptionRequest(
+      requestId, 'rpc.subscribe.dwn.processMessage',
+      { message: subscribeMessage, target: alice.did },
+      subscriptionId,
+    );
+    socket.send(JSON.stringify(subscribeRequest));
+
+    // Wait for the subscription confirmation response (matched by request id)
+    await new Promise<void>((resolve, reject) => {
+      const handler = (event: { data: any }): void => {
+        const data = JSON.parse(event.data.toString());
+        if (data.id === requestId) {
+          socket.removeEventListener('message', handler);
+          if (data.error) {
+            reject(new Error(`subscribe failed: ${data.error.message}`));
+          } else {
+            resolve();
+          }
+        }
+      };
+      socket.addEventListener('message', handler);
+      setTimeout(() => reject(new Error('subscribe response timeout')), 3000);
+    });
+
+    // Now listen for subscription event messages (matched by subscription id)
+    socket.addEventListener('message', (event: { data: any }) => {
+      const data = JSON.parse(event.data.toString());
+      if (data.id === subscriptionId && data.result?.subscription) {
+        receivedMessages.push(data.result.subscription as SubscriptionMessage);
+      }
+    });
+
+    const sendAck = (cursor: string): void => {
+      const ackRequest = createJsonRpcAck(subscriptionId, cursor);
+      socket.send(JSON.stringify(ackRequest));
+    };
+
+    const waitForMessages = async (count: number, timeoutMs = 2000): Promise<void> => {
+      await waitUntil(() => receivedMessages.length >= count, timeoutMs);
+    };
+
+    const close = async (): Promise<void> => {
+      // Send subscription close request
+      const closeRequestId = uuidv4();
+      const closeRequest = createJsonRpcSubscriptionRequest(
+        closeRequestId, 'rpc.subscribe.close', {}, subscriptionId
+      );
+      socket.send(JSON.stringify(closeRequest));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      socket.close();
+    };
+
+    return { receivedMessages, subscriptionId, socket, sendAck, waitForMessages, close };
+  }
+
+  /**
+   * Helper: writes N records for a given persona and schema via HTTP, returning CIDs.
+   */
+  async function writeRecords(alice: any, count: number, schema = 'foo/bar'): Promise<string[]> {
+    const cids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const writeMessage = await TestDataGenerator.generateRecordsWrite({
+        author     : alice,
+        schema,
+        dataFormat : 'text/plain'
+      });
+
+      const writeResult = await sendHttpMessage({
+        url     : httpUrl,
+        target  : alice.did,
+        message : writeMessage.message,
+        data    : writeMessage.dataBytes,
+      });
+      expect(writeResult.status.code).toBe(202);
+      cids.push(await Message.getCid(writeMessage.message));
+    }
+    return cids;
+  }
+
+  it('should buffer events when maxInFlight is reached and flush on rpc.ack', async () => {
+    await setupServer(2); // maxInFlight = 2
+
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+    const { message } = await TestDataGenerator.generateRecordsSubscribe({
+      author : alice,
+      filter : { schema: 'foo/bar' }
+    });
+
+    const { receivedMessages, sendAck, waitForMessages, close } = await rawSubscribe(alice, message);
+
+    // Write 4 records — only 2 should be delivered (maxInFlight=2)
+    const cids = await writeRecords(alice, 4);
+
+    // Wait for the first 2 to arrive
+    await waitForMessages(2);
+
+    // Give some extra time to make sure no more arrive
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(receivedMessages).toHaveLength(2);
+
+    // Ack the 2nd cursor — should free 2 slots and flush 2 buffered events
+    sendAck(receivedMessages[1].cursor);
+
+    await waitForMessages(4);
+    expect(receivedMessages).toHaveLength(4);
+
+    // All 4 CIDs should be accounted for
+    const receivedCids = await Promise.all(
+      receivedMessages
+        .filter((m): boolean => m.type === 'event')
+        .map(async (m) => Message.getCid(m.event.message))
+    );
+    expect(receivedCids.sort()).toEqual([...cids].sort());
+
+    await close();
+  });
+
+  it('should deliver events incrementally as individual rpc.ack messages are sent', async () => {
+    await setupServer(1); // maxInFlight = 1
+
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+    const { message } = await TestDataGenerator.generateRecordsSubscribe({
+      author : alice,
+      filter : { schema: 'foo/bar' }
+    });
+
+    const { receivedMessages, sendAck, waitForMessages, close } = await rawSubscribe(alice, message);
+
+    // Write 3 records
+    await writeRecords(alice, 3);
+
+    // Only 1 should arrive (maxInFlight=1)
+    await waitForMessages(1);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(receivedMessages).toHaveLength(1);
+
+    // Ack it — next event should arrive
+    sendAck(receivedMessages[0].cursor);
+    await waitForMessages(2);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(receivedMessages).toHaveLength(2);
+
+    // Ack again — third event should arrive
+    sendAck(receivedMessages[1].cursor);
+    await waitForMessages(3);
+    expect(receivedMessages).toHaveLength(3);
+
+    await close();
+  });
+
+  it('should work with auto-ack from JsonRpcSocket client when many events exceed maxInFlight', async () => {
+    await setupServer(2); // maxInFlight = 2
+
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+    const { message } = await TestDataGenerator.generateRecordsSubscribe({
+      author : alice,
+      filter : { schema: 'foo/bar' }
+    });
+
+    // Use the regular JsonRpcSocket client which auto-acks via WebSocketDwnRpcClient logic.
+    // Here we replicate auto-ack inline.
+    const records: string[] = [];
+    const connection = await JsonRpcSocket.connect(wsUrl);
+    const subscriptionId = uuidv4();
+
+    const dwnRequest = createJsonRpcSubscriptionRequest(
+      uuidv4(), 'rpc.subscribe.dwn.processMessage',
+      { message, target: alice.did },
+      subscriptionId,
+    );
+
+    const { response, close } = await connection.subscribe(dwnRequest, (resp) => {
+      const subscriptionMsg = resp.result?.subscription as SubscriptionMessage;
+      if (!subscriptionMsg || subscriptionMsg.type !== 'event') {
+        return;
+      }
+
+      Message.getCid(subscriptionMsg.event.message).then((cid) => records.push(cid));
+
+      // Auto-ack like the real client does
+      if (subscriptionMsg.cursor) {
+        connection.send(createJsonRpcAck(subscriptionId, subscriptionMsg.cursor));
+      }
+    });
+
+    expect(response.error).toBeUndefined();
+    expect(response.result.reply.status.code).toBe(200);
+
+    // Write 5 records — more than maxInFlight, but auto-ack should drain them all
+    const cids = await writeRecords(alice, 5);
+    await waitUntil(() => records.length >= 5);
+
+    expect(records.sort()).toEqual([...cids].sort());
+
+    await close();
+  });
+
+  it('should buffer many events and drain them all when acked', async () => {
+    await setupServer(1); // maxInFlight = 1
+
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+    const { message } = await TestDataGenerator.generateRecordsSubscribe({
+      author : alice,
+      filter : { schema: 'foo/bar' }
+    });
+
+    const { receivedMessages, sendAck, waitForMessages, close } = await rawSubscribe(alice, message);
+
+    // Write 10 records — only 1 should be delivered immediately (maxInFlight=1)
+    const cids = await writeRecords(alice, 10);
+    await waitForMessages(1);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(receivedMessages).toHaveLength(1);
+
+    // Drain all 10 by acking one at a time
+    for (let i = 0; i < 9; i++) {
+      sendAck(receivedMessages[receivedMessages.length - 1].cursor);
+      await waitForMessages(receivedMessages.length + 1);
+    }
+
+    expect(receivedMessages).toHaveLength(10);
+
+    const receivedCids = await Promise.all(
+      receivedMessages
+        .filter((m): boolean => m.type === 'event')
+        .map(async (m) => Message.getCid(m.event.message))
+    );
+    expect(receivedCids.sort()).toEqual([...cids].sort());
+
+    await close();
+  });
+
+  it('should handle rpc.ack for an unknown subscription gracefully', async () => {
+    await setupServer(2);
+
+    const socket = new WebSocket(wsUrl);
+    await new Promise<void>((resolve, reject) => {
+      socket.onopen = (): void => resolve();
+      socket.onerror = (err): void => reject(err);
+      setTimeout(() => reject(new Error('connect timeout')), 3000);
+    });
+
+    // Send an ack for a subscription that doesn't exist
+    const ackRequest = createJsonRpcAck('nonexistent-sub-id', 'some-cursor');
+    socket.send(JSON.stringify(ackRequest));
+
+    // Should get back a success response (the handler still responds 200 OK
+    // because ackSubscription silently ignores unknown flow controllers)
+    const response = await new Promise<any>((resolve, reject) => {
+      socket.addEventListener('message', (event: { data: any }) => {
+        resolve(JSON.parse(event.data.toString()));
+      });
+      setTimeout(() => reject(new Error('ack response timeout')), 3000);
+    });
+
+    // The ack handler returns a success response even for unknown subscriptions
+    // because it delegates to socketConnection.ackSubscription which silently
+    // ignores flow controllers that don't exist.
+    expect(response.result).toBeDefined();
+
+    socket.close();
   });
 });


### PR DESCRIPTION
## Summary

Adds server-side sliding window backpressure for WebSocket subscription event delivery (Phase 3B of the subscription architecture revamp). The server enforces a `maxInFlight` window per subscription — when the window is full, events are buffered until the client acknowledges receipt via `rpc.ack`.

## Key Changes

### dwn-server
- **`FlowController`** (`src/connection/flow-controller.ts`): Per-subscription sliding window that tracks unacked cursors, buffers overflow, and closes the subscription if buffer exceeds 1000 to prevent OOM
- **`rpc.ack` handler** (`src/json-rpc-handlers/subscription/ack.ts`): JSON-RPC handler that validates params and delegates to `FlowController.ack(cursor)`
- **`SocketConnection`**: Creates a `FlowController` per subscription, exposes `ackSubscription()` for the handler, cleans up on close
- **`WsApi` / `InMemoryConnectionManager`**: Thread `maxInFlight` from config through to `SocketConnection`
- **Config**: `DWN_MAX_IN_FLIGHT` env var (default 32), exposed in `/info` endpoint as `maxInFlight`

### dwn-clients
- **`createJsonRpcAck()`**: Factory for `rpc.ack` JSON-RPC notifications
- **`WebSocketDwnRpcClient`**: Auto-sends `rpc.ack` after each subscription event handler completes
- **`ServerInfo`**: Added optional `maxInFlight` field

## Wire Format

```jsonc
// Client → Server (notification, no id)
{
  "jsonrpc": "2.0",
  "method": "rpc.ack",
  "params": { "cursor": "<opaque-cursor-from-last-event>" },
  "subscription": { "id": "<subscription-id>" }
}
```

Cumulative: acking cursor X acknowledges all events up to and including X.

## Test Coverage

- **13 FlowController unit tests**: window enforcement, buffering, flush on ack, cumulative acks, overflow, EOSE handling, JSON-RPC framing
- **5 end-to-end WebSocket tests**: window blocking with manual ack, incremental draining (maxInFlight=1), auto-ack with JsonRpcSocket client, bulk buffer drain (10 events through maxInFlight=1), unknown subscription ack handling

All 118 dwn-server tests pass. All lint passes across the monorepo.

## Builds on

- Phase 3A: #289 (SubscriptionMessage wire format)
- Phase 2: #284 (cursor-based subscribe with EOSE)
- Phase 1: #274 (EventLog architecture)