### PR TITLE
fix(api): clean up misleading race condition TODOs in Web5.connect() and tests (#61)

### DIFF
--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -500,17 +500,14 @@ export class Web5 {
           throw new Error(`Failed to connect to wallet: ${error.message}`);
         }
       } else {
-        // No connected identity found and no connectOptions provided, use local Identities
-        // Query the Agent's DWN tenant for identity records.
+        // No connected (WalletConnect) identity and no walletConnectOptions provided.
+        // Look for an existing local identity, or create one on first use.
         const identities = await userAgent.identity.list();
 
-        // If an existing identity is not found found, create a new one.
-        const existingIdentityCount = identities.length;
-        if (existingIdentityCount === 0) {
-          // since we are creating a new identity, we will want to register sync for the created Did
+        if (identities.length === 0) {
           registerSync = true;
 
-          // Generate a new Identity for the end-user.
+          // First use — generate a new Identity for the end-user.
           identity = await userAgent.identity.create({
             didMethod  : 'dht',
             metadata   : { name: 'Default' },
@@ -540,8 +537,9 @@ export class Web5 {
           });
 
         } else {
-          // If multiple identities are found, use the first one.
-          // TODO: Implement selecting a connectedDid from multiple identities
+          // Reconnecting — use the first local identity. When the agent manages
+          // multiple identities (e.g. created via agent.identity.create()), the
+          // first one returned by the store is used as the default for connect().
           identity = identities[0];
         }
       }

--- a/packages/api/tests/protocol.spec.ts
+++ b/packages/api/tests/protocol.spec.ts
@@ -9,8 +9,7 @@ import emailProtocolDefinition from './fixtures/protocol-definitions/email.json'
 import { TestDataGenerator } from './utils/test-data-generator.js';
 import { testDwnUrl } from './utils/test-config.js';
 
-// TODO: Come up with a better way of resolving the TS errors.
-const testDwnUrls: string[] = [testDwnUrl];
+const testDwnUrls = [testDwnUrl];
 
 describe('Protocol', () => {
   let aliceDid: BearerDid;

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -282,25 +282,21 @@ describe('web5 api', () => {
       expect(walletConnectSpy.called).toBe(false);
     });
 
-    it('defaults to the first identity if multiple identities exist', async () => {
-      // scenario: For some reason more than one identity exists when attempting to re-connect to `Web5`
-      // the first identity in the array should be the one selected
-      // TODO: this has happened due to a race condition somewhere. Dig into this issue
-      // and implement a better way to select/manage DIDs when using `Web5.connect()`
-
-      // create an identity by connecting
+    it('reconnects with the first identity when multiple identities exist', async () => {
+      // When additional identities are created via agent.identity.create() (e.g. for
+      // multi-persona use), connect() should still return the same DID on reconnect.
       sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
       const { web5, did } = await Web5.connect({ techPreview: { dwnEndpoints: [ testDwnUrl ] }, sync: 'off' });
       expect(web5).toBeDefined();
       expect(did).toBeDefined();
 
-      // create a second identity
+      // Create a second identity outside of connect() (multi-persona scenario).
       await testHarness.agent.identity.create({
         didMethod : 'jwk',
         metadata  : { name: 'Second' }
       });
 
-      // connect again
+      // Reconnecting should return the same DID as the first connect().
       const { did: did2 } = await Web5.connect({ sync: 'off' });
       expect(did2).toBe(did);
     });


### PR DESCRIPTION
## Summary

- Remove incorrect race condition framing from `Web5.connect()` identity resolution and associated test TODOs
- Remove stale TODO and unnecessary type annotation in `protocol.spec.ts`

## Analysis

The TODO at `web5.spec.ts:288` described a "race condition" causing multiple identities during reconnection. Investigation found this is **not a race condition** — `Web5.connect()` creates a new `Web5UserAgent` per call with its own LevelDB-backed store (file-locked), so concurrent calls cannot race on identity creation.

Multiple identities under one agent is a **legitimate, supported state**: apps can create additional identities via `agent.identity.create()` for multi-persona use (the web-wallet app does exactly this, treating each identity as a "persona" — Social, Professional, Gaming, etc.). The "pick first identity" reconnection behavior is correct for the simple-app use case that `Web5.connect()` serves.

## Changes

**`packages/api/src/web5.ts`:**
- Removed `existingIdentityCount` intermediate variable
- Replaced misleading comments and TODO with clear documentation of the reconnection behavior

**`packages/api/tests/web5.spec.ts`:**
- Renamed test to "reconnects with the first identity when multiple identities exist"
- Removed race condition TODO and updated comments to describe multi-persona reconnection

**`packages/api/tests/protocol.spec.ts`:**
- Removed stale TODO about TS errors — the explicit `string[]` annotation was never needed

## Issue status

Items 2 and 3 from #61 (the `xit` skipped tests) were already resolved in PR #426. This PR resolves the remaining items 1 and 4.

Closes #61