### PR TITLE
fix(dwn-sdk-js): improve squash crash safety, purging, schema strictness, and test coverage

### DIFF
--- a/packages/dwn-sdk-js/json-schemas/interface-methods/protocol-rule-set.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/protocol-rule-set.json
@@ -147,7 +147,8 @@
     },
     "$squash": {
       "$comment": "When true, enables squash writes at this protocol path — a RecordsWrite with squash: true atomically creates a snapshot and deletes all older sibling records",
-      "type": "boolean"
+      "type": "boolean",
+      "enum": [true]
     },
     "$tags": {
       "type": "object",

--- a/packages/dwn-sdk-js/src/core/resumable-task-manager.ts
+++ b/packages/dwn-sdk-js/src/core/resumable-task-manager.ts
@@ -3,6 +3,7 @@ import type { ManagedResumableTask, ResumableTaskStore } from '../types/resumabl
 
 export enum ResumableTaskName {
   RecordsDelete = 'RecordsDelete',
+  RecordsSquash = 'RecordsSquash',
 }
 
 export type ResumableTask = {
@@ -26,7 +27,8 @@ export class ResumableTaskManager {
     this.resumableTaskHandlers = {
       // NOTE: The arrow function is IMPORTANT here, else the `this` context will be lost within the invoked method.
       // e.g. code within performRecordsDelete() won't know `this` refers to the `storageController` instance.
-      [ResumableTaskName.RecordsDelete]: async (task): Promise<void> => await storageController.performRecordsDelete(task),
+      [ResumableTaskName.RecordsDelete] : async (task): Promise<void> => await storageController.performRecordsDelete(task),
+      [ResumableTaskName.RecordsSquash] : async (task): Promise<void> => await storageController.performRecordsSquash(task),
     };
   }
 

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -1,6 +1,6 @@
 import type { Filter } from '../types/query-types.js';
+import type { GenericMessageReply } from '../types/message-types.js';
 import type { MessageStore } from '../types/message-store.js';
-import type { GenericMessage, GenericMessageReply } from '../types/message-types.js';
 import type { HandlerDependencies, MethodHandler } from '../types/method-handler.js';
 import type { RecordsQueryReplyEntry, RecordsWriteMessage } from '../types/records-types.js';
 
@@ -17,6 +17,7 @@ import { ProtocolAuthorization } from '../core/protocol-authorization.js';
 import { Records } from '../utils/records.js';
 import { RecordsGrantAuthorization } from '../core/records-grant-authorization.js';
 import { RecordsWrite } from '../interfaces/records-write.js';
+import { ResumableTaskName } from '../core/resumable-task-manager.js';
 import { SortDirection } from '../types/query-types.js';
 import { StorageController } from '../store/storage-controller.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
@@ -181,9 +182,12 @@ export class RecordsWriteHandler implements MethodHandler {
     );
 
     // Squash processing: if the incoming write is a squash, delete all older sibling records
-    // at the same protocol path and parent context.
+    // at the same protocol path and parent context. Uses the resumable task system for crash safety.
     if (message.descriptor.squash === true) {
-      await this.processSquash(tenant, message);
+      await this.deps.resumableTaskManager!.run({
+        name : ResumableTaskName.RecordsSquash,
+        data : { tenant, message }
+      });
     }
 
     // Dispatch post-processing hooks to the core protocol, if applicable.
@@ -349,9 +353,10 @@ export class RecordsWriteHandler implements MethodHandler {
         undefined,
         this.deps.coreProtocols,
       );
-    } catch {
+    } catch (error) {
       // If the protocol definition can't be found, skip the backstop check.
       // Authorization will handle the missing protocol error later.
+      console.warn(`enforceSquashBackstop: failed to fetch protocol definition for '${message.descriptor.protocol}':`, error);
       return;
     }
 
@@ -405,91 +410,6 @@ export class RecordsWriteHandler implements MethodHandler {
         `at protocol path '${message.descriptor.protocolPath}'.`
       );
     }
