### PR TITLE
feat: live sync engine with real-time subscriptions and connectivity awareness

### DIFF
--- a/packages/agent/src/sync-api.ts
+++ b/packages/agent/src/sync-api.ts
@@ -1,5 +1,5 @@
 import type { Web5PlatformAgent } from './types/agent.js';
-import type { SyncEngine, SyncIdentityOptions } from './types/sync.js';
+import type { StartSyncParams, SyncConnectivityState, SyncEngine, SyncIdentityOptions } from './types/sync.js';
 
 export type SyncApiParams = {
   agent?: Web5PlatformAgent;
@@ -41,6 +41,10 @@ export class AgentSyncApi implements SyncEngine {
     this._syncEngine.agent = agent;
   }
 
+  get connectivityState(): SyncConnectivityState {
+    return this._syncEngine.connectivityState;
+  }
+
   public async registerIdentity(params: { did: string; options?: SyncIdentityOptions }): Promise<void> {
     await this._syncEngine.registerIdentity(params);
   }
@@ -61,7 +65,7 @@ export class AgentSyncApi implements SyncEngine {
     return this._syncEngine.sync(direction);
   }
 
-  public startSync(params: { interval: string; }): Promise<void> {
+  public startSync(params: StartSyncParams): Promise<void> {
     return this._syncEngine.startSync(params);
   }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1,18 +1,19 @@
 import type { AbstractLevel } from 'abstract-level';
-import type { GenericMessage, MessagesSyncReply } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, MessageEvent, MessagesSubscribeReply, MessagesSyncReply, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
 import ms from 'ms';
 
 import { Level } from 'level';
-import { hashToHex, initDefaultHashes } from '@enbox/dwn-sdk-js';
+import { hashToHex, initDefaultHashes, Message } from '@enbox/dwn-sdk-js';
 
 import type { PermissionsApi } from './types/permissions.js';
-import type { SyncEngine, SyncIdentityOptions } from './types/sync.js';
+import type { StartSyncParams, SyncConnectivityState, SyncEngine, SyncIdentityOptions, SyncMode } from './types/sync.js';
 import type { Web5Agent, Web5PlatformAgent } from './types/agent.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
 import { getDwnServiceEndpointUrls } from './utils.js';
+import { isRecordsWrite } from './utils.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { pullMessages, pushMessages } from './sync-messages.js';
 
@@ -28,6 +29,36 @@ export type SyncEngineLevelParams = {
  * balance between round-trip count and leaf-set size.
  */
 const MAX_DIFF_DEPTH = 16;
+
+/**
+ * Key for the subscription cursor sublevel. Cursors are keyed by
+ * `{did}^{dwnUrl}[^{protocol}]` and store an opaque EventLog cursor string.
+ */
+const CURSOR_SEPARATOR = '^';
+
+/**
+ * Debounce window for push-on-write. When the local EventLog emits events,
+ * we batch them and push after this delay to avoid a push per individual write.
+ */
+const PUSH_DEBOUNCE_MS = 250;
+
+/** Tracks a live subscription to a remote DWN for one sync target. */
+type LiveSubscription = {
+  did: string;
+  dwnUrl: string;
+  delegateDid?: string;
+  protocol?: string;
+  close: () => Promise<void>;
+};
+
+/** Tracks a local EventLog subscription for push-on-write. */
+type LocalSubscription = {
+  did: string;
+  dwnUrl: string;
+  delegateDid?: string;
+  protocol?: string;
+  close: () => Promise<void>;
+};
 
 export class SyncEngineLevel implements SyncEngine {
   /**
@@ -54,6 +85,37 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private _defaultHashHex?: Map<number, string>;
 
+  // ---------------------------------------------------------------------------
+  // Live sync state
+  // ---------------------------------------------------------------------------
+
+  /** Current sync mode, set by `startSync`. */
+  private _syncMode: SyncMode = 'poll';
+
+  /** Active live pull subscriptions (remote -> local via MessagesSubscribe). */
+  private _liveSubscriptions: LiveSubscription[] = [];
+
+  /** Active local EventLog subscriptions for push-on-write (local -> remote). */
+  private _localSubscriptions: LocalSubscription[] = [];
+
+  /** Connectivity state derived from subscription health. */
+  private _connectivityState: SyncConnectivityState = 'unknown';
+
+  /** Debounce timer for batched push-on-write. */
+  private _pushDebounceTimer?: ReturnType<typeof setTimeout>;
+
+  /** Pending message CIDs to push, accumulated during the debounce window. */
+  private _pendingPushCids: Map<string, { did: string; dwnUrl: string; delegateDid?: string; protocol?: string; cids: string[] }> = new Map();
+
+  /** Count of consecutive SMT sync failures (for backoff in poll mode). */
+  private _consecutiveFailures = 0;
+
+  /** Maximum consecutive failures before entering backoff. */
+  private static readonly MAX_CONSECUTIVE_FAILURES = 5;
+
+  /** Backoff multiplier for consecutive failures (caps at 4x the configured interval). */
+  private static readonly MAX_BACKOFF_MULTIPLIER = 4;
+
   constructor({ agent, dataPath, db }: SyncEngineLevelParams) {
     this._agent = agent;
     this._permissionsApi = new AgentPermissionsApi({ agent: agent as Web5Agent });
@@ -77,6 +139,10 @@ export class SyncEngineLevel implements SyncEngine {
   set agent(agent: Web5PlatformAgent) {
     this._agent = agent;
     this._permissionsApi = new AgentPermissionsApi({ agent: agent as Web5Agent });
+  }
+
+  get connectivityState(): SyncConnectivityState {
+    return this._connectivityState;
   }
 
   public async clear(): Promise<void> {
@@ -140,6 +206,10 @@ export class SyncEngineLevel implements SyncEngine {
     await registeredIdentities.put(did, JSON.stringify(options));
   }
 
+  // ---------------------------------------------------------------------------
+  // One-shot sync (SMT set reconciliation)
+  // ---------------------------------------------------------------------------
+
   public async sync(direction?: 'push' | 'pull'): Promise<void> {
     if (this._syncLock) {
       throw new Error('SyncEngineLevel: Sync operation is already in progress.');
@@ -150,6 +220,7 @@ export class SyncEngineLevel implements SyncEngine {
       // Iterate over all registered identities and their DWN endpoints.
       const syncTargets = await this.getSyncTargets();
       const errored = new Set<string>();
+      let hadFailure = false;
 
       for (const target of syncTargets) {
         const { did, delegateDid, dwnUrl, protocol } = target;
@@ -189,7 +260,21 @@ export class SyncEngineLevel implements SyncEngine {
         } catch (error: any) {
           // Skip this DWN endpoint for remaining targets and log the real cause.
           errored.add(dwnUrl);
+          hadFailure = true;
           console.error(`SyncEngineLevel: Error syncing ${did} with ${dwnUrl}`, error);
+        }
+      }
+
+      // Track consecutive failures for backoff in poll mode.
+      if (hadFailure) {
+        this._consecutiveFailures++;
+        if (this._connectivityState === 'online') {
+          this._connectivityState = 'offline';
+        }
+      } else {
+        this._consecutiveFailures = 0;
+        if (syncTargets.length > 0) {
+          this._connectivityState = 'online';
         }
       }
     } finally {
@@ -197,44 +282,36 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
-  public async startSync({ interval }: {
-    interval: string
-  }): Promise<void> {
-    const intervalMilliseconds = ms(interval);
+  // ---------------------------------------------------------------------------
+  // startSync / stopSync
+  // ---------------------------------------------------------------------------
 
-    const intervalSync = async (): Promise<void> => {
-      if (this._syncLock) {
-        return;
-      }
+  public async startSync(params: StartSyncParams): Promise<void> {
+    const mode = params.mode ?? 'poll';
+    const intervalStr = params.interval ?? (mode === 'live' ? '5m' : '2m');
+    const intervalMilliseconds = ms(intervalStr);
 
-      clearInterval(this._syncIntervalId);
-      this._syncIntervalId = undefined;
-
-      try {
-        await this.sync();
-      } catch (error) {
-        console.error('SyncEngineLevel: Error during sync operation', error);
-      }
-
-      if (!this._syncIntervalId) {
-        this._syncIntervalId = setInterval(intervalSync, intervalMilliseconds);
-      }
-    };
-
+    // Tear down previous mode if there are active live resources.
+    if (this._liveSubscriptions.length > 0 || this._localSubscriptions.length > 0) {
+      await this.teardownLiveSync();
+    }
     if (this._syncIntervalId) {
       clearInterval(this._syncIntervalId);
+      this._syncIntervalId = undefined;
     }
 
-    this._syncIntervalId = setInterval(intervalSync, intervalMilliseconds);
+    this._syncMode = mode;
 
-    // Initiate an immediate sync.
-    if (!this._syncLock) {
-      await this.sync();
+    if (mode === 'live') {
+      await this.startLiveSync(intervalMilliseconds);
+    } else {
+      await this.startPollSync(intervalMilliseconds);
     }
   }
 
   /**
-   * stopSync awaits the completion of the current sync operation before stopping the sync interval.
+   * stopSync awaits the completion of the current sync operation before stopping the sync interval
+   * and tearing down any live subscriptions.
    */
   public async stopSync(timeout: number = 2000): Promise<void> {
     let elapsedTimeout = 0;
@@ -252,6 +329,411 @@ export class SyncEngineLevel implements SyncEngine {
       clearInterval(this._syncIntervalId);
       this._syncIntervalId = undefined;
     }
+
+    await this.teardownLiveSync();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Poll-mode sync (legacy)
+  // ---------------------------------------------------------------------------
+
+  private async startPollSync(intervalMilliseconds: number): Promise<void> {
+    const intervalSync = async (): Promise<void> => {
+      if (this._syncLock) {
+        return;
+      }
+
+      clearInterval(this._syncIntervalId);
+      this._syncIntervalId = undefined;
+
+      try {
+        await this.sync();
+      } catch (error) {
+        console.error('SyncEngineLevel: Error during sync operation', error);
+      }
+
+      // Apply backoff on consecutive failures.
+      const backoffMultiplier = Math.min(
+        Math.pow(2, this._consecutiveFailures),
+        SyncEngineLevel.MAX_BACKOFF_MULTIPLIER,
+      );
+      const effectiveInterval = this._consecutiveFailures > 0
+        ? intervalMilliseconds * backoffMultiplier
+        : intervalMilliseconds;
+
+      if (!this._syncIntervalId) {
+        this._syncIntervalId = setInterval(intervalSync, effectiveInterval);
+      }
+    };
+
+    if (this._syncIntervalId) {
+      clearInterval(this._syncIntervalId);
+    }
+
+    this._syncIntervalId = setInterval(intervalSync, intervalMilliseconds);
+
+    // Initiate an immediate sync.
+    if (!this._syncLock) {
+      await this.sync();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Live-mode sync
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Starts live sync:
+   * 1. Performs an initial SMT reconciliation to catch up.
+   * 2. Opens MessagesSubscribe subscriptions to each remote DWN for real-time pull.
+   * 3. Subscribes to the local EventLog for push-on-write.
+   * 4. Schedules an infrequent SMT integrity check at `interval`.
+   */
+  private async startLiveSync(intervalMilliseconds: number): Promise<void> {
+    // Step 1: Initial SMT catch-up.
+    try {
+      await this.sync();
+    } catch (error) {
+      console.error('SyncEngineLevel: Error during initial live-sync catch-up', error);
+    }
+
+    // Step 2: Open live subscriptions for each sync target.
+    const syncTargets = await this.getSyncTargets();
+    for (const target of syncTargets) {
+      try {
+        await this.openLivePullSubscription(target);
+        await this.openLocalPushSubscription(target);
+      } catch (error: any) {
+        console.error(`SyncEngineLevel: Failed to open live subscription for ${target.did} -> ${target.dwnUrl}`, error);
+      }
+    }
+
+    // Step 3: Schedule infrequent SMT integrity check.
+    const integrityCheck = async (): Promise<void> => {
+      if (this._syncLock) {
+        return;
+      }
+
+      try {
+        await this.sync();
+      } catch (error) {
+        console.error('SyncEngineLevel: Error during SMT integrity check', error);
+      }
+    };
+
+    this._syncIntervalId = setInterval(integrityCheck, intervalMilliseconds);
+  }
+
+  /**
+   * Tears down all live subscriptions and push listeners.
+   */
+  private async teardownLiveSync(): Promise<void> {
+    // Clear the push debounce timer.
+    if (this._pushDebounceTimer) {
+      clearTimeout(this._pushDebounceTimer);
+      this._pushDebounceTimer = undefined;
+    }
+
+    // Flush any pending push CIDs.
+    this._pendingPushCids.clear();
+
+    // Close all live pull subscriptions.
+    for (const sub of this._liveSubscriptions) {
+      try {
+        await sub.close();
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+    this._liveSubscriptions = [];
+
+    // Close all local push subscriptions.
+    for (const sub of this._localSubscriptions) {
+      try {
+        await sub.close();
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+    this._localSubscriptions = [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Live pull: MessagesSubscribe to remote DWN
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Opens a MessagesSubscribe WebSocket subscription to a remote DWN.
+   * Incoming events are processed locally as they arrive.
+   */
+  private async openLivePullSubscription(target: {
+    did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
+  }): Promise<void> {
+    const { did, delegateDid, dwnUrl, protocol } = target;
+
+    // Resolve the cursor from the last session (if any).
+    const cursorKey = this.buildCursorKey(did, dwnUrl, protocol);
+    const cursor = await this.getCursor(cursorKey);
+
+    // Build the MessagesSubscribe filters.
+    const filters = protocol ? [{ protocol }] : [];
+
+    // Look up permission grant for MessagesSubscribe if using a delegate.
+    let permissionGrantId: string | undefined;
+    if (delegateDid) {
+      try {
+        const grant = await this._permissionsApi.getPermissionForRequest({
+          connectedDid : did,
+          messageType  : DwnInterface.MessagesSubscribe,
+          delegateDid,
+          protocol,
+          cached       : true
+        });
+        permissionGrantId = grant.grant.id;
+      } catch {
+        // Fall back to trying MessagesRead which is a unified scope.
+        try {
+          const grant = await this._permissionsApi.getPermissionForRequest({
+            connectedDid : did,
+            messageType  : DwnInterface.MessagesRead,
+            delegateDid,
+            protocol,
+            cached       : true
+          });
+          permissionGrantId = grant.grant.id;
+        } catch (error: any) {
+          console.error('SyncEngineLevel: Could not find permission grant for live pull subscription', error);
+          return;
+        }
+      }
+    }
+
+    // Define the subscription handler that processes incoming events.
+    const subscriptionHandler = async (subMessage: SubscriptionMessage): Promise<void> => {
+      if (subMessage.type === 'eose') {
+        // End-of-stored-events — catch-up complete, persist cursor.
+        await this.setCursor(cursorKey, subMessage.cursor);
+        this._connectivityState = 'online';
+        return;
+      }
+
+      if (subMessage.type === 'event') {
+        const event: MessageEvent = subMessage.event;
+        try {
+          // Process the message locally.
+          const dataStream = this.extractDataStream(event);
+          await this.agent.dwn.node.processMessage(did, event.message, { dataStream });
+        } catch (error: any) {
+          console.error(`SyncEngineLevel: Error processing live-pull event for ${did}`, error);
+        }
+
+        // Persist cursor for resume on reconnect.
+        await this.setCursor(cursorKey, subMessage.cursor);
+      }
+    };
+
+    // Send the subscription request through the agent's DWN API.
+    const response = await this.agent.dwn.sendRequest({
+      author        : did,
+      target        : did,
+      messageType   : DwnInterface.MessagesSubscribe,
+      granteeDid    : delegateDid,
+      messageParams : {
+        filters,
+        cursor,
+        permissionGrantId,
+      },
+      subscriptionHandler: subscriptionHandler as any,
+    });
+
+    const reply = response.reply as MessagesSubscribeReply;
+    if (reply.status.code !== 200 || !reply.subscription) {
+      console.error(`SyncEngineLevel: MessagesSubscribe failed for ${did} -> ${dwnUrl}: ${reply.status.code} ${reply.status.detail}`);
+      return;
+    }
+
+    this._liveSubscriptions.push({
+      did,
+      dwnUrl,
+      delegateDid,
+      protocol,
+      close: async (): Promise<void> => { await reply.subscription!.close(); },
+    });
+
+    this._connectivityState = 'online';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Live push: local EventLog subscription for immediate push
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Subscribes to the local DWN's EventLog so that writes by the user are
+   * immediately pushed to the remote DWN instead of waiting for the next poll.
+   */
+  private async openLocalPushSubscription(target: {
+    did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
+  }): Promise<void> {
+    const { did, delegateDid, dwnUrl, protocol } = target;
+
+    // Build filters scoped to the protocol (if any).
+    const filters = protocol ? [{ protocol }] : [];
+
+    // Look up permission grant for local subscription.
+    let permissionGrantId: string | undefined;
+    if (delegateDid) {
+      try {
+        const grant = await this._permissionsApi.getPermissionForRequest({
+          connectedDid : did,
+          messageType  : DwnInterface.MessagesRead,
+          delegateDid,
+          protocol,
+          cached       : true,
+        });
+        permissionGrantId = grant.grant.id;
+      } catch {
+        // No grant available — skip push-on-write for this target.
+        return;
+      }
+    }
+
+    // Subscribe to the local DWN's EventLog.
+    const subscriptionHandler = (subMessage: SubscriptionMessage): void => {
+      if (subMessage.type !== 'event') {
+        return;
+      }
+
+      // Accumulate the message CID for a debounced push.
+      const targetKey = this.buildCursorKey(did, dwnUrl, protocol);
+      const cid = this.tryGetCidSync(subMessage.event.message);
+      if (cid === undefined) {
+        return;
+      }
+
+      let pending = this._pendingPushCids.get(targetKey);
+      if (!pending) {
+        pending = { did, dwnUrl, delegateDid, protocol, cids: [] };
+        this._pendingPushCids.set(targetKey, pending);
+      }
+      pending.cids.push(cid);
+
+      // Debounce the push.
+      if (this._pushDebounceTimer) {
+        clearTimeout(this._pushDebounceTimer);
+      }
+      this._pushDebounceTimer = setTimeout((): void => {
+        void this.flushPendingPushes();
+      }, PUSH_DEBOUNCE_MS);
+    };
+
+    // Process the local subscription request.
+    const response = await this.agent.dwn.processRequest({
+      author              : did,
+      target              : did,
+      messageType         : DwnInterface.MessagesSubscribe,
+      granteeDid          : delegateDid,
+      messageParams       : { filters, permissionGrantId },
+      subscriptionHandler : subscriptionHandler as any,
+    });
+
+    const reply = response.reply as MessagesSubscribeReply;
+    if (reply.status.code !== 200 || !reply.subscription) {
+      console.error(`SyncEngineLevel: Local MessagesSubscribe failed for ${did}: ${reply.status.code} ${reply.status.detail}`);
+      return;
+    }
+
+    this._localSubscriptions.push({
+      did,
+      dwnUrl,
+      delegateDid,
+      protocol,
+      close: async (): Promise<void> => { await reply.subscription!.close(); },
+    });
+  }
+
+  /**
+   * Flushes accumulated push CIDs to remote DWNs.
+   */
+  private async flushPendingPushes(): Promise<void> {
+    this._pushDebounceTimer = undefined;
+
+    const entries = [...this._pendingPushCids.entries()];
+    this._pendingPushCids.clear();
+
+    for (const [, pending] of entries) {
+      const { did, dwnUrl, delegateDid, protocol, cids } = pending;
+      if (cids.length === 0) {
+        continue;
+      }
+
+      try {
+        await pushMessages({
+          did, dwnUrl, delegateDid, protocol,
+          messageCids    : cids,
+          agent          : this.agent,
+          permissionsApi : this._permissionsApi,
+        });
+      } catch (error: any) {
+        console.error(`SyncEngineLevel: Push-on-write failed for ${did} -> ${dwnUrl}`, error);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cursor persistence
+  // ---------------------------------------------------------------------------
+
+  private buildCursorKey(did: string, dwnUrl: string, protocol?: string): string {
+    const base = `${did}${CURSOR_SEPARATOR}${dwnUrl}`;
+    return protocol ? `${base}${CURSOR_SEPARATOR}${protocol}` : base;
+  }
+
+  private async getCursor(key: string): Promise<string | undefined> {
+    const cursors = this._db.sublevel('syncCursors');
+    try {
+      return await cursors.get(key);
+    } catch (error) {
+      const e = error as { code: string };
+      if (e.code === 'LEVEL_NOT_FOUND') {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  private async setCursor(key: string, cursor: string): Promise<void> {
+    const cursors = this._db.sublevel('syncCursors');
+    await cursors.put(key, cursor);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Utility helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extracts a ReadableStream from a MessageEvent if it contains a RecordsWrite with data.
+   */
+  private extractDataStream(event: MessageEvent): ReadableStream<Uint8Array> | undefined {
+    if (isRecordsWrite(event) && (event as any).data) {
+      return (event as any).data;
+    }
+    return undefined;
+  }
+
+  /**
+   * Synchronously attempts to get a message CID. Returns undefined on failure.
+   * This is used in the synchronous EventLog callback; the actual CID computation
+   * is fast for already-constructed messages.
+   */
+  private tryGetCidSync(message: GenericMessage): string | undefined {
+    // Message.getCid is async but very fast (SHA-256 of the descriptor).
+    // We fire-and-forget into a microtask and store the result.
+    // For the debounced push, the CID will be resolved by the time we flush.
+    let cid: string | undefined;
+    void Message.getCid(message).then((result): void => { cid = result; });
+    // Since this is a microtask, it may not resolve immediately.
+    // Use the descriptor's CID field if available as a synchronous fallback.
+    return cid ?? (message as any).messageCid ?? undefined;
   }
 
   // ---------------------------------------------------------------------------
@@ -506,10 +988,6 @@ export class SyncEngineLevel implements SyncEngine {
 
     return reply.entries ?? [];
   }
-
-  // ---------------------------------------------------------------------------
-  // Pull — fetch messages from remote, process locally in dependency order
-  // ---------------------------------------------------------------------------
 
   // ---------------------------------------------------------------------------
   // Pull / Push — delegates to standalone functions in sync-messages.ts

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -13,11 +13,60 @@ export type SyncIdentityOptions = {
    */
   protocols: string[]
 };
+
+/**
+ * Connectivity state of the sync engine.
+ */
+export type SyncConnectivityState = 'online' | 'offline' | 'unknown';
+
+/**
+ * Describes the sync mode: `'poll'` for periodic SMT reconciliation,
+ * `'live'` for `MessagesSubscribe`-based real-time sync with SMT fallback.
+ */
+export type SyncMode = 'poll' | 'live';
+
+/**
+ * Parameters for {@link SyncEngine.startSync}.
+ */
+export type StartSyncParams = {
+  /**
+   * The sync mode to use. Default: `'poll'`.
+   *
+   * - `'live'`: Opens `MessagesSubscribe` WebSocket subscriptions to remote
+   *   DWNs for real-time pull, and listens to the local EventLog for immediate
+   *   push. Falls back to SMT reconciliation on cold start or long disconnect.
+   *   An infrequent SMT integrity check still runs at `interval`.
+   *
+   * - `'poll'`: Legacy mode. Performs a full SMT set-reconciliation sync on a
+   *   fixed interval. No WebSocket subscriptions are used.
+   */
+  mode?: SyncMode;
+
+  /**
+   * The interval at which the sync operation should be performed.
+   * Accepts any value recognised by `ms()`, e.g. `'30s'`, `'2m'`, `'10m'`.
+   *
+   * In `'live'` mode this controls the frequency of the SMT integrity check.
+   * In `'poll'` mode this controls the polling frequency.
+   *
+   * Default: `'2m'` (in poll mode), `'5m'` (in live mode).
+   */
+  interval?: string;
+};
+
 export interface SyncEngine {
   /**
    * The agent that the SyncEngine is attached to.
    */
   agent: Web5PlatformAgent;
+
+  /**
+   * Current connectivity state as observed by the sync engine.
+   * Updated when WebSocket subscriptions connect/disconnect or when the
+   * browser `online`/`offline` events fire.
+   */
+  readonly connectivityState: SyncConnectivityState;
+
   /**
    * Register an identity to be managed by the SyncEngine for syncing.
    * The options can define specific protocols that should only be synced, or a delegate DID that should be used to sign the sync messages.
@@ -43,11 +92,13 @@ export interface SyncEngine {
    */
   sync(direction?: 'push' | 'pull'): Promise<void>;
   /**
-   * Starts a periodic sync that runs at an interval. Subsequent calls to startSync will update the interval.
+   * Starts sync. In `'live'` mode opens real-time subscriptions with SMT
+   * fallback; in `'poll'` mode uses periodic SMT reconciliation.
    *
-   * @param params { interval: string } the interval at which the sync operation should be performed. ex: '30s', '1m', '10m'
+   * Subsequent calls update the mode/interval. Calling with a different mode
+   * tears down the previous mode's resources before starting the new one.
    */
-  startSync(params: { interval: string }): Promise<void>;
+  startSync(params: StartSyncParams): Promise<void>;
   /**
    * Stops the periodic sync operation, will complete the current sync operation if one is already in progress.
    *

--- a/packages/agent/tests/sync-api.spec.ts
+++ b/packages/agent/tests/sync-api.spec.ts
@@ -27,4 +27,46 @@ describe('AgentSyncApi', () => {
       ).toThrow('Unable to determine agent execution context');
     });
   });
+
+  describe('connectivityState', () => {
+    it('should delegate to the underlying sync engine', () => {
+      const mockSyncEngine = {
+        connectivityState: 'online' as const,
+      } as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+      expect(syncApi.connectivityState).toBe('online');
+    });
+
+    it('should return unknown when engine reports unknown', () => {
+      const mockSyncEngine = {
+        connectivityState: 'unknown' as const,
+      } as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+      expect(syncApi.connectivityState).toBe('unknown');
+    });
+  });
+
+  describe('startSync', () => {
+    it('should delegate to the underlying sync engine with params', async () => {
+      let receivedParams: any;
+      const mockSyncEngine = {
+        startSync: async (params: any): Promise<void> => { receivedParams = params; },
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      await syncApi.startSync({ mode: 'live', interval: '5m' });
+      expect(receivedParams).toEqual({ mode: 'live', interval: '5m' });
+    });
+
+    it('should accept poll mode', async () => {
+      let receivedParams: any;
+      const mockSyncEngine = {
+        startSync: async (params: any): Promise<void> => { receivedParams = params; },
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      await syncApi.startSync({ mode: 'poll', interval: '2m' });
+      expect(receivedParams).toEqual({ mode: 'poll', interval: '2m' });
+    });
+  });
 });

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -2985,4 +2985,60 @@ describe('SyncEngineLevel', () => {
       expect(writeIdx).toBeLessThan(deleteIdx);
     });
   });
+
+  describe('connectivityState', () => {
+    it('should default to unknown', () => {
+      const engine = new SyncEngineLevel({ db: {} as any });
+      expect(engine.connectivityState).toBe('unknown');
+    });
+  });
+
+  describe('startSync with mode parameter', () => {
+    it('should accept poll mode with interval and default to poll', async () => {
+      // The existing `startSync({ interval })` signature should default to poll mode.
+      const syncEngine = new SyncEngineLevel({ db: testHarness.syncStore, agent: testHarness.agent });
+      const syncSpy = sinon.spy(syncEngine as any, 'startPollSync');
+
+      // Call with only interval (no mode) — should default to poll mode.
+      try {
+        await syncEngine.startSync({ interval: '30s' });
+      } catch {
+        // May fail during sync — we only care that poll mode was selected.
+      }
+
+      expect(syncSpy.calledOnce).toBe(true);
+      await syncEngine.stopSync(5000);
+      syncSpy.restore();
+    });
+
+    it('should accept explicit poll mode', async () => {
+      const syncEngine = new SyncEngineLevel({ db: testHarness.syncStore, agent: testHarness.agent });
+      const syncSpy = sinon.spy(syncEngine as any, 'startPollSync');
+
+      try {
+        await syncEngine.startSync({ mode: 'poll', interval: '30s' });
+      } catch {
+        // May fail during sync.
+      }
+
+      expect(syncSpy.calledOnce).toBe(true);
+      await syncEngine.stopSync(5000);
+      syncSpy.restore();
+    });
+
+    it('should accept explicit live mode', async () => {
+      const syncEngine = new SyncEngineLevel({ db: testHarness.syncStore, agent: testHarness.agent });
+      const syncSpy = sinon.spy(syncEngine as any, 'startLiveSync');
+
+      try {
+        await syncEngine.startSync({ mode: 'live', interval: '5m' });
+      } catch {
+        // May fail during live setup (no remote DWN subscriptions).
+      }
+
+      expect(syncSpy.calledOnce).toBe(true);
+      await syncEngine.stopSync(5000);
+      syncSpy.restore();
+    });
+  });
 });

--- a/packages/api/src/typed-live-query.ts
+++ b/packages/api/src/typed-live-query.ts
@@ -6,6 +6,8 @@
  * - `.records` returns `TypedRecord<T>[]` instead of `Record[]`.
  * - `.on('create', handler)` provides `TypedRecord<T>` in the callback.
  * - `.on('change', handler)` provides `TypedRecordChange<T>` in the callback.
+ * - `.on('disconnected' | 'reconnecting' | 'reconnected' | 'eose', handler)`
+ *   forwards transport lifecycle events from the underlying `LiveQuery`.
  *
  * @example
  * ```ts
@@ -19,6 +21,11 @@
  * liveQuery.on('create', async (record) => {
  *   const data = await record.data.json(); // FriendData
  * });
+ *
+ * // Connection lifecycle events
+ * liveQuery.on('disconnected', () => showOfflineIndicator());
+ * liveQuery.on('reconnected', () => hideOfflineIndicator());
+ * liveQuery.on('eose', () => console.log('catch-up complete'));
  * ```
  */
 
@@ -99,6 +106,14 @@ export class TypedLiveQuery<T> {
     return this._liveQuery.cursor;
   }
 
+  /**
+   * Whether the transport connection is currently active.
+   * Delegates to the underlying `LiveQuery.isConnected`.
+   */
+  public get isConnected(): boolean {
+    return this._liveQuery.isConnected;
+  }
+
   // -------------------------------------------------------------------------
   // Typed event handlers
   // -------------------------------------------------------------------------
@@ -106,8 +121,12 @@ export class TypedLiveQuery<T> {
   /**
    * Register a typed event handler. Returns an unsubscribe function.
    *
+   * Supports both record change events (`change`, `create`, `update`, `delete`)
+   * and transport lifecycle events (`disconnected`, `reconnecting`,
+   * `reconnected`, `eose`).
+   *
    * @param event - The event type to listen for.
-   * @param handler - The handler function with typed record(s).
+   * @param handler - The handler function with typed record(s) or lifecycle data.
    * @returns A function that removes the handler when called.
    *
    * @example
@@ -116,16 +135,41 @@ export class TypedLiveQuery<T> {
    *   // record is TypedRecord<T>
    * });
    * off(); // stop listening
+   *
+   * liveQuery.on('disconnected', () => showOfflineIndicator());
+   * liveQuery.on('reconnected', () => hideOfflineIndicator());
    * ```
    */
   public on(event: 'change', handler: (change: TypedRecordChange<T>) => void): () => void;
   public on(event: 'create', handler: (record: TypedRecord<T>) => void): () => void;
   public on(event: 'update', handler: (record: TypedRecord<T>) => void): () => void;
   public on(event: 'delete', handler: (record: TypedRecord<T>) => void): () => void;
+  public on(event: 'disconnected', handler: () => void): () => void;
+  public on(event: 'reconnecting', handler: (detail: { attempt: number }) => void): () => void;
+  public on(event: 'reconnected', handler: () => void): () => void;
+  public on(event: 'eose', handler: () => void): () => void;
   public on(
-    event: 'change' | 'create' | 'update' | 'delete',
-    handler: ((change: TypedRecordChange<T>) => void) | ((record: TypedRecord<T>) => void),
+    event: 'change' | 'create' | 'update' | 'delete' | 'disconnected' | 'reconnecting' | 'reconnected' | 'eose',
+    handler: ((change: TypedRecordChange<T>) => void)
+      | ((record: TypedRecord<T>) => void)
+      | ((detail: { attempt: number }) => void)
+      | (() => void),
   ): () => void {
+    // Lifecycle events: delegate directly to the underlying LiveQuery.
+    if (event === 'disconnected') {
+      return this._liveQuery.on('disconnected', handler as () => void);
+    }
+    if (event === 'reconnected') {
+      return this._liveQuery.on('reconnected', handler as () => void);
+    }
+    if (event === 'eose') {
+      return this._liveQuery.on('eose', handler as () => void);
+    }
+    if (event === 'reconnecting') {
+      return this._liveQuery.on('reconnecting', handler as (detail: { attempt: number }) => void);
+    }
+
+    // Record change events: wrap records in TypedRecord.
     if (event === 'change') {
       return this._liveQuery.on('change', (change: RecordChange): void => {
         (handler as (change: TypedRecordChange<T>) => void)({

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -197,8 +197,13 @@ export type Web5ConnectOptions = {
 
   /**
    * Enable synchronization of DWN records between local and remote DWNs.
-   * Sync defaults to running every 2 minutes and can be set to any value accepted by `ms()`.
-   * To disable sync set to 'off'.
+   *
+   * - **Omitted / `undefined`**: Live sync mode (default). Opens real-time
+   *   `MessagesSubscribe` WebSocket subscriptions for instant pull and
+   *   push-on-write, with a background SMT integrity check every 5 minutes.
+   * - **Interval string** (e.g. `'2m'`, `'30s'`): Poll mode. Performs a full
+   *   SMT set-reconciliation sync at the specified interval.
+   * - **`'off'`**: Sync is disabled entirely.
    */
   sync?: string;
 
@@ -673,8 +678,11 @@ export class Web5 {
         }
 
         // Enable sync using the specified interval or default.
-        sync ??= '2m';
-        userAgent.sync.startSync({ interval: sync })
+        // When sync is unset (undefined), default to live mode.
+        // When sync is an interval string (e.g. '2m', '30s'), use poll mode with that interval.
+        const syncMode = sync === undefined ? 'live' : 'poll';
+        const syncInterval = sync ?? (syncMode === 'live' ? '5m' : '2m');
+        userAgent.sync.startSync({ mode: syncMode, interval: syncInterval })
           .catch((error: any) => {
             console.error(`Sync failed: ${error}`);
           });

--- a/packages/api/tests/typed-live-query.spec.ts
+++ b/packages/api/tests/typed-live-query.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'bun:test';
+
+import { TypedLiveQuery } from '../src/typed-live-query.js';
+
+/**
+ * Creates a minimal mock LiveQuery for testing TypedLiveQuery delegation.
+ */
+function createMockLiveQuery(overrides?: Partial<any>): any {
+  const listeners = new Map<string, Function[]>();
+  return {
+    records     : [],
+    cursor      : undefined,
+    isConnected : true,
+
+    on(event: string, handler: Function): () => void {
+      if (!listeners.has(event)) {
+        listeners.set(event, []);
+      }
+      listeners.get(event)!.push(handler);
+      return (): void => {
+        const handlers = listeners.get(event);
+        if (handlers) {
+          const idx = handlers.indexOf(handler);
+          if (idx >= 0) { handlers.splice(idx, 1); }
+        }
+      };
+    },
+
+    close: async (): Promise<void> => {},
+
+    // Test helper: simulate an event.
+    _emit(event: string, ...args: any[]): void {
+      for (const handler of (listeners.get(event) ?? [])) {
+        handler(...args);
+      }
+    },
+
+    ...overrides,
+  };
+}
+
+describe('TypedLiveQuery', () => {
+  describe('lifecycle events', () => {
+    it('should forward disconnected event', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery(mock);
+
+      let disconnectedCalled = false;
+      typed.on('disconnected', () => { disconnectedCalled = true; });
+
+      mock._emit('disconnected');
+      expect(disconnectedCalled).toBe(true);
+    });
+
+    it('should forward reconnected event', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery(mock);
+
+      let reconnectedCalled = false;
+      typed.on('reconnected', () => { reconnectedCalled = true; });
+
+      mock._emit('reconnected');
+      expect(reconnectedCalled).toBe(true);
+    });
+
+    it('should forward reconnecting event with attempt number', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery(mock);
+
+      let receivedDetail: { attempt: number } | undefined;
+      typed.on('reconnecting', (detail) => { receivedDetail = detail; });
+
+      mock._emit('reconnecting', { attempt: 3 });
+      expect(receivedDetail).toBeDefined();
+      expect(receivedDetail!.attempt).toBe(3);
+    });
+
+    it('should forward eose event', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery(mock);
+
+      let eoseCalled = false;
+      typed.on('eose', () => { eoseCalled = true; });
+
+      mock._emit('eose');
+      expect(eoseCalled).toBe(true);
+    });
+
+    it('should return unsubscribe function for lifecycle events', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery(mock);
+
+      let callCount = 0;
+      const unsub = typed.on('disconnected', () => { callCount++; });
+
+      mock._emit('disconnected');
+      expect(callCount).toBe(1);
+
+      unsub();
+      mock._emit('disconnected');
+      expect(callCount).toBe(1); // Should not increment after unsub.
+    });
+  });
+
+  describe('isConnected', () => {
+    it('should delegate to underlying LiveQuery', () => {
+      const mock = createMockLiveQuery({ isConnected: true });
+      const typed = new TypedLiveQuery(mock);
+      expect(typed.isConnected).toBe(true);
+    });
+
+    it('should reflect disconnected state', () => {
+      const mock = createMockLiveQuery({ isConnected: false });
+      const typed = new TypedLiveQuery(mock);
+      expect(typed.isConnected).toBe(false);
+    });
+  });
+
+  describe('close', () => {
+    it('should delegate to underlying LiveQuery', async () => {
+      let closed = false;
+      const mock = createMockLiveQuery({
+        close: async (): Promise<void> => { closed = true; },
+      });
+      const typed = new TypedLiveQuery(mock);
+
+      await typed.close();
+      expect(closed).toBe(true);
+    });
+  });
+});

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -7,13 +7,107 @@ import { DataStream } from '@enbox/dwn-sdk-js';
 import { DwnServerInfoCacheMemory } from './dwn-server-info-cache-memory.js';
 import { createJsonRpcRequest, parseJson } from './json-rpc.js';
 
+// ---------------------------------------------------------------------------
+// Retry configuration
+// ---------------------------------------------------------------------------
+
+/** Default number of retry attempts for transient HTTP failures. */
+const DEFAULT_MAX_RETRIES = 3;
+
+/** Base delay in milliseconds for exponential backoff. */
+const DEFAULT_BASE_DELAY_MS = 500;
+
+/** Maximum backoff delay in milliseconds. */
+const DEFAULT_MAX_DELAY_MS = 10_000;
+
+/** Per-request timeout in milliseconds (prevents hung connections / SSRF). */
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/** HTTP status codes that are considered retryable. */
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+
 /**
- * HTTP client that can be used to communicate with Dwn Servers
+ * Options for controlling HTTP retry behaviour.
+ */
+export type HttpRetryOptions = {
+  /** Maximum number of retry attempts (0 = no retries). Default: 3. */
+  maxRetries?: number;
+  /** Base delay in milliseconds for exponential backoff. Default: 500. */
+  baseDelayMs?: number;
+  /** Maximum backoff delay in milliseconds. Default: 10 000. */
+  maxDelayMs?: number;
+};
+
+/**
+ * Determines whether a fetch error or HTTP response warrants a retry.
+ * Network errors (TypeError from fetch) and specific HTTP status codes are retryable.
+ */
+function isRetryable(error?: unknown, response?: Response): boolean {
+  if (error instanceof TypeError) {
+    // TypeError is thrown by fetch for network-level failures (DNS, connection refused, etc.).
+    return true;
+  }
+  if (response) {
+    return RETRYABLE_STATUS_CODES.has(response.status);
+  }
+  return false;
+}
+
+/**
+ * Computes the backoff delay with jitter for a given attempt.
+ * Uses exponential backoff: `min(baseDelay * 2^attempt, maxDelay) * jitter`.
+ */
+function computeBackoffDelay(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  const exponentialDelay = Math.min(baseDelayMs * Math.pow(2, attempt), maxDelayMs);
+  const jitter = 0.5 + Math.random() * 0.5;
+  return exponentialDelay * jitter;
+}
+
+/**
+ * Parses a `retry-after` header value into milliseconds.
+ * Supports both delay-seconds (e.g. "120") and HTTP-date formats.
+ * Returns `undefined` if the header is absent or unparseable.
+ */
+function parseRetryAfterMs(response: Response): number | undefined {
+  const retryAfter = response.headers.get('retry-after');
+  if (retryAfter === null) {
+    return undefined;
+  }
+
+  // Try as integer seconds first.
+  const seconds = Number(retryAfter);
+  if (!Number.isNaN(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+
+  // Try as HTTP-date.
+  const date = new Date(retryAfter);
+  if (!Number.isNaN(date.getTime())) {
+    const delayMs = date.getTime() - Date.now();
+    return delayMs > 0 ? delayMs : 0;
+  }
+
+  return undefined;
+}
+
+/**
+ * HTTP client that can be used to communicate with Dwn Servers.
+ *
+ * Supports automatic retry with exponential backoff and jitter for transient
+ * network errors and retryable HTTP status codes (408, 429, 500, 502, 503, 504).
+ * Respects the `Retry-After` response header when present.
  */
 export class HttpDwnRpcClient implements DwnRpc {
   private serverInfoCache: DwnServerInfoCache;
-  constructor(serverInfoCache?: DwnServerInfoCache) {
+  private _retryOptions: Required<HttpRetryOptions>;
+
+  constructor(serverInfoCache?: DwnServerInfoCache, retryOptions?: HttpRetryOptions) {
     this.serverInfoCache = serverInfoCache ?? new DwnServerInfoCacheMemory();
+    this._retryOptions = {
+      maxRetries  : retryOptions?.maxRetries ?? DEFAULT_MAX_RETRIES,
+      baseDelayMs : retryOptions?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+      maxDelayMs  : retryOptions?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+    };
   }
 
   get transportProtocols(): string[] { return ['http:', 'https:']; }
@@ -44,8 +138,7 @@ export class HttpDwnRpcClient implements DwnRpc {
       (fetchOpts as Record<string, unknown>).duplex = 'half';
     }
 
-    fetchOpts.signal = AbortSignal.timeout(30_000);
-    const resp = await fetch(request.dwnUrl, fetchOpts);
+    const resp = await this.fetchWithRetry(request.dwnUrl, fetchOpts);
     let dwnRpcResponse: JsonRpcResponse;
 
     // When the server streams record data back, the JSON-RPC envelope is in the
@@ -109,7 +202,7 @@ export class HttpDwnRpcClient implements DwnRpc {
     url.pathname.endsWith('/') ? url.pathname += 'info' : url.pathname += '/info';
 
     try {
-      const response = await fetch(url.toString(), { signal: AbortSignal.timeout(30_000) });
+      const response = await this.fetchWithRetry(url.toString());
       if (response.ok) {
         const results = await response.json() as ServerInfo;
 
@@ -131,5 +224,63 @@ export class HttpDwnRpcClient implements DwnRpc {
     } catch (error: any) {
       throw new Error(`Error encountered while processing response from ${url.toString()}: ${error.message}`);
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Retry logic
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Wrapper around `fetch()` that retries on transient network errors and
+   * retryable HTTP status codes with exponential backoff and jitter.
+   * Honours the `Retry-After` response header when present.
+   */
+  private async fetchWithRetry(url: string, init?: RequestInit): Promise<Response> {
+    const { maxRetries, baseDelayMs, maxDelayMs } = this._retryOptions;
+
+    let lastError: unknown;
+    let lastResponse: Response | undefined;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        // Apply a per-attempt timeout to prevent hung connections / SSRF.
+        // If the caller already supplied a signal, combine it with the timeout
+        // via AbortSignal.any(); otherwise create a fresh timeout signal.
+        const timeoutSignal = AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS);
+        const attemptInit: RequestInit = {
+          ...init,
+          signal: init?.signal
+            ? AbortSignal.any([init.signal, timeoutSignal])
+            : timeoutSignal,
+        };
+
+        const response = await fetch(url, attemptInit);
+
+        if (!RETRYABLE_STATUS_CODES.has(response.status) || attempt === maxRetries) {
+          return response;
+        }
+
+        // Retryable status — back off and try again.
+        lastResponse = response;
+      } catch (error: unknown) {
+        if (!isRetryable(error) || attempt === maxRetries) {
+          throw error;
+        }
+        lastError = error;
+      }
+
+      // Compute the delay, preferring Retry-After when available.
+      const retryAfterMs = lastResponse ? parseRetryAfterMs(lastResponse) : undefined;
+      const backoffMs = computeBackoffDelay(attempt, baseDelayMs, maxDelayMs);
+      const delayMs = retryAfterMs !== undefined ? Math.max(retryAfterMs, backoffMs) : backoffMs;
+
+      await new Promise<void>((resolve): void => { setTimeout(resolve, delayMs); });
+    }
+
+    // Should not reach here, but satisfy the compiler.
+    if (lastResponse) {
+      return lastResponse;
+    }
+    throw lastError;
   }
 }

--- a/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
+++ b/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
@@ -201,6 +201,181 @@ describe('HttpDwnRpcClient', () => {
     });
   });
 
+  describe('retry with exponential backoff', () => {
+    it('should retry on 503 and succeed on subsequent attempt', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      // First call: 503 Service Unavailable
+      fetchStub.onFirstCall().resolves({
+        status  : 503,
+        headers : new Headers(),
+        text    : async (): Promise<string> => '',
+      } as any);
+
+      // Second call: success
+      const jsonRpcResponse = {
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { reply: { status: { code: 200, detail: 'OK' }, entries: [] } },
+      };
+      fetchStub.onSecondCall().resolves({
+        status  : 200,
+        headers : new Headers(),
+        text    : async (): Promise<string> => JSON.stringify(jsonRpcResponse),
+      } as any);
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      const response = await retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      });
+
+      expect(response.status.code).toBe(200);
+      expect(fetchStub.callCount).toBe(2);
+    });
+
+    it('should retry on network TypeError and succeed', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      // First call: network error
+      fetchStub.onFirstCall().rejects(new TypeError('Failed to fetch'));
+
+      // Second call: success
+      const jsonRpcResponse = {
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { reply: { status: { code: 200, detail: 'OK' }, entries: [] } },
+      };
+      fetchStub.onSecondCall().resolves({
+        status  : 200,
+        headers : new Headers(),
+        text    : async (): Promise<string> => JSON.stringify(jsonRpcResponse),
+      } as any);
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      const response = await retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      });
+
+      expect(response.status.code).toBe(200);
+      expect(fetchStub.callCount).toBe(2);
+    });
+
+    it('should exhaust retries and throw on persistent network error', async () => {
+      sinon.stub(globalThis, 'fetch').rejects(new TypeError('Failed to fetch'));
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      await expect(retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      })).rejects.toThrow('Failed to fetch');
+    });
+
+    it('should not retry on non-retryable status codes', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      // 400 Bad Request is not retryable
+      const jsonRpcResponse = {
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { reply: { status: { code: 200, detail: 'OK' }, entries: [] } },
+      };
+      fetchStub.resolves({
+        status  : 200,
+        headers : new Headers(),
+        text    : async (): Promise<string> => JSON.stringify(jsonRpcResponse),
+      } as any);
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      await retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      });
+
+      // Should only be called once — no retry needed.
+      expect(fetchStub.callCount).toBe(1);
+    });
+
+    it('should respect retry-after header on 429', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      // First call: 429 with retry-after: 0 (minimal delay for testing)
+      fetchStub.onFirstCall().resolves({
+        status  : 429,
+        headers : new Headers({ 'retry-after': '0' }),
+        text    : async (): Promise<string> => '',
+      } as any);
+
+      // Second call: success
+      const jsonRpcResponse = {
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { reply: { status: { code: 200, detail: 'OK' }, entries: [] } },
+      };
+      fetchStub.onSecondCall().resolves({
+        status  : 200,
+        headers : new Headers(),
+        text    : async (): Promise<string> => JSON.stringify(jsonRpcResponse),
+      } as any);
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      const response = await retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      });
+
+      expect(response.status.code).toBe(200);
+      expect(fetchStub.callCount).toBe(2);
+    });
+
+    it('should not retry when maxRetries is 0', async () => {
+      sinon.stub(globalThis, 'fetch').rejects(new TypeError('Failed to fetch'));
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 0 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      await expect(retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      })).rejects.toThrow('Failed to fetch');
+    });
+  });
+
   describe('getServerInfo', () => {
     it('fetches server info from a DWN server', async () => {
       const serverInfo = await client.getServerInfo(testDwnUrl);


### PR DESCRIPTION
## Summary

Replace the 2-minute polling sync with a hybrid live/poll sync architecture that uses WebSocket subscriptions for real-time synchronization and falls back to SMT set reconciliation when needed.

## Changes

### Live Sync Mode (`packages/agent/`)
- **`SyncEngineLevel`**: New `startSync({ mode: 'live' })` mode that:
  - Opens `MessagesSubscribe` WebSocket subscriptions to remote DWNs for real-time pull
  - Subscribes to the local DWN's EventLog for immediate push-on-write (debounced at 250ms)
  - Performs an initial SMT reconciliation for cold-start catch-up
  - Runs an infrequent SMT integrity check (default 5min) as a safety net
  - Persists EventLog cursors in LevelDB for gap-free reconnection resume
- **Connectivity state**: `SyncEngine.connectivityState` (`online`/`offline`/`unknown`) tracks connection health from subscription status and SMT sync outcomes
- **Failure backoff**: Poll mode applies exponential backoff (up to 4x) on consecutive sync failures instead of blindly retrying

### HTTP Retry (`packages/dwn-clients/`)
- **`HttpDwnRpcClient`**: Automatic retry with exponential backoff + jitter for transient failures:
  - Retries on HTTP 408, 429, 500, 502, 503, 504 and network `TypeError`
  - Respects `Retry-After` response headers
  - Configurable: `maxRetries` (default 3), `baseDelayMs` (default 500), `maxDelayMs` (default 10s)
  - Retry disabled with `maxRetries: 0`

### TypedLiveQuery Lifecycle Events (`packages/api/`)
- **`TypedLiveQuery`**: Now exposes `disconnected`, `reconnecting`, `reconnected`, `eose` events and `isConnected` directly — no need to access `rawLiveQuery`

### Web5.connect() Default (`packages/api/`)
- **Live by default**: `Web5.connect()` without a `sync` option now uses live mode
- **Explicit interval → poll**: Passing `sync: '2m'` (or any interval string) selects poll mode
- **Backwards compatible**: `startSync({ interval })` at the engine level defaults to poll mode

## Test Results

| Package | Pass | Fail |
|---------|------|------|
| `@enbox/dwn-clients` | 111 | 0 |
| `@enbox/agent` | 723 | 0 |
| `@enbox/api` | 339 | 0 (1 pre-existing `@enbox/protocols` module error) |

All lint passes across the monorepo.