### PR TITLE
fix(security): add fetch timeouts and SSRF protection for did:web resolution

### DIFF
--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -84,6 +84,7 @@ async function initClient({
     headers : {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
+    signal: AbortSignal.timeout(30_000),
   });
 
   if (!parResponse.ok) {
@@ -112,7 +113,7 @@ async function initClient({
   });
 
   // subscribe to receiving a response from the wallet with default TTL. receive ciphertext of {@link Web5ConnectAuthResponse}
-  const authResponse = await pollWithTtl(() => fetch(tokenUrl));
+  const authResponse = await pollWithTtl(() => fetch(tokenUrl, { signal: AbortSignal.timeout(30_000) }));
 
   if (authResponse) {
     const jwe = await authResponse?.text();

--- a/packages/agent/src/oidc.ts
+++ b/packages/agent/src/oidc.ts
@@ -410,7 +410,7 @@ async function verifyJwt({ jwt }: { jwt: string }): Promise<Record<string, unkno
  * using the encryption key passed via QR code.
  */
 const getAuthRequest = async (request_uri: string, encryption_key: string): Promise<Web5ConnectAuthRequest> => {
-  const authRequest = await fetch(request_uri);
+  const authRequest = await fetch(request_uri, { signal: AbortSignal.timeout(30_000) });
   const jwe = await authRequest.text();
   const jwt = await decryptAuthRequest({
     jwe,
@@ -832,6 +832,7 @@ async function submitAuthResponse(
     headers : {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
+    signal: AbortSignal.timeout(30_000),
   });
 }
 

--- a/packages/dids/src/methods/did-dht-pkarr.ts
+++ b/packages/dids/src/methods/did-dht-pkarr.ts
@@ -44,7 +44,7 @@ export async function pkarrGet({ gatewayUri, publicKeyBytes }: {
   // Transmit the Get request to the DID DHT Gateway or Pkarr Relay and get the response.
   let response: Response;
   try {
-    response = await fetch(url, { method: 'GET' });
+    response = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(30_000) });
 
     if (!response.ok) {
       throw new DidError(DidErrorCode.NotFound, `Pkarr record not found for: ${identifier}`);
@@ -113,7 +113,8 @@ export async function pkarrPut({ gatewayUri, bep44Message }: {
     response = await fetch(url, {
       method  : 'PUT',
       headers : { 'Content-Type': 'application/octet-stream' },
-      body
+      body,
+      signal  : AbortSignal.timeout(30_000),
     });
 
   } catch (error: any) {

--- a/packages/dids/src/methods/did-ion.ts
+++ b/packages/dids/src/methods/did-ion.ts
@@ -600,7 +600,8 @@ export class DidIon extends DidMethod {
         method  : 'POST',
         mode    : 'cors',
         headers : { 'Content-Type': 'application/json' },
-        body    : JSON.stringify(createOperation)
+        body    : JSON.stringify(createOperation),
+        signal  : AbortSignal.timeout(30_000),
       });
 
       // Return the result of processing the Create operation, including the updated DID metadata
@@ -681,7 +682,7 @@ export class DidIon extends DidMethod {
       });
 
       // Attempt to retrieve the DID document and metadata from the Sidetree node.
-      const response = await fetch(resolutionUrl);
+      const response = await fetch(resolutionUrl, { signal: AbortSignal.timeout(30_000) });
 
       // If the DID document was not found, return an error.
       if (!response.ok) {

--- a/packages/dids/src/methods/did-web.ts
+++ b/packages/dids/src/methods/did-web.ts
@@ -4,6 +4,46 @@ import { Did } from '../did.js';
 import { DidMethod } from './did-method.js';
 import { EMPTY_DID_RESOLUTION_RESULT } from '../types/did-resolution.js';
 
+/** Default fetch timeout for DID document retrieval (30 seconds). */
+const FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Returns `true` when the hostname is a private, loopback, or link-local
+ * address.  Used to block SSRF via crafted `did:web` identifiers such as
+ * `did:web:169.254.169.254` or `did:web:localhost`.
+ */
+function isPrivateHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+
+  if (h === 'localhost' || h === 'localhost.') { return true; }
+
+  // IPv4 literal check
+  const parts = h.split('.');
+  if (parts.length === 4) {
+    const octets = parts.map(Number);
+    if (octets.every((o) => !Number.isNaN(o) && o >= 0 && o <= 255)) {
+      const [a, b] = octets;
+      if (a === 10) { return true; } // 10.0.0.0/8
+      if (a === 172 && b >= 16 && b <= 31) { return true; } // 172.16.0.0/12
+      if (a === 192 && b === 168) { return true; } // 192.168.0.0/16
+      if (a === 127) { return true; } // 127.0.0.0/8
+      if (a === 169 && b === 254) { return true; } // 169.254.0.0/16
+      if (a === 0) { return true; } // 0.0.0.0/8
+    }
+  }
+
+  // IPv6 literal check (bracket-wrapped by URL parser)
+  let v6 = h;
+  if (v6.startsWith('[') && v6.endsWith(']')) { v6 = v6.slice(1, -1); }
+  if (v6.includes(':')) {
+    if (v6 === '::1' || v6 === '::' || v6 === '::0') { return true; }
+    if (v6.startsWith('fe80:') || v6.startsWith('fe80%')) { return true; }
+    if (v6.startsWith('fc') || v6.startsWith('fd')) { return true; }
+  }
+
+  return false;
+}
+
 /**
  * The `DidWeb` class provides an implementation of the `did:web` DID method.
  *
@@ -71,8 +111,19 @@ export class DidWeb extends DidMethod {
       `${baseUrl}/.well-known/did.json`;
 
     try {
+      // Block requests to private/loopback/link-local addresses (SSRF protection).
+      const parsedUrl = new URL(didDocumentUrl);
+      if (isPrivateHostname(parsedUrl.hostname)) {
+        return {
+          ...EMPTY_DID_RESOLUTION_RESULT,
+          didResolutionMetadata: { error: 'notFound' }
+        };
+      }
+
       // Perform an HTTP GET request to obtain the DID document.
-      const response = await fetch(didDocumentUrl);
+      const response = await fetch(didDocumentUrl, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
 
       // If the response status code is not 200, return an error.
       if (!response.ok) {throw new Error('HTTP error status code returned');}

--- a/packages/dids/tests/methods/did-ion.test.ts
+++ b/packages/dids/tests/methods/did-ion.test.ts
@@ -669,7 +669,8 @@ describe('DidIon', () => {
 
       expect(resolutionResult).toEqual(mockResult);
       expect(fetchStub).toHaveBeenCalledWith(
-        `https://dev.uniresolver.io/1.0/identifiers/${didUri}`
+        `https://dev.uniresolver.io/1.0/identifiers/${didUri}`,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
       expect(fetchStub).toHaveBeenCalledTimes(1);
     });

--- a/packages/dwn-clients/src/dwn-registrar.ts
+++ b/packages/dwn-clients/src/dwn-registrar.ts
@@ -21,7 +21,8 @@ export class DwnRegistrar {
 
     // fetch the terms-of-service
     const termsOfServiceGetResponse = await fetch(termsOfUseEndpoint, {
-      method: 'GET',
+      method : 'GET',
+      signal : AbortSignal.timeout(30_000),
     });
 
     if (termsOfServiceGetResponse.status !== 200) {
@@ -34,7 +35,8 @@ export class DwnRegistrar {
 
     // fetch the proof-of-work challenge
     const proofOfWorkChallengeGetResponse = await fetch(proofOfWorkEndpoint, {
-      method: 'GET',
+      method : 'GET',
+      signal : AbortSignal.timeout(30_000),
     });
     const { challengeNonce, maximumAllowedHashValue }: ProofOfWorkChallengeModel =
       await proofOfWorkChallengeGetResponse.json();
@@ -65,6 +67,7 @@ export class DwnRegistrar {
       method  : 'POST',
       headers : { 'Content-Type': 'application/json' },
       body    : JSON.stringify(registrationRequest),
+      signal  : AbortSignal.timeout(30_000),
     });
 
     if (registrationResponse.status !== 200) {
@@ -149,6 +152,7 @@ export class DwnRegistrar {
         code,
         redirectUri,
       }),
+      signal: AbortSignal.timeout(30_000),
     });
 
     if (response.status !== 200) {
@@ -177,6 +181,7 @@ export class DwnRegistrar {
         grantType: 'refresh_token',
         refreshToken,
       }),
+      signal: AbortSignal.timeout(30_000),
     });
 
     if (response.status !== 200) {
@@ -216,6 +221,7 @@ export class DwnRegistrar {
       method  : 'POST',
       headers : { 'Content-Type': 'application/json' },
       body    : JSON.stringify(registrationRequest),
+      signal  : AbortSignal.timeout(30_000),
     });
 
     if (response.status !== 200) {

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -44,6 +44,7 @@ export class HttpDwnRpcClient implements DwnRpc {
       (fetchOpts as Record<string, unknown>).duplex = 'half';
     }
 
+    fetchOpts.signal = AbortSignal.timeout(30_000);
     const resp = await fetch(request.dwnUrl, fetchOpts);
     let dwnRpcResponse: JsonRpcResponse;
 
@@ -108,7 +109,7 @@ export class HttpDwnRpcClient implements DwnRpc {
     url.pathname.endsWith('/') ? url.pathname += 'info' : url.pathname += '/info';
 
     try {
-      const response = await fetch(url.toString());
+      const response = await fetch(url.toString(), { signal: AbortSignal.timeout(30_000) });
       if (response.ok) {
         const results = await response.json() as ServerInfo;
 

--- a/packages/dwn-clients/src/rpc-client.ts
+++ b/packages/dwn-clients/src/rpc-client.ts
@@ -128,7 +128,7 @@ export class HttpWeb5RpcClient extends HttpDwnRpcClient implements Web5Rpc {
     let jsonRpcResponse: JsonRpcResponse;
 
     try {
-      const response = await fetch(httpRequest);
+      const response = await fetch(httpRequest, { signal: AbortSignal.timeout(30_000) });
 
       if (response.ok) {
         jsonRpcResponse = await response.json();

--- a/packages/dwn-server/src/admin/webhook-manager.ts
+++ b/packages/dwn-server/src/admin/webhook-manager.ts
@@ -200,7 +200,7 @@ export class WebhookManager {
 
     for (let attempt = 0; attempt <= WebhookManager.#maxRetries; attempt++) {
       try {
-        const response = await fetch(url, { method: 'POST', headers, body });
+        const response = await fetch(url, { method: 'POST', headers, body, signal: AbortSignal.timeout(10_000) });
         if (response.ok) {
           return;
         }


### PR DESCRIPTION
## Summary

- Add `AbortSignal.timeout(30_000)` to **all 17 external `fetch()` calls** across `dids`, `dwn-clients`, `agent`, and `dwn-server` to prevent indefinite hangs from unresponsive remote servers
- Block `did:web` resolution requests to private/loopback/link-local IP addresses (RFC 1918/3927/5735) to prevent SSRF via crafted DIDs like `did:web:169.254.169.254` or `did:web:localhost`
- Webhook delivery uses a 10s timeout (vs 30s default) since it already has 4-attempt retry logic with exponential backoff

## Changes by package

| Package | File | Change |
|---|---|---|
| `@enbox/dids` | `did-web.ts` | SSRF guard (`isPrivateHostname`) + 30s timeout |
| `@enbox/dids` | `did-dht-pkarr.ts` | 30s timeout on GET + PUT |
| `@enbox/dids` | `did-ion.ts` | 30s timeout on publish + resolve |
| `@enbox/dids` | `did-ion.test.ts` | Updated mock assertion for new `signal` param |
| `@enbox/dwn-clients` | `http-dwn-rpc-client.ts` | 30s timeout on sendDwnRequest + getServerInfo |
| `@enbox/dwn-clients` | `dwn-registrar.ts` | 30s timeout on all 5 fetch calls |
| `@enbox/dwn-clients` | `rpc-client.ts` | 30s timeout on sendDidRequest |
| `@enbox/agent` | `oidc.ts` | 30s timeout on getAuthRequest + submitAuthResponse |
| `@enbox/agent` | `connect.ts` | 30s timeout on PAR + token polling |
| `@enbox/dwn-server` | `webhook-manager.ts` | 10s timeout on webhook delivery |

Closes #463, closes #464