### PR TITLE
fix(dwn-server): build only required packages in Dockerfile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,16 @@ jobs:
           filters: |
             dwn-server:
               - 'packages/dwn-server/**'
+              - 'packages/dwn-sdk-js/**'
+              - 'packages/dwn-sql-store/**'
+              - 'packages/dwn-clients/**'
+              - 'packages/common/**'
+              - 'packages/crypto/**'
+              - 'packages/dids/**'
               - 'build/**'
               - 'fly.toml'
+              - '.dockerignore'
+              - 'bun.lock'
 
   deploy-dwn-server:
     name: Deploy DWN Server

--- a/packages/dwn-server/Dockerfile
+++ b/packages/dwn-server/Dockerfile
@@ -1,4 +1,4 @@
-# Stage 1: Builder - Build the entire monorepo
+# Stage 1: Builder - Build dwn-server and its dependencies
 FROM oven/bun:1 AS builder
 
 WORKDIR /app
@@ -21,8 +21,10 @@ COPY packages/ ./packages/
 # Install all dependencies
 RUN bun install --frozen-lockfile
 
-# Build all packages
-RUN bun run --filter '*' build
+# Build only packages needed by dwn-server (others have src/ excluded via .dockerignore)
+RUN bun run --filter '@enbox/common' --filter '@enbox/crypto' --filter '@enbox/dids' \
+    --filter '@enbox/dwn-sdk-js' --filter '@enbox/dwn-sql-store' --filter '@enbox/dwn-clients' \
+    --filter '@enbox/dwn-server-admin-ui' --filter '@enbox/dwn-server' build
 
 # Stage 2: Runner - Slim bun image
 FROM oven/bun:1-slim AS runner


### PR DESCRIPTION
## Summary

- **Fix Docker build failure**: The Dockerfile ran `bun run --filter '*' build` which tried to build all monorepo packages, but `.dockerignore` excludes `src/` for packages not needed by dwn-server (`agent`, `api`, `browser`, `protocols`, `protocol-codegen`). This caused `tsc` to fail with `TS18003: No inputs were found` every time the deploy actually ran. All prior "successes" in the Deploy workflow were actually **skipped** jobs (no dwn-server path changes detected) — every real deploy has failed since the Dockerfile was introduced in #408.

- **Broaden deploy trigger paths**: The deploy workflow only watched `packages/dwn-server/**`, missing changes to dependency packages. Now also triggers on changes to `common`, `crypto`, `dids`, `dwn-sdk-js`, `dwn-sql-store`, `dwn-clients`, `.dockerignore`, and `bun.lock`.

## Verified

Docker build tested locally — all 8 required packages build cleanly with zero errors.