### PR TITLE
test(agent,dwn-clients,api): expand test coverage for live sync and connectivity

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1037,7 +1037,7 @@ export class SyncEngineLevel implements SyncEngine {
    * Delegate to the standalone `topologicalSort` function.
    * Tests call `SyncEngineLevel.topologicalSort(...)` so this static method must remain.
    */
-  static topologicalSort<T extends { message: GenericMessage }>(
+  public static topologicalSort<T extends { message: GenericMessage }>(
     messages: T[]
   ): T[] {
     return topologicalSort(messages);
@@ -1055,14 +1055,13 @@ export class SyncEngineLevel implements SyncEngine {
     const targets: { did: string; dwnUrl: string; delegateDid?: string; protocol?: string }[] = [];
 
     for await (const [did, options] of this._db.sublevel('registeredIdentities').iterator()) {
-      const { protocols, delegateDid } = await new Promise<SyncIdentityOptions>((resolve): void => {
-        try {
-          const parsed = JSON.parse(options) as SyncIdentityOptions;
-          resolve({ protocols: parsed.protocols, delegateDid: parsed.delegateDid });
-        } catch {
-          resolve({ protocols: [] });
-        }
-      });
+      let parsed: SyncIdentityOptions;
+      try {
+        parsed = JSON.parse(options) as SyncIdentityOptions;
+      } catch {
+        parsed = { protocols: [] };
+      }
+      const { protocols, delegateDid } = parsed;
 
       const dwnEndpointUrls = await getDwnServiceEndpointUrls(did, this.agent.did);
       if (dwnEndpointUrls.length === 0) {

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -11,7 +11,7 @@ export type SyncIdentityOptions = {
   /**
    * The protocols that should be synced for this identity, if an empty array is provided, all messages for all protocols will be synced.
    */
-  protocols: string[]
+  protocols: string[];
 };
 
 /**

--- a/packages/agent/tests/sync-api.spec.ts
+++ b/packages/agent/tests/sync-api.spec.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it } from 'bun:test';
+import sinon from 'sinon';
+
+import { afterEach, describe, expect, it } from 'bun:test';
 
 import type { SyncEngine } from '../src/types/sync.js';
 
 import { AgentSyncApi } from '../src/sync-api.js';
 
 describe('AgentSyncApi', () => {
+
+  afterEach(() => {
+    sinon.restore();
+  });
 
   describe('get agent', () => {
     it(`returns the 'agent' instance property`, async () => {
@@ -28,6 +34,19 @@ describe('AgentSyncApi', () => {
     });
   });
 
+  describe('set agent', () => {
+    it('should forward the agent to the underlying sync engine', () => {
+      const mockSyncEngine: any = {};
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      const mockAgent: any = { agentDid: 'did:method:new-agent' };
+      syncApi.agent = mockAgent;
+
+      expect(syncApi.agent.agentDid).toBe('did:method:new-agent');
+      expect(mockSyncEngine.agent).toBe(mockAgent);
+    });
+  });
+
   describe('connectivityState', () => {
     it('should delegate to the underlying sync engine', () => {
       const mockSyncEngine = {
@@ -43,6 +62,127 @@ describe('AgentSyncApi', () => {
       } as SyncEngine;
       const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
       expect(syncApi.connectivityState).toBe('unknown');
+    });
+
+    it('should return offline when engine reports offline', () => {
+      const mockSyncEngine = {
+        connectivityState: 'offline' as const,
+      } as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+      expect(syncApi.connectivityState).toBe('offline');
+    });
+  });
+
+  describe('registerIdentity', () => {
+    it('should delegate to the underlying sync engine', async () => {
+      const registerSpy = sinon.spy();
+      const mockSyncEngine = {
+        registerIdentity: registerSpy,
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      const params = { did: 'did:example:123', options: { protocols: ['https://foo.xyz'] } };
+      await syncApi.registerIdentity(params);
+
+      expect(registerSpy.calledOnce).toBe(true);
+      expect(registerSpy.firstCall.args[0]).toEqual(params);
+    });
+  });
+
+  describe('unregisterIdentity', () => {
+    it('should delegate to the underlying sync engine', async () => {
+      const unregisterSpy = sinon.spy();
+      const mockSyncEngine = {
+        unregisterIdentity: unregisterSpy,
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      await syncApi.unregisterIdentity('did:example:123');
+
+      expect(unregisterSpy.calledOnce).toBe(true);
+      expect(unregisterSpy.firstCall.args[0]).toBe('did:example:123');
+    });
+  });
+
+  describe('getIdentityOptions', () => {
+    it('should delegate to the underlying sync engine and return result', async () => {
+      const expectedOptions = { protocols: ['https://foo.xyz'], delegateDid: 'did:example:delegate' };
+      const mockSyncEngine = {
+        getIdentityOptions: sinon.stub().resolves(expectedOptions),
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      const result = await syncApi.getIdentityOptions('did:example:123');
+
+      expect(result).toEqual(expectedOptions);
+    });
+
+    it('should return undefined for unregistered identity', async () => {
+      const mockSyncEngine = {
+        getIdentityOptions: sinon.stub().resolves(undefined),
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      const result = await syncApi.getIdentityOptions('did:example:unknown');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('updateIdentityOptions', () => {
+    it('should delegate to the underlying sync engine', async () => {
+      const updateSpy = sinon.spy();
+      const mockSyncEngine = {
+        updateIdentityOptions: updateSpy,
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      const params = { did: 'did:example:123', options: { protocols: ['https://bar.xyz'] } };
+      await syncApi.updateIdentityOptions(params);
+
+      expect(updateSpy.calledOnce).toBe(true);
+      expect(updateSpy.firstCall.args[0]).toEqual(params);
+    });
+  });
+
+  describe('sync', () => {
+    it('should delegate to the underlying sync engine without direction', async () => {
+      const syncSpy = sinon.spy();
+      const mockSyncEngine = {
+        sync: syncSpy,
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      await syncApi.sync();
+
+      expect(syncSpy.calledOnce).toBe(true);
+      expect(syncSpy.firstCall.args[0]).toBeUndefined();
+    });
+
+    it('should delegate with push direction', async () => {
+      const syncSpy = sinon.spy();
+      const mockSyncEngine = {
+        sync: syncSpy,
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      await syncApi.sync('push');
+
+      expect(syncSpy.calledOnce).toBe(true);
+      expect(syncSpy.firstCall.args[0]).toBe('push');
+    });
+
+    it('should delegate with pull direction', async () => {
+      const syncSpy = sinon.spy();
+      const mockSyncEngine = {
+        sync: syncSpy,
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      await syncApi.sync('pull');
+
+      expect(syncSpy.calledOnce).toBe(true);
+      expect(syncSpy.firstCall.args[0]).toBe('pull');
     });
   });
 
@@ -67,6 +207,34 @@ describe('AgentSyncApi', () => {
 
       await syncApi.startSync({ mode: 'poll', interval: '2m' });
       expect(receivedParams).toEqual({ mode: 'poll', interval: '2m' });
+    });
+  });
+
+  describe('stopSync', () => {
+    it('should delegate to the underlying sync engine without timeout', async () => {
+      const stopSpy = sinon.spy();
+      const mockSyncEngine = {
+        stopSync: stopSpy,
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      await syncApi.stopSync();
+
+      expect(stopSpy.calledOnce).toBe(true);
+      expect(stopSpy.firstCall.args[0]).toBeUndefined();
+    });
+
+    it('should delegate with custom timeout', async () => {
+      const stopSpy = sinon.spy();
+      const mockSyncEngine = {
+        stopSync: stopSpy,
+      } as unknown as SyncEngine;
+      const syncApi = new AgentSyncApi({ syncEngine: mockSyncEngine });
+
+      await syncApi.stopSync(5000);
+
+      expect(stopSpy.calledOnce).toBe(true);
+      expect(stopSpy.firstCall.args[0]).toBe(5000);
     });
   });
 });

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -2779,6 +2779,115 @@ describe('SyncEngineLevel', () => {
         expect(options).toEqual({ protocols: [] });
       });
     });
+
+    describe('connectivity state transitions', () => {
+      it('should transition to online after a successful sync with registered targets', async () => {
+        // Reset connectivity state (shared syncEngine may have been set to 'online' by prior tests).
+        syncEngine['_connectivityState'] = 'unknown';
+        expect(syncEngine.connectivityState).toBe('unknown');
+
+        // Register Alice's DID to be synchronized.
+        await testHarness.agent.sync.registerIdentity({
+          did: alice.did.uri,
+        });
+
+        await syncEngine.sync();
+
+        expect(syncEngine.connectivityState).toBe('online');
+      });
+
+      it('should transition to offline after a sync failure', async () => {
+        syncEngine['_connectivityState'] = 'unknown';
+
+        // Register Alice's DID.
+        await testHarness.agent.sync.registerIdentity({
+          did: alice.did.uri,
+        });
+
+        // First sync to get to online state.
+        await syncEngine.sync();
+        expect(syncEngine.connectivityState).toBe('online');
+
+        // Now stub getLocalRoot to throw, simulating a failure.
+        const getLocalRootStub = sinon.stub(syncEngine as any, 'getLocalRoot').rejects(new Error('simulated failure'));
+
+        // Suppress console.error for the expected error.
+        const consoleErrorStub = sinon.stub(console, 'error');
+
+        await syncEngine.sync();
+        expect(syncEngine.connectivityState).toBe('offline');
+
+        getLocalRootStub.restore();
+        consoleErrorStub.restore();
+      });
+
+      it('should transition back to online after recovery from failures', async () => {
+        syncEngine['_connectivityState'] = 'unknown';
+
+        // Register Alice's DID.
+        await testHarness.agent.sync.registerIdentity({
+          did: alice.did.uri,
+        });
+
+        // Successful sync -> online.
+        await syncEngine.sync();
+        expect(syncEngine.connectivityState).toBe('online');
+
+        // Failing sync -> offline.
+        const getLocalRootStub = sinon.stub(syncEngine as any, 'getLocalRoot').rejects(new Error('simulated failure'));
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await syncEngine.sync();
+        expect(syncEngine.connectivityState).toBe('offline');
+
+        // Restore and sync successfully -> back to online.
+        getLocalRootStub.restore();
+        consoleErrorStub.restore();
+        await syncEngine.sync();
+        expect(syncEngine.connectivityState).toBe('online');
+      });
+
+      it('should remain unknown when there are no sync targets', async () => {
+        // Reset connectivity state by reconstructing.
+        syncEngine['_connectivityState'] = 'unknown';
+
+        // No identities registered (stores already cleared in beforeEach).
+        await syncEngine.sync();
+
+        // Connectivity state should remain unknown when there are no targets.
+        expect(syncEngine.connectivityState).toBe('unknown');
+      });
+    });
+
+    describe('errored set behavior', () => {
+      it('should skip subsequent targets for the same DWN URL after a failure', async () => {
+        // Create two identities that share the same DWN URL.
+        const alice2 = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
+        const bob2 = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
+        await syncEngine.registerIdentity({ did: alice2.did.uri });
+        await syncEngine.registerIdentity({ did: bob2.did.uri });
+
+        // Stub getLocalRoot to fail for the first target.
+        const consoleErrorStub = sinon.stub(console, 'error');
+        const getLocalRootStub = sinon.stub(syncEngine as any, 'getLocalRoot');
+        getLocalRootStub.onFirstCall().rejects(new Error('DWN unreachable'));
+        getLocalRootStub.callThrough(); // subsequent calls succeed
+
+        await syncEngine.sync();
+
+        // The error should have been logged.
+        expect(consoleErrorStub.called).toBe(true);
+
+        // Since both identities share the same DWN URL, the first failure should
+        // add it to the errored set, and the second identity's sync for that URL
+        // should be skipped (no additional error for it).
+        // We can verify by checking the number of getLocalRoot calls:
+        // only 1 call (the first target), not 2.
+        expect(getLocalRootStub.callCount).toBe(1);
+
+        getLocalRootStub.restore();
+        consoleErrorStub.restore();
+      });
+    });
   });
 
   describe('topologicalSort', () => {

--- a/packages/api/tests/typed-live-query.spec.ts
+++ b/packages/api/tests/typed-live-query.spec.ts
@@ -3,6 +3,16 @@ import { describe, expect, it } from 'bun:test';
 import { TypedLiveQuery } from '../src/typed-live-query.js';
 
 /**
+ * Creates a minimal mock Record for testing TypedLiveQuery record wrapping.
+ */
+function createMockRecord(id: string): any {
+  return {
+    id,
+    data: { json: async (): Promise<any> => ({ id }) },
+  };
+}
+
+/**
  * Creates a minimal mock LiveQuery for testing TypedLiveQuery delegation.
  */
 function createMockLiveQuery(overrides?: Partial<any>): any {
@@ -100,6 +110,51 @@ describe('TypedLiveQuery', () => {
       mock._emit('disconnected');
       expect(callCount).toBe(1); // Should not increment after unsub.
     });
+
+    it('should return unsubscribe function for reconnected event', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery(mock);
+
+      let callCount = 0;
+      const unsub = typed.on('reconnected', () => { callCount++; });
+
+      mock._emit('reconnected');
+      expect(callCount).toBe(1);
+
+      unsub();
+      mock._emit('reconnected');
+      expect(callCount).toBe(1);
+    });
+
+    it('should return unsubscribe function for eose event', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery(mock);
+
+      let callCount = 0;
+      const unsub = typed.on('eose', () => { callCount++; });
+
+      mock._emit('eose');
+      expect(callCount).toBe(1);
+
+      unsub();
+      mock._emit('eose');
+      expect(callCount).toBe(1);
+    });
+
+    it('should return unsubscribe function for reconnecting event', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery(mock);
+
+      let callCount = 0;
+      const unsub = typed.on('reconnecting', () => { callCount++; });
+
+      mock._emit('reconnecting', { attempt: 1 });
+      expect(callCount).toBe(1);
+
+      unsub();
+      mock._emit('reconnecting', { attempt: 2 });
+      expect(callCount).toBe(1);
+    });
   });
 
   describe('isConnected', () => {
@@ -113,6 +168,150 @@ describe('TypedLiveQuery', () => {
       const mock = createMockLiveQuery({ isConnected: false });
       const typed = new TypedLiveQuery(mock);
       expect(typed.isConnected).toBe(false);
+    });
+  });
+
+  describe('records', () => {
+    it('should wrap underlying records as TypedRecord instances', () => {
+      const mockRecords = [createMockRecord('rec-1'), createMockRecord('rec-2')];
+      const mock = createMockLiveQuery({ records: mockRecords });
+      const typed = new TypedLiveQuery<{ id: string }>(mock);
+
+      const records = typed.records;
+      expect(records).toHaveLength(2);
+      // TypedRecord wraps the underlying Record; the original record is accessible.
+      expect(records[0]).toBeDefined();
+      expect(records[1]).toBeDefined();
+    });
+
+    it('should cache typed records on subsequent accesses', () => {
+      const mockRecords = [createMockRecord('rec-1')];
+      const mock = createMockLiveQuery({ records: mockRecords });
+      const typed = new TypedLiveQuery<{ id: string }>(mock);
+
+      const first = typed.records;
+      const second = typed.records;
+      expect(first).toBe(second); // Same array reference.
+    });
+
+    it('should return empty array when no records', () => {
+      const mock = createMockLiveQuery({ records: [] });
+      const typed = new TypedLiveQuery<{ id: string }>(mock);
+
+      expect(typed.records).toHaveLength(0);
+    });
+  });
+
+  describe('cursor', () => {
+    it('should delegate to underlying LiveQuery cursor', () => {
+      const mockCursor = { messageCid: 'cid-abc', value: '2024-01-01' };
+      const mock = createMockLiveQuery({ cursor: mockCursor });
+      const typed = new TypedLiveQuery(mock);
+
+      expect(typed.cursor).toBe(mockCursor);
+    });
+
+    it('should return undefined when no cursor', () => {
+      const mock = createMockLiveQuery({ cursor: undefined });
+      const typed = new TypedLiveQuery(mock);
+
+      expect(typed.cursor).toBeUndefined();
+    });
+  });
+
+  describe('rawLiveQuery', () => {
+    it('should return the underlying LiveQuery instance', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery(mock);
+
+      expect(typed.rawLiveQuery).toBe(mock);
+    });
+  });
+
+  describe('record change events', () => {
+    it('should wrap change event records as TypedRecord', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery<{ id: string }>(mock);
+
+      let receivedChange: any;
+      typed.on('change', (change) => { receivedChange = change; });
+
+      const mockRecord = createMockRecord('change-rec');
+      mock._emit('change', { type: 'create', record: mockRecord });
+
+      expect(receivedChange).toBeDefined();
+      expect(receivedChange.type).toBe('create');
+      // The record should be wrapped in a TypedRecord.
+      expect(receivedChange.record).toBeDefined();
+    });
+
+    it('should wrap create event records as TypedRecord', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery<{ id: string }>(mock);
+
+      let receivedRecord: any;
+      typed.on('create', (record) => { receivedRecord = record; });
+
+      const mockRecord = createMockRecord('create-rec');
+      mock._emit('create', mockRecord);
+
+      expect(receivedRecord).toBeDefined();
+    });
+
+    it('should wrap update event records as TypedRecord', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery<{ id: string }>(mock);
+
+      let receivedRecord: any;
+      typed.on('update', (record) => { receivedRecord = record; });
+
+      const mockRecord = createMockRecord('update-rec');
+      mock._emit('update', mockRecord);
+
+      expect(receivedRecord).toBeDefined();
+    });
+
+    it('should wrap delete event records as TypedRecord', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery<{ id: string }>(mock);
+
+      let receivedRecord: any;
+      typed.on('delete', (record) => { receivedRecord = record; });
+
+      const mockRecord = createMockRecord('delete-rec');
+      mock._emit('delete', mockRecord);
+
+      expect(receivedRecord).toBeDefined();
+    });
+
+    it('should return unsubscribe function for change event', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery<{ id: string }>(mock);
+
+      let callCount = 0;
+      const unsub = typed.on('change', () => { callCount++; });
+
+      mock._emit('change', { type: 'create', record: createMockRecord('r') });
+      expect(callCount).toBe(1);
+
+      unsub();
+      mock._emit('change', { type: 'create', record: createMockRecord('r') });
+      expect(callCount).toBe(1);
+    });
+
+    it('should return unsubscribe function for create event', () => {
+      const mock = createMockLiveQuery();
+      const typed = new TypedLiveQuery<{ id: string }>(mock);
+
+      let callCount = 0;
+      const unsub = typed.on('create', () => { callCount++; });
+
+      mock._emit('create', createMockRecord('r'));
+      expect(callCount).toBe(1);
+
+      unsub();
+      mock._emit('create', createMockRecord('r'));
+      expect(callCount).toBe(1);
     });
   });
 

