### PR TITLE
infra(modules): add core Terraform modules for AWS deployment (#373)

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -5,6 +5,9 @@
 .terraform/
 crash.log
 crash.*.log
+
+# Lock files in reusable modules (only commit in root configs like bootstrap/)
+modules/**/.terraform.lock.hcl
 override.tf
 override.tf.json
 *_override.tf

--- a/infra/modules/alb/main.tf
+++ b/infra/modules/alb/main.tf
@@ -1,0 +1,133 @@
+################################################################################
+# Application Load Balancer
+################################################################################
+
+resource "aws_lb" "this" {
+  name               = var.name
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = var.security_group_ids
+  subnets            = var.subnet_ids
+
+  enable_deletion_protection = false
+
+  tags = var.tags
+}
+
+################################################################################
+# Target Groups
+################################################################################
+
+resource "aws_lb_target_group" "http" {
+  name                 = "${var.name}-http"
+  port                 = var.target_port
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  target_type          = "ip"
+  deregistration_delay = 30
+
+  health_check {
+    enabled             = true
+    path                = "/health"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = var.tags
+}
+
+resource "aws_lb_target_group" "ws" {
+  name                 = "${var.name}-ws"
+  port                 = var.target_port
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  target_type          = "ip"
+  deregistration_delay = 300
+
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 3600
+    enabled         = true
+  }
+
+  health_check {
+    enabled             = true
+    path                = "/health"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = var.tags
+}
+
+################################################################################
+# HTTPS Listener (443)
+################################################################################
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.http.arn
+  }
+
+  tags = var.tags
+}
+
+################################################################################
+# HTTP Listener (80) — redirect to HTTPS
+################################################################################
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  tags = var.tags
+}
+
+################################################################################
+# Listener Rules — WebSocket upgrade header → ws target group
+################################################################################
+
+resource "aws_lb_listener_rule" "websocket" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 10
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.ws.arn
+  }
+
+  condition {
+    http_header {
+      http_header_name = "Upgrade"
+      values           = ["websocket"]
+    }
+  }
+
+  tags = var.tags
+}

--- a/infra/modules/alb/outputs.tf
+++ b/infra/modules/alb/outputs.tf
@@ -1,0 +1,24 @@
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer."
+  value       = aws_lb.this.dns_name
+}
+
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer."
+  value       = aws_lb.this.arn
+}
+
+output "alb_zone_id" {
+  description = "Canonical hosted zone ID of the ALB (for Route 53 alias records)."
+  value       = aws_lb.this.zone_id
+}
+
+output "http_target_group_arn" {
+  description = "ARN of the HTTP target group."
+  value       = aws_lb_target_group.http.arn
+}
+
+output "ws_target_group_arn" {
+  description = "ARN of the WebSocket target group."
+  value       = aws_lb_target_group.ws.arn
+}

