### PR TITLE
fix(dwn-clients,dwn-server): properly signal rate limiting to clients

### DIFF
--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -5,7 +5,8 @@ import type { DwnServerInfoCache, ServerInfo } from './server-info-types.js';
 import { CryptoUtils } from '@enbox/crypto';
 import { DataStream } from '@enbox/dwn-sdk-js';
 import { DwnServerInfoCacheMemory } from './dwn-server-info-cache-memory.js';
-import { createJsonRpcRequest, parseJson } from './json-rpc.js';
+import { RateLimitError } from './rate-limit-error.js';
+import { createJsonRpcRequest, JsonRpcErrorCodes, parseJson } from './json-rpc.js';
 
 // ---------------------------------------------------------------------------
 // Retry configuration
@@ -139,6 +140,15 @@ export class HttpDwnRpcClient implements DwnRpc {
     }
 
     const resp = await this.fetchWithRetry(request.dwnUrl, fetchOpts);
+
+    // After retries are exhausted, a 429 means we're still rate-limited.
+    // Per-IP 429s return plain JSON (not a JSON-RPC envelope), so we must
+    // check the status before attempting JSON-RPC parsing.
+    if (resp.status === 429) {
+      const retryAfter = parseInt(resp.headers.get('retry-after') ?? '1', 10);
+      throw new RateLimitError(retryAfter);
+    }
+
     let dwnRpcResponse: JsonRpcResponse;
 
     // When the server streams record data back, the JSON-RPC envelope is in the