-  }
-
-  /**
-   * Processes a squash write: deletes all sibling records at the same protocol path and parent
-   * context whose `messageTimestamp` is strictly older than the squash record's `messageTimestamp`.
-   * Unlike normal `RecordsDelete` tombstones, squash targets are fully purged — no initial writes
-   * are retained.
-   */
-  private async processSquash(tenant: string, squashMessage: RecordsWriteMessage): Promise<void> {
-    const { protocol, protocolPath, messageTimestamp } = squashMessage.descriptor;
-
-    // Build a filter to find all sibling records at the same protocol path and parent context
-    const filter: Filter = {
-      interface    : DwnInterfaceName.Records,
-      method       : DwnMethodName.Write,
-      protocol,
-      protocolPath : protocolPath,
-    };
-
-    // Scope by parent context for nested records
-    const parentContextId = Records.getParentContextFromOfContextId(squashMessage.contextId);
-    if (parentContextId !== undefined && parentContextId !== '') {
-      const prefixFilter = FilterUtility.constructPrefixFilterAsRangeFilter(parentContextId);
-      filter.contextId = prefixFilter;
-    }
-
-    // Query for all records at this path and context
-    const { messages: siblingMessages } = await this.deps.messageStore.query(tenant, [filter]);
-
-    // Group messages by recordId
-    const recordIdToMessages = new Map<string, GenericMessage[]>();
-    for (const msg of siblingMessages) {
-      const recordId = (msg as RecordsWriteMessage).recordId;
-      const existing = recordIdToMessages.get(recordId);
-      if (existing !== undefined) {
-        existing.push(msg);
-      } else {
-        recordIdToMessages.set(recordId, [msg]);
-      }
-    }
-
-    // Delete all records whose messageTimestamp is strictly older than the squash record's timestamp.
-    // Skip the squash record itself.
-    for (const [recordId, messages] of recordIdToMessages) {
-      if (recordId === squashMessage.recordId) {
-        continue;
-      }
-
-      // Check if ALL messages for this recordId are older than the squash timestamp.
-      // We use the newest message's timestamp to determine if the record predates the squash.
-      const newestMessage = await Message.getNewestMessage(messages);
-      if (newestMessage === undefined) {
-        continue;
-      }
-
-      const newestTimestamp = (newestMessage as RecordsWriteMessage).descriptor.messageTimestamp;
-      if (newestTimestamp < messageTimestamp) {
-        // Fully purge this record — all messages (including initial write) and their data
-        await this.purgeRecord(tenant, messages);
-      }
-    }
-  }
-
-  /**
-   * Fully purges all messages of a single record — deletes data, state index entries,
-   * and message store entries. Unlike normal record deletion, no initial write is retained.
-   */
-  private async purgeRecord(tenant: string, recordMessages: GenericMessage[]): Promise<void> {
-    // Delete data from the data store for any RecordsWrite messages that have large data
-    const recordsWrites = recordMessages.filter(
-      (msg: GenericMessage): boolean => msg.descriptor.method === DwnMethodName.Write
-    );
-    if (recordsWrites.length > 0) {
-      const newestWrite = (await Message.getNewestMessage(recordsWrites)) as RecordsWriteMessage;
-      await this.deps.dataStore!.delete(tenant, newestWrite.recordId, newestWrite.descriptor.dataCid);
-    }
-
-    // Delete state index entries and message store entries
-    const messageCids = await Promise.all(
-      recordMessages.map((msg: GenericMessage): Promise<string> => Message.getCid(msg))
-    );
-    await this.deps.stateIndex!.delete(tenant, messageCids);
-    await Promise.all(
-      messageCids.map((cid: string): Promise<void> => this.deps.messageStore.delete(tenant, cid))
-    );
   }
 
   private async authorizeRecordsWrite(tenant: string, recordsWrite: RecordsWrite, messageStore: MessageStore): Promise<void> {

--- a/packages/dwn-sdk-js/src/store/storage-controller.ts
+++ b/packages/dwn-sdk-js/src/store/storage-controller.ts
@@ -1,11 +1,13 @@
 import type { DataStore } from '../types/data-store.js';
 import type { EventLog } from '../types/subscriptions.js';
+import type { Filter } from '../types/query-types.js';
 import type { GenericMessage } from '../types/message-types.js';
 import type { MessageStore } from '../types/message-store.js';
 import type { StateIndex } from '../types/state-index.js';
 import type { RecordsDeleteMessage, RecordsQueryReplyEntry, RecordsWriteMessage } from '../types/records-types.js';
 
 import { DwnConstant } from '../core/dwn-constant.js';
+import { FilterUtility } from '../utils/filter.js';
 import { Message } from '../core/message.js';
 import { Records } from '../utils/records.js';
 import { RecordsDelete } from '../interfaces/records-delete.js';
@@ -16,6 +18,11 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 export type ResumableRecordsDeleteData = {
   tenant: string;
   message: RecordsDeleteMessage;
+};
+
+export type ResumableRecordsSquashData = {
+  tenant: string;
+  message: RecordsWriteMessage;
 };
 
 /**
@@ -80,6 +87,76 @@ export class StorageController {
     await StorageController.deleteAllOlderMessagesButKeepInitialWrite(
       tenant, existingMessages, message, this.messageStore, this.dataStore, this.stateIndex
     );
+  }
+
+  /**
+   * Performs the squash processing for a `RecordsWrite` with `squash: true`.
+   * Deletes all sibling records at the same protocol path and parent context whose
+   * `messageTimestamp` is strictly older than the squash record's `messageTimestamp`.
+   * Unlike normal `RecordsDelete` tombstones, squash targets are fully purged — no initial writes
+   * are retained.
+   *
+   * This method is idempotent — it can be safely re-run on resume after a crash.
+   */
+  public async performRecordsSquash({ tenant, message }: ResumableRecordsSquashData): Promise<void> {
+    const { protocol, protocolPath, messageTimestamp } = message.descriptor;
+
+    // Build a filter to find all sibling records at the same protocol path and parent context.
+    // We query by interface only (not method) so that both RecordsWrite and RecordsDelete messages are found.
+    const filter: Filter = {
+      interface    : DwnInterfaceName.Records,
+      protocol,
+      protocolPath : protocolPath,
+    };
+
+    // Scope by parent context for nested records
+    const parentContextId = Records.getParentContextFromOfContextId(message.contextId);
+    if (parentContextId !== undefined && parentContextId !== '') {
+      const prefixFilter = FilterUtility.constructPrefixFilterAsRangeFilter(parentContextId);
+      filter.contextId = prefixFilter;
+    }
+
+    // Query for all records at this path and context
+    const { messages: siblingMessages } = await this.messageStore.query(tenant, [filter]);
+
+    // Group messages by recordId — RecordsWrite messages use `message.recordId`,
+    // RecordsDelete messages use `message.descriptor.recordId`.
+    const recordIdToMessages = new Map<string, GenericMessage[]>();
+    for (const msg of siblingMessages) {
+      let recordId: string;
+      if (Records.isRecordsWrite(msg)) {
+        recordId = msg.recordId;
+      } else {
+        recordId = (msg as RecordsDeleteMessage).descriptor.recordId;
+      }
+
+      const existing = recordIdToMessages.get(recordId);
+      if (existing !== undefined) {
+        existing.push(msg);
+      } else {
+        recordIdToMessages.set(recordId, [msg]);
+      }
+    }
+
+    // Delete all records whose newest message timestamp is strictly older than the squash timestamp.
+    // Skip the squash record itself.
+    for (const [recordId, messages] of recordIdToMessages) {
+      if (recordId === message.recordId) {
+        continue;
+      }
+
+      // Use the newest message's timestamp to determine if the record predates the squash.
+      const newestMessage = await Message.getNewestMessage(messages);
+      if (newestMessage === undefined) {
+        continue;
+      }
+
+      const newestTimestamp = newestMessage.descriptor.messageTimestamp;
+      if (newestTimestamp < messageTimestamp) {
+        // Fully purge this record — all messages (including initial write) and their data
+        await StorageController.purgeRecordMessages(tenant, messages, this.messageStore, this.dataStore, this.stateIndex);
+      }
+    }
   }
 
   /**
@@ -164,7 +241,7 @@ export class StorageController {
    * Purges (permanent hard-delete) all messages of the SAME `recordId` given and their associated data and events.
    * Assumes that the given `recordMessages` are all of the same `recordId`.
    */
-  private static async purgeRecordMessages(
+  public static async purgeRecordMessages(
     tenant: string,
     recordMessages: GenericMessage[],
     messageStore: MessageStore,

--- a/packages/dwn-sdk-js/tests/features/records-squash.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-squash.spec.ts
@@ -7,8 +7,10 @@ import sinon from 'sinon';
 import { DataStream } from '../../src/utils/data-stream.js';
 import { DidKey } from '@enbox/dids';
 import { Dwn } from '../../src/dwn.js';
+import { DwnConstant } from '../../src/core/dwn-constant.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Jws } from '../../src/utils/jws.js';
+import { RecordsDelete } from '../../src/interfaces/records-delete.js';
 import { RecordsWrite } from '../../src/interfaces/records-write.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
@@ -684,6 +686,500 @@ export function testRecordsSquash(): void {
 
         // verify the descriptor does not have squash
         expect(record.message.descriptor.squash).toBeUndefined();
+      });
+    });
+
+    describe('protocol definition validation — $squash: false', () => {
+      it('should reject a protocol definition with $squash: false at schema validation time', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const invalidProtocol: ProtocolDefinition = {
+          protocol  : 'http://squash-false-test.xyz',
+          published : true,
+          types     : { note: {} },
+          structure : {
+            note: {
+              $squash  : false as unknown as boolean,
+              $actions : [{ who: 'anyone', can: ['create', 'read'] }],
+            }
+          }
+        };
+
+        // $squash: false is rejected by JSON schema validation (enum: [true]) during message creation
+        await expect(TestDataGenerator.generateProtocolsConfigure({
+          author             : alice,
+          protocolDefinition : invalidProtocol,
+        })).rejects.toThrow('must be equal to one of the allowed values');
+      });
+    });
+
+    describe('root-level squash path', () => {
+      it('should squash records at a root-level protocol path (no parent context)', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        // protocol with $squash at root level
+        const rootSquashProtocol: ProtocolDefinition = {
+          protocol  : 'http://root-squash.xyz',
+          published : true,
+          types     : { note: {} },
+          structure : {
+            note: {
+              $squash  : true,
+              $actions : [{ who: 'anyone', can: ['create', 'read'] }],
+            }
+          }
+        };
+
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author             : alice,
+          protocolDefinition : rootSquashProtocol,
+        });
+        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(configReply.status.code).toBe(202);
+
+        // create several root-level records
+        const records = [];
+        for (let i = 0; i < 4; i++) {
+          const timestamp = Time.createOffsetTimestamp({ seconds: i + 1 });
+          const record = await TestDataGenerator.generateRecordsWrite({
+            author           : alice,
+            protocol         : rootSquashProtocol.protocol,
+            protocolPath     : 'note',
+            messageTimestamp : timestamp,
+            dateCreated      : timestamp,
+          });
+          const reply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+          expect(reply.status.code).toBe(202);
+          records.push(record);
+        }
+
+        // squash all root-level records
+        const squashTimestamp = Time.createOffsetTimestamp({ seconds: 10 });
+        const squashRecord = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol         : rootSquashProtocol.protocol,
+          protocolPath     : 'note',
+          messageTimestamp : squashTimestamp,
+          dateCreated      : squashTimestamp,
+          squash           : true,
+        });
+        const squashReply = await dwn.processMessage(alice.did, squashRecord.message, { dataStream: squashRecord.dataStream });
+        expect(squashReply.status.code).toBe(202);
+
+        // query: only the squash record should remain
+        const query = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            protocol     : rootSquashProtocol.protocol,
+            protocolPath : 'note',
+          },
+        });
+        const queryReply = await dwn.processMessage(alice.did, query.message);
+        expect(queryReply.status.code).toBe(200);
+        expect(queryReply.entries!.length).toBe(1);
+        expect(queryReply.entries![0].recordId).toBe(squashRecord.message.recordId);
+      });
+
+      it('should enforce backstop at a root-level protocol path', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const rootSquashProtocol: ProtocolDefinition = {
+          protocol  : 'http://root-squash-backstop.xyz',
+          published : true,
+          types     : { note: {} },
+          structure : {
+            note: {
+              $squash  : true,
+              $actions : [{ who: 'anyone', can: ['create', 'read'] }],
+            }
+          }
+        };
+
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author             : alice,
+          protocolDefinition : rootSquashProtocol,
+        });
+        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(configReply.status.code).toBe(202);
+
+        // create a squash
+        const squashTimestamp = Time.createOffsetTimestamp({ seconds: 10 });
+        const squashRecord = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol         : rootSquashProtocol.protocol,
+          protocolPath     : 'note',
+          messageTimestamp : squashTimestamp,
+          dateCreated      : squashTimestamp,
+          squash           : true,
+        });
+        const squashReply = await dwn.processMessage(alice.did, squashRecord.message, { dataStream: squashRecord.dataStream });
+        expect(squashReply.status.code).toBe(202);
+
+        // attempt a write older than the squash — should be rejected
+        const olderTimestamp = Time.createOffsetTimestamp({ seconds: 5 });
+        const olderRecord = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol         : rootSquashProtocol.protocol,
+          protocolPath     : 'note',
+          messageTimestamp : olderTimestamp,
+          dateCreated      : olderTimestamp,
+        });
+        const olderReply = await dwn.processMessage(alice.did, olderRecord.message, { dataStream: olderRecord.dataStream });
+        expect(olderReply.status.code).toBe(409);
+        expect(olderReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationSquashBackstop);
+      });
+    });
+
+    describe('cross-context isolation', () => {
+      it('should not delete records under a different parent context', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const { protocol, documentContextId: docAContextId } = await setupProtocolAndDocument(alice);
+
+        // create a second document (different parent context)
+        const docB = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          protocol,
+          protocolPath : 'document',
+        });
+        const docBReply = await dwn.processMessage(alice.did, docB.message, { dataStream: docB.dataStream });
+        expect(docBReply.status.code).toBe(202);
+        const docBContextId = docB.message.contextId;
+
+        // create patches under document A
+        const patchTimestamp = Time.createOffsetTimestamp({ seconds: 1 });
+        const patchA = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : docAContextId,
+          messageTimestamp : patchTimestamp,
+          dateCreated      : patchTimestamp,
+        });
+        const patchAReply = await dwn.processMessage(alice.did, patchA.message, { dataStream: patchA.dataStream });
+        expect(patchAReply.status.code).toBe(202);
+
+        // create patches under document B
+        const patchB = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : docBContextId,
+          messageTimestamp : patchTimestamp,
+          dateCreated      : patchTimestamp,
+        });
+        const patchBReply = await dwn.processMessage(alice.did, patchB.message, { dataStream: patchB.dataStream });
+        expect(patchBReply.status.code).toBe(202);
+
+        // squash under document A
+        const squashTimestamp = Time.createOffsetTimestamp({ seconds: 10 });
+        const squashA = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : docAContextId,
+          messageTimestamp : squashTimestamp,
+          dateCreated      : squashTimestamp,
+          squash           : true,
+        });
+        const squashAReply = await dwn.processMessage(alice.did, squashA.message, { dataStream: squashA.dataStream });
+        expect(squashAReply.status.code).toBe(202);
+
+        // verify patchA was deleted (squash under doc A)
+        const queryA = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            protocol,
+            protocolPath : 'document/patch',
+            contextId    : docAContextId,
+          },
+        });
+        const queryAReply = await dwn.processMessage(alice.did, queryA.message);
+        expect(queryAReply.status.code).toBe(200);
+        expect(queryAReply.entries!.length).toBe(1);
+        expect(queryAReply.entries![0].recordId).toBe(squashA.message.recordId);
+
+        // verify patchB is still present (different parent context)
+        const queryB = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            protocol,
+            protocolPath : 'document/patch',
+            contextId    : docBContextId,
+          },
+        });
+        const queryBReply = await dwn.processMessage(alice.did, queryB.message);
+        expect(queryBReply.status.code).toBe(200);
+        expect(queryBReply.entries!.length).toBe(1);
+        expect(queryBReply.entries![0].recordId).toBe(patchB.message.recordId);
+      });
+    });
+
+    describe('squash with large data (data store cleanup)', () => {
+      it('should delete data from the data store for records with large data', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const { protocol, documentContextId } = await setupProtocolAndDocument(alice);
+
+        // create a patch with data larger than maxDataSizeAllowedToBeEncoded so it goes to the data store
+        const largeData = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1);
+        const patchTimestamp = Time.createOffsetTimestamp({ seconds: 1 });
+        const patch = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : documentContextId,
+          messageTimestamp : patchTimestamp,
+          dateCreated      : patchTimestamp,
+          data             : largeData,
+        });
+        const patchReply = await dwn.processMessage(alice.did, patch.message, { dataStream: DataStream.fromBytes(largeData) });
+        expect(patchReply.status.code).toBe(202);
+
+        // verify data exists in the data store
+        const dataBeforeSquash = await dataStore.get(alice.did, patch.message.recordId, patch.message.descriptor.dataCid);
+        expect(dataBeforeSquash).toBeDefined();
+
+        // squash
+        const squashTimestamp = Time.createOffsetTimestamp({ seconds: 10 });
+        const squashRecord = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : documentContextId,
+          messageTimestamp : squashTimestamp,
+          dateCreated      : squashTimestamp,
+          squash           : true,
+        });
+        const squashReply = await dwn.processMessage(alice.did, squashRecord.message, { dataStream: squashRecord.dataStream });
+        expect(squashReply.status.code).toBe(202);
+
+        // verify data was deleted from the data store
+        const dataAfterSquash = await dataStore.get(alice.did, patch.message.recordId, patch.message.descriptor.dataCid);
+        expect(dataAfterSquash).toBeUndefined();
+      });
+    });
+
+    describe('squash backstop — equal timestamps', () => {
+      it('should reject a write whose messageTimestamp equals the most recent squash timestamp', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const { protocol, documentContextId } = await setupProtocolAndDocument(alice);
+
+        // create a squash
+        const squashTimestamp = Time.createOffsetTimestamp({ seconds: 10 });
+        const squashRecord = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : documentContextId,
+          messageTimestamp : squashTimestamp,
+          dateCreated      : squashTimestamp,
+          squash           : true,
+        });
+        const squashReply = await dwn.processMessage(alice.did, squashRecord.message, { dataStream: squashRecord.dataStream });
+        expect(squashReply.status.code).toBe(202);
+
+        // attempt a write with the exact same timestamp as the squash — should be rejected
+        const equalTimestampRecord = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : documentContextId,
+          messageTimestamp : squashTimestamp,
+          dateCreated      : squashTimestamp,
+        });
+        const equalReply = await dwn.processMessage(
+          alice.did, equalTimestampRecord.message, { dataStream: equalTimestampRecord.dataStream }
+        );
+        expect(equalReply.status.code).toBe(409);
+        expect(equalReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationSquashBackstop);
+      });
+    });
+
+    describe('squash authorization — negative', () => {
+      it('should reject squash when the author has neither squash nor create permission', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        // protocol where only author of document can create patches and only editors can squash
+        // bob has no role at all
+        const restrictedProtocol: ProtocolDefinition = {
+          protocol  : 'http://restricted-squash.xyz',
+          published : true,
+          types     : {
+            document : {},
+            editor   : {},
+            patch    : {},
+          },
+          structure: {
+            document: {
+              $actions : [{ who: 'anyone', can: ['create', 'read'] }],
+              editor   : {
+                $role    : true,
+                $actions : [{ who: 'author', of: 'document', can: ['create', 'delete'] }],
+              },
+              patch: {
+                $squash  : true,
+                $actions : [
+                  { who: 'author', of: 'document', can: ['create', 'read'] },
+                  { role: 'document/editor', can: ['squash'] },
+                ],
+              }
+            }
+          }
+        };
+
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author             : alice,
+          protocolDefinition : restrictedProtocol,
+        });
+        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(configReply.status.code).toBe(202);
+
+        // alice creates a document
+        const document = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          protocol     : restrictedProtocol.protocol,
+          protocolPath : 'document',
+        });
+        const docReply = await dwn.processMessage(alice.did, document.message, { dataStream: document.dataStream });
+        expect(docReply.status.code).toBe(202);
+
+        const documentContextId = document.message.contextId;
+
+        // alice creates a patch (she is author of document, so she has 'create' permission)
+        const patchTimestamp = Time.createOffsetTimestamp({ seconds: 1 });
+        const patch = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol         : restrictedProtocol.protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : documentContextId,
+          messageTimestamp : patchTimestamp,
+          dateCreated      : patchTimestamp,
+        });
+        const patchReply = await dwn.processMessage(alice.did, patch.message, { dataStream: patch.dataStream });
+        expect(patchReply.status.code).toBe(202);
+
+        // bob tries to squash — bob is NOT author of document and has no editor role
+        // the squash action checks 'squash' first (no role), then falls back to 'create' (bob is not author of document)
+        const squashTimestamp = Time.createOffsetTimestamp({ seconds: 10 });
+        const bobSquash = await RecordsWrite.create({
+          signer           : Jws.createSigner(bob),
+          protocol         : restrictedProtocol.protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : documentContextId,
+          dataFormat       : 'application/json',
+          data             : TestDataGenerator.randomBytes(32),
+          messageTimestamp : squashTimestamp,
+          dateCreated      : squashTimestamp,
+          squash           : true,
+        });
+
+        const bobSquashReply = await dwn.processMessage(
+          alice.did, bobSquash.message, { dataStream: DataStream.fromBytes(TestDataGenerator.randomBytes(32)) }
+        );
+        // bob should be rejected — either 401 (authorization failure)
+        expect(bobSquashReply.status.code).toBe(401);
+      });
+    });
+
+    describe('squash purges RecordsDelete messages', () => {
+      it('should purge RecordsDelete tombstones for records that predate the squash', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        // Use a protocol with $squash but without $immutable so records can be deleted
+        const deletableSquashProtocol: ProtocolDefinition = {
+          protocol  : 'http://deletable-squash.xyz',
+          published : true,
+          types     : {
+            document : {},
+            patch    : {},
+          },
+          structure: {
+            document: {
+              $actions : [{ who: 'anyone', can: ['create', 'read'] }],
+              patch    : {
+                $squash  : true,
+                $actions : [{ who: 'anyone', can: ['create', 'read', 'delete'] }],
+              }
+            }
+          }
+        };
+
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author             : alice,
+          protocolDefinition : deletableSquashProtocol,
+        });
+        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
+        expect(configReply.status.code).toBe(202);
+
+        // create parent document
+        const document = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          protocol     : deletableSquashProtocol.protocol,
+          protocolPath : 'document',
+        });
+        const docReply = await dwn.processMessage(alice.did, document.message, { dataStream: document.dataStream });
+        expect(docReply.status.code).toBe(202);
+        const documentContextId = document.message.contextId;
+
+        // create a patch record
+        const patchTimestamp = Time.createOffsetTimestamp({ seconds: 1 });
+        const patch = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol         : deletableSquashProtocol.protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : documentContextId,
+          messageTimestamp : patchTimestamp,
+          dateCreated      : patchTimestamp,
+        });
+        const patchReply = await dwn.processMessage(alice.did, patch.message, { dataStream: patch.dataStream });
+        expect(patchReply.status.code).toBe(202);
+
+        // delete that patch record (messageTimestamp must be after the patch for the delete to be accepted)
+        const deleteTimestamp = Time.createOffsetTimestamp({ seconds: 2 });
+        const deleteRecord = await RecordsDelete.create({
+          recordId         : patch.message.recordId,
+          messageTimestamp : deleteTimestamp,
+          signer           : Jws.createSigner(alice),
+        });
+        const deleteReply = await dwn.processMessage(alice.did, deleteRecord.message);
+        expect(deleteReply.status.code).toBe(202);
+
+        // squash — this should purge patch1 (deleted, newest message timestamp is seconds: 2)
+        const squashTimestamp = Time.createOffsetTimestamp({ seconds: 5 });
+        const squashRecord = await TestDataGenerator.generateRecordsWrite({
+          author           : alice,
+          protocol         : deletableSquashProtocol.protocol,
+          protocolPath     : 'document/patch',
+          parentContextId  : documentContextId,
+          messageTimestamp : squashTimestamp,
+          dateCreated      : squashTimestamp,
+          squash           : true,
+        });
+        const squashReply = await dwn.processMessage(alice.did, squashRecord.message, { dataStream: squashRecord.dataStream });
+        expect(squashReply.status.code).toBe(202);
+
+        // query for all records — should see only the squash record (deleted patch1 was fully purged)
+        const query = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            protocol     : deletableSquashProtocol.protocol,
+            protocolPath : 'document/patch',
+          },
+        });
+        const queryReply = await dwn.processMessage(alice.did, query.message);
+        expect(queryReply.status.code).toBe(200);
+        expect(queryReply.entries!.length).toBe(1);
+        expect(queryReply.entries![0].recordId).toBe(squashRecord.message.recordId);
+
+        // verify the deleted patch1's messages are fully purged from message store
+        // by querying for it directly — should not be found (both the initial write and the RecordsDelete tombstone should be gone)
+        const directQuery = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : { recordId: patch.message.recordId },
+        });
+        const directReply = await dwn.processMessage(alice.did, directQuery.message);
+        expect(directReply.status.code).toBe(200);
+        expect(directReply.entries!.length).toBe(0);
       });
     });
   });