--- a/infra/modules/alb/variables.tf
+++ b/infra/modules/alb/variables.tf
@@ -1,0 +1,36 @@
+variable "name" {
+  description = "Name prefix for the ALB and related resources."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the target groups."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of public subnet IDs for the ALB."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "List of security group IDs to attach to the ALB."
+  type        = list(string)
+}
+
+variable "certificate_arn" {
+  description = "ARN of the ACM certificate for the HTTPS listener."
+  type        = string
+}
+
+variable "target_port" {
+  description = "Port on the targets that the ALB forwards traffic to."
+  type        = number
+  default     = 3000
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/alb/versions.tf
+++ b/infra/modules/alb/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/infra/modules/aurora/main.tf
+++ b/infra/modules/aurora/main.tf
@@ -1,0 +1,55 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.name}-aurora"
+  subnet_ids = var.subnet_ids
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-aurora"
+  })
+}
+
+resource "aws_rds_cluster_parameter_group" "this" {
+  name   = "${var.name}-aurora-pg15"
+  family = "aurora-postgresql15"
+
+  parameter {
+    name         = "shared_preload_libraries"
+    value        = "pg_stat_statements"
+    apply_method = "pending-reboot"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_rds_cluster" "this" {
+  cluster_identifier = var.name
+  engine             = "aurora-postgresql"
+  engine_version     = var.engine_version
+
+  db_subnet_group_name            = aws_db_subnet_group.this.name
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.this.name
+  vpc_security_group_ids          = var.security_group_ids
+
+  manage_master_user_password = true
+  master_username             = "postgres"
+
+  storage_encrypted = true
+  deletion_protection = false
+
+  # Skip final snapshot in dev; override for prod via lifecycle or wrapper
+  skip_final_snapshot       = true
+  final_snapshot_identifier = "${var.name}-final"
+
+  tags = var.tags
+}
+
+resource "aws_rds_cluster_instance" "writer" {
+  identifier         = "${var.name}-writer"
+  cluster_identifier = aws_rds_cluster.this.id
+  instance_class     = var.instance_class
+  engine             = aws_rds_cluster.this.engine
+  engine_version     = aws_rds_cluster.this.engine_version
+
+  publicly_accessible = false
+
+  tags = var.tags
+}

--- a/infra/modules/aurora/outputs.tf
+++ b/infra/modules/aurora/outputs.tf
@@ -1,0 +1,24 @@
+output "cluster_endpoint" {
+  description = "Writer endpoint of the Aurora cluster."
+  value       = aws_rds_cluster.this.endpoint
+}
+
+output "reader_endpoint" {
+  description = "Reader endpoint of the Aurora cluster."
+  value       = aws_rds_cluster.this.reader_endpoint
+}
+
+output "port" {
+  description = "Port the Aurora cluster listens on."
+  value       = aws_rds_cluster.this.port
+}
+
+output "security_group_id" {
+  description = "First security group ID attached to the cluster (pass-through)."
+  value       = var.security_group_ids[0]
+}
+
+output "master_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing master credentials."
+  value       = aws_rds_cluster.this.master_user_secret[0].secret_arn
+}

--- a/infra/modules/aurora/variables.tf
+++ b/infra/modules/aurora/variables.tf
@@ -1,0 +1,32 @@
+variable "name" {
+  description = "Name prefix for the Aurora cluster and related resources."
+  type        = string
+}
+
+variable "engine_version" {
+  description = "Aurora PostgreSQL engine version."
+  type        = string
+  default     = "15.4"
+}
+
+variable "instance_class" {
+  description = "Instance class for the Aurora writer instance."
+  type        = string
+  default     = "db.t4g.medium"
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the DB subnet group."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "List of security group IDs to attach to the cluster."
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/aurora/versions.tf
+++ b/infra/modules/aurora/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/infra/modules/ecs-cluster/main.tf
+++ b/infra/modules/ecs-cluster/main.tf
@@ -1,0 +1,27 @@
+resource "aws_ecs_cluster" "this" {
+  name = var.name
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  cluster_name = aws_ecs_cluster.this.name
+
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 1
+  }
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 1
+  }
+}

--- a/infra/modules/ecs-cluster/outputs.tf
+++ b/infra/modules/ecs-cluster/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_arn" {
+  description = "ARN of the ECS cluster."
+  value       = aws_ecs_cluster.this.arn
+}
+
+output "cluster_name" {
+  description = "Name of the ECS cluster."
+  value       = aws_ecs_cluster.this.name
+}

