### PR TITLE
fix(dwn-sdk-js): authorize deleted record reads against newest write

### DIFF
--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -61,24 +61,35 @@ export class RecordsReadHandler implements MethodHandler {
 
     const matchedMessage = existingMessages[0];
 
-    // if the matched message is a RecordsDelete, we mark the record as not-found and return both the RecordsDelete and the initial RecordsWrite
-    // TODO: https://github.com/enboxorg/enbox/issues/222
-    // Consider performing authorization checks like when records exists before returning RecordsDelete and initial RecordsWrite of a deleted record
+    // If the matched message is a RecordsDelete, authorize against the newest RecordsWrite
+    // (for parity with the live-record path which authorizes against the latest write),
+    // then return 404 with both the RecordsDelete and the initial RecordsWrite.
     if (matchedMessage.descriptor.method === DwnMethodName.Delete) {
       const recordsDeleteMessage = matchedMessage as RecordsDeleteMessage;
-      const initialWrite = await RecordsWrite.fetchInitialRecordsWriteMessage(this.messageStore, tenant, recordsDeleteMessage.descriptor.recordId);
+      const recordId = recordsDeleteMessage.descriptor.recordId;
 
+      const initialWrite = await RecordsWrite.fetchInitialRecordsWriteMessage(this.messageStore, tenant, recordId);
       if (initialWrite === undefined) {
         return messageReplyFromError(new DwnError(
           DwnErrorCode.RecordsReadInitialWriteNotFound,
-          'Initial write for deleted record not found'
+          'initial write for deleted record not found'
         ), 400);
       }
 
-      // Perform authorization before returning the delete and initial write messages
-      const parsedInitialWrite = await RecordsWrite.parse(initialWrite);
+      // Authorize against the newest RecordsWrite so that mutable properties like `published`
+      // reflect the record's state at the time of deletion, not just the initial write.
+      let newestWrite;
       try {
-        await RecordsReadHandler.authorizeRecordsRead(tenant, recordsRead, parsedInitialWrite, this.messageStore);
+        newestWrite = await RecordsWrite.fetchNewestRecordsWrite(this.messageStore, tenant, recordId);
+      } catch {
+        // If newest write is not found (should not happen since initial write exists),
+        // fall back to the initial write for authorization.
+        newestWrite = initialWrite;
+      }
+      const parsedNewestWrite = await RecordsWrite.parse(newestWrite);
+
+      try {
+        await RecordsReadHandler.authorizeRecordsRead(tenant, recordsRead, parsedNewestWrite, this.messageStore);
       } catch (error) {
         return messageReplyFromError(error, 401);
       }
@@ -87,7 +98,7 @@ export class RecordsReadHandler implements MethodHandler {
         status : { code: 404, detail: 'Not Found' },
         entry  : {
           recordsDelete: recordsDeleteMessage,
-          initialWrite
+          initialWrite,
         }
       };
     }

--- a/packages/dwn-sdk-js/tests/scenarios/deleted-record.spec.ts
+++ b/packages/dwn-sdk-js/tests/scenarios/deleted-record.spec.ts
@@ -1,9 +1,10 @@
 import type { DidResolver } from '@enbox/dids';
 import type { EventLog } from '../../src/types/subscriptions.js';
-import type { DataStore, MessageStore, ResumableTaskStore, StateIndex } from '../../src/index.js';
+import type { DataStore, MessageStore, RecordsReadReply, ResumableTaskStore, StateIndex } from '../../src/index.js';
 
 import freeForAllProtocolDefinition from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
 import sinon from 'sinon';
+import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { TestDataGenerator } from '../utils/test-data-generator.js';
@@ -11,7 +12,7 @@ import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 
-import { DataStream, Dwn, Jws, ProtocolsConfigure, RecordsRead } from '../../src/index.js';
+import { DataStream, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Jws, PermissionsProtocol, ProtocolsConfigure, RecordsRead, Time } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { Encoder, RecordsDelete, RecordsWrite } from '../../src/index.js';
 
@@ -109,6 +110,392 @@ export function testDeletedRecordScenarios(): void {
       expect(readReply.entry!.recordsDelete).toEqual(recordsDelete.message);
       expect(readReply.entry!.initialWrite).toBeDefined();
       expect(readReply.entry!.initialWrite).toEqual(recordsWriteMessage);
+    });
+
+    // =========================================================================
+    // Authorization checks for deleted record reads (#222)
+    // =========================================================================
+
+    describe('deleted record read authorization', () => {
+      it('should allow the non-owner author to read their own deleted record', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        // Install the free-for-all protocol on Alice's DWN
+        const protocolDefinition = freeForAllProtocolDefinition;
+        const protocolsConfigure = await ProtocolsConfigure.create({
+          signer     : Jws.createSigner(alice),
+          definition : protocolDefinition
+        });
+        await dwn.processMessage(alice.did, protocolsConfigure.message);
+
+        // Bob writes a record to Alice's DWN (via 'anyone' can 'create')
+        const data = Encoder.stringToBytes('bob writes a post');
+        const { message: writeMessage } = await RecordsWrite.create({
+          signer       : Jws.createSigner(bob),
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'post',
+          schema       : protocolDefinition.types.post.schema,
+          dataFormat   : protocolDefinition.types.post.dataFormats[0],
+          data,
+        });
+        const writeReply = await dwn.processMessage(alice.did, writeMessage, { dataStream: DataStream.fromBytes(data) });
+        expect(writeReply.status.code).toBe(202);
+
+        // Alice (tenant) deletes Bob's record
+        const recordsDelete = await RecordsDelete.create({
+          signer   : Jws.createSigner(alice),
+          recordId : writeMessage.recordId,
+        });
+        const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+        expect(deleteReply.status.code).toBe(202);
+
+        // Bob (non-owner author) should be able to read the deleted record
+        const bobRead = await RecordsRead.create({
+          signer : Jws.createSigner(bob),
+          filter : { recordId: writeMessage.recordId },
+        });
+        const readReply = await dwn.processMessage(alice.did, bobRead.message) as RecordsReadReply;
+        expect(readReply.status.code).toBe(404);
+        expect(readReply.entry!.recordsDelete).toBeDefined();
+        expect(readReply.entry!.initialWrite).toBeDefined();
+      });
+
+      it('should allow the recipient to read a deleted record', async () => {
+        const alice = await TestDataGenerator.generatePersona();
+        const bob = await TestDataGenerator.generatePersona();
+        TestStubGenerator.stubDidResolver(didResolver, [alice, bob]);
+
+        // Install a protocol where recipient can read (requires `of` property)
+        const protocolDefinition = {
+          protocol  : 'http://recipient-read.xyz',
+          published : true,
+          types     : {
+            note: {
+              schema      : 'note',
+              dataFormats : ['application/json'],
+            },
+          },
+          structure: {
+            note: {
+              $actions: [
+                { who: 'anyone', can: ['create', 'delete'] },
+                { who: 'recipient', of: 'note', can: ['read'] },
+              ],
+            },
+          },
+        };
+
+        const protocolsConfigure = await ProtocolsConfigure.create({
+          signer     : Jws.createSigner(alice),
+          definition : protocolDefinition,
+        });
+        await dwn.processMessage(alice.did, protocolsConfigure.message);
+
+        // Alice writes a record with Bob as recipient
+        const data = Encoder.stringToBytes('secret note for bob');
+        const { message: writeMessage } = await RecordsWrite.create({
+          signer       : Jws.createSigner(alice),
+          recipient    : bob.did,
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'note',
+          schema       : 'note',
+          dataFormat   : 'application/json',
+          data,
+        });
+        await dwn.processMessage(alice.did, writeMessage, { dataStream: DataStream.fromBytes(data) });
+
+        // Alice deletes the record
+        const recordsDelete = await RecordsDelete.create({
+          signer   : Jws.createSigner(alice),
+          recordId : writeMessage.recordId,
+        });
+        await dwn.processMessage(alice.did, recordsDelete.message);
+
+        // Bob (recipient) should be able to read the deleted record
+        const bobRead = await RecordsRead.create({
+          signer : Jws.createSigner(bob),
+          filter : { recordId: writeMessage.recordId },
+        });
+        const readReply = await dwn.processMessage(alice.did, bobRead.message) as RecordsReadReply;
+        expect(readReply.status.code).toBe(404);
+        expect(readReply.entry!.recordsDelete).toBeDefined();
+        expect(readReply.entry!.initialWrite).toBeDefined();
+      });
+
+      it('should allow a grant holder to read a deleted record', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        // Install protocol
+        const protocolDefinition = freeForAllProtocolDefinition;
+        const protocolsConfigure = await ProtocolsConfigure.create({
+          signer     : Jws.createSigner(alice),
+          definition : protocolDefinition,
+        });
+        await dwn.processMessage(alice.did, protocolsConfigure.message);
+
+        // Alice writes a record
+        const data = Encoder.stringToBytes('some post');
+        const { message: writeMessage } = await RecordsWrite.create({
+          signer       : Jws.createSigner(alice),
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'post',
+          schema       : protocolDefinition.types.post.schema,
+          dataFormat   : protocolDefinition.types.post.dataFormats[0],
+          data,
+        });
+        await dwn.processMessage(alice.did, writeMessage, { dataStream: DataStream.fromBytes(data) });
+
+        // Alice deletes the record
+        const recordsDelete = await RecordsDelete.create({
+          signer   : Jws.createSigner(alice),
+          recordId : writeMessage.recordId,
+        });
+        await dwn.processMessage(alice.did, recordsDelete.message);
+
+        // Alice creates a read grant for Bob
+        const permissionGrant = await PermissionsProtocol.createGrant({
+          signer      : Jws.createSigner(alice),
+          grantedTo   : bob.did,
+          dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 }),
+          scope       : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        const grantDataStream = DataStream.fromBytes(permissionGrant.permissionGrantBytes);
+        await dwn.processMessage(alice.did, permissionGrant.recordsWrite.message, { dataStream: grantDataStream });
+
+        // Bob reads the deleted record using the grant
+        const bobRead = await RecordsRead.create({
+          signer            : Jws.createSigner(bob),
+          permissionGrantId : permissionGrant.recordsWrite.message.recordId,
+          filter            : { recordId: writeMessage.recordId },
+        });
+        const readReply = await dwn.processMessage(alice.did, bobRead.message) as RecordsReadReply;
+        expect(readReply.status.code).toBe(404);
+        expect(readReply.entry!.recordsDelete).toBeDefined();
+        expect(readReply.entry!.initialWrite).toBeDefined();
+      });
+
+      it('should allow a protocol role holder to read a deleted record', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        // Install thread-role protocol
+        const protocolDefinition = threadRoleProtocolDefinition;
+        const protocolsConfigure = await ProtocolsConfigure.create({
+          signer     : Jws.createSigner(alice),
+          definition : protocolDefinition,
+        });
+        await dwn.processMessage(alice.did, protocolsConfigure.message);
+
+        // Alice creates a thread
+        const threadWrite = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'thread',
+        });
+        await dwn.processMessage(alice.did, threadWrite.message, { dataStream: threadWrite.dataStream });
+        const threadContextId = threadWrite.message.contextId!;
+
+        // Alice assigns Bob as a participant (role)
+        const participantWrite = await TestDataGenerator.generateRecordsWrite({
+          author          : alice,
+          recipient       : bob.did,
+          protocol        : protocolDefinition.protocol,
+          protocolPath    : 'thread/participant',
+          parentContextId : threadContextId,
+        });
+        await dwn.processMessage(alice.did, participantWrite.message, { dataStream: participantWrite.dataStream });
+
+        // Bob creates a chat message (via participant role)
+        const chatWrite = await TestDataGenerator.generateRecordsWrite({
+          author          : bob,
+          protocol        : protocolDefinition.protocol,
+          protocolPath    : 'thread/chat',
+          protocolRole    : 'thread/participant',
+          parentContextId : threadContextId,
+        });
+        await dwn.processMessage(alice.did, chatWrite.message, { dataStream: chatWrite.dataStream });
+
+        // Alice deletes the chat message
+        const recordsDelete = await RecordsDelete.create({
+          signer   : Jws.createSigner(alice),
+          recordId : chatWrite.message.recordId,
+        });
+        await dwn.processMessage(alice.did, recordsDelete.message);
+
+        // Bob reads the deleted chat message using his participant role
+        const bobRead = await RecordsRead.create({
+          signer       : Jws.createSigner(bob),
+          protocolRole : 'thread/participant',
+          filter       : {
+            recordId: chatWrite.message.recordId,
+          },
+        });
+        const readReply = await dwn.processMessage(alice.did, bobRead.message) as RecordsReadReply;
+        expect(readReply.status.code).toBe(404);
+        expect(readReply.entry!.recordsDelete).toBeDefined();
+        expect(readReply.entry!.initialWrite).toBeDefined();
+      });
+
+      it('should allow anonymous read of a deleted record that was published', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        // Install protocol
+        const protocolDefinition = freeForAllProtocolDefinition;
+        const protocolsConfigure = await ProtocolsConfigure.create({
+          signer     : Jws.createSigner(alice),
+          definition : protocolDefinition,
+        });
+        await dwn.processMessage(alice.did, protocolsConfigure.message);
+
+        // Alice writes a published record
+        const data = Encoder.stringToBytes('public post');
+        const { message: writeMessage } = await RecordsWrite.create({
+          signer       : Jws.createSigner(alice),
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'post',
+          schema       : protocolDefinition.types.post.schema,
+          dataFormat   : protocolDefinition.types.post.dataFormats[0],
+          published    : true,
+          data,
+        });
+        await dwn.processMessage(alice.did, writeMessage, { dataStream: DataStream.fromBytes(data) });
+
+        // Alice deletes the record
+        const recordsDelete = await RecordsDelete.create({
+          signer   : Jws.createSigner(alice),
+          recordId : writeMessage.recordId,
+        });
+        await dwn.processMessage(alice.did, recordsDelete.message);
+
+        // Anonymous read (no signer) should succeed because the record was published
+        const anonRead = await RecordsRead.create({
+          filter: { recordId: writeMessage.recordId },
+        });
+        const readReply = await dwn.processMessage(alice.did, anonRead.message) as RecordsReadReply;
+        expect(readReply.status.code).toBe(404);
+        expect(readReply.entry!.recordsDelete).toBeDefined();
+        expect(readReply.entry!.initialWrite).toBeDefined();
+      });
+
+      it('should reject an unauthorized user from reading a deleted record', async () => {
+        const alice = await TestDataGenerator.generatePersona();
+        const bob = await TestDataGenerator.generatePersona();
+        const carol = await TestDataGenerator.generatePersona();
+        TestStubGenerator.stubDidResolver(didResolver, [alice, bob, carol]);
+
+        // Install a protocol where only author and recipient can read (no 'anyone' can 'read')
+        const protocolDefinition = {
+          protocol  : 'http://restricted-read.xyz',
+          published : true,
+          types     : {
+            note: {
+              schema      : 'note',
+              dataFormats : ['application/json'],
+            },
+          },
+          structure: {
+            note: {
+              $actions: [
+                { who: 'anyone', can: ['create', 'delete'] },
+                { who: 'recipient', of: 'note', can: ['read'] },
+              ],
+            },
+          },
+        };
+
+        const protocolsConfigure = await ProtocolsConfigure.create({
+          signer     : Jws.createSigner(alice),
+          definition : protocolDefinition,
+        });
+        await dwn.processMessage(alice.did, protocolsConfigure.message);
+
+        // Alice writes a record with Bob as recipient
+        const data = Encoder.stringToBytes('private note');
+        const { message: writeMessage } = await RecordsWrite.create({
+          signer       : Jws.createSigner(alice),
+          recipient    : bob.did,
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'note',
+          schema       : 'note',
+          dataFormat   : 'application/json',
+          data,
+        });
+        await dwn.processMessage(alice.did, writeMessage, { dataStream: DataStream.fromBytes(data) });
+
+        // Alice deletes the record
+        const recordsDelete = await RecordsDelete.create({
+          signer   : Jws.createSigner(alice),
+          recordId : writeMessage.recordId,
+        });
+        await dwn.processMessage(alice.did, recordsDelete.message);
+
+        // Carol (neither author, recipient, nor tenant) tries to read — should be rejected
+        const carolRead = await RecordsRead.create({
+          signer : Jws.createSigner(carol),
+          filter : { recordId: writeMessage.recordId },
+        });
+        const readReply = await dwn.processMessage(alice.did, carolRead.message) as RecordsReadReply;
+        expect(readReply.status.code).toBe(401);
+        expect(readReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationActionNotAllowed);
+      });
+
+      it('should authorize against the newest write when a record was updated before deletion', async () => {
+        // Scenario: Alice writes a record (unpublished), updates it to published, then deletes it.
+        // An anonymous reader should be able to get the 404 + metadata because the newest write was published.
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        // Install protocol
+        const protocolDefinition = freeForAllProtocolDefinition;
+        const protocolsConfigure = await ProtocolsConfigure.create({
+          signer     : Jws.createSigner(alice),
+          definition : protocolDefinition,
+        });
+        await dwn.processMessage(alice.did, protocolsConfigure.message);
+
+        // Alice writes an unpublished record
+        const data = Encoder.stringToBytes('initially unpublished');
+        const recordsWrite = await RecordsWrite.create({
+          signer       : Jws.createSigner(alice),
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'post',
+          schema       : protocolDefinition.types.post.schema,
+          dataFormat   : protocolDefinition.types.post.dataFormats[0],
+          data,
+        });
+        await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: DataStream.fromBytes(data) });
+
+        // Alice updates the record to published
+        const updatedData = Encoder.stringToBytes('now published');
+        const recordsUpdate = await RecordsWrite.createFrom({
+          recordsWriteMessage : recordsWrite.message,
+          signer              : Jws.createSigner(alice),
+          published           : true,
+          data                : updatedData,
+        });
+        await dwn.processMessage(alice.did, recordsUpdate.message, { dataStream: DataStream.fromBytes(updatedData) });
+
+        // Alice deletes the record
+        const recordsDelete = await RecordsDelete.create({
+          signer   : Jws.createSigner(alice),
+          recordId : recordsWrite.message.recordId,
+        });
+        await dwn.processMessage(alice.did, recordsDelete.message);
+
+        // Anonymous read should succeed because the newest write had published: true
+        const anonRead = await RecordsRead.create({
+          filter: { recordId: recordsWrite.message.recordId },
+        });
+        const readReply = await dwn.processMessage(alice.did, anonRead.message) as RecordsReadReply;
+        expect(readReply.status.code).toBe(404);
+        expect(readReply.entry!.recordsDelete).toBeDefined();
+        expect(readReply.entry!.initialWrite).toBeDefined();
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

