### PR TITLE
fix(security): harden HTTP API and JWE decryption against common attack vectors

### DIFF
--- a/packages/agent/src/hd-identity-vault.ts
+++ b/packages/agent/src/hd-identity-vault.ts
@@ -250,7 +250,8 @@ export class HdIdentityVault implements IdentityVault<{ InitializeResult: string
         jwe        : cekJwe,
         key        : Convert.string(oldPassword).toUint8Array(),
         crypto     : this.crypto,
-        keyManager : new LocalKeyManager()
+        keyManager : new LocalKeyManager(),
+        options    : { minP2cCount: 1 }, // Vault decrypts its own JWEs; no external-input floor needed.
       }));
       contentEncryptionKey = Convert.uint8Array(contentEncryptionKeyBytes).toObject() as Jwk;
 
@@ -297,7 +298,8 @@ export class HdIdentityVault implements IdentityVault<{ InitializeResult: string
       jwe        : didJwe,
       key        : this._contentEncryptionKey!,
       crypto     : this.crypto,
-      keyManager : new LocalKeyManager()
+      keyManager : new LocalKeyManager(),
+      options    : { minP2cCount: 1 }, // Vault decrypts its own JWEs; no external-input floor needed.
     });
 
     // Convert the DID from a byte array to PortableDid format.
@@ -759,7 +761,8 @@ export class HdIdentityVault implements IdentityVault<{ InitializeResult: string
         jwe        : cekJwe,
         key        : Convert.string(password).toUint8Array(),
         crypto     : this.crypto,
-        keyManager : new LocalKeyManager()
+        keyManager : new LocalKeyManager(),
+        options    : { minP2cCount: 1 }, // Vault decrypts its own JWEs; no external-input floor needed.
       });
       const contentEncryptionKey = Convert.uint8Array(contentEncryptionKeyBytes).toObject() as Jwk;
 

