### PR TITLE
Bootstrap Terraform State Backend + AWS OIDC (#372)

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,16 @@
+# Terraform local state & working files
+*.tfstate
+*.tfstate.backup
+*.tfstate.*.backup
+.terraform/
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# tfvars may contain secrets — never commit
+*.auto.tfvars
+*.auto.tfvars.json
+terraform.tfvars

--- a/infra/bootstrap/.terraform.lock.hcl
+++ b/infra/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.33.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:MxndtTQD9qHGQwIjScLlY4BQZgdjJ1Lsq1TdwodsxmU=",
+    "zh:207f3f9db05c11429a241b84deeecfbd4caa941792c2c49b09c8c85cd59474dd",
+    "zh:25c36ad1f4617aeb23f8cd18efc7856127db721f6cf3e2e474236af019ce9ad1",
+    "zh:2685af1f3eb9abfce3168777463eaaad9dba5687f9f84d8bb579cb878bcfa18b",
+    "zh:57e28457952cf43923533af0a9bb322164be5fc3d66c080b5c59ee81950e9ef6",
+    "zh:5b6cd074f9e3a8d91841e739d259fe11f181e69c4019e3321231b35c0dde08c8",
+    "zh:6e3251500cebf1effb9c68d49041268ea270f75b122b94d261af231a8ebfa981",
+    "zh:7eee56f52f4b94637793508f3e83f68855f5f884a77aed2bd2fe77480c89e33d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e228c92db1b9e36a0f899d6ab7446e6b8cf3183112d4f1c1613d6827a0ed3d6",
+    "zh:b34a84475e91715352ed1119b21e51a81d8ad12e93c86d4e78cd2d315d02dcab",
+    "zh:cdcc05a423a78a9b2c4e2844c58ecbf2ce6a3117cab353fa05197782d6f76667",
+    "zh:d0f5f6b1399cfa1b64f3e824bee9e39ff15d5a540ff197e9bfc157fe354a8426",
+    "zh:d9525dbb53468dee6b8e6d15669d25957e9872bf1cd386231dff93c8c659f1d7",
+    "zh:ed37db2df08b961a7fc390164273e602767ca6922f57560daa9678a2e1315fd0",
+    "zh:f6adc66b86e12041a2d3739600e6a153a1f5752dd363db11469f6f4dbd090080",
+  ]
+}