--- a/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
+++ b/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
@@ -374,6 +374,91 @@ describe('HttpDwnRpcClient', () => {
         message,
       })).rejects.toThrow('Failed to fetch');
     });
+
+    it('should exhaust retries and return last response on persistent retryable status', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      // All calls return 503.
+      const body = JSON.stringify({
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { reply: { status: { code: 503, detail: 'Service Unavailable' }, entries: [] } },
+      });
+      fetchStub.resolves({
+        status  : 503,
+        headers : new Headers(),
+        text    : async (): Promise<string> => body,
+      } as any);
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      // After exhausting retries the last response is returned (not thrown).
+      const response = await retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      });
+
+      expect(response.status.code).toBe(503);
+      // 1 initial + 2 retries = 3 total calls.
+      expect(fetchStub.callCount).toBe(3);
+    });
+
+    it('should apply per-attempt timeout via AbortSignal', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      // Verify that every fetch call receives a signal.
+      const jsonRpcResponse = {
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { reply: { status: { code: 200, detail: 'OK' }, entries: [] } },
+      };
+      fetchStub.callsFake(async (_url: string, init?: RequestInit): Promise<Response> => {
+        // The fetchWithRetry method should always attach a signal.
+        expect(init?.signal).toBeDefined();
+        expect(init!.signal!.aborted).toBe(false);
+        return {
+          status  : 200,
+          headers : new Headers(),
+          text    : async (): Promise<string> => JSON.stringify(jsonRpcResponse),
+        } as any;
+      });
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 1, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      const response = await retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      });
+
+      expect(response.status.code).toBe(200);
+      expect(fetchStub.callCount).toBe(1);
+    });
+
+    it('should not retry on non-retryable errors (e.g. RangeError)', async () => {
+      sinon.stub(globalThis, 'fetch').rejects(new RangeError('Invalid argument'));
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 3, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      await expect(retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+      })).rejects.toThrow('Invalid argument');
+    });
   });
 
   describe('getServerInfo', () => {
@@ -415,6 +500,37 @@ describe('HttpDwnRpcClient', () => {
         expect(error.message).toContain('Error encountered while processing response');
         expect(error.message).toContain('network error');
       }
+    });
+
+    it('retries on transient failure then succeeds for getServerInfo', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      // First call: 503
+      fetchStub.onFirstCall().resolves({
+        status  : 503,
+        headers : new Headers(),
+      } as any);
+
+      // Second call: success
+      fetchStub.onSecondCall().resolves({
+        ok     : true,
+        status : 200,
+        json   : async (): Promise<any> => ({
+          maxFileSize              : 1_000_000,
+          registrationRequirements : [],
+          server                   : 'test-server',
+          sdkVersion               : '1.0.0',
+          url                      : 'http://localhost:9999',
+          version                  : '1.0.0',
+          webSocketSupport         : true,
+        }),
+      } as any);
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 });
+      const serverInfo = await retryClient.getServerInfo('http://localhost:9999');
+
+      expect(serverInfo.maxFileSize).toBe(1_000_000);
+      expect(fetchStub.callCount).toBe(2);
     });
 
     it('accepts a custom server info cache', async () => {


### PR DESCRIPTION
## Summary

- Adds **36 new tests** across 4 packages to improve coverage for the live sync and connectivity features from #485
- Fixes 3 minor code quality issues identified during the review

## Code Fixes

- **Remove unnecessary `Promise` wrapper** around synchronous `JSON.parse` in `SyncEngineLevel.getSyncTargets()` — was wrapping a sync operation in a `new Promise` for no reason
- **Add missing semicolon** on `protocols: string[]` in `types/sync.ts`
- **Add missing `public` modifier** on `static topologicalSort` in `SyncEngineLevel`

## New Tests

| Package | File | New Tests | Coverage Area |
|---|---|---|---|
| `dwn-clients` | `http-dwn-rpc-client.spec.ts` | +4 | Retry exhaustion on persistent 503, per-attempt `AbortSignal` timeout, non-retryable error passthrough, `getServerInfo` retry |
| `agent` | `sync-api.spec.ts` | +12 | Full delegation coverage: `set agent`, `registerIdentity`, `unregisterIdentity`, `getIdentityOptions`, `updateIdentityOptions`, `sync` (all directions), `stopSync` (default + custom timeout), `connectivityState` (offline) |
| `agent` | `sync-engine-level.spec.ts` | +5 | Connectivity state transitions (`unknown` → `online` → `offline` → recovery), errored set DWN URL skipping |
| `api` | `typed-live-query.spec.ts` | +15 | Record wrapping for `change`/`create`/`update`/`delete` events, `cursor` + `rawLiveQuery` getters, `records` caching, unsubscribe for all lifecycle event types |

## Verification

- All lint passes (`bun run lint`)
- dwn-clients: 115 pass, 0 fail
- agent: 740 pass, 4 skip, 0 fail
- api: 354 pass, 0 fail (excluding pre-existing `@enbox/protocols` issue)