--- a/packages/agent/src/prototyping/crypto/jose/jwe-flattened.ts
+++ b/packages/agent/src/prototyping/crypto/jose/jwe-flattened.ts
@@ -270,7 +270,10 @@ export class FlattenedJwe {
         ? Convert.base64Url(jwe.encrypted_key).toUint8Array()
         : undefined;
 
-      cek = await JweKeyManagement.decrypt({ key, encryptedKey, joseHeader, keyManager, crypto });
+      cek = await JweKeyManagement.decrypt(
+        { key, encryptedKey, joseHeader, keyManager, crypto },
+        { minP2cCount: options.minP2cCount }
+      );
 
     } catch (error: any) {
       // If the error is a CryptoError with code "InvalidJwe" or "AlgorithmNotSupported", re-throw.

--- a/packages/agent/src/prototyping/crypto/jose/jwe.ts
+++ b/packages/agent/src/prototyping/crypto/jose/jwe.ts
@@ -33,6 +33,15 @@ export interface JweDecryptOptions {
    *
    */
   allowedEncValues?: string[];
+
+  /**
+   * Minimum acceptable PBES2 iteration count ("p2c") for key derivation during decryption.
+   * Per RFC 7518 Section 4.8.1.2, a minimum of 1000 is RECOMMENDED. Set to a lower value
+   * only for test environments where speed is prioritized over security.
+   *
+   * @default 1000
+   */
+  minP2cCount?: number;
 }
 
 /**
@@ -281,11 +290,12 @@ export interface JweKeyManagementDecryptParams<TKeyManager, TCrypto> {
    */
   joseHeader: JweHeaderParams;
 
-  /** Key Manager instanceß responsible for managing cryptographic keys. */
+  /** Key Manager instance responsible for managing cryptographic keys. */
   keyManager: TKeyManager;
 
   /** Crypto API instance that provides the necessary cryptographic operations. */
   crypto: TCrypto;
+
 }
 
 /**
@@ -424,8 +434,10 @@ export class JweKeyManagement {
    */
   public static async decrypt<TKeyManager extends KeyManager, TCrypto extends CryptoApi>({
     key, encryptedKey, joseHeader, crypto
-  }: JweKeyManagementDecryptParams<TKeyManager, TCrypto>
+  }: JweKeyManagementDecryptParams<TKeyManager, TCrypto>,
+  options?: { minP2cCount?: number }
   ): Promise<KeyIdentifier | Jwk> {
+    const minP2cCount = options?.minP2cCount ?? 1000;
     // Determine the Key Management Mode employed by the algorithm specified by the "alg"
     // (algorithm) Header Parameter.
     switch (joseHeader.alg) {
@@ -458,6 +470,16 @@ export class JweKeyManagement {
 
         if (typeof joseHeader.p2c !== 'number') {
           throw new CryptoError(CryptoErrorCode.InvalidJwe, 'JOSE Header "p2c" (PBES2 Count) is missing or not a number.');
+        }
+
+        // Per RFC 7518, Section 4.8.1.2, a minimum iteration count of 1000 is RECOMMENDED.
+        // Enforce this floor to prevent an attacker from supplying a crafted JWE with a
+        // trivially low iteration count that would weaken key derivation.
+        if (joseHeader.p2c < minP2cCount) {
+          throw new CryptoError(
+            CryptoErrorCode.InvalidJwe,
+            `JOSE Header "p2c" (PBES2 Count) is ${joseHeader.p2c}, which is below the minimum of ${minP2cCount}.`
+          );
         }
 
         if (typeof joseHeader.p2s !== 'string') {

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -27,8 +27,12 @@ import { existsSync, readFileSync } from 'fs';
 
 import { config } from './config.js';
 import { jsonRpcRouter } from './json-rpc-api.js';
+import { validateAdminAuth } from './admin/admin-auth.js';
 import { Web5ConnectServer } from './web5-connect/web5-connect-server.js';
 import { requestCounter, responseHistogram } from './metrics.js';
+
+/** Property names that must never be used as keys when building objects from user input. */
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 // Resolve admin UI dist path at module load time. Gracefully handle the case
 // where the admin UI package is not installed.
@@ -79,7 +83,7 @@ export class HttpApi {
   ): Promise<HttpApi> {
     const httpApi = new HttpApi();
 
-    log.info(config);
+    log.info(HttpApi.#redactConfig(config));
 
     httpApi.#packageInfo = {
       server: config.serverName,
@@ -184,10 +188,15 @@ export class HttpApi {
         }
 
         // --- CORS headers ---
-        response.headers.set('access-control-allow-origin', '*');
-        response.headers.set('access-control-allow-methods', 'GET, POST, OPTIONS');
-        response.headers.set('access-control-allow-headers', '*');
-        response.headers.set('access-control-expose-headers', 'dwn-response');
+        // Admin API and metrics endpoints do not receive wildcard CORS headers
+        // to limit cross-origin access when the admin token is configured.
+        const isAdminRoute = path.startsWith('/admin') || path === '/metrics';
+        if (!isAdminRoute) {
+          response.headers.set('access-control-allow-origin', '*');
+          response.headers.set('access-control-allow-methods', 'GET, POST, OPTIONS');
+          response.headers.set('access-control-allow-headers', '*');
+          response.headers.set('access-control-expose-headers', 'dwn-response');
+        }
 
         // --- Response-time metrics ---
         const elapsed = performance.now() - startTime;
@@ -285,6 +294,13 @@ export class HttpApi {
     }
 
     if (method === 'GET' && path === '/metrics') {
+      // Metrics require admin authentication when an admin token is configured.
+      if (this.#config.adminToken) {
+        const authError = validateAdminAuth(req, this.#config);
+        if (authError) {
+          return authError;
+        }
+      }
       try {
         const metricsBody = await register.metrics();
         return new Response(metricsBody, {
@@ -406,6 +422,38 @@ export class HttpApi {
     }
 
     return new Response('Not Found', { status: 404 });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Security helpers
+  // ---------------------------------------------------------------------------
+
+  /** Returns `true` if the given key is a prototype-pollution-dangerous property name. */
+  static #isDangerousKey(key: string | undefined): boolean {
+    return key !== undefined && DANGEROUS_KEYS.has(key);
+  }
+
+  /** Returns `true` if any element in `keys` is a dangerous property name. */
+  static #hasDangerousKey(keys: string[]): boolean {
+    return keys.some(k => DANGEROUS_KEYS.has(k));
+  }
+
+  /** Returns a shallow copy of the config with sensitive values redacted for logging. */
+  static #redactConfig(cfg: DwnServerConfig): Record<string, unknown> {
+    const redacted: Record<string, unknown> = { ...cfg };
+    const sensitiveKeys = ['adminToken', 'providerAuthJwtSecret'];
+    for (const key of sensitiveKeys) {
+      if (redacted[key]) {
+        redacted[key] = '[REDACTED]';
+      }
+    }
+    // Redact passwords in connection-string-like values.
+    for (const [key, value] of Object.entries(redacted)) {
+      if (typeof value === 'string' && /^(?:postgres|mysql|sqlite):\/\//.test(value) && value.includes('@')) {
+        redacted[key] = value.replace(/:\/\/([^:]+):([^@]+)@/, '://$1:****@');
+      }
+    }
+    return redacted;
   }
 
   // ---------------------------------------------------------------------------
@@ -557,6 +605,9 @@ export class HttpApi {
       for (const [param, value] of url.searchParams) {
         const keys = param.split('.');
         const lastKey = keys.pop();
+        if (HttpApi.#hasDangerousKey(keys) || HttpApi.#isDangerousKey(lastKey)) {
+          continue;
+        }
         const nestObj = (obj: Record<string, any>, key: string): Record<string, any> =>
           obj[key] = obj[key] || {};
         const lastLevelObject = keys.reduce(nestObj, queryOptions);
@@ -638,6 +689,9 @@ export class HttpApi {
       for (const [param, value] of url.searchParams) {
         const keys = param.split('.');
         const lastKey = keys.pop();
+        if (HttpApi.#hasDangerousKey(keys) || HttpApi.#isDangerousKey(lastKey)) {
+          continue;
+        }
         const nestObj = (obj: Record<string, any>, key: string): Record<string, any> =>
           obj[key] = obj[key] || {};
         const lastLevelObject = keys.reduce(nestObj, recordsQueryOptions);

--- a/packages/dwn-server/tests/admin/admin-api.test.ts
+++ b/packages/dwn-server/tests/admin/admin-api.test.ts
@@ -608,7 +608,10 @@ describe('Enhanced Prometheus metrics', () => {
     await dwnServer.start();
 
     try {
-      const response = await fetch(`http://localhost:${port}/metrics`);
+      // Metrics now require admin auth when an admin token is configured.
+      const response = await fetch(`http://localhost:${port}/metrics`, {
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
       expect(response.status).toBe(200);
       const metricsText = await response.text();
 


### PR DESCRIPTION
## Summary

Security hardening based on a comprehensive audit of the codebase. Fixes **2 HIGH** and **3 MEDIUM** severity vulnerabilities.

### HIGH severity

- **Prototype pollution via query parameters** — unauthenticated HTTP GET endpoints (`/read/protocols` and `/query/records`) parsed dot-delimited query params into nested objects without filtering dangerous keys like `__proto__`, `constructor`, `prototype`. An attacker could pollute `Object.prototype` for the entire process. Now silently skips dangerous keys.
- **Secrets logged at startup** — `log.info(config)` dumped the full config including `adminToken`, `providerAuthJwtSecret`, and database passwords in connection strings. Now uses `#redactConfig()` to replace sensitive values with `[REDACTED]` / `****`.

### MEDIUM severity

- **Wildcard CORS on admin routes** — `Access-Control-Allow-Origin: *` was applied globally including `/admin/api/*` and `/metrics`. Now restricted to DWN protocol endpoints only; admin routes no longer receive wildcard CORS headers.
- **Unauthenticated `/metrics` endpoint** — Prometheus metrics (tenant counts, request counts, data sizes) were exposed without authentication. Now requires admin bearer token when `adminToken` is configured; falls back to open when no token is set (backward compatible).
- **No minimum PBES2 iteration count on JWE decryption** — `JweKeyManagement.decrypt()` accepted any `p2c` value including `1`, allowing an attacker who can supply a crafted JWE to force trivially weak key derivation. Now enforces `p2c >= 1000` by default (configurable via `minP2cCount` option per RFC 7518 Section 4.8.1.2). Internal vault decryption passes `minP2cCount: 1` since it decrypts its own JWEs.

### Files changed

| File | Changes |
|------|---------|
| `packages/dwn-server/src/http-api.ts` | Prototype pollution guard, config redaction, CORS restriction, metrics auth |
| `packages/agent/src/prototyping/crypto/jose/jwe.ts` | `minP2cCount` option + enforcement |
| `packages/agent/src/prototyping/crypto/jose/jwe-flattened.ts` | Pass `minP2cCount` through to key management |
| `packages/agent/src/hd-identity-vault.ts` | Pass `minP2cCount: 1` for internal vault JWE decryption |
| `packages/dwn-server/tests/admin/admin-api.test.ts` | Update metrics test to pass admin auth header |

### Remaining issues filed

17 additional findings (6 MEDIUM, 11 LOW) were filed as GitHub issues: #462 — #478

### Testing

- `bun run lint` — 0 errors
- `bun run --filter @enbox/dwn-server build` — pass
- `bun run --filter @enbox/agent build` — pass
- `dwn-server` tests: **388 pass / 0 fail**
- `agent` vault tests: **70 pass / 0 fail**