### PR TITLE
feat(dwn-sdk-js): add $immutable protocol structure directive for write-once records (#296)

### DIFF
--- a/packages/dwn-sdk-js/json-schemas/interface-methods/protocol-rule-set.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/protocol-rule-set.json
@@ -134,6 +134,10 @@
         }
       }
     },
+    "$immutable": {
+      "$comment": "When true, records at this protocol path cannot be updated after initial write",
+      "type": "boolean"
+    },
     "$tags": {
       "type": "object",
       "minProperties": 1,

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -78,6 +78,7 @@ export enum DwnErrorCode {
   ProtocolAuthorizationIncorrectProtocolPath = 'ProtocolAuthorizationIncorrectProtocolPath',
   ProtocolAuthorizationDuplicateRoleRecipient = 'ProtocolAuthorizationDuplicateRoleRecipient',
   ProtocolAuthorizationEncryptionRequired = 'ProtocolAuthorizationEncryptionRequired',
+  ProtocolAuthorizationImmutableRecord = 'ProtocolAuthorizationImmutableRecord',
   ProtocolAuthorizationInvalidSchema = 'ProtocolAuthorizationInvalidSchema',
   ProtocolAuthorizationInvalidType = 'ProtocolAuthorizationInvalidType',
   ProtocolAuthorizationMatchingRoleRecordNotFound = 'ProtocolAuthorizationMatchingRoleRecordNotFound',

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -458,3 +458,30 @@ export async function verifyRecordLimit(
     );
   }
 }
+
+/**
+ * Verifies that an update is not attempted on a record whose protocol path has `$immutable: true`.
+ *
+ * Only non-initial writes (updates) are rejected — initial writes are always allowed.
+ * `RecordsDelete` is not affected by this check; immutability prevents data mutation, not removal.
+ *
+ * @throws {DwnError} with `ProtocolAuthorizationImmutableRecord` if an update is attempted on an immutable record.
+ */
+export async function verifyImmutability(
+  incomingMessage: RecordsWrite,
+  ruleSet: ProtocolRuleSet,
+): Promise<void> {
+  if (ruleSet.$immutable !== true) {
+    return;
+  }
+
+  const isInitialWrite = await incomingMessage.isInitialWrite();
+  if (isInitialWrite) {
+    return;
+  }
+
+  throw new DwnError(
+    DwnErrorCode.ProtocolAuthorizationImmutableRecord,
+    `record at protocol path '${incomingMessage.message.descriptor.protocolPath}' is immutable: updates are not allowed.`
+  );
+}

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -19,6 +19,7 @@ import { authorizeAgainstAllowedActions, verifyInvokedRole } from './protocol-au
 import { constructRecordChain, fetchInitialWrite, getGoverningTimestamp } from './record-chain.js';
 import {
   verifyAsRoleRecordIfNeeded,
+  verifyImmutability,
   verifyProtocolPathAndContextId,
   verifyRecordLimit,
   verifySizeLimit,
@@ -100,6 +101,9 @@ export class ProtocolAuthorization {
 
     // Verify protocol tags
     verifyTagsIfNeeded(incomingMessage, ruleSet);
+
+    // Verify immutability — reject updates to write-once records
+    await verifyImmutability(incomingMessage, ruleSet);
 
     // Verify record count limit
     await verifyRecordLimit(tenant, incomingMessage, ruleSet, messageStore);

--- a/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
@@ -418,6 +418,22 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
       }
     }
 
