### PR TITLE
test(dwn-server): add AdminStore tests for content-addressed datastore

### DIFF
--- a/packages/dwn-server/tests/admin/admin-store.test.ts
+++ b/packages/dwn-server/tests/admin/admin-store.test.ts
@@ -1,6 +1,9 @@
+import type { Dialect } from '@enbox/dwn-sql-store';
+
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 
 import { join } from 'path';
+import { Kysely } from 'kysely';
 import { tmpdir } from 'os';
 import {
   DataStoreSql,
@@ -16,11 +19,22 @@ import { AdminStore } from '../../src/admin/admin-store.js';
 import { getDialectFromUrl } from '../../src/storage.js';
 import { RegistrationStore } from '../../src/registration/registration-store.js';
 
+/**
+ * Minimal Kysely type for direct SQL verification queries.
+ * Matches the `dataRefs` and `dataBlocks` tables created by `DataStoreSql`.
+ */
+interface TestDatabase {
+  dataRefs: { tenant: string; recordId: string; dataCid: string; dataSize: number };
+  dataBlocks: { rootDataCid: string; blockCid: string; data: Uint8Array };
+}
+
 describe('AdminStore', () => {
   let adminStore: AdminStore;
   let registrationStore: RegistrationStore;
   let dwn: Dwn;
   let tmpDir: string;
+  /** Direct SQL access for verification queries against dataRefs/dataBlocks. */
+  let rawDb: Kysely<TestDatabase>;
 
   beforeAll(async () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'admin-store-test-'));
@@ -28,7 +42,7 @@ describe('AdminStore', () => {
 
     // All stores MUST share the same dialect instance so they share the same
     // underlying SQLite database connection (file-based SQLite).
-    const sharedDialect = getDialectFromUrl(sqliteUrl);
+    const sharedDialect: Dialect = getDialectFromUrl(sqliteUrl);
 
     const dataStore = new DataStoreSql(sharedDialect);
     const messageStore = new MessageStoreSql(sharedDialect);
@@ -47,11 +61,13 @@ describe('AdminStore', () => {
 
     adminStore = AdminStore.createFromDialect(sharedDialect, 100)!;
     registrationStore = await RegistrationStore.create(sharedDialect);
+    rawDb = new Kysely<TestDatabase>({ dialect: sharedDialect });
   });
 
   afterAll(async () => {
     await dwn.close();
     await adminStore.close();
+    await rawDb.destroy();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -396,6 +412,391 @@ describe('AdminStore', () => {
       for (let i = 1; i < protocols.length; i++) {
         expect(protocols[i - 1].messageCount).toBeGreaterThanOrEqual(protocols[i].messageCount);
       }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getTenantStorageSize() — content-addressed datastore
+  // ---------------------------------------------------------------------------
+
+  // Data must exceed DwnConstant.maxDataSizeAllowedToBeEncoded (30_000 bytes) to be
+  // stored in the DataStore (dataRefs/dataBlocks). Smaller data is stored inline in
+  // messageStoreMessages.encodedData and never touches dataRefs.
+  const LARGE_DATA_SIZE = 40_000;
+
+  describe('getTenantStorageSize()', () => {
+    it('should return the correct byte total for a tenant with data records', async () => {
+      const persona = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+
+      const data = TestDataGenerator.randomBytes(LARGE_DATA_SIZE);
+      const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: persona, data });
+      const result = await dwn.processMessage(persona.did, recordsWrite.message, { dataStream });
+      expect(result.status.code).toBe(202);
+
+      const storageSize = await adminStore.getTenantStorageSize(persona.did);
+      expect(storageSize).toBe(data.length);
+    });
+
+    it('should return 0 for a tenant with no data records', async () => {
+      const storageSize = await adminStore.getTenantStorageSize('did:key:no-data-at-all');
+      expect(storageSize).toBe(0);
+    });
+
+    it('should sum storage across multiple data records for one tenant', async () => {
+      const persona = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+
+      const sizes = [LARGE_DATA_SIZE, LARGE_DATA_SIZE + 1000, LARGE_DATA_SIZE + 2000];
+      for (const size of sizes) {
+        const data = TestDataGenerator.randomBytes(size);
+        const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: persona, data });
+        const result = await dwn.processMessage(persona.did, recordsWrite.message, { dataStream });
+        expect(result.status.code).toBe(202);
+      }
+
+      const expectedTotal = sizes.reduce((a, b): number => a + b, 0);
+      const storageSize = await adminStore.getTenantStorageSize(persona.did);
+      expect(storageSize).toBe(expectedTotal);
+    });
+
+    it('should count storage independently per tenant when sharing the same dataCid', async () => {
+      const tenantA = await TestDataGenerator.generateDidKeyPersona();
+      const tenantB = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, tenantA);
+      await TestDataGenerator.installDefaultTestProtocol(dwn, tenantB);
+
+      // Write the exact same bytes to both tenants — same dataCid.
+      const sharedData = TestDataGenerator.randomBytes(LARGE_DATA_SIZE);
+      const writeA = await TestDataGenerator.generateRecordsWrite({ author: tenantA, data: sharedData });
+      const writeB = await TestDataGenerator.generateRecordsWrite({ author: tenantB, data: sharedData });
+      expect((await dwn.processMessage(tenantA.did, writeA.recordsWrite.message, { dataStream: writeA.dataStream })).status.code).toBe(202);
+      expect((await dwn.processMessage(tenantB.did, writeB.recordsWrite.message, { dataStream: writeB.dataStream })).status.code).toBe(202);
+
+      // Each tenant should report its own storage independently.
+      const sizeA = await adminStore.getTenantStorageSize(tenantA.did);
+      const sizeB = await adminStore.getTenantStorageSize(tenantB.did);
+      expect(sizeA).toBe(sharedData.length);
+      expect(sizeB).toBe(sharedData.length);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getTenantCount() — dedicated tests
+  // ---------------------------------------------------------------------------
+
+  describe('getTenantCount()', () => {
+    it('should return the correct count of distinct tenants', async () => {
+      // Create N fresh tenants.
+      const countBefore = await adminStore.getTenantCount();
+      const newTenantCount = 3;
+      for (let i = 0; i < newTenantCount; i++) {
+        const persona = await TestDataGenerator.generateDidKeyPersona();
+        await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+        const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: persona });
+        await dwn.processMessage(persona.did, recordsWrite.message, { dataStream });
+      }
+
+      const countAfter = await adminStore.getTenantCount();
+      expect(countAfter).toBe(countBefore + newTenantCount);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getTenantStats() — dedicated store-level tests
+  // ---------------------------------------------------------------------------
+
+  describe('getTenantStats()', () => {
+    it('should return correct aggregated stats for a tenant', async () => {
+      const persona = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+
+      const data = TestDataGenerator.randomBytes(LARGE_DATA_SIZE);
+      const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: persona, data });
+      const result = await dwn.processMessage(persona.did, recordsWrite.message, { dataStream });
+      expect(result.status.code).toBe(202);
+
+      const stats = await adminStore.getTenantStats(persona.did);
+
+      // Protocol install (ProtocolsConfigure) + RecordsWrite = at least 2 messages.
+      expect(stats.messageCount).toBeGreaterThanOrEqual(2);
+      expect(stats.dataStorageBytes).toBe(data.length);
+      expect(stats.protocolCount).toBeGreaterThanOrEqual(1);
+      expect(stats.protocols.length).toBe(stats.protocolCount);
+    });
+
+    it('should return all-zero stats for a nonexistent tenant', async () => {
+      const stats = await adminStore.getTenantStats('did:key:does-not-exist-stats');
+      expect(stats.messageCount).toBe(0);
+      expect(stats.dataStorageBytes).toBe(0);
+      expect(stats.protocolCount).toBe(0);
+      expect(stats.protocols).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getGlobalStats() — value correctness
+  // ---------------------------------------------------------------------------
+
+  describe('getGlobalStats() — value correctness', () => {
+    it('should return correct totalMessages and tenantCount', async () => {
+      // Force a fresh calculation.
+      const stats = await adminStore.getGlobalStats({ refresh: true });
+      expect(typeof stats.totalMessages).toBe('number');
+      expect(stats.totalMessages).toBeGreaterThan(0);
+      expect(stats.tenantCount).toBeGreaterThan(0);
+    });
+
+    it('should return correct totalDataBytes from dataRefs', async () => {
+      // Sum all dataSize values from dataRefs as ground truth.
+      const groundTruth = await rawDb
+        .selectFrom('dataRefs')
+        .select(rawDb.fn.sum<number>('dataSize').as('total'))
+        .executeTakeFirstOrThrow();
+
+      const stats = await adminStore.getGlobalStats({ refresh: true });
+      expect(stats.totalDataBytes).toBe(Number(groundTruth.total) || 0);
+    });
+
+    it('should include per-tenant data in totalDataBytes when tenants share a dataCid', async () => {
+      const statsBefore = await adminStore.getGlobalStats({ refresh: true });
+
+      const tenantA = await TestDataGenerator.generateDidKeyPersona();
+      const tenantB = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, tenantA);
+      await TestDataGenerator.installDefaultTestProtocol(dwn, tenantB);
+
+      // Write the same large data to both tenants (must exceed 30KB to use dataStore).
+      const sharedData = TestDataGenerator.randomBytes(LARGE_DATA_SIZE);
+      const writeA = await TestDataGenerator.generateRecordsWrite({ author: tenantA, data: sharedData });
+      const writeB = await TestDataGenerator.generateRecordsWrite({ author: tenantB, data: sharedData });
+      expect((await dwn.processMessage(tenantA.did, writeA.recordsWrite.message, { dataStream: writeA.dataStream })).status.code).toBe(202);
+      expect((await dwn.processMessage(tenantB.did, writeB.recordsWrite.message, { dataStream: writeB.dataStream })).status.code).toBe(202);
+
+      const statsAfter = await adminStore.getGlobalStats({ refresh: true });
+
+      // Both refs are counted — total should increase by 2 * sharedData.length.
+      expect(statsAfter.totalDataBytes).toBe(statsBefore.totalDataBytes + (2 * sharedData.length));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // purgeTenantData() — content-addressed GC
+  // ---------------------------------------------------------------------------
+
+  describe('purgeTenantData() — content-addressed GC', () => {
+    it('should delete dataRefs for the purged tenant', async () => {
+      const persona = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+
+      const data = TestDataGenerator.randomBytes(LARGE_DATA_SIZE);
+      const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: persona, data });
+      expect((await dwn.processMessage(persona.did, recordsWrite.message, { dataStream })).status.code).toBe(202);
+
+      // Verify data exists before purge.
+      expect(await adminStore.getTenantStorageSize(persona.did)).toBe(data.length);
+
+      await adminStore.purgeTenantData(persona.did);
+
+      // dataRefs should be empty for this tenant.
+      expect(await adminStore.getTenantStorageSize(persona.did)).toBe(0);
+    });
+
+    it('should garbage-collect dataBlocks when the last ref is deleted', async () => {
+      const persona = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+
+      const data = TestDataGenerator.randomBytes(LARGE_DATA_SIZE);
+      const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: persona, data });
+      expect((await dwn.processMessage(persona.did, recordsWrite.message, { dataStream })).status.code).toBe(202);
+
+      // Find the dataCid to verify block cleanup.
+      const refs = await rawDb
+        .selectFrom('dataRefs')
+        .select('dataCid')
+        .where('tenant', '=', persona.did)
+        .execute();
+      expect(refs.length).toBeGreaterThan(0);
+      const dataCid = refs[0].dataCid;
+
+      // Confirm blocks exist.
+      const blocksBefore = await rawDb
+        .selectFrom('dataBlocks')
+        .select('blockCid')
+        .where('rootDataCid', '=', dataCid)
+        .execute();
+      expect(blocksBefore.length).toBeGreaterThan(0);
+
+      // Purge the only tenant referencing this dataCid.
+      await adminStore.purgeTenantData(persona.did);
+
+      // Blocks should be garbage-collected.
+      const blocksAfter = await rawDb
+        .selectFrom('dataBlocks')
+        .select('blockCid')
+        .where('rootDataCid', '=', dataCid)
+        .execute();
+      expect(blocksAfter.length).toBe(0);
+    });
+
+    it('should NOT garbage-collect dataBlocks when another tenant still references the same dataCid', async () => {
+      const tenantA = await TestDataGenerator.generateDidKeyPersona();
+      const tenantB = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, tenantA);
+      await TestDataGenerator.installDefaultTestProtocol(dwn, tenantB);
+
+      // Write identical large data to both tenants — produces the same dataCid.
+      const sharedData = TestDataGenerator.randomBytes(LARGE_DATA_SIZE);
+      const writeA = await TestDataGenerator.generateRecordsWrite({ author: tenantA, data: sharedData });
+      const writeB = await TestDataGenerator.generateRecordsWrite({ author: tenantB, data: sharedData });
+      expect((await dwn.processMessage(tenantA.did, writeA.recordsWrite.message, { dataStream: writeA.dataStream })).status.code).toBe(202);
+      expect((await dwn.processMessage(tenantB.did, writeB.recordsWrite.message, { dataStream: writeB.dataStream })).status.code).toBe(202);
+
+      // Find the shared dataCid.
+      const refsA = await rawDb
+        .selectFrom('dataRefs')
+        .select('dataCid')
+        .where('tenant', '=', tenantA.did)
+        .execute();
+      const refsB = await rawDb
+        .selectFrom('dataRefs')
+        .select('dataCid')
+        .where('tenant', '=', tenantB.did)
+        .execute();
+      expect(refsA.length).toBeGreaterThan(0);
+      expect(refsB.length).toBeGreaterThan(0);
+      // Same dataCid (same bytes).
+      expect(refsA[0].dataCid).toBe(refsB[0].dataCid);
+      const dataCid = refsA[0].dataCid;
+
+      // Purge tenant A only.
+      await adminStore.purgeTenantData(tenantA.did);
+
+      // Blocks should still exist because tenant B still references the dataCid.
+      const blocksAfter = await rawDb
+        .selectFrom('dataBlocks')
+        .select('blockCid')
+        .where('rootDataCid', '=', dataCid)
+        .execute();
+      expect(blocksAfter.length).toBeGreaterThan(0);
+
+      // Tenant B's storage should still be intact.
+      expect(await adminStore.getTenantStorageSize(tenantB.did)).toBe(sharedData.length);
+    });
+
+    it('should garbage-collect after both tenants sharing a dataCid are purged', async () => {
+      const tenantA = await TestDataGenerator.generateDidKeyPersona();
+      const tenantB = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, tenantA);
+      await TestDataGenerator.installDefaultTestProtocol(dwn, tenantB);
+
+      const sharedData = TestDataGenerator.randomBytes(LARGE_DATA_SIZE);
+      const writeA = await TestDataGenerator.generateRecordsWrite({ author: tenantA, data: sharedData });
+      const writeB = await TestDataGenerator.generateRecordsWrite({ author: tenantB, data: sharedData });
+      expect((await dwn.processMessage(tenantA.did, writeA.recordsWrite.message, { dataStream: writeA.dataStream })).status.code).toBe(202);
+      expect((await dwn.processMessage(tenantB.did, writeB.recordsWrite.message, { dataStream: writeB.dataStream })).status.code).toBe(202);
+
+      const refs = await rawDb
+        .selectFrom('dataRefs')
+        .select('dataCid')
+        .where('tenant', '=', tenantA.did)
+        .execute();
+      const dataCid = refs[0].dataCid;
+
+      // Purge tenant A — blocks should remain.
+      await adminStore.purgeTenantData(tenantA.did);
+      let blocks = await rawDb.selectFrom('dataBlocks').select('blockCid').where('rootDataCid', '=', dataCid).execute();
+      expect(blocks.length).toBeGreaterThan(0);
+
+      // Purge tenant B — now blocks should be garbage-collected.
+      await adminStore.purgeTenantData(tenantB.did);
+      blocks = await rawDb.selectFrom('dataBlocks').select('blockCid').where('rootDataCid', '=', dataCid).execute();
+      expect(blocks.length).toBe(0);
+    });
+
+    it('should handle multiple records with different dataCids for one tenant', async () => {
+      const persona = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+
+      const dataCids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const data = TestDataGenerator.randomBytes(LARGE_DATA_SIZE + i * 1000);
+        const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: persona, data });
+        expect((await dwn.processMessage(persona.did, recordsWrite.message, { dataStream })).status.code).toBe(202);
+      }
+
+      // Collect all dataCids for this tenant.
+      const refs = await rawDb.selectFrom('dataRefs').select('dataCid').where('tenant', '=', persona.did).execute();
+      for (const ref of refs) {
+        dataCids.push(ref.dataCid);
+      }
+      expect(dataCids.length).toBe(3);
+
+      // Purge.
+      await adminStore.purgeTenantData(persona.did);
+
+      // All refs and blocks should be gone.
+      for (const cid of dataCids) {
+        const remaining = await rawDb.selectFrom('dataBlocks').select('blockCid').where('rootDataCid', '=', cid).execute();
+        expect(remaining.length).toBe(0);
+      }
+      expect(await adminStore.getTenantStorageSize(persona.did)).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // exportTenantData() — with real data
+  // ---------------------------------------------------------------------------
+
+  describe('exportTenantData()', () => {
+    it('should export messages and dataRecords for a tenant', async () => {
+      const persona = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+
+      const data = TestDataGenerator.randomBytes(LARGE_DATA_SIZE);
+      const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: persona, data });
+      expect((await dwn.processMessage(persona.did, recordsWrite.message, { dataStream })).status.code).toBe(202);
+
+      const exported = await adminStore.exportTenantData(persona.did);
+
+      // Metadata.
+      expect(exported.metadata.tenant).toBe(persona.did);
+      expect(exported.metadata.exportedAt).toBeDefined();
+      expect(exported.metadata.messageCount).toBeGreaterThanOrEqual(2); // ProtocolsConfigure + RecordsWrite
+      expect(exported.metadata.dataRecordCount).toBeGreaterThanOrEqual(1);
+
+      // Messages should include expected fields.
+      expect(exported.messages.length).toBe(exported.metadata.messageCount);
+      const recordsMsg = exported.messages.find((m): boolean => m.method === 'Write' && m.interface === 'Records');
+      expect(recordsMsg).toBeDefined();
+      expect(recordsMsg!.messageCid).toBeDefined();
+      expect(recordsMsg!.recordId).toBeDefined();
+
+      // Data records from dataRefs.
+      expect(exported.dataRecords.length).toBe(exported.metadata.dataRecordCount);
+      const dataRec = exported.dataRecords[0];
+      expect(dataRec.recordId).toBeDefined();
+      expect(dataRec.dataCid).toBeDefined();
+      expect(dataRec.dataSize).toBe(data.length);
+    });
+
+    it('should return empty results for a nonexistent tenant', async () => {
+      const exported = await adminStore.exportTenantData('did:key:totally-nonexistent');
+      expect(exported.metadata.messageCount).toBe(0);
+      expect(exported.metadata.dataRecordCount).toBe(0);
+      expect(exported.messages).toEqual([]);
+      expect(exported.dataRecords).toEqual([]);
+    });
+
+    it('should return empty dataRecords when tenant has only protocol messages', async () => {
+      const persona = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+      // No RecordsWrite — only ProtocolsConfigure messages.
+
+      const exported = await adminStore.exportTenantData(persona.did);
+      expect(exported.metadata.messageCount).toBeGreaterThanOrEqual(1);
+      expect(exported.metadata.dataRecordCount).toBe(0);
+      expect(exported.dataRecords).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add 18 new tests to `AdminStore` covering test gaps introduced by the content-addressed datastore refactor (`dataRefs`/`dataBlocks` tables from #427)
- All new tests use data > 30KB (`LARGE_DATA_SIZE = 40_000`) to ensure data flows through `DataStoreSql.put()` into `dataRefs`/`dataBlocks` rather than being stored inline in `messageStoreMessages.encodedData`

## Test Coverage Added

| Method | Tests | What's covered |
|---|---|---|
| `getTenantStorageSize()` | 4 | Correct total, zero for no data, sum across records, independent per-tenant with shared `dataCid` |
| `getTenantCount()` | 1 | Correct distinct tenant count |
| `getTenantStats()` | 2 | Correct aggregated stats, all-zero for nonexistent tenant |
| `getGlobalStats()` | 3 | Correct totals, correct `totalDataBytes` from `dataRefs`, shared `dataCid` accounting |
| `purgeTenantData()` | 5 | Delete `dataRefs`, GC blocks on last ref, preserve blocks when another tenant shares `dataCid`, GC after both tenants purged, multiple different `dataCids` |
| `exportTenantData()` | 3 | Export with real data, empty for nonexistent tenant, empty `dataRecords` for protocol-only tenant |

## Verification

- `bun run test:node` — 368 pass, 0 fail
- `bun run lint` — clean, 0 warnings

Closes gaps identified during the #427 content-addressed datastore migration.