### PR TITLE
fix(dwn-server): fix GROUP BY error in admin getGlobalStats

### DIFF
--- a/packages/dwn-server/src/admin/admin-store.ts
+++ b/packages/dwn-server/src/admin/admin-store.ts
@@ -216,18 +216,18 @@ export class AdminStore {
         .executeTakeFirstOrThrow(),
       this.db
         .selectFrom('messageStoreMessages')
-        .select(this.db.fn.countAll<number>().as('count'))
+        .select(
+          this.db.fn.count<number>('protocol').distinct().as('count')
+        )
         .where('protocol', 'is not', null)
-        .select('protocol')
-        .distinct()
-        .execute(),
+        .executeTakeFirstOrThrow(),
     ]);
 
     this.cachedGlobalStats = {
       tenantCount,
       totalMessages  : Number(messageStats.count),
       totalDataBytes : Number(dataStats.totalBytes) || 0,
-      totalProtocols : protocolStats.length,
+      totalProtocols : Number(protocolStats.count),
     };
     this.cachedGlobalStatsTimestamp = now;
 


### PR DESCRIPTION
## Summary

- Fix SQL error on the admin dashboard overview page (`/admin/api/stats` returning 500)

## Details

The `getGlobalStats()` protocol count query used `COUNT(*)` with `.select('protocol').distinct()`, generating:

```sql
SELECT COUNT(*), DISTINCT "protocol" FROM "messageStoreMessages" WHERE "protocol" IS NOT NULL
```

PostgreSQL rejects this because `protocol` is not in a GROUP BY clause when used alongside an aggregate. The fix uses `COUNT(DISTINCT protocol)` which generates correct SQL:

```sql
SELECT COUNT(DISTINCT "protocol") AS "count" FROM "messageStoreMessages" WHERE "protocol" IS NOT NULL
```

This also changes the result from an array (`.execute()` → `.length`) to a single row (`.executeTakeFirstOrThrow()` → `.count`), which is more efficient.

## Testing

All 191 admin tests pass. The bug only manifests on PostgreSQL (SQLite is more permissive with GROUP BY).