### PR TITLE
fix(browser): replace broken importMetaIfSupported with direct import.meta.url

### DIFF
--- a/packages/browser/src/web-features.ts
+++ b/packages/browser/src/web-features.ts
@@ -62,17 +62,6 @@ interface DrlMediaElement extends HTMLElement {
   __src__?: string;
 }
 
-// This is in place to prevent our `bundler-bonanza` repo from failing for Node CJS builds
-// Not sure if this is working as expected in all environments, crated an issue
-// TODO: https://github.com/enboxorg/enbox/issues/767
-function importMetaIfSupported(): { url: string } | undefined {
-  try {
-    return new Function('return import.meta')() as { url: string };
-  } catch {
-    return undefined;
-  }
-}
-
 let didResolver = new UniversalResolver({ didResolvers: [DidDht, DidWeb] });
 const didUrlRegex = /^https?:\/\/dweb\/([^/]+)\/?(.*)?$/;
 const httpToHttpsRegex = /^http:/;
@@ -221,9 +210,8 @@ async function installWorker(options: ActivatePolyfillsOptions = {}): Promise<vo
       if (!registration) {
         const installUrl: string | undefined =
         options.path ||
-        (globalThis.document
-          ? (document?.currentScript as HTMLScriptElement | null)?.src
-          : importMetaIfSupported()?.url);
+        (document?.currentScript as HTMLScriptElement | null)?.src ||
+        import.meta.url;
         if (installUrl)
         {navigator.serviceWorker
           .register(installUrl, { type: 'module' })


### PR DESCRIPTION
## Summary

Deletes `importMetaIfSupported()` which never worked, and replaces the Service Worker registration fallback with `import.meta.url`.

Closes #509

## Problem

`importMetaIfSupported()` uses `new Function('return import.meta')()` to dynamically access `import.meta`. This **always returns `undefined`** because:

1. **`new Function()` creates a classic script** — `import.meta` is a SyntaxError in classic scripts per the ECMAScript spec. The try/catch silently swallows the error and returns `undefined`.
2. **The call site is dead code** — it's only reached when `globalThis.document` is falsy, but Branch B (where it lives) only runs in DOM window contexts where `document` is always truthy.
3. **`document.currentScript` is also null for ESM** — per spec it's `null` inside `<script type="module">` and after async execution.

Net effect: unless the user passes `options.path` explicitly, SW auto-registration silently fails.

## Fix

The old fallback chain:
```typescript
options.path ||
(globalThis.document
  ? document?.currentScript?.src
  : importMetaIfSupported()?.url)
```

The new fallback chain:
```typescript
options.path ||
document?.currentScript?.src ||
import.meta.url
```

This is safe because `@enbox/browser` is ESM-only (`"type": "module"`, no CJS entry point). `import.meta.url` is always available and correctly resolved by all modern bundlers (Webpack 5, Rollup, Vite, esbuild).

This also eliminates a CSP concern — `new Function()` is blocked by `script-src` directives that omit `unsafe-eval`.

## Testing

All 46 browser tests pass. TypeScript strict compilation and lint pass.