### PR DESCRIPTION
## Summary

Follow-up improvements to the `$squash` feature (PR #497) based on a thorough re-review of the spec and implementation.

### Production fixes

- **Crash-safe squash via ResumableTaskManager** — Squash processing now runs through `ResumableTaskManager` (matching the `prune` precedent) instead of inline in the handler. If the process crashes mid-purge, the task resumes on restart. Added `ResumableTaskName.RecordsSquash` and `StorageController.performRecordsSquash()`.
- **RecordsDelete tombstone purging** — `performRecordsSquash()` now queries by `interface: Records` (not `method: Write`), so `RecordsDelete` messages and their retained initial writes are also purged when they predate the squash.
- **`$squash` schema strictness** — Added `"enum": [true]` to `$squash` in `protocol-rule-set.json`, rejecting `$squash: false` at schema validation time (previously it was silently accepted as a no-op).
- **Backstop error logging** — Changed the bare `catch` in `enforceSquashBackstop` to log a `console.warn` when protocol definition fetch fails, aiding debugging while still deferring to authorization for the actual error.

### Test coverage (+7 new test cases)

| Test | What it verifies |
|---|---|
| `$squash: false` rejection | Schema validation rejects `$squash: false` at message creation |
| Root-level squash | Squash works at root protocol paths (no parent context) |
| Root-level backstop | Backstop enforced at root protocol paths |
| Cross-context isolation | Squash under doc A doesn't delete records under doc B |
| Large data cleanup | Data store entries cleaned up for records > 30KB |
| Equal timestamp backstop | Backstop rejects writes with timestamp == squash timestamp |
| Unauthorized squash | Rejects squash from a DID without squash or create permission |
| RecordsDelete purging | Squash purges RecordsDelete tombstones alongside initial writes |

### Spec updates (separate repo: `enboxorg/dwn-spec`)

- Changed "same `parentId`" to "within the same parent context" (matches implementation)
- Replaced "emit delete events" step with a note clarifying the prune precedent (no per-record events; squash `RecordsWrite` is the deletion signal; receiving nodes re-execute squash locally)
- Added `"enum": [true]` to `$squash` JSON Schema definition

### Verification

- Lint: 0 errors, 0 warnings
- Build: clean
- Tests: 1153 pass, 0 fail (full DWN SDK suite)