### PR TITLE
feat(api): add Proxy-based repository pattern for protocol-backed CRUD

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -34,6 +34,8 @@ export * from './read-only-record.js';
 export * from './record.js';
 export * from './record-data.js';
 export * from './record-types.js';
+export * from './repository.js';
+export * from './repository-types.js';
 export * from './typed-live-query.js';
 export * from './typed-record.js';
 export * from './typed-web5.js';

--- a/packages/api/src/repository-types.ts
+++ b/packages/api/src/repository-types.ts
@@ -1,0 +1,249 @@
+/**
+ * Type-level machinery for the protocol repository pattern.
+ *
+ * These types produce a statically-typed CRUD API shape from a
+ * `ProtocolDefinition` + `SchemaMap`, with singleton detection
+ * (via `$recordLimit: { max: 1 }`) and nested-path awareness.
+ *
+ * All types are purely compile-time — they produce no runtime code.
+ *
+ * @module
+ */
+
+import type { SchemaMap } from './protocol-types.js';
+import type { TypedLiveQuery } from './typed-live-query.js';
+import type { TypedRecord } from './typed-record.js';
+import type {
+  DataForPath,
+  TypedQueryRequest,
+  TypedSubscribeRequest,
+  TypedWriteRequest,
+} from './typed-web5.js';
+import type { DwnPaginationCursor, DwnResponseStatus } from '@enbox/agent';
+import type { ProtocolDefinition, ProtocolRuleSet } from '@enbox/dwn-sdk-js';
+
+// ---------------------------------------------------------------------------
+// Structure navigation
+// ---------------------------------------------------------------------------
+
+/**
+ * Navigates a `ProtocolRuleSet` tree to the node at a slash-delimited path.
+ */
+type RuleSetAtPath<R, Path extends string> =
+  Path extends `${infer Head}/${infer Tail}`
+    ? Head extends keyof R
+      ? R[Head] extends ProtocolRuleSet
+        ? RuleSetAtPath<R[Head], Tail>
+        : never
+      : never
+    : Path extends keyof R
+      ? R[Path] extends ProtocolRuleSet
+        ? R[Path]
+        : never
+      : never;
+
+// ---------------------------------------------------------------------------
+// Singleton detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the `$recordLimit` from a rule set node, if present.
+ */
+type RecordLimitAtRuleSet<RS> =
+  RS extends { $recordLimit: infer L } ? L : never;
+
+/**
+ * `true` when the rule set at `Path` has `$recordLimit: { max: 1 }`.
+ */
+export type IsSingleton<D extends ProtocolDefinition, Path extends string> =
+  RecordLimitAtRuleSet<RuleSetAtPath<D['structure'], Path>> extends { max: 1 }
+    ? true
+    : false;
+
+// ---------------------------------------------------------------------------
+// Data type resolution
+// ---------------------------------------------------------------------------
+
+/** Resolves the TypeScript data type for a given path. */
+type DataAt<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+  Path extends string,
+> = DataForPath<D, M, Path>;
+
+// ---------------------------------------------------------------------------
+// Common option types
+// ---------------------------------------------------------------------------
+
+/**
+ * Write options for a collection `create()` call.
+ * Omits `data` (passed separately) and protocol-injected fields.
+ */
+export type CollectionCreateOptions<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+  Path extends string,
+> = Omit<TypedWriteRequest<D, M, Path>, 'data' | 'parentContextId'> & {
+  data: DataAt<D, M, Path>;
+};
+
+/**
+ * Write options for a singleton `set()` call.
+ */
+export type SingletonSetOptions<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+  Path extends string,
+> = Omit<TypedWriteRequest<D, M, Path>, 'data' | 'parentContextId'> & {
+  data: DataAt<D, M, Path>;
+};
+
+// ---------------------------------------------------------------------------
+// CRUD shapes
+// ---------------------------------------------------------------------------
+
+/** CRUD API for a root-level collection (unbounded or max > 1). */
+export type CollectionCRUD<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+  Path extends string,
+> = {
+  create(options: CollectionCreateOptions<D, M, Path>): Promise<TypedRecord<DataAt<D, M, Path>> & DwnResponseStatus>;
+  query(options?: TypedQueryRequest): Promise<{ records: TypedRecord<DataAt<D, M, Path>>[]; cursor?: DwnPaginationCursor } & DwnResponseStatus>;
+  get(recordId: string): Promise<TypedRecord<DataAt<D, M, Path>>>;
+  delete(recordId: string): Promise<DwnResponseStatus>;
+  subscribe(options?: TypedSubscribeRequest): Promise<TypedLiveQuery<DataAt<D, M, Path>>>;
+};
+
+/** CRUD API for a root-level singleton ($recordLimit max: 1). */
+export type SingletonCRUD<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+  Path extends string,
+> = {
+  set(options: SingletonSetOptions<D, M, Path>): Promise<TypedRecord<DataAt<D, M, Path>> & DwnResponseStatus>;
+  get(): Promise<TypedRecord<DataAt<D, M, Path>> | undefined>;
+  delete(recordId: string): Promise<DwnResponseStatus>;
+};
+
+/** CRUD API for a nested collection (parent context required). */
+export type NestedCollectionCRUD<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+  Path extends string,
+> = {
+  create(
+    parentContextId: string,
+    options: CollectionCreateOptions<D, M, Path>,
+  ): Promise<TypedRecord<DataAt<D, M, Path>> & DwnResponseStatus>;
+  query(
+    parentContextId: string,
+    options?: TypedQueryRequest,
+  ): Promise<{ records: TypedRecord<DataAt<D, M, Path>>[]; cursor?: DwnPaginationCursor } & DwnResponseStatus>;
+  get(recordId: string): Promise<TypedRecord<DataAt<D, M, Path>>>;
+  delete(recordId: string): Promise<DwnResponseStatus>;
+  subscribe(
+    parentContextId: string,
+    options?: TypedSubscribeRequest,
+  ): Promise<TypedLiveQuery<DataAt<D, M, Path>>>;
+};
+
+/** CRUD API for a nested singleton ($recordLimit max: 1). */
+export type NestedSingletonCRUD<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+  Path extends string,
+> = {
+  set(
+    parentContextId: string,
+    options: SingletonSetOptions<D, M, Path>,
+  ): Promise<TypedRecord<DataAt<D, M, Path>> & DwnResponseStatus>;
+  get(parentContextId: string): Promise<TypedRecord<DataAt<D, M, Path>> | undefined>;
+  delete(recordId: string): Promise<DwnResponseStatus>;
+};
+
+// ---------------------------------------------------------------------------
+// Recursive repository node
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the child type names (non-`$`-prefixed keys that extend ProtocolRuleSet)
+ * from a rule set node.
+ */
+type ChildKeys<RS> = {
+  [K in Extract<keyof RS, string>]: K extends `$${string}`
+    ? never
+    : RS[K] extends ProtocolRuleSet
+      ? K
+      : never;
+}[Extract<keyof RS, string>];
+
+/**
+ * Builds nested repository nodes for all children of a given rule set.
+ */
+type ChildNodes<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+  RS,
+  ParentPath extends string,
+> = {
+  [K in ChildKeys<RS>]: RepositoryNode<D, M, RS[K], `${ParentPath}/${K}`, true>;
+};
+
+/**
+ * A single node in the repository tree. Provides CRUD methods appropriate
+ * to whether the path is root/nested and singleton/collection, plus child
+ * nodes for further nesting.
+ */
+export type RepositoryNode<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+  RS,
+  Path extends string,
+  IsNested extends boolean = false,
+> =
+  // Choose CRUD shape based on singleton + nested status
+  (IsNested extends true
+    ? (IsSingleton<D, Path> extends true
+      ? NestedSingletonCRUD<D, M, Path>
+      : NestedCollectionCRUD<D, M, Path>)
+    : (IsSingleton<D, Path> extends true
+      ? SingletonCRUD<D, M, Path>
+      : CollectionCRUD<D, M, Path>))
+  // Plus child nodes for deeper nesting
+  & ChildNodes<D, M, RS, Path>;
+
+// ---------------------------------------------------------------------------
+// Top-level repository type
+// ---------------------------------------------------------------------------
+
+/**
+ * The top-level repository type for a protocol definition.
+ *
+ * Maps each root-level type name in the protocol's `structure` to a
+ * `RepositoryNode` with the appropriate CRUD methods and nested children.
+ *
+ * @example
+ * ```ts
+ * const social: Repository<typeof SocialGraphDef, SocialGraphSchemaMap>;
+ *
+ * // Root collection
+ * await social.friend.create({ data: { did: '...' } });
+ * await social.friend.query();
+ *
+ * // Nested under group
+ * await social.group.member.create(groupCtxId, { data: { did: '...' } });
+ * ```
+ */
+export type Repository<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+> = {
+  [K in Extract<keyof D['structure'], string> as K extends `$${string}` ? never : K]:
+    D['structure'][K] extends ProtocolRuleSet
+      ? RepositoryNode<D, M, D['structure'][K], K>
+      : never;
+} & {
+  /** Install (configure) the protocol. Idempotent — no-op if already installed. */
+  configure(options?: { encryption?: boolean }): Promise<DwnResponseStatus>;
+};

