### PR TITLE
fix(dwn-server): prevent error leakage, reduce default record size, cap pending auth codes

### DIFF
--- a/packages/dwn-server/src/config.ts
+++ b/packages/dwn-server/src/config.ts
@@ -40,8 +40,14 @@ export const config = {
    * Otherwise we resort to the path within the docker server image, located at `/dwn-server/package.json`.
    */
   packageJsonPath   : process.env.DWN_SERVER_PACKAGE_JSON || '/dwn-server/package.json',
-  // max size of data that can be provided with a RecordsWrite
-  maxRecordDataSize : bytes(process.env.MAX_RECORD_DATA_SIZE || '1gb'),
+  /**
+   * Maximum size of data that can be provided with a RecordsWrite.
+   * Request bodies up to this size are buffered fully into memory, so the
+   * default should be conservative enough to prevent memory exhaustion from
+   * concurrent large uploads. Operators can raise the limit via the
+   * `MAX_RECORD_DATA_SIZE` env var (e.g. `'1gb'`).
+   */
+  maxRecordDataSize : bytes(process.env.MAX_RECORD_DATA_SIZE || '100mb'),
 
   /**
    * Maximum number of unacknowledged subscription events the server will send

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -239,6 +239,9 @@ export class HttpApi {
   }
 
   async close(): Promise<void> {
+    if (this.#openAuthHandler) {
+      this.#openAuthHandler.destroy();
+    }
     if (this.#server) {
       this.#server.stop(true); // close all connections immediately
     }
@@ -709,7 +712,8 @@ export class HttpApi {
         headers: { 'content-type': 'application/json' },
       });
     } catch (error) {
-      return Response.json(error, { status: 400 });
+      log.error('Error processing query records request', error);
+      return Response.json({ error: 'Bad Request' }, { status: 400 });
     }
   }
 
@@ -734,7 +738,7 @@ export class HttpApi {
     if (method === 'POST' && path === '/registration'
       && this.#config.registrationStoreUrl !== undefined) {
       const requestBody = await req.json();
-      log.info('Registration request:', requestBody);
+      log.info('Registration request received');
 
       try {
         await this.registrationManager.handleRegistrationRequest(requestBody);

--- a/packages/dwn-server/src/json-rpc-handlers/dwn/process-message.ts
+++ b/packages/dwn-server/src/json-rpc-handlers/dwn/process-message.ts
@@ -159,14 +159,16 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (
 
     return responsePayload;
   } catch (error) {
+    // Log the full error internally but return a generic message to the client
+    // to avoid leaking implementation details (SQL errors, file paths, etc.).
+    log.error('handleDwnProcessMessage error', error);
+
     const jsonRpcResponse = createJsonRpcErrorResponse(
       requestId,
       JsonRpcErrorCodes.InternalError,
-      error.message,
+      'an unexpected error occurred while processing the message',
     );
 
-    // log the unhandled error response
-    log.error('handleDwnProcessMessage error', jsonRpcResponse, dwnRequest, error);
     return { jsonRpcResponse } as HandlerResponse;
   }
 };

--- a/packages/dwn-server/src/registration/open-auth-handler.ts
+++ b/packages/dwn-server/src/registration/open-auth-handler.ts
@@ -18,6 +18,15 @@ import log from 'loglevel';
  * The JWTs issued here are verified by {@link JwtProviderAuthPlugin} using
  * the same shared secret (`DWN_PROVIDER_AUTH_JWT_SECRET`).
  */
+/**
+ * Maximum number of pending authorization codes held in memory.
+ * When the limit is reached, new authorize requests are rejected with 503.
+ */
+const MAX_PENDING_CODES = 10_000;
+
+/** Interval (ms) at which expired authorization codes are purged. */
+const CLEANUP_INTERVAL_MS = 60_000;
+
 export class OpenAuthHandler {
   #secret: Uint8Array;
   #issuer: string;
@@ -25,12 +34,22 @@ export class OpenAuthHandler {
   #pendingCodes: Map<string, { redirectUri: string; expiresAt: number }>;
   /** Registration token TTL in seconds. Default: 1 year. */
   #tokenTtlSeconds: number;
+  /** Periodic cleanup timer for expired codes. */
+  #cleanupTimer: ReturnType<typeof setInterval>;
 
   private constructor(secret: Uint8Array, issuer: string, tokenTtlSeconds: number) {
     this.#secret = secret;
     this.#issuer = issuer;
     this.#pendingCodes = new Map();
     this.#tokenTtlSeconds = tokenTtlSeconds;
+
+    // Periodically purge expired codes so memory does not grow unbounded
+    // even when no new authorize requests arrive.
+    this.#cleanupTimer = setInterval(() => this.#cleanExpiredCodes(), CLEANUP_INTERVAL_MS);
+    // Allow the process to exit even if the timer is still running.
+    if (this.#cleanupTimer.unref) {
+      this.#cleanupTimer.unref();
+    }
   }
 
   /**
@@ -63,6 +82,15 @@ export class OpenAuthHandler {
       return Response.json(
         { error: 'missing redirect_uri parameter' },
         { status: 400 },
+      );
+    }
+
+    // Reject new codes when the map is at capacity to prevent memory exhaustion.
+    if (this.#pendingCodes.size >= MAX_PENDING_CODES) {
+      log.warn(`OpenAuthHandler: pending codes map is full (${MAX_PENDING_CODES}), rejecting authorize request`);
+      return Response.json(
+        { error: 'server is busy, try again later' },
+        { status: 503 },
       );
     }
 
@@ -215,6 +243,12 @@ export class OpenAuthHandler {
       .setIssuedAt()
       .setExpirationTime(`${ttlSeconds}s`)
       .sign(this.#secret);
+  }
+
+  /** Stops the periodic cleanup timer and clears all pending codes. */
+  public destroy(): void {
+    clearInterval(this.#cleanupTimer);
+    this.#pendingCodes.clear();
   }
 
   /** Remove expired authorization codes from the pending map. */

--- a/packages/dwn-server/tests/dwn-process-message.test.ts
+++ b/packages/dwn-server/tests/dwn-process-message.test.ts
@@ -239,7 +239,8 @@ describe('handleDwnProcessMessage', () => {
 
     expect(jsonRpcResponse.error).toBeDefined();
     expect(jsonRpcResponse.error.code).toBe(JsonRpcErrorCodes.InternalError);
-    expect(jsonRpcResponse.error.message).toBe('unexpected error');
+    // The handler returns a generic message instead of the raw error to avoid leaking internals.
+    expect(jsonRpcResponse.error.message).toBe('an unexpected error occurred while processing the message');
     await dwn.close();
   });
 

--- a/packages/dwn-server/tests/http-api.test.ts
+++ b/packages/dwn-server/tests/http-api.test.ts
@@ -1,4 +1,4 @@
-import type { Dwn, DwnError, Persona, ProtocolsConfigureMessage, RecordsQueryReply } from '@enbox/dwn-sdk-js';
+import type { Dwn, Persona, ProtocolsConfigureMessage, RecordsQueryReply } from '@enbox/dwn-sdk-js';
 import type { JsonRpcErrorResponse, JsonRpcResponse } from '@enbox/dwn-clients';
 
 import { Convert } from '@enbox/common';
@@ -8,7 +8,6 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { v4 as uuidv4 } from 'uuid';
 import {
   DataStream,
-  DwnErrorCode,
   ProtocolsConfigure,
   RecordsQuery,
   TestDataGenerator,
@@ -921,8 +920,8 @@ describe('http api', function () {
       );
       expect(response.status).toBe(400);
 
-      const responseBody = await response.json() as DwnError;
-      expect(responseBody.code).toBe(DwnErrorCode.SchemaValidatorAdditionalPropertyNotAllowed);
+      const responseBody = await response.json();
+      expect(responseBody.error).toBe('Bad Request');
     });
   });
 


### PR DESCRIPTION
## Summary

Three security hardening fixes for `dwn-server`, all MEDIUM severity from the audit.

### 1. Prevent internal error message leakage (#467)

**Before:** Unhandled exceptions returned raw `error.message` to clients via JSON-RPC, and `#handleQueryRecords` serialized the entire error object as the response body. Registration request bodies (potentially containing auth tokens) were logged verbatim.

**After:**
- `handleDwnProcessMessage` returns `"an unexpected error occurred while processing the message"` — full error is still logged server-side
- `#handleQueryRecords` returns `{ error: "Bad Request" }` instead of the raw error object
- Registration handler logs `"Registration request received"` instead of the full request body

### 2. Reduce default max record data size (#465)

**Before:** `maxRecordDataSize` defaulted to `1gb`. Since request bodies are fully buffered via `new Uint8Array(await req.arrayBuffer())`, a handful of concurrent 1GB uploads could OOM the server.

**After:** Default is `100mb`. Operators can raise via `MAX_RECORD_DATA_SIZE` env var.

### 3. Cap unbounded pending auth codes map (#466)

**Before:** The `#pendingCodes` map in `OpenAuthHandler` grew without bound. Expired code cleanup only ran when a new code was issued. An attacker flooding `/provider-auth/authorize` could exhaust memory.

**After:**
- Map capped at 10,000 entries; returns `503 Service Unavailable` when full
- Periodic cleanup timer (60s) purges expired codes independently of request flow
- `destroy()` method added and wired into `HttpApi.close()` for clean shutdown
- Timer is `unref()`'d so it doesn't prevent process exit

### Files changed

| File | Changes |
|------|---------|
| `src/json-rpc-handlers/dwn/process-message.ts` | Generic error message in catch block |
| `src/http-api.ts` | Generic error in query handler, redacted registration log, destroy handler on close |
| `src/config.ts` | `maxRecordDataSize` default `1gb` → `100mb` |
| `src/registration/open-auth-handler.ts` | Map cap, periodic cleanup timer, `destroy()` |
| `tests/dwn-process-message.test.ts` | Updated assertion for generic error message |
| `tests/http-api.test.ts` | Updated assertion for generic error response, removed unused imports |

### Testing

- `dwn-server`: **388 pass / 0 fail**
- Lint: clean
- Build: clean

Closes #465, #466, #467