### PR TITLE
fix(dwn-server-admin-ui): align UI field names with admin API response shapes

### DIFF
--- a/packages/dwn-server-admin-ui/src/views/Overview.tsx
+++ b/packages/dwn-server-admin-ui/src/views/Overview.tsx
@@ -78,7 +78,7 @@ export function Overview() {
               </div>
             )}
           </div>
-          {health.checks && health.checks.length > 0 && (
+          {health.checks && Object.keys(health.checks).length > 0 && (
             <div class="table-container">
               <table>
                 <thead>
@@ -89,14 +89,14 @@ export function Overview() {
                   </tr>
                 </thead>
                 <tbody>
-                  {health.checks.map((check: any) => (
-                    <tr key={check.name}>
-                      <td>{check.name}</td>
+                  {Object.entries(health.checks).map(([name, check]: [string, any]) => (
+                    <tr key={name}>
+                      <td>{name}</td>
                       <td>
                         <span class={`status-dot ${check.status === 'healthy' ? 'healthy' : check.status === 'unhealthy' ? 'unhealthy' : 'unknown'}`} />
                         {check.status}
                       </td>
-                      <td>{check.latency !== undefined ? `${check.latency}ms` : '—'}</td>
+                      <td>{check.latencyMs !== undefined ? `${check.latencyMs}ms` : '—'}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -116,20 +116,20 @@ export function Overview() {
           </div>
           <div class="stat-card">
             <div class="label">Messages</div>
-            <div class="value">{formatNumber(stats.messages?.total ?? 0)}</div>
+            <div class="value">{formatNumber(stats.storage?.totalMessages ?? 0)}</div>
           </div>
           <div class="stat-card">
             <div class="label">Storage</div>
-            <div class="value">{formatBytes(stats.storage?.totalBytes ?? 0)}</div>
+            <div class="value">{formatBytes(stats.storage?.totalDataBytes ?? 0)}</div>
           </div>
           <div class="stat-card">
             <div class="label">Protocols</div>
-            <div class="value">{formatNumber(stats.protocols?.count ?? 0)}</div>
+            <div class="value">{formatNumber(stats.storage?.totalProtocols ?? 0)}</div>
           </div>
           <div class="stat-card">
             <div class="label">WebSocket</div>
-            <div class="value">{formatNumber(stats.websocket?.active ?? 0)}</div>
-            <div class="sub">{formatNumber(stats.websocket?.subscriptions ?? 0)} subscriptions</div>
+            <div class="value">{formatNumber(stats.connections?.websocket?.active ?? 0)}</div>
+            <div class="sub">{formatNumber(stats.connections?.websocket?.subscriptions ?? 0)} subscriptions</div>
           </div>
           <div class="stat-card">
             <div class="label">Uptime</div>
@@ -149,18 +149,18 @@ export function Overview() {
             <div>
               <div style="font-size:12px;font-weight:600;color:var(--color-text-secondary);margin-bottom:8px">Per-IP</div>
               <div style="font-size:13px">
-                <span class={`badge ${rateLimits.perIp?.enabled ? 'badge-success' : 'badge-muted'}`}>
-                  {rateLimits.perIp?.enabled ? 'Enabled' : 'Disabled'}
+                <span class={`badge ${rateLimits.config?.perIp?.enabled ? 'badge-success' : 'badge-muted'}`}>
+                  {rateLimits.config?.perIp?.enabled ? 'Enabled' : 'Disabled'}
                 </span>
-                {rateLimits.perIp?.enabled && (
+                {rateLimits.config?.perIp?.enabled && (
                   <span style="margin-left:8px;color:var(--color-text-secondary)">
-                    {rateLimits.perIp.rps} rps / {rateLimits.perIp.burst} burst
+                    {rateLimits.config.perIp.requestsPerSecond} rps / {rateLimits.config.perIp.burst} burst
                   </span>
                 )}
               </div>
-              {rateLimits.perIp?.activeEntries !== undefined && (
+              {rateLimits.activeEntries?.ip !== undefined && (
                 <div style="font-size:12px;color:var(--color-text-muted);margin-top:4px">
-                  {formatNumber(rateLimits.perIp.activeEntries)} active entries
+                  {formatNumber(rateLimits.activeEntries.ip)} active entries
                 </div>
               )}
             </div>
@@ -168,18 +168,18 @@ export function Overview() {
             <div>
               <div style="font-size:12px;font-weight:600;color:var(--color-text-secondary);margin-bottom:8px">Per-Tenant</div>
               <div style="font-size:13px">
-                <span class={`badge ${rateLimits.perTenant?.enabled ? 'badge-success' : 'badge-muted'}`}>
-                  {rateLimits.perTenant?.enabled ? 'Enabled' : 'Disabled'}
+                <span class={`badge ${rateLimits.config?.perTenant?.enabled ? 'badge-success' : 'badge-muted'}`}>
+                  {rateLimits.config?.perTenant?.enabled ? 'Enabled' : 'Disabled'}
                 </span>
-                {rateLimits.perTenant?.enabled && (
+                {rateLimits.config?.perTenant?.enabled && (
                   <span style="margin-left:8px;color:var(--color-text-secondary)">
-                    {rateLimits.perTenant.rps} rps / {rateLimits.perTenant.burst} burst
+                    {rateLimits.config.perTenant.requestsPerSecond} rps / {rateLimits.config.perTenant.burst} burst
                   </span>
                 )}
               </div>
-              {rateLimits.perTenant?.activeEntries !== undefined && (
+              {rateLimits.activeEntries?.tenant !== undefined && (
                 <div style="font-size:12px;color:var(--color-text-muted);margin-top:4px">
-                  {formatNumber(rateLimits.perTenant.activeEntries)} active entries
+                  {formatNumber(rateLimits.activeEntries.tenant)} active entries
                 </div>
               )}
             </div>

--- a/packages/dwn-server-admin-ui/src/views/Tenants.tsx
+++ b/packages/dwn-server-admin-ui/src/views/Tenants.tsx
@@ -43,7 +43,7 @@ function TenantList() {
     return <div class="loading">Loading...</div>;
   }
 
-  const items = tenants?.tenants ?? [];
+  const items = tenants?.data ?? [];
   const nextCursor = tenants?.cursor;
 
   return (
@@ -78,7 +78,7 @@ function TenantList() {
                     </a>
                   </td>
                   <td>{formatNumber(t.messageCount ?? 0)}</td>
-                  <td>{formatBytes(t.storageBytes ?? 0)}</td>
+                  <td>{formatBytes(t.dataStorageBytes ?? 0)}</td>
                 </tr>
               ))}
             </tbody>
@@ -207,8 +207,8 @@ function TenantDetail({ did }: { did: string }) {
         <h2 style="margin-top:8px;word-break:break-all;font-family:var(--font-mono);font-size:14px">{did}</h2>
         {tenant && (
           <div style="display:flex;gap:8px;margin-top:8px">
-            <span class={`badge ${tenant.active !== false ? 'badge-success' : 'badge-muted'}`}>
-              {tenant.active !== false ? 'Active' : 'Inactive'}
+            <span class={`badge ${tenant.isActive !== false ? 'badge-success' : 'badge-muted'}`}>
+              {tenant.isActive !== false ? 'Active' : 'Inactive'}
             </span>
             <span class={`badge ${tenant.suspended ? 'badge-danger' : 'badge-success'}`}>
               {tenant.suspended ? 'Suspended' : 'Not Suspended'}
@@ -255,11 +255,11 @@ function TenantDetail({ did }: { did: string }) {
         <div class="stat-grid">
           <div class="stat-card">
             <div class="label">Messages</div>
-            <div class="value">{formatNumber(tenant?.messageCount ?? 0)}</div>
+            <div class="value">{formatNumber(tenant?.storage?.messageCount ?? 0)}</div>
           </div>
           <div class="stat-card">
             <div class="label">Data Storage</div>
-            <div class="value">{formatBytes(tenant?.storageBytes ?? 0)}</div>
+            <div class="value">{formatBytes(tenant?.storage?.dataStorageBytes ?? 0)}</div>
           </div>
           <div class="stat-card">
             <div class="label">Protocols</div>
@@ -296,24 +296,24 @@ function TenantDetail({ did }: { did: string }) {
         <div class="card">
           <div class="card-header">
             <h3>Quota</h3>
-            <span class={`badge ${quota.source === 'unlimited' ? 'badge-muted' : 'badge-info'}`}>
-              {quota.source ?? 'unknown'}
+            <span class={`badge ${quota.quota?.source === 'unlimited' ? 'badge-muted' : 'badge-info'}`}>
+              {quota.quota?.source ?? 'unknown'}
             </span>
           </div>
-          {quota.source !== 'unlimited' && (
+          {quota.quota?.source !== 'unlimited' && (
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
-              {quota.limits?.maxMessages !== undefined && (
+              {quota.quota?.maxMessages !== undefined && (
                 <div>
                   <div style="font-size:12px;color:var(--color-text-muted);margin-bottom:4px">Messages</div>
                   <div style="font-size:13px">
-                    {formatNumber(quota.usage?.messages ?? 0)} / {formatNumber(quota.limits.maxMessages)}
+                    {formatNumber(quota.usage?.messageCount ?? 0)} / {formatNumber(quota.quota.maxMessages)}
                   </div>
                   <div style="background:var(--color-border);border-radius:4px;height:6px;margin-top:6px;overflow:hidden">
                     <div
                       style={{
-                        width      : `${Math.min(100, ((quota.usage?.messages ?? 0) / quota.limits.maxMessages) * 100)}%`,
+                        width      : `${Math.min(100, ((quota.usage?.messageCount ?? 0) / quota.quota.maxMessages) * 100)}%`,
                         height     : '100%',
-                        background : ((quota.usage?.messages ?? 0) / quota.limits.maxMessages) > 0.9
+                        background : ((quota.usage?.messageCount ?? 0) / quota.quota.maxMessages) > 0.9
                           ? 'var(--color-danger)'
                           : 'var(--color-primary)',
                         borderRadius: '4px',
@@ -322,18 +322,18 @@ function TenantDetail({ did }: { did: string }) {
                   </div>
                 </div>
               )}
-              {quota.limits?.maxStorageBytes !== undefined && (
+              {quota.quota?.maxStorageBytes !== undefined && (
                 <div>
                   <div style="font-size:12px;color:var(--color-text-muted);margin-bottom:4px">Storage</div>
                   <div style="font-size:13px">
-                    {formatBytes(quota.usage?.storageBytes ?? 0)} / {formatBytes(quota.limits.maxStorageBytes)}
+                    {formatBytes(quota.usage?.storageBytes ?? 0)} / {formatBytes(quota.quota.maxStorageBytes)}
                   </div>
                   <div style="background:var(--color-border);border-radius:4px;height:6px;margin-top:6px;overflow:hidden">
                     <div
                       style={{
-                        width      : `${Math.min(100, ((quota.usage?.storageBytes ?? 0) / quota.limits.maxStorageBytes) * 100)}%`,
+                        width      : `${Math.min(100, ((quota.usage?.storageBytes ?? 0) / quota.quota.maxStorageBytes) * 100)}%`,
                         height     : '100%',
-                        background : ((quota.usage?.storageBytes ?? 0) / quota.limits.maxStorageBytes) > 0.9
+                        background : ((quota.usage?.storageBytes ?? 0) / quota.quota.maxStorageBytes) > 0.9
                           ? 'var(--color-danger)'
                           : 'var(--color-primary)',
                         borderRadius: '4px',


### PR DESCRIPTION
## Summary

- Fix field name mismatches between admin dashboard UI views and the actual admin API response shapes, which caused zeros/empty data to display throughout the dashboard

### Overview.tsx
- **Stats**: `stats.messages?.total` → `stats.storage?.totalMessages`, `stats.storage?.totalBytes` → `stats.storage?.totalDataBytes`, `stats.protocols?.count` → `stats.storage?.totalProtocols`
- **WebSocket**: `stats.websocket?.active` → `stats.connections?.websocket?.active` (and subscriptions)
- **Rate limits**: `rateLimits.perIp?.enabled` → `rateLimits.config?.perIp?.enabled`, `.rps` → `.requestsPerSecond`, `rateLimits.perIp?.activeEntries` → `rateLimits.activeEntries?.ip` (same pattern for perTenant)
- **Health checks**: API returns `checks` as `Record<string, {status, latencyMs}>` (object keyed by name), not an array — converted to `Object.entries()` iteration; fixed `check.latency` → `check.latencyMs`

### Tenants.tsx
- **List view**: `tenants?.tenants` → `tenants?.data` (PaginatedResponse), `t.storageBytes` → `t.dataStorageBytes`
- **Detail view**: `tenant.active` → `tenant.isActive`, `tenant?.messageCount` → `tenant?.storage?.messageCount`, `tenant?.storageBytes` → `tenant?.storage?.dataStorageBytes`
- **Quota card**: `quota.source` → `quota.quota?.source`, `quota.limits?.maxMessages` → `quota.quota?.maxMessages`, `quota.usage?.messages` → `quota.usage?.messageCount`