+    // Warn when `$immutable: true` is combined with `$actions` that include `update` or `co-update`.
+    // The `$immutable` directive overrides any update permission — updates are always rejected.
+    if (ruleSet.$immutable === true && actionRules.length > 0) {
+      const hasUpdateAction = actionRules.some(
+        (rule: ProtocolActionRule): boolean =>
+          rule.can.includes(ProtocolAction.Update) || rule.can.includes(ProtocolAction.CoUpdate)
+      );
+      if (hasUpdateAction) {
+        console.warn(
+          `ProtocolsConfigure: protocol path '${ruleSetProtocolPath}' has $immutable: true ` +
+          `but $actions include 'update' or 'co-update'. The $immutable directive takes ` +
+          `precedence — updates will always be rejected regardless of action rules.`
+        );
+      }
+    }
+
     // Validate nested rule sets
     for (const recordType in ruleSet) {
       if (recordType.startsWith('$')) {
@@ -478,7 +494,7 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
     }
 
     // validate that `$ref` nodes do not have other directives
-    const forbiddenDirectives = ['$actions', '$role', '$size', '$tags', '$encryption', '$recordLimit'] as const;
+    const forbiddenDirectives = ['$actions', '$role', '$size', '$tags', '$encryption', '$recordLimit', '$immutable'] as const;
     for (const directive of forbiddenDirectives) {
       if (ruleSet[directive] !== undefined) {
         throw new DwnError(

--- a/packages/dwn-sdk-js/src/types/protocols-types.ts
+++ b/packages/dwn-sdk-js/src/types/protocols-types.ts
@@ -286,6 +286,14 @@ export type ProtocolRuleSet = {
   $recordLimit?: ProtocolRecordLimitDefinition;
 
   /**
+   * If `$immutable` is `true`, records at this protocol path are write-once: they can be
+   * created but never updated after the initial write. `RecordsDelete` is still governed
+   * by `$actions` — immutability means the record's data cannot change, not that it
+   * cannot be removed.
+   */
+  $immutable?: boolean;
+
+  /**
    * Non-`$`-prefixed keys are nested child `ProtocolRuleSet` entries.
    * At runtime, JSON Schema validation ensures only valid child rule sets appear here.
    */

--- a/packages/dwn-sdk-js/tests/features/records-immutable.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-immutable.spec.ts
@@ -1,0 +1,378 @@
+import type { DidResolver } from '@enbox/dids';
+import type { EventLog } from '../../src/types/subscriptions.js';
+import type { DataStore, MessageStore, ProtocolDefinition, ResumableTaskStore, StateIndex } from '../../src/index.js';
+
+import sinon from 'sinon';
+
+import { DidKey } from '@enbox/dids';
+import { Dwn } from '../../src/dwn.js';
+import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { Jws } from '../../src/utils/jws.js';
+import { ProtocolsConfigure } from '../../src/interfaces/protocols-configure.js';
+import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestEventLog } from '../test-event-stream.js';
+import { TestStores } from '../test-stores.js';
+import { UniversalResolver } from '@enbox/dids';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+export function testRecordsImmutable(): void {
+  describe('Records $immutable', () => {
+    let didResolver: DidResolver;
+    let messageStore: MessageStore;
+    let dataStore: DataStore;
+    let resumableTaskStore: ResumableTaskStore;
+    let stateIndex: StateIndex;
+    let eventLog: EventLog;
+    let dwn: Dwn;
+
+    // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+    // so that different test suites can reuse the same backend store for testing
+    beforeAll(async () => {
+      didResolver = new UniversalResolver({ didResolvers: [DidKey] });
+
+      const stores = TestStores.get();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      resumableTaskStore = stores.resumableTaskStore;
+      stateIndex = stores.stateIndex;
+      eventLog = TestEventLog.get();
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, stateIndex, eventLog, resumableTaskStore });
+    });
+
+    beforeEach(async () => {
+      sinon.restore();
+
+      await messageStore.clear();
+      await dataStore.clear();
+      await resumableTaskStore.clear();
+      await stateIndex.clear();
+    });
+
+    afterAll(async () => {
+      await dwn.close();
+    });
+
+    describe('ProtocolsConfigure validation', () => {
+      it('should accept a protocol definition with $immutable: true', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://immutable-test.xyz',
+          published : true,
+          types     : { credential: {} },
+          structure : {
+            credential: {
+              $immutable : true,
+              $actions   : [{ who: 'anyone', can: ['create', 'read'] }],
+            }
+          }
+        };
+
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+
+        const reply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(reply.status.code).toBe(202);
+      });
+
+      it('should reject $immutable on a $ref node', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const badDefinition: ProtocolDefinition = {
+          protocol  : 'https://bad-immutable-ref.example.com',
+          published : true,
+          uses      : { threads: 'https://threads.example.com' },
+          types     : {},
+          structure : {
+            thread: {
+              $ref       : 'threads:thread',
+              $immutable : true,
+            },
+          },
+        };
+
+        try {
+          await ProtocolsConfigure.create({
+            definition : badDefinition,
+            signer     : Jws.createSigner(alice),
+          });
+          throw new Error('Expected an error to be thrown');
+        } catch (error: any) {
+          expect(error.message).toContain(DwnErrorCode.ProtocolsConfigureInvalidRefNodeHasDirectives);
+        }
+      });
+
+      it('should warn when $immutable is combined with update or co-update actions', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const warnSpy = sinon.spy(console, 'warn');
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://immutable-warn-test.xyz',
+          published : true,
+          types     : { credential: {} },
+          structure : {
+            credential: {
+              $immutable : true,
+              $actions   : [{ who: 'anyone', can: ['create', 'update'] }],
+            }
+          }
+        };
+
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+
+        const reply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(reply.status.code).toBe(202);
+
+        expect(warnSpy.called).toBe(true);
+        expect(warnSpy.firstCall.args[0]).toContain('$immutable: true');
+        expect(warnSpy.firstCall.args[0]).toContain('update');
+      });
+    });
+
+    describe('runtime enforcement', () => {
+      it('should allow initial writes to immutable protocol paths', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://immutable-test.xyz',
+          published : true,
+          types     : { credential: {} },
+          structure : {
+            credential: {
+              $immutable : true,
+              $actions   : [{ who: 'anyone', can: ['create', 'read'] }],
+            }
+          }
+        };
+
+        const protocol = protocolDefinition.protocol;
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+
+        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(configReply.status.code).toBe(202);
+
+        const record = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          recipient    : alice.did,
+          protocol,
+          protocolPath : 'credential',
+        });
+
+        const reply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+        expect(reply.status.code).toBe(202);
+      });
+
+      it('should reject updates to records at immutable protocol paths', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://immutable-test.xyz',
+          published : true,
+          types     : { credential: {} },
+          structure : {
+            credential: {
+              $immutable : true,
+              $actions   : [{ who: 'anyone', can: ['create', 'read'] }],
+            }
+          }
+        };
+
+        const protocol = protocolDefinition.protocol;
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+
+        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(configReply.status.code).toBe(202);
+
+        // initial write — should succeed
+        const record = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          recipient    : alice.did,
+          protocol,
+          protocolPath : 'credential',
+        });
+
+        const writeReply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+        expect(writeReply.status.code).toBe(202);
+
+        // update the same record — should be rejected
+        const updatedRecord = await TestDataGenerator.generateFromRecordsWrite({
+          author        : alice,
+          existingWrite : record.recordsWrite,
+        });
+
+        const updateReply = await dwn.processMessage(alice.did, updatedRecord.message, { dataStream: updatedRecord.dataStream });
+        expect(updateReply.status.code).toBe(400);
+        expect(updateReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationImmutableRecord);
+      });
+
+      it('should still allow deletion of immutable records when authorized by $actions', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://immutable-test.xyz',
+          published : true,
+          types     : { credential: {} },
+          structure : {
+            credential: {
+              $immutable : true,
+              $actions   : [{ who: 'anyone', can: ['create', 'read', 'delete'] }],
+            }
+          }
+        };
+
+        const protocol = protocolDefinition.protocol;
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+
+        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(configReply.status.code).toBe(202);
+
+        // initial write
+        const record = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          recipient    : alice.did,
+          protocol,
+          protocolPath : 'credential',
+        });
+
+        const writeReply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+        expect(writeReply.status.code).toBe(202);
+
+        // delete — should succeed even though record is immutable
+        const deleteRecord = await TestDataGenerator.generateRecordsDelete({
+          author   : alice,
+          recordId : record.message.recordId,
+        });
+
+        const deleteReply = await dwn.processMessage(alice.did, deleteRecord.message);
+        expect(deleteReply.status.code).toBe(202);
+      });
+
+      it('should allow updates to non-immutable protocol paths in the same protocol', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://mixed-immutable-test.xyz',
+          published : true,
+          types     : {
+            credential : {},
+            note       : {},
+          },
+          structure: {
+            credential: {
+              $immutable : true,
+              $actions   : [{ who: 'anyone', can: ['create', 'read'] }],
+            },
+            note: {
+              $actions: [{ who: 'anyone', can: ['create', 'read', 'update'] }],
+            }
+          }
+        };
+
+        const protocol = protocolDefinition.protocol;
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+
+        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(configReply.status.code).toBe(202);
+
+        // write a note
+        const noteRecord = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          recipient    : alice.did,
+          protocol,
+          protocolPath : 'note',
+        });
+
+        const noteReply = await dwn.processMessage(alice.did, noteRecord.message, { dataStream: noteRecord.dataStream });
+        expect(noteReply.status.code).toBe(202);
+
+        // update the note — should succeed because note is NOT immutable
+        const updatedNote = await TestDataGenerator.generateFromRecordsWrite({
+          author        : alice,
+          existingWrite : noteRecord.recordsWrite,
+        });
+
+        const updateReply = await dwn.processMessage(alice.did, updatedNote.message, { dataStream: updatedNote.dataStream });
+        expect(updateReply.status.code).toBe(202);
+
+        // write an immutable credential
+        const credRecord = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          recipient    : alice.did,
+          protocol,
+          protocolPath : 'credential',
+        });
+
+        const credReply = await dwn.processMessage(alice.did, credRecord.message, { dataStream: credRecord.dataStream });
+        expect(credReply.status.code).toBe(202);
+
+        // try to update the credential — should be rejected
+        const updatedCred = await TestDataGenerator.generateFromRecordsWrite({
+          author        : alice,
+          existingWrite : credRecord.recordsWrite,
+        });
+
+        const credUpdateReply = await dwn.processMessage(alice.did, updatedCred.message, { dataStream: updatedCred.dataStream });
+        expect(credUpdateReply.status.code).toBe(400);
+        expect(credUpdateReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationImmutableRecord);
+      });
+
+      it('should allow multiple initial writes (different records) to the same immutable protocol path', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://immutable-test.xyz',
+          published : true,
+          types     : { credential: {} },
+          structure : {
+            credential: {
+              $immutable : true,
+              $actions   : [{ who: 'anyone', can: ['create', 'read'] }],
+            }
+          }
+        };
+
+        const protocol = protocolDefinition.protocol;
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+
+        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(configReply.status.code).toBe(202);
+
+        // write multiple distinct records — all should succeed
+        for (let i = 0; i < 3; i++) {
+          const record = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            recipient    : alice.did,
+            protocol,
+            protocolPath : 'credential',
+          });
+
+          const reply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+          expect(reply.status.code).toBe(202);
+        }
+      });
+    });
+  });
+}
+
+testRecordsImmutable();

