### PR TITLE
infra(modules): add NATS JetStream module — Fargate + EFS + CloudMap (#374)

### DIFF
--- a/infra/modules/nats/main.tf
+++ b/infra/modules/nats/main.tf
@@ -1,0 +1,328 @@
+################################################################################
+# Data sources & locals
+################################################################################
+
+data "aws_region" "current" {}
+
+locals {
+  # Per-node NATS server command arguments.
+  # Single-node: JetStream only. Multi-node: adds cluster routing.
+  nats_commands = { for i in range(var.replica_count) : i => concat(
+    [
+      "-n", "nats-${i}",
+      "-js",
+      "-sd", "/data",
+      "-ms", var.jetstream_max_mem,
+      "-fs", var.jetstream_max_file,
+      "-p", "4222",
+      "-m", "8222",
+    ],
+    var.replica_count > 1 ? [
+      "--cluster_name", "${var.name}-nats",
+      "--cluster", "nats://0.0.0.0:6222",
+      "--routes", join(",", [
+        for j in range(var.replica_count) :
+        "nats-route://nats-${j}.${var.cloudmap_namespace_name}:6222"
+      ]),
+    ] : [],
+  ) }
+}
+
+################################################################################
+# CloudMap — private DNS namespace + per-node service entries
+################################################################################
+
+resource "aws_service_discovery_private_dns_namespace" "this" {
+  name = var.cloudmap_namespace_name
+  vpc  = var.vpc_id
+
+  tags = var.tags
+}
+
+resource "aws_service_discovery_service" "nats" {
+  count = var.replica_count
+
+  name = "nats-${count.index}"
+
+  dns_config {
+    namespace_id   = aws_service_discovery_private_dns_namespace.this.id
+    routing_policy = "MULTIVALUE"
+
+    dns_records {
+      type = "A"
+      ttl  = 10
+    }
+  }
+
+  health_check_custom_config {}
+
+  tags = var.tags
+}
+
+################################################################################
+# EFS — encrypted filesystem with per-node access points
+################################################################################
+
+resource "aws_efs_file_system" "nats" {
+  encrypted        = true
+  throughput_mode   = var.efs_throughput_mode
+  performance_mode = "generalPurpose"
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nats-data"
+  })
+}
+
+resource "aws_security_group" "efs" {
+  name_prefix = "${var.name}-nats-efs-"
+  description = "Allow NFS from NATS tasks"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "NFS from NATS"
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [var.nats_security_group_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nats-efs"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_efs_mount_target" "nats" {
+  count = length(var.subnet_ids)
+
+  file_system_id  = aws_efs_file_system.nats.id
+  subnet_id       = var.subnet_ids[count.index]
+  security_groups = [aws_security_group.efs.id]
+}
+
+# Each NATS node gets an isolated root directory on the shared filesystem.
+# UID/GID 1000 matches the `nats` user in the nats:alpine image.
+resource "aws_efs_access_point" "nats" {
+  count = var.replica_count
+
+  file_system_id = aws_efs_file_system.nats.id
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+
+  root_directory {
+    path = "/nats-${count.index}"
+
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "0755"
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nats-${count.index}"
+  })
+}
+
+################################################################################
+# IAM — Execution role (image pull, logs) + Task role (EFS access)
+################################################################################
+
+data "aws_iam_policy_document" "ecs_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name               = "${var.name}-nats-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "execution" {
+  # Pull public images (NATS from Docker Hub still needs ECR auth token)
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = ["*"]
+  }
+
+  # CloudWatch Logs
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.nats.arn}:*"]
+  }
+}
+
+resource "aws_iam_role_policy" "execution" {
+  name   = "${var.name}-nats-exec"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.execution.json
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name}-nats-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "task_efs" {
+  statement {
+    actions = [
+      "elasticfilesystem:ClientMount",
+      "elasticfilesystem:ClientWrite",
+    ]
+    resources = [aws_efs_file_system.nats.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "task_efs" {
+  name   = "efs-access"
+  role   = aws_iam_role.task.id
+  policy = data.aws_iam_policy_document.task_efs.json
+}
+
+################################################################################
+# CloudWatch Log Group
+################################################################################
+
+resource "aws_cloudwatch_log_group" "nats" {
+  name              = "/ecs/${var.name}-nats"
+  retention_in_days = var.log_retention_days
+
+  tags = var.tags
+}
+
+################################################################################
+# ECS — per-node task definitions and services
+################################################################################
+
+resource "aws_ecs_task_definition" "nats" {
+  count = var.replica_count
+
+  family                   = "${var.name}-nats-${count.index}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "nats"
+      image     = var.nats_image
+      essential = true
+      command   = local.nats_commands[count.index]
+
+      portMappings = concat(
+        [
+          { containerPort = 4222, protocol = "tcp" }, # client
+          { containerPort = 8222, protocol = "tcp" }, # monitoring
+        ],
+        var.replica_count > 1 ? [
+          { containerPort = 6222, protocol = "tcp" }, # cluster routing
+        ] : [],
+      )
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz || exit 1"]
+        interval    = 15
+        timeout     = 5
+        retries     = 3
+        startPeriod = 15
+      }
+
+      mountPoints = [
+        {
+          sourceVolume  = "nats-data"
+          containerPath = "/data"
+          readOnly      = false
+        },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.nats.name
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "nats-${count.index}"
+        }
+      }
+    },
+  ])
+
+  volume {
+    name = "nats-data"
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.nats.id
+      transit_encryption      = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.nats[count.index].id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_service" "nats" {
+  count = var.replica_count
+
+  name            = "${var.name}-nats-${count.index}"
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.nats[count.index].arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [var.nats_security_group_id]
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.nats[count.index].arn
+  }
+
+  # Stateful single-task service: stop old task before starting new one
+  # to avoid two tasks writing to the same EFS access point.
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  # Ensure EFS mount targets are ready before starting tasks
+  depends_on = [aws_efs_mount_target.nats]
+
+  tags = var.tags
+}

