### PR TITLE
infra(environments): add dev and prod Terraform root configurations (#375)

### DIFF
--- a/infra/environments/dev/backend.tf
+++ b/infra/environments/dev/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "enbox-terraform-state"
+    key            = "env/dev/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "enbox-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -1,0 +1,283 @@
+################################################################################
+# Locals
+################################################################################
+
+locals {
+  name        = "dwn-dev"
+  environment = "dev"
+
+  s3_bucket_name = "${local.name}-data-${var.aws_region}"
+
+  tags = {
+    Project     = "dwn"
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+################################################################################
+# Secrets Manager — populated post-apply (see outputs for instructions)
+################################################################################
+
+resource "aws_secretsmanager_secret" "database_url" {
+  name = "dwn/${local.environment}/database-url"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "database_url" {
+  secret_id     = aws_secretsmanager_secret.database_url.id
+  secret_string = "postgres://postgres:CHANGE_ME@${module.aurora.cluster_endpoint}:${module.aurora.port}/dwn"
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+resource "aws_secretsmanager_secret" "admin_token" {
+  name = "dwn/${local.environment}/admin-token"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "admin_token" {
+  secret_id     = aws_secretsmanager_secret.admin_token.id
+  secret_string = "CHANGE_ME"
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+################################################################################
+# VPC — 2 AZs, single NAT gateway
+################################################################################
+
+module "vpc" {
+  source = "../../modules/vpc"
+
+  name               = local.name
+  azs                = ["${var.aws_region}a", "${var.aws_region}b"]
+  public_subnets     = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnets    = ["10.0.11.0/24", "10.0.12.0/24"]
+  data_subnets       = ["10.0.21.0/24", "10.0.22.0/24"]
+  single_nat_gateway = true
+
+  tags = local.tags
+}
+
+################################################################################
+# Aurora PostgreSQL 15 — single writer, db.t4g.medium
+################################################################################
+
+module "aurora" {
+  source = "../../modules/aurora"
+
+  name               = local.name
+  subnet_ids         = module.vpc.data_subnet_ids
+  security_group_ids = [module.vpc.sg_aurora_id]
+  instance_class     = "db.t4g.medium"
+
+  tags = local.tags
+}
+
+################################################################################
+# ECS Cluster — Fargate + Fargate Spot
+################################################################################
+
+module "ecs_cluster" {
+  source = "../../modules/ecs-cluster"
+
+  name = local.name
+  tags = local.tags
+}
+
+################################################################################
+# ALB — internet-facing, HTTPS with WebSocket routing
+################################################################################
+
+module "alb" {
+  source = "../../modules/alb"
+
+  name               = local.name
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.public_subnet_ids
+  security_group_ids = [module.vpc.sg_alb_id]
+  certificate_arn    = var.certificate_arn
+
+  tags = local.tags
+}
+
+################################################################################
+# S3 — DWN data storage with intelligent tiering
+################################################################################
+
+module "s3_data" {
+  source = "../../modules/s3-data"
+
+  name              = local.s3_bucket_name
+  allowed_role_arns = [module.dwn_http.task_role_arn, module.dwn_ws.task_role_arn]
+
+  tags = local.tags
+}
+
+################################################################################
+# NATS JetStream — single node for dev
+################################################################################
+
+module "nats" {
+  source = "../../modules/nats"
+
+  name                   = local.name
+  cluster_arn            = module.ecs_cluster.cluster_arn
+  vpc_id                 = module.vpc.vpc_id
+  subnet_ids             = module.vpc.private_subnet_ids
+  nats_security_group_id = module.vpc.sg_nats_id
+  cpu                    = 256
+  memory                 = 512
+  replica_count          = 1
+  log_retention_days     = 7
+
+  tags = local.tags
+}
+
+################################################################################
+# ECS Service — DWN HTTP (API + Records)
+################################################################################
+
+module "dwn_http" {
+  source = "../../modules/ecs-service"
+
+  name               = "${local.name}-http"
+  cluster_arn        = module.ecs_cluster.cluster_arn
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [module.vpc.sg_dwn_id]
+  image              = var.dwn_image
+  container_port     = 3000
+  cpu                = 512
+  memory             = 1024
+  desired_count      = 1
+  target_group_arn   = module.alb.http_target_group_arn
+  autoscaling_min    = 1
+  autoscaling_max    = 2
+  log_retention_days = 7
+
+  environment = {
+    DS_PORT                   = "3000"
+    DS_WEBSOCKET_SERVER       = "false"
+    DWN_SERVER_LOG_LEVEL      = "INFO"
+    DWN_S3_DATA_BUCKET        = local.s3_bucket_name
+    MAX_RECORD_DATA_SIZE      = "1gb"
+    NATS_URL                  = module.nats.nats_url
+    DWN_EVENT_LOG_PLUGIN_PATH = "/app/dist/esm/src/plugins/event-log-nats.js"
+  }
+
+  secrets = {
+    DWN_STORAGE                = aws_secretsmanager_secret.database_url.arn
+    DWN_TTL_CACHE_URL          = aws_secretsmanager_secret.database_url.arn
+    DWN_REGISTRATION_STORE_URL = aws_secretsmanager_secret.database_url.arn
+    DWN_ADMIN_TOKEN            = aws_secretsmanager_secret.admin_token.arn
+  }
+
+  tags = local.tags
+}
+
+################################################################################
+# ECS Service — DWN WebSocket
+################################################################################
+
+module "dwn_ws" {
+  source = "../../modules/ecs-service"
+
+  name               = "${local.name}-ws"
+  cluster_arn        = module.ecs_cluster.cluster_arn
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [module.vpc.sg_dwn_id]
+  image              = var.dwn_image
+  container_port     = 3000
+  cpu                = 512
+  memory             = 1024
+  desired_count      = 1
+  target_group_arn   = module.alb.ws_target_group_arn
+  autoscaling_min    = 1
+  autoscaling_max    = 2
+  log_retention_days = 7
+
+  environment = {
+    DS_PORT                   = "3000"
+    DS_WEBSOCKET_SERVER       = "true"
+    DWN_SERVER_LOG_LEVEL      = "INFO"
+    DWN_MAX_IN_FLIGHT         = "64"
+    NATS_URL                  = module.nats.nats_url
+    DWN_EVENT_LOG_PLUGIN_PATH = "/app/dist/esm/src/plugins/event-log-nats.js"
+  }
+
+  secrets = {
+    DWN_STORAGE                = aws_secretsmanager_secret.database_url.arn
+    DWN_TTL_CACHE_URL          = aws_secretsmanager_secret.database_url.arn
+    DWN_REGISTRATION_STORE_URL = aws_secretsmanager_secret.database_url.arn
+    DWN_ADMIN_TOKEN            = aws_secretsmanager_secret.admin_token.arn
+  }
+
+  tags = local.tags
+}
+
+################################################################################
+# IAM — S3 data access for DWN task roles
+################################################################################
+
+resource "aws_iam_role_policy" "dwn_http_s3" {
+  name = "s3-data-access"
+  role = split("/", module.dwn_http.task_role_arn)[1]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "${module.s3_data.bucket_arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = module.s3_data.bucket_arn
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "dwn_ws_s3" {
+  name = "s3-data-access"
+  role = split("/", module.dwn_ws.task_role_arn)[1]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "${module.s3_data.bucket_arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = module.s3_data.bucket_arn
+      },
+    ]
+  })
+}
+
+################################################################################
+# Monitoring — CloudWatch alarms for primary service
+################################################################################
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  name               = local.name
+  cluster_name       = module.ecs_cluster.cluster_name
+  service_name       = module.dwn_http.service_name
+  alb_arn_suffix     = module.alb.alb_arn_suffix
+  aurora_cluster_id  = local.name
+
+  tags = local.tags
+}

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -1,0 +1,67 @@
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer."
+  value       = module.alb.alb_dns_name
+}
+
+output "aurora_writer_endpoint" {
+  description = "Aurora PostgreSQL writer endpoint."
+  value       = module.aurora.cluster_endpoint
+}
+
+output "aurora_master_secret_arn" {
+  description = "Secrets Manager ARN for Aurora master credentials."
+  value       = module.aurora.master_secret_arn
+}
+
+output "database_url_secret_arn" {
+  description = "Secrets Manager ARN for DWN database connection string. Update post-apply with the real password."
+  value       = aws_secretsmanager_secret.database_url.arn
+}
+
+output "admin_token_secret_arn" {
+  description = "Secrets Manager ARN for DWN admin token. Update post-apply with a strong token."
+  value       = aws_secretsmanager_secret.admin_token.arn
+}
+
+output "nats_url" {
+  description = "NATS JetStream connection URL for DWN services."
+  value       = module.nats.nats_url
+}
+
+output "s3_data_bucket" {
+  description = "S3 bucket name for DWN data storage."
+  value       = module.s3_data.bucket_name
+}
+
+output "dwn_http_log_group" {
+  description = "CloudWatch log group for the DWN HTTP service."
+  value       = module.dwn_http.log_group_name
+}
+
+output "dwn_ws_log_group" {
+  description = "CloudWatch log group for the DWN WebSocket service."
+  value       = module.dwn_ws.log_group_name
+}
+
+output "post_apply_instructions" {
+  description = "Steps to complete after first apply."
+  value       = <<-EOT
+    1. Get the Aurora master password:
+       aws secretsmanager get-secret-value --secret-id ${module.aurora.master_secret_arn} \
+         --query SecretString --output text | jq -r .password
+
+    2. Update the database URL secret with the real password:
+       aws secretsmanager put-secret-value \
+         --secret-id ${aws_secretsmanager_secret.database_url.id} \
+         --secret-string "postgres://postgres:REAL_PASSWORD@${module.aurora.cluster_endpoint}:${module.aurora.port}/dwn"
+
+    3. Update the admin token secret:
+       aws secretsmanager put-secret-value \
+         --secret-id ${aws_secretsmanager_secret.admin_token.id} \
+         --secret-string "$(openssl rand -hex 32)"
+
+    4. Force new ECS deployments to pick up the updated secrets:
+       aws ecs update-service --cluster ${module.ecs_cluster.cluster_name} --service ${module.dwn_http.service_name} --force-new-deployment
+       aws ecs update-service --cluster ${module.ecs_cluster.cluster_name} --service ${module.dwn_ws.service_name} --force-new-deployment
+  EOT
+}

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -1,0 +1,15 @@
+variable "aws_region" {
+  description = "AWS region to deploy into."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for the ALB HTTPS listener."
+  type        = string
+}
+
+variable "dwn_image" {
+  description = "DWN server container image URI (e.g. 123456789.dkr.ecr.us-east-1.amazonaws.com/dwn-server:latest)."
+  type        = string
+}

--- a/infra/environments/dev/versions.tf
+++ b/infra/environments/dev/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/environments/prod/backend.tf
+++ b/infra/environments/prod/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "enbox-terraform-state"
+    key            = "env/prod/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "enbox-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -1,0 +1,285 @@
+################################################################################
+# Locals
+################################################################################
+
+locals {
+  name        = "dwn-prod"
+  environment = "prod"
+
+  s3_bucket_name = "${local.name}-data-${var.aws_region}"
+
+  tags = {
+    Project     = "dwn"
+    Environment = local.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+################################################################################
+# Secrets Manager — populated post-apply (see outputs for instructions)
+################################################################################
+
+resource "aws_secretsmanager_secret" "database_url" {
+  name = "dwn/${local.environment}/database-url"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "database_url" {
+  secret_id     = aws_secretsmanager_secret.database_url.id
+  secret_string = "postgres://postgres:CHANGE_ME@${module.aurora.cluster_endpoint}:${module.aurora.port}/dwn"
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+resource "aws_secretsmanager_secret" "admin_token" {
+  name = "dwn/${local.environment}/admin-token"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "admin_token" {
+  secret_id     = aws_secretsmanager_secret.admin_token.id
+  secret_string = "CHANGE_ME"
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+################################################################################
+# VPC — 3 AZs, per-AZ NAT gateways (HA)
+################################################################################
+
+module "vpc" {
+  source = "../../modules/vpc"
+
+  name               = local.name
+  azs                = ["${var.aws_region}a", "${var.aws_region}b", "${var.aws_region}c"]
+  public_subnets     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnets    = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+  data_subnets       = ["10.0.21.0/24", "10.0.22.0/24", "10.0.23.0/24"]
+  single_nat_gateway = false
+
+  tags = local.tags
+}
+
+################################################################################
+# Aurora PostgreSQL 15 — db.r6g.xlarge writer
+################################################################################
+
+module "aurora" {
+  source = "../../modules/aurora"
+
+  name               = local.name
+  subnet_ids         = module.vpc.data_subnet_ids
+  security_group_ids = [module.vpc.sg_aurora_id]
+  instance_class     = "db.r6g.xlarge"
+
+  tags = local.tags
+}
+
+################################################################################
+# ECS Cluster — Fargate + Fargate Spot
+################################################################################
+
+module "ecs_cluster" {
+  source = "../../modules/ecs-cluster"
+
+  name = local.name
+  tags = local.tags
+}
+
+################################################################################
+# ALB — internet-facing, HTTPS with WebSocket routing
+################################################################################
+
+module "alb" {
+  source = "../../modules/alb"
+
+  name               = local.name
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.public_subnet_ids
+  security_group_ids = [module.vpc.sg_alb_id]
+  certificate_arn    = var.certificate_arn
+
+  tags = local.tags
+}
+
+################################################################################
+# S3 — DWN data storage with intelligent tiering
+################################################################################
+
+module "s3_data" {
+  source = "../../modules/s3-data"
+
+  name              = local.s3_bucket_name
+  allowed_role_arns = [module.dwn_http.task_role_arn, module.dwn_ws.task_role_arn]
+
+  tags = local.tags
+}
+
+################################################################################
+# NATS JetStream — 3-node cluster for prod
+################################################################################
+
+module "nats" {
+  source = "../../modules/nats"
+
+  name                   = local.name
+  cluster_arn            = module.ecs_cluster.cluster_arn
+  vpc_id                 = module.vpc.vpc_id
+  subnet_ids             = module.vpc.private_subnet_ids
+  nats_security_group_id = module.vpc.sg_nats_id
+  cpu                    = 1024
+  memory                 = 2048
+  replica_count          = 3
+  efs_throughput_mode    = "elastic"
+  log_retention_days     = 30
+
+  tags = local.tags
+}
+
+################################################################################
+# ECS Service — DWN HTTP (API + Records)
+################################################################################
+
+module "dwn_http" {
+  source = "../../modules/ecs-service"
+
+  name               = "${local.name}-http"
+  cluster_arn        = module.ecs_cluster.cluster_arn
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [module.vpc.sg_dwn_id]
+  image              = var.dwn_image
+  container_port     = 3000
+  cpu                = 1024
+  memory             = 2048
+  desired_count      = 2
+  target_group_arn   = module.alb.http_target_group_arn
+  autoscaling_min    = 2
+  autoscaling_max    = 20
+  log_retention_days = 30
+
+  environment = {
+    DS_PORT                   = "3000"
+    DS_WEBSOCKET_SERVER       = "false"
+    DWN_SERVER_LOG_LEVEL      = "INFO"
+    DWN_S3_DATA_BUCKET        = local.s3_bucket_name
+    MAX_RECORD_DATA_SIZE      = "1gb"
+    NATS_URL                  = module.nats.nats_url
+    DWN_EVENT_LOG_PLUGIN_PATH = "/app/dist/esm/src/plugins/event-log-nats.js"
+  }
+
+  secrets = {
+    DWN_STORAGE                = aws_secretsmanager_secret.database_url.arn
+    DWN_TTL_CACHE_URL          = aws_secretsmanager_secret.database_url.arn
+    DWN_REGISTRATION_STORE_URL = aws_secretsmanager_secret.database_url.arn
+    DWN_ADMIN_TOKEN            = aws_secretsmanager_secret.admin_token.arn
+  }
+
+  tags = local.tags
+}
+
+################################################################################
+# ECS Service — DWN WebSocket
+################################################################################
+
+module "dwn_ws" {
+  source = "../../modules/ecs-service"
+
+  name               = "${local.name}-ws"
+  cluster_arn        = module.ecs_cluster.cluster_arn
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [module.vpc.sg_dwn_id]
+  image              = var.dwn_image
+  container_port     = 3000
+  cpu                = 1024
+  memory             = 2048
+  desired_count      = 2
+  target_group_arn   = module.alb.ws_target_group_arn
+  autoscaling_min    = 2
+  autoscaling_max    = 10
+  log_retention_days = 30
+
+  environment = {
+    DS_PORT                   = "3000"
+    DS_WEBSOCKET_SERVER       = "true"
+    DWN_SERVER_LOG_LEVEL      = "INFO"
+    DWN_MAX_IN_FLIGHT         = "64"
+    NATS_URL                  = module.nats.nats_url
+    DWN_EVENT_LOG_PLUGIN_PATH = "/app/dist/esm/src/plugins/event-log-nats.js"
+  }
+
+  secrets = {
+    DWN_STORAGE                = aws_secretsmanager_secret.database_url.arn
+    DWN_TTL_CACHE_URL          = aws_secretsmanager_secret.database_url.arn
+    DWN_REGISTRATION_STORE_URL = aws_secretsmanager_secret.database_url.arn
+    DWN_ADMIN_TOKEN            = aws_secretsmanager_secret.admin_token.arn
+  }
+
+  tags = local.tags
+}
+
+################################################################################
+# IAM — S3 data access for DWN task roles
+################################################################################
+
+resource "aws_iam_role_policy" "dwn_http_s3" {
+  name = "s3-data-access"
+  role = split("/", module.dwn_http.task_role_arn)[1]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "${module.s3_data.bucket_arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = module.s3_data.bucket_arn
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "dwn_ws_s3" {
+  name = "s3-data-access"
+  role = split("/", module.dwn_ws.task_role_arn)[1]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "${module.s3_data.bucket_arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = module.s3_data.bucket_arn
+      },
+    ]
+  })
+}
+
+################################################################################
+# Monitoring — CloudWatch alarms with SNS notifications
+################################################################################
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  name              = local.name
+  cluster_name      = module.ecs_cluster.cluster_name
+  service_name      = module.dwn_http.service_name
+  alb_arn_suffix    = module.alb.alb_arn_suffix
+  aurora_cluster_id = local.name
+  sns_topic_arn     = var.sns_topic_arn
+
+  tags = local.tags
+}

--- a/infra/environments/prod/outputs.tf
+++ b/infra/environments/prod/outputs.tf
@@ -1,0 +1,67 @@
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer."
+  value       = module.alb.alb_dns_name
+}
+
+output "aurora_writer_endpoint" {
+  description = "Aurora PostgreSQL writer endpoint."
+  value       = module.aurora.cluster_endpoint
+}
+
+output "aurora_master_secret_arn" {
+  description = "Secrets Manager ARN for Aurora master credentials."
+  value       = module.aurora.master_secret_arn
+}
+
+output "database_url_secret_arn" {
+  description = "Secrets Manager ARN for DWN database connection string. Update post-apply with the real password."
+  value       = aws_secretsmanager_secret.database_url.arn
+}
+
+output "admin_token_secret_arn" {
+  description = "Secrets Manager ARN for DWN admin token. Update post-apply with a strong token."
+  value       = aws_secretsmanager_secret.admin_token.arn
+}
+
+output "nats_url" {
+  description = "NATS JetStream connection URL for DWN services."
+  value       = module.nats.nats_url
+}
+
+output "s3_data_bucket" {
+  description = "S3 bucket name for DWN data storage."
+  value       = module.s3_data.bucket_name
+}
+
+output "dwn_http_log_group" {
+  description = "CloudWatch log group for the DWN HTTP service."
+  value       = module.dwn_http.log_group_name
+}
+
+output "dwn_ws_log_group" {
+  description = "CloudWatch log group for the DWN WebSocket service."
+  value       = module.dwn_ws.log_group_name
+}
+
+output "post_apply_instructions" {
+  description = "Steps to complete after first apply."
+  value       = <<-EOT
+    1. Get the Aurora master password:
+       aws secretsmanager get-secret-value --secret-id ${module.aurora.master_secret_arn} \
+         --query SecretString --output text | jq -r .password
+
+    2. Update the database URL secret with the real password:
+       aws secretsmanager put-secret-value \
+         --secret-id ${aws_secretsmanager_secret.database_url.id} \
+         --secret-string "postgres://postgres:REAL_PASSWORD@${module.aurora.cluster_endpoint}:${module.aurora.port}/dwn"
+
+    3. Update the admin token secret:
+       aws secretsmanager put-secret-value \
+         --secret-id ${aws_secretsmanager_secret.admin_token.id} \
+         --secret-string "$(openssl rand -hex 32)"
+
+    4. Force new ECS deployments to pick up the updated secrets:
+       aws ecs update-service --cluster ${module.ecs_cluster.cluster_name} --service ${module.dwn_http.service_name} --force-new-deployment
+       aws ecs update-service --cluster ${module.ecs_cluster.cluster_name} --service ${module.dwn_ws.service_name} --force-new-deployment
+  EOT
+}

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -1,0 +1,21 @@
+variable "aws_region" {
+  description = "AWS region to deploy into."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for the ALB HTTPS listener."
+  type        = string
+}
+
+variable "dwn_image" {
+  description = "DWN server container image URI (e.g. 123456789.dkr.ecr.us-east-1.amazonaws.com/dwn-server:v1.2.3)."
+  type        = string
+}
+
+variable "sns_topic_arn" {
+  description = "SNS topic ARN for CloudWatch alarm notifications."
+  type        = string
+  default     = ""
+}

--- a/infra/environments/prod/versions.tf
+++ b/infra/environments/prod/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/modules/alb/outputs.tf
+++ b/infra/modules/alb/outputs.tf
@@ -22,3 +22,8 @@ output "ws_target_group_arn" {
   description = "ARN of the WebSocket target group."
   value       = aws_lb_target_group.ws.arn
 }
+
+output "alb_arn_suffix" {
+  description = "ARN suffix of the ALB (for CloudWatch metric dimensions)."
+  value       = aws_lb.this.arn_suffix
+}

--- a/infra/modules/nats/main.tf
+++ b/infra/modules/nats/main.tf
@@ -1,0 +1,328 @@
+################################################################################
+# Data sources & locals
+################################################################################
+
+data "aws_region" "current" {}
+
+locals {
+  # Per-node NATS server command arguments.
+  # Single-node: JetStream only. Multi-node: adds cluster routing.
+  nats_commands = { for i in range(var.replica_count) : i => concat(
+    [
+      "-n", "nats-${i}",
+      "-js",
+      "-sd", "/data",
+      "-ms", var.jetstream_max_mem,
+      "-fs", var.jetstream_max_file,
+      "-p", "4222",
+      "-m", "8222",
+    ],
+    var.replica_count > 1 ? [
+      "--cluster_name", "${var.name}-nats",
+      "--cluster", "nats://0.0.0.0:6222",
+      "--routes", join(",", [
+        for j in range(var.replica_count) :
+        "nats-route://nats-${j}.${var.cloudmap_namespace_name}:6222"
+      ]),
+    ] : [],
+  ) }
+}
+
+################################################################################
+# CloudMap — private DNS namespace + per-node service entries
+################################################################################
+
+resource "aws_service_discovery_private_dns_namespace" "this" {
+  name = var.cloudmap_namespace_name
+  vpc  = var.vpc_id
+
+  tags = var.tags
+}
+
+resource "aws_service_discovery_service" "nats" {
+  count = var.replica_count
+
+  name = "nats-${count.index}"
+
+  dns_config {
+    namespace_id   = aws_service_discovery_private_dns_namespace.this.id
+    routing_policy = "MULTIVALUE"
+
+    dns_records {
+      type = "A"
+      ttl  = 10
+    }
+  }
+
+  health_check_custom_config {}
+
+  tags = var.tags
+}
+
+################################################################################
+# EFS — encrypted filesystem with per-node access points
+################################################################################
+
+resource "aws_efs_file_system" "nats" {
+  encrypted        = true
+  throughput_mode   = var.efs_throughput_mode
+  performance_mode = "generalPurpose"
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nats-data"
+  })
+}
+
+resource "aws_security_group" "efs" {
+  name_prefix = "${var.name}-nats-efs-"
+  description = "Allow NFS from NATS tasks"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "NFS from NATS"
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [var.nats_security_group_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nats-efs"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_efs_mount_target" "nats" {
+  count = length(var.subnet_ids)
+
+  file_system_id  = aws_efs_file_system.nats.id
+  subnet_id       = var.subnet_ids[count.index]
+  security_groups = [aws_security_group.efs.id]
+}
+
+# Each NATS node gets an isolated root directory on the shared filesystem.
+# UID/GID 1000 matches the `nats` user in the nats:alpine image.
+resource "aws_efs_access_point" "nats" {
+  count = var.replica_count
+
+  file_system_id = aws_efs_file_system.nats.id
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+
+  root_directory {
+    path = "/nats-${count.index}"
+
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "0755"
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nats-${count.index}"
+  })
+}
+
+################################################################################
+# IAM — Execution role (image pull, logs) + Task role (EFS access)
+################################################################################
+
+data "aws_iam_policy_document" "ecs_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name               = "${var.name}-nats-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "execution" {
+  # Pull public images (NATS from Docker Hub still needs ECR auth token)
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = ["*"]
+  }
+
+  # CloudWatch Logs
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.nats.arn}:*"]
+  }
+}
+
+resource "aws_iam_role_policy" "execution" {
+  name   = "${var.name}-nats-exec"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.execution.json
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name}-nats-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "task_efs" {
+  statement {
+    actions = [
+      "elasticfilesystem:ClientMount",
+      "elasticfilesystem:ClientWrite",
+    ]
+    resources = [aws_efs_file_system.nats.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "task_efs" {
+  name   = "efs-access"
+  role   = aws_iam_role.task.id
+  policy = data.aws_iam_policy_document.task_efs.json
+}
+
+################################################################################
+# CloudWatch Log Group
+################################################################################
+
+resource "aws_cloudwatch_log_group" "nats" {
+  name              = "/ecs/${var.name}-nats"
+  retention_in_days = var.log_retention_days
+
+  tags = var.tags
+}
+
+################################################################################
+# ECS — per-node task definitions and services
+################################################################################
+
+resource "aws_ecs_task_definition" "nats" {
+  count = var.replica_count
+
+  family                   = "${var.name}-nats-${count.index}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "nats"
+      image     = var.nats_image
+      essential = true
+      command   = local.nats_commands[count.index]
+
+      portMappings = concat(
+        [
+          { containerPort = 4222, protocol = "tcp" }, # client
+          { containerPort = 8222, protocol = "tcp" }, # monitoring
+        ],
+        var.replica_count > 1 ? [
+          { containerPort = 6222, protocol = "tcp" }, # cluster routing
+        ] : [],
+      )
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz || exit 1"]
+        interval    = 15
+        timeout     = 5
+        retries     = 3
+        startPeriod = 15
+      }
+
+      mountPoints = [
+        {
+          sourceVolume  = "nats-data"
+          containerPath = "/data"
+          readOnly      = false
+        },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.nats.name
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "nats-${count.index}"
+        }
+      }
+    },
+  ])
+
+  volume {
+    name = "nats-data"
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.nats.id
+      transit_encryption      = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.nats[count.index].id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_service" "nats" {
+  count = var.replica_count
+
+  name            = "${var.name}-nats-${count.index}"
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.nats[count.index].arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [var.nats_security_group_id]
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.nats[count.index].arn
+  }
+
+  # Stateful single-task service: stop old task before starting new one
+  # to avoid two tasks writing to the same EFS access point.
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  # Ensure EFS mount targets are ready before starting tasks
+  depends_on = [aws_efs_mount_target.nats]
+
+  tags = var.tags
+}