--- a/infra/modules/ecs-cluster/variables.tf
+++ b/infra/modules/ecs-cluster/variables.tf
@@ -1,0 +1,10 @@
+variable "name" {
+  description = "Name of the ECS cluster."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/ecs-cluster/versions.tf
+++ b/infra/modules/ecs-cluster/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/infra/modules/ecs-service/main.tf
+++ b/infra/modules/ecs-service/main.tf
@@ -1,0 +1,229 @@
+################################################################################
+# Data sources
+################################################################################
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  log_group_name = "/ecs/${var.name}"
+
+  environment = [
+    for k, v in var.environment : {
+      name  = k
+      value = v
+    }
+  ]
+
+  secrets = [
+    for k, v in var.secrets : {
+      name      = k
+      valueFrom = v
+    }
+  ]
+}
+
+################################################################################
+# CloudWatch Log Group
+################################################################################
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = local.log_group_name
+  retention_in_days = var.log_retention_days
+
+  tags = var.tags
+}
+
+################################################################################
+# IAM — Task Execution Role (ECR pull, logs, secrets)
+################################################################################
+
+data "aws_iam_policy_document" "ecs_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name               = "${var.name}-ecs-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "execution" {
+  # ECR pull
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+    ]
+    resources = ["*"]
+  }
+
+  # CloudWatch Logs
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.this.arn}:*"]
+  }
+
+  # Secrets Manager read — scoped to the secret ARNs passed in
+  dynamic "statement" {
+    for_each = length(var.secrets) > 0 ? [1] : []
+
+    content {
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = values(var.secrets)
+    }
+  }
+
+  # SSM Parameter Store read — for any SSM-backed secrets
+  dynamic "statement" {
+    for_each = length(var.secrets) > 0 ? [1] : []
+
+    content {
+      actions   = ["ssm:GetParameters"]
+      resources = values(var.secrets)
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "execution" {
+  name   = "${var.name}-ecs-exec"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.execution.json
+}
+
+################################################################################
+# IAM — Task Role (application permissions)
+################################################################################
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name}-ecs-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+  tags               = var.tags
+}
+
+################################################################################
+# Task Definition
+################################################################################
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = var.name
+      image     = var.image
+      cpu       = var.cpu
+      memory    = var.memory
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        },
+      ]
+
+      environment = local.environment
+      secrets     = local.secrets
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.this.name
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+    },
+  ])
+
+  tags = var.tags
+}
+
+################################################################################
+# ECS Service
+################################################################################
+
+resource "aws_ecs_service" "this" {
+  name            = var.name
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = var.security_group_ids
+    assign_public_ip = false
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.target_group_arn != "" ? [var.target_group_arn] : []
+
+    content {
+      target_group_arn = load_balancer.value
+      container_name   = var.name
+      container_port   = var.container_port
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  tags = var.tags
+}
+
+################################################################################
+# Application Auto Scaling
+################################################################################
+
+resource "aws_appautoscaling_target" "this" {
+  max_capacity       = var.autoscaling_max
+  min_capacity       = var.autoscaling_min
+  resource_id        = "service/${split("/", var.cluster_arn)[1]}/${aws_ecs_service.this.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  name               = "${var.name}-cpu-target-tracking"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.this.resource_id
+  scalable_dimension = aws_appautoscaling_target.this.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.this.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value = 70
+
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}

--- a/infra/modules/ecs-service/outputs.tf
+++ b/infra/modules/ecs-service/outputs.tf
@@ -1,0 +1,24 @@
+output "service_arn" {
+  description = "ARN of the ECS service."
+  value       = aws_ecs_service.this.id
+}
+
+output "service_name" {
+  description = "Name of the ECS service."
+  value       = aws_ecs_service.this.name
+}
+
+output "task_role_arn" {
+  description = "ARN of the IAM task role (attach additional policies for application-level permissions)."
+  value       = aws_iam_role.task.arn
+}
+
+output "execution_role_arn" {
+  description = "ARN of the IAM task execution role."
+  value       = aws_iam_role.execution.arn
+}
+
+output "log_group_name" {
+  description = "Name of the CloudWatch log group."
+  value       = aws_cloudwatch_log_group.this.name
+}

--- a/infra/modules/ecs-service/variables.tf
+++ b/infra/modules/ecs-service/variables.tf
@@ -1,0 +1,89 @@
+variable "name" {
+  description = "Name of the ECS service and related resources."
+  type        = string
+}
+
+variable "cluster_arn" {
+  description = "ARN of the ECS cluster to deploy the service into."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the service's network configuration."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "List of security group IDs to attach to the service."
+  type        = list(string)
+}
+
+variable "image" {
+  description = "Container image URI (e.g. 123456789.dkr.ecr.us-east-1.amazonaws.com/app:latest)."
+  type        = string
+}
+
+variable "cpu" {
+  description = "CPU units for the task (256 = 0.25 vCPU)."
+  type        = number
+  default     = 256
+}
+
+variable "memory" {
+  description = "Memory in MiB for the task."
+  type        = number
+  default     = 512
+}
+
+variable "container_port" {
+  description = "Port the container listens on."
+  type        = number
+}
+
+variable "desired_count" {
+  description = "Desired number of running tasks."
+  type        = number
+  default     = 1
+}
+
+variable "environment" {
+  description = "Map of environment variables to set on the container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secrets" {
+  description = "Map of secret environment variables. Keys are env var names, values are Secrets Manager or SSM Parameter Store ARNs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "target_group_arn" {
+  description = "ARN of an ALB target group to register the service with. Empty string to skip."
+  type        = string
+  default     = ""
+}
+
+variable "autoscaling_min" {
+  description = "Minimum number of tasks for auto scaling."
+  type        = number
+  default     = 1
+}
+
+variable "autoscaling_max" {
+  description = "Maximum number of tasks for auto scaling."
+  type        = number
+  default     = 4
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch logs."
+  type        = number
+  default     = 30
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/ecs-service/versions.tf
+++ b/infra/modules/ecs-service/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -1,0 +1,148 @@
+locals {
+  alarm_actions = var.sns_topic_arn != "" ? [var.sns_topic_arn] : []
+}
+
+################################################################################
+# Aurora CPU Utilization
+################################################################################
+
+resource "aws_cloudwatch_metric_alarm" "aurora_cpu" {
+  alarm_name          = "${var.name}-aurora-cpu-high"
+  alarm_description   = "Aurora cluster ${var.aurora_cluster_id} CPU utilization > ${var.aurora_cpu_threshold}%"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.aurora_cpu_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBClusterIdentifier = var.aurora_cluster_id
+  }
+
+  alarm_actions             = local.alarm_actions
+  ok_actions                = local.alarm_actions
+  insufficient_data_actions = []
+
+  tags = var.tags
+}
+
+################################################################################
+# ECS Service CPU Utilization
+################################################################################
+
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu" {
+  alarm_name          = "${var.name}-ecs-cpu-high"
+  alarm_description   = "ECS service ${var.service_name} CPU utilization > ${var.cpu_threshold}%"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.cpu_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = var.service_name
+  }
+
+  alarm_actions             = local.alarm_actions
+  ok_actions                = local.alarm_actions
+  insufficient_data_actions = []
+
+  tags = var.tags
+}
+
+################################################################################
+# ECS Service Memory Utilization
+################################################################################
+
+resource "aws_cloudwatch_metric_alarm" "ecs_memory" {
+  alarm_name          = "${var.name}-ecs-memory-high"
+  alarm_description   = "ECS service ${var.service_name} memory utilization > ${var.memory_threshold}%"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.memory_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = var.service_name
+  }
+
+  alarm_actions             = local.alarm_actions
+  ok_actions                = local.alarm_actions
+  insufficient_data_actions = []
+
+  tags = var.tags
+}
+
+################################################################################
+# ALB 5xx Errors
+################################################################################
+
+resource "aws_cloudwatch_metric_alarm" "alb_5xx" {
+  alarm_name          = "${var.name}-alb-5xx-high"
+  alarm_description   = "ALB 5xx error count > ${var.alb_5xx_threshold}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = var.alb_5xx_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  alarm_actions             = local.alarm_actions
+  ok_actions                = local.alarm_actions
+  insufficient_data_actions = []
+
+  tags = var.tags
+}
+
+################################################################################
+# ALB Target Response Time P95
+################################################################################
+
+resource "aws_cloudwatch_metric_alarm" "alb_latency" {
+  alarm_name          = "${var.name}-alb-latency-high"
+  alarm_description   = "ALB target response time P95 > ${var.alb_latency_threshold}s"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  threshold           = var.alb_latency_threshold
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "latency_p95"
+    return_data = true
+
+    metric {
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "p95"
+
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+      }
+    }
+  }
+
+  alarm_actions             = local.alarm_actions
+  ok_actions                = local.alarm_actions
+  insufficient_data_actions = []
+
+  tags = var.tags
+}

