### PR TITLE
feat(dwn-server): admin Phase 2 — enhanced metrics, activity log, connection inspector

### DIFF
--- a/packages/dwn-server/src/admin/activity-log.ts
+++ b/packages/dwn-server/src/admin/activity-log.ts
@@ -1,0 +1,100 @@
+import type { AdminActivityEvent } from './types.js';
+
+/** Default maximum number of events retained in the ring buffer. */
+export const DEFAULT_ACTIVITY_LOG_CAPACITY = 10_000;
+
+/**
+ * In-memory ring buffer that captures recent DWN request activity.
+ *
+ * Events are assigned a monotonically increasing `id` that acts as a cursor.
+ * When the buffer reaches capacity, the oldest events are evicted. This is
+ * **not** a persistent audit log — it is designed for real-time admin
+ * observability.
+ */
+export class ActivityLog {
+  readonly #capacity: number;
+  readonly #buffer: AdminActivityEvent[];
+  #nextId = 1;
+
+  constructor(capacity: number = DEFAULT_ACTIVITY_LOG_CAPACITY) {
+    this.#capacity = Math.max(1, capacity);
+    this.#buffer = [];
+  }
+
+  /**
+   * Records a new activity event. If the buffer is full, the oldest event is
+   * evicted.
+   */
+  public record(event: Omit<AdminActivityEvent, 'id' | 'timestamp'>): void {
+    const entry: AdminActivityEvent = {
+      id            : this.#nextId++,
+      timestamp     : new Date().toISOString(),
+      tenant        : event.tenant,
+      interface     : event.interface,
+      method        : event.method,
+      statusCode    : event.statusCode,
+      transport     : event.transport,
+      dataSizeBytes : event.dataSizeBytes,
+    };
+
+    if (this.#buffer.length >= this.#capacity) {
+      this.#buffer.shift();
+    }
+
+    this.#buffer.push(entry);
+  }
+
+  /**
+   * Returns recent events, optionally filtered by a cursor (returns events
+   * with `id > since`) and limited to `limit` entries.
+   */
+  public getEvents(options?: {
+    since? : number;
+    limit? : number;
+  }): { events: AdminActivityEvent[]; cursor?: number } {
+    const since = options?.since ?? 0;
+    const limit = options?.limit ?? 50;
+
+    // Binary search for the start index (events are ordered by id).
+    let startIdx = 0;
+    if (since > 0 && this.#buffer.length > 0) {
+      let lo = 0;
+      let hi = this.#buffer.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if (this.#buffer[mid].id <= since) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
+      }
+      startIdx = lo;
+    }
+
+    const events = this.#buffer.slice(startIdx, startIdx + limit);
+    const cursor = events.length > 0 ? events[events.length - 1].id : undefined;
+
+    return { events, cursor };
+  }
+
+  /**
+   * Returns the current number of events in the buffer.
+   */
+  public get size(): number {
+    return this.#buffer.length;
+  }
+
+  /**
+   * Returns the configured capacity of the ring buffer.
+   */
+  public get capacity(): number {
+    return this.#capacity;
+  }
+
+  /**
+   * Clears all events from the buffer.
+   */
+  public clear(): void {
+    this.#buffer.length = 0;
+  }
+}

--- a/packages/dwn-server/src/admin/admin-api.ts
+++ b/packages/dwn-server/src/admin/admin-api.ts
@@ -1,15 +1,23 @@
 import type { Dwn } from '@enbox/dwn-sdk-js';
 
+import type { ActivityLog } from './activity-log.js';
 import type { AdminStore } from './admin-store.js';
 import type { ConnectionManager } from '../connection/connection-manager.js';
 import type { DwnServerConfig } from '../config.js';
 import type { RegistrationManager } from '../registration/registration-manager.js';
 import type { RegistrationStore } from '../registration/registration-store.js';
-import type { AdminServerStats, AdminTenantDetail, AdminTenantSummary, PaginatedResponse } from './types.js';
+import type { AdminConnectionSnapshot, AdminServerStats, AdminTenantDetail, AdminTenantSummary, PaginatedResponse } from './types.js';
 
 import log from 'loglevel';
 
 import { validateAdminAuth } from './admin-auth.js';