--- a/infra/modules/nats/outputs.tf
+++ b/infra/modules/nats/outputs.tf
@@ -1,0 +1,39 @@
+output "nats_url" {
+  description = "NATS client connection URL(s) for DWN services."
+  value       = join(",", [for i in range(var.replica_count) : "nats://nats-${i}.${var.cloudmap_namespace_name}:4222"])
+}
+
+output "efs_filesystem_id" {
+  description = "EFS filesystem ID used for JetStream persistent storage."
+  value       = aws_efs_file_system.nats.id
+}
+
+output "efs_filesystem_arn" {
+  description = "EFS filesystem ARN."
+  value       = aws_efs_file_system.nats.arn
+}
+
+output "service_arns" {
+  description = "ARNs of the NATS ECS services."
+  value       = aws_ecs_service.nats[*].id
+}
+
+output "task_definition_arns" {
+  description = "ARNs of the NATS ECS task definitions."
+  value       = aws_ecs_task_definition.nats[*].arn
+}
+
+output "cloudmap_namespace_id" {
+  description = "CloudMap private DNS namespace ID (for reuse by other modules)."
+  value       = aws_service_discovery_private_dns_namespace.this.id
+}
+
+output "cloudmap_service_arns" {
+  description = "ARNs of the per-node CloudMap service discovery entries."
+  value       = aws_service_discovery_service.nats[*].arn
+}
+
+output "efs_security_group_id" {
+  description = "Security group ID for the EFS filesystem (NFS access)."
+  value       = aws_security_group.efs.id
+}