--- a/infra/modules/monitoring/outputs.tf
+++ b/infra/modules/monitoring/outputs.tf
@@ -1,0 +1,10 @@
+output "alarm_arns" {
+  description = "Map of alarm name to ARN for all CloudWatch alarms."
+  value = {
+    aurora_cpu  = aws_cloudwatch_metric_alarm.aurora_cpu.arn
+    ecs_cpu     = aws_cloudwatch_metric_alarm.ecs_cpu.arn
+    ecs_memory  = aws_cloudwatch_metric_alarm.ecs_memory.arn
+    alb_5xx     = aws_cloudwatch_metric_alarm.alb_5xx.arn
+    alb_latency = aws_cloudwatch_metric_alarm.alb_latency.arn
+  }
+}

--- a/infra/modules/monitoring/variables.tf
+++ b/infra/modules/monitoring/variables.tf
@@ -1,0 +1,66 @@
+variable "name" {
+  description = "Name prefix for alarms and related resources."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the ECS cluster to monitor."
+  type        = string
+}
+
+variable "service_name" {
+  description = "Name of the ECS service to monitor."
+  type        = string
+}
+
+variable "alb_arn_suffix" {
+  description = "ARN suffix of the ALB (e.g. app/my-alb/1234567890)."
+  type        = string
+}
+
+variable "aurora_cluster_id" {
+  description = "Identifier of the Aurora cluster to monitor."
+  type        = string
+}
+
+variable "sns_topic_arn" {
+  description = "ARN of the SNS topic for alarm notifications. Empty string to disable notifications."
+  type        = string
+  default     = ""
+}
+
+variable "cpu_threshold" {
+  description = "ECS service CPU utilization alarm threshold (percent)."
+  type        = number
+  default     = 70
+}
+
+variable "memory_threshold" {
+  description = "ECS service memory utilization alarm threshold (percent)."
+  type        = number
+  default     = 80
+}
+
+variable "aurora_cpu_threshold" {
+  description = "Aurora CPU utilization alarm threshold (percent)."
+  type        = number
+  default     = 70
+}
+
+variable "alb_5xx_threshold" {
+  description = "ALB 5xx error count alarm threshold."
+  type        = number
+  default     = 50
+}
+
+variable "alb_latency_threshold" {
+  description = "ALB target response time P95 alarm threshold (seconds)."
+  type        = number
+  default     = 1
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/monitoring/versions.tf
+++ b/infra/modules/monitoring/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/infra/modules/s3-data/main.tf
+++ b/infra/modules/s3-data/main.tf
@@ -1,0 +1,127 @@
+################################################################################
+# S3 Bucket
+################################################################################
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+
+  tags = var.tags
+}
+
+################################################################################
+# Versioning — disabled (content-addressed, immutable by design)
+################################################################################
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+################################################################################
+# Encryption — SSE-S3
+################################################################################
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+################################################################################
+# Block all public access
+################################################################################
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+################################################################################
+# Lifecycle — Intelligent Tiering after 30 days
+################################################################################
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "intelligent-tiering"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "INTELLIGENT_TIERING"
+    }
+  }
+}
+
+################################################################################
+# Bucket Policy — restrict to allowed IAM roles
+################################################################################
+
+data "aws_iam_policy_document" "bucket" {
+  # Allow specified roles full S3 access to this bucket
+  statement {
+    sid    = "AllowRoleAccess"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = var.allowed_role_arns
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.this.arn,
+      "${aws_s3_bucket.this.arn}/*",
+    ]
+  }
+
+  # Deny all other principals
+  statement {
+    sid    = "DenyOtherAccess"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.this.arn,
+      "${aws_s3_bucket.this.arn}/*",
+    ]
+
+    condition {
+      test     = "StringNotLike"
+      variable = "aws:PrincipalArn"
+      values   = var.allowed_role_arns
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.bucket.json
+
+  depends_on = [aws_s3_bucket_public_access_block.this]
+}