+import {
+  activeTenants,
+  totalDataBytes,
+  totalMessages,
+  websocketConnections,
+  websocketSubscriptions,
+} from '../metrics.js';
 
 /**
  * Handles all `/admin/api/*` routes.
@@ -22,8 +30,10 @@ export class AdminApi {
   #registrationManager: RegistrationManager | undefined;
   #registrationStore: RegistrationStore | undefined;
   #connectionManager: ConnectionManager | undefined;
+  #activityLog: ActivityLog | undefined;
   #startTime: number;
   #packageInfo: { version?: string };
+  #metricsInterval: ReturnType<typeof setInterval> | undefined;
 
   private constructor() {
     this.#startTime = Date.now();
@@ -39,6 +49,7 @@ export class AdminApi {
     registrationManager?: RegistrationManager;
     registrationStore? : RegistrationStore;
     connectionManager? : ConnectionManager;
+    activityLog? : ActivityLog;
     packageInfo? : { version?: string };
   }): AdminApi {
     const api = new AdminApi();
@@ -48,6 +59,7 @@ export class AdminApi {
     api.#registrationManager = options.registrationManager;
     api.#registrationStore = options.registrationStore;
     api.#connectionManager = options.connectionManager;
+    api.#activityLog = options.activityLog;
     api.#packageInfo = options.packageInfo ?? {};
     return api;
   }
@@ -124,6 +136,16 @@ export class AdminApi {
           const did = decodeURIComponent(match[1]);
           return this.#handleTenantUnsuspend(did);
         }
+      }
+
+      // --- Activity events ---
+      if (method === 'GET' && subPath === '/events') {
+        return this.#handleEvents(url);
+      }
+
+      // --- WebSocket connections ---
+      if (method === 'GET' && subPath === '/connections') {
+        return this.#handleConnections();
       }
 
       // --- Info (smoke test) ---
@@ -430,26 +452,104 @@ export class AdminApi {
     return Response.json({ success: true, did });
   }
 
+  /**
+   * Returns recent DWN activity events from the in-memory ring buffer.
+   */
+  #handleEvents(url: URL): Response {
+    if (!this.#activityLog) {
+      return Response.json(
+        { error: 'Activity log is not enabled.' },
+        { status: 501 },
+      );
+    }
+
+    const since = parseInt(url.searchParams.get('since') ?? '0');
+    const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '50'), 1000);
+
+    const { events, cursor } = this.#activityLog.getEvents({ since, limit });
+
+    return Response.json({ events, cursor });
+  }
+
+  /**
+   * Returns snapshots of active WebSocket connections and their subscriptions.
+   */
+  #handleConnections(): Response {
+    const connections: AdminConnectionSnapshot[] = this.#connectionManager
+      ? this.#connectionManager.getConnectionSnapshots()
+      : [];
+
+    return Response.json({ connections });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Periodic metrics updater
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Starts a periodic timer that updates Prometheus gauge metrics from the
+   * admin store and connection manager. The interval is configured via
+   * `adminMetricsUpdateIntervalSeconds` (default 30s).
+   */
+  public startMetricsUpdater(): void {
+    if (this.#metricsInterval) {
+      return;
+    }
+
+    const intervalMs = (this.#config.adminMetricsUpdateIntervalSeconds ?? 30) * 1000;
+
+    // Run immediately, then on interval.
+    this.#updateMetrics();
+    this.#metricsInterval = setInterval(() => {
+      this.#updateMetrics();
+    }, intervalMs);
+  }
+
+  /**
+   * Stops the periodic metrics updater.
+   */
+  public stopMetricsUpdater(): void {
+    if (this.#metricsInterval) {
+      clearInterval(this.#metricsInterval);
+      this.#metricsInterval = undefined;
+    }
+  }
+
+  /**
+   * Fetches stats from the admin store and connection manager, and sets
+   * Prometheus gauge values accordingly.
+   */
+  #updateMetrics(): void {
+    // Connection gauges (synchronous).
+    websocketConnections.set(this.#getConnectionCount());
+    websocketSubscriptions.set(this.#getSubscriptionCount());
+
+    // Store-based gauges (async — fire and forget).
+    if (this.#adminStore) {
+      this.#adminStore.getGlobalStats({ refresh: true }).then((stats) => {
+        activeTenants.set(stats.tenantCount);
+        totalMessages.set(stats.totalMessages);
+        totalDataBytes.set(stats.totalDataBytes);
+      }).catch((err) => {
+        log.error('Failed to update Prometheus gauge metrics:', err);
+      });
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 
   #getConnectionCount(): number {
-    if (this.#connectionManager && 'connections' in this.#connectionManager) {
-      return (this.#connectionManager as any).connections.size;
+    if (this.#connectionManager) {
+      return this.#connectionManager.getConnectionCount();
     }
     return 0;
   }
 
   #getSubscriptionCount(): number {
-    if (this.#connectionManager && 'connections' in this.#connectionManager) {
-      let count = 0;
-      (this.#connectionManager as any).connections.forEach((conn: any) => {
-        if (conn.subscriptions) {
-          count += conn.subscriptions.size;
-        }
-      });
-      return count;
+    if (this.#connectionManager) {
+      return this.#connectionManager.getSubscriptionCount();
     }
     return 0;
   }

--- a/packages/dwn-server/src/admin/index.ts
+++ b/packages/dwn-server/src/admin/index.ts
@@ -1,9 +1,13 @@
+export { ActivityLog } from './activity-log.js';
 export { AdminApi } from './admin-api.js';
 export { AdminStore } from './admin-store.js';
 export { validateAdminAuth } from './admin-auth.js';
 export type {
+  AdminActivityEvent,
+  AdminConnectionSnapshot,
   AdminHealthCheck,
   AdminServerStats,
+  AdminSubscriptionSnapshot,
   AdminTenantDetail,
   AdminTenantSummary,
   GlobalStats,

--- a/packages/dwn-server/src/admin/types.ts
+++ b/packages/dwn-server/src/admin/types.ts
@@ -97,3 +97,51 @@ export type PaginatedResponse<T> = {
   cursor? : string;
   totalCount : number;
 };
+
+/**
+ * A single DWN activity event captured by the in-memory ring buffer.
+ */
+export type AdminActivityEvent = {
+  /** Monotonically increasing event ID (used as cursor). */
+  id : number;
+  /** ISO-8601 timestamp of the event. */
+  timestamp : string;
+  /** The tenant DID the request targeted. */
+  tenant : string;
+  /** DWN interface (e.g. `Records`, `Protocols`, `Events`). */
+  interface : string;
+  /** DWN method (e.g. `Write`, `Query`, `Read`, `Subscribe`). */
+  method : string;
+  /** DWN status code returned (e.g. 200, 202, 401). */
+  statusCode : number;
+  /** Transport used (`http` or `ws`). */
+  transport : 'http' | 'ws';
+  /** Data size in bytes (if applicable). */
+  dataSizeBytes? : number;
+};
+
+/**
+ * Snapshot of a single subscription's flow control state.
+ */
+export type AdminSubscriptionSnapshot = {
+  /** Subscription JSON-RPC ID. */
+  id : string | number;
+  /** Number of events sent but not yet acknowledged. */
+  inflight : number;
+  /** Number of events buffered waiting for the window to open. */
+  buffered : number;
+};
+
+/**
+ * Snapshot of a single WebSocket connection for the admin inspector.
+ */
+export type AdminConnectionSnapshot = {
+  /** Unique connection identifier. */
+  id : string;
+  /** ISO-8601 timestamp when the connection was established. */
+  connectedAt : string;
+  /** Number of active subscriptions on this connection. */
+  subscriptionCount : number;
+  /** Per-subscription flow control state. */
+  subscriptions : AdminSubscriptionSnapshot[];
+};

--- a/packages/dwn-server/src/config.ts
+++ b/packages/dwn-server/src/config.ts
@@ -84,6 +84,18 @@ export const config = {
       ? readAdminTokenFromFile(process.env.DWN_ADMIN_TOKEN_FILE)
       : undefined
   ),
+
+  /**
+   * Maximum number of recent DWN activity events retained in the in-memory
+   * ring buffer for the admin `/events` endpoint. Defaults to 10,000.
+   */
+  adminActivityLogCapacity: parseInt(process.env.DWN_ADMIN_ACTIVITY_LOG_CAPACITY || '10000'),
+
+  /**
+   * Interval (in seconds) at which Prometheus gauge metrics are updated from
+   * the admin store. Defaults to 30 seconds.
+   */
+  adminMetricsUpdateIntervalSeconds: parseInt(process.env.DWN_ADMIN_METRICS_UPDATE_INTERVAL || '30'),
 };
 
 /**

--- a/packages/dwn-server/src/connection/connection-manager.ts
+++ b/packages/dwn-server/src/connection/connection-manager.ts
@@ -1,3 +1,5 @@
+import type { ActivityLog } from '../admin/activity-log.js';
+import type { AdminConnectionSnapshot } from '../admin/types.js';
 import type { Dwn } from '@enbox/dwn-sdk-js';
 import type { ServerWebSocket } from 'bun';
 
@@ -12,7 +14,13 @@ export interface ConnectionManager {
   /** connect handler invoked when a new WebSocket connection is established. */
   connect(socket: ServerWebSocket<WsData>): Promise<void>;
   /** closes all of the connections */
-  closeAll(): Promise<void>
+  closeAll(): Promise<void>;
+  /** Returns the number of active connections. */
+  getConnectionCount(): number;
+  /** Returns the total number of active subscriptions across all connections. */
+  getSubscriptionCount(): number;
+  /** Returns serializable snapshots of all active connections. */
+  getConnectionSnapshots(): AdminConnectionSnapshot[];
 }
 
 /**
@@ -24,13 +32,14 @@ export class InMemoryConnectionManager implements ConnectionManager {
     private dwn: Dwn,
     private connections: Map<ServerWebSocket<WsData>, SocketConnection> = new Map(),
     private maxInFlight?: number,
+    private activityLog?: ActivityLog,
   ) {}
 
   async connect(socket: ServerWebSocket<WsData>): Promise<void> {
     const connection = new SocketConnection(socket, this.dwn, () => {
       // this is the onClose handler to clean up any closed connections.
       this.connections.delete(socket);
-    }, this.maxInFlight);
+    }, this.maxInFlight, this.activityLog);
 
     // Attach the connection to the ws.data so Bun's websocket handlers can delegate to it.
     socket.data.connection = connection;
@@ -42,5 +51,25 @@ export class InMemoryConnectionManager implements ConnectionManager {
     const closePromises: Promise<void>[] = [];
     this.connections.forEach((connection) => closePromises.push(connection.close()));
     await Promise.all(closePromises);
+  }
+
+  getConnectionCount(): number {
+    return this.connections.size;
+  }
+
+  getSubscriptionCount(): number {
+    let count = 0;
+    this.connections.forEach((conn) => {
+      count += conn.subscriptionCount;
+    });
+    return count;
+  }
+
+  getConnectionSnapshots(): AdminConnectionSnapshot[] {
+    const snapshots: AdminConnectionSnapshot[] = [];
+    this.connections.forEach((conn) => {
+      snapshots.push(conn.toSnapshot());
+    });
+    return snapshots;
   }
 }

--- a/packages/dwn-server/src/connection/socket-connection.ts
+++ b/packages/dwn-server/src/connection/socket-connection.ts
@@ -1,3 +1,5 @@
+import type { ActivityLog } from '../admin/activity-log.js';
+import type { AdminConnectionSnapshot } from '../admin/types.js';
 import type { RequestContext } from '../lib/json-rpc-router.js';
 import type { ServerWebSocket } from 'bun';
 import type { WsData } from '../http-api.js';
@@ -25,6 +27,12 @@ const HEARTBEAT_INTERVAL = 30_000;
  * and `close()` methods on this class.
  */
 export class SocketConnection {
+  /** Unique identifier for this connection (for admin introspection). */
+  public readonly id: string = uuidv4();
+
+  /** Timestamp when the connection was established (for admin introspection). */
+  public readonly connectedAt: number = Date.now();
+
   private heartbeatInterval: ReturnType<typeof setInterval>;
   private subscriptions: Map<JsonRpcId, JsonRpcSubscription> = new Map();
   private flowControllers: Map<JsonRpcId, FlowController> = new Map();
@@ -35,6 +43,7 @@ export class SocketConnection {
     private dwn: Dwn,
     private onCloseCallback?: () => void,
     private maxInFlight: number = DEFAULT_MAX_IN_FLIGHT,
+    private activityLog?: ActivityLog,
   ){
     // Bun handles ping/pong automatically at the protocol level, but we still
     // want an application-level heartbeat to detect dead connections.
@@ -184,6 +193,33 @@ export class SocketConnection {
   }
 
   /**
+   * Returns the number of active subscriptions on this connection.
+   */
+  get subscriptionCount(): number {
+    return this.subscriptions.size;
+  }
+
+  /**
+   * Returns a serializable snapshot of this connection for the admin inspector.
+   */
+  toSnapshot(): AdminConnectionSnapshot {
+    const subscriptions = Array.from(this.flowControllers.entries()).map(
+      ([id, fc]): AdminConnectionSnapshot['subscriptions'][number] => ({
+        id       : id as string | number,
+        inflight : fc.inFlightCount,
+        buffered : fc.bufferCount,
+      }),
+    );
+
+    return {
+      id                : this.id,
+      connectedAt       : new Date(this.connectedAt).toISOString(),
+      subscriptionCount : this.subscriptions.size,
+      subscriptions,
+    };
+  }
+
+  /**
    * Sends a JSON encoded string through the WebSocket.
    */
   private send(response: JsonRpcResponse | JsonRpcErrorResponse): void {
@@ -228,6 +264,7 @@ export class SocketConnection {
       transport        : 'ws',
       dwn              : this.dwn,
       socketConnection : this,
+      activityLog      : this.activityLog,
     };
 
     // methods that expect a long-running subscription begin with `rpc.subscribe.`

--- a/packages/dwn-server/src/dwn-server.ts
+++ b/packages/dwn-server/src/dwn-server.ts
@@ -10,6 +10,7 @@ import log from 'loglevel';
 import prefix from 'loglevel-plugin-prefix';
 import { Dwn, EventEmitterEventLog } from '@enbox/dwn-sdk-js';
 
+import { ActivityLog } from './admin/activity-log.js';
 import { AdminApi } from './admin/admin-api.js';
 import { AdminStore } from './admin/admin-store.js';
 import { config as defaultConfig } from './config.js';
@@ -122,9 +123,12 @@ export class DwnServer {
 
     // Initialize admin API if an admin token is configured.
     let adminApi: AdminApi | undefined;
+    let activityLog: ActivityLog | undefined;
+
     if (this.config.adminToken) {
       const storageUrl = this.config.messageStore;
       const adminStore = AdminStore.create(storageUrl);
+      activityLog = new ActivityLog(this.config.adminActivityLogCapacity);
 
       adminApi = AdminApi.create({
         config            : this.config,
@@ -132,18 +136,23 @@ export class DwnServer {
         adminStore,
         registrationManager,
         registrationStore : registrationManager?.getRegistrationStore(),
+        activityLog,
       });
 
       log.info('Admin API enabled');
     }
 
-    this.#httpApi = await HttpApi.create(this.config, this.dwn, registrationManager, adminApi);
+    this.#httpApi = await HttpApi.create(
+      this.config, this.dwn, registrationManager, adminApi, activityLog,
+    );
 
     await this.#httpApi.start(this.config.port);
     log.info(`HttpServer listening on port ${this.config.port}`);
 
     if (this.config.webSocketSupport) {
-      this.#wsApi = new WsApi(this.#httpApi, this.dwn, undefined, this.config.maxInFlight);
+      this.#wsApi = new WsApi(
+        this.#httpApi, this.dwn, undefined, this.config.maxInFlight, activityLog,
+      );
       this.#wsApi.start();
       log.info('WebSocketServer ready...');
 
@@ -151,6 +160,11 @@ export class DwnServer {
       if (adminApi) {
         adminApi.setConnectionManager(this.#wsApi.connectionManager);
       }
+    }
+
+    // Start periodic Prometheus gauge updates.
+    if (adminApi) {
+      adminApi.startMetricsUpdater();
     }
   }
 

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DataStream, DateSort, type Dwn, ProtocolsQuery, RecordsQuery, RecordsRead } from '@enbox/dwn-sdk-js';
 
 
+import type { ActivityLog } from './admin/activity-log.js';
 import type { AdminApi } from './admin/admin-api.js';
 import type { DwnServerConfig } from './config.js';
 import type { DwnServerError } from './dwn-error.js';
@@ -35,6 +36,7 @@ export class HttpApi {
   #packageInfo: { version?: string, sdkVersion?: string, server: string };
   #server!: Server<WsData>;
   #adminApi: AdminApi | undefined;
+  #activityLog: ActivityLog | undefined;
   web5ConnectServer: Web5ConnectServer;
   registrationManager: RegistrationManager;
   dwn: Dwn;
@@ -45,7 +47,8 @@ export class HttpApi {
   private constructor() { }
 
   public static async create(
-    config: DwnServerConfig, dwn: Dwn, registrationManager?: RegistrationManager, adminApi?: AdminApi,
+    config: DwnServerConfig, dwn: Dwn, registrationManager?: RegistrationManager,
+    adminApi?: AdminApi, activityLog?: ActivityLog,
   ): Promise<HttpApi> {
     const httpApi = new HttpApi();
 
@@ -68,6 +71,7 @@ export class HttpApi {
     httpApi.#config = config;
     httpApi.dwn = dwn;
     httpApi.#adminApi = adminApi;
+    httpApi.#activityLog = activityLog;
 
     if (registrationManager !== undefined) {
       httpApi.registrationManager = registrationManager;
@@ -352,9 +356,10 @@ export class HttpApi {
     }
 
     const requestContext: RequestContext = {
-      dwn        : this.dwn,
-      transport  : 'http',
-      dataStream : requestDataStream,
+      dwn         : this.dwn,
+      transport   : 'http',
+      dataStream  : requestDataStream,
+      activityLog : this.#activityLog,
     };
     const { jsonRpcResponse, dataStream: responseDataStream } =
       await jsonRpcRouter.handle(dwnRpcRequest, requestContext);

--- a/packages/dwn-server/src/index.ts
+++ b/packages/dwn-server/src/index.ts
@@ -1,5 +1,12 @@
-export { AdminApi, AdminStore } from './admin/index.js';
-export type { AdminHealthCheck, AdminServerStats, AdminTenantDetail, AdminTenantSummary } from './admin/index.js';
+export { ActivityLog, AdminApi, AdminStore } from './admin/index.js';
+export type {
+  AdminActivityEvent,
+  AdminConnectionSnapshot,
+  AdminHealthCheck,
+  AdminServerStats,
+  AdminTenantDetail,
+  AdminTenantSummary,
+} from './admin/index.js';
 export { DwnServerConfig } from './config.js';
 export { DwnServer, DwnServerOptions } from './dwn-server.js';
 export { HttpApi } from './http-api.js';

--- a/packages/dwn-server/src/json-rpc-handlers/dwn/process-message.ts
+++ b/packages/dwn-server/src/json-rpc-handlers/dwn/process-message.ts
@@ -10,6 +10,7 @@ import type {
   JsonRpcHandler,
 } from '../../lib/json-rpc-router.js';
 
+import { requestDataBytesTotal } from '../../metrics.js';
 import {
   createJsonRpcErrorResponse,
   createJsonRpcSuccessResponse,
@@ -105,6 +106,27 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (
     const responsePayload: HandlerResponse = { jsonRpcResponse };
     if (recordDataStream) {
       responsePayload.dataStream = recordDataStream;
+    }
+
+    // Capture activity event and per-request metrics.
+    const dwnInterface = message.descriptor.interface as string;
+    const dwnMethod = message.descriptor.method as string;
+    const statusCode = reply.status?.code ?? 0;
+    const dataSizeBytes = (message.descriptor as { dataSize?: number }).dataSize;
+
+    if (dataSizeBytes !== undefined && dataSizeBytes > 0) {
+      requestDataBytesTotal.inc({ interface: dwnInterface, method: dwnMethod }, dataSizeBytes);
+    }
+
+    if (context.activityLog) {
+      context.activityLog.record({
+        tenant    : target,
+        interface : dwnInterface,
+        method    : dwnMethod,
+        statusCode,
+        transport,
+        dataSizeBytes,
+      });
     }
 
     return responsePayload;

--- a/packages/dwn-server/src/lib/json-rpc-router.ts
+++ b/packages/dwn-server/src/lib/json-rpc-router.ts
@@ -1,3 +1,4 @@
+import type { ActivityLog } from '../admin/activity-log.js';
 import type { SocketConnection } from '../connection/socket-connection.js';
 import type { Dwn, SubscriptionListener } from '@enbox/dwn-sdk-js';
 import type { JsonRpcId, JsonRpcRequest, JsonRpcResponse } from '@enbox/dwn-clients';
@@ -15,6 +16,8 @@ export type RequestContext = {
   }
   /** The `ReadableStream` associated with a `RecordsWrite` request only used in `http` requests */
   dataStream?: ReadableStream<Uint8Array>;
+  /** The admin activity log for capturing DWN request events (optional). */
+  activityLog?: ActivityLog;
 };
 
 export type HandlerResponse = {

--- a/packages/dwn-server/src/metrics.ts
+++ b/packages/dwn-server/src/metrics.ts
@@ -1,4 +1,8 @@
-import { Counter, Histogram } from 'prom-client';
+import { Counter, Gauge, Histogram } from 'prom-client';
+
+// ---------------------------------------------------------------------------
+// Existing metrics
+// ---------------------------------------------------------------------------
 
 export const requestCounter = new Counter({
   name       : 'dwn_requests_total',
@@ -11,4 +15,49 @@ export const responseHistogram = new Histogram({
   help       : 'response histogram',
   buckets    : [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
   labelNames : ['route', 'code'],
+});
+
+// ---------------------------------------------------------------------------
+// Enhanced gauges — updated periodically by AdminApi.startMetricsUpdater()
+// ---------------------------------------------------------------------------
+
+/** Number of active (registered) tenants. */
+export const activeTenants = new Gauge({
+  name : 'dwn_active_tenants',
+  help : 'number of active registered tenants',
+});
+
+/** Total messages stored across all tenants. */
+export const totalMessages = new Gauge({
+  name : 'dwn_total_messages',
+  help : 'total messages stored across all tenants',
+});
+
+/** Total data storage in bytes across all tenants. */
+export const totalDataBytes = new Gauge({
+  name : 'dwn_total_data_bytes',
+  help : 'total data storage bytes across all tenants',
+});
+
+/** Number of active WebSocket connections. */
+export const websocketConnections = new Gauge({
+  name : 'dwn_websocket_connections',
+  help : 'number of active websocket connections',
+});
+
+/** Number of active WebSocket subscriptions. */
+export const websocketSubscriptions = new Gauge({
+  name : 'dwn_websocket_subscriptions',
+  help : 'number of active websocket subscriptions',
+});
+
+// ---------------------------------------------------------------------------
+// Enhanced counters — incremented per-request
+// ---------------------------------------------------------------------------
+
+/** Total data bytes written via RecordsWrite, labeled by interface + method. */
+export const requestDataBytesTotal = new Counter({
+  name       : 'dwn_request_data_bytes_total',
+  help       : 'total data bytes processed in DWN requests',
+  labelNames : ['interface', 'method'],
 });

--- a/packages/dwn-server/src/ws-api.ts
+++ b/packages/dwn-server/src/ws-api.ts
@@ -1,3 +1,4 @@
+import type { ActivityLog } from './admin/activity-log.js';
 import type { Dwn } from '@enbox/dwn-sdk-js';
 import type { ServerWebSocket } from 'bun';
 
@@ -10,9 +11,13 @@ export class WsApi {
   dwn: Dwn;
   #connectionManager: ConnectionManager;
 
-  constructor(httpApi: HttpApi, dwn: Dwn, connectionManager?: ConnectionManager, maxInFlight?: number) {
+  constructor(
+    httpApi: HttpApi, dwn: Dwn, connectionManager?: ConnectionManager,
+    maxInFlight?: number, activityLog?: ActivityLog,
+  ) {
     this.dwn = dwn;
-    this.#connectionManager = connectionManager || new InMemoryConnectionManager(dwn, new Map(), maxInFlight);
+    this.#connectionManager = connectionManager ||
+      new InMemoryConnectionManager(dwn, new Map(), maxInFlight, activityLog);
 
     // Wire up the WebSocket open event from Bun.serve() to the connection manager.
     httpApi.onWebSocketConnection = (ws: ServerWebSocket<WsData>): void => {

--- a/packages/dwn-server/tests/admin/admin-api.test.ts
+++ b/packages/dwn-server/tests/admin/admin-api.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { mkdtempSync, rmSync } from 'fs';
 
+import { ActivityLog } from '../../src/admin/activity-log.js';
 import { config as defaultConfig } from '../../src/config.js';
 import { DwnServer } from '../../src/dwn-server.js';
 
@@ -359,5 +360,272 @@ describe('validateAdminAuth', () => {
     });
     const result = validateAdminAuth(req, { ...defaultConfig, adminToken: 'secret' });
     expect(result).toBeNull();
+  });
+});
+
+// =============================================================================
+// Phase 2 tests
+// =============================================================================
+
+describe('ActivityLog', () => {
+  it('should record and retrieve events', () => {
+    const log = new ActivityLog(100);
+
+    log.record({
+      tenant     : 'did:test:a',
+      interface  : 'Records',
+      method     : 'Write',
+      statusCode : 202,
+      transport  : 'http',
+    });
+
+    log.record({
+      tenant        : 'did:test:b',
+      interface     : 'Records',
+      method        : 'Query',
+      statusCode    : 200,
+      transport     : 'ws',
+      dataSizeBytes : 1024,
+    });
+
+    expect(log.size).toBe(2);
+
+    const { events, cursor } = log.getEvents();
+    expect(events.length).toBe(2);
+    expect(events[0].tenant).toBe('did:test:a');
+    expect(events[0].interface).toBe('Records');
+    expect(events[0].method).toBe('Write');
+    expect(events[0].statusCode).toBe(202);
+    expect(events[0].transport).toBe('http');
+    expect(events[0].id).toBe(1);
+    expect(events[1].id).toBe(2);
+    expect(events[1].dataSizeBytes).toBe(1024);
+    expect(cursor).toBe(2);
+  });
+
+  it('should support cursor-based pagination with the since parameter', () => {
+    const log = new ActivityLog(100);
+
+    for (let i = 0; i < 10; i++) {
+      log.record({
+        tenant     : `did:test:t${i}`,
+        interface  : 'Records',
+        method     : 'Write',
+        statusCode : 202,
+        transport  : 'http',
+      });
+    }
+
+    // Get first 3.
+    const page1 = log.getEvents({ limit: 3 });
+    expect(page1.events.length).toBe(3);
+    expect(page1.cursor).toBe(3);
+
+    // Get next 3 using cursor.
+    const page2 = log.getEvents({ since: page1.cursor, limit: 3 });
+    expect(page2.events.length).toBe(3);
+    expect(page2.events[0].id).toBe(4);
+    expect(page2.cursor).toBe(6);
+  });
+
+  it('should evict oldest events when capacity is exceeded', () => {
+    const log = new ActivityLog(5);
+
+    for (let i = 0; i < 8; i++) {
+      log.record({
+        tenant     : `did:test:t${i}`,
+        interface  : 'Records',
+        method     : 'Write',
+        statusCode : 202,
+        transport  : 'http',
+      });
+    }
+
+    expect(log.size).toBe(5);
+    expect(log.capacity).toBe(5);
+
+    const { events } = log.getEvents({ limit: 100 });
+    // Should contain events 4-8 (ids 4, 5, 6, 7, 8).
+    expect(events[0].id).toBe(4);
+    expect(events[4].id).toBe(8);
+  });
+
+  it('should return empty results when no events match the cursor', () => {
+    const log = new ActivityLog(100);
+
+    log.record({
+      tenant     : 'did:test:a',
+      interface  : 'Records',
+      method     : 'Write',
+      statusCode : 202,
+      transport  : 'http',
+    });
+
+    const { events, cursor } = log.getEvents({ since: 999 });
+    expect(events.length).toBe(0);
+    expect(cursor).toBeUndefined();
+  });
+
+  it('should clear all events', () => {
+    const log = new ActivityLog(100);
+
+    log.record({
+      tenant     : 'did:test:a',
+      interface  : 'Records',
+      method     : 'Write',
+      statusCode : 202,
+      transport  : 'http',
+    });
+
+    expect(log.size).toBe(1);
+    log.clear();
+    expect(log.size).toBe(0);
+  });
+});
+
+describe('AdminApi — Phase 2 endpoints', () => {
+  let dwnServer: DwnServer;
+  let port: number;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    port = 9400 + Math.floor(Math.random() * 900);
+    tmpDir = mkdtempSync(join(tmpdir(), 'dwn-admin-phase2-'));
+    dwnServer = new DwnServer({ config: createTestConfig(port, tmpDir) });
+    await dwnServer.start();
+  });
+
+  afterAll(async () => {
+    await dwnServer.stop();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('GET /admin/api/events', () => {
+    it('should return an events array (possibly empty)', async () => {
+      const response = await adminFetch({ port }, '/events');
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.events).toBeInstanceOf(Array);
+    });
+
+    it('should capture events after a DWN request', async () => {
+      // Send a DWN request to the server (RecordsQuery via JSON-RPC).
+      const dwnRequest = {
+        jsonrpc : '2.0',
+        id      : 'test-events-1',
+        method  : 'dwn.processMessage',
+        params  : {
+          target  : 'did:test:events',
+          message : {
+            descriptor: {
+              interface        : 'Records',
+              method           : 'Query',
+              messageTimestamp : new Date().toISOString(),
+              filter           : {},
+            },
+          },
+        },
+      };
+
+      await fetch(`http://localhost:${port}`, {
+        method  : 'POST',
+        headers : { 'dwn-request': JSON.stringify(dwnRequest) },
+      });
+
+      // Check events endpoint.
+      const response = await adminFetch({ port }, '/events');
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.events.length).toBeGreaterThanOrEqual(1);
+
+      const event = body.events.find((e: any): boolean => e.tenant === 'did:test:events');
+      expect(event).toBeDefined();
+      expect(event.interface).toBe('Records');
+      expect(event.method).toBe('Query');
+      expect(event.transport).toBe('http');
+      expect(typeof event.statusCode).toBe('number');
+      expect(typeof event.timestamp).toBe('string');
+    });
+
+    it('should support since and limit query parameters', async () => {
+      // Get current events to establish a baseline cursor.
+      const baseline = await adminFetch({ port }, '/events');
+      const baseBody = await baseline.json();
+      const cursor = baseBody.cursor ?? 0;
+
+      // Send another request to create a new event.
+      const dwnRequest = {
+        jsonrpc : '2.0',
+        id      : 'test-events-2',
+        method  : 'dwn.processMessage',
+        params  : {
+          target  : 'did:test:events2',
+          message : {
+            descriptor: {
+              interface        : 'Records',
+              method           : 'Query',
+              messageTimestamp : new Date().toISOString(),
+              filter           : {},
+            },
+          },
+        },
+      };
+
+      await fetch(`http://localhost:${port}`, {
+        method  : 'POST',
+        headers : { 'dwn-request': JSON.stringify(dwnRequest) },
+      });
+
+      // Fetch events since cursor.
+      const response = await adminFetch({ port }, `/events?since=${cursor}&limit=1`);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.events.length).toBe(1);
+      expect(body.events[0].tenant).toBe('did:test:events2');
+    });
+  });
+
+  describe('GET /admin/api/connections', () => {
+    it('should return connections array (empty when no WS connections)', async () => {
+      const response = await adminFetch({ port }, '/connections');
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.connections).toBeInstanceOf(Array);
+      // No WS support in test config, so connections should be empty.
+      expect(body.connections.length).toBe(0);
+    });
+  });
+});
+
+describe('Enhanced Prometheus metrics', () => {
+  it('should expose new gauge metrics at the /metrics endpoint', async () => {
+    // Use an existing server with admin enabled.
+    const port = 9500 + Math.floor(Math.random() * 900);
+    const tmpDir = mkdtempSync(join(tmpdir(), 'dwn-admin-metrics-'));
+    const dwnServer = new DwnServer({ config: createTestConfig(port, tmpDir) });
+    await dwnServer.start();
+
+    try {
+      const response = await fetch(`http://localhost:${port}/metrics`);
+      expect(response.status).toBe(200);
+      const metricsText = await response.text();
+
+      // Check new gauges exist.
+      expect(metricsText).toContain('dwn_active_tenants');
+      expect(metricsText).toContain('dwn_total_messages');
+      expect(metricsText).toContain('dwn_total_data_bytes');
+      expect(metricsText).toContain('dwn_websocket_connections');
+      expect(metricsText).toContain('dwn_websocket_subscriptions');
+
+      // Check new counter exists.
+      expect(metricsText).toContain('dwn_request_data_bytes_total');
+
+      // Original metrics should still be present.
+      expect(metricsText).toContain('dwn_requests_total');
+      expect(metricsText).toContain('http_response');
+    } finally {
+      await dwnServer.stop();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Implements Phase 2 of the admin dashboard (#316): enhanced Prometheus metrics, an in-memory activity event log, and a WebSocket connection inspector.

- **Enhanced Prometheus metrics** — 5 new gauges (tenants, messages, data bytes, WS connections, subscriptions) updated periodically from AdminStore, plus a `dwn_request_data_bytes_total` counter labeled by interface/method
- **Activity log ring buffer** — in-memory buffer (default 10K entries, configurable) capturing DWN request events with cursor-based pagination via `GET /admin/api/events`
- **WebSocket connection inspector** — `GET /admin/api/connections` returns active connections with per-subscription flow control state (inflight, buffered)
- **10 new tests**, 0 regressions across 149 total tests

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/admin/api/events?since=&limit=` | Recent DWN activity events (cursor-based) |
| `GET` | `/admin/api/connections` | Active WebSocket connections with subscription state |

## New Prometheus metrics

| Metric | Type | Description |
|--------|------|-------------|
| `dwn_active_tenants` | Gauge | Registered tenant count |
| `dwn_total_messages` | Gauge | Total stored messages |
| `dwn_total_data_bytes` | Gauge | Total data storage bytes |
| `dwn_websocket_connections` | Gauge | Active WebSocket connections |
| `dwn_websocket_subscriptions` | Gauge | Active subscriptions |
| `dwn_request_data_bytes_total` | Counter | Data bytes per interface/method |

## New configuration

| Env var | Default | Description |
|---------|---------|-------------|
| `DWN_ADMIN_ACTIVITY_LOG_CAPACITY` | `10000` | Max events in ring buffer |
| `DWN_ADMIN_METRICS_UPDATE_INTERVAL` | `30` | Gauge update interval (seconds) |

## New files

- `src/admin/activity-log.ts` — Ring buffer with binary search cursor lookup
- Updated 13 existing source files

## Key changes

- `ConnectionManager` interface gains `getConnectionCount()`, `getSubscriptionCount()`, `getConnectionSnapshots()` — replacing unsafe `as any` casts
- `SocketConnection` gains `id`, `connectedAt`, `subscriptionCount`, `toSnapshot()`
- `RequestContext` gains optional `activityLog` field
- `process-message.ts` captures activity events and data byte metrics after DWN processing
- `AdminApi` gains periodic metrics updater (`startMetricsUpdater`/`stopMetricsUpdater`)

## How to test

```bash
bun run --filter @enbox/dwn-server build
bun test --filter @enbox/dwn-server

# Try it locally
DWN_ADMIN_TOKEN=my-secret bun packages/dwn-server/dist/esm/src/main.js
curl -H "Authorization: Bearer my-secret" http://localhost:3000/admin/api/events
curl -H "Authorization: Bearer my-secret" http://localhost:3000/admin/api/connections
curl http://localhost:3000/metrics | grep dwn_active_tenants
```

Closes #323, #324
Epic: #316