### PR TITLE
feat(dwn-clients): extend ServerInfo and registration types for provider-auth-v0

### DIFF
--- a/packages/dwn-clients/src/index.ts
+++ b/packages/dwn-clients/src/index.ts
@@ -4,6 +4,7 @@ export * from './dwn-server-info-cache-memory.js';
 export * from './http-dwn-rpc-client.js';
 export * from './json-rpc.js';
 export * from './json-rpc-socket.js';
+export * from './provider-directory-types.js';
 export * from './registration-types.js';
 export * from './rpc-client.js';
 export * from './server-info-types.js';

--- a/packages/dwn-clients/src/provider-directory-types.ts
+++ b/packages/dwn-clients/src/provider-directory-types.ts
@@ -1,0 +1,41 @@
+/**
+ * A service tier offered by a DWN provider.
+ */
+export type DwnProviderTier = {
+  /** Tier name (e.g. "Free", "Pro", "Enterprise"). */
+  name : string;
+  /** Human-readable description of what the tier includes. */
+  description : string;
+  /** Human-readable pricing (e.g. "$5/mo", "Free", "Contact us"). */
+  pricing? : string;
+};
+
+/**
+ * A single DWN provider listing in a provider directory.
+ * Used by wallets to present a curated list of DWN providers to users.
+ */
+export type DwnProviderListing = {
+  /** Display name of the provider (e.g. "Enbox Cloud"). */
+  name : string;
+  /** Short description of the provider. */
+  description : string;
+  /** DWN server base URL — used for `GET /info` discovery. */
+  url : string;
+  /** URL to the provider's logo image. */
+  logoUrl? : string;
+  /** Available service tiers. */
+  tiers? : DwnProviderTier[];
+};
+
+/**
+ * A directory of DWN providers.
+ * This is a static JSON document maintained by the wallet provider.
+ */
+export type DwnProviderDirectory = {
+  /** Schema version (e.g. "1.0"). */
+  version : string;
+  /** ISO 8601 timestamp of when the directory was last updated. */
+  updated : string;
+  /** List of DWN providers. */
+  providers : DwnProviderListing[];
+};

--- a/packages/dwn-clients/src/registration-types.ts
+++ b/packages/dwn-clients/src/registration-types.ts
@@ -11,16 +11,63 @@ export type ProofOfWorkChallengeModel = {
  */
 export type RegistrationData = {
   did: string;
-  termsOfServiceHash: string;
+  termsOfServiceHash?: string;
 };
 
 /**
  * Full registration request body for `POST /registration`.
  */
 export type RegistrationRequest = {
-  proofOfWork: {
+  proofOfWork?: {
     challengeNonce: string;
     responseNonce: string;
   },
-  registrationData: RegistrationData
+  /**
+   * Provider-auth-v0 credentials. Present when the server requires
+   * `'provider-auth-v0'` registration.
+   */
+  providerAuth?: {
+    /** The registration token obtained from the token exchange endpoint. */
+    registrationToken: string;
+  },
+  registrationData: RegistrationData,
+};
+
+/**
+ * Request body for `POST {tokenUrl}` — exchanges an authorization code for a
+ * registration token. Sent by the wallet to the provider's auth service.
+ */
+export type TokenExchangeRequest = {
+  /** Grant type identifier. */
+  grantType : 'authorization_code';
+  /** The authorization code received from the provider's redirect. */
+  code : string;
+  /** The redirect URI used in the authorization request (must match exactly). */
+  redirectUri : string;
+};
+
+/**
+ * Response body from `POST {tokenUrl}` or `POST {refreshUrl}` — contains the
+ * registration token and optional refresh token.
+ */
+export type TokenExchangeResponse = {
+  /** Opaque registration token for use with `POST /registration`. */
+  registrationToken : string;
+  /** Opaque refresh token for obtaining new registration tokens. */
+  refreshToken? : string;
+  /** Token lifetime in seconds. If absent, the token does not expire. */
+  expiresIn? : number;
+  /** Token type hint (e.g. `'bearer'`). */
+  tokenType : string;
+};
+
+/**
+ * Request body for `POST {refreshUrl}` — refreshes an expired registration
+ * token.
+ */
+export type TokenRefreshRequest = {
+  /** Grant type identifier. */
+  grantType : 'refresh_token';
+  /** The refresh token obtained from a prior token exchange. */
+  refreshToken : string;
 };

--- a/packages/dwn-clients/src/server-info-types.ts
+++ b/packages/dwn-clients/src/server-info-types.ts
@@ -1,5 +1,21 @@
 import type { KeyValueStore } from '@enbox/common';
 
+/**
+ * Configuration for provider-auth-v0 registration.
+ * Present in {@link ServerInfo} when `'provider-auth-v0'` is listed in
+ * {@link ServerInfo.registrationRequirements | registrationRequirements}.
+ */
+export type ProviderAuthInfo = {
+  /** URL to redirect user for authentication/signup/payment. Can be on the DWN server or an external domain. */
+  authorizeUrl : string;
+  /** URL where the wallet exchanges an authorization code for a registration token. */
+  tokenUrl : string;
+  /** URL to refresh an expired registration token. If absent, tokens do not support refresh. */
+  refreshUrl? : string;
+  /** URL for user-facing account management dashboard. If absent, no management UI is available. */
+  managementUrl? : string;
+};
+
 export type ServerInfo = {
   /** the maximum file size the user can request to store */
   maxFileSize: number,
@@ -9,6 +25,11 @@ export type ServerInfo = {
    * window. When absent, the server does not enforce backpressure.
    */
   maxInFlight?: number,
+  /**
+   * Provider-auth-v0 configuration. Present when `'provider-auth-v0'` is
+   * included in {@link registrationRequirements}.
+   */
+  providerAuth?: ProviderAuthInfo,
   /**
    * an array of strings representing the server's registration requirements.
    *


### PR DESCRIPTION
## Summary
- Add `ProviderAuthInfo` type and optional `providerAuth` field to `ServerInfo`
- Make `proofOfWork` and `termsOfServiceHash` optional in `RegistrationRequest` to support provider-auth alongside PoW
- Add `providerAuth.registrationToken` field to `RegistrationRequest`
- Add `TokenExchangeRequest`, `TokenExchangeResponse`, `TokenRefreshRequest` types for the auth code exchange flow
- Add `DwnProviderListing`, `DwnProviderTier`, `DwnProviderDirectory` types for wallet provider directories

## Verification
- Lint: passes
- Build: passes
- All new fields are optional for full backward compatibility

Closes #400, closes #402
Part of #399