### PR TITLE
feat(dwn-sdk-js): refactor DataStoreLevel — content-addressed dedup (#412)

### DIFF
--- a/packages/dwn-sdk-js/src/store/data-store-level.ts
+++ b/packages/dwn-sdk-js/src/store/data-store-level.ts
@@ -1,4 +1,5 @@
 import type { ImportResult } from 'ipfs-unixfs-importer';
+import type { LevelWrapper } from './level-wrapper.js';
 import type { DataStore, DataStoreGetResult, DataStorePutResult } from '../types/data-store.js';
 
 import { BlockstoreLevel } from './blockstore-level.js';
@@ -7,12 +8,20 @@ import { DataStream } from '../utils/data-stream.js';
 import { exporter } from 'ipfs-unixfs-exporter';
 import { importer } from 'ipfs-unixfs-importer';
 
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
 /**
  * A simple implementation of {@link DataStore} that works in both the browser and server-side.
  * Leverages LevelDB under the hood.
  *
- * It has the following structure (`+` represents an additional sublevel/partition):
- *   'data' + <tenant> + <recordId> + <dataCid> -> <data>
+ * It has the following sublevel structure (`+` represents an additional sublevel):
+ *   'refs'      + <tenant> + <recordId>  : key <dataCid>  → JSON { dataSize }
+ *   'blocks'    + <dataCid>              : key <blockCid>  → block data (shared)
+ *   'refcounts' : key <dataCid>                            → JSON { count, dataSize }
+ *
+ * Identical data (same dataCid) is stored only once in the blocks sublevel.
+ * Multiple (tenant, recordId) pairs can reference the same blocks.
  */
 export class DataStoreLevel implements DataStore {
   config: DataStoreLevelConfig;
@@ -41,29 +50,74 @@ export class DataStoreLevel implements DataStore {
   }
 
   async put(tenant: string, recordId: string, dataCid: string, dataStream: ReadableStream<Uint8Array>): Promise<DataStorePutResult> {
-    const blockstoreForData = await this.getBlockstoreForStoringData(tenant, recordId, dataCid);
+    // Check if this exact ref already exists (idempotent re-put).
+    const refsPartition = await this.getRefsPartition(tenant, recordId);
+    const existingRef = await refsPartition.get(dataCid);
+    if (existingRef) {
+      await dataStream.cancel();
+      const { dataSize } = JSON.parse(textDecoder.decode(existingRef)) as { dataSize: number };
+      return { dataSize };
+    }
 
-    const asyncDataBlocks = importer([{ content: DataStream.asAsyncIterable(dataStream) }], blockstoreForData, { cidVersion: 1 });
+    // Check refcount — if > 0, blocks already exist for this dataCid.
+    const refcountsPartition = await this.getRefcountsPartition();
+    const rawRefcount = await refcountsPartition.get(dataCid);
+    const refcountData = rawRefcount
+      ? JSON.parse(textDecoder.decode(rawRefcount)) as { count: number; dataSize: number }
+      : { count: 0, dataSize: 0 };
 
-    // NOTE: the last block contains the root CID as well as info to derive the data size
-    let dataDagRoot!: ImportResult;
-    for await (dataDagRoot of asyncDataBlocks) { ; }
+    let dataSize: number;
 
-    return {
-      dataSize: Number(dataDagRoot.unixfs?.fileSize() ?? dataDagRoot.size)
-    };
+    if (refcountData.count > 0) {
+      // Blocks already exist — skip import.
+      await dataStream.cancel();
+      dataSize = refcountData.dataSize;
+    } else {
+      // First write — import blocks into the shared blocks partition.
+      const blocksPartition = await this.getBlocksPartition(dataCid);
+      const asyncDataBlocks = importer(
+        [{ content: DataStream.asAsyncIterable(dataStream) }],
+        blocksPartition,
+        { cidVersion: 1 }
+      );
+
+      // NOTE: the last block contains the root CID as well as info to derive the data size.
+      let dataDagRoot!: ImportResult;
+      for await (dataDagRoot of asyncDataBlocks) { ; }
+      dataSize = Number(dataDagRoot.unixfs?.fileSize() ?? dataDagRoot.size);
+    }
+
+    // Write ref entry.
+    await refsPartition.put(dataCid, textEncoder.encode(JSON.stringify({ dataSize })));
+
+    // Increment refcount.
+    await refcountsPartition.put(dataCid, textEncoder.encode(JSON.stringify({
+      count: refcountData.count + 1,
+      dataSize,
+    })));
+
+    return { dataSize };
   }
 
   public async get(tenant: string, recordId: string, dataCid: string): Promise<DataStoreGetResult | undefined> {
-    const blockstoreForData = await this.getBlockstoreForStoringData(tenant, recordId, dataCid);
+    // Check ref exists.
+    const refsPartition = await this.getRefsPartition(tenant, recordId);
+    const rawRef = await refsPartition.get(dataCid);
+    if (!rawRef) {
+      return undefined;
+    }
 
-    const exists = await blockstoreForData.has(dataCid);
+    const { dataSize } = JSON.parse(textDecoder.decode(rawRef)) as { dataSize: number };
+
+    // Export from the shared blocks partition.
+    const blocksPartition = await this.getBlocksPartition(dataCid);
+    const exists = await blocksPartition.has(dataCid);
     if (!exists) {
       return undefined;
     }
 
-    // data is chunked into dag-pb unixfs blocks. re-inflate the chunks.
-    const dataDagRoot = await exporter(dataCid, blockstoreForData);
+    // Data is chunked into DAG-PB UnixFS blocks. Re-inflate the chunks.
+    const dataDagRoot = await exporter(dataCid, blocksPartition);
     const contentIterator = dataDagRoot.content();
 
     const dataStream = new ReadableStream<Uint8Array>({
@@ -77,21 +131,42 @@ export class DataStoreLevel implements DataStore {
       }
     });
 
-    let dataSize = dataDagRoot.size;
-
-    if (dataDagRoot.type === 'file' || dataDagRoot.type === 'directory') {
-      dataSize = dataDagRoot.unixfs.fileSize();
-    }
-
-    return {
-      dataSize: Number(dataSize),
-      dataStream,
-    };
+    return { dataSize, dataStream };
   }
 
   public async delete(tenant: string, recordId: string, dataCid: string): Promise<void> {
-    const blockstoreForData = await this.getBlockstoreForStoringData(tenant, recordId, dataCid);
-    await blockstoreForData.clear();
+    // Check ref exists.
+    const refsPartition = await this.getRefsPartition(tenant, recordId);
+    const rawRef = await refsPartition.get(dataCid);
+    if (!rawRef) {
+      return;
+    }
+
+    // Remove ref.
+    await refsPartition.delete(dataCid);
+
+    // Decrement refcount and GC blocks if this was the last ref.
+    const refcountsPartition = await this.getRefcountsPartition();
+    const rawRefcount = await refcountsPartition.get(dataCid);
+    if (!rawRefcount) {
+      return;
+    }
+
+    const refcountData = JSON.parse(textDecoder.decode(rawRefcount)) as { count: number; dataSize: number };
+    const newCount = refcountData.count - 1;
+
+    if (newCount <= 0) {
+      // Last reference removed — garbage-collect blocks and refcount entry.
+      const blocksPartition = await this.getBlocksPartition(dataCid);
+      await blocksPartition.clear();
+      await refcountsPartition.delete(dataCid);
+    } else {
+      // Other references remain — update the count.
+      await refcountsPartition.put(dataCid, textEncoder.encode(JSON.stringify({
+        count    : newCount,
+        dataSize : refcountData.dataSize,
+      })));
+    }
   }
 
   /**
@@ -102,15 +177,30 @@ export class DataStoreLevel implements DataStore {
   }
 
   /**
-   * Gets the blockstore used for storing data for the given `tenant -> `recordId` -> `dataCid`.
+   * Gets the refs sublevel for the given tenant and recordId.
+   * Caller uses `dataCid` as the key within the returned partition.
    */
-  private async getBlockstoreForStoringData(tenant: string, recordId: string, dataCid: string): Promise<BlockstoreLevel> {
-    const dataPartitionName = 'data';
-    const blockstoreForData = await this.blockstore.partition(dataPartitionName);
-    const blockstoreOfGivenTenant = await blockstoreForData.partition(tenant);
-    const blockstoreOfGivenRecordId = await blockstoreOfGivenTenant.partition(recordId);
-    const blockstoreOfGivenDataCidOfRecordId = await blockstoreOfGivenRecordId.partition(dataCid);
-    return blockstoreOfGivenDataCidOfRecordId;
+  private async getRefsPartition(tenant: string, recordId: string): Promise<LevelWrapper<Uint8Array>> {
+    const refsRoot = await this.blockstore.db.partition('refs');
+    const tenantPartition = await refsRoot.partition(tenant);
+    return tenantPartition.partition(recordId);
+  }
+
+  /**
+   * Gets the shared blocks sublevel for the given dataCid.
+   * Used as a Blockstore for ipfs-unixfs-importer/exporter.
+   */
+  private async getBlocksPartition(dataCid: string): Promise<BlockstoreLevel> {
+    const blocksRoot = await this.blockstore.partition('blocks');
+    return blocksRoot.partition(dataCid);
+  }
+
+  /**
+   * Gets the refcounts sublevel.
+   * Key: `dataCid` → JSON `{ count, dataSize }`.
+   */
+  private async getRefcountsPartition(): Promise<LevelWrapper<Uint8Array>> {
+    return this.blockstore.db.partition('refcounts');
   }
 
 }

--- a/packages/dwn-sdk-js/tests/store/data-store-level.spec.ts
+++ b/packages/dwn-sdk-js/tests/store/data-store-level.spec.ts
@@ -47,7 +47,7 @@ describe('DataStoreLevel Test Suite', () => {
       }
     });
 
-    it('should duplicate same data if written to different tenants', async () => {
+    it('should deduplicate same data across tenants', async () => {
       const alice = await TestDataGenerator.randomCborSha256Cid();
       const bob = await TestDataGenerator.randomCborSha256Cid();
 
@@ -55,20 +55,48 @@ describe('DataStoreLevel Test Suite', () => {
       const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
 
       // write data to alice's DWN
-      const aliceDataStream = DataStream.fromBytes(dataBytes);
       const aliceRecordId = await TestDataGenerator.randomCborSha256Cid();
-      await store.put(alice, aliceRecordId, dataCid, aliceDataStream);
+      await store.put(alice, aliceRecordId, dataCid, DataStream.fromBytes(dataBytes));
 
       // write same data to bob's DWN
-      const bobDataStream = DataStream.fromBytes(dataBytes);
       const bobRecordId = await TestDataGenerator.randomCborSha256Cid();
-      await store.put(bob, bobRecordId, dataCid, bobDataStream);
+      await store.put(bob, bobRecordId, dataCid, DataStream.fromBytes(dataBytes));
 
-      // verify that both alice and bob's blockstore have their own reference to data CID
-      const blockstoreOfAliceRecord = await store['getBlockstoreForStoringData'](alice, aliceRecordId, dataCid);
-      const blockstoreOfBobRecord = await store['getBlockstoreForStoringData'](bob, bobRecordId, dataCid);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfAliceRecord.db.keys())).toEqual([ dataCid ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfBobRecord.db.keys())).toEqual([ dataCid ]);
+      // verify blocks are shared — only one set of blocks in the blocks partition
+      const blocksPartition = await store['getBlocksPartition'](dataCid);
+      const blockKeys = await ArrayUtility.fromAsyncGenerator(blocksPartition.db.keys());
+      expect(blockKeys).toEqual([ dataCid ]);
+
+      // verify both tenants can read the data
+      const aliceResult = (await store.get(alice, aliceRecordId, dataCid))!;
+      expect(aliceResult).toBeDefined();
+      expect(await DataStream.toBytes(aliceResult.dataStream)).toEqual(dataBytes);
+
+      const bobResult = (await store.get(bob, bobRecordId, dataCid))!;
+      expect(bobResult).toBeDefined();
+      expect(await DataStream.toBytes(bobResult.dataStream)).toEqual(dataBytes);
+    });
+
+    it('should be idempotent for the same (tenant, recordId, dataCid)', async () => {
+      const tenant = await TestDataGenerator.randomCborSha256Cid();
+      const recordId = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(100);
+      const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+      // first put
+      const result1 = await store.put(tenant, recordId, dataCid, DataStream.fromBytes(dataBytes));
+      expect(result1.dataSize).toBe(100);
+
+      // second put — should be idempotent
+      const result2 = await store.put(tenant, recordId, dataCid, DataStream.fromBytes(dataBytes));
+      expect(result2.dataSize).toBe(100);
+
+      // refcount should still be 1 (not 2)
+      const refcountsPartition = await store['getRefcountsPartition']();
+      const rawRefcount = await refcountsPartition.get(dataCid);
+      const refcountData = JSON.parse(new TextDecoder().decode(rawRefcount!));
+      expect(refcountData.count).toBe(1);
     });
   });
 
@@ -111,7 +139,8 @@ describe('DataStoreLevel Test Suite', () => {
       await store.put(tenant, recordId, dataCid, dataStream);
 
       const keysBeforeDelete = await ArrayUtility.fromAsyncGenerator(store.blockstore.db.keys());
-      expect(keysBeforeDelete.length).toBe(40);
+      // 40 block keys + 1 ref key + 1 refcount key = 42
+      expect(keysBeforeDelete.length).toBe(42);
 
       await store.delete(tenant, recordId, dataCid);
 
@@ -119,56 +148,111 @@ describe('DataStoreLevel Test Suite', () => {
       expect(keysAfterDelete.length).toBe(0);
     });
 
-    it('should only delete data in the sublevel of the corresponding record', async () => {
+    it('should keep shared blocks when deleting one ref but other refs remain', async () => {
       const alice = await TestDataGenerator.randomCborSha256Cid();
       const bob = await TestDataGenerator.randomCborSha256Cid();
 
       const dataBytes = TestDataGenerator.randomBytes(100);
       const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
 
-      // alice writes a records with data
-      const dataStream1 = DataStream.fromBytes(dataBytes);
+      const aliceRecordId = await TestDataGenerator.randomCborSha256Cid();
+      const bobRecordId = await TestDataGenerator.randomCborSha256Cid();
+
+      await store.put(alice, aliceRecordId, dataCid, DataStream.fromBytes(dataBytes));
+      await store.put(bob, bobRecordId, dataCid, DataStream.fromBytes(dataBytes));
+
+      // delete alice's ref — bob should still be able to read
+      await store.delete(alice, aliceRecordId, dataCid);
+
+      const aliceResult = await store.get(alice, aliceRecordId, dataCid);
+      expect(aliceResult).toBeUndefined();
+
+      const bobResult = (await store.get(bob, bobRecordId, dataCid))!;
+      expect(bobResult).toBeDefined();
+      expect(await DataStream.toBytes(bobResult.dataStream)).toEqual(dataBytes);
+    });
+
+    it('should garbage-collect blocks when last ref is deleted', async () => {
+      const alice = await TestDataGenerator.randomCborSha256Cid();
+      const bob = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(100);
+      const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+      const aliceRecordId = await TestDataGenerator.randomCborSha256Cid();
+      const bobRecordId = await TestDataGenerator.randomCborSha256Cid();
+
+      await store.put(alice, aliceRecordId, dataCid, DataStream.fromBytes(dataBytes));
+      await store.put(bob, bobRecordId, dataCid, DataStream.fromBytes(dataBytes));
+
+      // verify blocks exist
+      const blocksPartition = await store['getBlocksPartition'](dataCid);
+      expect(await blocksPartition.db.isEmpty()).toBe(false);
+
+      // delete alice's ref — blocks should still exist (bob still references them)
+      await store.delete(alice, aliceRecordId, dataCid);
+      expect(await blocksPartition.db.isEmpty()).toBe(false);
+
+      // delete bob's ref — last ref gone, blocks should be garbage-collected
+      await store.delete(bob, bobRecordId, dataCid);
+      const blocksAfter = await store['getBlocksPartition'](dataCid);
+      expect(await blocksAfter.db.isEmpty()).toBe(true);
+
+      // refcount should be gone too
+      const refcountsPartition = await store['getRefcountsPartition']();
+      expect(await refcountsPartition.get(dataCid)).toBeUndefined();
+    });
+
+    it('should only delete the specified ref without affecting other records', async () => {
+      const alice = await TestDataGenerator.randomCborSha256Cid();
+      const bob = await TestDataGenerator.randomCborSha256Cid();
+
+      const dataBytes = TestDataGenerator.randomBytes(100);
+      const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
+
+      // alice writes two records with same data
       const recordId1 = await TestDataGenerator.randomCborSha256Cid();
-      await store.put(alice, recordId1, dataCid, dataStream1);
-
-      // alice writes a different record with same data again
-      const dataStream2 = DataStream.fromBytes(dataBytes);
       const recordId2 = await TestDataGenerator.randomCborSha256Cid();
-      await store.put(alice, recordId2, dataCid, dataStream2);
+      await store.put(alice, recordId1, dataCid, DataStream.fromBytes(dataBytes));
+      await store.put(alice, recordId2, dataCid, DataStream.fromBytes(dataBytes));
 
-      // bob writes a records with same data
-      const dataStream3 = DataStream.fromBytes(dataBytes);
+      // bob writes two records with same data
       const recordId3 = await TestDataGenerator.randomCborSha256Cid();
-      await store.put(bob, recordId3, dataCid, dataStream3);
-
-      // bob writes a different record with same data again
-      const dataStream4 = DataStream.fromBytes(dataBytes);
       const recordId4 = await TestDataGenerator.randomCborSha256Cid();
-      await store.put(bob, recordId4, dataCid, dataStream4);
+      await store.put(bob, recordId3, dataCid, DataStream.fromBytes(dataBytes));
+      await store.put(bob, recordId4, dataCid, DataStream.fromBytes(dataBytes));
 
-      // verify that all 4 records have reference to the same data CID
-      const blockstoreOfRecord1 = await store['getBlockstoreForStoringData'](alice, recordId1, dataCid);
-      const blockstoreOfRecord2 = await store['getBlockstoreForStoringData'](alice, recordId2, dataCid);
-      const blockstoreOfRecord3 = await store['getBlockstoreForStoringData'](bob, recordId3, dataCid);
-      const blockstoreOfRecord4 = await store['getBlockstoreForStoringData'](bob, recordId4, dataCid);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord1.db.keys())).toEqual([ dataCid ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord2.db.keys())).toEqual([ dataCid ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord3.db.keys())).toEqual([ dataCid ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord4.db.keys())).toEqual([ dataCid ]);
+      // all four records should be readable
+      expect(await store.get(alice, recordId1, dataCid)).toBeDefined();
+      expect(await store.get(alice, recordId2, dataCid)).toBeDefined();
+      expect(await store.get(bob, recordId3, dataCid)).toBeDefined();
+      expect(await store.get(bob, recordId4, dataCid)).toBeDefined();
 
       // alice deletes one of the two records
       await store.delete(alice, recordId1, dataCid);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord1.db.keys())).toEqual([ ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord2.db.keys())).toEqual([ dataCid ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord3.db.keys())).toEqual([ dataCid ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord4.db.keys())).toEqual([ dataCid ]);
+      expect(await store.get(alice, recordId1, dataCid)).toBeUndefined();
+      expect(await store.get(alice, recordId2, dataCid)).toBeDefined();
+      expect(await store.get(bob, recordId3, dataCid)).toBeDefined();
+      expect(await store.get(bob, recordId4, dataCid)).toBeDefined();
 
       // alice deletes the other record
       await store.delete(alice, recordId2, dataCid);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord1.db.keys())).toEqual([ ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord2.db.keys())).toEqual([ ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord3.db.keys())).toEqual([ dataCid ]);
-      expect(await ArrayUtility.fromAsyncGenerator(blockstoreOfRecord4.db.keys())).toEqual([ dataCid ]);
+      expect(await store.get(alice, recordId1, dataCid)).toBeUndefined();
+      expect(await store.get(alice, recordId2, dataCid)).toBeUndefined();
+      expect(await store.get(bob, recordId3, dataCid)).toBeDefined();
+      expect(await store.get(bob, recordId4, dataCid)).toBeDefined();
+
+      // bob deletes first record
+      await store.delete(bob, recordId3, dataCid);
+      expect(await store.get(bob, recordId3, dataCid)).toBeUndefined();
+      expect(await store.get(bob, recordId4, dataCid)).toBeDefined();
+
+      // bob deletes last record — everything should be cleaned up
+      await store.delete(bob, recordId4, dataCid);
+      expect(await store.get(bob, recordId4, dataCid)).toBeUndefined();
+
+      const keysAfterDelete = await ArrayUtility.fromAsyncGenerator(store.blockstore.db.keys());
+      expect(keysAfterDelete.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

Refactors `DataStoreLevel` to deduplicate identical data across tenants and records, resolving #412. Previously each `(tenant, recordId, dataCid)` tuple stored its own copy of all DAG-PB blocks. Now blocks are stored once in a shared sublevel with reference counting.

## Changes

### New sublevel structure

```
refs/{tenant}/{recordId}  : key {dataCid}  → JSON { dataSize }
blocks/{dataCid}          : key {blockCid} → block data (shared)
refcounts                 : key {dataCid}  → JSON { count, dataSize }
```

### Dedup behavior

- **`put()`**: checks refcount — if >0, blocks already exist, skips import and cancels the incoming stream. Idempotent re-puts (same tenant/recordId/dataCid) are detected via the refs sublevel.
- **`get()`**: confirms ref exists, reads `dataSize` from ref, exports from shared blocks partition.
- **`delete()`**: removes ref, decrements refcount. When refcount hits 0, garbage-collects the blocks sublevel and removes the refcount entry.
- **`clear()`**: unchanged — clears the entire root LevelDB (all sublevels).

### DataStore interface

No changes — dedup is an internal implementation detail. All callers continue to pass `(tenant, recordId, dataCid)`.

## Files changed

| File | Change |
|---|---|
| `packages/dwn-sdk-js/src/store/data-store-level.ts` | Full rewrite — refs + shared blocks + refcounts |
| `packages/dwn-sdk-js/tests/store/data-store-level.spec.ts` | 9 tests: 3 new (dedup, idempotent put, GC), 2 updated, 4 unchanged |

## Test results

- `data-store-level.spec.ts`: **9 pass, 0 fail**
- Full `dwn-sdk-js` suite: **1081 pass, 0 fail** (0 regressions)
- Lint: clean