### PR TITLE
fix(api): cache records getter, normalize path slashes, and test HTTP schema resolution

### DIFF
--- a/packages/api/src/typed-web5.ts
+++ b/packages/api/src/typed-web5.ts
@@ -229,6 +229,7 @@ export class TypedWeb5<
   private _definition: D;
   private _configured: boolean = false;
   private _validPaths: Set<string>;
+  private _records?: TypedWeb5<D, M>['records'];
 
   constructor(dwn: DwnApi, protocol: TypedProtocol<D, M>) {
     this._dwn = dwn;
@@ -345,7 +346,11 @@ export class TypedWeb5<
       request?: TypedSubscribeRequest,
     ) => Promise<TypedSubscribeResponse<DataForPath<D, M, Path>>>;
     } {
-    return {
+    if (this._records !== undefined) {
+      return this._records;
+    }
+
+    const cached = {
       /**
        * Create a new record at the given protocol path.
        *
@@ -356,8 +361,9 @@ export class TypedWeb5<
         path: Path,
         request: TypedCreateRequest<D, M, Path>,
       ): Promise<TypedCreateResponse<DataForPath<D, M, Path>>> => {
-        this._assertReady(path);
-        const typeName = lastSegment(path);
+        const normalizedPath = normalizePath(path);
+        this._assertReady(normalizedPath);
+        const typeName = lastSegment(normalizedPath);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
         const { status, record } = await this._dwn.records.write({
@@ -371,7 +377,7 @@ export class TypedWeb5<
           protocolRole    : request.protocolRole,
           tags            : request.tags,
           protocol        : this._definition.protocol,
-          protocolPath    : path,
+          protocolPath    : normalizedPath,
           ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
           dataFormat      : request.dataFormat ?? typeEntry?.dataFormats?.[0],
         });
@@ -392,8 +398,9 @@ export class TypedWeb5<
         path: Path,
         request?: TypedQueryRequest,
       ): Promise<TypedQueryResponse<DataForPath<D, M, Path>>> => {
-        this._assertReady(path);
-        const typeName = lastSegment(path);
+        const normalizedPath = normalizePath(path);
+        this._assertReady(normalizedPath);
+        const typeName = lastSegment(normalizedPath);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
         const { status, records, cursor } = await this._dwn.records.query({
@@ -402,7 +409,7 @@ export class TypedWeb5<
           filter     : {
             ...request?.filter,
             protocol     : this._definition.protocol,
-            protocolPath : path,
+            protocolPath : normalizedPath,
             ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
           },
           dateSort     : request?.dateSort,
@@ -427,8 +434,9 @@ export class TypedWeb5<
         path: Path,
         request: TypedReadRequest,
       ): Promise<TypedReadResponse<DataForPath<D, M, Path>>> => {
-        this._assertReady(path);
-        const typeName = lastSegment(path);
+        const normalizedPath = normalizePath(path);
+        this._assertReady(normalizedPath);
+        const typeName = lastSegment(normalizedPath);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
         const { status, record } = await this._dwn.records.read({
@@ -438,7 +446,7 @@ export class TypedWeb5<
           filter     : {
             ...request.filter,
             protocol     : this._definition.protocol,
-            protocolPath : path,
+            protocolPath : normalizedPath,
             ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
           },
         });
@@ -459,7 +467,7 @@ export class TypedWeb5<
         _path: Path,
         request: TypedDeleteRequest,
       ): Promise<DwnResponseStatus> => {
-        this._assertReady(_path);
+        this._assertReady(normalizePath(_path));
         return this._dwn.records.delete({
           from     : request.from,
           protocol : this._definition.protocol,
@@ -481,8 +489,9 @@ export class TypedWeb5<
         path: Path,
         request?: TypedSubscribeRequest,
       ): Promise<TypedSubscribeResponse<DataForPath<D, M, Path>>> => {
-        this._assertReady(path);
-        const typeName = lastSegment(path);
+        const normalizedPath = normalizePath(path);
+        this._assertReady(normalizedPath);
+        const typeName = lastSegment(normalizedPath);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
         const { status, liveQuery } = await this._dwn.records.subscribe({
@@ -490,7 +499,7 @@ export class TypedWeb5<
           filter : {
             ...request?.filter,
             protocol     : this._definition.protocol,
-            protocolPath : path,
+            protocolPath : normalizedPath,
             ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
           },
           protocolRole: request?.protocolRole,
@@ -502,6 +511,9 @@ export class TypedWeb5<
         };
       },
     };
+
+    this._records = cached;
+    return cached;
   }
 }
 
@@ -518,6 +530,15 @@ export class TypedWeb5<
  */
 function definitionsEqual(a: unknown, b: unknown): boolean {
   return stableStringify(a) === stableStringify(b);
+}
+
+/**
+ * Strips leading and trailing slashes from a path.
+ *
+ * `'friend/'` → `'friend'`, `'/group/member/'` → `'group/member'`.
+ */
+function normalizePath(path: string): string {
+  return path.replace(/^\/+|\/+$/g, '');
 }
 
 /**

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -134,6 +134,13 @@ describe('TypedProtocol API', () => {
       const typed = new TypedWeb5(dwnAlice, TodoProtocol);
       expect(typed.definition).toBe(TodoProtocolDefinition);
     });
+
+    it('should return the same records object on repeated access', () => {
+      const typed = new TypedWeb5(dwnAlice, TodoProtocol);
+      const records1 = typed.records;
+      const records2 = typed.records;
+      expect(records1).toBe(records2);
+    });
   });
 
   describe('TypedWeb5.records', () => {
@@ -523,6 +530,46 @@ describe('TypedProtocol API', () => {
       it('should report isConfigured as true after configure()', () => {
         // `typed` is configured in beforeEach
         expect(typed.isConfigured).toBe(true);
+      });
+
+      it('should normalize trailing slashes on create()', async () => {
+        const { status, record } = await typed.records.create('list/' as any, {
+          data: { name: 'Trailing Slash' },
+        });
+
+        expect(status.code).toBe(202);
+        expect(record.protocolPath).toBe('list');
+      });
+
+      it('should normalize trailing slashes on query()', async () => {
+        await typed.records.create('list', { data: { name: 'Slash Test' } });
+
+        const { status, records } = await typed.records.query('list/' as any);
+        expect(status.code).toBe(200);
+        expect(records.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it('should normalize leading slashes', async () => {
+        const { status, record } = await typed.records.create('/list' as any, {
+          data: { name: 'Leading Slash' },
+        });
+
+        expect(status.code).toBe(202);
+        expect(record.protocolPath).toBe('list');
+      });
+
+      it('should normalize nested paths with trailing slashes', async () => {
+        const { record: listRecord } = await typed.records.create('list', {
+          data: { name: 'Nested Slash Test' },
+        });
+
+        const { status, record } = await typed.records.create('list/task/' as any, {
+          data            : { title: 'Slashed Task', completed: false },
+          parentContextId : listRecord.contextId,
+        });
+
+        expect(status.code).toBe(202);
+        expect(record.protocolPath).toBe('list/task');
       });
     });
 

--- a/packages/protocol-codegen/tests/codegen.spec.ts
+++ b/packages/protocol-codegen/tests/codegen.spec.ts
@@ -39,6 +39,43 @@ describe('resolveSchema()', () => {
     expect(result.schema!.title).toBe('ListData');
   });
 
+  it('should resolve via HTTP fetch (strategy 3) when local files are missing', async () => {
+    // Serve a JSON Schema from a local HTTP server.
+    const httpSchema = JSON.stringify({
+      $schema    : 'http://json-schema.org/draft-07/schema#',
+      type       : 'object',
+      properties : { label: { type: 'string' } },
+      required   : ['label'],
+    });
+
+    const server = Bun.serve({
+      port  : 0,
+      fetch : () => new Response(httpSchema, {
+        headers: { 'content-type': 'application/json' },
+      }),
+    });
+
+    try {
+      // Use a schemas dir with no matching files so local strategies fail.
+      const emptyDir = join(FIXTURES_DIR, 'schemas-empty');
+      const { mkdirSync, existsSync: dirExists } = await import('node:fs');
+      if (!dirExists(emptyDir)) { mkdirSync(emptyDir, { recursive: true }); }
+
+      const result = await resolveSchema(
+        'notfound',
+        `http://localhost:${server.port}/schemas/widget`,
+        emptyDir,
+      );
+
+      expect(result.source).toBe('http');
+      expect(result.schema).toBeDefined();
+      expect(result.schema!.type).toBe('object');
+      expect(result.schema!.required).toEqual(['label']);
+    } finally {
+      server.stop();
+    }
+  });
+
   it('should return unresolved when no schema file exists and URI is not fetchable', async () => {
     const result = await resolveSchema(
       'missing',
@@ -234,6 +271,62 @@ describe('generateTypes()', () => {
 
     // photo — binary
     expect(code).toContain('export type PhotoData = Blob;');
+  });
+
+  it('should generate types from HTTP-resolved schemas', async () => {
+    // Serve a schema without a `title` field so json-schema-to-typescript
+    // uses the type name we provide (WidgetData).
+    const httpSchema = JSON.stringify({
+      $schema              : 'http://json-schema.org/draft-07/schema#',
+      type                 : 'object',
+      properties           : { label: { type: 'string' }, count: { type: 'number' } },
+      required             : ['label'],
+      additionalProperties : false,
+    });
+
+    const server = Bun.serve({
+      port  : 0,
+      fetch : () => new Response(httpSchema, {
+        headers: { 'content-type': 'application/json' },
+      }),
+    });
+
+    try {
+      const emptyDir = join(FIXTURES_DIR, 'schemas-empty');
+      const { mkdirSync, existsSync: dirExists } = await import('node:fs');
+      if (!dirExists(emptyDir)) { mkdirSync(emptyDir, { recursive: true }); }
+
+      const definition = {
+        protocol  : 'https://example.com/protocols/http-test',
+        published : true,
+        types     : {
+          widget: {
+            schema      : `http://localhost:${server.port}/schemas/widget`,
+            dataFormats : ['application/json'],
+          },
+        },
+        structure: {
+          widget: {},
+        },
+      };
+
+      const { code, resolutions } = await generateTypes(definition, {
+        schemasDir   : emptyDir,
+        protocolName : 'HttpTest',
+      });
+
+      // Schema should have been resolved via HTTP.
+      expect(resolutions.get('widget')!.source).toBe('http');
+
+      // Generated code should contain the interface from the HTTP schema.
+      expect(code).toContain('export interface WidgetData');
+      expect(code).toContain('label: string');
+      expect(code).toContain('count?: number');
+      expect(code).toContain('export type HttpTestSchemaMap');
+      expect(code).toContain('widget: WidgetData;');
+    } finally {
+      server.stop();
+    }
   });
 
   it('should PascalCase type names correctly', async () => {


### PR DESCRIPTION
## Summary

Implements 3 low-priority improvements from the typed protocols audit:

- **Cache `records` getter** — The `TypedWeb5.records` getter now caches its return object so repeated access (`typed.records.create()`, `typed.records.query()`) reuses the same object instead of allocating a new one with 5 arrow functions each time
- **Normalize path slashes** — Leading and trailing slashes are stripped from protocol paths via `normalizePath()` so that `'friend/'`, `'/friend'`, and `'list/task/'` all resolve correctly
- **Test HTTP fetch schema resolution** — Added 2 tests to `@enbox/protocol-codegen` that spin up a local `Bun.serve()` HTTP server, serve a JSON Schema, and verify the HTTP fetch strategy (strategy 3) resolves successfully through both `resolveSchema()` and `generateTypes()`

## Test results

| File | Tests | Status |
|---|---|---|
| `typed-protocol.spec.ts` | 42 (was 37, +5 new) | All pass |
| `repository.spec.ts` | 31 | All pass |
| `protocols-integration.spec.ts` | 16 | All pass |
| `codegen.spec.ts` | 17 (was 15, +2 new) | All pass |

Lint and build both pass cleanly.

## Changed files

| File | Change |
|---|---|
| `packages/api/src/typed-web5.ts` | `_records` cache field, `normalizePath()` helper, normalized path usage in all 5 CRUD methods |
| `packages/api/tests/typed-protocol.spec.ts` | 1 records caching test + 4 slash normalization tests |
| `packages/protocol-codegen/tests/codegen.spec.ts` | 2 HTTP fetch strategy tests (resolveSchema + generateTypes) |