### PR TITLE
fix(dwn-sdk-js): return 410 with recordsWrite when DataStore has no data for existing record

### DIFF
--- a/packages/dwn-relay/src/stores/relay-data-store.ts
+++ b/packages/dwn-relay/src/stores/relay-data-store.ts
@@ -151,7 +151,7 @@ export class RelayDataStore implements DataStore {
       return local;
     }
 
-    // If no proxy configured, return undefined (standard 404 behavior)
+    // If no proxy configured, return undefined (DWN returns 410 to the requester)
     if (!this.#proxy) {
       return undefined;
     }

--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -122,8 +122,12 @@ export class RecordsReadHandler implements MethodHandler {
     } else {
       const result = await this.deps.dataStore!.get(tenant, matchedRecordsWrite.recordId, matchedRecordsWrite.descriptor.dataCid);
       if (result?.dataStream === undefined) {
+        // The message envelope exists but the record data is unavailable (e.g., evicted
+        // by a storage-constrained node, or read proxying to peer endpoints failed).
+        // Return 410 with the recordsWrite so the requester can try an alternative endpoint.
         return {
-          status: { code: 404, detail: 'Not Found' }
+          status : { code: 410, detail: 'Record data not available' },
+          entry  : { recordsWrite: matchedRecordsWrite },
         };
       }
       data = result.dataStream;

--- a/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
@@ -1752,7 +1752,7 @@ export function testRecordsReadHandler(): void {
         expect(readReply.status.code).toBe(404);
       });
 
-      it('should return 404 underlying data store cannot locate the data when data is above threshold', async () => {
+      it('should return 410 with recordsWrite when data store cannot locate the data for large records', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
         await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
 
@@ -1775,7 +1775,11 @@ export function testRecordsReadHandler(): void {
         });
 
         const readReply = await dwn.processMessage(alice.did, recordsRead.message);
-        expect(readReply.status.code).toBe(404);
+        expect(readReply.status.code).toBe(410);
+        expect(readReply.status.detail).toBe('Record data not available');
+        // The reply should include the recordsWrite envelope so the client can try another endpoint
+        expect((readReply as any).entry?.recordsWrite).toBeDefined();
+        expect((readReply as any).entry?.recordsWrite.recordId).toBe(message.recordId);
       });
 
       describe('data from encodedData', () => {


### PR DESCRIPTION
## Summary

- When `RecordsRead` finds the message envelope in `MessageStore` but `DataStore.get()` returns no data (e.g., evicted by a cache node, or read-proxy failure), return **410** `Record data not available` with the `recordsWrite` envelope instead of a bare 404.
- This lets the requester distinguish "record never existed" (404) from "data unavailable at this endpoint" (410) and try alternative endpoints listed in the DID document.
- Updated the corresponding test to expect 410 and verify the `recordsWrite` envelope is present in the reply.
- Updated a comment in `relay-data-store.ts` to reflect the new 410 semantics.

## Changes

| File | Change |
|------|--------|
| `packages/dwn-sdk-js/src/handlers/records-read.ts` | Return 410 + `recordsWrite` envelope when DataStore returns no data |
| `packages/dwn-sdk-js/tests/handlers/records-read.spec.ts` | Updated test to expect 410, verify detail message and envelope |
| `packages/dwn-relay/src/stores/relay-data-store.ts` | Comment update (404 → 410 reference) |

## Testing

- Full dwn-sdk-js test suite: **662 tests pass, 0 failures**
- Lint: clean
- Existing 404 tests for "record doesn't exist" and "record was deleted" remain unchanged and correct

## Related

- Closes #527
- Spec side: dwn-spec PR #48 (adds 410 to the spec's RecordsRead response table)