### PR TITLE
feat(dwn-sdk-js): wire CoreProtocol hooks into handlers and remove hardcoded special-casing (#417, #418, #419, #420, #421)

### DIFF
--- a/packages/dwn-sdk-js/src/core/grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/grant-authorization.ts
@@ -3,6 +3,7 @@ import type { MessageStore } from '../types/message-store.js';
 import type { PermissionGrant } from '../protocols/permission-grant.js';
 
 import { Message } from './message.js';
+import { PERMISSIONS_REVOCATION_PATH } from './core-protocol.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
@@ -109,7 +110,7 @@ export class GrantAuthorization {
     // Check if grant has been revoked
     const query = {
       parentId          : permissionGrant.id,
-      protocolPath      : `grant/revocation`, // NOTE: this is optional, not referencing PermissionsProtocol.revocationPath due to circular dependency
+      protocolPath      : PERMISSIONS_REVOCATION_PATH,
       isLatestBaseState : true
     };
     const { messages: revokes } = await messageStore.query(grantedFor, [query]);

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -1,3 +1,4 @@
+import type { CoreProtocolRegistry } from './core-protocol.js';
 import type { Filter } from '../types/query-types.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { RecordsCount } from '../interfaces/records-count.js';
@@ -10,7 +11,6 @@ import type { RecordsWriteMessage } from '../types/records-types.js';
 import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage } from '../types/protocols-types.js';
 
 import { getRuleSetAtPath } from '../utils/protocols.js';
-import { PermissionsProtocol } from '../protocols/permissions.js';
 import { SortDirection } from '../types/query-types.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
@@ -47,6 +47,7 @@ export class ProtocolAuthorization {
     tenant: string,
     incomingMessage: RecordsWrite,
     messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
     // Determine the governing timestamp for protocol definition lookup.
     // For an initial write, this is the message's own timestamp.
@@ -61,19 +62,23 @@ export class ProtocolAuthorization {
       incomingMessage.message.descriptor.protocol!,
       messageStore,
       governingTimestamp,
+      coreProtocols,
     );
+
+    // Create a bound fetch function that captures the registry for downstream callbacks.
+    const boundFetchDefinition = ProtocolAuthorization.createBoundFetchDefinition(coreProtocols);
 
     // verify declared protocol type exists in protocol and that it conforms to type specification.
     // For cross-protocol composition, the type may be defined in a referenced protocol.
     await verifyTypeWithComposition(
       tenant, incomingMessage.message, protocolDefinition, messageStore,
-      ProtocolAuthorization.fetchProtocolDefinition, governingTimestamp
+      boundFetchDefinition, governingTimestamp
     );
 
     // validate `protocolPath`
     await verifyProtocolPathAndContextId(
       tenant, incomingMessage, messageStore,
-      ProtocolAuthorization.fetchProtocolDefinition, governingTimestamp,
+      boundFetchDefinition, governingTimestamp,
     );
 
     // get the rule set for the inbound message
@@ -108,6 +113,7 @@ export class ProtocolAuthorization {
     tenant: string,
     incomingMessage: RecordsWrite,
     messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
     const existingInitialWrite = await fetchInitialWrite(tenant, incomingMessage.message.recordId, messageStore);
 
@@ -132,6 +138,7 @@ export class ProtocolAuthorization {
       incomingMessage.message.descriptor.protocol!,
       messageStore,
       governingTimestamp,
+      coreProtocols,
     );
 
     // get the rule set for the inbound message
@@ -139,6 +146,8 @@ export class ProtocolAuthorization {
       incomingMessage.message.descriptor.protocolPath!,
       protocolDefinition,
     );
+
+    const boundFetchDefinition = ProtocolAuthorization.createBoundFetchDefinition(coreProtocols);
 
     // If the incoming message has `protocolRole` in the descriptor, validate the invoked role
     await verifyInvokedRole(
@@ -148,7 +157,7 @@ export class ProtocolAuthorization {
       incomingMessage.message.contextId!,
       protocolDefinition,
       messageStore,
-      ProtocolAuthorization.fetchProtocolDefinition,
+      boundFetchDefinition,
       governingTimestamp,
     );
 
@@ -173,6 +182,7 @@ export class ProtocolAuthorization {
     incomingMessage: RecordsRead,
     newestRecordsWrite: RecordsWrite,
     messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
     // fetch record chain
     const recordChain: RecordsWriteMessage[] =
@@ -193,6 +203,7 @@ export class ProtocolAuthorization {
       newestRecordsWrite.message.descriptor.protocol!,
       messageStore,
       governingTimestamp,
+      coreProtocols,
     );
 
     // get the rule set for the inbound message
@@ -200,6 +211,8 @@ export class ProtocolAuthorization {
       newestRecordsWrite.message.descriptor.protocolPath!,
       protocolDefinition,
     );
+
+    const boundFetchDefinition = ProtocolAuthorization.createBoundFetchDefinition(coreProtocols);
 
     // If the incoming message has `protocolRole` in the descriptor, validate the invoked role
     await verifyInvokedRole(
@@ -209,7 +222,7 @@ export class ProtocolAuthorization {
       newestRecordsWrite.message.contextId!,
       protocolDefinition,
       messageStore,
-      ProtocolAuthorization.fetchProtocolDefinition,
+      boundFetchDefinition,
       governingTimestamp,
     );
 
@@ -228,6 +241,7 @@ export class ProtocolAuthorization {
     tenant: string,
     incomingMessage: RecordsCount | RecordsQuery | RecordsSubscribe,
     messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
     const { protocol, protocolPath, contextId } = incomingMessage.message.descriptor.filter;
 
@@ -236,6 +250,8 @@ export class ProtocolAuthorization {
       tenant,
       protocol!, // `authorizeQueryOrSubscribe` is only called if `protocol` is present
       messageStore,
+      undefined,
+      coreProtocols,
     );
 
     // get the rule set for the inbound message
@@ -243,6 +259,8 @@ export class ProtocolAuthorization {
       protocolPath!, // presence of `protocolPath` is verified in `parse()`
       protocolDefinition,
     );
+
+    const boundFetchDefinition = ProtocolAuthorization.createBoundFetchDefinition(coreProtocols);
 
     // If the incoming message has `protocolRole` in the descriptor, validate the invoked role
     await verifyInvokedRole(
@@ -252,7 +270,7 @@ export class ProtocolAuthorization {
       contextId,
       protocolDefinition,
       messageStore,
-      ProtocolAuthorization.fetchProtocolDefinition,
+      boundFetchDefinition,
     );
 
     // verify method invoked against the allowed actions in the rule set
@@ -275,6 +293,7 @@ export class ProtocolAuthorization {
     incomingMessage: RecordsDelete,
     recordsWrite: RecordsWrite,
     messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
 
     // fetch record chain
@@ -295,6 +314,7 @@ export class ProtocolAuthorization {
       recordsWrite.message.descriptor.protocol!,
       messageStore,
       governingTimestamp,
+      coreProtocols,
     );
 
     // get the rule set for the inbound message
@@ -302,6 +322,8 @@ export class ProtocolAuthorization {
       recordsWrite.message.descriptor.protocolPath!,
       protocolDefinition,
     );
+
+    const boundFetchDefinition = ProtocolAuthorization.createBoundFetchDefinition(coreProtocols);
 
     // If the incoming message has `protocolRole` in the descriptor, validate the invoked role
     await verifyInvokedRole(
@@ -311,7 +333,7 @@ export class ProtocolAuthorization {
       recordsWrite.message.contextId!,
       protocolDefinition,
       messageStore,
-      ProtocolAuthorization.fetchProtocolDefinition,
+      boundFetchDefinition,
       governingTimestamp,
     );
 
@@ -331,16 +353,25 @@ export class ProtocolAuthorization {
    * When `messageTimestamp` is provided, returns the protocol definition that was active at that
    * point in time — i.e. the ProtocolsConfigure with the greatest `messageTimestamp` that is <= the
    * given timestamp. When not provided, returns the latest (current) protocol definition.
+   *
+   * When `coreProtocols` is provided, core protocol definitions are returned directly from the
+   * registry without a message store query. The extra parameter does not affect the
+   * `FetchProtocolDefinitionFn` callback type — callers that pass this function as a callback
+   * should bind the registry via a closure (see `createBoundFetchDefinition`).
    */
   public static async fetchProtocolDefinition(
     tenant: string,
     protocolUri: string,
     messageStore: MessageStore,
     messageTimestamp?: string,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<ProtocolDefinition> {
-    // if first-class protocol, return the definition from const object directly without going to data store
-    if (protocolUri === PermissionsProtocol.uri) {
-      return PermissionsProtocol.definition;
+    // if the protocol is a registered core protocol, return the definition directly without a store query
+    if (coreProtocols !== undefined) {
+      const coreDefinition = coreProtocols.getDefinition(protocolUri);
+      if (coreDefinition !== undefined) {
+        return coreDefinition;
+      }
     }
 
     // fetch the corresponding protocol definition
@@ -371,6 +402,23 @@ export class ProtocolAuthorization {
 
     const protocolMessage = protocols[0] as ProtocolsConfigureMessage;
     return protocolMessage.descriptor.definition;
+  }
+
+  /**
+   * Creates a `FetchProtocolDefinitionFn` closure that binds the given `CoreProtocolRegistry`.
+   * This allows core protocol definitions to be resolved from the registry without changing
+   * the `FetchProtocolDefinitionFn` type signature — zero ripple to downstream consumers
+   * like `protocol-authorization-action.ts` and `protocol-authorization-validation.ts`.
+   */
+  private static createBoundFetchDefinition(coreProtocols?: CoreProtocolRegistry): FetchProtocolDefinitionFn {
+    return (
+      tenant: string,
+      protocolUri: string,
+      messageStore: MessageStore,
+      messageTimestamp?: string,
+    ): Promise<ProtocolDefinition> => {
+      return ProtocolAuthorization.fetchProtocolDefinition(tenant, protocolUri, messageStore, messageTimestamp, coreProtocols);
+    };
   }
 
   /**

--- a/packages/dwn-sdk-js/src/dwn.ts
+++ b/packages/dwn-sdk-js/src/dwn.ts
@@ -80,6 +80,7 @@ export class Dwn {
       [DwnInterfaceName.Messages + DwnMethodName.Subscribe]: new MessagesSubscribeHandler(
         this.didResolver,
         this.messageStore,
+        this._coreProtocols,
         this.eventLog,
       ),
       [DwnInterfaceName.Messages + DwnMethodName.Sync]: new MessagesSyncHandler(
@@ -101,32 +102,38 @@ export class Dwn {
       [DwnInterfaceName.Records + DwnMethodName.Count]: new RecordsCountHandler(
         this.didResolver,
         this.messageStore,
+        this._coreProtocols,
       ),
       [DwnInterfaceName.Records + DwnMethodName.Delete]: new RecordsDeleteHandler(
         this.didResolver,
         this.messageStore,
-        this.resumableTaskManager
+        this.resumableTaskManager,
+        this._coreProtocols,
       ),
       [DwnInterfaceName.Records + DwnMethodName.Query]: new RecordsQueryHandler(
         this.didResolver,
         this.messageStore,
-        this.dataStore
+        this.dataStore,
+        this._coreProtocols,
       ),
       [DwnInterfaceName.Records + DwnMethodName.Read]: new RecordsReadHandler(
         this.didResolver,
         this.messageStore,
-        this.dataStore
+        this.dataStore,
+        this._coreProtocols,
       ),
       [DwnInterfaceName.Records + DwnMethodName.Subscribe]: new RecordsSubscribeHandler(
         this.didResolver,
         this.messageStore,
-        this.eventLog
+        this._coreProtocols,
+        this.eventLog,
       ),
       [DwnInterfaceName.Records + DwnMethodName.Write]: new RecordsWriteHandler(
         this.didResolver,
         this.messageStore,
         this.dataStore,
         this.stateIndex,
+        this._coreProtocols,
         this.eventLog
       )
     };

--- a/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
@@ -1,3 +1,4 @@
+import type { CoreProtocolRegistry } from '../core/core-protocol.js';
 import type { DidResolver } from '@enbox/dids';
 import type { MessageStore } from '../types/message-store.js';
 import type { MethodHandler } from '../types/method-handler.js';
@@ -17,7 +18,8 @@ export class MessagesSubscribeHandler implements MethodHandler {
   constructor(
     private didResolver: DidResolver,
     private messageStore: MessageStore,
-    private eventLog?: EventLog
+    private coreProtocols?: CoreProtocolRegistry,
+    private eventLog?: EventLog,
   ) {}
 
   public async handle({
@@ -51,7 +53,7 @@ export class MessagesSubscribeHandler implements MethodHandler {
     }
 
     const { filters, cursor: eventLogCursor } = message.descriptor;
-    const messagesFilters = Messages.convertFilters(filters);
+    const messagesFilters = Messages.convertFilters(filters, this.coreProtocols);
     const messageCid = await Message.getCid(message);
 
     try {

--- a/packages/dwn-sdk-js/src/handlers/records-count.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-count.ts
@@ -1,3 +1,4 @@
+import type { CoreProtocolRegistry } from '../core/core-protocol.js';
 import type { DidResolver } from '@enbox/dids';
 import type { Filter } from '../types/query-types.js';
 import type { MessageStore } from '../types//message-store.js';
@@ -14,7 +15,11 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export class RecordsCountHandler implements MethodHandler {
 
-  constructor(private didResolver: DidResolver, private messageStore: MessageStore) { }
+  constructor(
+    private didResolver: DidResolver,
+    private messageStore: MessageStore,
+    private coreProtocols?: CoreProtocolRegistry,
+  ) { }
 
   public async handle({
     tenant,
@@ -37,7 +42,7 @@ export class RecordsCountHandler implements MethodHandler {
       try {
         await authenticate(message.authorization!, this.didResolver);
 
-        await RecordsCountHandler.authorizeRecordsCount(tenant, recordsCount, this.messageStore);
+        await RecordsCountHandler.authorizeRecordsCount(tenant, recordsCount, this.messageStore, this.coreProtocols);
       } catch (e) {
         return messageReplyFromError(e, 401);
       }
@@ -167,7 +172,8 @@ export class RecordsCountHandler implements MethodHandler {
   private static async authorizeRecordsCount(
     tenant: string,
     recordsCount: RecordsCount,
-    messageStore: MessageStore
+    messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
 
     if (Message.isSignedByAuthorDelegate(recordsCount.message)) {
@@ -178,7 +184,7 @@ export class RecordsCountHandler implements MethodHandler {
     // this is because we dynamically filter out records that the caller is not authorized to see.
     // Currently only run protocol authorization if message deliberately invokes a protocol role.
     if (Records.shouldProtocolAuthorize(recordsCount.signaturePayload!)) {
-      await ProtocolAuthorization.authorizeQueryOrSubscribe(tenant, recordsCount, messageStore);
+      await ProtocolAuthorization.authorizeQueryOrSubscribe(tenant, recordsCount, messageStore, coreProtocols);
     }
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-delete.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-delete.ts
@@ -1,3 +1,4 @@
+import type { CoreProtocolRegistry } from '../core/core-protocol.js';
 import type { DidResolver } from '@enbox/dids';
 import type { GenericMessageReply } from '../types/message-types.js';
 import type { MessageStore } from '../types//message-store.js';
@@ -23,6 +24,7 @@ export class RecordsDeleteHandler implements MethodHandler {
     private didResolver: DidResolver,
     private messageStore: MessageStore,
     private resumableTaskManager: ResumableTaskManager,
+    private coreProtocols?: CoreProtocolRegistry,
   ) { }
 
   public async handle({
@@ -78,7 +80,8 @@ export class RecordsDeleteHandler implements MethodHandler {
         tenant,
         recordsDelete,
         initialWrite!,
-        this.messageStore
+        this.messageStore,
+        this.coreProtocols,
       );
     } catch (e) {
       return messageReplyFromError(e, 401);
@@ -104,7 +107,8 @@ export class RecordsDeleteHandler implements MethodHandler {
     tenant: string,
     recordsDelete: RecordsDelete,
     recordsWrite: RecordsWrite,
-    messageStore: MessageStore
+    messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
 
     if (Message.isSignedByAuthorDelegate(recordsDelete.message)) {
@@ -124,7 +128,7 @@ export class RecordsDeleteHandler implements MethodHandler {
         messageStore,
       });
     } else {
-      await ProtocolAuthorization.authorizeDelete(tenant, recordsDelete, recordsWrite, messageStore);
+      await ProtocolAuthorization.authorizeDelete(tenant, recordsDelete, recordsWrite, messageStore, coreProtocols);
     }
   }
 };

--- a/packages/dwn-sdk-js/src/handlers/records-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-query.ts
@@ -1,3 +1,4 @@
+import type { CoreProtocolRegistry } from '../core/core-protocol.js';
 import type { DataStore } from '../types/data-store.js';
 import type { DidResolver } from '@enbox/dids';
 import type { MessageStore } from '../types//message-store.js';
@@ -19,7 +20,12 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export class RecordsQueryHandler implements MethodHandler {
 
-  constructor(private didResolver: DidResolver, private messageStore: MessageStore, private dataStore: DataStore) { }
+  constructor(
+    private didResolver: DidResolver,
+    private messageStore: MessageStore,
+    private dataStore: DataStore,
+    private coreProtocols?: CoreProtocolRegistry,
+  ) { }
 
   public async handle({
     tenant,
@@ -44,7 +50,7 @@ export class RecordsQueryHandler implements MethodHandler {
       try {
         await authenticate(message.authorization!, this.didResolver);
 
-        await RecordsQueryHandler.authorizeRecordsQuery(tenant, recordsQuery, this.messageStore);
+        await RecordsQueryHandler.authorizeRecordsQuery(tenant, recordsQuery, this.messageStore, this.coreProtocols);
       } catch (e) {
         return messageReplyFromError(e, 401);
       }
@@ -249,7 +255,8 @@ export class RecordsQueryHandler implements MethodHandler {
   private static async authorizeRecordsQuery(
     tenant: string,
     recordsQuery: RecordsQuery,
-    messageStore: MessageStore
+    messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
 
     if (Message.isSignedByAuthorDelegate(recordsQuery.message)) {
@@ -260,7 +267,7 @@ export class RecordsQueryHandler implements MethodHandler {
     // this is because we dynamically filter out records that the caller is not authorized to see.
     // Currently only run protocol authorization if message deliberately invokes a protocol role.
     if (Records.shouldProtocolAuthorize(recordsQuery.signaturePayload!)) {
-      await ProtocolAuthorization.authorizeQueryOrSubscribe(tenant, recordsQuery, messageStore);
+      await ProtocolAuthorization.authorizeQueryOrSubscribe(tenant, recordsQuery, messageStore, coreProtocols);
     }
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -1,3 +1,4 @@
+import type { CoreProtocolRegistry } from '../core/core-protocol.js';
 import type { DataStore } from '../types/data-store.js';
 import type { DidResolver } from '@enbox/dids';
 import type { Filter } from '../types/query-types.js';
@@ -21,7 +22,12 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export class RecordsReadHandler implements MethodHandler {
 
-  constructor(private didResolver: DidResolver, private messageStore: MessageStore, private dataStore: DataStore) { }
+  constructor(
+    private didResolver: DidResolver,
+    private messageStore: MessageStore,
+    private dataStore: DataStore,
+    private coreProtocols?: CoreProtocolRegistry,
+  ) { }
 
   public async handle({
     tenant,
@@ -89,7 +95,7 @@ export class RecordsReadHandler implements MethodHandler {
       const parsedNewestWrite = await RecordsWrite.parse(newestWrite);
 
       try {
-        await RecordsReadHandler.authorizeRecordsRead(tenant, recordsRead, parsedNewestWrite, this.messageStore);
+        await RecordsReadHandler.authorizeRecordsRead(tenant, recordsRead, parsedNewestWrite, this.messageStore, this.coreProtocols);
       } catch (error) {
         return messageReplyFromError(error, 401);
       }
@@ -107,7 +113,10 @@ export class RecordsReadHandler implements MethodHandler {
     const matchedRecordsWrite = matchedMessage as RecordsQueryReplyEntry;
 
     try {
-      await RecordsReadHandler.authorizeRecordsRead(tenant, recordsRead, await RecordsWrite.parse(matchedRecordsWrite), this.messageStore);
+      const parsedWrite = await RecordsWrite.parse(matchedRecordsWrite);
+      await RecordsReadHandler.authorizeRecordsRead(
+        tenant, recordsRead, parsedWrite, this.messageStore, this.coreProtocols,
+      );
     } catch (error) {
       return messageReplyFromError(error, 401);
     }
@@ -156,7 +165,8 @@ export class RecordsReadHandler implements MethodHandler {
     tenant: string,
     recordsRead: RecordsRead,
     matchedRecordsWrite: RecordsWrite,
-    messageStore: MessageStore
+    messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
     if (Message.isSignedByAuthorDelegate(recordsRead.message)) {
       await recordsRead.authorizeDelegate(matchedRecordsWrite.message, messageStore);
@@ -186,7 +196,7 @@ export class RecordsReadHandler implements MethodHandler {
         messageStore
       });
     } else {
-      await ProtocolAuthorization.authorizeRead(tenant, recordsRead, matchedRecordsWrite, messageStore);
+      await ProtocolAuthorization.authorizeRead(tenant, recordsRead, matchedRecordsWrite, messageStore, coreProtocols);
     }
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -1,3 +1,4 @@
+import type { CoreProtocolRegistry } from '../core/core-protocol.js';
 import type { DidResolver } from '@enbox/dids';
 import type { MessageSort } from '../types/message-types.js';
 import type { MessageStore } from '../types//message-store.js';
@@ -20,7 +21,12 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export class RecordsSubscribeHandler implements MethodHandler {
 
-  constructor(private didResolver: DidResolver, private messageStore: MessageStore, private eventLog?: EventLog) { }
+  constructor(
+    private didResolver: DidResolver,
+    private messageStore: MessageStore,
+    private coreProtocols?: CoreProtocolRegistry,
+    private eventLog?: EventLog,
+  ) { }
 
   public async handle({
     tenant,
@@ -59,7 +65,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
       // authentication and authorization
       try {
         await authenticate(message.authorization!, this.didResolver);
-        await RecordsSubscribeHandler.authorizeRecordsSubscribe(tenant, recordsSubscribe, this.messageStore);
+        await RecordsSubscribeHandler.authorizeRecordsSubscribe(tenant, recordsSubscribe, this.messageStore, this.coreProtocols);
       } catch (error) {
         return messageReplyFromError(error, 401);
       }
@@ -320,7 +326,8 @@ export class RecordsSubscribeHandler implements MethodHandler {
   public static async authorizeRecordsSubscribe(
     tenant: string,
     recordsSubscribe: RecordsSubscribe,
-    messageStore: MessageStore
+    messageStore: MessageStore,
+    coreProtocols?: CoreProtocolRegistry,
   ): Promise<void> {
 
     if (Message.isSignedByAuthorDelegate(recordsSubscribe.message)) {
@@ -331,7 +338,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
     // this is because we dynamically filter out records that the caller is not authorized to see.
     // Currently only run protocol authorization if message deliberately invokes a protocol role.
     if (Records.shouldProtocolAuthorize(recordsSubscribe.signaturePayload!)) {
-      await ProtocolAuthorization.authorizeQueryOrSubscribe(tenant, recordsSubscribe, messageStore);
+      await ProtocolAuthorization.authorizeQueryOrSubscribe(tenant, recordsSubscribe, messageStore, coreProtocols);
     }
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -1,3 +1,4 @@
+import type { CoreProtocolRegistry } from '../core/core-protocol.js';
 import type { DataStore } from '../types/data-store.js';
 import type { DidResolver } from '@enbox/dids';
 import type { EventLog } from '../types/subscriptions.js';
@@ -31,6 +32,7 @@ export class RecordsWriteHandler implements MethodHandler {
     private messageStore: MessageStore,
     private dataStore: DataStore,
     private stateIndex: StateIndex,
+    private coreProtocols: CoreProtocolRegistry,
     private eventLog?: EventLog
   ) { }
 
@@ -43,7 +45,7 @@ export class RecordsWriteHandler implements MethodHandler {
     try {
       recordsWrite = await RecordsWrite.parse(message);
 
-      await ProtocolAuthorization.validateReferentialIntegrity(tenant, recordsWrite, this.messageStore);
+      await ProtocolAuthorization.validateReferentialIntegrity(tenant, recordsWrite, this.messageStore, this.coreProtocols);
     } catch (e) {
       return messageReplyFromError(e, 400);
     }
@@ -51,7 +53,7 @@ export class RecordsWriteHandler implements MethodHandler {
     // authentication & authorization
     try {
       await authenticate(message.authorization, this.didResolver, message.attestation);
-      await RecordsWriteHandler.authorizeRecordsWrite(tenant, recordsWrite, this.messageStore);
+      await this.authorizeRecordsWrite(tenant, recordsWrite, this.messageStore);
     } catch (e) {
       return messageReplyFromError(e, 401);
     }
@@ -92,6 +94,12 @@ export class RecordsWriteHandler implements MethodHandler {
       };
     }
 
+    // Look up the core protocol (if any) for the incoming message so that lifecycle hooks
+    // can be dispatched generically rather than checking for specific protocol URIs.
+    const coreProtocol = message.descriptor.protocol !== undefined
+      ? this.coreProtocols.get(message.descriptor.protocol)
+      : undefined;
+
     try {
       if (newestExistingMessage?.descriptor.method === DwnMethodName.Delete) {
         throw new DwnError(
@@ -100,11 +108,12 @@ export class RecordsWriteHandler implements MethodHandler {
         );
       }
 
-      // NOTE: We want to perform additional validation before storing the RecordsWrite.
-      // This is necessary for core DWN RecordsWrite that needs additional processing and allows us to fail before the storing and post processing.
-      //
-      // Example: Ensures that the protocol tag of a permission revocation RecordsWrite and the parent grant's scoped protocol match.
-      await this.preProcessingForCoreRecordsWrite(tenant, message);
+      // Dispatch pre-processing hooks to the core protocol, if applicable.
+      // This allows core protocols to perform cross-record validation before storage
+      // (e.g. ensuring revocation tag consistency with the parent grant's scoped protocol).
+      if (coreProtocol?.preProcessWrite !== undefined) {
+        await coreProtocol.preProcessWrite(tenant, message, this.messageStore);
+      }
 
       // NOTE: We allow isLatestBaseState to be true ONLY if the incoming message comes with data, or if the incoming message is NOT an initial write
       // This would allow an initial write to be written to the DB without data, but having it not queryable,
@@ -146,8 +155,8 @@ export class RecordsWriteHandler implements MethodHandler {
           error.code === DwnErrorCode.RecordsWriteNotAllowedAfterDelete ||
           error.code === DwnErrorCode.RecordsWriteDataCidMismatch ||
           error.code === DwnErrorCode.RecordsWriteDataSizeMismatch ||
-          error.code.startsWith('PermissionsProtocolValidate') ||
-          error.code.startsWith('SchemaValidator')) {
+          error.code.startsWith('SchemaValidator') ||
+          this.coreProtocols.mapErrorToStatusCode(error.code) !== undefined) {
           return messageReplyFromError(error, 400);
         }
       }
@@ -170,90 +179,19 @@ export class RecordsWriteHandler implements MethodHandler {
       tenant, existingMessages, newestMessage, this.messageStore, this.dataStore, this.stateIndex
     );
 
-    await this.postProcessingForCoreRecordsWrite(tenant, recordsWrite);
+    // Dispatch post-processing hooks to the core protocol, if applicable.
+    // This allows core protocols to perform cascading side effects after a successful write
+    // (e.g. deleting messages authorized by a revoked grant).
+    if (coreProtocol?.postProcessWrite !== undefined) {
+      await coreProtocol.postProcessWrite(tenant, recordsWrite, {
+        messageStore : this.messageStore,
+        dataStore    : this.dataStore,
+        stateIndex   : this.stateIndex,
+      });
+    }
 
     return messageReply;
   };
-
-  /**
-   * Performs additional necessary validation before storing the RecordsWrite if it is a core DWN RecordsWrite that needs additional processing.
-   * For instance: a Permission revocation RecordsWrite.
-   */
-  private async preProcessingForCoreRecordsWrite(tenant: string, recordsWriteMessage: RecordsWriteMessage): Promise<void> {
-
-    // we validate the protocol tag of the revocation message against the grant's scoped protocol
-    // to do this we will fetch the grant, and compare the the scoped protocol value to the protocol tag of the revocation message
-    if (recordsWriteMessage.descriptor.protocol === PermissionsProtocol.uri &&
-      recordsWriteMessage.descriptor.protocolPath === PermissionsProtocol.revocationPath) {
-
-      // get the parentId of the revocation message, which is the permissionGrantId
-      // fetch the grant in order to get the grant's protocol
-      const permissionGrantId = recordsWriteMessage.descriptor.parentId!;
-      const grant = await PermissionsProtocol.fetchGrant(tenant, this.messageStore, permissionGrantId);
-
-      // get the protocol values of the revocation message from the protocol tag and the protocol from the grant scope if they are defined
-      // compare the two values ensuring they must match
-      const revokeTagProtocol = recordsWriteMessage.descriptor.tags?.protocol;
-      const grantProtocol = 'protocol' in grant.scope ? grant.scope.protocol : undefined;
-      if (grantProtocol !== revokeTagProtocol) {
-        throw new DwnError(
-          DwnErrorCode.PermissionsProtocolValidateRevocationProtocolTagMismatch,
-          `Revocation protocol ${revokeTagProtocol} does not match grant protocol ${grantProtocol}`
-        );
-      }
-    }
-  }
-
-  private static validateSchemaForCoreRecordsWrite(recordsWriteMessage: RecordsWriteMessage, dataBytes: Uint8Array): void {
-    if (recordsWriteMessage.descriptor.protocol === PermissionsProtocol.uri) {
-      PermissionsProtocol.validateSchema(recordsWriteMessage, dataBytes);
-    }
-  }
-
-  /**
-   * Performs additional necessary tasks if the RecordsWrite handled is a core DWN RecordsWrite that need additional processing.
-   * For instance: when a Permission revocation is written, all messages authorized by the revoked grant
-   * that were created after the revocation timestamp are deleted from all stores.
-   */
-  private async postProcessingForCoreRecordsWrite(tenant: string, recordsWrite: RecordsWrite): Promise<void> {
-    if (recordsWrite.message.descriptor.protocol !== PermissionsProtocol.uri ||
-      recordsWrite.message.descriptor.protocolPath !== PermissionsProtocol.revocationPath) {
-      return;
-    }
-
-    // Delete all messages authorized by the revoked grant that were created after the revocation.
-    // `permissionGrantId` is indexed via the RecordsWriteDescriptor spread in constructIndexes().
-    const permissionGrantId = recordsWrite.message.descriptor.parentId!;
-    const grantAuthorizedMessagesQuery = {
-      permissionGrantId,
-      dateCreated: { gte: recordsWrite.message.descriptor.messageTimestamp },
-    };
-    const { messages: grantAuthorizedMessages } = await this.messageStore.query(tenant, [grantAuthorizedMessagesQuery]);
-
-    if (grantAuthorizedMessages.length === 0) {
-      return;
-    }
-
-    // Delete data from the data store first to avoid orphaned data blobs in case of crash.
-    // Only RecordsWrite messages with data larger than maxDataSizeAllowedToBeEncoded have data in the data store.
-    for (const message of grantAuthorizedMessages) {
-      if (message.descriptor.method === DwnMethodName.Write) {
-        const recordsWriteMessage = message as RecordsWriteMessage;
-        if (recordsWriteMessage.descriptor.dataSize > DwnConstant.maxDataSizeAllowedToBeEncoded) {
-          await this.dataStore.delete(tenant, recordsWriteMessage.recordId, recordsWriteMessage.descriptor.dataCid);
-        }
-      }
-    }
-
-    // Compute CIDs for all messages to delete.
-    const messageCids = await Promise.all(grantAuthorizedMessages.map((message): Promise<string> => Message.getCid(message)));
-
-    // Delete from state index before message store so we don't have orphaned state entries.
-    await this.stateIndex.delete(tenant, messageCids);
-
-    // Finally delete all messages from the message store.
-    await Promise.all(messageCids.map((cid): Promise<void> => this.messageStore.delete(tenant, cid)));
-  }
 
   /**
    * Returns a `RecordsQueryReplyEntry` with a copy of the incoming message and the incoming data encoded to `Base64URL`.
@@ -278,7 +216,13 @@ export class RecordsWriteHandler implements MethodHandler {
       const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
       RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, dataCid, dataBytes.length);
 
-      RecordsWriteHandler.validateSchemaForCoreRecordsWrite(message, dataBytes);
+      // Dispatch schema validation to the core protocol, if applicable.
+      const coreProtocol = message.descriptor.protocol !== undefined
+        ? this.coreProtocols.get(message.descriptor.protocol)
+        : undefined;
+      if (coreProtocol?.validateRecord !== undefined) {
+        coreProtocol.validateRecord(message, dataBytes);
+      }
 
       messageWithOptionalEncodedData = await this.cloneAndAddEncodedData(message, dataBytes);
     } else {
@@ -374,7 +318,7 @@ export class RecordsWriteHandler implements MethodHandler {
     }
   }
 
-  private static async authorizeRecordsWrite(tenant: string, recordsWrite: RecordsWrite, messageStore: MessageStore): Promise<void> {
+  private async authorizeRecordsWrite(tenant: string, recordsWrite: RecordsWrite, messageStore: MessageStore): Promise<void> {
     // if owner signature is given (`owner` is not `undefined`), it must be the same as the tenant DID
     if (recordsWrite.owner !== undefined && recordsWrite.owner !== tenant) {
       throw new DwnError(
@@ -408,7 +352,7 @@ export class RecordsWriteHandler implements MethodHandler {
         messageStore
       });
     } else {
-      await ProtocolAuthorization.authorizeWrite(tenant, recordsWrite, messageStore);
+      await ProtocolAuthorization.authorizeWrite(tenant, recordsWrite, messageStore, this.coreProtocols);
     }
   }
 }

--- a/packages/dwn-sdk-js/src/utils/messages.ts
+++ b/packages/dwn-sdk-js/src/utils/messages.ts
@@ -1,10 +1,9 @@
+import type { CoreProtocolRegistry } from '../core/core-protocol.js';
 import type { Filter } from '../types/query-types.js';
 import type { MessagesFilter } from '../types/messages-types.js';
 
 import { FilterUtility } from './filter.js';
 import { normalizeProtocolUrl } from './url.js';
-import { PermissionsProtocol } from '../protocols/permissions.js';
-import { Records } from './records.js';
 import { isEmptyObject, removeUndefinedProperties } from './object.js';
 
 
@@ -42,54 +41,35 @@ export class Messages {
   /**
    *  Converts an incoming array of MessagesFilter into an array of Filter usable by MessageLog.
    *
+   * When a `CoreProtocolRegistry` is provided, each registered core protocol's
+   * `constructAdditionalMessageFilter` hook is invoked per filter. This replaces the previous
+   * hardcoded permission-records shadow filter with a generic loop over all core protocols.
+   *
    * @param filters An array of MessagesFilter
+   * @param coreProtocols Optional registry of core protocols whose additional filters are injected.
    * @returns {Filter[]} an array of generic Filter able to be used when querying.
    */
-  public static convertFilters(filters: MessagesFilter[]): Filter[] {
+  public static convertFilters(filters: MessagesFilter[], coreProtocols?: CoreProtocolRegistry): Filter[] {
 
     const messagesQueryFilters: Filter[] = [];
 
-    // convert each filter individually by the specific type of filter it is
-    // we must check for the type of filter in a specific order to make a reductive decision as to which filters need converting
-    // first we check for `MessagesRecordsFilter` fields for conversion
-    // otherwise it is `MessagesMessageFilter` fields for conversion
     for (const filter of filters) {
-      // extract the protocol tag filter from the incoming message record filter
-      // this filters for permission grants, requests and revocations associated with a targeted protocol
-      // since permissions are their own protocol, we added an additional tag index when writing the permission messages
-      // so that we can filter for permission records here
-      const permissionRecordsFilter = this.constructPermissionRecordsFilter(filter);
-      if (permissionRecordsFilter) {
-        messagesQueryFilters.push(permissionRecordsFilter);
+      // Ask each core protocol whether it needs an additional shadow filter for this query.
+      // For example, the Permissions protocol injects a filter for grants/requests/revocations
+      // tagged with the target protocol so they appear alongside that protocol's own records.
+      if (coreProtocols !== undefined) {
+        for (const coreProtocol of coreProtocols.all()) {
+          const additionalFilter = coreProtocol.constructAdditionalMessageFilter?.(filter);
+          if (additionalFilter !== undefined) {
+            messagesQueryFilters.push(additionalFilter);
+          }
+        }
       }
 
       messagesQueryFilters.push(this.convertFilter(filter));
     }
 
     return messagesQueryFilters;
-  }
-
-  /**
-   * Constructs a filter that gets associated permission records if protocol is in the given filter.
-   */
-  private static constructPermissionRecordsFilter(filter: MessagesFilter): Filter | undefined {
-    const { protocol, messageTimestamp } = filter;
-    if (protocol !== undefined) {
-      const taggedFilter = {
-        protocol: PermissionsProtocol.uri,
-        ...Records.convertTagsFilter({ protocol })
-      } as Filter;
-
-      if (messageTimestamp != undefined) {
-        // if we filter by message timestamp, we also want to filter the permission messages by the same timestamp range
-        const messageTimestampFilter = FilterUtility.convertRangeCriterion(messageTimestamp);
-        if (messageTimestampFilter) {
-          taggedFilter.messageTimestamp = messageTimestampFilter;
-        }
-      }
-
-      return taggedFilter;
-    }
   }
 
   /**

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -134,7 +134,7 @@ export function testMessagesSubscribeHandler(): void {
         // add an invalid property to the descriptor
         (message['descriptor'] as any)['invalid'] = 'invalid';
 
-        const messagesSubscribeHandler = new MessagesSubscribeHandler(didResolver, messageStore, eventLog);
+        const messagesSubscribeHandler = new MessagesSubscribeHandler(didResolver, messageStore, undefined, eventLog);
 
         const reply = await messagesSubscribeHandler.handle({ tenant: alice.did, message, subscriptionHandler: (_) => {} });
         expect(reply.status.code).toBe(400);

--- a/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
@@ -24,7 +24,7 @@ import { RecordsWriteHandler } from '../../src/handlers/records-write.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
-import { DataStoreLevel, Dwn, MessageStoreLevel, ProtocolsConfigure, RecordsWrite, Time } from '../../src/index.js';
+import { CoreProtocolRegistry, DataStoreLevel, Dwn, MessageStoreLevel, ProtocolsConfigure, RecordsWrite, Time } from '../../src/index.js';
 import { defaultTestProtocolDefinition, TestDataGenerator } from '../utils/test-data-generator.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 
@@ -2332,7 +2332,7 @@ export function testRecordsQueryHandler(): void {
           ...aliceMessagesForBobPromise,
         ];
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, new CoreProtocolRegistry(), eventLog);
 
         const messages: GenericMessage[] = [];
         for await (const { recordsWrite, message, dataBytes } of messagePromises) {

--- a/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
@@ -479,7 +479,7 @@ export function testRecordsSubscribeHandler(): void {
         const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
         const eventLogStub = sinon.createStubInstance(EventEmitterEventLog);
 
-        const recordsSubscribeHandler = new RecordsSubscribeHandler(didResolver, messageStoreStub, eventLogStub);
+        const recordsSubscribeHandler = new RecordsSubscribeHandler(didResolver, messageStoreStub, undefined, eventLogStub);
         const reply = await recordsSubscribeHandler.handle({ tenant, message, subscriptionHandler: () => {} });
 
         expect(reply.status.code).toBe(401);
@@ -493,7 +493,7 @@ export function testRecordsSubscribeHandler(): void {
         const didResolver = TestStubGenerator.createDidResolverStub(author!);
         const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
         const eventLogStub = sinon.createStubInstance(EventEmitterEventLog);
-        const recordsSubscribeHandler = new RecordsSubscribeHandler(didResolver, messageStoreStub, eventLogStub);
+        const recordsSubscribeHandler = new RecordsSubscribeHandler(didResolver, messageStoreStub, undefined, eventLogStub);
 
         // stub the `parse()` function to throw an error
         sinon.stub(RecordsSubscribe, 'parse').throws('anyError');

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -38,14 +38,14 @@ import { ProtocolAuthorization } from '../../src/core/protocol-authorization.js'
 import { RecordsRead } from '../../src/interfaces/records-read.js';
 import { RecordsWrite } from '../../src/interfaces/records-write.js';
 import { RecordsWriteHandler } from '../../src/handlers/records-write.js';
-import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { Time } from '../../src/utils/time.js';
 import { X25519 } from '@enbox/crypto';
 import { ContentEncryptionAlgorithm, Encryption } from '../../src/utils/encryption.js';
-import { DataStoreLevel, DwnConstant, DwnInterfaceName, DwnMethodName, KeyDerivationScheme, MessageStoreLevel, PermissionsProtocol, RecordsDelete, RecordsQuery } from '../../src/index.js';
+import { CoreProtocolRegistry, DataStoreLevel, DwnConstant, DwnInterfaceName, DwnMethodName, KeyDerivationScheme, MessageStoreLevel, PermissionsProtocol, RecordsDelete, RecordsQuery } from '../../src/index.js';
+import { defaultTestProtocolDefinition, TestDataGenerator } from '../utils/test-data-generator.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnError, DwnErrorCode } from '../../src/core/dwn-error.js';
 
@@ -93,27 +93,40 @@ export function testRecordsWriteHandler(): void {
         await dwn.close();
       });
 
-      it('should call preProcessingForCoreRecordsWrite after authorization and before storage', async () => {
-        // We create spy or stub for authorization, preProcessingForCoreRecordsWrite and processMessageWithDataStream methods
-        // When we trigger a failure for `preProcessingForCoreRecordsWrite`, we expect the `processMessageWithDataStream` method to not be called
-
-        const authorizationSpy = sinon.spy(RecordsWriteHandler as any, 'authorizeRecordsWrite');
-        const processDataStreamSpy = sinon.spy(RecordsWriteHandler.prototype as any, 'processMessageWithDataStream');
-        const preProcessingForCoreRecordsWriteSpy = sinon.stub(RecordsWriteHandler.prototype as any, 'preProcessingForCoreRecordsWrite')
-          .throws(new DwnError(DwnErrorCode.PermissionsProtocolValidateScopeProtocolMismatch, 'Some Error'));
-
+      it('should dispatch preProcessWrite hook via CoreProtocolRegistry and abort before storage on failure', async () => {
+        // Register a mock core protocol whose preProcessWrite hook throws.
+        // Verify that authorization completes but processMessageWithDataStream is never reached.
         const alice = await TestDataGenerator.generateDidKeyPersona();
         await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+        const authorizationSpy = sinon.spy(RecordsWriteHandler.prototype as any, 'authorizeRecordsWrite');
+        const processDataStreamSpy = sinon.spy(RecordsWriteHandler.prototype as any, 'processMessageWithDataStream');
+
+        // Register a mock core protocol that matches the default test protocol's URI
+        const coreProtocols: CoreProtocolRegistry = (dwn as any)._coreProtocols;
+        const protocolUri = defaultTestProtocolDefinition.protocol;
+        coreProtocols.register({
+          uri             : protocolUri,
+          definition      : defaultTestProtocolDefinition,
+          preProcessWrite : (): Promise<void> => {
+            throw new DwnError(
+              DwnErrorCode.PermissionsProtocolValidateScopeProtocolMismatch, 'mock pre-process failure',
+            );
+          },
+          mapErrorToStatusCode: (code: string): number | undefined => {
+            return code.startsWith('PermissionsProtocolValidate') ? 400 : undefined;
+          },
+        });
+
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice });
         const reply = await dwn.processMessage(alice.did, message, { dataStream });
         expect(reply.status.code).toBe(400);
 
-        // expect that authorization and preProcessingForCoreRecordsWrite are both called once
         expect(authorizationSpy.calledOnce).toBe(true);
-        expect(preProcessingForCoreRecordsWriteSpy.calledOnce).toBe(true);
-
-        // expect that processMessageWithDataStream is NOT called since preProcessingForCoreRecordsWrite failed before reaching it
         expect(processDataStreamSpy.called).toBe(false);
+
+        // Cleanup: unregister the mock so it doesn't affect other tests
+        (coreProtocols as any)._protocols.delete(protocolUri);
       });
 
       it('should only be able to overwrite existing record if new record has a later `messageTimestamp` value', async () => {
@@ -3051,7 +3064,7 @@ export function testRecordsWriteHandler(): void {
         // replace valid `encryption` property with a mismatching one — mutate the iv to cause CID mismatch
         message.encryption!.iv = Encoder.stringToBase64Url('any value which will result in a different CID');
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, new CoreProtocolRegistry(), eventLog);
         const writeReply = await recordsWriteHandler.handle({ tenant: alice.did, message, dataStream: dataStream! });
 
         expect(writeReply.status.code).toBe(400);
@@ -4431,7 +4444,9 @@ export function testRecordsWriteHandler(): void {
         const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
         const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStoreStub, dataStoreStub, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(
+          didResolver, messageStoreStub, dataStoreStub, stateIndex, new CoreProtocolRegistry(), eventLog,
+        );
         const reply = await recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
 
         expect(reply.status.code).toBe(400);
@@ -4455,7 +4470,9 @@ export function testRecordsWriteHandler(): void {
         const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
         const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStoreStub, dataStoreStub, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(
+          didResolver, messageStoreStub, dataStoreStub, stateIndex, new CoreProtocolRegistry(), eventLog,
+        );
         const reply = await recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
 
         expect(reply.status.code).toBe(400);
@@ -4476,7 +4493,9 @@ export function testRecordsWriteHandler(): void {
         // stub protocol validation so the handler reaches authentication/authorization
         sinon.stub(ProtocolAuthorization, 'validateReferentialIntegrity').resolves();
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStoreStub, dataStoreStub, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(
+          didResolver, messageStoreStub, dataStoreStub, stateIndex, new CoreProtocolRegistry(), eventLog,
+        );
         const reply = await recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
 
         expect(reply.status.code).toBe(401);
@@ -4494,7 +4513,9 @@ export function testRecordsWriteHandler(): void {
         // stub protocol validation so the handler reaches authentication/authorization
         sinon.stub(ProtocolAuthorization, 'validateReferentialIntegrity').resolves();
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStoreStub, dataStoreStub, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(
+          didResolver, messageStoreStub, dataStoreStub, stateIndex, new CoreProtocolRegistry(), eventLog,
+        );
 
         const tenant = await (await TestDataGenerator.generatePersona()).did; // unauthorized tenant
         const reply = await recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
@@ -4527,7 +4548,9 @@ export function testRecordsWriteHandler(): void {
         const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
         const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStoreStub, dataStoreStub, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(
+          didResolver, messageStoreStub, dataStoreStub, stateIndex, new CoreProtocolRegistry(), eventLog,
+        );
         const reply = await recordsWriteHandler.handle({ tenant, message, dataStream: dataStream! });
 
         expect(reply.status.code).toBe(400);
@@ -4539,7 +4562,7 @@ export function testRecordsWriteHandler(): void {
         const bob = await TestDataGenerator.generateDidKeyPersona();
         const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: alice, attesters: [alice, bob] });
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, new CoreProtocolRegistry(), eventLog);
         const writeReply = await recordsWriteHandler.handle({ tenant: alice.did, message, dataStream: dataStream! });
 
         expect(writeReply.status.code).toBe(400);
@@ -4554,7 +4577,7 @@ export function testRecordsWriteHandler(): void {
         const anotherWrite = await TestDataGenerator.generateRecordsWrite({ attesters: [alice] });
         message.attestation = anotherWrite.message.attestation;
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, new CoreProtocolRegistry(), eventLog);
         const writeReply = await recordsWriteHandler.handle({ tenant: alice.did, message, dataStream: dataStream! });
 
         expect(writeReply.status.code).toBe(400);
@@ -4571,7 +4594,7 @@ export function testRecordsWriteHandler(): void {
         const attestationNotReferencedByAuthorization = await RecordsWrite['createAttestation'](descriptorCid, Jws.createSigners([bob]));
         message.attestation = attestationNotReferencedByAuthorization;
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(didResolver, messageStore, dataStore, stateIndex, new CoreProtocolRegistry(), eventLog);
         const writeReply = await recordsWriteHandler.handle({ tenant: alice.did, message, dataStream: dataStream! });
 
         expect(writeReply.status.code).toBe(400);
@@ -4597,7 +4620,9 @@ export function testRecordsWriteHandler(): void {
         // stub protocol validation so the handler reaches the process methods
         sinon.stub(ProtocolAuthorization, 'validateReferentialIntegrity').resolves();
 
-        const recordsWriteHandler = new RecordsWriteHandler(didResolverStub, messageStoreStub, dataStoreStub, stateIndex, eventLog);
+        const recordsWriteHandler = new RecordsWriteHandler(
+          didResolverStub, messageStoreStub, dataStoreStub, stateIndex, new CoreProtocolRegistry(), eventLog,
+        );
 
         // simulate throwing unexpected error
         sinon.stub(recordsWriteHandler as any, 'processMessageWithoutDataStream').throws(new Error('an unknown error in recordsWriteHandler.processMessageWithoutDataStream()'));

--- a/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
@@ -43,7 +43,9 @@ describe('RecordsWrite', () => {
 
       const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
 
-      await RecordsWriteHandler['authorizeRecordsWrite'](alice.did, recordsWrite, messageStoreStub);
+      // authorizeRecordsWrite is a private instance method; invoke via bracket notation on an instance
+      const handler = new RecordsWriteHandler({} as any, messageStoreStub, {} as any, {} as any, undefined as any);
+      await (handler as any).authorizeRecordsWrite(alice.did, recordsWrite, messageStoreStub);
     });
 
     it('should include permissionGrantId in the descriptor when provided', async () => {

--- a/packages/dwn-sdk-js/tests/utils/messages.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/messages.spec.ts
@@ -1,15 +1,23 @@
 import type { Filter } from '../../src/types/query-types.js';
 import type { MessagesFilter } from '../../src/types/messages-types.js';
 
+import { CoreProtocolRegistry } from '../../src/core/core-protocol.js';
 import { FilterUtility } from '../../src/utils/filter.js';
 import { Messages } from '../../src/utils/messages.js';
-import { DwnInterfaceName, DwnMethodName, PermissionsProtocol, TestDataGenerator } from '../../src/index.js';
+import { PermissionsProtocol } from '../../src/protocols/permissions.js';
+import { DwnInterfaceName, DwnMethodName, TestDataGenerator } from '../../src/index.js';
 
 import sinon from 'sinon';
 
-import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 describe('Messages Utils', () => {
+  let coreProtocols: CoreProtocolRegistry;
+
+  beforeAll(() => {
+    coreProtocols = new CoreProtocolRegistry();
+    coreProtocols.register(new PermissionsProtocol());
+  });
 
   afterAll(() => {
     sinon.restore();
@@ -87,7 +95,7 @@ describe('Messages Utils', () => {
       // we should expect the MessagesFilter to be split into two MessageStore Filters
       // the first filter should be the protocol tag filter applied to the permissions protocol uri
       // the second filter should be the remaining filter, only containing a protocol filter to the protocol we are targeting
-      const protocolMessageFilter: Filter[] = Messages.convertFilters([protocolMessagesFilter]);
+      const protocolMessageFilter: Filter[] = Messages.convertFilters([protocolMessagesFilter], coreProtocols);
       expect(protocolMessageFilter.length).toBe(2);
 
       const permissionRecordsFilter = protocolMessageFilter[0];
@@ -109,7 +117,7 @@ describe('Messages Utils', () => {
         method    : DwnMethodName.Write
       };
 
-      const messageFilter: Filter[] = Messages.convertFilters([otherMessagesFilter]);
+      const messageFilter: Filter[] = Messages.convertFilters([otherMessagesFilter], coreProtocols);
       expect(messageFilter.length).toBe(2);
 
       const protocolTagFilter2 = messageFilter[0];
@@ -140,7 +148,7 @@ describe('Messages Utils', () => {
         messageTimestamp : { from: dateUpdatedTimestamp }
       };
 
-      const messageFilter: Filter[] = Messages.convertFilters([withDateUpdatedFilter]);
+      const messageFilter: Filter[] = Messages.convertFilters([withDateUpdatedFilter], coreProtocols);
       expect(messageFilter.length).toBe(2);
       expect(messageFilter[0].protocol).toBe(PermissionsProtocol.uri);
       expect(messageFilter[0]['tag.protocol']).toBe(exampleProtocol);


### PR DESCRIPTION
## Summary

Second PR in the Core Protocols Framework epic (#413). Replaces all hardcoded `PermissionsProtocol` special-casing in DWN handlers with generic `CoreProtocolRegistry` dispatch, completing the refactor started in #425.

- **RecordsWriteHandler** (#417): Remove `preProcessingForCoreRecordsWrite`, `postProcessingForCoreRecordsWrite`, and `validateSchemaForCoreRecordsWrite` — replaced with generic `coreProtocol?.preProcessWrite()`, `coreProtocol?.postProcessWrite()`, `coreProtocol?.validateRecord()` dispatch; replace `error.code.startsWith('PermissionsProtocolValidate')` with `coreProtocols.mapErrorToStatusCode()`; change `authorizeRecordsWrite` from static to instance method
- **protocol-authorization.ts** (#418): Remove `PermissionsProtocol` import; replace `PermissionsProtocol.uri` bypass in `fetchProtocolDefinition` with `coreProtocols.getDefinition()` lookup; add `createBoundFetchDefinition` factory for zero-ripple callback injection; thread optional `coreProtocols?` through all 5 public authorization methods
- **grant-authorization.ts** (#419): Replace hardcoded `'grant/revocation'` string with `PERMISSIONS_REVOCATION_PATH` constant (defined in `core-protocol.ts` to break circular dependency)
- **messages.ts** (#420): Remove `PermissionsProtocol` and `Records` imports; replace `constructPermissionRecordsFilter()` with generic `coreProtocols.all()` loop calling `constructAdditionalMessageFilter` hooks
- **Tests** (#421): All test files updated for new handler constructor signatures; `messages.spec.ts` creates `CoreProtocolRegistry` with `PermissionsProtocol` registered; `records-write.spec.ts` test rewritten to use mock core protocol registration

## Design decisions

- **`FetchProtocolDefinitionFn` type unchanged**: A `createBoundFetchDefinition(coreProtocols)` factory creates closures that capture the registry — zero ripple to `protocol-authorization-action.ts` and `protocol-authorization-validation.ts`
- **Constructor injection**: `CoreProtocolRegistry` is threaded to all Records handlers and `MessagesSubscribeHandler` via constructor params (consistent with existing `didResolver`, `messageStore` pattern)
- **`authorizeRecordsWrite` → instance method**: Changed from static so it can access `this.coreProtocols` without explicit parameter threading
- **`PermissionsProtocol.fetchGrant()` calls unchanged**: Direct calls in `messages-read.ts` and other authorization files stay as-is (clean API, not special-casing)

## Verification

- **Lint**: 0 errors across all packages
- **Build**: `@enbox/dwn-sdk-js` builds clean (0 type errors)
- **Tests**: 1078 pass, 0 fail

## Files changed (17)

**Source (11):**
`grant-authorization.ts`, `protocol-authorization.ts`, `dwn.ts`, `messages-subscribe.ts`, `records-count.ts`, `records-delete.ts`, `records-query.ts`, `records-read.ts`, `records-subscribe.ts`, `records-write.ts`, `messages.ts`

**Tests (6):**
`messages-subscribe.spec.ts`, `records-query.spec.ts`, `records-subscribe.spec.ts`, `records-write.spec.ts`, `records-write.spec.ts` (interfaces), `messages.spec.ts`

Closes #417, closes #418, closes #419, closes #420, closes #421
Part of #413