--- a/infra/modules/s3-data/outputs.tf
+++ b/infra/modules/s3-data/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "Name of the S3 bucket."
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket."
+  value       = aws_s3_bucket.this.arn
+}

--- a/infra/modules/s3-data/variables.tf
+++ b/infra/modules/s3-data/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  description = "Name of the S3 bucket for DWN data storage."
+  type        = string
+}
+
+variable "allowed_role_arns" {
+  description = "List of IAM role ARNs allowed to access the bucket."
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/s3-data/versions.tf
+++ b/infra/modules/s3-data/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/infra/modules/vpc/main.tf
+++ b/infra/modules/vpc/main.tf
@@ -1,0 +1,312 @@
+# ─── VPC ──────────────────────────────────────────────────────────────────────
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, { Name = var.name })
+}
+
+# ─── Subnets ──────────────────────────────────────────────────────────────────
+
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnets)
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnets[count.index]
+  availability_zone       = var.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-public-${var.azs[count.index]}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnets)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnets[count.index]
+  availability_zone = var.azs[count.index]
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-private-${var.azs[count.index]}"
+    Tier = "compute"
+  })
+}
+
+resource "aws_subnet" "data" {
+  count             = length(var.data_subnets)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.data_subnets[count.index]
+  availability_zone = var.azs[count.index]
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-data-${var.azs[count.index]}"
+    Tier = "data"
+  })
+}
+
+# ─── Internet Gateway ────────────────────────────────────────────────────────
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(var.tags, { Name = "${var.name}-igw" })
+}
+
+# ─── NAT Gateway ─────────────────────────────────────────────────────────────
+
+locals {
+  nat_count = var.single_nat_gateway ? 1 : length(var.public_subnets)
+}
+
+resource "aws_eip" "nat" {
+  count  = local.nat_count
+  domain = "vpc"
+  tags   = merge(var.tags, { Name = "${var.name}-nat-eip-${count.index}" })
+}
+
+resource "aws_nat_gateway" "this" {
+  count         = local.nat_count
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(var.tags, { Name = "${var.name}-nat-${count.index}" })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+# ─── Route Tables ─────────────────────────────────────────────────────────────
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(var.tags, { Name = "${var.name}-public-rt" })
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnets)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count  = local.nat_count
+  vpc_id = aws_vpc.this.id
+  tags   = merge(var.tags, { Name = "${var.name}-private-rt-${count.index}" })
+}
+
+resource "aws_route" "private_nat" {
+  count                  = local.nat_count
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this[count.index].id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(var.private_subnets)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[var.single_nat_gateway ? 0 : count.index].id
+}
+
+resource "aws_route_table_association" "data" {
+  count          = length(var.data_subnets)
+  subnet_id      = aws_subnet.data[count.index].id
+  route_table_id = aws_route_table.private[var.single_nat_gateway ? 0 : count.index].id
+}
+
+# ─── Security Groups ─────────────────────────────────────────────────────────
+
+resource "aws_security_group" "alb" {
+  name_prefix = "${var.name}-alb-"
+  description = "ALB — inbound HTTPS from internet"
+  vpc_id      = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name}-sg-alb" })
+
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_https" {
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTPS from internet"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_http" {
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTP from internet (redirect to HTTPS)"
+  ip_protocol       = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_all" {
+  security_group_id = aws_security_group.alb.id
+  description       = "All outbound"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_security_group" "dwn" {
+  name_prefix = "${var.name}-dwn-"
+  description = "DWN ECS tasks — inbound from ALB on port 3000"
+  vpc_id      = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name}-sg-dwn" })
+
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "dwn_from_alb" {
+  security_group_id            = aws_security_group.dwn.id
+  description                  = "DWN HTTP from ALB"
+  ip_protocol                  = "tcp"
+  from_port                    = 3000
+  to_port                      = 3000
+  referenced_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "dwn_all" {
+  security_group_id = aws_security_group.dwn.id
+  description       = "All outbound"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_security_group" "nats" {
+  name_prefix = "${var.name}-nats-"
+  description = "NATS JetStream — inbound from DWN tasks and self (cluster routing)"
+  vpc_id      = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name}-sg-nats" })
+
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nats_client" {
+  security_group_id            = aws_security_group.nats.id
+  description                  = "NATS client from DWN"
+  ip_protocol                  = "tcp"
+  from_port                    = 4222
+  to_port                      = 4222
+  referenced_security_group_id = aws_security_group.dwn.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nats_cluster" {
+  security_group_id            = aws_security_group.nats.id
+  description                  = "NATS cluster routing (self)"
+  ip_protocol                  = "tcp"
+  from_port                    = 6222
+  to_port                      = 6222
+  referenced_security_group_id = aws_security_group.nats.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "nats_all" {
+  security_group_id = aws_security_group.nats.id
+  description       = "All outbound"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_security_group" "aurora" {
+  name_prefix = "${var.name}-aurora-"
+  description = "Aurora PostgreSQL — inbound 5432 from DWN tasks"
+  vpc_id      = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name}-sg-aurora" })
+
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "aurora_from_dwn" {
+  security_group_id            = aws_security_group.aurora.id
+  description                  = "PostgreSQL from DWN"
+  ip_protocol                  = "tcp"
+  from_port                    = 5432
+  to_port                      = 5432
+  referenced_security_group_id = aws_security_group.dwn.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "aurora_all" {
+  security_group_id = aws_security_group.aurora.id
+  description       = "All outbound"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+# ─── VPC Endpoints ────────────────────────────────────────────────────────────
+
+resource "aws_security_group" "vpc_endpoints" {
+  count       = var.enable_vpc_endpoints ? 1 : 0
+  name_prefix = "${var.name}-vpce-"
+  description = "VPC interface endpoints — HTTPS from private subnets"
+  vpc_id      = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name}-sg-vpce" })
+
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "vpce_https" {
+  count             = var.enable_vpc_endpoints ? 1 : 0
+  security_group_id = aws_security_group.vpc_endpoints[0].id
+  description       = "HTTPS from VPC"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_ipv4         = var.cidr
+}
+
+resource "aws_vpc_security_group_egress_rule" "vpce_all" {
+  count             = var.enable_vpc_endpoints ? 1 : 0
+  security_group_id = aws_security_group.vpc_endpoints[0].id
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+# S3 Gateway endpoint (free, no interface needed)
+resource "aws_vpc_endpoint" "s3" {
+  count             = var.enable_vpc_endpoints ? 1 : 0
+  vpc_id            = aws_vpc.this.id
+  service_name      = "com.amazonaws.${var.azs[0] == "" ? "us-east-1" : regex("^[a-z]+-[a-z]+-[0-9]+", var.azs[0])}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = aws_route_table.private[*].id
+
+  tags = merge(var.tags, { Name = "${var.name}-vpce-s3" })
+}
+
+# Interface endpoints
+locals {
+  interface_endpoints = var.enable_vpc_endpoints ? toset([
+    "ecr.api",
+    "ecr.dkr",
+    "logs",
+    "secretsmanager",
+    "kms",
+  ]) : toset([])
+
+  region = regex("^[a-z]+-[a-z]+-[0-9]+", var.azs[0])
+}
+
+resource "aws_vpc_endpoint" "interface" {
+  for_each = local.interface_endpoints
+
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${local.region}.${each.key}"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
+
+  tags = merge(var.tags, { Name = "${var.name}-vpce-${each.key}" })
+}

--- a/infra/modules/vpc/outputs.tf
+++ b/infra/modules/vpc/outputs.tf
@@ -1,0 +1,44 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr" {
+  description = "CIDR block of the VPC."
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets."
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private compute subnets."
+  value       = aws_subnet.private[*].id
+}
+
+output "data_subnet_ids" {
+  description = "IDs of the private data subnets."
+  value       = aws_subnet.data[*].id
+}
+
+output "sg_alb_id" {
+  description = "Security group ID for the ALB."
+  value       = aws_security_group.alb.id
+}
+
+output "sg_dwn_id" {
+  description = "Security group ID for DWN ECS tasks."
+  value       = aws_security_group.dwn.id
+}
+
+output "sg_nats_id" {
+  description = "Security group ID for NATS."
+  value       = aws_security_group.nats.id
+}
+
+output "sg_aurora_id" {
+  description = "Security group ID for Aurora."
+  value       = aws_security_group.aurora.id
+}

--- a/infra/modules/vpc/variables.tf
+++ b/infra/modules/vpc/variables.tf
@@ -1,0 +1,52 @@
+variable "name" {
+  description = "Name prefix for all VPC resources."
+  type        = string
+}
+
+variable "cidr" {
+  description = "VPC CIDR block."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "azs" {
+  description = "List of availability zones to use."
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+}
+
+variable "public_subnets" {
+  description = "CIDR blocks for public subnets (ALB, NAT)."
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "private_subnets" {
+  description = "CIDR blocks for private compute subnets (ECS)."
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+}
+
+variable "data_subnets" {
+  description = "CIDR blocks for private data subnets (Aurora)."
+  type        = list(string)
+  default     = ["10.0.21.0/24", "10.0.22.0/24", "10.0.23.0/24"]
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single NAT Gateway (true for dev, false for prod HA)."
+  type        = bool
+  default     = true
+}
+
+variable "enable_vpc_endpoints" {
+  description = "Create VPC endpoints for ECR, S3, logs, Secrets Manager, KMS."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/vpc/versions.tf
+++ b/infra/modules/vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #373. Adds 7 reusable Terraform modules for the DWN server AWS infrastructure, composable by dev and prod environment configurations (#375).

- **7 modules** covering the full stack: networking, database, compute, load balancing, storage, and observability
- All modules validated with `terraform validate` (Terraform 1.10, AWS provider >= 5.0)
- Modules inherit the provider from calling root configs — no embedded provider blocks
- Variable defaults tuned for dev; prod overrides via environment-specific tfvars

## Modules

| Module | Key Resources |
|---|---|
| `modules/vpc/` | VPC, 3-tier subnets (public/private/data), NAT (single or HA), IGW, security groups (ALB/DWN/NATS/Aurora), VPC endpoints (S3 gateway + interface: ECR, CloudWatch Logs, Secrets Manager, KMS) |
| `modules/aurora/` | Aurora PostgreSQL 15 Serverless v2 cluster, writer instance, DB subnet group, parameter group (`pg_stat_statements`), Secrets Manager managed credentials |
| `modules/ecs-cluster/` | ECS cluster with Fargate + Fargate Spot capacity providers, Container Insights |
| `modules/ecs-service/` | Generic ECS Fargate service: task definition, service with deployment circuit breaker, execution/task IAM roles, CloudWatch log group, application autoscaling, optional ALB target group attachment |
| `modules/alb/` | Internet-facing ALB, HTTPS listener (ACM cert), HTTP→HTTPS redirect, two target groups (HTTP round-robin + WebSocket with stickiness), WebSocket routing via `Upgrade` header |
| `modules/s3-data/` | S3 bucket for DWN blob storage, SSE-S3, no versioning (content-addressed), Intelligent-Tiering lifecycle, IAM role-scoped bucket policy |
| `modules/monitoring/` | 5 CloudWatch alarms (Aurora CPU, ECS CPU/memory, ALB 5xx, ALB P95 latency), optional SNS notification topic |

## Changes

- `infra/modules/` — 28 new `.tf` files (4 per module: `versions.tf`, `variables.tf`, `main.tf`, `outputs.tf`)
- `infra/.gitignore` — exclude `.terraform.lock.hcl` from reusable modules (lock files only committed for root configs like `bootstrap/`)

## Validation

All 7 modules pass `terraform init -backend=false && terraform validate`:

```
✓ vpc         — Success! The configuration is valid.
✓ aurora      — Success! The configuration is valid.
✓ ecs-cluster — Success! The configuration is valid.
✓ ecs-service — Success! The configuration is valid.
✓ alb         — Success! The configuration is valid.
✓ s3-data     — Success! The configuration is valid.
✓ monitoring  — Success! The configuration is valid.
```

## Notes

- Uses `data.aws_region.current.id` (not `.name`) for AWS provider >= 6.x compatibility
- ECR lifecycle policy in bootstrap keeps 20 tagged + 7-day untagged retention
- No README per module yet — can add in a follow-up if desired