### PR TITLE
fix(docs): replace enbox.org with enbox.id

### DIFF
--- a/docs/architecture/eu-confidential-dwn-deployment.md
+++ b/docs/architecture/eu-confidential-dwn-deployment.md
@@ -311,7 +311,7 @@ spec:
               mountPath: /tls-config
       containers:
         - name: dwn-server
-          image: registry.ovh.enbox.org/dwn-server:main
+          image: registry.ovh.enbox.id/dwn-server:main
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
## Summary

- Updates container registry URL from `registry.ovh.enbox.org` to `registry.ovh.enbox.id` in the EU confidential DWN deployment doc
- Only occurrence of `enbox.org` in the repo