### PR TITLE
feat(api): runtime guards, path validation, singleton race fix, and comprehensive tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "@enbox/crypto": "workspace:*",
         "@enbox/dids": "workspace:*",
         "@enbox/dwn-sdk-js": "workspace:*",
+        "@enbox/protocols": "workspace:*",
         "@types/node": "20.14.8",
         "@types/sinon": "17.0.3",
         "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -89,6 +89,7 @@
     "@enbox/crypto": "workspace:*",
     "@enbox/dids": "workspace:*",
     "@enbox/dwn-sdk-js": "workspace:*",
+    "@enbox/protocols": "workspace:*",
     "@types/node": "20.14.8",
     "@types/sinon": "17.0.3",
     "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/packages/api/src/repository.ts
+++ b/packages/api/src/repository.ts
@@ -38,6 +38,15 @@ import type { ProtocolDefinition, ProtocolRuleSet } from '@enbox/dwn-sdk-js';
 // ---------------------------------------------------------------------------
 
 /**
+ * Checks whether a DWN response status indicates that the record limit
+ * has been exceeded. The DWN engine returns a 400 status with a detail
+ * message containing "record limit" when `$recordLimit` rejects a write.
+ */
+function isRecordLimitExceeded(status: { code: number; detail: string }): boolean {
+  return status.code === 400 && status.detail.includes('record limit');
+}
+
+/**
  * Checks whether a protocol rule set at a given path is a singleton
  * (has `$recordLimit: { max: 1 }`).
  */
