### PR TITLE
ci: add Terraform plan/apply workflow with OIDC and environment gates (#376)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,296 @@
+# ---------------------------------------------------------------------------
+# Terraform Plan / Apply
+#
+# - PRs touching infra/** get a plan diff posted as a comment.
+# - Merge to main auto-applies dev, then prod (with manual approval).
+# - Uses GitHub OIDC to assume AWS IAM roles (no long-lived credentials).
+# - Module-only changes trigger plans for both environments.
+# ---------------------------------------------------------------------------
+
+name: Terraform
+
+on:
+  pull_request:
+    paths: ['infra/**']
+  push:
+    branches: [main]
+    paths: ['infra/**']
+
+concurrency:
+  group: terraform-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  id-token: write      # OIDC federation
+  contents: read
+  pull-requests: write  # Post plan comments
+
+env:
+  AWS_REGION: us-east-1
+  TERRAFORM_VERSION: "1.10.0"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Detect which environments were affected by the change
+  # ---------------------------------------------------------------------------
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      dev: ${{ steps.filter.outputs.dev }}
+      prod: ${{ steps.filter.outputs.prod }}
+      environments: ${{ steps.envs.outputs.environments }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            dev:
+              - 'infra/environments/dev/**'
+              - 'infra/modules/**'
+            prod:
+              - 'infra/environments/prod/**'
+              - 'infra/modules/**'
+
+      - name: Build environment list
+        id: envs
+        run: |
+          envs='[]'
+          if [[ "${{ steps.filter.outputs.dev }}" == "true" ]]; then
+            envs=$(echo "$envs" | jq -c '. + ["dev"]')
+          fi
+          if [[ "${{ steps.filter.outputs.prod }}" == "true" ]]; then
+            envs=$(echo "$envs" | jq -c '. + ["prod"]')
+          fi
+          echo "environments=$envs" >> "$GITHUB_OUTPUT"
+          echo "Affected environments: $envs"
+
+  # ---------------------------------------------------------------------------
+  # Plan — runs for each affected environment
+  # ---------------------------------------------------------------------------
+  plan:
+    name: Plan (${{ matrix.environment }})
+    needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.environments != '[]' &&
+      vars.AWS_TERRAFORM_ROLE_ARN != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJson(needs.detect-changes.outputs.environments) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_TERRAFORM_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        working-directory: infra/environments/${{ matrix.environment }}
+        run: terraform init -input=false
+
+      - name: Set Terraform variables
+        run: |
+          if [[ "${{ matrix.environment }}" == "prod" ]]; then
+            echo "TF_VAR_certificate_arn=${TF_CERT_ARN_PROD:-arn:aws:acm:us-east-1:000000000000:certificate/placeholder}" >> "$GITHUB_ENV"
+            echo "TF_VAR_dwn_image=${TF_DWN_IMAGE_PROD:-000000000000.dkr.ecr.us-east-1.amazonaws.com/dwn-server:latest}" >> "$GITHUB_ENV"
+            echo "TF_VAR_sns_topic_arn=${TF_SNS_TOPIC_ARN_PROD:-}" >> "$GITHUB_ENV"
+          else
+            echo "TF_VAR_certificate_arn=${TF_CERT_ARN_DEV:-arn:aws:acm:us-east-1:000000000000:certificate/placeholder}" >> "$GITHUB_ENV"
+            echo "TF_VAR_dwn_image=${TF_DWN_IMAGE_DEV:-000000000000.dkr.ecr.us-east-1.amazonaws.com/dwn-server:latest}" >> "$GITHUB_ENV"
+          fi
+        env:
+          TF_CERT_ARN_DEV: ${{ vars.TF_CERT_ARN_DEV }}
+          TF_CERT_ARN_PROD: ${{ vars.TF_CERT_ARN_PROD }}
+          TF_DWN_IMAGE_DEV: ${{ vars.TF_DWN_IMAGE_DEV }}
+          TF_DWN_IMAGE_PROD: ${{ vars.TF_DWN_IMAGE_PROD }}
+          TF_SNS_TOPIC_ARN_PROD: ${{ vars.TF_SNS_TOPIC_ARN_PROD }}
+
+      - name: Terraform Plan
+        id: plan
+        working-directory: infra/environments/${{ matrix.environment }}
+        run: terraform plan -no-color -input=false -out=plan.tfplan
+        continue-on-error: true
+
+      - name: Generate plan summary
+        if: always() && steps.plan.outcome == 'success'
+        working-directory: infra/environments/${{ matrix.environment }}
+        run: terraform show -no-color plan.tfplan > plan.txt
+
+      - name: Upload plan artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.plan.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan-${{ matrix.environment }}
+          path: infra/environments/${{ matrix.environment }}/plan.tfplan
+          retention-days: 1
+
+      - name: Post plan to PR
+        if: github.event_name == 'pull_request' && always() && steps.plan.outcome != 'cancelled'
+        uses: actions/github-script@v7
+        env:
+          ENV_NAME: ${{ matrix.environment }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { ENV_NAME, PLAN_OUTCOME } = process.env;
+            const marker = `<!-- terraform-plan-${ENV_NAME} -->`;
+            const status = PLAN_OUTCOME === 'success' ? '✅' : '❌';
+
+            let planText = 'Plan failed — check workflow logs for details.';
+            const planFile = `infra/environments/${ENV_NAME}/plan.txt`;
+            if (fs.existsSync(planFile)) {
+              planText = fs.readFileSync(planFile, 'utf8');
+              if (planText.length > 60000) {
+                planText = planText.substring(0, 60000) + '\n\n... (truncated)';
+              }
+            }
+
+            const body = [
+              marker,
+              `### Terraform Plan — \`${ENV_NAME}\` ${status}`,
+              '',
+              '<details>',
+              '<summary>Show plan output</summary>',
+              '',
+              '```',
+              planText,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if plan failed
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+  # ---------------------------------------------------------------------------
+  # Apply Dev — auto-deploys on merge to main
+  # ---------------------------------------------------------------------------
+  apply-dev:
+    name: Apply (dev)
+    needs: [detect-changes, plan]
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.detect-changes.outputs.dev == 'true' &&
+      needs.plan.result == 'success'
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_TERRAFORM_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        working-directory: infra/environments/dev
+        run: terraform init -input=false
+
+      - name: Download plan
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan-dev
+          path: infra/environments/dev
+
+      - name: Terraform Apply
+        working-directory: infra/environments/dev
+        run: terraform apply -no-color -input=false plan.tfplan
+
+  # ---------------------------------------------------------------------------
+  # Apply Prod — requires manual approval via GitHub Environment protection
+  # ---------------------------------------------------------------------------
+  apply-prod:
+    name: Apply (prod)
+    needs: [detect-changes, plan, apply-dev]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.plan.result == 'success' &&
+      (needs.apply-dev.result == 'success' || needs.apply-dev.result == 'skipped') &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.detect-changes.outputs.prod == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_TERRAFORM_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        working-directory: infra/environments/prod
+        run: terraform init -input=false
+
+      - name: Download plan
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan-prod
+          path: infra/environments/prod
+
+      - name: Terraform Apply
+        working-directory: infra/environments/prod
+        run: terraform apply -no-color -input=false plan.tfplan


### PR DESCRIPTION
## Summary

Closes #376. Adds a GitHub Actions workflow (`.github/workflows/terraform.yml`) that automates Terraform plan on PRs and apply on merge to main.

## Workflow Flow

```
PR touching infra/**:
  detect-changes → plan (matrix: affected envs) → PR comment with diff

Merge to main:
  detect-changes → plan (matrix) → apply-dev (auto) → apply-prod (manual approval)
```

## Jobs

| Job | Trigger | Description |
|---|---|---|
| `detect-changes` | PR + push | Uses `dorny/paths-filter` to determine affected environments. Module changes (`infra/modules/**`) trigger both. |
| `plan` | PR + push | Matrix over affected environments. Posts plan diff as PR comment (updates existing comment). Uploads plan artifact on push. |
| `apply-dev` | push to main | Downloads plan artifact, runs `terraform apply`. Uses GitHub Environment `development` (no protection rules). |
| `apply-prod` | push to main | Same as dev but uses GitHub Environment `production` (requires manual approval). Runs after dev succeeds or is skipped. |

## Key Design Decisions

| Decision | Rationale |
|---|---|
| **Plan re-run on merge** | PR plan may be stale; re-plan on main ensures apply uses current state |
| **Plan artifact (1-day retention)** | Plan file passed from plan to apply job; short retention since it's single-use |
| **`terraform_wrapper: false`** | Avoids `hashicorp/setup-terraform` stdout capture issues with large plans; plan output captured via `terraform show` to file instead |
| **Placeholder var defaults** | If `TF_CERT_ARN_DEV` etc. aren't set yet (pre-bootstrap), plan still runs with placeholder values |
| **`always()` on apply-prod** | Allows prod apply even when apply-dev was skipped (prod-only changes) |
| **Per-PR concurrency** | PRs get independent plan runs; main runs queue sequentially |

## Required GitHub Configuration

### Repository Variables

| Variable | Description |
|---|---|
| `AWS_TERRAFORM_ROLE_ARN` | IAM role ARN for OIDC (created by bootstrap module) |
| `TF_CERT_ARN_DEV` | ACM certificate ARN for dev ALB |
| `TF_CERT_ARN_PROD` | ACM certificate ARN for prod ALB |
| `TF_DWN_IMAGE_DEV` | ECR image URI for dev |
| `TF_DWN_IMAGE_PROD` | ECR image URI for prod |
| `TF_SNS_TOPIC_ARN_PROD` | SNS topic ARN for prod alarms (optional) |

### GitHub Environments

| Environment | Protection |
|---|---|
| `development` | None (auto-deploy) |
| `production` | Required reviewers |

## Validation

- YAML syntax validated (Python yaml.safe_load)
- Workflow is a no-op until `AWS_TERRAFORM_ROLE_ARN` is configured (guard on plan job)