--- a/infra/modules/nats/outputs.tf
+++ b/infra/modules/nats/outputs.tf
@@ -1,0 +1,39 @@
+output "nats_url" {
+  description = "NATS client connection URL(s) for DWN services."
+  value       = join(",", [for i in range(var.replica_count) : "nats://nats-${i}.${var.cloudmap_namespace_name}:4222"])
+}
+
+output "efs_filesystem_id" {
+  description = "EFS filesystem ID used for JetStream persistent storage."
+  value       = aws_efs_file_system.nats.id
+}
+
+output "efs_filesystem_arn" {
+  description = "EFS filesystem ARN."
+  value       = aws_efs_file_system.nats.arn
+}
+
+output "service_arns" {
+  description = "ARNs of the NATS ECS services."
+  value       = aws_ecs_service.nats[*].id
+}
+
+output "task_definition_arns" {
+  description = "ARNs of the NATS ECS task definitions."
+  value       = aws_ecs_task_definition.nats[*].arn
+}
+
+output "cloudmap_namespace_id" {
+  description = "CloudMap private DNS namespace ID (for reuse by other modules)."
+  value       = aws_service_discovery_private_dns_namespace.this.id
+}
+
+output "cloudmap_service_arns" {
+  description = "ARNs of the per-node CloudMap service discovery entries."
+  value       = aws_service_discovery_service.nats[*].arn
+}
+
+output "efs_security_group_id" {
+  description = "Security group ID for the EFS filesystem (NFS access)."
+  value       = aws_security_group.efs.id
+}

