### PR TITLE
fix(api): align repository return types with runtime and include schemas in distribution

### DIFF
--- a/packages/api/src/repository-types.ts
+++ b/packages/api/src/repository-types.ts
@@ -108,11 +108,11 @@ export type CollectionCRUD<
   M extends SchemaMap,
   Path extends string,
 > = {
-  create(options: CollectionCreateOptions<D, M, Path>): Promise<TypedRecord<DataAt<D, M, Path>> & DwnResponseStatus>;
-  query(options?: TypedQueryRequest): Promise<{ records: TypedRecord<DataAt<D, M, Path>>[]; cursor?: DwnPaginationCursor } & DwnResponseStatus>;
+  create(options: CollectionCreateOptions<D, M, Path>): Promise<DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> }>;
+  query(options?: TypedQueryRequest): Promise<DwnResponseStatus & { records: TypedRecord<DataAt<D, M, Path>>[]; cursor?: DwnPaginationCursor }>;
   get(recordId: string): Promise<TypedRecord<DataAt<D, M, Path>>>;
   delete(recordId: string): Promise<DwnResponseStatus>;
-  subscribe(options?: TypedSubscribeRequest): Promise<TypedLiveQuery<DataAt<D, M, Path>>>;
+  subscribe(options?: TypedSubscribeRequest): Promise<TypedLiveQuery<DataAt<D, M, Path>> | undefined>;
 };
 
 /** CRUD API for a root-level singleton ($recordLimit max: 1). */
@@ -121,7 +121,7 @@ export type SingletonCRUD<
   M extends SchemaMap,
   Path extends string,
 > = {
-  set(options: SingletonSetOptions<D, M, Path>): Promise<TypedRecord<DataAt<D, M, Path>> & DwnResponseStatus>;
+  set(options: SingletonSetOptions<D, M, Path>): Promise<DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> }>;
   get(): Promise<TypedRecord<DataAt<D, M, Path>> | undefined>;
   delete(recordId: string): Promise<DwnResponseStatus>;
 };
@@ -135,17 +135,17 @@ export type NestedCollectionCRUD<
   create(
     parentContextId: string,
     options: CollectionCreateOptions<D, M, Path>,
-  ): Promise<TypedRecord<DataAt<D, M, Path>> & DwnResponseStatus>;
+  ): Promise<DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> }>;
   query(
     parentContextId: string,
     options?: TypedQueryRequest,
-  ): Promise<{ records: TypedRecord<DataAt<D, M, Path>>[]; cursor?: DwnPaginationCursor } & DwnResponseStatus>;
+  ): Promise<DwnResponseStatus & { records: TypedRecord<DataAt<D, M, Path>>[]; cursor?: DwnPaginationCursor }>;
   get(recordId: string): Promise<TypedRecord<DataAt<D, M, Path>>>;
   delete(recordId: string): Promise<DwnResponseStatus>;
   subscribe(
     parentContextId: string,
     options?: TypedSubscribeRequest,
-  ): Promise<TypedLiveQuery<DataAt<D, M, Path>>>;
+  ): Promise<TypedLiveQuery<DataAt<D, M, Path>> | undefined>;
 };
 
 /** CRUD API for a nested singleton ($recordLimit max: 1). */
@@ -157,7 +157,7 @@ export type NestedSingletonCRUD<
   set(
     parentContextId: string,
     options: SingletonSetOptions<D, M, Path>,
-  ): Promise<TypedRecord<DataAt<D, M, Path>> & DwnResponseStatus>;
+  ): Promise<DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> }>;
   get(parentContextId: string): Promise<TypedRecord<DataAt<D, M, Path>> | undefined>;
   delete(recordId: string): Promise<DwnResponseStatus>;
 };

--- a/packages/api/src/repository.ts
+++ b/packages/api/src/repository.ts
@@ -89,12 +89,12 @@ function buildRootCollectionMethods(
   return {
     async create(options: Record<string, unknown>): Promise<unknown> {
       const { status, record } = await typed.records.create(path, options as never);
-      return { status, record, ...status };
+      return { status, record };
     },
 
     async query(options?: Record<string, unknown>): Promise<unknown> {
       const { status, records, cursor } = await typed.records.query(path, options as never);
-      return { status, records, cursor, ...status };
+      return { status, records, cursor };
     },
 
     async get(recordId: string): Promise<unknown> {
@@ -132,11 +132,11 @@ function buildRootSingletonMethods(
           data: options.data,
           ...(options.tags !== undefined ? { tags: options.tags } : {}),
         } as never);
-        return { status, record, ...status };
+        return { status, record };
       }
       // Create new
       const { status, record } = await typed.records.create(path, options as never);
-      return { status, record, ...status };
+      return { status, record };
     },
 
     async get(): Promise<unknown> {
@@ -163,7 +163,7 @@ function buildNestedCollectionMethods(
         ...options,
         parentContextId,
       } as never);
-      return { status, record, ...status };
+      return { status, record };
     },
 
     async query(parentContextId: string, options?: Record<string, unknown>): Promise<unknown> {
@@ -174,7 +174,7 @@ function buildNestedCollectionMethods(
           contextId: parentContextId,
         },
       } as never);
-      return { status, records, cursor, ...status };
+      return { status, records, cursor };
     },
 
     async get(recordId: string): Promise<unknown> {
@@ -220,14 +220,14 @@ function buildNestedSingletonMethods(
           data: options.data,
           ...(options.tags !== undefined ? { tags: options.tags } : {}),
         } as never);
-        return { status, record, ...status };
+        return { status, record };
       }
 
       const { status, record } = await typed.records.create(path, {
         ...options,
         parentContextId,
       } as never);