- **Fix:** The `RecordsRead` handler was authorizing deleted records against the **initial** `RecordsWrite` instead of the **newest** `RecordsWrite`. This caused incorrect authorization when mutable properties (e.g. `published`) were updated before deletion — an anonymous read of a record that was updated to `published: true` before deletion would be rejected because the initial write had `published: false`.
- **Change:** Use `fetchNewestRecordsWrite` for the authorization path (matching the live-record behavior), with a defensive fallback to the initial write. The response shape is unchanged — `initialWrite` is still returned.
- **Tests:** 7 new tests covering all deleted record read authorization paths (author, recipient, grant, protocol role, anonymous/published, unauthorized rejection, newest-write edge case).

## Details

### The Bug

In `records-read.ts`, the handler had two code paths:

| Path | Authorization against | Correct? |
|---|---|---|
| Live record | Newest `RecordsWrite` | Yes |
| Deleted record | Initial `RecordsWrite` | **No** — misses updates to `published`, `recipient`, etc. |

### The Fix

Replace `fetchInitialRecordsWriteMessage` with `fetchNewestRecordsWrite` in the deleted-record authorization path (`records-read.ts:64-103`). If the newest write fetch fails (shouldn't happen — a deleted record must have at least one write), fall back to the initial write defensively.

### New Tests (`deleted-record.spec.ts`)

| # | Test | Verifies |
|---|---|---|
| 1 | Non-owner author reads own deleted record | Author-based auth works for deleted records |
| 2 | Recipient reads deleted record | Protocol `recipient` role auth works for deleted records |
| 3 | Grant holder reads deleted record | `PermissionsGrant`-based auth works for deleted records |
| 4 | Protocol role holder reads deleted record | Thread-role protocol auth works for deleted records |
| 5 | Anonymous reads published-then-deleted record | `published: true` check works for deleted records |
| 6 | Unauthorized user rejected | Non-authorized reads still fail for deleted records |
| 7 | Auth uses newest write after update-then-delete | The core edge case — `published` updated before deletion |

### Verification

- Lint: 0 errors, 0 warnings
- Tests: 1078 pass, 0 fail (7 new + 1071 baseline)
- Build: clean

Closes #222