--- a/infra/modules/nats/variables.tf
+++ b/infra/modules/nats/variables.tf
@@ -1,0 +1,94 @@
+variable "name" {
+  description = "Name prefix for all NATS resources."
+  type        = string
+}
+
+variable "cluster_arn" {
+  description = "ARN of the ECS cluster to deploy NATS into."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for CloudMap namespace and EFS security group."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for ECS tasks and EFS mount targets."
+  type        = list(string)
+}
+
+variable "nats_security_group_id" {
+  description = "Security group ID for NATS tasks (inbound 4222, 6222)."
+  type        = string
+}
+
+variable "nats_image" {
+  description = "NATS container image."
+  type        = string
+  default     = "nats:2.10-alpine"
+}
+
+variable "cpu" {
+  description = "CPU units for each NATS task (256 = 0.25 vCPU)."
+  type        = number
+  default     = 512
+}
+
+variable "memory" {
+  description = "Memory in MiB for each NATS task."
+  type        = number
+  default     = 1024
+}
+
+variable "replica_count" {
+  description = "Number of NATS nodes (1 for dev, 3 for prod)."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.replica_count >= 1 && var.replica_count <= 5
+    error_message = "replica_count must be between 1 and 5."
+  }
+}
+
+variable "jetstream_max_mem" {
+  description = "JetStream max in-memory storage per node (e.g. 256MB)."
+  type        = string
+  default     = "256MB"
+}
+
+variable "jetstream_max_file" {
+  description = "JetStream max file storage per node (e.g. 10GB)."
+  type        = string
+  default     = "10GB"
+}
+
+variable "efs_throughput_mode" {
+  description = "EFS throughput mode: bursting or elastic."
+  type        = string
+  default     = "bursting"
+
+  validation {
+    condition     = contains(["bursting", "elastic"], var.efs_throughput_mode)
+    error_message = "efs_throughput_mode must be 'bursting' or 'elastic'."
+  }
+}
+
+variable "cloudmap_namespace_name" {
+  description = "Private DNS namespace name for NATS service discovery."
+  type        = string
+  default     = "nats.local"
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch logs."
+  type        = number
+  default     = 14
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/nats/versions.tf
+++ b/infra/modules/nats/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #375. Adds root Terraform configurations for dev and prod environments that compose all 8 infrastructure modules with environment-appropriate sizing.

**Depends on:** #446 (NATS module) — cherry-picked into this branch for composition and validation.

## Environment Sizing

| Resource | Dev | Prod |
|---|---|---|
| VPC AZs | 2 | 3 |
| NAT Gateways | 1 (shared) | 1 per AZ (HA) |
| Aurora writer | `db.t4g.medium` | `db.r6g.xlarge` |
| DWN HTTP tasks | 1 (scale to 2) | 2 (scale to 20) |
| DWN WS tasks | 1 (scale to 2) | 2 (scale to 10) |
| DWN CPU / Memory | 0.5 vCPU / 1 GB | 1 vCPU / 2 GB |
| NATS replicas | 1 | 3 |
| NATS CPU / Memory | 0.25 vCPU / 512 MB | 1 vCPU / 2 GB |
| EFS throughput | bursting | elastic |
| CloudWatch retention | 7 days | 30 days |
| SNS alarms | disabled | configurable |

## Module Composition

```
environments/dev/main.tf
  ├── module "vpc"         → 2-AZ VPC, single NAT, VPC endpoints
  ├── module "aurora"      → PostgreSQL 15, t4g.medium writer
  ├── module "ecs_cluster" → Fargate + Fargate Spot
  ├── module "alb"         → HTTPS, WebSocket routing
  ├── module "s3_data"     → DWN blob storage, IAM-scoped
  ├── module "nats"        → 1-node JetStream + EFS
  ├── module "dwn_http"    → HTTP API service → ALB http target group
  ├── module "dwn_ws"      → WebSocket service → ALB ws target group
  ├── module "monitoring"  → CloudWatch alarms (Aurora, ECS, ALB)
  ├── aws_iam_role_policy  → S3 access for both DWN task roles
  └── aws_secretsmanager   → database-url + admin-token secrets
```

## Key Design Decisions

| Decision | Rationale |
|---|---|
| **Secrets Manager with `ignore_changes`** | Placeholder secrets created on first apply; values populated out-of-band; Terraform won't overwrite manual updates |
| **`local.s3_bucket_name` for env var** | Breaks circular dependency between S3 module (needs task role ARN) and ECS service (needs bucket name) |
| **Separate S3 IAM policies** | Task roles created by ecs-service module; S3 access attached via `aws_iam_role_policy` in env config |
| **`post_apply_instructions` output** | Guides operators through Aurora password retrieval and secret population on Day 1 |

## Changes

- `infra/environments/dev/` — 5 new files (versions, backend, variables, main, outputs)
- `infra/environments/prod/` — 5 new files (same structure, prod sizing)
- `infra/modules/alb/outputs.tf` — add `alb_arn_suffix` output for CloudWatch metric dimensions
- `infra/modules/nats/` — cherry-picked from #446 for module composition

## Validation

```
✓ environments/dev  — Success! The configuration is valid.
✓ environments/prod — Success! The configuration is valid.
```

Both environments compose all 9 modules (8 shared + NATS) and validate with Terraform 1.10 / AWS provider v6.33.0.