### PR TITLE
fix(security): harden low-severity attack surfaces

### DIFF
--- a/packages/dids/src/did.ts
+++ b/packages/dids/src/did.ts
@@ -145,6 +145,9 @@ export class Did {
     // Return null if the input string is empty or not provided.
     if (!didUri) {return null;}
 
+    // Guard against ReDoS: reject unreasonably long URIs before executing the regex.
+    if (didUri.length > 2048) {return null;}
+
     // Execute the regex pattern on the input string to extract URI components.
     const match = Did.DID_URI_PATTERN.exec(didUri);
 

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -18,12 +18,12 @@ import type { SocketConnection } from './connection/socket-connection.js';
 import log from 'loglevel';
 
 import { Convert } from '@enbox/common';
-import { join } from 'path';
 import { register } from 'prom-client';
 import { v4 as uuidv4 } from 'uuid';
 import { createJsonRpcErrorResponse, JsonRpcErrorCodes } from '@enbox/dwn-clients';
 import { DataStream, DateSort, type Dwn, ProtocolsQuery, RecordsQuery, RecordsRead } from '@enbox/dwn-sdk-js';
 import { existsSync, readFileSync } from 'fs';
+import { join, resolve } from 'path';
 
 import { config } from './config.js';
 import { jsonRpcRouter } from './json-rpc-api.js';
@@ -211,6 +211,7 @@ export class HttpApi {
       },
 
       websocket: {
+        maxPayloadLength: self.#config.maxRecordDataSize,
         open(ws: ServerWebSocket<WsData>): void {
           if (self.onWebSocketConnection) {
             self.onWebSocketConnection(ws);
@@ -271,6 +272,12 @@ export class HttpApi {
       filePath = join(this.#adminUiPath, 'index.html');
     } else {
       filePath = join(this.#adminUiPath, relativePath);
+    }
+
+    // Prevent path traversal: resolved path must stay within the admin UI directory.
+    const resolvedBase = resolve(this.#adminUiPath);
+    if (!resolve(filePath).startsWith(resolvedBase)) {
+      return null;
     }
 
     if (!existsSync(filePath)) {

--- a/packages/dwn-server/src/plugins/event-log-nats.ts
+++ b/packages/dwn-server/src/plugins/event-log-nats.ts
@@ -118,8 +118,13 @@ function encodePayload(payload: NatsEventPayload): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(payload));
 }
 
-function decodePayload(data: Uint8Array): NatsEventPayload {
-  return JSON.parse(new TextDecoder().decode(data)) as NatsEventPayload;
+function decodePayload(data: Uint8Array): NatsEventPayload | undefined {
+  try {
+    return JSON.parse(new TextDecoder().decode(data)) as NatsEventPayload;
+  } catch {
+    log.error('NatsEventLog: failed to decode payload, skipping corrupt message');
+    return undefined;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -247,6 +252,9 @@ export default class NatsEventLog implements EventLog {
 
       for await (const msg of iter) {
         const payload = decodePayload(msg.data);
+        if (payload === undefined) {
+          continue;
+        }
 
         if (!matchAnyFilter(payload.indexes, filters)) {
           continue;
@@ -328,6 +336,10 @@ export default class NatsEventLog implements EventLog {
           }
 
           const payload = decodePayload(msg.data);
+          if (payload === undefined) {
+            msg.ack();
+            continue;
+          }
 
           if (!matchAnyFilter(payload.indexes, filters)) {
             msg.ack();

--- a/packages/dwn-server/src/web5-connect/sql-ttl-cache.ts
+++ b/packages/dwn-server/src/web5-connect/sql-ttl-cache.ts
@@ -103,7 +103,13 @@ export class SqlTtlCache {
       return undefined;
     }
 
-    return JSON.parse(entry.value);
+    try {
+      return JSON.parse(entry.value);
+    } catch {
+      // Corrupt entry — remove it and return undefined.
+      this.delete(key); // no need to await
+      return undefined;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Addresses 4 low-severity security issues identified during the security audit:

- **Path traversal guard in admin UI** (#468): `resolve()` + `startsWith()` check prevents `../` escape from the admin UI dist directory
- **ReDoS guard in `DID.parse()`** (#474): Rejects URIs longer than 2,048 characters before executing the regex with nested quantifiers
- **WebSocket message size limit** (#475): Sets `maxPayloadLength` to `maxRecordDataSize` (default 100MB) on the Bun WebSocket config, preventing unbounded memory allocation from oversized frames
- **JSON.parse safety** (#476): Wraps `JSON.parse()` in try/catch in NATS event log `decodePayload()` and SQL TTL cache `get()`, gracefully handling corrupt data instead of crashing

## Testing

- All lint checks pass (`bun run lint`)
- `@enbox/dids`: 303 pass, 0 fail
- `@enbox/dwn-server`: 388 pass, 0 fail

Closes #468, #474, #475, #476