### PR TITLE
feat(protocols): add JSON schemas, $recordLimit singletons, and rename write() to create()

### DIFF
--- a/packages/api/src/repository-types.ts
+++ b/packages/api/src/repository-types.ts
@@ -15,9 +15,9 @@ import type { TypedLiveQuery } from './typed-live-query.js';
 import type { TypedRecord } from './typed-record.js';
 import type {
   DataForPath,
+  TypedCreateRequest,
   TypedQueryRequest,
   TypedSubscribeRequest,
-  TypedWriteRequest,
 } from './typed-web5.js';
 import type { DwnPaginationCursor, DwnResponseStatus } from '@enbox/agent';
 import type { ProtocolDefinition, ProtocolRuleSet } from '@enbox/dwn-sdk-js';
@@ -83,7 +83,7 @@ export type CollectionCreateOptions<
   D extends ProtocolDefinition,
   M extends SchemaMap,
   Path extends string,
-> = Omit<TypedWriteRequest<D, M, Path>, 'data' | 'parentContextId'> & {
+> = Omit<TypedCreateRequest<D, M, Path>, 'data' | 'parentContextId'> & {
   data: DataAt<D, M, Path>;
 };
 
@@ -94,7 +94,7 @@ export type SingletonSetOptions<
   D extends ProtocolDefinition,
   M extends SchemaMap,
   Path extends string,
-> = Omit<TypedWriteRequest<D, M, Path>, 'data' | 'parentContextId'> & {
+> = Omit<TypedCreateRequest<D, M, Path>, 'data' | 'parentContextId'> & {
   data: DataAt<D, M, Path>;
 };
 

--- a/packages/api/src/repository.ts
+++ b/packages/api/src/repository.ts
@@ -88,7 +88,7 @@ function buildRootCollectionMethods(
 ): Record<string, Function> {
   return {
     async create(options: Record<string, unknown>): Promise<unknown> {
-      const { status, record } = await typed.records.write(path, options as never);
+      const { status, record } = await typed.records.create(path, options as never);
       return { status, record, ...status };
     },
 
@@ -135,7 +135,7 @@ function buildRootSingletonMethods(
         return { status, record, ...status };
       }
       // Create new
-      const { status, record } = await typed.records.write(path, options as never);
+      const { status, record } = await typed.records.create(path, options as never);
       return { status, record, ...status };
     },
 
@@ -159,7 +159,7 @@ function buildNestedCollectionMethods(
 ): Record<string, Function> {
   return {
     async create(parentContextId: string, options: Record<string, unknown>): Promise<unknown> {
-      const { status, record } = await typed.records.write(path, {
+      const { status, record } = await typed.records.create(path, {
         ...options,
         parentContextId,
       } as never);
@@ -223,7 +223,7 @@ function buildNestedSingletonMethods(
         return { status, record, ...status };
       }
 
-      const { status, record } = await typed.records.write(path, {
+      const { status, record } = await typed.records.create(path, {
         ...options,
         parentContextId,
       } as never);

--- a/packages/api/src/typed-web5.ts
+++ b/packages/api/src/typed-web5.ts
@@ -17,8 +17,8 @@
  * // Install the protocol
  * await social.configure();
  *
- * // Write — path and data type are checked at compile time
- * const { record } = await social.records.write('thread', {
+ * // Create — path and data type are checked at compile time
+ * const { record } = await social.records.create('thread', {
  *   data: { title: 'Hello World', body: '...' },
  * });
  * // record is TypedRecord<ThreadData>
@@ -91,8 +91,8 @@ type DataFormatForPath<
 // Request / response types
 // ---------------------------------------------------------------------------
 
-/** Options for {@link TypedWeb5} `records.write()`. */
-export type TypedWriteRequest<
+/** Options for {@link TypedWeb5} `records.create()`. */
+export type TypedCreateRequest<
   D extends ProtocolDefinition,
   M extends SchemaMap,
   Path extends string,
@@ -115,8 +115,8 @@ export type TypedWriteRequest<
   encryption?: boolean;
 };
 
-/** Response from {@link TypedWeb5} `records.write()`. */
-export type TypedWriteResponse<T = unknown> = DwnResponseStatus & {
+/** Response from {@link TypedWeb5} `records.create()`. */
+export type TypedCreateResponse<T = unknown> = DwnResponseStatus & {
   record: TypedRecord<T>;
 };
 
@@ -208,7 +208,7 @@ export type TypedSubscribeResponse<T = unknown> = DwnResponseStatus & {
  *
  * await social.configure();
  *
- * const { record } = await social.records.write('friend', {
+ * const { record } = await social.records.create('friend', {
  *   data: { did: 'did:example:alice', alias: 'Alice' },
  * });
  * const data = await record.data.json(); // FriendData — no cast
@@ -254,10 +254,6 @@ export class TypedWeb5<
    * @param options - Optional overrides like `encryption`.
    */
   public async configure(options?: { encryption?: boolean }): Promise<DwnResponseStatus & { protocol?: Protocol }> {
-    // Strip extended properties (e.g. $recordLimit) that the DWN engine
-    // does not yet support, so the protocol can still be configured.
-    const cleanDefinition = stripExtendedProperties(this._definition);
-
     // Query for an existing installation of this protocol.
     const { protocols } = await this._dwn.protocols.query({
       filter: { protocol: this._definition.protocol },
@@ -266,14 +262,14 @@ export class TypedWeb5<
     // If already installed with the same definition, return it as-is.
     if (protocols.length > 0) {
       const existing = protocols[0];
-      if (definitionsEqual(existing.definition, cleanDefinition)) {
+      if (definitionsEqual(existing.definition, this._definition)) {
         return { status: { code: 200, detail: 'OK' }, protocol: existing };
       }
     }
 
     // Not installed or definition has changed — configure the new version.
     return this._dwn.protocols.configure({
-      definition : cleanDefinition as D,
+      definition : this._definition,
       encryption : options?.encryption,
     });
   }
@@ -289,10 +285,10 @@ export class TypedWeb5<
    * that carry the resolved data type from the schema map.
    */
   public get records(): {
-    write: <Path extends ProtocolPaths<D> & string>(
+    create: <Path extends ProtocolPaths<D> & string>(
       path: Path,
-      request: TypedWriteRequest<D, M, Path>,
-    ) => Promise<TypedWriteResponse<DataForPath<D, M, Path>>>;
+      request: TypedCreateRequest<D, M, Path>,
+    ) => Promise<TypedCreateResponse<DataForPath<D, M, Path>>>;
 
     query: <Path extends ProtocolPaths<D> & string>(
       path: Path,
@@ -316,15 +312,15 @@ export class TypedWeb5<
     } {
     return {
       /**
-       * Write a record at the given protocol path.
+       * Create a new record at the given protocol path.
        *
        * @param path - The protocol path (e.g. `'friend'`, `'group/member'`).
-       * @param request - Write options including typed `data`.
+       * @param request - Create options including typed `data`.
        */
-      write: async <Path extends ProtocolPaths<D> & string>(
+      create: async <Path extends ProtocolPaths<D> & string>(
         path: Path,
-        request: TypedWriteRequest<D, M, Path>,
-      ): Promise<TypedWriteResponse<DataForPath<D, M, Path>>> => {
+        request: TypedCreateRequest<D, M, Path>,
+      ): Promise<TypedCreateResponse<DataForPath<D, M, Path>>> => {
         const typeName = lastSegment(path);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
@@ -490,45 +486,6 @@ function definitionsEqual(a: unknown, b: unknown): boolean {
 function lastSegment(path: string): string {
   const parts = path.split('/');
   return parts[parts.length - 1];
-}
-
-/**
- * Extended property keys that appear in the developer-facing protocol
- * definition but are not yet recognized by the DWN engine's JSON schema
- * validator. These are stripped before sending the definition to the DWN.
- */
-const EXTENDED_RULE_SET_KEYS = new Set(['$recordLimit']);
-
-/**
- * Deep-clones a protocol definition, removing extended properties
- * (e.g. `$recordLimit`) from every rule set node in `structure`.
- *
- * This allows developers to annotate their protocol definitions with
- * repository-layer metadata without breaking DWN protocol configuration.
- */
-function stripExtendedProperties(definition: ProtocolDefinition): ProtocolDefinition {
-  return {
-    ...definition,
-    structure: stripStructure(definition.structure) as ProtocolDefinition['structure'],
-  };
-}
-
-/**
- * Recursively strips extended properties from a protocol structure object.
- */
-function stripStructure(
-  obj: globalThis.Record<string, unknown>,
-): globalThis.Record<string, unknown> {
-  const result: globalThis.Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj)) {
-    if (EXTENDED_RULE_SET_KEYS.has(key)) { continue; }
-    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-      result[key] = stripStructure(value as globalThis.Record<string, unknown>);
-    } else {
-      result[key] = value;
-    }
-  }
-  return result;
 }
 
 /**

--- a/packages/api/tests/repository.spec.ts
+++ b/packages/api/tests/repository.spec.ts
@@ -99,7 +99,7 @@ const ProfileProtocolDefinition = {
       $actions: [
         { who: 'anyone', can: ['create', 'read'] },
       ],
-      $recordLimit: { max: 1 },
+      $recordLimit: { max: 1, strategy: 'reject' },
     },
     group: {
       $actions: [
@@ -109,7 +109,7 @@ const ProfileProtocolDefinition = {
         $actions: [
           { who: 'anyone', can: ['create', 'read'] },
         ],
-        $recordLimit: { max: 1 },
+        $recordLimit: { max: 1, strategy: 'reject' },
       },
       member: {
         $actions: [

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -200,9 +200,9 @@ describe('TypedProtocol API', () => {
       });
     });
 
-    describe('write()', () => {
-      it('should write a record and return a TypedRecord', async () => {
-        const { status, record } = await typed.records.write('list', {
+    describe('create()', () => {
+      it('should create a record and return a TypedRecord', async () => {
+        const { status, record } = await typed.records.create('list', {
           data: { name: 'Groceries', description: 'Weekly shopping' },
         });
 
@@ -215,13 +215,13 @@ describe('TypedProtocol API', () => {
 
       it('should write a record at a nested path', async () => {
         // First create a parent list
-        const { record: listRecord } = await typed.records.write('list', {
+        const { record: listRecord } = await typed.records.create('list', {
           data: { name: 'Work Tasks' },
         });
         expect(listRecord).toBeDefined();
 
         // Write a task nested under the list
-        const { status, record: taskRecord } = await typed.records.write('list/task', {
+        const { status, record: taskRecord } = await typed.records.create('list/task', {
           data            : { title: 'Review PR', completed: false },
           parentContextId : listRecord.contextId,
         });
@@ -234,7 +234,7 @@ describe('TypedProtocol API', () => {
 
       it('should read back written JSON data via TypedRecord.data.json() without manual cast', async () => {
         const inputData = { name: 'Shopping', description: 'Grocery list' };
-        const { record } = await typed.records.write('list', { data: inputData });
+        const { record } = await typed.records.create('list', { data: inputData });
         expect(record).toBeDefined();
 
         // No need for .json<TodoSchemaMap['list']>() — it's inferred!
@@ -244,7 +244,7 @@ describe('TypedProtocol API', () => {
       });
 
       it('should provide access to the underlying Record via rawRecord', async () => {
-        const { record } = await typed.records.write('list', {
+        const { record } = await typed.records.create('list', {
           data: { name: 'Raw Test' },
         });
 
@@ -256,8 +256,8 @@ describe('TypedProtocol API', () => {
     describe('query()', () => {
       it('should query records and return TypedRecord instances', async () => {
         // Write two lists
-        await typed.records.write('list', { data: { name: 'List A' } });
-        await typed.records.write('list', { data: { name: 'List B' } });
+        await typed.records.create('list', { data: { name: 'List A' } });
+        await typed.records.create('list', { data: { name: 'List B' } });
 
         const { status, records } = await typed.records.query('list');
 
@@ -269,17 +269,17 @@ describe('TypedProtocol API', () => {
       });
 
       it('should apply additional filters', async () => {
-        const { record: listRecord } = await typed.records.write('list', {
+        const { record: listRecord } = await typed.records.create('list', {
           data: { name: 'Work' },
         });
         expect(listRecord).toBeDefined();
 
         // Write tasks under the list
-        await typed.records.write('list/task', {
+        await typed.records.create('list/task', {
           data            : { title: 'Task 1', completed: false },
           parentContextId : listRecord.contextId,
         });
-        await typed.records.write('list/task', {
+        await typed.records.create('list/task', {
           data            : { title: 'Task 2', completed: true },
           parentContextId : listRecord.contextId,
         });
@@ -295,7 +295,7 @@ describe('TypedProtocol API', () => {
       });
 
       it('should read typed data from queried TypedRecords without manual cast', async () => {
-        await typed.records.write('list', { data: { name: 'Query Test' } });
+        await typed.records.create('list', { data: { name: 'Query Test' } });
 
         const { records } = await typed.records.query('list');
         expect(records.length).toBeGreaterThanOrEqual(1);
@@ -308,7 +308,7 @@ describe('TypedProtocol API', () => {
 
     describe('read()', () => {
       it('should read a single record by recordId and return a TypedRecord', async () => {
-        const { record: written } = await typed.records.write('list', {
+        const { record: written } = await typed.records.create('list', {
           data: { name: 'Reading List' },
         });
         expect(written).toBeDefined();
@@ -326,7 +326,7 @@ describe('TypedProtocol API', () => {
 
     describe('delete()', () => {
       it('should delete a record by recordId', async () => {
-        const { record } = await typed.records.write('list', {
+        const { record } = await typed.records.create('list', {
           data: { name: 'To Delete' },
         });
         expect(record).toBeDefined();
@@ -345,12 +345,12 @@ describe('TypedProtocol API', () => {
     describe('schema-less types', () => {
       it('should write and query a type that has no schema (only dataFormats)', async () => {
         // Create a parent list and task for the attachment to nest under.
-        const { record: listRecord } = await typed.records.write('list', {
+        const { record: listRecord } = await typed.records.create('list', {
           data: { name: 'Attachments Test' },
         });
         expect(listRecord).toBeDefined();
 
-        const { record: taskRecord } = await typed.records.write('list/task', {
+        const { record: taskRecord } = await typed.records.create('list/task', {
           data            : { title: 'Task with attachment', completed: false },
           parentContextId : listRecord.contextId,
         });
@@ -359,7 +359,7 @@ describe('TypedProtocol API', () => {
         // Write a binary attachment — the 'attachment' type has no schema,
         // only dataFormats: ['application/octet-stream', 'image/png', 'image/jpeg'].
         const blob = new Blob(['binary-content'], { type: 'application/octet-stream' });
-        const { status: writeStatus, record: attachmentRecord } = await typed.records.write(
+        const { status: writeStatus, record: attachmentRecord } = await typed.records.create(
           'list/task/attachment',
           {
             data            : blob,
@@ -409,7 +409,7 @@ describe('TypedProtocol API', () => {
         });
 
         // Write a record — should trigger subscription
-        await typed.records.write('list', { data: { name: 'Subscribed List' } });
+        await typed.records.create('list', { data: { name: 'Subscribed List' } });
 
         // Give subscription handler time to fire
         await new Promise((resolve) => setTimeout(resolve, 100));
@@ -423,7 +423,7 @@ describe('TypedProtocol API', () => {
 
       it('should provide typed initial records in liveQuery.records', async () => {
         // Write a record first
-        await typed.records.write('list', { data: { name: 'Pre-existing' } });
+        await typed.records.create('list', { data: { name: 'Pre-existing' } });
 
         // Subscribe — should include the pre-existing record in the snapshot
         const { liveQuery } = await typed.records.subscribe('list');
@@ -449,7 +449,7 @@ describe('TypedProtocol API', () => {
 
     describe('TypedRecord lifecycle methods', () => {
       it('should update a record and return a new TypedRecord', async () => {
-        const { record } = await typed.records.write('list', {
+        const { record } = await typed.records.create('list', {
           data: { name: 'Original' },
         });
         expect(record).toBeInstanceOf(TypedRecord);
@@ -466,7 +466,7 @@ describe('TypedProtocol API', () => {
       });
 
       it('should delete a record via TypedRecord.delete()', async () => {
-        const { record } = await typed.records.write('list', {
+        const { record } = await typed.records.create('list', {
           data: { name: 'Delete Me' },
         });
 
@@ -478,7 +478,7 @@ describe('TypedProtocol API', () => {
       });
 
       it('should forward toJSON() from the underlying Record', async () => {
-        const { record } = await typed.records.write('list', {
+        const { record } = await typed.records.create('list', {
           data: { name: 'JSON Test' },
         });
 
@@ -488,7 +488,7 @@ describe('TypedProtocol API', () => {
       });
 
       it('should forward toString() from the underlying Record', async () => {
-        const { record } = await typed.records.write('list', {
+        const { record } = await typed.records.create('list', {
           data: { name: 'String Test' },
         });
 

--- a/packages/protocols/schemas/connect/wallet.json
+++ b/packages/protocols/schemas/connect/wallet.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/connect/wallet",
+  "title": "WalletData",
+  "description": "Data shape for wallet connection info.",
+  "type": "object",
+  "properties": {
+    "webWallets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "URLs of web wallet applications associated with this DID."
+    }
+  },
+  "required": ["webWallets"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/lists/collaborator.json
+++ b/packages/protocols/schemas/lists/collaborator.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/lists/collaborator",
+  "title": "CollaboratorData",
+  "description": "Data shape for a collaborator record.",
+  "type": "object",
+  "properties": {
+    "did": {
+      "type": "string",
+      "description": "The DID of the collaborator."
+    },
+    "alias": {
+      "type": "string",
+      "description": "An optional alias for the collaborator."
+    }
+  },
+  "required": ["did"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/lists/comment.json
+++ b/packages/protocols/schemas/lists/comment.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/lists/comment",
+  "title": "CommentData",
+  "description": "Data shape for a comment on a list item.",
+  "type": "object",
+  "properties": {
+    "text": {
+      "type": "string",
+      "description": "The comment text."
+    }
+  },
+  "required": ["text"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/lists/folder.json
+++ b/packages/protocols/schemas/lists/folder.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/lists/folder",
+  "title": "FolderData",
+  "description": "Data shape for a folder record.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the folder."
+    },
+    "icon": {
+      "type": "string",
+      "description": "An optional icon for the folder."
+    },
+    "sortOrder": {
+      "type": "number",
+      "description": "An optional sort order for display."
+    }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/lists/item.json
+++ b/packages/protocols/schemas/lists/item.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/lists/item",
+  "title": "ItemData",
+  "description": "Data shape for a list item.",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "The title of the item."
+    },
+    "url": {
+      "type": "string",
+      "description": "An optional URL associated with the item."
+    },
+    "note": {
+      "type": "string",
+      "description": "An optional note about the item."
+    },
+    "completed": {
+      "type": "boolean",
+      "description": "Whether the item is completed."
+    },
+    "sortOrder": {
+      "type": "number",
+      "description": "An optional sort order for display."
+    }
+  },
+  "required": ["title"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/lists/list.json
+++ b/packages/protocols/schemas/lists/list.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/lists/list",
+  "title": "ListData",
+  "description": "Data shape for a list record.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the list."
+    },
+    "description": {
+      "type": "string",
+      "description": "An optional description of the list."
+    },
+    "icon": {
+      "type": "string",
+      "description": "An optional icon for the list."
+    },
+    "listType": {
+      "type": "string",
+      "enum": ["todo", "bookmarks", "reading", "custom"],
+      "description": "The type of list."
+    }
+  },
+  "required": ["name", "listType"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/preferences/locale.json
+++ b/packages/protocols/schemas/preferences/locale.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/preferences/locale",
+  "title": "LocaleData",
+  "description": "Data shape for locale preferences.",
+  "type": "object",
+  "properties": {
+    "language": {
+      "type": "string",
+      "description": "The preferred language (e.g. BCP 47 tag)."
+    },
+    "region": {
+      "type": "string",
+      "description": "An optional region code."
+    },
+    "timezone": {
+      "type": "string",
+      "description": "An optional IANA timezone identifier."
+    },
+    "dateFormat": {
+      "type": "string",
+      "description": "An optional date format string."
+    },
+    "hourCycle": {
+      "type": "string",
+      "enum": ["12h", "24h"],
+      "description": "An optional hour cycle preference."
+    }
+  },
+  "required": ["language"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/preferences/notification.json
+++ b/packages/protocols/schemas/preferences/notification.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/preferences/notification",
+  "title": "NotificationData",
+  "description": "Data shape for notification preferences.",
+  "type": "object",
+  "properties": {
+    "channel": {
+      "type": "string",
+      "description": "The notification channel identifier."
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Whether the channel is enabled."
+    },
+    "quietHoursStart": {
+      "type": "string",
+      "description": "Optional quiet hours start time (HH:MM format)."
+    },
+    "quietHoursEnd": {
+      "type": "string",
+      "description": "Optional quiet hours end time (HH:MM format)."
+    }
+  },
+  "required": ["channel", "enabled"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/preferences/privacy.json
+++ b/packages/protocols/schemas/preferences/privacy.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/preferences/privacy",
+  "title": "PrivacyData",
+  "description": "Data shape for privacy preferences.",
+  "type": "object",
+  "properties": {
+    "cookieConsent": {
+      "type": "object",
+      "description": "Cookie consent preferences.",
+      "properties": {
+        "analytics": {
+          "type": "boolean",
+          "description": "Whether analytics cookies are consented to."
+        },
+        "marketing": {
+          "type": "boolean",
+          "description": "Whether marketing cookies are consented to."
+        },
+        "functional": {
+          "type": "boolean",
+          "description": "Whether functional cookies are consented to."
+        }
+      },
+      "required": ["analytics", "marketing", "functional"],
+      "additionalProperties": false
+    },
+    "shareUsageData": {
+      "type": "boolean",
+      "description": "Whether usage data sharing is enabled."
+    }
+  },
+  "required": ["cookieConsent", "shareUsageData"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/preferences/theme.json
+++ b/packages/protocols/schemas/preferences/theme.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/preferences/theme",
+  "title": "ThemeData",
+  "description": "Data shape for theme preferences.",
+  "type": "object",
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["light", "dark", "system"],
+      "description": "The theme mode."
+    },
+    "accentColor": {
+      "type": "string",
+      "description": "An optional accent color."
+    },
+    "fontSize": {
+      "type": "string",
+      "enum": ["small", "medium", "large"],
+      "description": "An optional font size preference."
+    }
+  },
+  "required": ["mode"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/profile/link.json
+++ b/packages/protocols/schemas/profile/link.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/profile/link",
+  "title": "LinkData",
+  "description": "Data shape for a link record (e.g. social links).",
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string",
+      "description": "The URL of the link."
+    },
+    "title": {
+      "type": "string",
+      "description": "The display title of the link."
+    },
+    "icon": {
+      "type": "string",
+      "description": "An optional icon for the link."
+    },
+    "sortOrder": {
+      "type": "number",
+      "description": "An optional sort order for display."
+    }
+  },
+  "required": ["url", "title"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/profile/private-note.json
+++ b/packages/protocols/schemas/profile/private-note.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/profile/private-note",
+  "title": "PrivateNoteData",
+  "description": "Data shape for a private note (visible only to friends).",
+  "type": "object",
+  "properties": {
+    "content": {
+      "type": "string",
+      "description": "The content of the private note."
+    }
+  },
+  "required": ["content"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/profile/profile.json
+++ b/packages/protocols/schemas/profile/profile.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/profile/profile",
+  "title": "ProfileData",
+  "description": "Data shape for a profile record.",
+  "type": "object",
+  "properties": {
+    "displayName": {
+      "type": "string",
+      "description": "The display name of the identity."
+    },
+    "bio": {
+      "type": "string",
+      "description": "An optional biography."
+    },
+    "tagline": {
+      "type": "string",
+      "description": "An optional tagline."
+    },
+    "location": {
+      "type": "string",
+      "description": "An optional location."
+    },
+    "website": {
+      "type": "string",
+      "description": "An optional website URL."
+    },
+    "pronouns": {
+      "type": "string",
+      "description": "Optional pronouns."
+    }
+  },
+  "required": ["displayName"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/social-graph/block.json
+++ b/packages/protocols/schemas/social-graph/block.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/social-graph/block",
+  "title": "BlockData",
+  "description": "Data shape for a block record.",
+  "type": "object",
+  "properties": {
+    "did": {
+      "type": "string",
+      "description": "The DID of the blocked identity."
+    },
+    "reason": {
+      "type": "string",
+      "description": "An optional reason for blocking."
+    }
+  },
+  "required": ["did"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/social-graph/friend.json
+++ b/packages/protocols/schemas/social-graph/friend.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/social-graph/friend",
+  "title": "FriendData",
+  "description": "Data shape for a friend record.",
+  "type": "object",
+  "properties": {
+    "did": {
+      "type": "string",
+      "description": "The DID of the friend."
+    },
+    "alias": {
+      "type": "string",
+      "description": "An optional alias for the friend."
+    },
+    "note": {
+      "type": "string",
+      "description": "An optional note about the friend."
+    }
+  },
+  "required": ["did"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/social-graph/group.json
+++ b/packages/protocols/schemas/social-graph/group.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/social-graph/group",
+  "title": "GroupData",
+  "description": "Data shape for a group record.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the group."
+    },
+    "description": {
+      "type": "string",
+      "description": "An optional description of the group."
+    },
+    "icon": {
+      "type": "string",
+      "description": "An optional icon for the group."
+    }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/social-graph/member.json
+++ b/packages/protocols/schemas/social-graph/member.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/social-graph/member",
+  "title": "MemberData",
+  "description": "Data shape for a group member record.",
+  "type": "object",
+  "properties": {
+    "did": {
+      "type": "string",
+      "description": "The DID of the group member."
+    },
+    "alias": {
+      "type": "string",
+      "description": "An optional alias for the member."
+    }
+  },
+  "required": ["did"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/status/reaction.json
+++ b/packages/protocols/schemas/status/reaction.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/status/reaction",
+  "title": "ReactionData",
+  "description": "Data shape for a reaction to a status.",
+  "type": "object",
+  "properties": {
+    "emoji": {
+      "type": "string",
+      "description": "The reaction emoji."
+    }
+  },
+  "required": ["emoji"],
+  "additionalProperties": false
+}

--- a/packages/protocols/schemas/status/status.json
+++ b/packages/protocols/schemas/status/status.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://identity.foundation/schemas/status/status",
+  "title": "StatusData",
+  "description": "Data shape for a status update.",
+  "type": "object",
+  "properties": {
+    "text": {
+      "type": "string",
+      "description": "The status text."
+    },
+    "emoji": {
+      "type": "string",
+      "description": "An optional emoji for the status."
+    },
+    "activity": {
+      "type": "string",
+      "enum": ["online", "away", "busy", "offline"],
+      "description": "An optional activity state."
+    },
+    "expiresAt": {
+      "type": "string",
+      "description": "An optional ISO 8601 expiration timestamp."
+    }
+  },
+  "required": ["text"],
+  "additionalProperties": false
+}

--- a/packages/protocols/src/connect.ts
+++ b/packages/protocols/src/connect.ts
@@ -46,7 +46,8 @@ export const ConnectDefinition = {
   },
   structure: {
     wallet: {
-      $actions: [
+      $recordLimit : { max: 1, strategy: 'reject' },
+      $actions     : [
         { who: 'anyone', can: ['read'] },
       ],
     },

--- a/packages/protocols/src/preferences.ts
+++ b/packages/protocols/src/preferences.ts
@@ -90,13 +90,16 @@ export const PreferencesDefinition = {
   },
   structure: {
     theme: {
-      $actions: [],
+      $recordLimit : { max: 1, strategy: 'reject' },
+      $actions     : [],
     },
     locale: {
-      $actions: [],
+      $recordLimit : { max: 1, strategy: 'reject' },
+      $actions     : [],
     },
     privacy: {
-      $actions: [],
+      $recordLimit : { max: 1, strategy: 'reject' },
+      $actions     : [],
     },
     notification: {
       $actions : [],

--- a/packages/protocols/src/profile.ts
+++ b/packages/protocols/src/profile.ts
@@ -90,19 +90,22 @@ export const ProfileDefinition = {
   },
   structure: {
     profile: {
-      $size    : { max: 10000 },
-      $actions : [
+      $recordLimit : { max: 1, strategy: 'reject' },
+      $size        : { max: 10000 },
+      $actions     : [
         { who: 'anyone', can: ['read'] },
       ],
       avatar: {
-        $size    : { max: 12582912 },
-        $actions : [
+        $recordLimit : { max: 1, strategy: 'reject' },
+        $size        : { max: 12582912 },
+        $actions     : [
           { who: 'anyone', can: ['read'] },
         ],
       },
       hero: {
-        $size    : { max: 25165824 },
-        $actions : [
+        $recordLimit : { max: 1, strategy: 'reject' },
+        $size        : { max: 25165824 },
+        $actions     : [
           { who: 'anyone', can: ['read'] },
         ],
       },

--- a/packages/protocols/tests/protocols.spec.ts
+++ b/packages/protocols/tests/protocols.spec.ts
@@ -86,6 +86,12 @@ describe('@enbox/protocols', () => {
       expect(ProfileDefinition.structure.profile.hero.$size?.max).toBe(25165824);
     });
 
+    it('should enforce $recordLimit on profile, avatar, and hero singletons', () => {
+      expect(ProfileDefinition.structure.profile.$recordLimit).toEqual({ max: 1, strategy: 'reject' });
+      expect(ProfileDefinition.structure.profile.avatar.$recordLimit).toEqual({ max: 1, strategy: 'reject' });
+      expect(ProfileDefinition.structure.profile.hero.$recordLimit).toEqual({ max: 1, strategy: 'reject' });
+    });
+
     it('should use cross-protocol friend role for privateNote', () => {
       const actions = ProfileDefinition.structure.privateNote.$actions;
       expect(actions).toBeDefined();
@@ -116,6 +122,12 @@ describe('@enbox/protocols', () => {
 
     it('should require encryption for privacy type', () => {
       expect(PreferencesDefinition.types.privacy.encryptionRequired).toBe(true);
+    });
+
+    it('should enforce $recordLimit on theme, locale, and privacy singletons', () => {
+      expect(PreferencesDefinition.structure.theme.$recordLimit).toEqual({ max: 1, strategy: 'reject' });
+      expect(PreferencesDefinition.structure.locale.$recordLimit).toEqual({ max: 1, strategy: 'reject' });
+      expect(PreferencesDefinition.structure.privacy.$recordLimit).toEqual({ max: 1, strategy: 'reject' });
     });
 
     it('should require channel tag on notification records', () => {
@@ -231,6 +243,10 @@ describe('@enbox/protocols', () => {
 
     it('should define wallet type', () => {
       expect(ConnectDefinition.types.wallet).toBeDefined();
+    });
+
+    it('should enforce $recordLimit on wallet singleton', () => {
+      expect(ConnectDefinition.structure.wallet.$recordLimit).toEqual({ max: 1, strategy: 'reject' });
     });
 
     it('should allow anyone to read wallet records', () => {


### PR DESCRIPTION
## Summary

- Add 19 JSON Schema files for all typed protocol data shapes, organized by protocol subdirectory under `packages/protocols/schemas/`
- Declare 7 singleton types with `$recordLimit: { max: 1, strategy: 'reject' }` — profile, avatar, hero, theme, locale, privacy, wallet
- Remove the `stripExtendedProperties` workaround from `TypedWeb5` now that `$recordLimit` is natively supported by `dwn-sdk-js`
- Rename `TypedWeb5.records.write()` to `TypedWeb5.records.create()` for clearer intent semantics (write implies overwrite; create is unambiguous for new records — mutations use `record.update()`)

## Changes

### `@enbox/protocols`
- **19 JSON Schema files** in `schemas/{social-graph,profile,preferences,status,lists,connect}/` — each schema's `$id` matches the schema URI used in the protocol definition's `types` block
- **`$recordLimit`** added to `profile/profile`, `profile/avatar`, `profile/hero`, `preferences/theme`, `preferences/locale`, `preferences/privacy`, and `connect/wallet`
- **3 new tests** verifying `$recordLimit` on all singleton types (46 total, 0 fail)

### `@enbox/api`
- **Removed ~40 lines** of `stripExtendedProperties()` / `stripStructure()` / `EXTENDED_RULE_SET_KEYS` from `typed-web5.ts` — `configure()` now sends the definition as-is to the DWN
- **Renamed** `records.write()` → `records.create()`, `TypedWriteRequest` → `TypedCreateRequest`, `TypedWriteResponse` → `TypedCreateResponse`
- Updated `repository.ts`, `repository-types.ts`, and both test files (51 tests pass, 0 fail)

## Test results

```
@enbox/protocols:  46 pass, 0 fail
@enbox/api (typed-protocol + repository):  51 pass, 0 fail
Lint: clean on both packages
```