--- a/packages/api/src/repository.ts
+++ b/packages/api/src/repository.ts
@@ -1,0 +1,367 @@
+/**
+ * Protocol-aware repository factory.
+ *
+ * `repository()` takes a `TypedWeb5` instance and returns a Proxy-backed
+ * object whose shape mirrors the protocol's `structure` tree with
+ * ergonomic CRUD methods on each node.
+ *
+ * - **Collections** (default): `create`, `query`, `get`, `delete`, `subscribe`
+ * - **Singletons** (`$recordLimit: { max: 1 }`): `set`, `get`, `delete`
+ * - **Nested types**: first argument is `parentContextId`
+ * - **`configure()`**: idempotent protocol installation
+ *
+ * @example
+ * ```ts
+ * const social = repository(web5.using(SocialGraphProtocol));
+ * await social.configure();
+ *
+ * // Root collection
+ * const { record } = await social.friend.create({
+ *   data: { did: 'did:example:alice' },
+ * });
+ *
+ * // Nested under group
+ * const members = await social.group.member.query(groupContextId);
+ * ```
+ *
+ * @module
+ */
+
+import type { DwnResponseStatus } from '@enbox/agent';
+import type { Repository } from './repository-types.js';
+import type { SchemaMap } from './protocol-types.js';
+import type { TypedWeb5 } from './typed-web5.js';
+import type { ProtocolDefinition, ProtocolRuleSet } from '@enbox/dwn-sdk-js';
+
+// ---------------------------------------------------------------------------
+// Runtime helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks whether a protocol rule set at a given path is a singleton
+ * (has `$recordLimit: { max: 1 }`).
+ */
+function isSingletonPath(definition: ProtocolDefinition, path: string): boolean {
+  const segments = path.split('/');
+  let node: ProtocolRuleSet | undefined = definition.structure as unknown as ProtocolRuleSet;
+
+  for (const seg of segments) {
+    if (!node || typeof node !== 'object') { return false; }
+    node = (node as Record<string, ProtocolRuleSet>)[seg];
+  }
+
+  if (!node || typeof node !== 'object') { return false; }
+  const limit = (node as Record<string, unknown>)['$recordLimit'];
+  return limit !== undefined
+    && typeof limit === 'object'
+    && limit !== null
+    && (limit as Record<string, unknown>)['max'] === 1;
+}
+
+/**
+ * Returns the child type keys (non-`$`-prefixed) of a rule set node
+ * reached by the given path.
+ */
+function getChildKeys(definition: ProtocolDefinition, path: string): string[] {
+  const segments = path.split('/');
+  let node: Record<string, unknown> = definition.structure as unknown as Record<string, unknown>;
+
+  for (const seg of segments) {
+    if (!node || typeof node !== 'object') { return []; }
+    node = node[seg] as Record<string, unknown>;
+  }
+
+  if (!node || typeof node !== 'object') { return []; }
+  return Object.keys(node).filter((k) => !k.startsWith('$'));
+}
+
+// ---------------------------------------------------------------------------
+// CRUD method builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build collection CRUD methods for a root-level path.
+ */
+function buildRootCollectionMethods(
+  typed: TypedWeb5<ProtocolDefinition, SchemaMap>,
+  path: string,
+): Record<string, Function> {
+  return {
+    async create(options: Record<string, unknown>): Promise<unknown> {
+      const { status, record } = await typed.records.write(path, options as never);
+      return { status, record, ...status };
+    },
+
+    async query(options?: Record<string, unknown>): Promise<unknown> {
+      const { status, records, cursor } = await typed.records.query(path, options as never);
+      return { status, records, cursor, ...status };
+    },
+
+    async get(recordId: string): Promise<unknown> {
+      const { record } = await typed.records.read(path, {
+        filter: { recordId },
+      });
+      return record;
+    },
+
+    async delete(recordId: string): Promise<DwnResponseStatus> {
+      return typed.records.delete(path, { recordId });
+    },
+
+    async subscribe(options?: Record<string, unknown>): Promise<unknown> {
+      const { liveQuery } = await typed.records.subscribe(path, options as never);
+      return liveQuery;
+    },
+  };
+}
+
+/**
+ * Build singleton CRUD methods for a root-level path.
+ */
+function buildRootSingletonMethods(
+  typed: TypedWeb5<ProtocolDefinition, SchemaMap>,
+  path: string,
+): Record<string, Function> {
+  return {
+    async set(options: Record<string, unknown>): Promise<unknown> {
+      // Query for existing record
+      const { records } = await typed.records.query(path);
+      if (records.length > 0) {
+        // Update existing
+        const { status, record } = await records[0].update({
+          data: options.data,
+          ...(options.tags !== undefined ? { tags: options.tags } : {}),
+        } as never);
+        return { status, record, ...status };
+      }
+      // Create new
+      const { status, record } = await typed.records.write(path, options as never);
+      return { status, record, ...status };
+    },
+
+    async get(): Promise<unknown> {
+      const { records } = await typed.records.query(path);
+      return records.length > 0 ? records[0] : undefined;
+    },
+
+    async delete(recordId: string): Promise<DwnResponseStatus> {
+      return typed.records.delete(path, { recordId });
+    },
+  };
+}
+
+/**
+ * Build collection CRUD methods for a nested path.
+ */
+function buildNestedCollectionMethods(
+  typed: TypedWeb5<ProtocolDefinition, SchemaMap>,
+  path: string,
+): Record<string, Function> {
+  return {
+    async create(parentContextId: string, options: Record<string, unknown>): Promise<unknown> {
+      const { status, record } = await typed.records.write(path, {
+        ...options,
+        parentContextId,
+      } as never);
+      return { status, record, ...status };
+    },
+
+    async query(parentContextId: string, options?: Record<string, unknown>): Promise<unknown> {
+      const { status, records, cursor } = await typed.records.query(path, {
+        ...options,
+        filter: {
+          ...(options as Record<string, Record<string, unknown>>)?.filter,
+          contextId: parentContextId,
+        },
+      } as never);
+      return { status, records, cursor, ...status };
+    },
+
+    async get(recordId: string): Promise<unknown> {
+      const { record } = await typed.records.read(path, {
+        filter: { recordId },
+      });
+      return record;
+    },
+
+    async delete(recordId: string): Promise<DwnResponseStatus> {
+      return typed.records.delete(path, { recordId });
+    },
+
+    async subscribe(parentContextId: string, options?: Record<string, unknown>): Promise<unknown> {
+      const { liveQuery } = await typed.records.subscribe(path, {
+        ...options,
+        filter: {
+          ...(options as Record<string, Record<string, unknown>>)?.filter,
+          contextId: parentContextId,
+        },
+      } as never);
+      return liveQuery;
+    },
+  };
+}
+
+/**
+ * Build singleton CRUD methods for a nested path.
+ */
+function buildNestedSingletonMethods(
+  typed: TypedWeb5<ProtocolDefinition, SchemaMap>,
+  path: string,
+): Record<string, Function> {
+  return {
+    async set(parentContextId: string, options: Record<string, unknown>): Promise<unknown> {
+      // Query for existing record under this parent
+      const { records } = await typed.records.query(path, {
+        filter: { contextId: parentContextId },
+      } as never);
+
+      if (records.length > 0) {
+        const { status, record } = await records[0].update({
+          data: options.data,
+          ...(options.tags !== undefined ? { tags: options.tags } : {}),
+        } as never);
+        return { status, record, ...status };
+      }
+
+      const { status, record } = await typed.records.write(path, {
+        ...options,
+        parentContextId,
+      } as never);
+      return { status, record, ...status };
+    },
+
+    async get(parentContextId: string): Promise<unknown> {
+      const { records } = await typed.records.query(path, {
+        filter: { contextId: parentContextId },
+      } as never);
+      return records.length > 0 ? records[0] : undefined;
+    },
+
+    async delete(recordId: string): Promise<DwnResponseStatus> {
+      return typed.records.delete(path, { recordId });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Node builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a repository node for a given path, including CRUD methods
+ * and Proxy-based child nodes.
+ */
+function buildNode(
+  typed: TypedWeb5<ProtocolDefinition, SchemaMap>,
+  definition: ProtocolDefinition,
+  path: string,
+  isNested: boolean,
+): Record<string, unknown> {
+  const singleton = isSingletonPath(definition, path);
+
+  // Build CRUD methods based on root/nested and singleton/collection
+  let methods: Record<string, Function>;
+  if (isNested) {
+    methods = singleton
+      ? buildNestedSingletonMethods(typed, path)
+      : buildNestedCollectionMethods(typed, path);
+  } else {
+    methods = singleton
+      ? buildRootSingletonMethods(typed, path)
+      : buildRootCollectionMethods(typed, path);
+  }
+
+  // Use a Proxy to lazily build child nodes
+  const childKeys = getChildKeys(definition, path);
+  const childCache: Record<string, unknown> = {};
+
+  return new Proxy(methods, {
+    get(target: Record<string, unknown>, prop: string | symbol): unknown {
+      if (typeof prop !== 'string') { return undefined; }
+
+      // CRUD methods take priority
+      if (prop in target) { return target[prop]; }
+
+      // Lazily build child nodes
+      if (childKeys.includes(prop)) {
+        if (!(prop in childCache)) {
+          childCache[prop] = buildNode(typed, definition, `${path}/${prop}`, true);
+        }
+        return childCache[prop];
+      }
+
+      return undefined;
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a protocol-aware repository from a `TypedWeb5` instance.
+ *
+ * The returned object provides domain-specific CRUD methods that mirror
+ * the protocol's structure tree:
+ *
+ * - Root types: `repo.friend.create()`, `repo.friend.query()`
+ * - Nested types: `repo.group.member.create(groupCtxId, { data })`
+ * - Singletons: `repo.profile.set()`, `repo.profile.get()`
+ * - Protocol install: `repo.configure()`
+ *
+ * @param typed - A `TypedWeb5` instance from `web5.using(protocol)`.
+ * @returns A typed repository object.
+ *
+ * @example
+ * ```ts
+ * const social = repository(web5.using(SocialGraphProtocol));
+ * await social.configure();
+ *
+ * const rec = await social.friend.create({
+ *   data: { did: 'did:example:alice' },
+ * });
+ * const friends = await social.friend.query();
+ * ```
+ */
+export function repository<
+  D extends ProtocolDefinition,
+  M extends SchemaMap,
+>(typed: TypedWeb5<D, M>): Repository<D, M> {
+  const definition = typed.definition as ProtocolDefinition;
+
+  // Get root-level type keys from the structure
+  const rootKeys = Object.keys(definition.structure).filter((k) => !k.startsWith('$'));
+  const nodeCache: Record<string, unknown> = {};
+
+  const proxy = new Proxy({} as Record<string, unknown>, {
+    get(_target: Record<string, unknown>, prop: string | symbol): unknown {
+      if (typeof prop !== 'string') { return undefined; }
+
+      // configure() method
+      if (prop === 'configure') {
+        return async (options?: { encryption?: boolean }): Promise<DwnResponseStatus> => {
+          const result = await typed.configure(options);
+          return result;
+        };
+      }
+
+      // Root-level type nodes
+      if (rootKeys.includes(prop)) {
+        if (!(prop in nodeCache)) {
+          nodeCache[prop] = buildNode(
+            typed as unknown as TypedWeb5<ProtocolDefinition, SchemaMap>,
+            definition,
+            prop,
+            false,
+          );
+        }
+        return nodeCache[prop];
+      }
+
+      return undefined;
+    },
+  });
+
+  return proxy as unknown as Repository<D, M>;
+}

--- a/packages/api/src/typed-web5.ts
+++ b/packages/api/src/typed-web5.ts
@@ -254,6 +254,10 @@ export class TypedWeb5<
    * @param options - Optional overrides like `encryption`.
    */
   public async configure(options?: { encryption?: boolean }): Promise<DwnResponseStatus & { protocol?: Protocol }> {
+    // Strip extended properties (e.g. $recordLimit) that the DWN engine
+    // does not yet support, so the protocol can still be configured.
+    const cleanDefinition = stripExtendedProperties(this._definition);
+
     // Query for an existing installation of this protocol.
     const { protocols } = await this._dwn.protocols.query({
       filter: { protocol: this._definition.protocol },
@@ -262,14 +266,14 @@ export class TypedWeb5<
     // If already installed with the same definition, return it as-is.
     if (protocols.length > 0) {
       const existing = protocols[0];
-      if (definitionsEqual(existing.definition, this._definition)) {
+      if (definitionsEqual(existing.definition, cleanDefinition)) {
         return { status: { code: 200, detail: 'OK' }, protocol: existing };
       }
     }
 
     // Not installed or definition has changed — configure the new version.
     return this._dwn.protocols.configure({
-      definition : this._definition,
+      definition : cleanDefinition as D,
       encryption : options?.encryption,
     });
   }
@@ -486,6 +490,45 @@ function definitionsEqual(a: unknown, b: unknown): boolean {
 function lastSegment(path: string): string {
   const parts = path.split('/');
   return parts[parts.length - 1];
+}
+
+/**
+ * Extended property keys that appear in the developer-facing protocol
+ * definition but are not yet recognized by the DWN engine's JSON schema
+ * validator. These are stripped before sending the definition to the DWN.
+ */
+const EXTENDED_RULE_SET_KEYS = new Set(['$recordLimit']);
+
+/**
+ * Deep-clones a protocol definition, removing extended properties
+ * (e.g. `$recordLimit`) from every rule set node in `structure`.
+ *
+ * This allows developers to annotate their protocol definitions with
+ * repository-layer metadata without breaking DWN protocol configuration.
+ */
+function stripExtendedProperties(definition: ProtocolDefinition): ProtocolDefinition {
+  return {
+    ...definition,
+    structure: stripStructure(definition.structure) as ProtocolDefinition['structure'],
+  };
+}
+
+/**
+ * Recursively strips extended properties from a protocol structure object.
+ */
+function stripStructure(
+  obj: globalThis.Record<string, unknown>,
+): globalThis.Record<string, unknown> {
+  const result: globalThis.Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (EXTENDED_RULE_SET_KEYS.has(key)) { continue; }
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      result[key] = stripStructure(value as globalThis.Record<string, unknown>);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
 }
 
 /**

--- a/packages/api/tests/repository.spec.ts
+++ b/packages/api/tests/repository.spec.ts
@@ -1,0 +1,602 @@
+import type { BearerDid } from '@enbox/dids';
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+
+import sinon from 'sinon';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+
+import { defineProtocol } from '../src/define-protocol.js';
+import { DwnApi } from '../src/dwn-api.js';
+import { repository } from '../src/repository.js';
+import { testDwnUrl } from './utils/test-config.js';
+import { TypedRecord } from '../src/typed-record.js';
+import { TypedWeb5 } from '../src/typed-web5.js';
+
+// ---------------------------------------------------------------------------
+// Test protocol definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * A protocol with:
+ * - `list` — root collection
+ * - `list/task` — nested collection
+ * - `list/task/attachment` — deeply nested (no schema)
+ */
+const TodoProtocolDefinition = {
+  protocol  : 'https://example.com/protocols/todo-repo',
+  published : true,
+  types     : {
+    list: {
+      schema      : 'https://example.com/schemas/list',
+      dataFormats : ['application/json'],
+    },
+    task: {
+      schema      : 'https://example.com/schemas/task',
+      dataFormats : ['application/json'],
+    },
+    attachment: {
+      dataFormats: ['application/octet-stream', 'image/png'],
+    },
+  },
+  structure: {
+    list: {
+      $actions: [
+        { who: 'anyone', can: ['create', 'read'] },
+      ],
+      task: {
+        $actions: [
+          { who: 'anyone', can: ['create', 'read'] },
+        ],
+        attachment: {
+          $actions: [
+            { who: 'anyone', can: ['create', 'read'] },
+          ],
+        },
+      },
+    },
+  },
+} as const satisfies ProtocolDefinition;
+
+type TodoSchemaMap = {
+  list: { name: string; description?: string };
+  task: { title: string; completed: boolean };
+  attachment: Blob;
+};
+
+const TodoProtocol = defineProtocol(
+  TodoProtocolDefinition,
+  {} as TodoSchemaMap,
+);
+
+/**
+ * A protocol with a singleton type (root-level profile with $recordLimit).
+ * Also has a nested singleton (group/settings) and nested collection (group/member).
+ */
+const ProfileProtocolDefinition = {
+  protocol  : 'https://example.com/protocols/profile-repo',
+  published : true,
+  types     : {
+    profile: {
+      schema      : 'https://example.com/schemas/profile',
+      dataFormats : ['application/json'],
+    },
+    group: {
+      schema      : 'https://example.com/schemas/group',
+      dataFormats : ['application/json'],
+    },
+    settings: {
+      schema      : 'https://example.com/schemas/settings',
+      dataFormats : ['application/json'],
+    },
+    member: {
+      schema      : 'https://example.com/schemas/member',
+      dataFormats : ['application/json'],
+    },
+  },
+  structure: {
+    profile: {
+      $actions: [
+        { who: 'anyone', can: ['create', 'read'] },
+      ],
+      $recordLimit: { max: 1 },
+    },
+    group: {
+      $actions: [
+        { who: 'anyone', can: ['create', 'read'] },
+      ],
+      settings: {
+        $actions: [
+          { who: 'anyone', can: ['create', 'read'] },
+        ],
+        $recordLimit: { max: 1 },
+      },
+      member: {
+        $actions: [
+          { who: 'anyone', can: ['create', 'read'] },
+        ],
+      },
+    },
+  },
+} as const satisfies ProtocolDefinition;
+
+type ProfileSchemaMap = {
+  profile: { displayName: string; bio?: string };
+  group: { name: string };
+  settings: { theme: string; notifications: boolean };
+  member: { did: string; role: string };
+};
+
+const ProfileProtocol = defineProtocol(
+  ProfileProtocolDefinition,
+  {} as ProfileSchemaMap,
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testDwnUrls: string[] = [testDwnUrl];
+
+describe('repository()', () => {
+  let aliceDid: BearerDid;
+  let dwnAlice: DwnApi;
+  let testHarness: PlatformAgentTestHarness;
+
+  beforeAll(async () => {
+    testHarness = await PlatformAgentTestHarness.setup({
+      agentClass       : Web5UserAgent,
+      agentStores      : 'memory',
+      testDataLocation : '__TESTDATA__/repository',
+    });
+
+    await testHarness.clearStorage();
+    await testHarness.createAgentDid();
+
+    const alice = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
+    aliceDid = alice.did;
+
+    dwnAlice = new DwnApi({ agent: testHarness.agent, connectedDid: aliceDid.uri });
+  });
+
+  beforeEach(async () => {
+    sinon.restore();
+    await testHarness.syncStore.clear();
+    await testHarness.dwnDataStore.clear();
+    await testHarness.dwnStateIndex.clear();
+    await testHarness.dwnMessageStore.clear();
+    await testHarness.dwnResumableTaskStore.clear();
+    await testHarness.agent.permissions.clear();
+    testHarness.dwnStores.clear();
+  });
+
+  afterAll(async () => {
+    sinon.restore();
+    await testHarness.clearStorage();
+    await testHarness.closeStorage();
+  });
+
+  describe('configure()', () => {
+    it('should install the protocol via configure()', async () => {
+      const typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      const repo = repository(typed);
+
+      const result = await repo.configure();
+      expect(result.status.code).toBe(202);
+
+      // Verify protocol is installed
+      const { protocols } = await dwnAlice.protocols.query({
+        filter: { protocol: TodoProtocolDefinition.protocol },
+      });
+      expect(protocols.length).toBe(1);
+    });
+  });
+
+  describe('root collection CRUD', () => {
+    let typed: TypedWeb5<typeof TodoProtocolDefinition, TodoSchemaMap>;
+    let repo: any;
+
+    beforeEach(async () => {
+      typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      repo = repository(typed);
+      const { status } = await repo.configure();
+      expect(status.code).toBe(202);
+    });
+
+    it('should create a record via create()', async () => {
+      const result = await repo.list.create({
+        data: { name: 'Groceries', description: 'Weekly shopping' },
+      });
+
+      expect(result.code).toBe(202);
+      expect(result.record).toBeDefined();
+      expect(result.record).toBeInstanceOf(TypedRecord);
+
+      const data = await result.record.data.json();
+      expect(data.name).toBe('Groceries');
+      expect(data.description).toBe('Weekly shopping');
+    });
+
+    it('should query records via query()', async () => {
+      await repo.list.create({ data: { name: 'List A' } });
+      await repo.list.create({ data: { name: 'List B' } });
+
+      const result = await repo.list.query();
+
+      expect(result.code).toBe(200);
+      expect(result.records.length).toBe(2);
+      expect(result.records[0]).toBeInstanceOf(TypedRecord);
+      expect(result.records[1]).toBeInstanceOf(TypedRecord);
+    });
+
+    it('should get a single record by recordId via get()', async () => {
+      const { record: created } = await repo.list.create({
+        data: { name: 'Get Test' },
+      });
+
+      const fetched = await repo.list.get(created.id);
+
+      expect(fetched).toBeInstanceOf(TypedRecord);
+      const data = await fetched.data.json();
+      expect(data.name).toBe('Get Test');
+    });
+
+    it('should delete a record via delete()', async () => {
+      const { record } = await repo.list.create({
+        data: { name: 'To Delete' },
+      });
+
+      const deleteResult = await repo.list.delete(record.id);
+      expect(deleteResult.status.code).toBe(202);
+
+      // Verify it's gone
+      const { records } = await repo.list.query();
+      expect(records.length).toBe(0);
+    });
+
+    it('should subscribe to records via subscribe()', async () => {
+      const liveQuery = await repo.list.subscribe();
+      expect(liveQuery).toBeDefined();
+      expect(liveQuery.close).toBeDefined();
+
+      await liveQuery.close();
+    });
+  });
+
+  describe('nested collection CRUD', () => {
+    let typed: TypedWeb5<typeof TodoProtocolDefinition, TodoSchemaMap>;
+    let repo: any;
+
+    beforeEach(async () => {
+      typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      repo = repository(typed);
+      await repo.configure();
+    });
+
+    it('should create a nested record with parentContextId', async () => {
+      // Create parent list
+      const { record: listRecord } = await repo.list.create({
+        data: { name: 'Work Tasks' },
+      });
+
+      // Create nested task
+      const result = await repo.list.task.create(listRecord.contextId, {
+        data: { title: 'Review PR', completed: false },
+      });
+
+      expect(result.code).toBe(202);
+      expect(result.record).toBeInstanceOf(TypedRecord);
+      expect(result.record.protocolPath).toBe('list/task');
+
+      const data = await result.record.data.json();
+      expect(data.title).toBe('Review PR');
+      expect(data.completed).toBe(false);
+    });
+
+    it('should query nested records under a parent context', async () => {
+      const { record: listRecord } = await repo.list.create({
+        data: { name: 'Shopping' },
+      });
+
+      await repo.list.task.create(listRecord.contextId, {
+        data: { title: 'Buy milk', completed: false },
+      });
+      await repo.list.task.create(listRecord.contextId, {
+        data: { title: 'Buy bread', completed: true },
+      });
+
+      const result = await repo.list.task.query(listRecord.contextId);
+
+      expect(result.code).toBe(200);
+      expect(result.records.length).toBe(2);
+      expect(result.records[0]).toBeInstanceOf(TypedRecord);
+    });
+
+    it('should get a nested record by recordId', async () => {
+      const { record: listRecord } = await repo.list.create({
+        data: { name: 'Nested Get Test' },
+      });
+
+      const { record: taskRecord } = await repo.list.task.create(listRecord.contextId, {
+        data: { title: 'Task to get', completed: false },
+      });
+
+      const fetched = await repo.list.task.get(taskRecord.id);
+
+      expect(fetched).toBeInstanceOf(TypedRecord);
+      const data = await fetched.data.json();
+      expect(data.title).toBe('Task to get');
+    });
+
+    it('should delete a nested record by recordId', async () => {
+      const { record: listRecord } = await repo.list.create({
+        data: { name: 'Delete Nested Test' },
+      });
+
+      const { record: taskRecord } = await repo.list.task.create(listRecord.contextId, {
+        data: { title: 'Task to delete', completed: false },
+      });
+
+      const deleteResult = await repo.list.task.delete(taskRecord.id);
+      expect(deleteResult.status.code).toBe(202);
+
+      const { records } = await repo.list.task.query(listRecord.contextId);
+      expect(records.length).toBe(0);
+    });
+
+    it('should subscribe to nested records under a parent context', async () => {
+      const { record: listRecord } = await repo.list.create({
+        data: { name: 'Subscribe Nested Test' },
+      });
+
+      const liveQuery = await repo.list.task.subscribe(listRecord.contextId);
+      expect(liveQuery).toBeDefined();
+      expect(liveQuery.close).toBeDefined();
+
+      await liveQuery.close();
+    });
+  });
+
+  describe('deeply nested records', () => {
+    let typed: TypedWeb5<typeof TodoProtocolDefinition, TodoSchemaMap>;
+    let repo: any;
+
+    beforeEach(async () => {
+      typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      repo = repository(typed);
+      await repo.configure();
+    });
+
+    it('should access a deeply nested child node (list.task.attachment)', async () => {
+      const { record: listRecord } = await repo.list.create({
+        data: { name: 'Deep Nesting Test' },
+      });
+
+      const { record: taskRecord } = await repo.list.task.create(listRecord.contextId, {
+        data: { title: 'Task with attachment', completed: false },
+      });
+
+      const blob = new Blob(['file-content'], { type: 'application/octet-stream' });
+      const result = await repo.list.task.attachment.create(taskRecord.contextId, {
+        data: blob,
+      });
+
+      expect(result.code).toBe(202);
+      expect(result.record).toBeInstanceOf(TypedRecord);
+      expect(result.record.protocolPath).toBe('list/task/attachment');
+    });
+  });
+
+  describe('root singleton CRUD', () => {
+    let typed: TypedWeb5<typeof ProfileProtocolDefinition, ProfileSchemaMap>;
+    let repo: any;
+
+    beforeEach(async () => {
+      typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      repo = repository(typed);
+      await repo.configure();
+    });
+
+    it('should set a singleton record via set()', async () => {
+      const result = await repo.profile.set({
+        data: { displayName: 'Alice', bio: 'Hello world' },
+      });
+
+      expect(result.code).toBe(202);
+      expect(result.record).toBeInstanceOf(TypedRecord);
+
+      const data = await result.record.data.json();
+      expect(data.displayName).toBe('Alice');
+    });
+
+    it('should get a singleton record via get()', async () => {
+      await repo.profile.set({
+        data: { displayName: 'Alice' },
+      });
+
+      const record = await repo.profile.get();
+
+      expect(record).toBeInstanceOf(TypedRecord);
+      const data = await record.data.json();
+      expect(data.displayName).toBe('Alice');
+    });
+
+    it('should return undefined when singleton does not exist', async () => {
+      const record = await repo.profile.get();
+      expect(record).toBeUndefined();
+    });
+
+    it('should upsert on subsequent set() calls', async () => {
+      // First set
+      await repo.profile.set({
+        data: { displayName: 'Alice', bio: 'v1' },
+      });
+
+      // Second set (upsert)
+      const result = await repo.profile.set({
+        data: { displayName: 'Alice Updated', bio: 'v2' },
+      });
+
+      expect(result.code).toBe(202);
+
+      // Should still only have one record
+      const record = await repo.profile.get();
+      expect(record).toBeInstanceOf(TypedRecord);
+      const data = await record.data.json();
+      expect(data.displayName).toBe('Alice Updated');
+      expect(data.bio).toBe('v2');
+    });
+
+    it('should delete a singleton via delete()', async () => {
+      const { record } = await repo.profile.set({
+        data: { displayName: 'To Delete' },
+      });
+
+      const deleteResult = await repo.profile.delete(record.id);
+      expect(deleteResult.status.code).toBe(202);
+
+      const fetched = await repo.profile.get();
+      expect(fetched).toBeUndefined();
+    });
+  });
+
+  describe('nested singleton CRUD', () => {
+    let typed: TypedWeb5<typeof ProfileProtocolDefinition, ProfileSchemaMap>;
+    let repo: any;
+
+    beforeEach(async () => {
+      typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      repo = repository(typed);
+      await repo.configure();
+    });
+
+    it('should set a nested singleton under a parent context', async () => {
+      const { record: groupRecord } = await repo.group.create({
+        data: { name: 'Dev Team' },
+      });
+
+      const result = await repo.group.settings.set(groupRecord.contextId, {
+        data: { theme: 'dark', notifications: true },
+      });
+
+      expect(result.code).toBe(202);
+      expect(result.record).toBeInstanceOf(TypedRecord);
+      expect(result.record.protocolPath).toBe('group/settings');
+    });
+
+    it('should get a nested singleton under a parent context', async () => {
+      const { record: groupRecord } = await repo.group.create({
+        data: { name: 'Design Team' },
+      });
+
+      await repo.group.settings.set(groupRecord.contextId, {
+        data: { theme: 'light', notifications: false },
+      });
+
+      const record = await repo.group.settings.get(groupRecord.contextId);
+
+      expect(record).toBeInstanceOf(TypedRecord);
+      const data = await record.data.json();
+      expect(data.theme).toBe('light');
+      expect(data.notifications).toBe(false);
+    });
+
+    it('should return undefined when nested singleton does not exist', async () => {
+      const { record: groupRecord } = await repo.group.create({
+        data: { name: 'Empty Team' },
+      });
+
+      const record = await repo.group.settings.get(groupRecord.contextId);
+      expect(record).toBeUndefined();
+    });
+
+    it('should upsert nested singleton on subsequent set() calls', async () => {
+      const { record: groupRecord } = await repo.group.create({
+        data: { name: 'Upsert Team' },
+      });
+
+      await repo.group.settings.set(groupRecord.contextId, {
+        data: { theme: 'dark', notifications: true },
+      });
+
+      await repo.group.settings.set(groupRecord.contextId, {
+        data: { theme: 'light', notifications: false },
+      });
+
+      const record = await repo.group.settings.get(groupRecord.contextId);
+      expect(record).toBeInstanceOf(TypedRecord);
+      const data = await record.data.json();
+      expect(data.theme).toBe('light');
+      expect(data.notifications).toBe(false);
+    });
+  });
+
+  describe('mixed collection and singleton under same parent', () => {
+    let typed: TypedWeb5<typeof ProfileProtocolDefinition, ProfileSchemaMap>;
+    let repo: any;
+
+    beforeEach(async () => {
+      typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      repo = repository(typed);
+      await repo.configure();
+    });
+
+    it('should support both collection (member) and singleton (settings) under group', async () => {
+      const { record: groupRecord } = await repo.group.create({
+        data: { name: 'Mixed Team' },
+      });
+
+      // Create members (collection)
+      await repo.group.member.create(groupRecord.contextId, {
+        data: { did: 'did:example:bob', role: 'admin' },
+      });
+      await repo.group.member.create(groupRecord.contextId, {
+        data: { did: 'did:example:carol', role: 'member' },
+      });
+
+      // Set settings (singleton)
+      await repo.group.settings.set(groupRecord.contextId, {
+        data: { theme: 'dark', notifications: true },
+      });
+
+      // Query members
+      const { records: members } = await repo.group.member.query(groupRecord.contextId);
+      expect(members.length).toBe(2);
+
+      // Get singleton settings
+      const settings = await repo.group.settings.get(groupRecord.contextId);
+      expect(settings).toBeInstanceOf(TypedRecord);
+      const settingsData = await settings.data.json();
+      expect(settingsData.theme).toBe('dark');
+    });
+  });
+
+  describe('proxy node caching', () => {
+    it('should return the same child node on repeated access', () => {
+      const typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      const repo = repository(typed);
+
+      const task1 = repo.list.task;
+      const task2 = repo.list.task;
+      expect(task1).toBe(task2);
+    });
+  });
+
+  describe('undefined child access', () => {
+    it('should return undefined for non-existent child nodes', () => {
+      const typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      const repo = repository(typed);
+
+      const nonExistent = (repo.list as any).nonExistent;
+      expect(nonExistent).toBeUndefined();
+    });
+
+    it('should return undefined for non-existent root nodes', () => {
+      const typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      const repo = repository(typed);
+
+      const nonExistent = (repo as any).nonExistent;
+      expect(nonExistent).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Introduces a runtime Proxy-based repository factory (`repository()`) that generates domain-specific CRUD APIs from any typed protocol definition. This builds on the `TypedRecord<T>` and `TypedWeb5` foundation from #295.

- **Collections** (default): `create()`, `query()`, `get()`, `delete()`, `subscribe()`
- **Singletons** (`$recordLimit: { max: 1 }`): `set()` (with upsert semantics), `get()`, `delete()`
- **Nested types**: first argument is `parentContextId`
- **`configure()`**: idempotent protocol installation

### Example usage

```ts
const social = repository(web5.using(SocialGraphProtocol));
await social.configure();

// Root collection
const { record } = await social.friend.create({ data: { did: 'did:example:alice' } });
const friends = await social.friend.query();

// Singleton
await social.profile.set({ data: { displayName: 'Alice' } });
const profile = await social.profile.get();

// Nested under parent context
const members = await social.group.member.query(groupContextId);
```

## Changes

| File | Description |
|---|---|
| `packages/api/src/repository-types.ts` | Compile-time type machinery: `IsSingleton`, `CollectionCRUD`, `SingletonCRUD`, `NestedCollectionCRUD`, `NestedSingletonCRUD`, recursive `RepositoryNode`, top-level `Repository<D, M>` |
| `packages/api/src/repository.ts` | Runtime Proxy-based implementation with lazy child node construction, singleton detection via `$recordLimit`, `configure()` |
| `packages/api/src/typed-web5.ts` | Strip `$recordLimit` (and future extended properties) from protocol definitions before DWN configuration |
| `packages/api/src/index.ts` | Export repository modules |
| `packages/api/tests/repository.spec.ts` | 25 tests: root collections, nested collections, deeply nested records, root/nested singletons with upsert, mixed collection/singleton, proxy caching, undefined access |

## Test results

- **25 new tests** all pass
- **26 existing typed-protocol tests** still pass
- **294/302 full API suite** pass (8 pre-existing WebSocket subscription failures on `main`)
- Lint clean, build clean