### PR TITLE
feat(api): add TypedRecord<T> and TypedLiveQuery<T> for end-to-end type flow

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -34,6 +34,8 @@ export * from './read-only-record.js';
 export * from './record.js';
 export * from './record-data.js';
 export * from './record-types.js';
+export * from './typed-live-query.js';
+export * from './typed-record.js';
 export * from './typed-web5.js';
 export * from './vc-api.js';
 export * from './web5.js';

--- a/packages/api/src/typed-live-query.ts
+++ b/packages/api/src/typed-live-query.ts
@@ -1,0 +1,156 @@
+/**
+ * A type-safe wrapper around {@link LiveQuery} that carries the data type `T`
+ * through initial snapshot records and real-time change events.
+ *
+ * `TypedLiveQuery<T>` wraps a `LiveQuery` so that:
+ * - `.records` returns `TypedRecord<T>[]` instead of `Record[]`.
+ * - `.on('create', handler)` provides `TypedRecord<T>` in the callback.
+ * - `.on('change', handler)` provides `TypedRecordChange<T>` in the callback.
+ *
+ * @example
+ * ```ts
+ * const { liveQuery } = await typed.records.subscribe('friend');
+ * // liveQuery is TypedLiveQuery<FriendData>
+ *
+ * for (const record of liveQuery.records) {
+ *   const data = await record.data.json(); // FriendData
+ * }
+ *
+ * liveQuery.on('create', async (record) => {
+ *   const data = await record.data.json(); // FriendData
+ * });
+ * ```
+ */
+
+import type { PaginationCursor } from '@enbox/dwn-sdk-js';
+import type { LiveQuery, RecordChange } from './live-query.js';
+
+import { TypedRecord } from './typed-record.js';
+
+// ---------------------------------------------------------------------------
+// Typed change event
+// ---------------------------------------------------------------------------
+
+/**
+ * Describes a change to a record in a {@link TypedLiveQuery}.
+ *
+ * Same shape as {@link RecordChange} but with the record wrapped
+ * in a {@link TypedRecord}.
+ */
+export type TypedRecordChange<T> = {
+  /** Whether the record was created, updated, or deleted. */
+  type: RecordChange['type'];
+
+  /** The typed record affected by the change. */
+  record: TypedRecord<T>;
+};
+
+// ---------------------------------------------------------------------------
+// TypedLiveQuery class
+// ---------------------------------------------------------------------------
+
+/**
+ * A type-safe wrapper around {@link LiveQuery} that preserves the data type `T`
+ * through the initial snapshot and all subsequent change events.
+ *
+ * Obtain instances through `TypedWeb5.records.subscribe()` — never construct
+ * directly.
+ */
+export class TypedLiveQuery<T> {
+  /** The underlying untyped LiveQuery instance. */
+  private _liveQuery: LiveQuery;
+
+  /** Cached typed record array, built lazily from the underlying records. */
+  private _typedRecords?: TypedRecord<T>[];
+
+  constructor(liveQuery: LiveQuery) {
+    this._liveQuery = liveQuery;
+  }
+
+  // -------------------------------------------------------------------------
+  // Escape hatch
+  // -------------------------------------------------------------------------
+
+  /** Access the underlying untyped {@link LiveQuery} for advanced use cases. */
+  public get rawLiveQuery(): LiveQuery {
+    return this._liveQuery;
+  }
+
+  // -------------------------------------------------------------------------
+  // Typed initial snapshot
+  // -------------------------------------------------------------------------
+
+  /** The initial snapshot of matching records, typed as `TypedRecord<T>[]`. */
+  public get records(): TypedRecord<T>[] {
+    if (!this._typedRecords) {
+      this._typedRecords = this._liveQuery.records.map(
+        (record) => new TypedRecord<T>(record),
+      );
+    }
+    return this._typedRecords;
+  }
+
+  /**
+   * Pagination cursor for fetching the next page of initial results.
+   *
+   * `undefined` when there are no more results.
+   */
+  public get cursor(): PaginationCursor | undefined {
+    return this._liveQuery.cursor;
+  }
+
+  // -------------------------------------------------------------------------
+  // Typed event handlers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Register a typed event handler. Returns an unsubscribe function.
+   *
+   * @param event - The event type to listen for.
+   * @param handler - The handler function with typed record(s).
+   * @returns A function that removes the handler when called.
+   *
+   * @example
+   * ```ts
+   * const off = liveQuery.on('create', (record) => {
+   *   // record is TypedRecord<T>
+   * });
+   * off(); // stop listening
+   * ```
+   */
+  public on(event: 'change', handler: (change: TypedRecordChange<T>) => void): () => void;
+  public on(event: 'create', handler: (record: TypedRecord<T>) => void): () => void;
+  public on(event: 'update', handler: (record: TypedRecord<T>) => void): () => void;
+  public on(event: 'delete', handler: (record: TypedRecord<T>) => void): () => void;
+  public on(
+    event: 'change' | 'create' | 'update' | 'delete',
+    handler: ((change: TypedRecordChange<T>) => void) | ((record: TypedRecord<T>) => void),
+  ): () => void {
+    if (event === 'change') {
+      return this._liveQuery.on('change', (change: RecordChange): void => {
+        (handler as (change: TypedRecordChange<T>) => void)({
+          type   : change.type,
+          record : new TypedRecord<T>(change.record),
+        });
+      });
+    }
+
+    // For create/update/delete, the underlying LiveQuery handler receives a Record.
+    // Cast event to 'create' to satisfy the overload resolver — the actual value
+    // is always one of 'create' | 'update' | 'delete' at this point.
+    return this._liveQuery.on(event as 'create', (record): void => {
+      (handler as (record: TypedRecord<T>) => void)(new TypedRecord<T>(record));
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Close the underlying subscription and stop dispatching events.
+   */
+  public async close(): Promise<void> {
+    return this._liveQuery.close();
+  }
+}

--- a/packages/api/src/typed-record.ts
+++ b/packages/api/src/typed-record.ts
@@ -1,0 +1,309 @@
+/**
+ * A type-safe wrapper around {@link Record} that carries the data type `T`
+ * through its entire lifecycle — from write to read, query, update, and
+ * subscribe.
+ *
+ * `TypedRecord<T>` uses composition (not inheritance) to wrap the underlying
+ * untyped `Record` class. All read-only getters and lifecycle methods are
+ * forwarded, while data-access and mutation methods are enhanced with the
+ * generic `T`:
+ *
+ * - `.data.json()` returns `Promise<T>` instead of `Promise<unknown>`.
+ * - `.update({ data })` accepts `Partial<T>` for the data payload.
+ *
+ * @example
+ * ```ts
+ * const { record } = await typed.records.write('friend', {
+ *   data: { did: 'did:example:alice', alias: 'Alice' },
+ * });
+ *
+ * // record is TypedRecord<FriendData>
+ * const data = await record.data.json(); // FriendData — no manual cast
+ * ```
+ */
+
+import type { Record } from './record.js';
+import type { RecordData } from './record-data.js';
+import type { DwnDateSort, DwnMessage, DwnPaginationCursor, DwnResponseStatus } from '@enbox/agent';
+import type { RecordDeleteParams, RecordModel, RecordUpdateParams } from './record-types.js';
+
+import type { DwnInterface } from '@enbox/agent';
+
+// ---------------------------------------------------------------------------
+// Typed data accessor
+// ---------------------------------------------------------------------------
+
+/**
+ * A data accessor that preserves the record's type parameter `T` on
+ * the `json()` method.
+ *
+ * All other methods (`blob`, `bytes`, `text`, `stream`, `then`, `catch`)
+ * are forwarded unchanged from the underlying {@link RecordData}.
+ */
+export type TypedRecordData<T> = Omit<RecordData, 'json'> & {
+  /** Parse the data as JSON, returning the typed data shape `T`. */
+  json: () => Promise<T>;
+};
+
+// ---------------------------------------------------------------------------
+// Typed update params
+// ---------------------------------------------------------------------------
+
+/**
+ * Update parameters for a {@link TypedRecord}.
+ *
+ * Extends the base `RecordUpdateParams` but narrows `data` from `unknown`
+ * to `Partial<T>`.
+ */
+export type TypedRecordUpdateParams<T> = Omit<RecordUpdateParams, 'data'> & {
+  /** The new data for the record. Type-checked against the schema map. */
+  data?: Partial<T>;
+};
+
+// ---------------------------------------------------------------------------
+// Typed update / delete results
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a {@link TypedRecord.update} operation.
+ */
+export type TypedRecordUpdateResult<T> = DwnResponseStatus & {
+  /** The updated record, carrying the same type parameter. */
+  record: TypedRecord<T>;
+};
+
+/**
+ * Result of a {@link TypedRecord.delete} operation.
+ */
+export type TypedRecordDeleteResult<T> = DwnResponseStatus & {
+  /** The deleted record, carrying the same type parameter. */
+  record: TypedRecord<T>;
+};
+
+// ---------------------------------------------------------------------------
+// TypedRecord class
+// ---------------------------------------------------------------------------
+
+/**
+ * A type-safe wrapper around {@link Record} that preserves the data type `T`.
+ *
+ * Obtain instances through `TypedWeb5.records.write()`, `.query()`, `.read()`,
+ * or `.subscribe()` — never construct directly.
+ */
+export class TypedRecord<T> {
+  /** The underlying untyped Record instance. */
+  private _record: Record;
+
+  constructor(record: Record) {
+    this._record = record;
+  }
+
+  // -------------------------------------------------------------------------
+  // Escape hatch
+  // -------------------------------------------------------------------------
+
+  /** Access the underlying untyped {@link Record} for advanced use cases. */
+  public get rawRecord(): Record {
+    return this._record;
+  }
+
+  // -------------------------------------------------------------------------
+  // Typed data accessor
+  // -------------------------------------------------------------------------
+
+  /**
+   * Returns the data of the current record with type-safe accessors.
+   *
+   * The `json()` method returns `Promise<T>` — no manual generic needed.
+   *
+   * @throws `Error` if the record has been deleted.
+   */
+  public get data(): TypedRecordData<T> {
+    const underlying = this._record.data;
+    return {
+      blob   : (): Promise<Blob> => underlying.blob(),
+      bytes  : (): Promise<Uint8Array> => underlying.bytes(),
+      json   : (): Promise<T> => underlying.json<T>(),
+      text   : (): Promise<string> => underlying.text(),
+      stream : (): Promise<ReadableStream> => underlying.stream(),
+      then   : underlying.then.bind(underlying),
+      catch  : underlying.catch.bind(underlying),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Typed mutation methods
+  // -------------------------------------------------------------------------
+
+  /**
+   * Update the current record on the DWN.
+   *
+   * @param params - Parameters including the typed `data` payload.
+   * @returns The status and an updated {@link TypedRecord}.
+   * @throws `Error` if the record has been deleted.
+   */
+  public async update(params: TypedRecordUpdateParams<T>): Promise<TypedRecordUpdateResult<T>> {
+    const { status, record } = await this._record.update(params as RecordUpdateParams);
+    return { status, record: new TypedRecord<T>(record) };
+  }
+
+  /**
+   * Delete the current record on the DWN.
+   *
+   * @param params - Delete parameters.
+   * @returns The status and a {@link TypedRecord} reflecting the deleted state.
+   */
+  public async delete(params?: RecordDeleteParams): Promise<TypedRecordDeleteResult<T>> {
+    const { status, record } = await this._record.delete(params);
+    return { status, record: new TypedRecord<T>(record) };
+  }
+
+  // -------------------------------------------------------------------------
+  // Forwarded lifecycle methods
+  // -------------------------------------------------------------------------
+
+  /**
+   * Stores the current record state to the owner's DWN.
+   *
+   * @param importRecord - If true, sign as owner before storing. Defaults to false.
+   */
+  public async store(importRecord: boolean = false): Promise<DwnResponseStatus> {
+    return this._record.store(importRecord);
+  }
+
+  /**
+   * Signs and optionally stores the record to the owner's DWN.
+   * Useful when importing a record signed by someone else.
+   *
+   * @param store - If true, store after signing. Defaults to true.
+   */
+  public async import(store: boolean = true): Promise<DwnResponseStatus> {
+    return this._record.import(store);
+  }
+
+  /**
+   * Send the current record to a remote DWN.
+   *
+   * @param target - Optional DID of the target DWN. Defaults to the connected DID.
+   */
+  public async send(target?: string): Promise<DwnResponseStatus> {
+    return this._record.send(target);
+  }
+
+  /**
+   * Returns a JSON representation of the Record instance.
+   */
+  public toJSON(): RecordModel {
+    return this._record.toJSON();
+  }
+
+  /**
+   * Returns a string representation of the Record instance.
+   */
+  public toString(): string {
+    return this._record.toString();
+  }
+
+  /**
+   * Returns a pagination cursor for the current record given a sort order.
+   */
+  public async paginationCursor(sort: DwnDateSort): Promise<DwnPaginationCursor | undefined> {
+    return this._record.paginationCursor(sort);
+  }
+
+  // -------------------------------------------------------------------------
+  // Forwarded immutable property getters
+  // -------------------------------------------------------------------------
+
+  /** Record's ID. */
+  public get id(): string { return this._record.id; }
+
+  /** Record's context ID. */
+  public get contextId(): string | undefined { return this._record.contextId; }
+
+  /** Record's creation date. */
+  public get dateCreated(): string { return this._record.dateCreated; }
+
+  /** Record's parent ID. */
+  public get parentId(): string | undefined { return this._record.parentId; }
+
+  /** Record's protocol. */
+  public get protocol(): string | undefined { return this._record.protocol; }
+
+  /** Record's protocol path. */
+  public get protocolPath(): string | undefined { return this._record.protocolPath; }
+
+  /** Record's recipient. */
+  public get recipient(): string | undefined { return this._record.recipient; }
+
+  /** Record's schema. */
+  public get schema(): string | undefined { return this._record.schema; }
+
+  // -------------------------------------------------------------------------
+  // Forwarded mutable property getters
+  // -------------------------------------------------------------------------
+
+  /** Record's data format. */
+  public get dataFormat(): string | undefined { return this._record.dataFormat; }
+
+  /** Record's data CID. */
+  public get dataCid(): string | undefined { return this._record.dataCid; }
+
+  /** Record's data size. */
+  public get dataSize(): number | undefined { return this._record.dataSize; }
+
+  /** Record's published date. */
+  public get datePublished(): string | undefined { return this._record.datePublished; }
+
+  /** Record's published status. */
+  public get published(): boolean | undefined { return this._record.published; }
+
+  /** Tags of the record. */
+  public get tags(): DwnMessage[DwnInterface.RecordsWrite]['descriptor']['tags'] | undefined {
+    return this._record.tags;
+  }
+
+  // -------------------------------------------------------------------------
+  // Forwarded state-dependent property getters
+  // -------------------------------------------------------------------------
+
+  /** DID that is the logical author of the Record. */
+  public get author(): string { return this._record.author; }
+
+  /** DID that is the original creator of the Record. */
+  public get creator(): string { return this._record.creator; }
+
+  /** Record's message timestamp. */
+  public get timestamp(): string { return this._record.timestamp; }
+
+  /** Record's encryption details. */
+  public get encryption(): DwnMessage[DwnInterface.RecordsWrite]['encryption'] {
+    return this._record.encryption;
+  }
+
+  /** Record's authorization. */
+  public get authorization(): DwnMessage[DwnInterface.RecordsWrite | DwnInterface.RecordsDelete]['authorization'] {
+    return this._record.authorization;
+  }
+
+  /** Record's attestation. */
+  public get attestation(): DwnMessage[DwnInterface.RecordsWrite]['attestation'] | undefined {
+    return this._record.attestation;
+  }
+
+  /** Role under which the author is writing the record. */
+  public get protocolRole(): string | undefined { return this._record.protocolRole; }
+
+  /** Record's deleted state. */
+  public get deleted(): boolean { return this._record.deleted; }
+
+  /** Record's initial write if the record has been updated. */
+  public get initialWrite(): DwnMessage[DwnInterface.RecordsWrite] | undefined {
+    return this._record.initialWrite;
+  }
+
+  /** The raw DWN message backing this record. */
+  public get rawMessage(): DwnMessage[DwnInterface.RecordsWrite] | DwnMessage[DwnInterface.RecordsDelete] {
+    return this._record.rawMessage;
+  }
+}

--- a/packages/api/src/typed-web5.ts
+++ b/packages/api/src/typed-web5.ts
@@ -6,6 +6,10 @@
  * and schema into every operation, and provides compile-time path
  * autocompletion plus typed data payloads via the schema map.
  *
+ * All record-returning methods wrap the underlying `Record` instances in
+ * {@link TypedRecord} so that type information flows through reads, queries,
+ * updates, and subscriptions without manual casts.
+ *
  * @example
  * ```ts
  * const social = web5.using(SocialProtocol);
@@ -17,24 +21,31 @@
  * const { record } = await social.records.write('thread', {
  *   data: { title: 'Hello World', body: '...' },
  * });
+ * // record is TypedRecord<ThreadData>
+ *
+ * const data = await record.data.json(); // ThreadData — no cast needed
  *
  * // Query — protocol and protocolPath are auto-injected
  * const { records } = await social.records.query('thread');
+ * // records is TypedRecord<ThreadData>[]
  *
- * // Subscribe — real-time changes via LiveQuery
+ * // Subscribe — real-time changes via TypedLiveQuery
  * const { liveQuery } = await social.records.subscribe('thread/reply');
- * liveQuery.on('create', (record) => { ... });
+ * liveQuery.on('create', (record) => {
+ *   // record is TypedRecord<ReplyData>
+ * });
  * ```
  */
 
 import type { DwnApi } from './dwn-api.js';
-import type { LiveQuery } from './live-query.js';
 import type { Protocol } from './protocol.js';
-import type { Record } from './record.js';
 
 import type { DateSort, ProtocolDefinition, ProtocolType, RecordsFilter } from '@enbox/dwn-sdk-js';
 import type { DwnPaginationCursor, DwnResponseStatus } from '@enbox/agent';
 import type { ProtocolPaths, SchemaMap, TypedProtocol, TypeNameAtPath } from './protocol-types.js';
+
+import { TypedLiveQuery } from './typed-live-query.js';
+import { TypedRecord } from './typed-record.js';
 
 // ---------------------------------------------------------------------------
 // Helper types
@@ -46,7 +57,7 @@ import type { ProtocolPaths, SchemaMap, TypedProtocol, TypeNameAtPath } from './
  * If the schema map contains a mapping for the type name at the given path,
  * that type is returned. Otherwise falls back to `unknown`.
  */
-type DataForPath<
+export type DataForPath<
   _D extends ProtocolDefinition,
   M extends SchemaMap,
   Path extends string,
@@ -105,8 +116,8 @@ export type TypedWriteRequest<
 };
 
 /** Response from {@link TypedWeb5} `records.write()`. */
-export type TypedWriteResponse = DwnResponseStatus & {
-  record: Record;
+export type TypedWriteResponse<T = unknown> = DwnResponseStatus & {
+  record: TypedRecord<T>;
 };
 
 /** Filter options for {@link TypedWeb5} `records.query()`. */
@@ -130,8 +141,8 @@ export type TypedQueryRequest = {
 };
 
 /** Response from {@link TypedWeb5} `records.query()`. */
-export type TypedQueryResponse = DwnResponseStatus & {
-  records: Record[];
+export type TypedQueryResponse<T = unknown> = DwnResponseStatus & {
+  records: TypedRecord<T>[];
   cursor?: DwnPaginationCursor;
 };
 
@@ -148,8 +159,8 @@ export type TypedReadRequest = {
 };
 
 /** Response from {@link TypedWeb5} `records.read()`. */
-export type TypedReadResponse = DwnResponseStatus & {
-  record: Record;
+export type TypedReadResponse<T = unknown> = DwnResponseStatus & {
+  record: TypedRecord<T>;
 };
 
 /** Options for {@link TypedWeb5} `records.delete()`. */
@@ -172,9 +183,9 @@ export type TypedSubscribeRequest = {
 };
 
 /** Response from {@link TypedWeb5} `records.subscribe()`. */
-export type TypedSubscribeResponse = DwnResponseStatus & {
-  /** The live query instance, or `undefined` if the request failed. */
-  liveQuery?: LiveQuery;
+export type TypedSubscribeResponse<T = unknown> = DwnResponseStatus & {
+  /** The typed live query instance, or `undefined` if the request failed. */
+  liveQuery?: TypedLiveQuery<T>;
 };
 
 // ---------------------------------------------------------------------------
@@ -184,6 +195,10 @@ export type TypedSubscribeResponse = DwnResponseStatus & {
 /**
  * A protocol-scoped API that auto-injects `protocol`, `protocolPath`, and
  * `schema` into every DWN operation.
+ *
+ * All record-returning methods wrap results in {@link TypedRecord} so that
+ * the data type `T` (resolved from the schema map) flows end-to-end — from
+ * write through read, query, update, and subscribe — without manual casts.
  *
  * Obtain an instance via `web5.using(typedProtocol)`.
  *
@@ -196,10 +211,14 @@ export type TypedSubscribeResponse = DwnResponseStatus & {
  * const { record } = await social.records.write('friend', {
  *   data: { did: 'did:example:alice', alias: 'Alice' },
  * });
+ * const data = await record.data.json(); // FriendData — no cast
  *
  * const { records } = await social.records.query('friend', {
  *   filter: { tags: { did: 'did:example:alice' } },
  * });
+ * for (const r of records) {
+ *   const d = await r.data.json(); // FriendData
+ * }
  * ```
  */
 export class TypedWeb5<
@@ -261,13 +280,35 @@ export class TypedWeb5<
    * Every method auto-injects the protocol URI, protocolPath, and schema
    * from the protocol definition. Path parameters provide compile-time
    * autocompletion via `ProtocolPaths<D>`.
+   *
+   * All methods return {@link TypedRecord} or {@link TypedLiveQuery} instances
+   * that carry the resolved data type from the schema map.
    */
   public get records(): {
-    write: <Path extends ProtocolPaths<D> & string>(path: Path, request: TypedWriteRequest<D, M, Path>) => Promise<TypedWriteResponse>;
-    query: <Path extends ProtocolPaths<D> & string>(path: Path, request?: TypedQueryRequest) => Promise<TypedQueryResponse>;
-    read: <Path extends ProtocolPaths<D> & string>(path: Path, request: TypedReadRequest) => Promise<TypedReadResponse>;
-    delete: <Path extends ProtocolPaths<D> & string>(path: Path, request: TypedDeleteRequest) => Promise<DwnResponseStatus>;
-    subscribe: <Path extends ProtocolPaths<D> & string>(path: Path, request?: TypedSubscribeRequest) => Promise<TypedSubscribeResponse>;
+    write: <Path extends ProtocolPaths<D> & string>(
+      path: Path,
+      request: TypedWriteRequest<D, M, Path>,
+    ) => Promise<TypedWriteResponse<DataForPath<D, M, Path>>>;
+
+    query: <Path extends ProtocolPaths<D> & string>(
+      path: Path,
+      request?: TypedQueryRequest,
+    ) => Promise<TypedQueryResponse<DataForPath<D, M, Path>>>;
+
+    read: <Path extends ProtocolPaths<D> & string>(
+      path: Path,
+      request: TypedReadRequest,
+    ) => Promise<TypedReadResponse<DataForPath<D, M, Path>>>;
+
+    delete: <Path extends ProtocolPaths<D> & string>(
+      path: Path,
+      request: TypedDeleteRequest,
+    ) => Promise<DwnResponseStatus>;
+
+    subscribe: <Path extends ProtocolPaths<D> & string>(
+      path: Path,
+      request?: TypedSubscribeRequest,
+    ) => Promise<TypedSubscribeResponse<DataForPath<D, M, Path>>>;
     } {
     return {
       /**
@@ -279,11 +320,11 @@ export class TypedWeb5<
       write: async <Path extends ProtocolPaths<D> & string>(
         path: Path,
         request: TypedWriteRequest<D, M, Path>,
-      ): Promise<TypedWriteResponse> => {
+      ): Promise<TypedWriteResponse<DataForPath<D, M, Path>>> => {
         const typeName = lastSegment(path);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
-        return this._dwn.records.write({
+        const { status, record } = await this._dwn.records.write({
           data            : request.data,
           store           : request.store,
           encryption      : request.encryption,
@@ -298,6 +339,11 @@ export class TypedWeb5<
           ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
           dataFormat      : request.dataFormat ?? typeEntry?.dataFormats?.[0],
         });
+
+        return {
+          status,
+          record: new TypedRecord<DataForPath<D, M, Path>>(record),
+        };
       },
 
       /**
@@ -309,11 +355,11 @@ export class TypedWeb5<
       query: async <Path extends ProtocolPaths<D> & string>(
         path: Path,
         request?: TypedQueryRequest,
-      ): Promise<TypedQueryResponse> => {
+      ): Promise<TypedQueryResponse<DataForPath<D, M, Path>>> => {
         const typeName = lastSegment(path);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
-        return this._dwn.records.query({
+        const { status, records, cursor } = await this._dwn.records.query({
           from       : request?.from,
           encryption : request?.encryption,
           filter     : {
@@ -326,6 +372,12 @@ export class TypedWeb5<
           pagination   : request?.pagination,
           protocolRole : request?.protocolRole,
         });
+
+        return {
+          status,
+          records: records.map((r) => new TypedRecord<DataForPath<D, M, Path>>(r)),
+          cursor,
+        };
       },
 
       /**
@@ -337,11 +389,11 @@ export class TypedWeb5<
       read: async <Path extends ProtocolPaths<D> & string>(
         path: Path,
         request: TypedReadRequest,
-      ): Promise<TypedReadResponse> => {
+      ): Promise<TypedReadResponse<DataForPath<D, M, Path>>> => {
         const typeName = lastSegment(path);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
-        return this._dwn.records.read({
+        const { status, record } = await this._dwn.records.read({
           from       : request.from,
           encryption : request.encryption,
           protocol   : this._definition.protocol,
@@ -352,6 +404,11 @@ export class TypedWeb5<
             ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
           },
         });
+
+        return {
+          status,
+          record: new TypedRecord<DataForPath<D, M, Path>>(record),
+        };
       },
 
       /**
@@ -374,8 +431,9 @@ export class TypedWeb5<
       /**
        * Subscribe to records at the given protocol path.
        *
-       * Returns a {@link LiveQuery} that atomically provides an initial snapshot
-       * and a real-time stream of deduplicated change events.
+       * Returns a {@link TypedLiveQuery} that atomically provides an initial
+       * snapshot and a real-time stream of deduplicated change events, with
+       * all records typed as `TypedRecord<T>`.
        *
        * @param path - The protocol path to subscribe to.
        * @param request - Optional filter and role.
@@ -383,11 +441,11 @@ export class TypedWeb5<
       subscribe: async <Path extends ProtocolPaths<D> & string>(
         path: Path,
         request?: TypedSubscribeRequest,
-      ): Promise<TypedSubscribeResponse> => {
+      ): Promise<TypedSubscribeResponse<DataForPath<D, M, Path>>> => {
         const typeName = lastSegment(path);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
-        return this._dwn.records.subscribe({
+        const { status, liveQuery } = await this._dwn.records.subscribe({
           from   : request?.from,
           filter : {
             ...request?.filter,
@@ -397,6 +455,11 @@ export class TypedWeb5<
           },
           protocolRole: request?.protocolRole,
         });
+
+        return {
+          status,
+          liveQuery: liveQuery ? new TypedLiveQuery<DataForPath<D, M, Path>>(liveQuery) : undefined,
+        };
       },
     };
   }

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -9,6 +9,8 @@ import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
 import { defineProtocol } from '../src/define-protocol.js';
 import { DwnApi } from '../src/dwn-api.js';
 import { testDwnUrl } from './utils/test-config.js';
+import { TypedLiveQuery } from '../src/typed-live-query.js';
+import { TypedRecord } from '../src/typed-record.js';
 import { TypedWeb5 } from '../src/typed-web5.js';
 
 // ---------------------------------------------------------------------------
@@ -199,13 +201,13 @@ describe('TypedProtocol API', () => {
     });
 
     describe('write()', () => {
-      it('should write a record at a root path', async () => {
+      it('should write a record and return a TypedRecord', async () => {
         const { status, record } = await typed.records.write('list', {
           data: { name: 'Groceries', description: 'Weekly shopping' },
         });
 
         expect(status.code).toBe(202);
-        expect(record).toBeDefined();
+        expect(record).toBeInstanceOf(TypedRecord);
         expect(record.protocolPath).toBe('list');
         expect(record.schema).toBe('https://example.com/schemas/list');
         expect(record.protocol).toBe('https://example.com/protocols/todo');
@@ -225,24 +227,34 @@ describe('TypedProtocol API', () => {
         });
 
         expect(status.code).toBe(202);
-        expect(taskRecord).toBeDefined();
+        expect(taskRecord).toBeInstanceOf(TypedRecord);
         expect(taskRecord.protocolPath).toBe('list/task');
         expect(taskRecord.schema).toBe('https://example.com/schemas/task');
       });
 
-      it('should read back written JSON data with correct types', async () => {
+      it('should read back written JSON data via TypedRecord.data.json() without manual cast', async () => {
         const inputData = { name: 'Shopping', description: 'Grocery list' };
         const { record } = await typed.records.write('list', { data: inputData });
         expect(record).toBeDefined();
 
-        const readBack = await record.data.json<TodoSchemaMap['list']>();
+        // No need for .json<TodoSchemaMap['list']>() — it's inferred!
+        const readBack = await record.data.json();
         expect(readBack.name).toBe('Shopping');
         expect(readBack.description).toBe('Grocery list');
+      });
+
+      it('should provide access to the underlying Record via rawRecord', async () => {
+        const { record } = await typed.records.write('list', {
+          data: { name: 'Raw Test' },
+        });
+
+        expect(record.rawRecord).toBeDefined();
+        expect(record.rawRecord.id).toBe(record.id);
       });
     });
 
     describe('query()', () => {
-      it('should query records at a given path', async () => {
+      it('should query records and return TypedRecord instances', async () => {
         // Write two lists
         await typed.records.write('list', { data: { name: 'List A' } });
         await typed.records.write('list', { data: { name: 'List B' } });
@@ -252,6 +264,8 @@ describe('TypedProtocol API', () => {
         expect(status.code).toBe(200);
         expect(records).toBeDefined();
         expect(records.length).toBe(2);
+        expect(records[0]).toBeInstanceOf(TypedRecord);
+        expect(records[1]).toBeInstanceOf(TypedRecord);
       });
 
       it('should apply additional filters', async () => {
@@ -277,11 +291,23 @@ describe('TypedProtocol API', () => {
 
         expect(records).toBeDefined();
         expect(records.length).toBe(2);
+        expect(records[0]).toBeInstanceOf(TypedRecord);
+      });
+
+      it('should read typed data from queried TypedRecords without manual cast', async () => {
+        await typed.records.write('list', { data: { name: 'Query Test' } });
+
+        const { records } = await typed.records.query('list');
+        expect(records.length).toBeGreaterThanOrEqual(1);
+
+        // data.json() returns the typed data directly
+        const data = await records[0].data.json();
+        expect(data.name).toBe('Query Test');
       });
     });
 
     describe('read()', () => {
-      it('should read a single record by recordId', async () => {
+      it('should read a single record by recordId and return a TypedRecord', async () => {
         const { record: written } = await typed.records.write('list', {
           data: { name: 'Reading List' },
         });
@@ -292,8 +318,8 @@ describe('TypedProtocol API', () => {
         });
 
         expect(status.code).toBe(200);
-        expect(readRecord).toBeDefined();
-        const data = await readRecord.data.json<TodoSchemaMap['list']>();
+        expect(readRecord).toBeInstanceOf(TypedRecord);
+        const data = await readRecord.data.json();
         expect(data.name).toBe('Reading List');
       });
     });
@@ -332,8 +358,6 @@ describe('TypedProtocol API', () => {
 
         // Write a binary attachment — the 'attachment' type has no schema,
         // only dataFormats: ['application/octet-stream', 'image/png', 'image/jpeg'].
-        // Before the fix, this would inject `schema: undefined` into the DWN
-        // filter, violating the JSON Schema which requires schema to be a string.
         const blob = new Blob(['binary-content'], { type: 'application/octet-stream' });
         const { status: writeStatus, record: attachmentRecord } = await typed.records.write(
           'list/task/attachment',
@@ -344,7 +368,7 @@ describe('TypedProtocol API', () => {
         );
 
         expect(writeStatus.code).toBe(202);
-        expect(attachmentRecord).toBeDefined();
+        expect(attachmentRecord).toBeInstanceOf(TypedRecord);
         expect(attachmentRecord.protocolPath).toBe('list/task/attachment');
         // Schema should be undefined — not set on the record.
         expect(attachmentRecord.schema).toBeUndefined();
@@ -358,20 +382,30 @@ describe('TypedProtocol API', () => {
         expect(queryStatus.code).toBe(200);
         expect(records.length).toBe(1);
         expect(records[0].id).toBe(attachmentRecord.id);
+        expect(records[0]).toBeInstanceOf(TypedRecord);
       });
     });
 
     describe('subscribe()', () => {
-      it('should subscribe and receive new records', async () => {
-        const received: string[] = [];
-
+      it('should subscribe and return a TypedLiveQuery', async () => {
         const { status, liveQuery } = await typed.records.subscribe('list');
 
         expect(status.code).toBe(200);
         expect(liveQuery).toBeDefined();
+        expect(liveQuery).toBeInstanceOf(TypedLiveQuery);
+
+        // Clean up
+        await liveQuery.close();
+      });
+
+      it('should receive new records as TypedRecord instances', async () => {
+        const received: TypedRecord<TodoSchemaMap['list']>[] = [];
+
+        const { liveQuery } = await typed.records.subscribe('list');
+        expect(liveQuery).toBeDefined();
 
         liveQuery.on('create', (record) => {
-          received.push(record.id);
+          received.push(record);
         });
 
         // Write a record — should trigger subscription
@@ -381,9 +415,86 @@ describe('TypedProtocol API', () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         expect(received.length).toBeGreaterThanOrEqual(1);
+        expect(received[0]).toBeInstanceOf(TypedRecord);
 
         // Clean up
         await liveQuery.close();
+      });
+
+      it('should provide typed initial records in liveQuery.records', async () => {
+        // Write a record first
+        await typed.records.write('list', { data: { name: 'Pre-existing' } });
+
+        // Subscribe — should include the pre-existing record in the snapshot
+        const { liveQuery } = await typed.records.subscribe('list');
+        expect(liveQuery).toBeDefined();
+
+        expect(liveQuery.records.length).toBeGreaterThanOrEqual(1);
+        expect(liveQuery.records[0]).toBeInstanceOf(TypedRecord);
+
+        const data = await liveQuery.records[0].data.json();
+        expect(data.name).toBe('Pre-existing');
+
+        await liveQuery.close();
+      });
+
+      it('should provide access to the raw LiveQuery via rawLiveQuery', async () => {
+        const { liveQuery } = await typed.records.subscribe('list');
+        expect(liveQuery).toBeDefined();
+        expect(liveQuery.rawLiveQuery).toBeDefined();
+
+        await liveQuery.close();
+      });
+    });
+
+    describe('TypedRecord lifecycle methods', () => {
+      it('should update a record and return a new TypedRecord', async () => {
+        const { record } = await typed.records.write('list', {
+          data: { name: 'Original' },
+        });
+        expect(record).toBeInstanceOf(TypedRecord);
+
+        const { status, record: updatedRecord } = await record.update({
+          data: { name: 'Updated', description: 'Now with description' },
+        });
+
+        expect(status.code).toBe(202);
+        expect(updatedRecord).toBeInstanceOf(TypedRecord);
+        const data = await updatedRecord.data.json();
+        expect(data.name).toBe('Updated');
+        expect(data.description).toBe('Now with description');
+      });
+
+      it('should delete a record via TypedRecord.delete()', async () => {
+        const { record } = await typed.records.write('list', {
+          data: { name: 'Delete Me' },
+        });
+
+        const { status, record: deletedRecord } = await record.delete();
+
+        expect(status.code).toBe(202);
+        expect(deletedRecord).toBeInstanceOf(TypedRecord);
+        expect(deletedRecord.deleted).toBe(true);
+      });
+
+      it('should forward toJSON() from the underlying Record', async () => {
+        const { record } = await typed.records.write('list', {
+          data: { name: 'JSON Test' },
+        });
+
+        const json = record.toJSON();
+        expect(json.protocol).toBe('https://example.com/protocols/todo');
+        expect(json.protocolPath).toBe('list');
+      });
+
+      it('should forward toString() from the underlying Record', async () => {
+        const { record } = await typed.records.write('list', {
+          data: { name: 'String Test' },
+        });
+
+        const str = record.toString();
+        expect(str).toContain('Record:');
+        expect(str).toContain(record.id);
       });
     });
   });


### PR DESCRIPTION
## Summary

- Introduces `TypedRecord<T>` — a type-safe wrapper around `Record` that carries the data type through its lifecycle
- Introduces `TypedLiveQuery<T>` — a type-safe wrapper around `LiveQuery` with typed event handlers
- Updates `TypedWeb5` so all record-returning methods (`write`, `query`, `read`, `subscribe`) return `TypedRecord<T>` / `TypedLiveQuery<T>` instead of the unparameterized `Record` / `LiveQuery`

## Motivation

Previously, `TypedWeb5` enforced type safety only on the **input** side — `records.write('friend', { data })` checked `data` against the schema map. But the returned `Record` was untyped, forcing developers to manually cast:

```ts
// Before — manual cast required on every read
const data = await record.data.json<FriendData>();
```

Now the type flows end-to-end:

```ts
// After — T is inferred from the path
const { record } = await typed.records.write('friend', { data: friendData });
const data = await record.data.json(); // FriendData — no cast needed

const { records } = await typed.records.query('friend');
for (const r of records) {
  const d = await r.data.json(); // FriendData
}

const { liveQuery } = await typed.records.subscribe('friend');
liveQuery.on('create', async (record) => {
  const d = await record.data.json(); // FriendData
});
```

## New Files

- `packages/api/src/typed-record.ts` — `TypedRecord<T>` class (composition over `Record`)
- `packages/api/src/typed-live-query.ts` — `TypedLiveQuery<T>` class (composition over `LiveQuery`)

## Changed Files

- `packages/api/src/typed-web5.ts` — Response types are now generic; methods wrap results in `TypedRecord`/`TypedLiveQuery`
- `packages/api/src/index.ts` — Exports the new modules
- `packages/api/tests/typed-protocol.spec.ts` — 26 tests covering all typed record operations

## Design Decisions

- **Composition over inheritance**: `TypedRecord<T>` wraps `Record` rather than extending it, avoiding deep coupling with `Record` internals
- **Escape hatches**: `.rawRecord` and `.rawLiveQuery` provide access to the underlying untyped instances for advanced use cases
- **Generic response types**: `TypedWriteResponse<T>`, `TypedQueryResponse<T>`, etc. default to `unknown` for backward compatibility
- **`DataForPath<D, M, Path>`** is now exported for use by the upcoming repository layer (PR2)

## Part of: Protocol DX Enhancement

This is PR 1 of 4:
1. **TypedRecord + TypedLiveQuery** (this PR)
2. Repository pattern — `repository()` with singleton-aware CRUD
3. `@enbox/protocol-codegen` — CLI for JSON Schema → TypeScript generation
4. Migrate `@enbox/protocols` to use codegen