### PR TITLE
fix(dwn-server): enable provider-auth registration on dev and warn on misconfigured tenant gate

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -47,6 +47,20 @@ resource "aws_secretsmanager_secret_version" "admin_token" {
   }
 }
 
+resource "aws_secretsmanager_secret" "provider_auth_jwt_secret" {
+  name = "dwn/${local.environment}/provider-auth-jwt-secret"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "provider_auth_jwt_secret" {
+  secret_id     = aws_secretsmanager_secret.provider_auth_jwt_secret.id
+  secret_string = "CHANGE_ME"
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
 ################################################################################
 # VPC — 2 AZs, single NAT gateway
 ################################################################################
@@ -169,13 +183,16 @@ module "dwn_http" {
     MAX_RECORD_DATA_SIZE      = "1gb"
     NATS_URL                  = module.nats.nats_url
     DWN_EVENT_LOG_PLUGIN_PATH = "/app/packages/dwn-server/dist/esm/src/plugins/event-log-nats.js"
+    DWN_BASE_URL              = "https://dev.aws.dwn.enbox.id"
+    DWN_PROVIDER_AUTH_ENABLED = "true"
   }
 
   secrets = {
-    DWN_STORAGE                = aws_secretsmanager_secret.database_url.arn
-    DWN_TTL_CACHE_URL          = aws_secretsmanager_secret.database_url.arn
-    DWN_REGISTRATION_STORE_URL = aws_secretsmanager_secret.database_url.arn
-    DWN_ADMIN_TOKEN            = aws_secretsmanager_secret.admin_token.arn
+    DWN_STORAGE                  = aws_secretsmanager_secret.database_url.arn
+    DWN_TTL_CACHE_URL            = aws_secretsmanager_secret.database_url.arn
+    DWN_REGISTRATION_STORE_URL   = aws_secretsmanager_secret.database_url.arn
+    DWN_ADMIN_TOKEN              = aws_secretsmanager_secret.admin_token.arn
+    DWN_PROVIDER_AUTH_JWT_SECRET = aws_secretsmanager_secret.provider_auth_jwt_secret.arn
   }
 
   tags = local.tags
@@ -209,13 +226,16 @@ module "dwn_ws" {
     DWN_MAX_IN_FLIGHT         = "64"
     NATS_URL                  = module.nats.nats_url
     DWN_EVENT_LOG_PLUGIN_PATH = "/app/packages/dwn-server/dist/esm/src/plugins/event-log-nats.js"
+    DWN_BASE_URL              = "https://dev.aws.dwn.enbox.id"
+    DWN_PROVIDER_AUTH_ENABLED = "true"
   }
 
   secrets = {
-    DWN_STORAGE                = aws_secretsmanager_secret.database_url.arn
-    DWN_TTL_CACHE_URL          = aws_secretsmanager_secret.database_url.arn
-    DWN_REGISTRATION_STORE_URL = aws_secretsmanager_secret.database_url.arn
-    DWN_ADMIN_TOKEN            = aws_secretsmanager_secret.admin_token.arn
+    DWN_STORAGE                  = aws_secretsmanager_secret.database_url.arn
+    DWN_TTL_CACHE_URL            = aws_secretsmanager_secret.database_url.arn
+    DWN_REGISTRATION_STORE_URL   = aws_secretsmanager_secret.database_url.arn
+    DWN_ADMIN_TOKEN              = aws_secretsmanager_secret.admin_token.arn
+    DWN_PROVIDER_AUTH_JWT_SECRET = aws_secretsmanager_secret.provider_auth_jwt_secret.arn
   }
 
   tags = local.tags

--- a/packages/dwn-server/src/dwn-server.ts
+++ b/packages/dwn-server/src/dwn-server.ts
@@ -146,6 +146,20 @@ export class DwnServer {
         providerAuthPlugin,
       });
 
+      // Warn if the tenant gate is active but no registration method is enabled.
+      // This is almost certainly a misconfiguration — new tenants will be rejected
+      // with 401 and have no way to register.
+      if (this.config.registrationStoreUrl
+        && !this.config.registrationProofOfWorkEnabled
+        && !providerAuthPlugin) {
+        log.warn(
+          '*** WARNING: DWN_REGISTRATION_STORE_URL is set (tenant gate active) but neither ' +
+          'proof-of-work (DWN_REGISTRATION_PROOF_OF_WORK_ENABLED) nor provider auth ' +
+          '(DWN_PROVIDER_AUTH_ENABLED + secret/plugin) is configured. ' +
+          'New tenants will be unable to register. ***',
+        );
+      }
+
       let eventLog: EventLog | undefined;
       if (this.config.webSocketSupport) {
         // If EventLog plugin is not specified, use `EventEmitterEventLog` implementation as default.


### PR DESCRIPTION
## Summary

The dev DWN server (`dev.aws.dwn.enbox.id`) has `DWN_REGISTRATION_STORE_URL` set (tenant gate active) but neither proof-of-work nor provider-auth is enabled. This means new tenants get 401'd with no way to register.

- **Terraform** (`infra/environments/dev/main.tf`): Add `DWN_PROVIDER_AUTH_ENABLED=true`, `DWN_BASE_URL`, and a new `DWN_PROVIDER_AUTH_JWT_SECRET` Secrets Manager secret to both HTTP and WS ECS services — matching what `fly.toml` already has for Fly.io
- **Server** (`packages/dwn-server/src/dwn-server.ts`): Add a startup warning when the tenant gate is active but no registration method is enabled, so this silent misconfiguration is immediately visible in logs

### Post-merge action
After applying the Terraform, update the `dwn/dev/provider-auth-jwt-secret` value in AWS Secrets Manager with a random base64-encoded 32-byte secret (it defaults to `CHANGE_ME`).