### PR TITLE
test(dwn-sdk-js): enable store-dependent browser tests — coverage 42% → 98% lines

### DIFF
--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
     include: [
       // --- CJS packages imported directly from src/ or tests/ ---
       'abstract-level',
+      'browser-level',
       'ajv',
       'ajv/dist/2020.js',
       'ajv/dist/runtime/ucs2length.js',
@@ -104,11 +105,9 @@ export default defineConfig({
     // another, producing intermittent 400s and missing results — especially in
     // Firefox where IndexedDB transaction scheduling differs from Chromium.
     fileParallelism: false,
-    // Browser-compatible tests. Most are pure-logic; a few use TestStores which
-    // resolve to IndexedDB-backed stores in browser mode (via level's browser
-    // field). The 29 function-wrapped handler/feature/scenario tests are excluded
-    // because they require the TestSuite orchestrator and would add ~978 tests.
-    // See https://github.com/enboxorg/enbox/issues/236 for the full plan.
+    // Browser-compatible tests. Pure-logic tests run individually; the 29
+    // store-dependent handler/feature/scenario tests run via the TestSuite
+    // orchestrator which injects IndexedDB-backed stores (via level's browser field).
     include: [
       'tests/utils/cid.spec.ts',
       // data-stream.spec.ts excluded: its 500KB×3 stream duplication test exceeds
@@ -150,8 +149,13 @@ export default defineConfig({
       'tests/protocols/permissions.spec.ts',
 
       'tests/scenarios/aggregator.spec.ts',
+
+      // Store-dependent tests: 29 handler/feature/scenario test functions run via
+      // the TestSuite orchestrator. Stores resolve to IndexedDB (browser-level)
+      // automatically through level's "browser" package.json field.
+      'tests/store-dependent-tests.spec.ts',
     ],
-    testTimeout : 15_000,
+    testTimeout : 30_000,
     // Retry failed tests once in CI. Firefox's ESM loader can occasionally
     // crash on dynamic module imports even with noDiscovery enabled — a
     // single retry is enough to recover from transient loader failures


### PR DESCRIPTION
## Summary

Enable the 29 store-dependent handler/feature/scenario tests in the `dwn-sdk-js` browser test suite. These tests use the `TestSuite` orchestrator which injects Level-backed stores that automatically resolve to IndexedDB (via `browser-level`) in Vite's browser mode.

## Changes

Single file modified: `packages/dwn-sdk-js/vitest.browser.config.ts`

- Add `browser-level` to `optimizeDeps.include` for CJS pre-bundling
- Add `tests/store-dependent-tests.spec.ts` to the browser test include list
- Bump `testTimeout` from 15s → 30s (662 store-dependent tests need headroom)
- Update comments to reflect the new test composition

## Coverage Results (Chromium)

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Test files | 43 | 44 | +1 |
| Tests | 336 | 998 | +662 |
| Statements | 58.88% | 85.44% | **+26.6%** |
| Lines | 42.04% | 98.47% | **+56.4%** |
| Functions | — | 96.64% | — |
| Branches | — | 63.82% | — |

## How it works

The `store-dependent-tests.spec.ts` file is a 7-line entry point that imports `TestSuite` and calls `runInjectableDependentTests()`. This orchestrator invokes 29 exported test functions (11 handlers, 15 features, 4 scenarios) that use `TestStores` and `TestEventLog` singletons. In the browser, the `level` package's `"browser"` field resolves to `browser-level`, which uses IndexedDB as the backing store — no test changes needed.

## Verification

```bash
# Tests (all 998 pass):
BROWSER=chromium bun run --filter @enbox/dwn-sdk-js test:browser

# Coverage:
BROWSER=chromium bun run --filter @enbox/dwn-sdk-js test:browser:coverage

# Lint (clean):
bun run lint
```