@@ -117,6 +126,11 @@ function buildRootCollectionMethods(
 
 /**
  * Build singleton CRUD methods for a root-level path.
+ *
+ * Uses a create-first strategy: attempts to create a new record, and if the
+ * DWN rejects it because the record limit is reached, falls back to querying
+ * the existing record and updating it. This avoids the race condition inherent
+ * in query-then-create/update.
  */
 function buildRootSingletonMethods(
   typed: TypedWeb5<ProtocolDefinition, SchemaMap>,
@@ -124,19 +138,22 @@ function buildRootSingletonMethods(
 ): Record<string, Function> {
   return {
     async set(options: Record<string, unknown>): Promise<unknown> {
-      // Query for existing record
-      const { records } = await typed.records.query(path);
-      if (records.length > 0) {
-        // Update existing
-        const { status, record } = await records[0].update({
-          data: options.data,
-          ...(options.tags !== undefined ? { tags: options.tags } : {}),
-        } as never);
-        return { status, record };
+      // Attempt to create — if limit not yet reached, this succeeds.
+      const createResult = await typed.records.create(path, options as never);
+
+      if (isRecordLimitExceeded(createResult.status)) {
+        // Record limit hit — query existing and update.
+        const { records } = await typed.records.query(path);
+        if (records.length > 0) {
+          const { status, record } = await records[0].update({
+            data: options.data,
+            ...(options.tags !== undefined ? { tags: options.tags } : {}),
+          } as never);
+          return { status, record };
+        }
       }
-      // Create new
-      const { status, record } = await typed.records.create(path, options as never);
-      return { status, record };
+
+      return { status: createResult.status, record: createResult.record };
     },
 
     async get(): Promise<unknown> {
@@ -203,6 +220,9 @@ function buildNestedCollectionMethods(
 
 /**
  * Build singleton CRUD methods for a nested path.
+ *
+ * Uses the same create-first strategy as root singletons to avoid race
+ * conditions between concurrent set() calls.
  */
 function buildNestedSingletonMethods(
   typed: TypedWeb5<ProtocolDefinition, SchemaMap>,
@@ -210,24 +230,28 @@ function buildNestedSingletonMethods(
 ): Record<string, Function> {
   return {
     async set(parentContextId: string, options: Record<string, unknown>): Promise<unknown> {
-      // Query for existing record under this parent
-      const { records } = await typed.records.query(path, {
-        filter: { contextId: parentContextId },
-      } as never);
-
-      if (records.length > 0) {
-        const { status, record } = await records[0].update({
-          data: options.data,
-          ...(options.tags !== undefined ? { tags: options.tags } : {}),
-        } as never);
-        return { status, record };
-      }
-
-      const { status, record } = await typed.records.create(path, {
+      // Attempt to create under this parent — succeeds if no record exists yet.
+      const createResult = await typed.records.create(path, {
         ...options,
         parentContextId,
       } as never);
-      return { status, record };
+
+      if (isRecordLimitExceeded(createResult.status)) {
+        // Record limit hit — query existing under this parent and update.
+        const { records } = await typed.records.query(path, {
+          filter: { contextId: parentContextId },
+        } as never);
+
+        if (records.length > 0) {
+          const { status, record } = await records[0].update({
+            data: options.data,
+            ...(options.tags !== undefined ? { tags: options.tags } : {}),
+          } as never);
+          return { status, record };
+        }
+      }
+
+      return { status: createResult.status, record: createResult.record };
     },
 
     async get(parentContextId: string): Promise<unknown> {

--- a/packages/api/src/typed-web5.ts
+++ b/packages/api/src/typed-web5.ts
@@ -227,10 +227,13 @@ export class TypedWeb5<
 > {
   private _dwn: DwnApi;
   private _definition: D;
+  private _configured: boolean = false;
+  private _validPaths: Set<string>;
 
   constructor(dwn: DwnApi, protocol: TypedProtocol<D, M>) {
     this._dwn = dwn;
     this._definition = protocol.definition;
+    this._validPaths = collectPaths(this._definition.structure);
   }
 
   /** The protocol URI. */
@@ -263,15 +266,47 @@ export class TypedWeb5<
     if (protocols.length > 0) {
       const existing = protocols[0];
       if (definitionsEqual(existing.definition, this._definition)) {
+        this._configured = true;
         return { status: { code: 200, detail: 'OK' }, protocol: existing };
       }
     }
 
     // Not installed or definition has changed — configure the new version.
-    return this._dwn.protocols.configure({
+    const result = await this._dwn.protocols.configure({
       definition : this._definition,
       encryption : options?.encryption,
     });
+
+    if (result.status.code === 202) {
+      this._configured = true;
+    }
+
+    return result;
+  }
+
+  /** Whether the protocol has been configured (installed) on the local DWN. */
+  public get isConfigured(): boolean {
+    return this._configured;
+  }
+
+  /**
+   * Validates that the protocol has been configured and that the path is
+   * recognized. Throws a descriptive error if either check fails.
+   */
+  private _assertReady(path: string): void {
+    if (!this._configured) {
+      throw new Error(
+        `TypedWeb5: protocol '${this._definition.protocol}' has not been configured. ` +
+        'Call configure() before performing record operations.',
+      );
+    }
+
+    if (!this._validPaths.has(path)) {
+      throw new Error(
+        `TypedWeb5: invalid protocol path '${path}'. ` +
+        `Valid paths are: ${[...this._validPaths].join(', ')}.`,
+      );
+    }
   }
 
   /**
@@ -321,6 +356,7 @@ export class TypedWeb5<
         path: Path,
         request: TypedCreateRequest<D, M, Path>,
       ): Promise<TypedCreateResponse<DataForPath<D, M, Path>>> => {
+        this._assertReady(path);
         const typeName = lastSegment(path);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
@@ -356,6 +392,7 @@ export class TypedWeb5<
         path: Path,
         request?: TypedQueryRequest,
       ): Promise<TypedQueryResponse<DataForPath<D, M, Path>>> => {
+        this._assertReady(path);
         const typeName = lastSegment(path);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
@@ -390,6 +427,7 @@ export class TypedWeb5<
         path: Path,
         request: TypedReadRequest,
       ): Promise<TypedReadResponse<DataForPath<D, M, Path>>> => {
+        this._assertReady(path);
         const typeName = lastSegment(path);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
@@ -421,6 +459,7 @@ export class TypedWeb5<
         _path: Path,
         request: TypedDeleteRequest,
       ): Promise<DwnResponseStatus> => {
+        this._assertReady(_path);
         return this._dwn.records.delete({
           from     : request.from,
           protocol : this._definition.protocol,
@@ -442,6 +481,7 @@ export class TypedWeb5<
         path: Path,
         request?: TypedSubscribeRequest,
       ): Promise<TypedSubscribeResponse<DataForPath<D, M, Path>>> => {
+        this._assertReady(path);
         const typeName = lastSegment(path);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
@@ -486,6 +526,35 @@ function definitionsEqual(a: unknown, b: unknown): boolean {
 function lastSegment(path: string): string {
   const parts = path.split('/');
   return parts[parts.length - 1];
+}
+
+/**
+ * Recursively collects all valid protocol path strings from a structure object.
+ *
+ * Given `{ foo: { bar: { $actions: [...] } } }`, returns `Set(['foo', 'foo/bar'])`.
+ * Keys starting with `$` are skipped.
+ */
+function collectPaths(
+  structure: Record<string, unknown>,
+  prefix: string = '',
+): Set<string> {
+  const paths = new Set<string>();
+
+  for (const key of Object.keys(structure)) {
+    if (key.startsWith('$')) { continue; }
+
+    const fullPath = prefix ? `${prefix}/${key}` : key;
+    paths.add(fullPath);
+
+    const child = structure[key];
+    if (child !== null && typeof child === 'object') {
+      for (const nested of collectPaths(child as Record<string, unknown>, fullPath)) {
+        paths.add(nested);
+      }
+    }
+  }
+
+  return paths;
 }
 
 /**

--- a/packages/api/tests/protocols-integration.spec.ts
+++ b/packages/api/tests/protocols-integration.spec.ts
@@ -1,0 +1,411 @@
+/**
+ * Integration tests for `@enbox/protocols` definitions.
+ *
+ * These tests configure each protocol on a real DWN, write records, read them
+ * back, and verify end-to-end correctness — including singleton upsert
+ * semantics, nested record creation, and tag enforcement.
+ *
+ * Protocols that compose with the Social Graph via `uses` require the Social
+ * Graph protocol to be installed first. Friend/collaborator-only actions
+ * (cross-tenant writes) are not tested here; this suite exercises owner-tenant
+ * operations.
+ *
+ * The test harness lives in `@enbox/api` because it provides the
+ * `PlatformAgentTestHarness` and `DwnApi` infrastructure needed for
+ * integration testing.
+ */
+
+import type { BearerDid } from '@enbox/dids';
+
+import sinon from 'sinon';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+
+import { DwnApi } from '../src/dwn-api.js';
+import { repository } from '../src/repository.js';
+import { testDwnUrl } from './utils/test-config.js';
+import { TypedRecord } from '../src/typed-record.js';
+import { TypedWeb5 } from '../src/typed-web5.js';
+
+import {
+  ConnectProtocol,
+  ListsProtocol,
+  ProfileProtocol,
+  SocialGraphProtocol,
+  StatusProtocol,
+} from '@enbox/protocols';
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+const testDwnUrls: string[] = [testDwnUrl];
+
+describe('@enbox/protocols integration', () => {
+  let aliceDid: BearerDid;
+  let dwnAlice: DwnApi;
+  let testHarness: PlatformAgentTestHarness;
+
+  beforeAll(async () => {
+    testHarness = await PlatformAgentTestHarness.setup({
+      agentClass       : Web5UserAgent,
+      agentStores      : 'memory',
+      testDataLocation : '__TESTDATA__/protocols-integration',
+    });
+
+    await testHarness.clearStorage();
+    await testHarness.createAgentDid();
+
+    const alice = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
+    aliceDid = alice.did;
+
+    dwnAlice = new DwnApi({ agent: testHarness.agent, connectedDid: aliceDid.uri });
+  });
+
+  beforeEach(async () => {
+    sinon.restore();
+    await testHarness.syncStore.clear();
+    await testHarness.dwnDataStore.clear();
+    await testHarness.dwnStateIndex.clear();
+    await testHarness.dwnMessageStore.clear();
+    await testHarness.dwnResumableTaskStore.clear();
+    await testHarness.agent.permissions.clear();
+    testHarness.dwnStores.clear();
+  });
+
+  afterAll(async () => {
+    sinon.restore();
+    await testHarness.clearStorage();
+    await testHarness.closeStorage();
+  });
+
+  /**
+   * Helper to install the Social Graph protocol as a prerequisite for
+   * protocols that compose with it via `uses`.
+   */
+  async function installSocialGraph(): Promise<void> {
+    const socialTyped = new TypedWeb5(dwnAlice, SocialGraphProtocol);
+    const { status } = await socialTyped.configure();
+    expect(status.code).toBeOneOf([200, 202]);
+  }
+
+  // -------------------------------------------------------------------------
+  // Social Graph Protocol
+  // -------------------------------------------------------------------------
+
+  describe('SocialGraphProtocol', () => {
+    it('should configure the protocol', async () => {
+      const typed = new TypedWeb5(dwnAlice, SocialGraphProtocol);
+      const { status } = await typed.configure();
+      expect(status.code).toBe(202);
+    });
+
+    it('should create a friend record with required recipient and tags', async () => {
+      const typed = new TypedWeb5(dwnAlice, SocialGraphProtocol);
+      await typed.configure();
+
+      // Friend has $role: true, so requires a recipient.
+      const { status, record } = await typed.records.create('friend', {
+        data      : { did: 'did:example:bob', alias: 'Bob' },
+        tags      : { did: 'did:example:bob' },
+        recipient : 'did:example:bob',
+      });
+
+      expect(status.code).toBe(202);
+      expect(record).toBeInstanceOf(TypedRecord);
+      expect(record.protocolPath).toBe('friend');
+
+      const data = await record.data.json();
+      expect(data.did).toBe('did:example:bob');
+      expect(data.alias).toBe('Bob');
+    });
+
+    it('should create a block record with tags', async () => {
+      const typed = new TypedWeb5(dwnAlice, SocialGraphProtocol);
+      await typed.configure();
+
+      const { status, record } = await typed.records.create('block', {
+        data : { did: 'did:example:troll', reason: 'spam' },
+        tags : { did: 'did:example:troll' },
+      });
+
+      expect(status.code).toBe(202);
+      expect(record.protocolPath).toBe('block');
+
+      const data = await record.data.json();
+      expect(data.did).toBe('did:example:troll');
+      expect(data.reason).toBe('spam');
+    });
+
+    it('should create a group with nested members', async () => {
+      const typed = new TypedWeb5(dwnAlice, SocialGraphProtocol);
+      await typed.configure();
+
+      const { record: groupRecord } = await typed.records.create('group', {
+        data: { name: 'Dev Team', description: 'Engineering' },
+      });
+      expect(groupRecord).toBeDefined();
+
+      const { status, record: memberRecord } = await typed.records.create('group/member', {
+        data            : { did: 'did:example:carol', alias: 'Carol' },
+        parentContextId : groupRecord.contextId,
+        tags            : { did: 'did:example:carol' },
+      });
+
+      expect(status.code).toBe(202);
+      expect(memberRecord.protocolPath).toBe('group/member');
+
+      const memberData = await memberRecord.data.json();
+      expect(memberData.did).toBe('did:example:carol');
+    });
+
+    it('should query friend records', async () => {
+      const typed = new TypedWeb5(dwnAlice, SocialGraphProtocol);
+      await typed.configure();
+
+      await typed.records.create('friend', {
+        data      : { did: 'did:example:alice' },
+        tags      : { did: 'did:example:alice' },
+        recipient : 'did:example:alice',
+      });
+      await typed.records.create('friend', {
+        data      : { did: 'did:example:bob' },
+        tags      : { did: 'did:example:bob' },
+        recipient : 'did:example:bob',
+      });
+
+      const { records } = await typed.records.query('friend');
+      expect(records.length).toBe(2);
+      expect(records[0]).toBeInstanceOf(TypedRecord);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Profile Protocol — requires Social Graph, uses singletons
+  // -------------------------------------------------------------------------
+
+  describe('ProfileProtocol', () => {
+    it('should configure after Social Graph is installed', async () => {
+      await installSocialGraph();
+
+      const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      const { status } = await typed.configure();
+      expect(status.code).toBe(202);
+    });
+
+    it('should set and get a singleton profile via repository', async () => {
+      await installSocialGraph();
+
+      const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      const repo = repository(typed);
+      await repo.configure();
+
+      const result = await repo.profile.set({
+        data: { displayName: 'Alice', bio: 'Building the future' },
+      });
+
+      expect(result.status.code).toBe(202);
+      expect(result.record).toBeInstanceOf(TypedRecord);
+
+      const data = await result.record.data.json();
+      expect(data.displayName).toBe('Alice');
+
+      // Get the singleton back
+      const fetched = await repo.profile.get();
+      expect(fetched).toBeInstanceOf(TypedRecord);
+      const fetchedData = await fetched.data.json();
+      expect(fetchedData.displayName).toBe('Alice');
+    });
+
+    it('should upsert a singleton profile on second set()', async () => {
+      await installSocialGraph();
+
+      const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      const repo = repository(typed);
+      await repo.configure();
+
+      // First set
+      await repo.profile.set({ data: { displayName: 'Alice v1' } });
+
+      // Second set — should upsert
+      const result = await repo.profile.set({
+        data: { displayName: 'Alice v2', bio: 'Updated bio' },
+      });
+
+      expect(result.status.code).toBe(202);
+
+      const fetched = await repo.profile.get();
+      expect(fetched).toBeInstanceOf(TypedRecord);
+      const data = await fetched.data.json();
+      expect(data.displayName).toBe('Alice v2');
+      expect(data.bio).toBe('Updated bio');
+    });
+
+    it('should create nested links under profile', async () => {
+      await installSocialGraph();
+
+      const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      const repo = repository(typed);
+      await repo.configure();
+
+      const { record: profileRecord } = await repo.profile.set({
+        data: { displayName: 'Alice' },
+      });
+
+      const linkResult = await repo.profile.link.create(profileRecord.contextId, {
+        data: { url: 'https://twitter.com/alice', title: 'Twitter' },
+      });
+
+      expect(linkResult.status.code).toBe(202);
+      expect(linkResult.record.protocolPath).toBe('profile/link');
+
+      const linkData = await linkResult.record.data.json();
+      expect(linkData.url).toBe('https://twitter.com/alice');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Connect Protocol — standalone, singleton wallet
+  // -------------------------------------------------------------------------
+
+  describe('ConnectProtocol', () => {
+    it('should configure and set wallet singleton', async () => {
+      const typed = new TypedWeb5(dwnAlice, ConnectProtocol);
+      const repo = repository(typed);
+      await repo.configure();
+
+      const result = await repo.wallet.set({
+        data: { webWallets: ['https://wallet.example.com'] },
+      });
+
+      expect(result.status.code).toBe(202);
+
+      const fetched = await repo.wallet.get();
+      expect(fetched).toBeInstanceOf(TypedRecord);
+      const data = await fetched.data.json();
+      expect(data.webWallets).toEqual(['https://wallet.example.com']);
+    });
+
+    it('should upsert wallet on second set()', async () => {
+      const typed = new TypedWeb5(dwnAlice, ConnectProtocol);
+      const repo = repository(typed);
+      await repo.configure();
+
+      await repo.wallet.set({
+        data: { webWallets: ['https://v1.wallet.com'] },
+      });
+
+      await repo.wallet.set({
+        data: { webWallets: ['https://v2.wallet.com', 'https://alt.wallet.com'] },
+      });
+
+      const fetched = await repo.wallet.get();
+      expect(fetched).toBeInstanceOf(TypedRecord);
+      const data = await fetched.data.json();
+      expect(data.webWallets).toEqual(['https://v2.wallet.com', 'https://alt.wallet.com']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Status Protocol — requires Social Graph, nested reactions
+  // -------------------------------------------------------------------------
+
+  describe('StatusProtocol', () => {
+    it('should configure and create a status record', async () => {
+      await installSocialGraph();
+
+      const typed = new TypedWeb5(dwnAlice, StatusProtocol);
+      await typed.configure();
+
+      const { status, record } = await typed.records.create('status', {
+        data: { text: 'Hello world!', emoji: '🌍' },
+      });
+
+      expect(status.code).toBe(202);
+      expect(record).toBeInstanceOf(TypedRecord);
+      expect(record.protocolPath).toBe('status');
+
+      const data = await record.data.json();
+      expect(data.text).toBe('Hello world!');
+    });
+
+    it('should query status records', async () => {
+      await installSocialGraph();
+
+      const typed = new TypedWeb5(dwnAlice, StatusProtocol);
+      await typed.configure();
+
+      await typed.records.create('status', { data: { text: 'Status 1' } });
+      await typed.records.create('status', { data: { text: 'Status 2' } });
+
+      const { records } = await typed.records.query('status');
+      expect(records.length).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Lists Protocol — requires Social Graph, deep nesting
+  // -------------------------------------------------------------------------
+
+  describe('ListsProtocol', () => {
+    it('should configure after Social Graph is installed', async () => {
+      await installSocialGraph();
+
+      const typed = new TypedWeb5(dwnAlice, ListsProtocol);
+      const { status } = await typed.configure();
+      expect(status.code).toBe(202);
+    });
+
+    it('should create folders with 3-level nesting', async () => {
+      await installSocialGraph();
+
+      const typed = new TypedWeb5(dwnAlice, ListsProtocol);
+      await typed.configure();
+
+      const { record: folder1 } = await typed.records.create('folder', {
+        data: { name: 'Projects' },
+      });
+      expect(folder1).toBeDefined();
+
+      const { record: folder2 } = await typed.records.create('folder/folder', {
+        data            : { name: 'Work' },
+        parentContextId : folder1.contextId,
+      });
+      expect(folder2).toBeDefined();
+      expect(folder2.protocolPath).toBe('folder/folder');
+
+      const { status, record: folder3 } = await typed.records.create('folder/folder/folder', {
+        data            : { name: 'Q1' },
+        parentContextId : folder2.contextId,
+      });
+      expect(status.code).toBe(202);
+      expect(folder3.protocolPath).toBe('folder/folder/folder');
+    });
+
+    it('should query nested folders under a parent', async () => {
+      await installSocialGraph();
+
+      const typed = new TypedWeb5(dwnAlice, ListsProtocol);
+      await typed.configure();
+
+      const { record: folder1 } = await typed.records.create('folder', {
+        data: { name: 'Root Folder' },
+      });
+
+      await typed.records.create('folder/folder', {
+        data            : { name: 'Sub A' },
+        parentContextId : folder1.contextId,
+      });
+      await typed.records.create('folder/folder', {
+        data            : { name: 'Sub B' },
+        parentContextId : folder1.contextId,
+      });
+
+      const { records } = await typed.records.query('folder/folder', {
+        filter: { contextId: folder1.contextId },
+      });
+      expect(records.length).toBe(2);
+    });
+  });
+});

--- a/packages/api/tests/repository.spec.ts
+++ b/packages/api/tests/repository.spec.ts
@@ -571,6 +571,62 @@ describe('repository()', () => {
     });
   });
 
+  describe('error paths', () => {
+    it('should throw when calling create() before configure()', async () => {
+      const typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      const repo = repository(typed);
+
+      await expect(
+        repo.list.create({ data: { name: 'Fail' } }),
+      ).rejects.toThrow('has not been configured');
+    });
+
+    it('should throw when calling query() before configure()', async () => {
+      const typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      const repo = repository(typed);
+
+      await expect(
+        repo.list.query(),
+      ).rejects.toThrow('has not been configured');
+    });
+
+    it('should throw when calling singleton set() before configure()', async () => {
+      const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      const repo = repository(typed);
+
+      await expect(
+        repo.profile.set({ data: { displayName: 'Fail' } }),
+      ).rejects.toThrow('has not been configured');
+    });
+
+    it('should throw when calling singleton get() before configure()', async () => {
+      const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      const repo = repository(typed);
+
+      await expect(
+        repo.profile.get(),
+      ).rejects.toThrow('has not been configured');
+    });
+
+    it('should throw when calling nested create() before configure()', async () => {
+      const typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      const repo = repository(typed);
+
+      await expect(
+        repo.list.task.create('ctx-123', { data: { title: 'Fail', completed: false } }),
+      ).rejects.toThrow('has not been configured');
+    });
+
+    it('should throw when calling nested singleton set() before configure()', async () => {
+      const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
+      const repo = repository(typed);
+
+      await expect(
+        repo.group.settings.set('ctx-123', { data: { theme: 'dark', notifications: true } }),
+      ).rejects.toThrow('has not been configured');
+    });
+  });
+
   describe('proxy node caching', () => {
     it('should return the same child node on repeated access', () => {
       const typed = new TypedWeb5(dwnAlice, TodoProtocol);

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -447,6 +447,85 @@ describe('TypedProtocol API', () => {
       });
     });
 
+    describe('error paths', () => {
+      it('should throw when calling create() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        await expect(
+          unconfigured.records.create('list', { data: { name: 'Fail' } }),
+        ).rejects.toThrow('has not been configured');
+      });
+
+      it('should throw when calling query() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        await expect(
+          unconfigured.records.query('list'),
+        ).rejects.toThrow('has not been configured');
+      });
+
+      it('should throw when calling read() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        await expect(
+          unconfigured.records.read('list', { filter: { recordId: 'abc' } }),
+        ).rejects.toThrow('has not been configured');
+      });
+
+      it('should throw when calling delete() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        await expect(
+          unconfigured.records.delete('list', { recordId: 'abc' }),
+        ).rejects.toThrow('has not been configured');
+      });
+
+      it('should throw when calling subscribe() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        await expect(
+          unconfigured.records.subscribe('list'),
+        ).rejects.toThrow('has not been configured');
+      });
+
+      it('should include the protocol URI in the not-configured error message', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        await expect(
+          unconfigured.records.create('list', { data: { name: 'Fail' } }),
+        ).rejects.toThrow('https://example.com/protocols/todo');
+      });
+
+      it('should throw on invalid protocol path', async () => {
+        // Configure first so the not-configured guard passes
+        await expect(
+          typed.records.create('nonexistent' as any, { data: {} }),
+        ).rejects.toThrow('invalid protocol path');
+      });
+
+      it('should include valid paths in the invalid path error message', async () => {
+        await expect(
+          typed.records.create('nonexistent' as any, { data: {} }),
+        ).rejects.toThrow('Valid paths are:');
+      });
+
+      it('should throw on invalid nested path', async () => {
+        await expect(
+          typed.records.query('list/nonexistent' as any),
+        ).rejects.toThrow('invalid protocol path');
+      });
+
+      it('should report isConfigured as false before configure()', () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+        expect(unconfigured.isConfigured).toBe(false);
+      });
+
+      it('should report isConfigured as true after configure()', () => {
+        // `typed` is configured in beforeEach
+        expect(typed.isConfigured).toBe(true);
+      });
+    });
+
     describe('TypedRecord lifecycle methods', () => {
       it('should update a record and return a new TypedRecord', async () => {
         const { record } = await typed.records.create('list', {


### PR DESCRIPTION
## Summary

Implements the 5 medium-priority improvements from the typed protocols audit:

- **"Protocol not configured" guard** — `TypedWeb5` now tracks a `_configured` flag and throws a descriptive error (including protocol URI) when any CRUD method is called before `configure()`
- **Runtime path validation** — All paths are validated against the protocol structure at runtime; invalid paths produce an error listing all valid paths
- **Singleton `set()` race condition fix** — Changed from query-then-create/update to create-first-then-fallback-to-update, using the DWN's `$recordLimit` rejection response to detect existing singletons
- **Integration tests for `@enbox/protocols`** — 16 end-to-end tests that configure real protocols on a DWN, write/read data, test singleton upsert semantics, and exercise nested record creation across SocialGraph, Profile, Connect, Status, and Lists protocols
- **Error path tests** — 11 new tests in `typed-protocol.spec.ts` and 6 in `repository.spec.ts` covering guard failures, invalid paths, and `isConfigured` getter

## Test results

| File | Tests | Status |
|---|---|---|
| `typed-protocol.spec.ts` | 37 (was 26, +11 error path) | All pass |
| `repository.spec.ts` | 31 (was 25, +6 error path) | All pass |
| `protocols-integration.spec.ts` | 16 (new) | All pass |
| **Total** | **84** | **0 failures** |

Lint and build both pass cleanly.

## Changed files

| File | Change |
|---|---|
| `packages/api/src/typed-web5.ts` | `_configured` flag, `isConfigured` getter, `_assertReady()` guard, `collectPaths()` helper |
| `packages/api/src/repository.ts` | `isRecordLimitExceeded()` helper, create-first singleton strategy in root + nested |
| `packages/api/tests/typed-protocol.spec.ts` | 11 error path tests |
| `packages/api/tests/repository.spec.ts` | 6 error path tests |
| `packages/api/tests/protocols-integration.spec.ts` | 16 integration tests (new file) |
| `packages/api/package.json` | Added `@enbox/protocols` as devDependency |