--- a/infra/modules/nats/variables.tf
+++ b/infra/modules/nats/variables.tf
@@ -1,0 +1,94 @@
+variable "name" {
+  description = "Name prefix for all NATS resources."
+  type        = string
+}
+
+variable "cluster_arn" {
+  description = "ARN of the ECS cluster to deploy NATS into."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for CloudMap namespace and EFS security group."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for ECS tasks and EFS mount targets."
+  type        = list(string)
+}
+
+variable "nats_security_group_id" {
+  description = "Security group ID for NATS tasks (inbound 4222, 6222)."
+  type        = string
+}
+
+variable "nats_image" {
+  description = "NATS container image."
+  type        = string
+  default     = "nats:2.10-alpine"
+}
+
+variable "cpu" {
+  description = "CPU units for each NATS task (256 = 0.25 vCPU)."
+  type        = number
+  default     = 512
+}
+
+variable "memory" {
+  description = "Memory in MiB for each NATS task."
+  type        = number
+  default     = 1024
+}
+
+variable "replica_count" {
+  description = "Number of NATS nodes (1 for dev, 3 for prod)."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.replica_count >= 1 && var.replica_count <= 5
+    error_message = "replica_count must be between 1 and 5."
+  }
+}
+
+variable "jetstream_max_mem" {
+  description = "JetStream max in-memory storage per node (e.g. 256MB)."
+  type        = string
+  default     = "256MB"
+}
+
+variable "jetstream_max_file" {
+  description = "JetStream max file storage per node (e.g. 10GB)."
+  type        = string
+  default     = "10GB"
+}
+
+variable "efs_throughput_mode" {
+  description = "EFS throughput mode: bursting or elastic."
+  type        = string
+  default     = "bursting"
+
+  validation {
+    condition     = contains(["bursting", "elastic"], var.efs_throughput_mode)
+    error_message = "efs_throughput_mode must be 'bursting' or 'elastic'."
+  }
+}
+
+variable "cloudmap_namespace_name" {
+  description = "Private DNS namespace name for NATS service discovery."
+  type        = string
+  default     = "nats.local"
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch logs."
+  type        = number
+  default     = 14
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/nats/versions.tf
+++ b/infra/modules/nats/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #374. Adds a reusable Terraform module (`modules/nats/`) that deploys a NATS JetStream cluster on ECS Fargate with EFS-backed persistent storage and CloudMap service discovery.

## Architecture

```
ECS Service per node (nats-0, nats-1, ..., nats-N)
  │
  ├── nats-0 → EFS access point /nats-0 → JetStream file storage
  ├── nats-1 → EFS access point /nats-1 → JetStream file storage
  └── nats-2 → EFS access point /nats-2 → JetStream file storage
  │
  └── CloudMap DNS: nats-{i}.nats.local → A record per task
```

## Key Design Decisions

| Decision | Rationale |
|---|---|
| **Separate ECS service per node** | Each node gets a unique CloudMap DNS name and EFS access point, enabling deterministic cluster routing and data isolation |
| **EFS over EBS** | Fargate doesn't support EBS; EFS adds ~1-2ms latency, acceptable for event log use case |
| **CloudMap DNS** | NATS cluster routes use `nats-route://nats-{i}.nats.local:6222` — CloudMap auto-registers task IPs |
| **Per-node EFS access points** | Isolated root directories (`/nats-0`, `/nats-1`, `/nats-2`) prevent data conflicts between nodes |
| **`min_healthy=0, max=100`** | Stateful single-task services: stop old task before starting new one to prevent concurrent EFS writes |
| **Single-node mode** | `replica_count=1` omits cluster config entirely — just standalone JetStream |

## Resources Created

- **CloudMap**: Private DNS namespace + per-node service entries
- **EFS**: Encrypted filesystem, mount targets per subnet, access points per node (UID/GID 1000 = `nats` user)
- **Security Group**: NFS (2049) from NATS SG to EFS
- **IAM**: Execution role (logs), task role (EFS mount/write)
- **CloudWatch**: Log group with configurable retention
- **ECS**: Per-node task definitions (NATS 2.10 Alpine, JetStream, health check via `/healthz`) and services

## Variables

| Variable | Default | Description |
|---|---|---|
| `replica_count` | `1` | 1 for dev, 3 for prod |
| `cpu` / `memory` | `512` / `1024` | 0.5 vCPU / 1 GB (dev) |
| `jetstream_max_mem` | `256MB` | In-memory storage limit per node |
| `jetstream_max_file` | `10GB` | File storage limit per node |
| `efs_throughput_mode` | `bursting` | `elastic` for prod |
| `cloudmap_namespace_name` | `nats.local` | Private DNS namespace |

## Outputs

- `nats_url` — Client connection string: `nats://nats-0.nats.local:4222[,nats-1...]`
- `efs_filesystem_id` / `efs_filesystem_arn`
- `service_arns`, `task_definition_arns`
- `cloudmap_namespace_id` — For reuse by other modules
- `efs_security_group_id`

## Validation

```
✓ nats — Success! The configuration is valid.
```

Validated with Terraform 1.10, AWS provider v6.33.0. No warnings.