### PR TITLE
fix(dwn-server): include aud claim in OpenAuthHandler JWT tokens

### DIFF
--- a/packages/dwn-server/src/registration/open-auth-handler.ts
+++ b/packages/dwn-server/src/registration/open-auth-handler.ts
@@ -210,6 +210,7 @@ export class OpenAuthHandler {
     return new jose.SignJWT({ purpose })
       .setProtectedHeader({ alg: 'HS256' })
       .setIssuer(this.#issuer)
+      .setAudience(this.#issuer)
       .setSubject(accountId)
       .setIssuedAt()
       .setExpirationTime(`${ttlSeconds}s`)


### PR DESCRIPTION
## Summary

- Fix: OpenAuthHandler-issued JWTs were missing the `aud` claim, causing registration to fail with `ProviderAuthTokenInvalid: missing required "aud" claim`
- The JWT plugin auto-configured via `DwnServer` sets `audience: baseUrl`, but `OpenAuthHandler.#signToken()` did not call `.setAudience()`

## Details

When `providerAuthJwtSecret` is set without a custom plugin path, `DwnServer` auto-creates the JWT plugin with `audience: this.config.baseUrl` (line 122). The `OpenAuthHandler` issues tokens but was not including the `aud` claim. The fix adds `.setAudience(this.#issuer)` to `#signToken()` — the audience and issuer are both the server's base URL.

Discovered during e2e testing of the live Fly.io deployment. Steps 1 (authorize) and 2 (token exchange) succeeded, but step 3 (registration) failed with HTTP 400.

## Testing

All 41 registration tests pass (`bun test tests/registration/`).