--- a/infra/bootstrap/backend.tf
+++ b/infra/bootstrap/backend.tf
@@ -1,0 +1,22 @@
+# ─── Terraform Backend ────────────────────────────────────────────────────────
+#
+# Phase 1 — initial bootstrap (local state):
+#   Leave this file as-is.  Run `terraform init && terraform apply` locally.
+#
+# Phase 2 — migrate to S3 (after the first apply creates the bucket + table):
+#   Uncomment the backend block below, then run:
+#     terraform init -migrate-state
+#
+# After migration, all state is stored in S3 with DynamoDB locking and the
+# local terraform.tfstate file can be deleted.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# terraform {
+#   backend "s3" {
+#     bucket         = "enbox-terraform-state"
+#     key            = "bootstrap/terraform.tfstate"
+#     region         = "us-east-1"
+#     dynamodb_table = "enbox-terraform-locks"
+#     encrypt        = true
+#   }
+# }

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -1,0 +1,371 @@
+# ─── Terraform State Backend ──────────────────────────────────────────────────
+#
+# S3 bucket + DynamoDB table for remote state with locking.
+
+resource "aws_s3_bucket" "state" {
+  bucket = var.state_bucket_name
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "locks" {
+  name         = var.lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# ─── ECR Repositories ────────────────────────────────────────────────────────
+
+resource "aws_ecr_repository" "dwn_server" {
+  name                 = "dwn-server"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "dwn_server" {
+  repository = aws_ecr_repository.dwn_server.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 20 tagged images"
+        selection = {
+          tagStatus   = "tagged"
+          tagPrefixList = ["v", "sha-"]
+          countType   = "imageCountMoreThan"
+          countNumber = 20
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Remove untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      },
+    ]
+  })
+}
+
+# ─── GitHub Actions OIDC Federation ──────────────────────────────────────────
+#
+# Allows GitHub Actions to assume AWS IAM roles without long-lived credentials.
+
+data "aws_iam_policy_document" "github_oidc_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_org}/${var.github_repo}:*"]
+    }
+  }
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["ffffffffffffffffffffffffffffffffffffffff"]
+}
+
+# ─── IAM Role: github-actions-terraform ──────────────────────────────────────
+#
+# Full infrastructure management for Terraform plan/apply in CI.
+
+resource "aws_iam_role" "github_actions_terraform" {
+  name               = "github-actions-terraform"
+  assume_role_policy = data.aws_iam_policy_document.github_oidc_trust.json
+
+  max_session_duration = 3600
+}
+
+data "aws_iam_policy_document" "terraform_permissions" {
+  # Terraform state access (S3 + DynamoDB)
+  statement {
+    sid    = "TerraformStateAccess"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.state.arn,
+      "${aws_s3_bucket.state.arn}/*",
+    ]
+  }
+
+  statement {
+    sid    = "TerraformStateLocking"
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [aws_dynamodb_table.locks.arn]
+  }
+
+  # Infrastructure management — scoped to what Terraform modules need.
+  statement {
+    sid    = "NetworkAndCompute"
+    effect = "Allow"
+    actions = [
+      # VPC
+      "ec2:Describe*",
+      "ec2:CreateVpc", "ec2:DeleteVpc", "ec2:ModifyVpcAttribute",
+      "ec2:CreateSubnet", "ec2:DeleteSubnet",
+      "ec2:CreateInternetGateway", "ec2:DeleteInternetGateway",
+      "ec2:AttachInternetGateway", "ec2:DetachInternetGateway",
+      "ec2:CreateNatGateway", "ec2:DeleteNatGateway",
+      "ec2:AllocateAddress", "ec2:ReleaseAddress", "ec2:AssociateAddress", "ec2:DisassociateAddress",
+      "ec2:CreateRouteTable", "ec2:DeleteRouteTable",
+      "ec2:CreateRoute", "ec2:DeleteRoute",
+      "ec2:AssociateRouteTable", "ec2:DisassociateRouteTable",
+      "ec2:CreateSecurityGroup", "ec2:DeleteSecurityGroup",
+      "ec2:AuthorizeSecurityGroupIngress", "ec2:RevokeSecurityGroupIngress",
+      "ec2:AuthorizeSecurityGroupEgress", "ec2:RevokeSecurityGroupEgress",
+      "ec2:CreateTags", "ec2:DeleteTags",
+      # ECS
+      "ecs:*",
+      # ELB
+      "elasticloadbalancing:*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "DatabaseAndStorage"
+    effect = "Allow"
+    actions = [
+      "rds:*",
+      "s3:*",
+      "ecr:*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "IAMPassRole"
+    effect = "Allow"
+    actions = [
+      "iam:GetRole",
+      "iam:PassRole",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:CreateServiceLinkedRole",
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:role/enbox-*",
+      "arn:aws:iam::${var.account_id}:role/aws-service-role/*",
+    ]
+  }
+
+  statement {
+    sid    = "Logging"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:DeleteLogGroup",
+      "logs:DescribeLogGroups",
+      "logs:PutRetentionPolicy",
+      "logs:TagResource",
+      "logs:UntagResource",
+      "logs:ListTagsForResource",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ACMCertificates"
+    effect = "Allow"
+    actions = [
+      "acm:RequestCertificate",
+      "acm:DeleteCertificate",
+      "acm:DescribeCertificate",
+      "acm:ListCertificates",
+      "acm:ListTagsForCertificate",
+      "acm:AddTagsToCertificate",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "SecretsManager"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:CreateSecret",
+      "secretsmanager:DeleteSecret",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:TagResource",
+      "secretsmanager:GetResourcePolicy",
+    ]
+    resources = [
+      "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:enbox-*",
+    ]
+  }
+
+  statement {
+    sid    = "ServiceDiscovery"
+    effect = "Allow"
+    actions = [
+      "servicediscovery:CreatePrivateDnsNamespace",
+      "servicediscovery:DeleteNamespace",
+      "servicediscovery:GetNamespace",
+      "servicediscovery:ListNamespaces",
+      "servicediscovery:CreateService",
+      "servicediscovery:DeleteService",
+      "servicediscovery:GetService",
+      "servicediscovery:TagResource",
+      "servicediscovery:GetOperation",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Route53"
+    effect = "Allow"
+    actions = [
+      "route53:GetHostedZone",
+      "route53:ListHostedZones",
+      "route53:ChangeResourceRecordSets",
+      "route53:GetChange",
+      "route53:ListResourceRecordSets",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_terraform" {
+  name   = "terraform-infra-management"
+  role   = aws_iam_role.github_actions_terraform.id
+  policy = data.aws_iam_policy_document.terraform_permissions.json
+}
+
+# ─── IAM Role: github-actions-ecr ────────────────────────────────────────────
+#
+# Minimal role for Docker build + push workflows.
+
+resource "aws_iam_role" "github_actions_ecr" {
+  name               = "github-actions-ecr"
+  assume_role_policy = data.aws_iam_policy_document.github_oidc_trust.json
+
+  max_session_duration = 3600
+}
+
+data "aws_iam_policy_document" "ecr_push" {
+  statement {
+    sid    = "ECRAuth"
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ECRPush"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+    ]
+    resources = [aws_ecr_repository.dwn_server.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_ecr" {
+  name   = "ecr-push"
+  role   = aws_iam_role.github_actions_ecr.id
+  policy = data.aws_iam_policy_document.ecr_push.json
+}

--- a/infra/bootstrap/outputs.tf
+++ b/infra/bootstrap/outputs.tf
@@ -1,0 +1,52 @@
+# ─── State Backend ────────────────────────────────────────────────────────────
+
+output "state_bucket_name" {
+  description = "S3 bucket holding Terraform remote state."
+  value       = aws_s3_bucket.state.id
+}
+
+output "state_bucket_arn" {
+  description = "ARN of the Terraform state S3 bucket."
+  value       = aws_s3_bucket.state.arn
+}
+
+output "lock_table_name" {
+  description = "DynamoDB table used for Terraform state locking."
+  value       = aws_dynamodb_table.locks.name
+}
+
+output "lock_table_arn" {
+  description = "ARN of the DynamoDB lock table."
+  value       = aws_dynamodb_table.locks.arn
+}
+
+# ─── ECR ──────────────────────────────────────────────────────────────────────
+
+output "ecr_dwn_server_url" {
+  description = "ECR repository URL for the dwn-server image."
+  value       = aws_ecr_repository.dwn_server.repository_url
+}
+
+output "ecr_dwn_server_arn" {
+  description = "ARN of the dwn-server ECR repository."
+  value       = aws_ecr_repository.dwn_server.arn
+}
+
+# ─── IAM Roles ────────────────────────────────────────────────────────────────
+
+output "github_actions_terraform_role_arn" {
+  description = "IAM role ARN for Terraform CI/CD (plan/apply)."
+  value       = aws_iam_role.github_actions_terraform.arn
+}
+
+output "github_actions_ecr_role_arn" {
+  description = "IAM role ARN for Docker build + ECR push."
+  value       = aws_iam_role.github_actions_ecr.arn
+}
+
+# ─── OIDC ─────────────────────────────────────────────────────────────────────
+
+output "github_oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC identity provider."
+  value       = aws_iam_openid_connect_provider.github.arn
+}

--- a/infra/bootstrap/variables.tf
+++ b/infra/bootstrap/variables.tf
@@ -1,0 +1,34 @@
+variable "region" {
+  description = "AWS region for all bootstrap resources."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "account_id" {
+  description = "AWS account ID. Used to scope IAM trust policies."
+  type        = string
+}
+
+variable "github_org" {
+  description = "GitHub organisation that owns the repository."
+  type        = string
+  default     = "enboxorg"
+}
+
+variable "github_repo" {
+  description = "GitHub repository name (without org prefix)."
+  type        = string
+  default     = "enbox"
+}
+
+variable "state_bucket_name" {
+  description = "Name of the S3 bucket for Terraform remote state."
+  type        = string
+  default     = "enbox-terraform-state"
+}
+
+variable "lock_table_name" {
+  description = "Name of the DynamoDB table for Terraform state locking."
+  type        = string
+  default     = "enbox-terraform-locks"
+}

--- a/infra/bootstrap/versions.tf
+++ b/infra/bootstrap/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project   = "enbox"
+      ManagedBy = "terraform"
+      Module    = "bootstrap"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- S3 state bucket with versioning, KMS encryption, and public access block for Terraform remote state
- DynamoDB table (`PAY_PER_REQUEST`) for state locking with `LockID` partition key
- ECR repository (`dwn-server`) with immutable tags, scan-on-push, and lifecycle policies
- GitHub Actions OIDC provider + two IAM roles:
  - `github-actions-terraform` — full infra management (VPC, ECS, RDS, S3, IAM, ACM, logs, etc.)
  - `github-actions-ecr` — minimal ECR push permissions for Docker build workflows
- `.gitignore` for Terraform state files, `.terraform/` dir, and `*.tfvars`
- Provider lock file (`.terraform.lock.hcl`) committed for reproducible builds

## Execution Steps

1. Set `account_id` variable and run `terraform init && terraform apply` locally
2. Uncomment the S3 backend block in `backend.tf`
3. Run `terraform init -migrate-state` to move state from local to S3
4. Commit the `backend.tf` change — all future infra goes through CI

## Directory Structure

```
infra/
  .gitignore
  bootstrap/
    versions.tf     # terraform >= 1.7, aws >= 5.0
    variables.tf    # account_id, region, github_org/repo, bucket/table names
    backend.tf      # starts local, migrated to S3 after first apply
    main.tf         # S3 bucket, DynamoDB, ECR, OIDC provider, IAM roles
    outputs.tf      # bucket/table names/ARNs, ECR URL, role ARNs
    .terraform.lock.hcl
```

Closes #372