@@ -167,6 +177,10 @@ export class HttpDwnRpcClient implements DwnRpc {
 
     if (dwnRpcResponse.error) {
       const { code, message } = dwnRpcResponse.error;
+      if (code === JsonRpcErrorCodes.TooManyRequests) {
+        const retryAfter = dwnRpcResponse.error.data?.retryAfterSec ?? 1;
+        throw new RateLimitError(retryAfter);
+      }
       throw new Error(`(${code}) - ${message}`);
     }
 
@@ -203,6 +217,10 @@ export class HttpDwnRpcClient implements DwnRpc {
 
     try {
       const response = await this.fetchWithRetry(url.toString());
+      if (response.status === 429) {
+        const retryAfter = parseInt(response.headers.get('retry-after') ?? '1', 10);
+        throw new RateLimitError(retryAfter);
+      }
       if (response.ok) {
         const results = await response.json() as ServerInfo;
 

--- a/packages/dwn-clients/src/index.ts
+++ b/packages/dwn-clients/src/index.ts
@@ -5,6 +5,7 @@ export * from './http-dwn-rpc-client.js';
 export * from './json-rpc.js';
 export * from './json-rpc-socket.js';
 export * from './provider-directory-types.js';
+export * from './rate-limit-error.js';
 export * from './registration-types.js';
 export * from './rpc-client.js';
 export * from './server-info-types.js';

--- a/packages/dwn-clients/src/json-rpc.ts
+++ b/packages/dwn-clients/src/json-rpc.ts
@@ -37,6 +37,7 @@ export enum JsonRpcErrorCodes {
   Unauthorized = -50401, // equivalent to HTTP Status 401
   Forbidden = -50403, // equivalent to HTTP Status 403
   Conflict = -50409, // equivalent to HTTP Status 409
+  TooManyRequests = -50429, // equivalent to HTTP Status 429
 }
 
 export type JsonRpcResponse = JsonRpcSuccessResponse | JsonRpcErrorResponse;

--- a/packages/dwn-clients/src/rate-limit-error.ts
+++ b/packages/dwn-clients/src/rate-limit-error.ts
@@ -1,0 +1,16 @@
+/**
+ * Thrown when a DWN server rejects a request due to rate limiting (HTTP 429).
+ *
+ * Consumers can catch this error to implement retry logic using the
+ * {@link retryAfterSec} value provided by the server.
+ */
+export class RateLimitError extends Error {
+  /** Seconds the client should wait before retrying, as reported by the server. */
+  public readonly retryAfterSec: number;
+
+  constructor(retryAfterSec: number, message?: string) {
+    super(message ?? `Rate limit exceeded, retry after ${retryAfterSec}s`);
+    this.name = 'RateLimitError';
+    this.retryAfterSec = retryAfterSec;
+  }
+}

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -548,6 +548,16 @@ export class HttpApi {
 
     if (jsonRpcResponse.error) {
       requestCounter.inc({ method: dwnRpcRequest.method, error: 1 });
+
+      // Return HTTP 429 with Retry-After header for rate-limit rejections.
+      if (jsonRpcResponse.error.code === JsonRpcErrorCodes.TooManyRequests) {
+        const retryAfterSec = jsonRpcResponse.error.data?.retryAfterSec ?? 1;
+        return Response.json(jsonRpcResponse, {
+          status  : 429,
+          headers : { 'retry-after': String(retryAfterSec) },
+        });
+      }
+
       return Response.json(jsonRpcResponse, { status: 500 });
     }
 

--- a/packages/dwn-server/src/json-rpc-handlers/dwn/process-message.ts
+++ b/packages/dwn-server/src/json-rpc-handlers/dwn/process-message.ts
@@ -82,8 +82,9 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (
         const retryAfterSec = Math.ceil(result.retryAfterMs / 1000);
         const jsonRpcResponse = createJsonRpcErrorResponse(
           requestId,
-          JsonRpcErrorCodes.InvalidRequest,
+          JsonRpcErrorCodes.TooManyRequests,
           `${DwnServerErrorCode.RateLimitExceeded}: tenant rate limit exceeded, retry after ${retryAfterSec}s`,
+          { retryAfterSec },
         );
         return { jsonRpcResponse };
       }

--- a/packages/dwn-server/tests/dwn-process-message.test.ts
+++ b/packages/dwn-server/tests/dwn-process-message.test.ts
@@ -269,8 +269,11 @@ describe('handleDwnProcessMessage', () => {
       const { jsonRpcResponse } = await handleDwnProcessMessage(dwnRequest2, context);
 
       expect(jsonRpcResponse.error).toBeDefined();
+      expect(jsonRpcResponse.error.code).toBe(JsonRpcErrorCodes.TooManyRequests);
       expect(jsonRpcResponse.error.message).toContain(DwnServerErrorCode.RateLimitExceeded);
       expect(jsonRpcResponse.error.message).toContain('retry after');
+      expect(jsonRpcResponse.error.data).toHaveProperty('retryAfterSec');
+      expect(jsonRpcResponse.error.data.retryAfterSec).toBeGreaterThan(0);
       await dwn.close();
     } finally {
       rateLimiter.destroy();


### PR DESCRIPTION
## Summary

- **Per-tenant rate limit now returns HTTP 429** (was 500) with `Retry-After` header, making it distinguishable from server errors for clients and proxies
- **Client no longer crashes on per-IP 429** — `HttpDwnRpcClient` checks HTTP status before attempting JSON-RPC parsing
- **New `RateLimitError` class** with `retryAfterSec` property for programmatic handling
- **New `TooManyRequests` JSON-RPC error code** (`-50429`) with structured `retryAfterSec` in the error `data` field

## What was broken

| Scenario | Before | After |
|---|---|---|
| Per-IP 429 received by client | `TypeError` crash (body isn't JSON-RPC) | `RateLimitError` thrown with `retryAfterSec` |
| Per-tenant rate limit over HTTP | HTTP 500 + generic JSON-RPC error (-32600) | HTTP 429 + `Retry-After` header + `TooManyRequests` code (-50429) |
| Per-tenant rate limit over WebSocket | JSON-RPC error (-32600), info buried in message string | JSON-RPC error (-50429) with structured `retryAfterSec` in `data` |

## Changes

| Package | File | Change |
|---|---|---|
| `@enbox/dwn-clients` | `json-rpc.ts` | Add `TooManyRequests = -50429` to `JsonRpcErrorCodes` |
| `@enbox/dwn-clients` | `rate-limit-error.ts` | New `RateLimitError` class (exported) |
| `@enbox/dwn-clients` | `http-dwn-rpc-client.ts` | Check HTTP 429 before JSON-RPC parse; detect `TooManyRequests` code |
| `@enbox/dwn-server` | `process-message.ts` | Use `TooManyRequests` code + pass `retryAfterSec` in error data |
| `@enbox/dwn-server` | `http-api.ts` | Map `TooManyRequests` JSON-RPC errors to HTTP 429 + `Retry-After` |
| `@enbox/dwn-server` | `dwn-process-message.test.ts` | Assert new error code and data field |

## Usage

```typescript
import { RateLimitError } from '@enbox/dwn-clients';

try {
  await client.sendDwnRequest(request);
} catch (error) {
  if (error instanceof RateLimitError) {
    console.log(`Rate limited. Retry after ${error.retryAfterSec}s`);
  }
}
```