### PR TITLE
feat(dwn-sdk-js): CoreProtocol interface, registry, and PermissionsProtocol implementation (#414, #415, #416)

### DIFF
--- a/packages/dwn-sdk-js/src/core/core-protocol.ts
+++ b/packages/dwn-sdk-js/src/core/core-protocol.ts
@@ -1,0 +1,136 @@
+import type { DataStore } from '../types/data-store.js';
+import type { Filter } from '../types/query-types.js';
+import type { MessagesFilter } from '../types/messages-types.js';
+import type { MessageStore } from '../types/message-store.js';
+import type { ProtocolDefinition } from '../types/protocols-types.js';
+import type { RecordsWrite } from '../interfaces/records-write.js';
+import type { RecordsWriteMessage } from '../types/records-types.js';
+import type { StateIndex } from '../types/state-index.js';
+
+/**
+ * Bundled store references passed to core protocol post-processing hooks.
+ */
+export type CoreProtocolStores = {
+  messageStore : MessageStore;
+  dataStore : DataStore;
+  stateIndex : StateIndex;
+};
+
+/**
+ * A core protocol is a hardcoded, immutable, always-installed DWN protocol
+ * with lifecycle hooks that participate in the Records message processing pipeline.
+ *
+ * Core protocols are returned from `fetchProtocolDefinition()` without a database
+ * lookup and cannot be overridden by `ProtocolsConfigure`. They provide system-level
+ * behavior (e.g., permissions) while riding on the Records interface for CRUD and sync.
+ */
+export interface CoreProtocol {
+  /** The immutable protocol definition. */
+  readonly definition: ProtocolDefinition;
+
+  /** The protocol URI (shorthand for `definition.protocol`). */
+  readonly uri: string;
+
+  /**
+   * Validate the data payload of a record being written under this protocol.
+   * Called after protocol authorization but before storage.
+   * @throws DwnError to reject the write with the appropriate status code.
+   */
+  validateRecord?(message: RecordsWriteMessage, dataBytes: Uint8Array): void;
+
+  /**
+   * Pre-processing hook: runs before storing a record under this protocol.
+   * Can perform cross-record validation (e.g., revocation tag consistency checks).
+   * @throws DwnError to reject the write.
+   */
+  preProcessWrite?(
+    tenant: string,
+    message: RecordsWriteMessage,
+    messageStore: MessageStore,
+  ): Promise<void>;
+
+  /**
+   * Post-processing hook: runs after successfully storing a record under this protocol.
+   * Can perform cascading side effects (e.g., cleanup of grant-authorized messages on revocation).
+   */
+  postProcessWrite?(
+    tenant: string,
+    recordsWrite: RecordsWrite,
+    stores: CoreProtocolStores,
+  ): Promise<void>;
+
+  /**
+   * Map an error code from this protocol's validation to an HTTP status code.
+   * Return `undefined` if the error code is not owned by this protocol.
+   */
+  mapErrorToStatusCode?(errorCode: string): number | undefined;
+
+  /**
+   * Construct an additional filter to include this protocol's records in
+   * protocol-scoped `MessagesFilter` conversions (e.g., sync, subscribe, read).
+   *
+   * This is used when permission records (or similar system records) are tagged
+   * with a target protocol and must appear alongside that protocol's records in
+   * message-level queries.
+   *
+   * Return `undefined` if no additional filter is needed for the given input.
+   */
+  constructAdditionalMessageFilter?(filter: MessagesFilter): Filter | undefined;
+}
+
+/**
+ * Well-known protocol path for permission grant revocation records.
+ * Defined here (rather than on `PermissionsProtocol`) to avoid circular
+ * dependencies between `grant-authorization.ts` and `protocols/permissions.ts`.
+ */
+export const PERMISSIONS_REVOCATION_PATH = 'grant/revocation';
+
+/**
+ * Registry of core protocols. Owned by a `Dwn` instance (not a static singleton)
+ * so that each DWN — including those in tests — gets an isolated registry.
+ */
+export class CoreProtocolRegistry {
+  private readonly _protocols: Map<string, CoreProtocol> = new Map();
+
+  /** Register a core protocol. */
+  public register(protocol: CoreProtocol): void {
+    this._protocols.set(protocol.uri, protocol);
+  }
+
+  /** Get a core protocol by URI, or `undefined` if not registered. */
+  public get(uri: string): CoreProtocol | undefined {
+    return this._protocols.get(uri);
+  }
+
+  /**
+   * Get the protocol definition for a core protocol, or `undefined`.
+   * Used by `fetchProtocolDefinition()` to bypass the message store for core protocols.
+   */
+  public getDefinition(uri: string): ProtocolDefinition | undefined {
+    return this._protocols.get(uri)?.definition;
+  }
+
+  /** Check whether a URI is a registered core protocol. */
+  public has(uri: string): boolean {
+    return this._protocols.has(uri);
+  }
+
+  /** Get all registered core protocols. */
+  public all(): CoreProtocol[] {
+    return [...this._protocols.values()];
+  }
+
+  /**
+   * Delegate error code mapping to all registered core protocols.
+   * Returns the first non-`undefined` status code, or `undefined` if no protocol claims the error.
+   */
+  public mapErrorToStatusCode(errorCode: string): number | undefined {
+    for (const protocol of this._protocols.values()) {
+      const status = protocol.mapErrorToStatusCode?.(errorCode);
+      if (status !== undefined) {
+        return status;
+      }
+    }
+    return undefined;
+  }
+}

--- a/packages/dwn-sdk-js/src/dwn.ts
+++ b/packages/dwn-sdk-js/src/dwn.ts
@@ -13,11 +13,13 @@ import type { ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryRe
 import type { RecordsCountMessage, RecordsCountReply, RecordsDeleteMessage, RecordsQueryMessage, RecordsQueryReply, RecordsReadMessage, RecordsReadReply, RecordsSubscribeMessage, RecordsSubscribeMessageOptions, RecordsSubscribeReply, RecordsWriteMessage, RecordsWriteMessageOptions } from './types/records-types.js';
 
 import { AllowAllTenantGate } from './core/tenant-gate.js';
+import { CoreProtocolRegistry } from './core/core-protocol.js';
 import { Message } from './core/message.js';
 import { messageReplyFromError } from './core/message-reply.js';
 import { MessagesReadHandler } from './handlers/messages-read.js';
 import { MessagesSubscribeHandler } from './handlers/messages-subscribe.js';
 import { MessagesSyncHandler } from './handlers/messages-sync.js';
+import { PermissionsProtocol } from './protocols/permissions.js';
 import { ProtocolsConfigureHandler } from './handlers/protocols-configure.js';
 import { ProtocolsQueryHandler } from './handlers/protocols-query.js';
 import { RecordsCountHandler } from './handlers/records-count.js';
@@ -42,6 +44,7 @@ export class Dwn {
   private eventLog?: EventLog;
   private storageController: StorageController;
   private resumableTaskManager: ResumableTaskManager;
+  private _coreProtocols: CoreProtocolRegistry;
 
   private constructor(config: DwnConfig) {
     this.didResolver = config.didResolver!;
@@ -63,6 +66,10 @@ export class Dwn {
       config.resumableTaskStore,
       this.storageController
     );
+
+    // Initialize the core protocol registry with built-in system protocols.
+    this._coreProtocols = new CoreProtocolRegistry();
+    this._coreProtocols.register(new PermissionsProtocol());
 
     this.methodHandlers = {
       [DwnInterfaceName.Messages + DwnMethodName.Read]: new MessagesReadHandler(
@@ -159,6 +166,15 @@ export class Dwn {
     await this.dataStore.close();
     await this.resumableTaskStore.close();
     await this.stateIndex.close();
+  }
+
+  /**
+   * The registry of core protocols (hardcoded, immutable, always-installed).
+   * Used by handlers and utilities that need to check whether a protocol URI
+   * belongs to a core protocol or to dispatch lifecycle hooks.
+   */
+  public get coreProtocols(): CoreProtocolRegistry {
+    return this._coreProtocols;
   }
 
   /**

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -9,6 +9,8 @@ export { ProtocolRecordLimitStrategy } from './types/protocols-types.js';
 export type { DataEncodedRecordsWriteMessage, RecordsCountDescriptor, RecordsCountMessage, RecordsCountReply, RecordsDeleteMessage, RecordsFilter, RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry, RecordsReadMessage, RecordsReadReply, RecordsSubscribeDescriptor, RecordsSubscribeMessage, RecordsSubscribeReply, RecordSubscriptionHandler, RecordsWriteDescriptor, RecordsWriteTags, RecordsWriteTagValue, RecordsWriteMessage, RecordsWriteSignaturePayload, RecordsDeleteDescriptor, RecordsQueryDescriptor, RecordsReadDescriptor, RecordsSubscribeMessageOptions, RecordsWriteMessageOptions, InternalRecordsWriteMessage, RecordEvent, RecordsWriteTagsFilter } from './types/records-types.js';
 export type { GeneralJws, SignatureEntry } from './types/jws-types.js';
 export { authenticate } from './core/auth.js';
+export { CoreProtocolRegistry, PERMISSIONS_REVOCATION_PATH } from './core/core-protocol.js';
+export type { CoreProtocol, CoreProtocolStores } from './core/core-protocol.js';
 export { AllowAllTenantGate } from './core/tenant-gate.js';
 export type { ActiveTenantCheckResult, TenantGate } from './core/tenant-gate.js';
 export { Cid } from './utils/cid.js';

--- a/packages/dwn-sdk-js/src/protocols/permissions.ts
+++ b/packages/dwn-sdk-js/src/protocols/permissions.ts
@@ -1,13 +1,20 @@
+import type { Filter } from '../types/query-types.js';
 import type { GenericMessage } from '../types/message-types.js';
+import type { MessagesFilter } from '../types/messages-types.js';
 import type { MessageSigner } from '../types/signer.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { ProtocolDefinition } from '../types/protocols-types.js';
+import type { CoreProtocol, CoreProtocolStores } from '../core/core-protocol.js';
 import type { DataEncodedRecordsWriteMessage, RecordsWriteMessage } from '../types/records-types.js';
 import type { PermissionConditions, PermissionGrantData, PermissionRequestData, PermissionRevocationData, PermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
 
+import { DwnConstant } from '../core/dwn-constant.js';
 import { Encoder } from '../utils/encoder.js';
+import { FilterUtility } from '../utils/filter.js';
+import { Message } from '../core/message.js';
 import { PermissionGrant } from './permission-grant.js';
 import { PermissionRequest } from './permission-request.js';
+import { Records } from '../utils/records.js';
 import { RecordsWrite } from '../../src/interfaces/records-write.js';
 import { Time } from '../utils/time.js';
 import { validateJsonSchema } from '../schema-validator.js';
@@ -79,8 +86,12 @@ export type PermissionRevocationCreateOptions = {
 
 /**
  * This is a first-class DWN protocol for managing permission grants of a given DWN.
+ *
+ * It implements the `CoreProtocol` interface so that its lifecycle hooks
+ * (validation, pre-processing, post-processing) are dispatched generically
+ * by the `CoreProtocolRegistry` rather than being hardcoded in handlers.
  */
-export class PermissionsProtocol {
+export class PermissionsProtocol implements CoreProtocol {
   /**
    * The URI of the DWN Permissions protocol.
    */
@@ -155,6 +166,137 @@ export class PermissionsProtocol {
       }
     }
   };
+
+  // ---------- CoreProtocol instance accessors ----------
+
+  /** @inheritdoc */
+  public get uri(): string {
+    return PermissionsProtocol.uri;
+  }
+
+  /** @inheritdoc */
+  public get definition(): ProtocolDefinition {
+    return PermissionsProtocol.definition;
+  }
+
+  // ---------- CoreProtocol lifecycle hooks ----------
+
+  /** @inheritdoc */
+  public validateRecord(message: RecordsWriteMessage, dataBytes: Uint8Array): void {
+    PermissionsProtocol.validateSchema(message, dataBytes);
+  }
+
+  /**
+   * Pre-processing hook for permission revocation records.
+   * Validates that the revocation's `tags.protocol` matches the grant's scoped protocol.
+   */
+  public async preProcessWrite(
+    tenant: string,
+    message: RecordsWriteMessage,
+    messageStore: MessageStore,
+  ): Promise<void> {
+    if (message.descriptor.protocolPath !== PermissionsProtocol.revocationPath) {
+      return;
+    }
+
+    // fetch the parent grant to compare the scoped protocol against the revocation tag
+    const permissionGrantId = message.descriptor.parentId!;
+    const grant = await PermissionsProtocol.fetchGrant(tenant, messageStore, permissionGrantId);
+
+    const revokeTagProtocol = message.descriptor.tags?.protocol;
+    const grantProtocol = 'protocol' in grant.scope ? grant.scope.protocol : undefined;
+    if (grantProtocol !== revokeTagProtocol) {
+      throw new DwnError(
+        DwnErrorCode.PermissionsProtocolValidateRevocationProtocolTagMismatch,
+        `Revocation protocol ${revokeTagProtocol} does not match grant protocol ${grantProtocol}`
+      );
+    }
+  }
+
+  /**
+   * Post-processing hook for permission revocation records.
+   * When a grant is revoked, all messages authorized by that grant and created
+   * after the revocation timestamp are deleted from all stores.
+   *
+   * Deletion order is deliberate to avoid orphaned data in case of crash:
+   *   1. data store  (large blobs first)
+   *   2. state index (SMT entries)
+   *   3. message store
+   */
+  public async postProcessWrite(
+    tenant: string,
+    recordsWrite: RecordsWrite,
+    stores: CoreProtocolStores,
+  ): Promise<void> {
+    if (recordsWrite.message.descriptor.protocolPath !== PermissionsProtocol.revocationPath) {
+      return;
+    }
+
+    const permissionGrantId = recordsWrite.message.descriptor.parentId!;
+    const grantAuthorizedMessagesQuery = {
+      permissionGrantId,
+      dateCreated: { gte: recordsWrite.message.descriptor.messageTimestamp },
+    };
+    const { messages: grantAuthorizedMessages } = await stores.messageStore.query(tenant, [grantAuthorizedMessagesQuery]);
+
+    if (grantAuthorizedMessages.length === 0) {
+      return;
+    }
+
+    // 1. Delete data from the data store first to avoid orphaned data blobs in case of crash.
+    //    Only RecordsWrite messages with data larger than maxDataSizeAllowedToBeEncoded have data in the data store.
+    for (const message of grantAuthorizedMessages) {
+      if (message.descriptor.method === DwnMethodName.Write) {
+        const recordsWriteMessage = message as RecordsWriteMessage;
+        if (recordsWriteMessage.descriptor.dataSize > DwnConstant.maxDataSizeAllowedToBeEncoded) {
+          await stores.dataStore.delete(tenant, recordsWriteMessage.recordId, recordsWriteMessage.descriptor.dataCid);
+        }
+      }
+    }
+
+    // 2. Compute CIDs and delete from state index before message store to avoid orphaned state entries.
+    const messageCids = await Promise.all(grantAuthorizedMessages.map((message): Promise<string> => Message.getCid(message)));
+    await stores.stateIndex.delete(tenant, messageCids);
+
+    // 3. Finally delete all messages from the message store.
+    await Promise.all(messageCids.map((cid): Promise<void> => stores.messageStore.delete(tenant, cid)));
+  }
+
+  /** @inheritdoc */
+  public mapErrorToStatusCode(errorCode: string): number | undefined {
+    if (errorCode.startsWith('PermissionsProtocolValidate')) {
+      return 400;
+    }
+    return undefined;
+  }
+
+  /**
+   * Constructs an additional filter for protocol-scoped message queries so that
+   * permission records (grants, requests, revocations) tagged with the target
+   * protocol appear alongside that protocol's own records in sync/subscribe/read results.
+   */
+  public constructAdditionalMessageFilter(filter: MessagesFilter): Filter | undefined {
+    const { protocol, messageTimestamp } = filter;
+    if (protocol === undefined) {
+      return undefined;
+    }
+
+    const taggedFilter = {
+      protocol: PermissionsProtocol.uri,
+      ...Records.convertTagsFilter({ protocol }),
+    } as Filter;
+
+    if (messageTimestamp !== undefined) {
+      const messageTimestampFilter = FilterUtility.convertRangeCriterion(messageTimestamp);
+      if (messageTimestampFilter) {
+        taggedFilter.messageTimestamp = messageTimestampFilter;
+      }
+    }
+
+    return taggedFilter;
+  }
+
+  // ---------- Static utility methods ----------
 
   public static parseRequest(base64UrlEncodedRequest: string): PermissionRequestData {
     return Encoder.base64UrlToObject(base64UrlEncodedRequest);


### PR DESCRIPTION
## Summary

Introduces the `CoreProtocol` framework — a generic pattern for hardcoded, immutable, always-installed DWN protocols with lifecycle hooks dispatched via a registry rather than hardcoded `if` checks in handlers.

- **`CoreProtocol` interface** with 5 optional hooks: `validateRecord`, `preProcessWrite`, `postProcessWrite`, `mapErrorToStatusCode`, `constructAdditionalMessageFilter`
- **`CoreProtocolRegistry`** (instance-level, owned by `Dwn`) for test isolation
- **`PermissionsProtocol` implements `CoreProtocol`** with instance accessors delegating to static properties, plus all 5 lifecycle hooks ported from scattered handler code
- **`PERMISSIONS_REVOCATION_PATH` constant** to break the circular dependency between `grant-authorization.ts` and `protocols/permissions.ts`

This is the foundational PR (issues #414, #415, #416) of the core protocols epic (#413). The hooks are defined but not yet dispatched — handler refactoring (#417–#420) and tests (#421) follow in subsequent PRs.

## Changes

| File | What |
|---|---|
| `src/core/core-protocol.ts` | New — `CoreProtocol` interface, `CoreProtocolStores` type, `CoreProtocolRegistry` class, `PERMISSIONS_REVOCATION_PATH` |
| `src/protocols/permissions.ts` | `PermissionsProtocol implements CoreProtocol` — instance accessors + 5 hooks |
| `src/dwn.ts` | `_coreProtocols` field, registry init in constructor, `coreProtocols` getter |
| `src/index.ts` | Export `CoreProtocol`, `CoreProtocolStores`, `CoreProtocolRegistry`, `PERMISSIONS_REVOCATION_PATH` |

## Verification

- Lint: clean (`bun run lint` — 0 errors)
- Build: clean (`tsc` — 0 errors)
- Tests: 1071 pass, 0 fail (`bun run test:node`)

Closes #414, closes #415, closes #416
Part of epic #413