### PR TITLE
feat(crypto): add COSE/CBOR support for TEE attestation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,6 +126,7 @@
         "@noble/ciphers": "0.5.3",
         "@noble/curves": "1.3.0",
         "@noble/hashes": "1.4.0",
+        "cborg": "^4.5.8",
       },
       "devDependencies": {
         "@types/node": "20.14.8",
@@ -931,7 +932,7 @@
 
     "catering": ["catering@2.1.1", "", {}, "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w=="],
 
-    "cborg": ["cborg@2.0.5", "", { "bin": { "cborg": "cli.js" } }, "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w=="],
+    "cborg": ["cborg@4.5.8", "", { "bin": { "cborg": "lib/bin.js" } }, "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -2215,6 +2216,8 @@
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "@ipld/dag-cbor/cborg": ["cborg@2.0.5", "", { "bin": { "cborg": "cli.js" } }, "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w=="],
+
     "@ipld/dag-cbor/multiformats": ["multiformats@12.1.3", "", {}, "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
@@ -2481,8 +2484,6 @@
 
     "@enbox/dwn-server/sinon/nise": ["nise@5.1.9", "", { "dependencies": { "@sinonjs/commons": "^3.0.0", "@sinonjs/fake-timers": "^11.2.2", "@sinonjs/text-encoding": "^0.7.2", "just-extend": "^6.2.0", "path-to-regexp": "^6.2.1" } }, "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww=="],
 
-    "@enbox/dwn-sql-store/@ipld/dag-cbor/cborg": ["cborg@4.5.8", "", { "bin": { "cborg": "lib/bin.js" } }, "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw=="],
-
     "@enbox/dwn-sql-store/@ipld/dag-cbor/multiformats": ["multiformats@12.1.3", "", {}, "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw=="],
 
     "@enbox/dwn-sql-store/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.19.8", "", { "os": "android", "cpu": "arm" }, "sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA=="],
@@ -2586,8 +2587,6 @@
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "ipfs-unixfs-exporter/@ipld/dag-cbor/cborg": ["cborg@4.5.8", "", { "bin": { "cborg": "lib/bin.js" } }, "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw=="],
 
     "ipfs-unixfs-exporter/@ipld/dag-cbor/multiformats": ["multiformats@12.1.3", "", {}, "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw=="],
 

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -68,10 +68,11 @@
     "bun": ">=1.0.0"
   },
   "dependencies": {
+    "@enbox/common": "workspace:*",
     "@noble/ciphers": "0.5.3",
     "@noble/curves": "1.3.0",
     "@noble/hashes": "1.4.0",
-    "@enbox/common": "workspace:*"
+    "cborg": "^4.5.8"
   },
   "devDependencies": {
     "@types/node": "20.14.8",

--- a/packages/crypto/src/cose/cbor.ts
+++ b/packages/crypto/src/cose/cbor.ts
@@ -1,0 +1,36 @@
+import { decode as cborDecode, encode as cborEncode } from 'cborg';
+
+/**
+ * CBOR (Concise Binary Object Representation) encoding and decoding utilities.
+ *
+ * Provides a thin wrapper around the `cborg` library, exposing `encode` and `decode`
+ * operations for use by COSE and EAT implementations.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc8949 | RFC 8949 — CBOR}
+ */
+export class Cbor {
+  /**
+   * Encodes a JavaScript value to a CBOR byte string.
+   *
+   * @param value - The value to encode. Supports objects, arrays, strings, numbers,
+   *   booleans, null, undefined, Uint8Array (encoded as CBOR byte string), and Map.
+   * @returns The CBOR-encoded bytes.
+   */
+  public static encode(value: unknown): Uint8Array {
+    return cborEncode(value);
+  }
+
+  /**
+   * Decodes a CBOR byte string to a JavaScript value.
+   *
+   * CBOR maps are decoded as JavaScript `Map` instances to support integer keys,
+   * which is required by COSE (RFC 9052) and EAT (RFC 9711).
+   *
+   * @param data - The CBOR-encoded bytes to decode.
+   * @returns The decoded JavaScript value.
+   * @throws If the input is not valid CBOR.
+   */
+  public static decode<T = unknown>(data: Uint8Array): T {
+    return cborDecode(data, { useMaps: true }) as T;
+  }
+}

--- a/packages/crypto/src/cose/cose-key.ts
+++ b/packages/crypto/src/cose/cose-key.ts
@@ -1,0 +1,344 @@
+import type { Jwk } from '../jose/jwk.js';
+
+import { Convert } from '@enbox/common';
+
+import { CryptoError, CryptoErrorCode } from '../crypto-error.js';
+
+/**
+ * COSE Key Type values (RFC 9052, Section 7).
+ *
+ * @see {@link https://www.iana.org/assignments/cose/cose.xhtml#key-type | IANA COSE Key Types}
+ */
+export enum CoseKeyType {
+  /** Octet Key Pair (e.g., Ed25519, X25519) */
+  OKP = 1,
+  /** Elliptic Curve (e.g., P-256, P-384, P-521) */
+  EC2 = 2,
+  /** Symmetric key */
+  Symmetric = 4,
+}
+
+/**
+ * COSE Elliptic Curve identifiers (RFC 9053, Section 7.1).
+ *
+ * @see {@link https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves | IANA COSE Elliptic Curves}
+ */
+export enum CoseEllipticCurve {
+  /** NIST P-256 (secp256r1) */
+  P256 = 1,
+  /** NIST P-384 (secp384r1) */
+  P384 = 2,
+  /** NIST P-521 (secp521r1) */
+  P521 = 3,
+  /** X25519 for ECDH */
+  X25519 = 4,
+  /** X448 for ECDH */
+  X448 = 5,
+  /** Ed25519 for EdDSA */
+  Ed25519 = 6,
+  /** Ed448 for EdDSA */
+  Ed448 = 7,
+  /** secp256k1 */
+  Secp256k1 = 8,
+}
+
+/**
+ * COSE Algorithm identifiers (RFC 9053).
+ *
+ * Only includes algorithms relevant to Enbox confidential compute.
+ *
+ * @see {@link https://www.iana.org/assignments/cose/cose.xhtml#algorithms | IANA COSE Algorithms}
+ */
+export enum CoseAlgorithm {
+  /** EdDSA (Ed25519 or Ed448) */
+  EdDSA = -8,
+  /** ECDSA with SHA-256 (P-256) */
+  ES256 = -7,
+  /** ECDSA with SHA-384 (P-384) */
+  ES384 = -35,
+  /** ECDSA with SHA-512 (P-521) */
+  ES512 = -36,
+  /** ECDSA with SHA-256 (secp256k1) */
+  ES256K = -47,
+}
+
+/**
+ * COSE Key common parameter labels (RFC 9052, Section 7.1).
+ */
+enum CoseKeyLabel {
+  /** Key Type (kty) */
+  Kty = 1,
+  /** Key ID (kid) */
+  Kid = 2,
+  /** Algorithm */
+  Alg = 3,
+  /** Key Operations */
+  KeyOps = 4,
+  /** Base IV */
+  BaseIv = 5,
+}
+
+/**
+ * COSE Key type-specific parameter labels.
+ *
+ * For OKP and EC2 keys, the curve and coordinate labels share the same
+ * negative-integer label space (RFC 9053, Section 7.1-7.2).
+ */
+enum CoseKeyParamLabel {
+  /** Curve identifier (OKP and EC2) */
+  Crv = -1,
+  /** X coordinate (OKP public key or EC2 x-coordinate) */
+  X = -2,
+  /** Y coordinate (EC2 only) */
+  Y = -3,
+  /** Private key (OKP d value or EC2 d value) */
+  D = -4,
+}
+
+/**
+ * Maps JWK curve names to COSE elliptic curve identifiers.
+ */
+const jwkCrvToCose: Record<string, CoseEllipticCurve> = {
+  'P-256'     : CoseEllipticCurve.P256,
+  'P-384'     : CoseEllipticCurve.P384,
+  'P-521'     : CoseEllipticCurve.P521,
+  'X25519'    : CoseEllipticCurve.X25519,
+  'Ed25519'   : CoseEllipticCurve.Ed25519,
+  'Ed448'     : CoseEllipticCurve.Ed448,
+  'secp256k1' : CoseEllipticCurve.Secp256k1,
+};
+
+/**
+ * Maps COSE elliptic curve identifiers to JWK curve names.
+ */
+const coseCrvToJwk: Record<number, string> = {
+  [CoseEllipticCurve.P256]      : 'P-256',
+  [CoseEllipticCurve.P384]      : 'P-384',
+  [CoseEllipticCurve.P521]      : 'P-521',
+  [CoseEllipticCurve.X25519]    : 'X25519',
+  [CoseEllipticCurve.Ed25519]   : 'Ed25519',
+  [CoseEllipticCurve.Ed448]     : 'Ed448',
+  [CoseEllipticCurve.Secp256k1] : 'secp256k1',
+};
+
+/**
+ * Maps JWK algorithm names to COSE algorithm identifiers.
+ */
+const jwkAlgToCose: Record<string, CoseAlgorithm> = {
+  'EdDSA'  : CoseAlgorithm.EdDSA,
+  'ES256'  : CoseAlgorithm.ES256,
+  'ES384'  : CoseAlgorithm.ES384,
+  'ES512'  : CoseAlgorithm.ES512,
+  'ES256K' : CoseAlgorithm.ES256K,
+};
+
+/**
+ * Maps COSE algorithm identifiers to JWK algorithm names.
+ */
+const coseAlgToJwk: Record<number, string> = {
+  [CoseAlgorithm.EdDSA]  : 'EdDSA',
+  [CoseAlgorithm.ES256]  : 'ES256',
+  [CoseAlgorithm.ES384]  : 'ES384',
+  [CoseAlgorithm.ES512]  : 'ES512',
+  [CoseAlgorithm.ES256K] : 'ES256K',
+};
+
+/**
+ * Utilities for converting between JWK and COSE key representations.
+ *
+ * COSE keys use integer labels and CBOR encoding, while JWK uses string
+ * property names and JSON. This class provides bidirectional conversion.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9052#section-7 | RFC 9052, Section 7}
+ */
+export class CoseKey {
+  /**
+   * Converts a JWK to a COSE key represented as a Map.
+   *
+   * @param jwk - The JWK to convert.
+   * @returns A Map with integer labels as keys, suitable for CBOR encoding.
+   * @throws {CryptoError} If the JWK key type or curve is not supported.
+   */
+  public static fromJwk(jwk: Jwk): Map<number, unknown> {
+    const coseKey = new Map<number, unknown>();
+
+    if (jwk.kty === 'OKP') {
+      coseKey.set(CoseKeyLabel.Kty, CoseKeyType.OKP);
+
+      const crv = jwk.crv;
+      if (crv === undefined || !(crv in jwkCrvToCose)) {
+        throw new CryptoError(CryptoErrorCode.AlgorithmNotSupported, `CoseKey: unsupported OKP curve '${crv}'`);
+      }
+      coseKey.set(CoseKeyParamLabel.Crv, jwkCrvToCose[crv]);
+
+      if (jwk.x !== undefined) {
+        coseKey.set(CoseKeyParamLabel.X, Convert.base64Url(jwk.x as string).toUint8Array());
+      }
+      if (jwk.d !== undefined) {
+        coseKey.set(CoseKeyParamLabel.D, Convert.base64Url(jwk.d as string).toUint8Array());
+      }
+    } else if (jwk.kty === 'EC') {
+      coseKey.set(CoseKeyLabel.Kty, CoseKeyType.EC2);
+
+      const crv = jwk.crv;
+      if (crv === undefined || !(crv in jwkCrvToCose)) {
+        throw new CryptoError(CryptoErrorCode.AlgorithmNotSupported, `CoseKey: unsupported EC curve '${crv}'`);
+      }
+      coseKey.set(CoseKeyParamLabel.Crv, jwkCrvToCose[crv]);
+
+      if (jwk.x !== undefined) {
+        coseKey.set(CoseKeyParamLabel.X, Convert.base64Url(jwk.x as string).toUint8Array());
+      }
+      if (jwk.y !== undefined) {
+        coseKey.set(CoseKeyParamLabel.Y, Convert.base64Url(jwk.y as string).toUint8Array());
+      }
+      if (jwk.d !== undefined) {
+        coseKey.set(CoseKeyParamLabel.D, Convert.base64Url(jwk.d as string).toUint8Array());
+      }
+    } else {
+      throw new CryptoError(CryptoErrorCode.AlgorithmNotSupported, `CoseKey: unsupported key type '${jwk.kty}'`);
+    }
+
+    if (jwk.kid !== undefined) {
+      coseKey.set(CoseKeyLabel.Kid, Convert.string(jwk.kid).toUint8Array());
+    }
+
+    if (jwk.alg !== undefined && jwk.alg in jwkAlgToCose) {
+      coseKey.set(CoseKeyLabel.Alg, jwkAlgToCose[jwk.alg]);
+    }
+
+    return coseKey;
+  }
+
+  /**
+   * Converts a COSE key Map to a JWK.
+   *
+   * @param coseKey - A Map with integer labels as keys (from CBOR decoding).
+   * @returns The equivalent JWK.
+   * @throws {CryptoError} If the COSE key type or curve is not supported.
+   */
+  public static toJwk(coseKey: Map<number, unknown>): Jwk {
+    const kty = coseKey.get(CoseKeyLabel.Kty) as number;
+
+    if (kty === CoseKeyType.OKP) {
+      const crv = coseKey.get(CoseKeyParamLabel.Crv) as number;
+      if (!(crv in coseCrvToJwk)) {
+        throw new CryptoError(CryptoErrorCode.AlgorithmNotSupported, `CoseKey: unsupported COSE OKP curve ${crv}`);
+      }
+
+      const jwk: Jwk = {
+        kty : 'OKP',
+        crv : coseCrvToJwk[crv],
+      };
+
+      const x = coseKey.get(CoseKeyParamLabel.X) as Uint8Array | undefined;
+      if (x !== undefined) {
+        jwk.x = Convert.uint8Array(x).toBase64Url();
+      }
+
+      const d = coseKey.get(CoseKeyParamLabel.D) as Uint8Array | undefined;
+      if (d !== undefined) {
+        jwk.d = Convert.uint8Array(d).toBase64Url();
+      }
+
+      CoseKey.applyCommonFields(coseKey, jwk);
+      return jwk;
+
+    } else if (kty === CoseKeyType.EC2) {
+      const crv = coseKey.get(CoseKeyParamLabel.Crv) as number;
+      if (!(crv in coseCrvToJwk)) {
+        throw new CryptoError(CryptoErrorCode.AlgorithmNotSupported, `CoseKey: unsupported COSE EC2 curve ${crv}`);
+      }
+
+      const jwk: Jwk = {
+        kty : 'EC',
+        crv : coseCrvToJwk[crv],
+      };
+
+      const x = coseKey.get(CoseKeyParamLabel.X) as Uint8Array | undefined;
+      if (x !== undefined) {
+        jwk.x = Convert.uint8Array(x).toBase64Url();
+      }
+
+      const y = coseKey.get(CoseKeyParamLabel.Y) as Uint8Array | undefined;
+      if (y !== undefined) {
+        jwk.y = Convert.uint8Array(y).toBase64Url();
+      }
+
+      const d = coseKey.get(CoseKeyParamLabel.D) as Uint8Array | undefined;
+      if (d !== undefined) {
+        jwk.d = Convert.uint8Array(d).toBase64Url();
+      }
+
+      CoseKey.applyCommonFields(coseKey, jwk);
+      return jwk;
+
+    } else {
+      throw new CryptoError(CryptoErrorCode.AlgorithmNotSupported, `CoseKey: unsupported COSE key type ${kty}`);
+    }
+  }
+
+  /**
+   * Infers the COSE algorithm identifier from a JWK.
+   *
+   * If the JWK has an `alg` field, it is used directly. Otherwise, the algorithm
+   * is inferred from the key type and curve.
+   *
+   * @param jwk - The JWK to infer the algorithm from.
+   * @returns The COSE algorithm identifier.
+   * @throws {CryptoError} If the algorithm cannot be determined.
+   */
+  public static algorithmFromJwk(jwk: Jwk): CoseAlgorithm {
+    if (jwk.alg !== undefined && jwk.alg in jwkAlgToCose) {
+      return jwkAlgToCose[jwk.alg];
+    }
+
+    // Infer from key type and curve.
+    if (jwk.kty === 'OKP') {
+      if (jwk.crv === 'Ed25519' || jwk.crv === 'Ed448') {
+        return CoseAlgorithm.EdDSA;
+      }
+    } else if (jwk.kty === 'EC') {
+      switch (jwk.crv) {
+        case 'P-256': return CoseAlgorithm.ES256;
+        case 'P-384': return CoseAlgorithm.ES384;
+        case 'P-521': return CoseAlgorithm.ES512;
+        case 'secp256k1': return CoseAlgorithm.ES256K;
+      }
+    }
+
+    throw new CryptoError(
+      CryptoErrorCode.AlgorithmNotSupported,
+      `CoseKey: cannot determine COSE algorithm for key type '${jwk.kty}' curve '${jwk.crv}'`
+    );
+  }
+
+  /**
+   * Maps a COSE algorithm identifier to a JWK algorithm name.
+   *
+   * @param alg - The COSE algorithm identifier.
+   * @returns The JWK algorithm name.
+   * @throws {CryptoError} If the algorithm is not supported.
+   */
+  public static algorithmToJwk(alg: CoseAlgorithm): string {
+    if (alg in coseAlgToJwk) {
+      return coseAlgToJwk[alg];
+    }
+    throw new CryptoError(CryptoErrorCode.AlgorithmNotSupported, `CoseKey: unsupported COSE algorithm ${alg}`);
+  }
+
+  /**
+   * Applies common COSE key fields (kid, alg) to a JWK.
+   */
+  private static applyCommonFields(coseKey: Map<number, unknown>, jwk: Jwk): void {
+    const kid = coseKey.get(CoseKeyLabel.Kid) as Uint8Array | undefined;
+    if (kid !== undefined) {
+      jwk.kid = Convert.uint8Array(kid).toString();
+    }
+
+    const alg = coseKey.get(CoseKeyLabel.Alg) as number | undefined;
+    if (alg !== undefined && alg in coseAlgToJwk) {
+      jwk.alg = coseAlgToJwk[alg];
+    }
+  }
+}

--- a/packages/crypto/src/cose/cose-sign1.ts
+++ b/packages/crypto/src/cose/cose-sign1.ts
@@ -1,0 +1,473 @@
+import type { Jwk } from '../jose/jwk.js';
+
+import { Cbor } from './cbor.js';
+import { Ed25519 } from '../primitives/ed25519.js';
+import { Secp256r1 } from '../primitives/secp256r1.js';
+import { CoseAlgorithm, CoseKey } from './cose-key.js';
+import { CryptoError, CryptoErrorCode } from '../crypto-error.js';
+
+/**
+ * COSE_Sign1 protected header parameters.
+ *
+ * The protected header is integrity-protected by inclusion in the Sig_structure.
+ * At minimum, it MUST contain the algorithm identifier.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9052#section-4 | RFC 9052, Section 4}
+ */
+export interface CoseSign1ProtectedHeader {
+  /** Algorithm identifier (label 1). Required. */
+  alg: CoseAlgorithm;
+
+  /** Content type (label 3). */
+  contentType?: string | number;
+
+  /** Key ID (label 4). */
+  kid?: Uint8Array;
+
+  /** Additional header parameters. */
+  [key: string]: unknown;
+}
+
+/**
+ * COSE_Sign1 unprotected header parameters.
+ *
+ * These parameters are NOT integrity-protected.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9052#section-4 | RFC 9052, Section 4}
+ */
+export interface CoseSign1UnprotectedHeader {
+  /** Key ID (label 4). */
+  kid?: Uint8Array;
+
+  /** Additional header parameters. */
+  [key: string]: unknown;
+}
+
+/**
+ * Parameters for creating a COSE_Sign1 structure.
+ */
+export interface CoseSign1CreateParams {
+  /** The signing key in JWK format. Must contain the private key (`d`). */
+  key: Jwk;
+
+  /** The payload to sign. */
+  payload: Uint8Array;
+
+  /**
+   * Protected header parameters. If omitted, the algorithm is inferred from the key
+   * and a minimal protected header `{ alg }` is used.
+   */
+  protectedHeader?: CoseSign1ProtectedHeader;
+
+  /** Unprotected header parameters. */
+  unprotectedHeader?: CoseSign1UnprotectedHeader;
+
+  /**
+   * External additional authenticated data (external_aad).
+   * Included in the Sig_structure but not in the COSE_Sign1 message itself.
+   * Defaults to empty bytes.
+   */
+  externalAad?: Uint8Array;
+
+  /**
+   * If true, the payload is detached (not included in the COSE_Sign1 serialization).
+   * The payload field in the CBOR array will be `null`.
+   */
+  detachedPayload?: boolean;
+}
+
+/**
+ * Parameters for verifying a COSE_Sign1 structure.
+ */
+export interface CoseSign1VerifyParams {
+  /** The COSE_Sign1 CBOR-encoded message to verify. */
+  coseSign1: Uint8Array;
+
+  /** The public key in JWK format for verification. */
+  key: Jwk;
+
+  /**
+   * External additional authenticated data (external_aad).
+   * Must match the value used during signing.
+   * Defaults to empty bytes.
+   */
+  externalAad?: Uint8Array;
+
+  /**
+   * Detached payload. Required if the COSE_Sign1 was created with `detachedPayload: true`.
+   */
+  payload?: Uint8Array;
+}
+
+/**
+ * Decoded COSE_Sign1 structure.
+ */
+export interface CoseSign1Decoded {
+  /** The protected header parameters (decoded from CBOR). */
+  protectedHeader: CoseSign1ProtectedHeader;
+
+  /** The raw protected header bytes (needed for signature verification). */
+  protectedHeaderBytes: Uint8Array;
+
+  /** The unprotected header parameters. */
+  unprotectedHeader: Map<number, unknown>;
+
+  /** The payload (null if detached). */
+  payload: Uint8Array | null;
+
+  /** The signature. */
+  signature: Uint8Array;
+}
+
+/**
+ * COSE header label constants (RFC 9052, Section 3.1).
+ */
+enum CoseHeaderLabel {
+  /** Algorithm identifier */
+  Alg = 1,
+  /** Critical headers */
+  Crit = 2,
+  /** Content type */
+  ContentType = 3,
+  /** Key ID */
+  Kid = 4,
+}
+
+/**
+ * CBOR tag for COSE_Sign1 (RFC 9052, Section 4.2).
+ */
+// const COSE_SIGN1_TAG = 18;
+
+/**
+ * COSE_Sign1 implementation per RFC 9052.
+ *
+ * Provides creation, verification, and decoding of COSE_Sign1 (single-signer)
+ * signed messages. This is the CBOR-based counterpart to JOSE/JWS and is used
+ * in TEE attestation (EAT tokens), CWT, and other COSE-based protocols.
+ *
+ * Supported algorithms:
+ * - EdDSA (Ed25519) — CoseAlgorithm.EdDSA (-8)
+ * - ES256 (P-256 / secp256r1 with SHA-256) — CoseAlgorithm.ES256 (-7)
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9052#section-4.3 | RFC 9052, Section 4.3}
+ */
+export class CoseSign1 {
+  /**
+   * Creates a COSE_Sign1 message.
+   *
+   * Constructs the `Sig_structure1` to-be-signed bytes per RFC 9052 Section 4.4,
+   * signs them with the provided key, and returns the CBOR-encoded COSE_Sign1 array:
+   *
+   * ```
+   * COSE_Sign1 = [
+   *   protected : bstr,       ; CBOR-encoded protected header
+   *   unprotected : map,      ; unprotected header parameters
+   *   payload : bstr / nil,   ; payload (nil if detached)
+   *   signature : bstr        ; signature
+   * ]
+   * ```
+   *
+   * @param params - The parameters for creating the COSE_Sign1 message.
+   * @returns The CBOR-encoded COSE_Sign1 message.
+   * @throws {CryptoError} If the algorithm is not supported or signing fails.
+   *
+   * @see {@link https://www.rfc-editor.org/rfc/rfc9052#section-4.3 | RFC 9052, Section 4.3}
+   * @see {@link https://www.rfc-editor.org/rfc/rfc9052#section-4.4 | RFC 9052, Section 4.4}
+   */
+  public static async create(params: CoseSign1CreateParams): Promise<Uint8Array> {
+    const {
+      key,
+      payload,
+      externalAad = new Uint8Array(0),
+      detachedPayload = false,
+    } = params;
+
+    // Build the protected header.
+    const alg = params.protectedHeader?.alg ?? CoseKey.algorithmFromJwk(key);
+    const protectedHeaderMap = CoseSign1.buildProtectedHeaderMap(
+      params.protectedHeader ?? { alg }
+    );
+    const protectedHeaderBytes = Cbor.encode(protectedHeaderMap);
+
+    // Build the unprotected header.
+    const unprotectedHeaderMap = params.unprotectedHeader !== undefined
+      ? CoseSign1.buildUnprotectedHeaderMap(params.unprotectedHeader)
+      : new Map<number, unknown>();
+
+    // Construct the Sig_structure1 (to-be-signed bytes).
+    const sigStructure = CoseSign1.buildSigStructure1(
+      protectedHeaderBytes, externalAad, payload
+    );
+    const toBeSigned = Cbor.encode(sigStructure);
+
+    // Sign the Sig_structure1 bytes.
+    const signature = await CoseSign1.signBytes(alg, key, toBeSigned);
+
+    // Assemble the COSE_Sign1 array.
+    const coseSign1Array = [
+      protectedHeaderBytes,
+      unprotectedHeaderMap,
+      detachedPayload ? null : payload,
+      signature,
+    ];
+
+    return Cbor.encode(coseSign1Array);
+  }
+
+  /**
+   * Verifies a COSE_Sign1 message.
+   *
+   * Decodes the CBOR-encoded message, reconstructs the `Sig_structure1`, and verifies
+   * the signature using the provided public key.
+   *
+   * @param params - The parameters for verifying the COSE_Sign1 message.
+   * @returns `true` if the signature is valid, `false` otherwise.
+   * @throws {CryptoError} If the message is malformed or the algorithm is not supported.
+   *
+   * @see {@link https://www.rfc-editor.org/rfc/rfc9052#section-4.4 | RFC 9052, Section 4.4}
+   */
+  public static async verify(params: CoseSign1VerifyParams): Promise<boolean> {
+    const {
+      coseSign1,
+      key,
+      externalAad = new Uint8Array(0),
+    } = params;
+
+    // Decode the COSE_Sign1 message.
+    const decoded = CoseSign1.decode(coseSign1);
+
+    // Resolve the payload (from message or detached parameter).
+    const payload = decoded.payload ?? params.payload ?? null;
+    if (payload === null) {
+      throw new CryptoError(
+        CryptoErrorCode.InvalidCoseSign1,
+        'CoseSign1: payload is detached but no payload was provided for verification'
+      );
+    }
+
+    // Reconstruct the Sig_structure1.
+    const sigStructure = CoseSign1.buildSigStructure1(
+      decoded.protectedHeaderBytes, externalAad, payload
+    );
+    const toBeSigned = Cbor.encode(sigStructure);
+
+    // Extract the algorithm from the protected header.
+    const alg = decoded.protectedHeader.alg;
+
+    // Verify the signature.
+    return CoseSign1.verifyBytes(alg, key, toBeSigned, decoded.signature);
+  }
+
+  /**
+   * Decodes a CBOR-encoded COSE_Sign1 message into its constituent parts.
+   *
+   * The COSE_Sign1 structure is a CBOR array of four elements:
+   * ```
+   * [protected, unprotected, payload, signature]
+   * ```
+   *
+   * The message may optionally be wrapped in CBOR tag 18.
+   *
+   * @param coseSign1 - The CBOR-encoded COSE_Sign1 message.
+   * @returns The decoded COSE_Sign1 components.
+   * @throws {CryptoError} If the message does not conform to COSE_Sign1 structure.
+   */
+  public static decode(coseSign1: Uint8Array): CoseSign1Decoded {
+    let decoded: unknown;
+    try {
+      decoded = Cbor.decode(coseSign1);
+    } catch {
+      throw new CryptoError(
+        CryptoErrorCode.InvalidCoseSign1,
+        'CoseSign1: failed to decode CBOR'
+      );
+    }
+
+    // Handle CBOR Tagged value (tag 18 for COSE_Sign1).
+    // The `cborg` library decodes tagged values as `Tagged` objects with `tag` and `value` properties.
+    if (decoded !== null && typeof decoded === 'object' && 'tag' in (decoded as Record<string, unknown>)) {
+      const tagged = decoded as { tag: number; value: unknown };
+      if (tagged.tag === 18) {
+        decoded = tagged.value;
+      }
+    }
+
+    // Validate the COSE_Sign1 array structure.
+    if (!Array.isArray(decoded) || decoded.length !== 4) {
+      throw new CryptoError(
+        CryptoErrorCode.InvalidCoseSign1,
+        'CoseSign1: expected a CBOR array of 4 elements [protected, unprotected, payload, signature]'
+      );
+    }
+
+    const [protectedHeaderBytes, unprotectedHeaderMap, payload, signature] = decoded as [
+      Uint8Array, Map<number, unknown>, Uint8Array | null, Uint8Array
+    ];
+
+    // Validate element types.
+    if (!(protectedHeaderBytes instanceof Uint8Array)) {
+      throw new CryptoError(
+        CryptoErrorCode.InvalidCoseSign1,
+        'CoseSign1: protected header must be a byte string'
+      );
+    }
+
+    if (!(signature instanceof Uint8Array)) {
+      throw new CryptoError(
+        CryptoErrorCode.InvalidCoseSign1,
+        'CoseSign1: signature must be a byte string'
+      );
+    }
+
+    // Decode the protected header.
+    let protectedHeaderMap: Map<number, unknown>;
+    if (protectedHeaderBytes.length === 0) {
+      protectedHeaderMap = new Map();
+    } else {
+      try {
+        protectedHeaderMap = Cbor.decode<Map<number, unknown>>(protectedHeaderBytes);
+      } catch {
+        throw new CryptoError(
+          CryptoErrorCode.InvalidCoseSign1,
+          'CoseSign1: failed to decode protected header CBOR'
+        );
+      }
+    }
+
+    // Extract the algorithm from the protected header.
+    const alg = protectedHeaderMap.get(CoseHeaderLabel.Alg);
+    if (alg === undefined || typeof alg !== 'number') {
+      throw new CryptoError(
+        CryptoErrorCode.InvalidCoseSign1,
+        'CoseSign1: protected header must contain an algorithm identifier (label 1)'
+      );
+    }
+
+    // Build the typed protected header.
+    const protectedHeader: CoseSign1ProtectedHeader = { alg: alg as CoseAlgorithm };
+
+    const contentType = protectedHeaderMap.get(CoseHeaderLabel.ContentType);
+    if (contentType !== undefined) {
+      protectedHeader.contentType = contentType as string | number;
+    }
+
+    const kid = protectedHeaderMap.get(CoseHeaderLabel.Kid);
+    if (kid !== undefined) {
+      protectedHeader.kid = kid as Uint8Array;
+    }
+
+    return {
+      protectedHeader,
+      protectedHeaderBytes,
+      unprotectedHeader : unprotectedHeaderMap instanceof Map ? unprotectedHeaderMap : new Map(),
+      payload           : payload instanceof Uint8Array ? payload : null,
+      signature,
+    };
+  }
+
+  /**
+   * Builds the Sig_structure1 array for COSE_Sign1 signing and verification.
+   *
+   * ```
+   * Sig_structure1 = [
+   *   context : "Signature1",
+   *   body_protected : bstr,
+   *   external_aad : bstr,
+   *   payload : bstr
+   * ]
+   * ```
+   *
+   * @see {@link https://www.rfc-editor.org/rfc/rfc9052#section-4.4 | RFC 9052, Section 4.4}
+   */
+  private static buildSigStructure1(
+    protectedHeaderBytes: Uint8Array,
+    externalAad: Uint8Array,
+    payload: Uint8Array,
+  ): unknown[] {
+    return [
+      'Signature1', // context string
+      protectedHeaderBytes, // body_protected
+      externalAad, // external_aad
+      payload, // payload
+    ];
+  }
+
+  /**
+   * Converts a {@link CoseSign1ProtectedHeader} to a CBOR Map with integer labels.
+   */
+  private static buildProtectedHeaderMap(header: CoseSign1ProtectedHeader): Map<number, unknown> {
+    const map = new Map<number, unknown>();
+
+    map.set(CoseHeaderLabel.Alg, header.alg);
+
+    if (header.contentType !== undefined) {
+      map.set(CoseHeaderLabel.ContentType, header.contentType);
+    }
+
+    if (header.kid !== undefined) {
+      map.set(CoseHeaderLabel.Kid, header.kid);
+    }
+
+    return map;
+  }
+
+  /**
+   * Converts a {@link CoseSign1UnprotectedHeader} to a CBOR Map with integer labels.
+   */
+  private static buildUnprotectedHeaderMap(header: CoseSign1UnprotectedHeader): Map<number, unknown> {
+    const map = new Map<number, unknown>();
+
+    if (header.kid !== undefined) {
+      map.set(CoseHeaderLabel.Kid, header.kid);
+    }
+
+    return map;
+  }
+
+  /**
+   * Signs the to-be-signed bytes with the appropriate algorithm.
+   */
+  private static async signBytes(
+    alg: CoseAlgorithm,
+    key: Jwk,
+    data: Uint8Array,
+  ): Promise<Uint8Array> {
+    switch (alg) {
+      case CoseAlgorithm.EdDSA:
+        return Ed25519.sign({ key, data });
+
+      case CoseAlgorithm.ES256:
+        return Secp256r1.sign({ key, data });
+
+      default:
+        throw new CryptoError(
+          CryptoErrorCode.AlgorithmNotSupported,
+          `CoseSign1: signing algorithm ${alg} is not supported`
+        );
+    }
+  }
+
+  /**
+   * Verifies a signature over the to-be-signed bytes with the appropriate algorithm.
+   */
+  private static async verifyBytes(
+    alg: CoseAlgorithm,
+    key: Jwk,
+    data: Uint8Array,
+    signature: Uint8Array,
+  ): Promise<boolean> {
+    switch (alg) {
+      case CoseAlgorithm.EdDSA:
+        return Ed25519.verify({ key, signature, data });
+
+      case CoseAlgorithm.ES256:
+        return Secp256r1.verify({ key, signature, data });
+
+      default:
+        throw new CryptoError(
+          CryptoErrorCode.AlgorithmNotSupported,
+          `CoseSign1: verification algorithm ${alg} is not supported`
+        );
+    }
+  }
+}

--- a/packages/crypto/src/cose/eat.ts
+++ b/packages/crypto/src/cose/eat.ts
@@ -1,0 +1,368 @@
+import type { CoseSign1ProtectedHeader } from './cose-sign1.js';
+import type { Jwk } from '../jose/jwk.js';
+
+import { Cbor } from './cbor.js';
+import { CoseSign1 } from './cose-sign1.js';
+import { CryptoError, CryptoErrorCode } from '../crypto-error.js';
+
+/**
+ * EAT (Entity Attestation Token) claim key constants.
+ *
+ * EAT reuses CWT registered claim keys and adds attestation-specific claims.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9711 | RFC 9711 — Entity Attestation Token (EAT)}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc8392 | RFC 8392 — CWT (CBOR Web Token)}
+ */
+export enum EatClaimKey {
+  /** Issuer (iss) — RFC 8392 */
+  Iss = 1,
+  /** Subject (sub) — RFC 8392 */
+  Sub = 2,
+  /** Audience (aud) — RFC 8392 */
+  Aud = 3,
+  /** Expiration Time (exp) — RFC 8392 */
+  Exp = 4,
+  /** Not Before (nbf) — RFC 8392 */
+  Nbf = 5,
+  /** Issued At (iat) — RFC 8392 */
+  Iat = 6,
+  /** CWT ID (cti) — RFC 8392 */
+  Cti = 7,
+  /** Nonce (eat_nonce) — RFC 9711, Section 4.1 */
+  Nonce = 10,
+  /** UEID (Universal Entity ID) — RFC 9711, Section 4.2.1 */
+  Ueid = 256,
+  /** SUEIDs (Semi-permanent UEIDs) — RFC 9711, Section 4.2.2 */
+  Sueids = 257,
+  /** OEM ID (Hardware OEM Identification) — RFC 9711, Section 4.2.3 */
+  Oemid = 258,
+  /** Hardware Model — RFC 9711, Section 4.2.4 */
+  Hwmodel = 259,
+  /** Hardware Version — RFC 9711, Section 4.2.5 */
+  Hwversion = 260,
+  /** Secure Boot — RFC 9711, Section 4.2.7 */
+  Secboot = 262,
+  /** Debug Status — RFC 9711, Section 4.2.8 */
+  Dbgstat = 263,
+  /** Location — RFC 9711, Section 4.2.9 */
+  Location = 264,
+  /** Profile — RFC 9711, Section 4.2.10 */
+  Profile = 265,
+  /** Submods (Submodules) — RFC 9711, Section 4.2.18 */
+  Submods = 266,
+  /** Measurement Results — RFC 9711, Section 4.2.15 */
+  Measres = 272,
+  /** Intended Use — RFC 9711, Section 4.2.14 */
+  Intuse = 268,
+}
+
+/**
+ * Debug status values for the `dbgstat` claim.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9711#section-4.2.8 | RFC 9711, Section 4.2.8}
+ */
+export enum EatDebugStatus {
+  /** Debug is enabled */
+  Enabled = 0,
+  /** Debug is disabled */
+  Disabled = 1,
+  /** Debug is disabled since manufacture */
+  DisabledSinceBoot = 2,
+  /** Debug is disabled permanently */
+  DisabledPermanently = 3,
+  /** Debug is disabled fully and permanently */
+  DisabledFullyAndPermanently = 4,
+}
+
+/**
+ * Security level for the `seclevel` claim.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9711#section-4.2.6 | RFC 9711, Section 4.2.6}
+ */
+export enum EatSecurityLevel {
+  /** Unrestricted — no security guarantees */
+  Unrestricted = 1,
+  /** Restricted — some restrictions on environment */
+  Restricted = 2,
+  /** Secure Restricted — hardware-enforced restrictions */
+  SecureRestricted = 3,
+  /** Hardware — hardware-isolated execution environment */
+  Hardware = 4,
+}
+
+/**
+ * Parsed EAT claims, providing typed access to standard and attestation-specific claims.
+ *
+ * All fields are optional because EAT does not mandate any specific claims; the
+ * required set depends on the attestation profile.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9711 | RFC 9711}
+ */
+export interface EatClaims {
+  /** Issuer — identifies the entity that issued the token. */
+  iss?: string;
+
+  /** Subject — identifies the entity that is the subject of the token. */
+  sub?: string;
+
+  /** Audience — identifies the intended recipient(s). */
+  aud?: string;
+
+  /** Expiration time (seconds since epoch). */
+  exp?: number;
+
+  /** Not Before (seconds since epoch). */
+  nbf?: number;
+
+  /** Issued At (seconds since epoch). */
+  iat?: number;
+
+  /** CWT ID — unique token identifier (byte string). */
+  cti?: Uint8Array;
+
+  /** Nonce — challenge value binding the token to a request. */
+  nonce?: Uint8Array | Uint8Array[];
+
+  /** Universal Entity ID. */
+  ueid?: Uint8Array;
+
+  /** Hardware model identifier. */
+  hwmodel?: Uint8Array;
+
+  /** Hardware version. */
+  hwversion?: unknown;
+
+  /** Debug status. */
+  dbgstat?: EatDebugStatus;
+
+  /** Measurement results — software component measurements. */
+  measres?: unknown;
+
+  /** Submodules — nested EAT tokens or claims from sub-components. */
+  submods?: Map<string, unknown>;
+
+  /**
+   * All raw claims as a Map for access to non-standard or profile-specific claims.
+   * Integer keys correspond to {@link EatClaimKey} values.
+   */
+  rawClaims: Map<number | string, unknown>;
+}
+
+/**
+ * Parameters for decoding an EAT token.
+ */
+export interface EatDecodeParams {
+  /** The CBOR-encoded EAT token (COSE_Sign1 envelope). */
+  token: Uint8Array;
+}
+
+/**
+ * Parameters for verifying and decoding an EAT token.
+ */
+export interface EatVerifyParams {
+  /** The CBOR-encoded EAT token (COSE_Sign1 envelope). */
+  token: Uint8Array;
+
+  /** The public key for signature verification, in JWK format. */
+  key: Jwk;
+
+  /** External additional authenticated data. Defaults to empty bytes. */
+  externalAad?: Uint8Array;
+}
+
+/**
+ * Result of decoding an EAT token.
+ */
+export interface EatDecodeResult {
+  /** The parsed protected header from the COSE_Sign1 envelope. */
+  protectedHeader: CoseSign1ProtectedHeader;
+
+  /** The parsed EAT claims from the payload. */
+  claims: EatClaims;
+}
+
+/**
+ * Entity Attestation Token (EAT) implementation per RFC 9711.
+ *
+ * EATs are CBOR-based attestation tokens carried in COSE_Sign1 envelopes.
+ * They are used by TEE platforms (ARM CCA, Intel TDX, AMD SEV-SNP, Nitro Enclaves)
+ * to provide hardware-rooted attestation evidence.
+ *
+ * This implementation focuses on decoding and verification of EAT tokens — the
+ * primary use case for a DWN node that needs to verify TEE attestation from
+ * compute modules.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9711 | RFC 9711 — Entity Attestation Token (EAT)}
+ */
+export class Eat {
+  /**
+   * Decodes an EAT token without verifying its signature.
+   *
+   * Use this method only when signature verification is performed separately
+   * (e.g., by a TEE attestation service) or for debugging/inspection.
+   *
+   * @param params - The parameters for decoding.
+   * @returns The decoded protected header and claims.
+   * @throws {CryptoError} If the token is not valid COSE_Sign1 or the payload is not valid CBOR.
+   */
+  public static decode({ token }: EatDecodeParams): EatDecodeResult {
+    // Decode the COSE_Sign1 envelope.
+    const coseSign1 = CoseSign1.decode(token);
+
+    if (coseSign1.payload === null) {
+      throw new CryptoError(
+        CryptoErrorCode.InvalidEat,
+        'Eat: token has detached payload; use verifyAndDecode with the payload provided separately'
+      );
+    }
+
+    // Decode the CBOR payload into claims.
+    const claims = Eat.parseClaims(coseSign1.payload);
+
+    return {
+      protectedHeader: coseSign1.protectedHeader,
+      claims,
+    };
+  }
+
+  /**
+   * Verifies the signature of an EAT token and decodes its claims.
+   *
+   * This is the primary method for processing EAT tokens from TEE attestation.
+   * It verifies the COSE_Sign1 signature using the provided public key, then
+   * parses the EAT claims from the payload.
+   *
+   * @param params - The parameters for verification and decoding.
+   * @returns The decoded protected header and claims if verification succeeds.
+   * @throws {CryptoError} If verification fails or the token is malformed.
+   */
+  public static async verifyAndDecode(params: EatVerifyParams): Promise<EatDecodeResult> {
+    const { token, key, externalAad } = params;
+
+    // Verify the COSE_Sign1 signature.
+    const isValid = await CoseSign1.verify({
+      coseSign1: token,
+      key,
+      externalAad,
+    });
+
+    if (!isValid) {
+      throw new CryptoError(
+        CryptoErrorCode.InvalidEat,
+        'Eat: signature verification failed'
+      );
+    }
+
+    // Decode and return claims (signature is already verified).
+    return Eat.decode({ token });
+  }
+
+  /**
+   * Parses CBOR-encoded EAT claims into a typed {@link EatClaims} object.
+   *
+   * Handles both integer-keyed (CBOR standard) and string-keyed claims.
+   *
+   * @param payload - The CBOR-encoded claims byte string.
+   * @returns The parsed EAT claims.
+   * @throws {CryptoError} If the payload is not valid CBOR or not a map.
+   */
+  private static parseClaims(payload: Uint8Array): EatClaims {
+    let rawClaims: Map<number | string, unknown>;
+
+    try {
+      const decoded = Cbor.decode<unknown>(payload);
+      if (decoded instanceof Map) {
+        rawClaims = decoded as Map<number | string, unknown>;
+      } else if (typeof decoded === 'object' && decoded !== null) {
+        // Some encoders produce plain objects instead of Maps for maps with string keys.
+        rawClaims = new Map(Object.entries(decoded));
+      } else {
+        throw new Error('not a map');
+      }
+    } catch (error) {
+      if (error instanceof CryptoError) {
+        throw error;
+      }
+      throw new CryptoError(
+        CryptoErrorCode.InvalidEat,
+        'Eat: payload is not a valid CBOR map'
+      );
+    }
+
+    const claims: EatClaims = { rawClaims };
+
+    // Extract standard CWT claims.
+    const iss = rawClaims.get(EatClaimKey.Iss);
+    if (iss !== undefined) {
+      claims.iss = iss as string;
+    }
+
+    const sub = rawClaims.get(EatClaimKey.Sub);
+    if (sub !== undefined) {
+      claims.sub = sub as string;
+    }
+
+    const aud = rawClaims.get(EatClaimKey.Aud);
+    if (aud !== undefined) {
+      claims.aud = aud as string;
+    }
+
+    const exp = rawClaims.get(EatClaimKey.Exp);
+    if (exp !== undefined) {
+      claims.exp = exp as number;
+    }
+
+    const nbf = rawClaims.get(EatClaimKey.Nbf);
+    if (nbf !== undefined) {
+      claims.nbf = nbf as number;
+    }
+
+    const iat = rawClaims.get(EatClaimKey.Iat);
+    if (iat !== undefined) {
+      claims.iat = iat as number;
+    }
+
+    const cti = rawClaims.get(EatClaimKey.Cti);
+    if (cti !== undefined) {
+      claims.cti = cti as Uint8Array;
+    }
+
+    // Extract EAT-specific claims.
+    const nonce = rawClaims.get(EatClaimKey.Nonce);
+    if (nonce !== undefined) {
+      claims.nonce = nonce as Uint8Array | Uint8Array[];
+    }
+
+    const ueid = rawClaims.get(EatClaimKey.Ueid);
+    if (ueid !== undefined) {
+      claims.ueid = ueid as Uint8Array;
+    }
+
+    const hwmodel = rawClaims.get(EatClaimKey.Hwmodel);
+    if (hwmodel !== undefined) {
+      claims.hwmodel = hwmodel as Uint8Array;
+    }
+
+    const hwversion = rawClaims.get(EatClaimKey.Hwversion);
+    if (hwversion !== undefined) {
+      claims.hwversion = hwversion;
+    }
+
+    const dbgstat = rawClaims.get(EatClaimKey.Dbgstat);
+    if (dbgstat !== undefined) {
+      claims.dbgstat = dbgstat as EatDebugStatus;
+    }
+
+    const measres = rawClaims.get(EatClaimKey.Measres);
+    if (measres !== undefined) {
+      claims.measres = measres;
+    }
+
+    const submods = rawClaims.get(EatClaimKey.Submods);
+    if (submods !== undefined) {
+      claims.submods = submods as Map<string, unknown>;
+    }
+
+    return claims;
+  }
+}

--- a/packages/crypto/src/crypto-error.ts
+++ b/packages/crypto/src/crypto-error.ts
@@ -34,6 +34,12 @@ export enum CryptoErrorCode {
   /** The encoding operation (either encoding or decoding) failed. */
   EncodingError = 'encodingError',
 
+  /** The COSE_Sign1 message does not conform to valid structure. */
+  InvalidCoseSign1 = 'invalidCoseSign1',
+
+  /** The EAT (Entity Attestation Token) is malformed or failed verification. */
+  InvalidEat = 'invalidEat',
+
   /** The JWE supplied does not conform to valid syntax. */
   InvalidJwe = 'invalidJwe',
 

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -2,6 +2,11 @@ export * from './crypto-error.js';
 export * from './local-key-manager.js';
 export * from './utils.js';
 
+export * from './cose/cbor.js';
+export * from './cose/cose-key.js';
+export * from './cose/cose-sign1.js';
+export * from './cose/eat.js';
+
 export * from './algorithms/aes-ctr.js';
 export * from './algorithms/aes-gcm.js';
 export * from './algorithms/aes-kw.js';

--- a/packages/crypto/tests/cose/cbor.test.ts
+++ b/packages/crypto/tests/cose/cbor.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'bun:test';
+
+import { Cbor } from '../../src/cose/cbor.js';
+
+describe('Cbor', () => {
+  describe('encode()', () => {
+    it('should encode a simple integer', () => {
+      const encoded = Cbor.encode(42);
+      expect(encoded).toBeInstanceOf(Uint8Array);
+      expect(encoded.length).toBeGreaterThan(0);
+    });
+
+    it('should encode a string', () => {
+      const encoded = Cbor.encode('hello');
+      expect(encoded).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should encode a Uint8Array as a CBOR byte string', () => {
+      const input = new Uint8Array([1, 2, 3, 4]);
+      const encoded = Cbor.encode(input);
+      expect(encoded).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should encode an object', () => {
+      const input = { a: 1, b: 'two', c: true };
+      const encoded = Cbor.encode(input);
+      expect(encoded).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should encode a Map', () => {
+      const input = new Map<number, unknown>([
+        [1, 'one'],
+        [2, 'two'],
+      ]);
+      const encoded = Cbor.encode(input);
+      expect(encoded).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should encode null and undefined', () => {
+      const encodedNull = Cbor.encode(null);
+      expect(encodedNull).toBeInstanceOf(Uint8Array);
+
+      const encodedUndefined = Cbor.encode(undefined);
+      expect(encodedUndefined).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should encode an array', () => {
+      const input = [1, 'two', true, null];
+      const encoded = Cbor.encode(input);
+      expect(encoded).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should encode a boolean', () => {
+      const encodedTrue = Cbor.encode(true);
+      const encodedFalse = Cbor.encode(false);
+      expect(encodedTrue).toBeInstanceOf(Uint8Array);
+      expect(encodedFalse).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should encode negative integers', () => {
+      const encoded = Cbor.encode(-42);
+      expect(encoded).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  describe('decode()', () => {
+    it('should round-trip a simple integer', () => {
+      const input = 42;
+      const encoded = Cbor.encode(input);
+      const decoded = Cbor.decode<number>(encoded);
+      expect(decoded).toBe(input);
+    });
+
+    it('should round-trip a string', () => {
+      const input = 'hello world';
+      const encoded = Cbor.encode(input);
+      const decoded = Cbor.decode<string>(encoded);
+      expect(decoded).toBe(input);
+    });
+
+    it('should round-trip a Uint8Array', () => {
+      const input = new Uint8Array([10, 20, 30, 40, 50]);
+      const encoded = Cbor.encode(input);
+      const decoded = Cbor.decode<Uint8Array>(encoded);
+      expect(decoded).toEqual(input);
+    });
+
+    it('should round-trip an object as a Map with string keys', () => {
+      const input = { x: 1, y: 'hello', z: false };
+      const encoded = Cbor.encode(input);
+      const decoded = Cbor.decode<Map<string, unknown>>(encoded);
+
+      // With useMaps: true, objects round-trip as Maps.
+      expect(decoded).toBeInstanceOf(Map);
+      expect(decoded.get('x')).toBe(1);
+      expect(decoded.get('y')).toBe('hello');
+      expect(decoded.get('z')).toBe(false);
+    });
+
+    it('should round-trip a Map with integer keys', () => {
+      const input = new Map<number, unknown>([
+        [1, -7],
+        [4, new Uint8Array([1, 2, 3])],
+      ]);
+      const encoded = Cbor.encode(input);
+      const decoded = Cbor.decode<Map<number, unknown>>(encoded);
+      expect(decoded).toBeInstanceOf(Map);
+      expect(decoded.get(1)).toBe(-7);
+      expect(decoded.get(4)).toEqual(new Uint8Array([1, 2, 3]));
+    });
+
+    it('should round-trip an array', () => {
+      const input = [1, 'two', true, null];
+      const encoded = Cbor.encode(input);
+      const decoded = Cbor.decode<unknown[]>(encoded);
+      expect(decoded).toEqual(input);
+    });
+
+    it('should round-trip null', () => {
+      const encoded = Cbor.encode(null);
+      const decoded = Cbor.decode(encoded);
+      expect(decoded).toBeNull();
+    });
+
+    it('should round-trip negative integers', () => {
+      const input = -100;
+      const encoded = Cbor.encode(input);
+      const decoded = Cbor.decode<number>(encoded);
+      expect(decoded).toBe(input);
+    });
+
+    it('should round-trip nested structures', () => {
+      const input = new Map<number, unknown>([
+        [1, new Map<number, unknown>([
+          [2, new Uint8Array([0xDE, 0xAD])],
+        ])],
+        [3, [1, 2, 3]],
+      ]);
+      const encoded = Cbor.encode(input);
+      const decoded = Cbor.decode<Map<number, unknown>>(encoded);
+      expect(decoded).toBeInstanceOf(Map);
+
+      const inner = decoded.get(1) as Map<number, unknown>;
+      expect(inner).toBeInstanceOf(Map);
+      expect(inner.get(2)).toEqual(new Uint8Array([0xDE, 0xAD]));
+      expect(decoded.get(3)).toEqual([1, 2, 3]);
+    });
+
+    it('should throw on invalid CBOR input', () => {
+      const invalidCbor = new Uint8Array([0xFF, 0xFF, 0xFF]);
+      expect(() => Cbor.decode(invalidCbor)).toThrow();
+    });
+  });
+});

--- a/packages/crypto/tests/cose/cose-key.test.ts
+++ b/packages/crypto/tests/cose/cose-key.test.ts
@@ -1,0 +1,222 @@
+import type { Jwk } from '../../src/jose/jwk.js';
+
+import { Convert } from '@enbox/common';
+import { describe, expect, it } from 'bun:test';
+
+import { CoseAlgorithm, CoseEllipticCurve, CoseKey, CoseKeyType } from '../../src/cose/cose-key.js';
+
+describe('CoseKey', () => {
+  // Test keys.
+  const ed25519Jwk: Jwk = {
+    kty : 'OKP',
+    crv : 'Ed25519',
+    x   : '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+    d   : 'nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A',
+    alg : 'EdDSA',
+    kid : 'test-ed25519',
+  };
+
+  const p256Jwk: Jwk = {
+    kty : 'EC',
+    crv : 'P-256',
+    x   : 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+    y   : 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+    d   : 'jpsQnnGQmL-YBIffS1BSyVKhrlmbvbzU_HP5_DW29TQ',
+    alg : 'ES256',
+    kid : 'test-p256',
+  };
+
+  const x25519Jwk: Jwk = {
+    kty : 'OKP',
+    crv : 'X25519',
+    x   : '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+  };
+
+  describe('fromJwk()', () => {
+    it('should convert an Ed25519 JWK to a COSE key Map', () => {
+      const coseKey = CoseKey.fromJwk(ed25519Jwk);
+
+      expect(coseKey).toBeInstanceOf(Map);
+      expect(coseKey.get(1)).toBe(CoseKeyType.OKP); // kty
+      expect(coseKey.get(-1)).toBe(CoseEllipticCurve.Ed25519); // crv
+      expect(coseKey.get(-2)).toBeInstanceOf(Uint8Array); // x
+      expect(coseKey.get(-4)).toBeInstanceOf(Uint8Array); // d
+      expect(coseKey.get(2)).toBeInstanceOf(Uint8Array); // kid
+      expect(coseKey.get(3)).toBe(CoseAlgorithm.EdDSA); // alg
+    });
+
+    it('should convert a P-256 JWK to a COSE key Map', () => {
+      const coseKey = CoseKey.fromJwk(p256Jwk);
+
+      expect(coseKey).toBeInstanceOf(Map);
+      expect(coseKey.get(1)).toBe(CoseKeyType.EC2);
+      expect(coseKey.get(-1)).toBe(CoseEllipticCurve.P256);
+      expect(coseKey.get(-2)).toBeInstanceOf(Uint8Array); // x
+      expect(coseKey.get(-3)).toBeInstanceOf(Uint8Array); // y
+      expect(coseKey.get(-4)).toBeInstanceOf(Uint8Array); // d
+      expect(coseKey.get(3)).toBe(CoseAlgorithm.ES256);
+    });
+
+    it('should convert a public-only OKP JWK (no d)', () => {
+      const publicOnlyJwk: Jwk = {
+        kty : 'OKP',
+        crv : 'Ed25519',
+        x   : '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+      };
+
+      const coseKey = CoseKey.fromJwk(publicOnlyJwk);
+      expect(coseKey.get(-2)).toBeInstanceOf(Uint8Array); // x
+      expect(coseKey.has(-4)).toBe(false); // no d
+    });
+
+    it('should convert an X25519 JWK', () => {
+      const coseKey = CoseKey.fromJwk(x25519Jwk);
+
+      expect(coseKey.get(1)).toBe(CoseKeyType.OKP);
+      expect(coseKey.get(-1)).toBe(CoseEllipticCurve.X25519);
+    });
+
+    it('should throw for unsupported key type', () => {
+      const unsupported: Jwk = { kty: 'oct' } as Jwk;
+      expect(() => CoseKey.fromJwk(unsupported)).toThrow('unsupported key type');
+    });
+
+    it('should throw for OKP with unsupported curve', () => {
+      const badCrv: Jwk = { kty: 'OKP', crv: 'FancyCurve' } as Jwk;
+      expect(() => CoseKey.fromJwk(badCrv)).toThrow('unsupported OKP curve');
+    });
+
+    it('should throw for EC with unsupported curve', () => {
+      const badCrv: Jwk = { kty: 'EC', crv: 'FancyCurve' } as Jwk;
+      expect(() => CoseKey.fromJwk(badCrv)).toThrow('unsupported EC curve');
+    });
+
+    it('should omit kid and alg when not present in JWK', () => {
+      const minimalJwk: Jwk = {
+        kty : 'OKP',
+        crv : 'Ed25519',
+        x   : '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+      };
+      const coseKey = CoseKey.fromJwk(minimalJwk);
+      expect(coseKey.has(2)).toBe(false); // kid
+      expect(coseKey.has(3)).toBe(false); // alg
+    });
+  });
+
+  describe('toJwk()', () => {
+    it('should round-trip an Ed25519 JWK through COSE', () => {
+      const coseKey = CoseKey.fromJwk(ed25519Jwk);
+      const roundTripped = CoseKey.toJwk(coseKey);
+
+      expect(roundTripped.kty).toBe('OKP');
+      expect(roundTripped.crv).toBe('Ed25519');
+      expect(roundTripped.x).toBe(ed25519Jwk.x);
+      expect(roundTripped.d).toBe(ed25519Jwk.d);
+      expect(roundTripped.alg).toBe('EdDSA');
+      expect(roundTripped.kid).toBe(ed25519Jwk.kid);
+    });
+
+    it('should round-trip a P-256 JWK through COSE', () => {
+      const coseKey = CoseKey.fromJwk(p256Jwk);
+      const roundTripped = CoseKey.toJwk(coseKey);
+
+      expect(roundTripped.kty).toBe('EC');
+      expect(roundTripped.crv).toBe('P-256');
+      expect(roundTripped.x).toBe(p256Jwk.x);
+      expect(roundTripped.y).toBe(p256Jwk.y);
+      expect(roundTripped.d).toBe(p256Jwk.d);
+      expect(roundTripped.alg).toBe('ES256');
+    });
+
+    it('should convert an OKP COSE key without d to a public-only JWK', () => {
+      const coseKey = new Map<number, unknown>([
+        [1, CoseKeyType.OKP],
+        [-1, CoseEllipticCurve.Ed25519],
+        [-2, Convert.base64Url('11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo').toUint8Array()],
+      ]);
+      const jwk = CoseKey.toJwk(coseKey);
+      expect(jwk.kty).toBe('OKP');
+      expect(jwk.crv).toBe('Ed25519');
+      expect(jwk.x).toBeDefined();
+      expect(jwk.d).toBeUndefined();
+    });
+
+    it('should throw for unsupported COSE key type', () => {
+      const badKey = new Map<number, unknown>([[1, 99]]);
+      expect(() => CoseKey.toJwk(badKey)).toThrow('unsupported COSE key type');
+    });
+
+    it('should throw for unsupported COSE OKP curve', () => {
+      const badKey = new Map<number, unknown>([
+        [1, CoseKeyType.OKP],
+        [-1, 99],
+      ]);
+      expect(() => CoseKey.toJwk(badKey)).toThrow('unsupported COSE OKP curve');
+    });
+
+    it('should throw for unsupported COSE EC2 curve', () => {
+      const badKey = new Map<number, unknown>([
+        [1, CoseKeyType.EC2],
+        [-1, 99],
+      ]);
+      expect(() => CoseKey.toJwk(badKey)).toThrow('unsupported COSE EC2 curve');
+    });
+  });
+
+  describe('algorithmFromJwk()', () => {
+    it('should return EdDSA for an Ed25519 JWK with alg set', () => {
+      expect(CoseKey.algorithmFromJwk(ed25519Jwk)).toBe(CoseAlgorithm.EdDSA);
+    });
+
+    it('should return ES256 for a P-256 JWK with alg set', () => {
+      expect(CoseKey.algorithmFromJwk(p256Jwk)).toBe(CoseAlgorithm.ES256);
+    });
+
+    it('should infer EdDSA from an Ed25519 JWK without alg', () => {
+      const jwk: Jwk = { kty: 'OKP', crv: 'Ed25519', x: 'abc' };
+      expect(CoseKey.algorithmFromJwk(jwk)).toBe(CoseAlgorithm.EdDSA);
+    });
+
+    it('should infer ES256 from a P-256 JWK without alg', () => {
+      const jwk: Jwk = { kty: 'EC', crv: 'P-256', x: 'abc', y: 'def' };
+      expect(CoseKey.algorithmFromJwk(jwk)).toBe(CoseAlgorithm.ES256);
+    });
+
+    it('should infer ES384 from a P-384 JWK without alg', () => {
+      const jwk: Jwk = { kty: 'EC', crv: 'P-384', x: 'abc', y: 'def' };
+      expect(CoseKey.algorithmFromJwk(jwk)).toBe(CoseAlgorithm.ES384);
+    });
+
+    it('should infer ES256K from a secp256k1 JWK without alg', () => {
+      const jwk: Jwk = { kty: 'EC', crv: 'secp256k1', x: 'abc', y: 'def' };
+      expect(CoseKey.algorithmFromJwk(jwk)).toBe(CoseAlgorithm.ES256K);
+    });
+
+    it('should throw for a JWK with unknown key type and no alg', () => {
+      const jwk: Jwk = { kty: 'oct' } as Jwk;
+      expect(() => CoseKey.algorithmFromJwk(jwk)).toThrow('cannot determine COSE algorithm');
+    });
+
+    it('should throw for X25519 (not a signing curve)', () => {
+      expect(() => CoseKey.algorithmFromJwk(x25519Jwk)).toThrow('cannot determine COSE algorithm');
+    });
+  });
+
+  describe('algorithmToJwk()', () => {
+    it('should map EdDSA to "EdDSA"', () => {
+      expect(CoseKey.algorithmToJwk(CoseAlgorithm.EdDSA)).toBe('EdDSA');
+    });
+
+    it('should map ES256 to "ES256"', () => {
+      expect(CoseKey.algorithmToJwk(CoseAlgorithm.ES256)).toBe('ES256');
+    });
+
+    it('should map ES384 to "ES384"', () => {
+      expect(CoseKey.algorithmToJwk(CoseAlgorithm.ES384)).toBe('ES384');
+    });
+
+    it('should throw for unsupported algorithm', () => {
+      expect(() => CoseKey.algorithmToJwk(999 as CoseAlgorithm)).toThrow('unsupported COSE algorithm');
+    });
+  });
+});

--- a/packages/crypto/tests/cose/cose-sign1.test.ts
+++ b/packages/crypto/tests/cose/cose-sign1.test.ts
@@ -1,0 +1,319 @@
+import type { Jwk } from '../../src/jose/jwk.js';
+
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+import { Cbor } from '../../src/cose/cbor.js';
+import { CoseAlgorithm } from '../../src/cose/cose-key.js';
+import { CoseSign1 } from '../../src/cose/cose-sign1.js';
+import { Ed25519 } from '../../src/primitives/ed25519.js';
+import { Secp256r1 } from '../../src/primitives/secp256r1.js';
+
+describe('CoseSign1', () => {
+  let ed25519PrivateKey: Jwk;
+  let ed25519PublicKey: Jwk;
+  let p256PrivateKey: Jwk;
+  let p256PublicKey: Jwk;
+
+  const testPayload = new TextEncoder().encode('This is a test payload for COSE_Sign1.');
+
+  beforeAll(async () => {
+    ed25519PrivateKey = await Ed25519.generateKey();
+    ed25519PublicKey = await Ed25519.computePublicKey({ key: ed25519PrivateKey });
+    p256PrivateKey = await Secp256r1.generateKey();
+    p256PublicKey = await Secp256r1.computePublicKey({ key: p256PrivateKey });
+  });
+
+  describe('create()', () => {
+    it('should create a COSE_Sign1 message with Ed25519', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key     : ed25519PrivateKey,
+        payload : testPayload,
+      });
+
+      expect(coseSign1).toBeInstanceOf(Uint8Array);
+      expect(coseSign1.length).toBeGreaterThan(0);
+    });
+
+    it('should create a COSE_Sign1 message with P-256 (ES256)', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key     : p256PrivateKey,
+        payload : testPayload,
+      });
+
+      expect(coseSign1).toBeInstanceOf(Uint8Array);
+      expect(coseSign1.length).toBeGreaterThan(0);
+    });
+
+    it('should create a COSE_Sign1 message with explicit protected header', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key             : ed25519PrivateKey,
+        payload         : testPayload,
+        protectedHeader : { alg: CoseAlgorithm.EdDSA },
+      });
+
+      expect(coseSign1).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should create a COSE_Sign1 with detached payload', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key             : ed25519PrivateKey,
+        payload         : testPayload,
+        detachedPayload : true,
+      });
+
+      // Decode and verify payload is null.
+      const decoded = CoseSign1.decode(coseSign1);
+      expect(decoded.payload).toBeNull();
+    });
+
+    it('should create a COSE_Sign1 with external AAD', async () => {
+      const externalAad = new TextEncoder().encode('additional-data');
+      const coseSign1 = await CoseSign1.create({
+        key     : ed25519PrivateKey,
+        payload : testPayload,
+        externalAad,
+      });
+
+      expect(coseSign1).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should create a COSE_Sign1 with kid in unprotected header', async () => {
+      const kid = new TextEncoder().encode('my-key-id');
+      const coseSign1 = await CoseSign1.create({
+        key               : ed25519PrivateKey,
+        payload           : testPayload,
+        unprotectedHeader : { kid },
+      });
+
+      const decoded = CoseSign1.decode(coseSign1);
+      expect(decoded.unprotectedHeader.get(4)).toEqual(kid);
+    });
+  });
+
+  describe('verify()', () => {
+    it('should verify a valid COSE_Sign1 message with Ed25519', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key     : ed25519PrivateKey,
+        payload : testPayload,
+      });
+
+      const isValid = await CoseSign1.verify({
+        coseSign1,
+        key: ed25519PublicKey,
+      });
+
+      expect(isValid).toBe(true);
+    });
+
+    it('should verify a valid COSE_Sign1 message with P-256 (ES256)', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key     : p256PrivateKey,
+        payload : testPayload,
+      });
+
+      const isValid = await CoseSign1.verify({
+        coseSign1,
+        key: p256PublicKey,
+      });
+
+      expect(isValid).toBe(true);
+    });
+
+    it('should return false for a tampered payload', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key     : ed25519PrivateKey,
+        payload : testPayload,
+      });
+
+      // Decode, tamper with payload, re-encode.
+      const decoded = Cbor.decode<[Uint8Array, Map<number, unknown>, Uint8Array, Uint8Array]>(coseSign1);
+      decoded[2] = new TextEncoder().encode('TAMPERED PAYLOAD');
+      const tampered = Cbor.encode(decoded);
+
+      const isValid = await CoseSign1.verify({
+        coseSign1 : tampered,
+        key       : ed25519PublicKey,
+      });
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should return false when verified with the wrong key', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key     : ed25519PrivateKey,
+        payload : testPayload,
+      });
+
+      // Generate a different key pair.
+      const otherKey = await Ed25519.generateKey();
+      const otherPublicKey = await Ed25519.computePublicKey({ key: otherKey });
+
+      const isValid = await CoseSign1.verify({
+        coseSign1,
+        key: otherPublicKey,
+      });
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should verify a COSE_Sign1 with external AAD', async () => {
+      const externalAad = new TextEncoder().encode('additional-data');
+
+      const coseSign1 = await CoseSign1.create({
+        key     : ed25519PrivateKey,
+        payload : testPayload,
+        externalAad,
+      });
+
+      // Verification with matching external AAD should succeed.
+      const isValid = await CoseSign1.verify({
+        coseSign1,
+        key: ed25519PublicKey,
+        externalAad,
+      });
+      expect(isValid).toBe(true);
+
+      // Verification with different external AAD should fail.
+      const isInvalid = await CoseSign1.verify({
+        coseSign1,
+        key         : ed25519PublicKey,
+        externalAad : new TextEncoder().encode('wrong-data'),
+      });
+      expect(isInvalid).toBe(false);
+    });
+
+    it('should verify a COSE_Sign1 with detached payload', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key             : ed25519PrivateKey,
+        payload         : testPayload,
+        detachedPayload : true,
+      });
+
+      const isValid = await CoseSign1.verify({
+        coseSign1,
+        key     : ed25519PublicKey,
+        payload : testPayload,
+      });
+      expect(isValid).toBe(true);
+    });
+
+    it('should throw when verifying a detached-payload message without providing payload', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key             : ed25519PrivateKey,
+        payload         : testPayload,
+        detachedPayload : true,
+      });
+
+      await expect(CoseSign1.verify({
+        coseSign1,
+        key: ed25519PublicKey,
+      })).rejects.toThrow('payload is detached');
+    });
+  });
+
+  describe('decode()', () => {
+    it('should decode a COSE_Sign1 message into its components', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key     : ed25519PrivateKey,
+        payload : testPayload,
+      });
+
+      const decoded = CoseSign1.decode(coseSign1);
+
+      expect(decoded.protectedHeader.alg).toBe(CoseAlgorithm.EdDSA);
+      expect(decoded.protectedHeaderBytes).toBeInstanceOf(Uint8Array);
+      expect(decoded.protectedHeaderBytes.length).toBeGreaterThan(0);
+      expect(decoded.unprotectedHeader).toBeInstanceOf(Map);
+      expect(decoded.payload).toEqual(testPayload);
+      expect(decoded.signature).toBeInstanceOf(Uint8Array);
+      expect(decoded.signature.length).toBeGreaterThan(0);
+    });
+
+    it('should decode a COSE_Sign1 with detached payload', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key             : ed25519PrivateKey,
+        payload         : testPayload,
+        detachedPayload : true,
+      });
+
+      const decoded = CoseSign1.decode(coseSign1);
+      expect(decoded.payload).toBeNull();
+    });
+
+    it('should throw for invalid CBOR input', () => {
+      const invalidCbor = new Uint8Array([0xFF, 0xFF, 0xFF]);
+      expect(() => CoseSign1.decode(invalidCbor)).toThrow('failed to decode CBOR');
+    });
+
+    it('should throw for a CBOR value that is not a 4-element array', () => {
+      const notAnArray = Cbor.encode('not an array');
+      expect(() => CoseSign1.decode(notAnArray)).toThrow('expected a CBOR array of 4 elements');
+
+      const tooFew = Cbor.encode([new Uint8Array(0), new Map()]);
+      expect(() => CoseSign1.decode(tooFew)).toThrow('expected a CBOR array of 4 elements');
+    });
+
+    it('should throw when protected header has no algorithm', () => {
+      // Create a COSE_Sign1-like array with an empty protected header.
+      const emptyProtected = Cbor.encode(new Map<number, unknown>());
+      const fakeSign1 = Cbor.encode([
+        emptyProtected,
+        new Map(),
+        new Uint8Array([1, 2, 3]),
+        new Uint8Array([4, 5, 6]),
+      ]);
+
+      expect(() => CoseSign1.decode(fakeSign1)).toThrow('must contain an algorithm identifier');
+    });
+
+    it('should extract content type from protected header', async () => {
+      const coseSign1 = await CoseSign1.create({
+        key             : ed25519PrivateKey,
+        payload         : testPayload,
+        protectedHeader : {
+          alg         : CoseAlgorithm.EdDSA,
+          contentType : 'application/eat+cwt',
+        },
+      });
+
+      const decoded = CoseSign1.decode(coseSign1);
+      expect(decoded.protectedHeader.contentType).toBe('application/eat+cwt');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('should create and verify with the same key pair (Ed25519)', async () => {
+      const payload = new TextEncoder().encode('round-trip test');
+      const coseSign1 = await CoseSign1.create({
+        key: ed25519PrivateKey,
+        payload,
+      });
+
+      const isValid = await CoseSign1.verify({
+        coseSign1,
+        key: ed25519PublicKey,
+      });
+      expect(isValid).toBe(true);
+
+      const decoded = CoseSign1.decode(coseSign1);
+      expect(decoded.payload).toEqual(payload);
+    });
+
+    it('should create and verify with the same key pair (P-256)', async () => {
+      const payload = new TextEncoder().encode('round-trip test P-256');
+      const coseSign1 = await CoseSign1.create({
+        key: p256PrivateKey,
+        payload,
+      });
+
+      const isValid = await CoseSign1.verify({
+        coseSign1,
+        key: p256PublicKey,
+      });
+      expect(isValid).toBe(true);
+
+      const decoded = CoseSign1.decode(coseSign1);
+      expect(decoded.payload).toEqual(payload);
+    });
+  });
+});