-      return { status, record, ...status };
+      return { status, record };
     },
 
     async get(parentContextId: string): Promise<unknown> {

--- a/packages/api/tests/repository.spec.ts
+++ b/packages/api/tests/repository.spec.ts
@@ -208,7 +208,7 @@ describe('repository()', () => {
         data: { name: 'Groceries', description: 'Weekly shopping' },
       });
 
-      expect(result.code).toBe(202);
+      expect(result.status.code).toBe(202);
       expect(result.record).toBeDefined();
       expect(result.record).toBeInstanceOf(TypedRecord);
 
@@ -223,7 +223,7 @@ describe('repository()', () => {
 
       const result = await repo.list.query();
 
-      expect(result.code).toBe(200);
+      expect(result.status.code).toBe(200);
       expect(result.records.length).toBe(2);
       expect(result.records[0]).toBeInstanceOf(TypedRecord);
       expect(result.records[1]).toBeInstanceOf(TypedRecord);
@@ -284,7 +284,7 @@ describe('repository()', () => {
         data: { title: 'Review PR', completed: false },
       });
 
-      expect(result.code).toBe(202);
+      expect(result.status.code).toBe(202);
       expect(result.record).toBeInstanceOf(TypedRecord);
       expect(result.record.protocolPath).toBe('list/task');
 
@@ -307,7 +307,7 @@ describe('repository()', () => {
 
       const result = await repo.list.task.query(listRecord.contextId);
 
-      expect(result.code).toBe(200);
+      expect(result.status.code).toBe(200);
       expect(result.records.length).toBe(2);
       expect(result.records[0]).toBeInstanceOf(TypedRecord);
     });
@@ -381,7 +381,7 @@ describe('repository()', () => {
         data: blob,
       });
 
-      expect(result.code).toBe(202);
+      expect(result.status.code).toBe(202);
       expect(result.record).toBeInstanceOf(TypedRecord);
       expect(result.record.protocolPath).toBe('list/task/attachment');
     });
@@ -402,7 +402,7 @@ describe('repository()', () => {
         data: { displayName: 'Alice', bio: 'Hello world' },
       });
 
-      expect(result.code).toBe(202);
+      expect(result.status.code).toBe(202);
       expect(result.record).toBeInstanceOf(TypedRecord);
 
       const data = await result.record.data.json();
@@ -437,7 +437,7 @@ describe('repository()', () => {
         data: { displayName: 'Alice Updated', bio: 'v2' },
       });
 
-      expect(result.code).toBe(202);
+      expect(result.status.code).toBe(202);
 
       // Should still only have one record
       const record = await repo.profile.get();
@@ -479,7 +479,7 @@ describe('repository()', () => {
         data: { theme: 'dark', notifications: true },
       });
 
-      expect(result.code).toBe(202);
+      expect(result.status.code).toBe(202);
       expect(result.record).toBeInstanceOf(TypedRecord);
       expect(result.record.protocolPath).toBe('group/settings');
     });

--- a/packages/protocols/package.json
+++ b/packages/protocols/package.json
@@ -25,6 +25,7 @@
   "license": "Apache-2.0",
   "files": [
     "dist",
+    "schemas",
     "src"
   ],
   "exports": {


### PR DESCRIPTION
## Summary

- Fix repository CRUD return types to match actual runtime values (was silently wrong due to `as unknown as Repository` cast)
- Fix `subscribe()` return type to include `undefined`
- Remove surplus `...status` spread from runtime returns
- Include `schemas/` in `@enbox/protocols` npm distribution

## Problem

The entire repository Proxy is cast via `as unknown as Repository<D, M>` (line 366 of `repository.ts`), which bypasses TypeScript's type checker completely. This allowed three categories of type/runtime mismatch to go undetected:

**1. `create()` / `set()` return type was wrong**

```typescript
// Declared type (WRONG):
create(): Promise<TypedRecord<T> & DwnResponseStatus>
// This intersection requires the result to be a TypedRecord instance
// with a .status property. Consumers would write:
result.id;          // TypedRecord.id — exists in type, UNDEFINED at runtime
result.data.json(); // TypedRecord.data — exists in type, THROWS at runtime

// Actual runtime value:
{ status: { code, detail }, record: TypedRecord<T> }
// Consumers need:
result.record.id;          // works
result.record.data.json(); // works
result.status.code;        // works
```

**2. `subscribe()` could return `undefined`**

```typescript
// Declared (WRONG): Promise<TypedLiveQuery<T>>
// Actual:           TypedLiveQuery<T> | undefined
```

**3. Surplus `...status` spread**

The runtime returns `{ status, record, ...status }` which spreads `code` and `detail` to the top level — undeclared surplus properties that leak implementation details.

## Fix

| Method | Before (wrong) | After (correct) |
|--------|----------------|-----------------|
| `create()` | `TypedRecord<T> & DwnResponseStatus` | `DwnResponseStatus & { record: TypedRecord<T> }` |
| `set()` | `TypedRecord<T> & DwnResponseStatus` | `DwnResponseStatus & { record: TypedRecord<T> }` |
| `query()` | `{ records, cursor? } & DwnResponseStatus` | `DwnResponseStatus & { records, cursor? }` |
| `subscribe()` | `TypedLiveQuery<T>` | `TypedLiveQuery<T> \| undefined` |

Runtime returns changed from `{ status, record, ...status }` to `{ status, record }` (no surplus spread).

Tests updated from `result.code` to `result.status.code` to match the corrected shape.

Also adds `"schemas"` to `@enbox/protocols` `package.json` `files` field so the 19 JSON Schema files are included in the published npm package.

## Test results

```
51 pass, 0 fail (typed-protocol + repository)
Lint: clean
```