--- a/packages/dwn-sdk-js/tests/test-suite.ts
+++ b/packages/dwn-sdk-js/tests/test-suite.ts
@@ -23,6 +23,7 @@ import { testProtocolsQueryHandler } from './handlers/protocols-query.spec.js';
 import { testProtocolUpdateAction } from './features/protocol-update-action.spec.js';
 import { testRecordsCountHandler } from './handlers/records-count.spec.js';
 import { testRecordsDeleteHandler } from './handlers/records-delete.spec.js';
+import { testRecordsImmutable } from './features/records-immutable.spec.js';
 import { testRecordsPrune } from './features/records-prune.spec.js';
 import { testRecordsQueryHandler } from './handlers/records-query.spec.js';
 import { testRecordsReadHandler } from './handlers/records-read.spec.js';
@@ -81,6 +82,7 @@ export class TestSuite {
     testProtocolCreateAction();
     testProtocolDeleteAction();
     testProtocolUpdateAction();
+    testRecordsImmutable();
     testRecordsPrune();
     testRecordsRecordLimit();
     testRecordsTags();


### PR DESCRIPTION
## Summary

Adds a `$immutable: true` directive to `ProtocolRuleSet` that declares records at a given protocol path as write-once — they can be created but never updated after the initial write.

- `RecordsDelete` is still governed by `$actions` — immutability means the record's data cannot change, not that it cannot be removed
- The check happens in `validateReferentialIntegrity()` alongside `verifySizeLimit()`, `verifyRecordLimit()`, etc.
- `$immutable` is forbidden on `$ref` nodes (like all other directives)

## Use cases

- **Credential issuance** — a VC record should never be modified after creation
- **Audit logs / event sourcing** — append-only records where each entry must not be retroactively altered
- **Attestation records** — signed attestations whose integrity depends on immutability
- **Receipts and proofs** — payment receipts, delivery confirmations

## Changes

| Layer | File | Change |
|---|---|---|
| Types | `protocols-types.ts` | Add `$immutable?: boolean` to `ProtocolRuleSet` |
| JSON Schema | `protocol-rule-set.json` | Add `"$immutable": { "type": "boolean" }` |
| Error codes | `dwn-error.ts` | Add `ProtocolAuthorizationImmutableRecord` |
| Install validation | `protocols-configure.ts` | Add to `$ref` forbidden list; warn if `$immutable` + `update`/`co-update` actions |
| Runtime | `protocol-authorization-validation.ts` | New `verifyImmutability()` — reject non-initial writes when `$immutable: true` |
| Orchestration | `protocol-authorization.ts` | Call `verifyImmutability()` from `validateReferentialIntegrity()` |

## Tests (8 new)

- Accept protocol definition with `$immutable: true`
- Reject `$immutable` on `$ref` nodes
- Warn when `$immutable` combined with `update`/`co-update` actions
- Allow initial writes to immutable protocol paths
- **Reject updates** to records at immutable protocol paths
- Allow deletion of immutable records (when authorized by `$actions`)
- Allow updates to non-immutable paths in the same protocol
- Allow multiple distinct initial writes to the same immutable path

## Verification

- Lint: passes
- Build: passes
- Tests: 1094 pass / 0 fail (8 new tests included)

Closes #296