--- a/packages/crypto/tests/cose/eat.test.ts
+++ b/packages/crypto/tests/cose/eat.test.ts
@@ -1,0 +1,237 @@
+import type { Jwk } from '../../src/jose/jwk.js';
+
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+import { Cbor } from '../../src/cose/cbor.js';
+import { CoseAlgorithm } from '../../src/cose/cose-key.js';
+import { CoseSign1 } from '../../src/cose/cose-sign1.js';
+import { Ed25519 } from '../../src/primitives/ed25519.js';
+import { Eat, EatClaimKey, EatDebugStatus } from '../../src/cose/eat.js';
+
+describe('Eat', () => {
+  let privateKey: Jwk;
+  let publicKey: Jwk;
+
+  beforeAll(async () => {
+    privateKey = await Ed25519.generateKey();
+    publicKey = await Ed25519.computePublicKey({ key: privateKey });
+  });
+
+  /**
+   * Helper: creates a COSE_Sign1-wrapped EAT token from a claims map.
+   */
+  async function createEatToken(
+    claims: Map<number, unknown>,
+    signingKey: Jwk = privateKey,
+  ): Promise<Uint8Array> {
+    const payload = Cbor.encode(claims);
+    return CoseSign1.create({
+      key             : signingKey,
+      payload,
+      protectedHeader : { alg: CoseAlgorithm.EdDSA },
+    });
+  }
+
+  describe('decode()', () => {
+    it('should decode an EAT token with standard CWT claims', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const claims = new Map<number, unknown>([
+        [EatClaimKey.Iss, 'https://attestation.example.com'],
+        [EatClaimKey.Sub, 'compute-module-001'],
+        [EatClaimKey.Iat, now],
+        [EatClaimKey.Exp, now + 3600],
+      ]);
+
+      const token = await createEatToken(claims);
+      const result = Eat.decode({ token });
+
+      expect(result.claims.iss).toBe('https://attestation.example.com');
+      expect(result.claims.sub).toBe('compute-module-001');
+      expect(result.claims.iat).toBe(now);
+      expect(result.claims.exp).toBe(now + 3600);
+      expect(result.protectedHeader.alg).toBe(CoseAlgorithm.EdDSA);
+    });
+
+    it('should decode an EAT token with attestation-specific claims', async () => {
+      const nonce = new Uint8Array([0xDE, 0xAD, 0xBE, 0xEF]);
+      const ueid = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05]);
+      const hwmodel = new Uint8Array([0x41, 0x52, 0x4D]); // "ARM" in ASCII bytes
+
+      const claims = new Map<number, unknown>([
+        [EatClaimKey.Nonce, nonce],
+        [EatClaimKey.Ueid, ueid],
+        [EatClaimKey.Hwmodel, hwmodel],
+        [EatClaimKey.Dbgstat, EatDebugStatus.DisabledPermanently],
+      ]);
+
+      const token = await createEatToken(claims);
+      const result = Eat.decode({ token });
+
+      expect(result.claims.nonce).toEqual(nonce);
+      expect(result.claims.ueid).toEqual(ueid);
+      expect(result.claims.hwmodel).toEqual(hwmodel);
+      expect(result.claims.dbgstat).toBe(EatDebugStatus.DisabledPermanently);
+    });
+
+    it('should provide raw claims map for non-standard claims', async () => {
+      const customClaimKey = 9999;
+      const claims = new Map<number, unknown>([
+        [EatClaimKey.Iss, 'test-issuer'],
+        [customClaimKey, 'custom-value'],
+      ]);
+
+      const token = await createEatToken(claims);
+      const result = Eat.decode({ token });
+
+      expect(result.claims.rawClaims.get(customClaimKey)).toBe('custom-value');
+    });
+
+    it('should decode submods claim', async () => {
+      const submods = new Map<string, unknown>([
+        ['platform', new Map<number, unknown>([
+          [EatClaimKey.Iss, 'platform-issuer'],
+        ])],
+      ]);
+
+      const claims = new Map<number, unknown>([
+        [EatClaimKey.Submods, submods],
+      ]);
+
+      const token = await createEatToken(claims);
+      const result = Eat.decode({ token });
+
+      expect(result.claims.submods).toBeDefined();
+    });
+
+    it('should decode a token with nonce array', async () => {
+      const nonces = [
+        new Uint8Array([0x01, 0x02]),
+        new Uint8Array([0x03, 0x04]),
+      ];
+      const claims = new Map<number, unknown>([
+        [EatClaimKey.Nonce, nonces],
+      ]);
+
+      const token = await createEatToken(claims);
+      const result = Eat.decode({ token });
+
+      expect(result.claims.nonce).toEqual(nonces);
+    });
+
+    it('should throw for a token with detached payload', async () => {
+      const claims = new Map<number, unknown>([
+        [EatClaimKey.Iss, 'test'],
+      ]);
+      const payload = Cbor.encode(claims);
+      const token = await CoseSign1.create({
+        key             : privateKey,
+        payload,
+        detachedPayload : true,
+      });
+
+      expect(() => Eat.decode({ token })).toThrow('detached payload');
+    });
+
+    it('should throw for a token with non-map payload', async () => {
+      // Create a COSE_Sign1 with a string payload instead of a CBOR map.
+      const payload = Cbor.encode('not a map');
+      const token = await CoseSign1.create({
+        key: privateKey,
+        payload,
+      });
+
+      expect(() => Eat.decode({ token })).toThrow('not a valid CBOR map');
+    });
+  });
+
+  describe('verifyAndDecode()', () => {
+    it('should verify and decode a valid EAT token', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const claims = new Map<number, unknown>([
+        [EatClaimKey.Iss, 'https://attestation.example.com'],
+        [EatClaimKey.Iat, now],
+        [EatClaimKey.Nonce, new Uint8Array([0xCA, 0xFE])],
+      ]);
+
+      const token = await createEatToken(claims);
+      const result = await Eat.verifyAndDecode({ token, key: publicKey });
+
+      expect(result.claims.iss).toBe('https://attestation.example.com');
+      expect(result.claims.iat).toBe(now);
+      expect(result.claims.nonce).toEqual(new Uint8Array([0xCA, 0xFE]));
+    });
+
+    it('should throw when signature verification fails', async () => {
+      const claims = new Map<number, unknown>([
+        [EatClaimKey.Iss, 'test'],
+      ]);
+
+      const token = await createEatToken(claims);
+
+      // Verify with a different key.
+      const otherKey = await Ed25519.generateKey();
+      const otherPublicKey = await Ed25519.computePublicKey({ key: otherKey });
+
+      await expect(
+        Eat.verifyAndDecode({ token, key: otherPublicKey })
+      ).rejects.toThrow('signature verification failed');
+    });
+
+    it('should verify with external AAD when provided', async () => {
+      const externalAad = new TextEncoder().encode('request-binding-data');
+      const claims = new Map<number, unknown>([
+        [EatClaimKey.Iss, 'test'],
+      ]);
+      const payload = Cbor.encode(claims);
+
+      const token = await CoseSign1.create({
+        key: privateKey,
+        payload,
+        externalAad,
+      });
+
+      // Verification with matching AAD should succeed.
+      const result = await Eat.verifyAndDecode({
+        token,
+        key: publicKey,
+        externalAad,
+      });
+      expect(result.claims.iss).toBe('test');
+
+      // Verification without AAD should fail.
+      await expect(
+        Eat.verifyAndDecode({ token, key: publicKey })
+      ).rejects.toThrow('signature verification failed');
+    });
+  });
+
+  describe('claim key enums', () => {
+    it('should have correct CWT claim key values', () => {
+      expect(EatClaimKey.Iss).toBe(1);
+      expect(EatClaimKey.Sub).toBe(2);
+      expect(EatClaimKey.Aud).toBe(3);
+      expect(EatClaimKey.Exp).toBe(4);
+      expect(EatClaimKey.Nbf).toBe(5);
+      expect(EatClaimKey.Iat).toBe(6);
+      expect(EatClaimKey.Cti).toBe(7);
+    });
+
+    it('should have correct EAT-specific claim key values', () => {
+      expect(EatClaimKey.Nonce).toBe(10);
+      expect(EatClaimKey.Ueid).toBe(256);
+      expect(EatClaimKey.Hwmodel).toBe(259);
+      expect(EatClaimKey.Dbgstat).toBe(263);
+      expect(EatClaimKey.Submods).toBe(266);
+    });
+  });
+
+  describe('debug status enum', () => {
+    it('should have correct debug status values', () => {
+      expect(EatDebugStatus.Enabled).toBe(0);
+      expect(EatDebugStatus.Disabled).toBe(1);
+      expect(EatDebugStatus.DisabledSinceBoot).toBe(2);
+      expect(EatDebugStatus.DisabledPermanently).toBe(3);
+      expect(EatDebugStatus.DisabledFullyAndPermanently).toBe(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds COSE_Sign1 (RFC 9052) and EAT (RFC 9711) support to `@enbox/crypto`, providing the cryptographic foundation for TEE attestation verification in confidential compute.

Closes #336

## Changes

### New modules (`packages/crypto/src/cose/`)

| Module | Description |
|---|---|
| `cbor.ts` | Thin wrapper around `cborg` with `useMaps: true` for integer-keyed CBOR maps |
| `cose-key.ts` | JWK ↔ COSE key conversion, algorithm/curve enums (`CoseAlgorithm`, `CoseEllipticCurve`, `CoseKeyType`) |
| `cose-sign1.ts` | COSE_Sign1 create/verify/decode — supports EdDSA (Ed25519) and ES256 (P-256) |
| `eat.ts` | EAT token decode and `verifyAndDecode` with typed claims (`EatClaims`, `EatClaimKey`, `EatDebugStatus`) |

### Other changes

- Added `InvalidCoseSign1` and `InvalidEat` to `CryptoErrorCode` enum
- Updated `src/index.ts` barrel exports for all COSE modules
- Added `cborg@4.5.8` dependency for CBOR encoding/decoding

### Tests

79 new tests across 4 test files covering:
- CBOR encode/decode round-trips (integer keys, nested structures, edge cases)
- JWK ↔ COSE key conversion (Ed25519, P-256, X25519, error cases)
- COSE_Sign1 create/verify/decode (Ed25519, P-256, detached payloads, external AAD, tamper detection)
- EAT decode and verifyAndDecode (CWT claims, attestation claims, signature verification, error cases)

All 640 crypto tests pass (79 new + 561 existing).

## Why

This is Phase 0 of the confidential computing pillar (#334). TEE attestation evidence from ARM CCA, Intel TDX, AMD SEV-SNP, and AWS Nitro uses COSE_Sign1-wrapped EAT tokens. The DWN needs to verify these tokens to validate compute module integrity before dispatching workloads.