### PR TITLE
test(agent): clean up stale test TODOs (#71)

### DIFF
--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -290,7 +290,6 @@ describe('web5 connect', () => {
       expect(result).toEqual(authRequest);
     });
 
-    // TODO: waiting for DWN feature complete
     it('should create permission grants for each selected did', async () => {
       const results = await Oidc.createPermissionGrants(
         providerIdentity.did.uri,

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -851,8 +851,7 @@ describe('AgentDwnApi', () => {
         signAsOwnerDelegate : true,
         granteeDid          : aliceDeviceX.did.uri,
         messageParams       : {
-          dataFormat     : 'text/plain', // TODO: not necessary
-          delegatedGrant : recordsWriteDelegateGrant.message,
+          delegatedGrant: recordsWriteDelegateGrant.message,
         },
         dataStream,
       });


### PR DESCRIPTION
## Summary

- Removed unnecessary `dataFormat: 'text/plain'` param from the owner-delegate sign test in `dwn-api.spec.ts`. The `rawMessage` path ignores `messageParams` fields other than `delegatedGrant` — confirmed test still passes.
- Removed stale `// TODO: waiting for DWN feature complete` comment from `createPermissionGrants` test in `connect.spec.ts`. The feature is implemented and the test runs; its only failure mode is did:dht Pkarr infrastructure availability.

Closes #71