### PR TITLE
feat(dwn-server): actor-based delivery target resolution (who: author/recipient + of)

### DIFF
--- a/packages/dwn-server/src/delivery-service.ts
+++ b/packages/dwn-server/src/delivery-service.ts
@@ -6,7 +6,7 @@ import type { MessageProcessedContext, MessageProcessedHook } from './message-pr
 import log from 'loglevel';
 
 import { createJsonRpcRequest } from '@enbox/dwn-clients';
-import { DwnInterfaceName, DwnMethodName, getRuleSetAtPath } from '@enbox/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName, getRuleSetAtPath, Message } from '@enbox/dwn-sdk-js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -320,10 +320,20 @@ export class DeliveryService implements MessageProcessedHook {
         }
       }
 
-      // Actor-based rules with `of` (author/recipient of ancestor records).
-      // These require walking the record chain which is complex — for the initial
-      // implementation we focus on role-based targets which cover the primary
-      // multi-party use case.
+      // Method 3: Actor-based discovery — `who: "author"/"recipient"` + `of` path.
+      // Find the ancestor record at the `of` protocol path within the same context,
+      // then extract its author or recipient as a delivery target.
+      if (rule.who !== undefined && rule.of !== undefined && rule.who !== 'anyone') {
+        // Skip cross-protocol `of` references (e.g., "threads:thread") for now.
+        if (!rule.of.includes(':')) {
+          const actorDid = await this.#queryActorFromAncestor(
+            tenant, protocolDefinition.protocol, rule.of, rule.who as string, contextId,
+          );
+          if (actorDid) {
+            targetDids.add(actorDid);
+          }
+        }
+      }
     }
 
     // Resolve endpoints for each target DID.
@@ -397,6 +407,72 @@ export class DeliveryService implements MessageProcessedHook {
     } catch (err) {
       log.warn(`DeliveryService: failed to query role recipients for ${rolePath}`, err);
       return [];
+    }
+  }
+
+  /**
+   * Queries the tenant's DWN for the ancestor record at the given protocol path
+   * (within the same context) and extracts the author or recipient DID.
+   *
+   * This is the delivery-side inverse of `checkActor()` in protocol authorization:
+   * instead of "is this DID the author/recipient?", we ask "who IS the author/recipient?".
+   *
+   * @param actorType - `"author"` or `"recipient"`.
+   * @returns The DID of the actor, or `undefined` if the ancestor cannot be found.
+   */
+  async #queryActorFromAncestor(
+    tenant: string,
+    protocolUri: string,
+    ofPath: string,
+    actorType: string,
+    contextId?: string,
+  ): Promise<string | undefined> {
+    try {
+      const filter: Record<string, unknown> = {
+        protocol     : protocolUri,
+        protocolPath : ofPath,
+      };
+
+      // Scope to the record's context. The `of` path identifies an ancestor,
+      // so the ancestor's contextId is a prefix of (or equal to) the current
+      // record's contextId. For a top-level `of` path (no slashes), the ancestor
+      // IS the context root — its recordId equals the first contextId segment.
+      if (contextId !== undefined) {
+        const ofDepth = ofPath.split('/').length;
+        const contextSegments = contextId.split('/');
+        // The ancestor at depth N has a contextId formed by the first N segments.
+        if (contextSegments.length >= ofDepth) {
+          filter.contextId = contextSegments.slice(0, ofDepth).join('/');
+        }
+      }
+
+      const queryMessage = {
+        descriptor: {
+          interface        : DwnInterfaceName.Records,
+          method           : DwnMethodName.Query,
+          messageTimestamp : new Date().toISOString(),
+          filter,
+        },
+      };
+
+      const reply = await this.#dwn.processMessage(tenant, queryMessage as GenericMessage);
+
+      if (reply.status.code !== 200 || !reply.entries || reply.entries.length === 0) {
+        return undefined;
+      }
+
+      const ancestor = reply.entries[0] as GenericMessage;
+
+      if (actorType === 'author') {
+        return Message.getAuthor(ancestor);
+      } else if (actorType === 'recipient') {
+        return (ancestor as { descriptor?: { recipient?: string } }).descriptor?.recipient;
+      }
+
+      return undefined;
+    } catch (err) {
+      log.warn(`DeliveryService: failed to query ancestor at ${ofPath} for actor resolution`, err);
+      return undefined;
     }
   }
 

--- a/packages/dwn-server/tests/delivery-service-coverage.test.ts
+++ b/packages/dwn-server/tests/delivery-service-coverage.test.ts
@@ -147,6 +147,40 @@ function recordsDeleteMessage(recordId = 'test-record'): GenericMessage {
   } as unknown as GenericMessage;
 }
 
+/**
+ * Creates a base64url-encoded JSON string (no padding).
+ * Used to mock JWS `protected` headers containing a `kid`.
+ */
+function base64UrlEncode(obj: Record<string, unknown>): string {
+  const json = JSON.stringify(obj);
+  return Buffer.from(json).toString('base64url');
+}
+
+/**
+ * Creates a mock ancestor RecordsWrite entry with the given author (via JWS)
+ * and optional recipient. The `authorization.signature` mimics the structure
+ * that `Message.getAuthor()` / `Jws.getSignerDid()` expects.
+ */
+function ancestorEntry(opts: { author: string; recipient?: string }): Record<string, unknown> {
+  return {
+    descriptor: {
+      interface    : DwnInterfaceName.Records,
+      method       : DwnMethodName.Write,
+      protocol     : 'http://example.com/social',
+      protocolPath : 'friend',
+      recipient    : opts.recipient,
+    },
+    authorization: {
+      signature: {
+        signatures: [{
+          protected : base64UrlEncode({ kid: `${opts.author}#key-1` }),
+          signature : 'fake-sig',
+        }],
+      },
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -678,12 +712,17 @@ describe('DeliveryService — coverage', () => {
         },
       };
 
-      // First call: ProtocolsQuery returns definition.
-      // No second call needed — the recipient comes from the record, not a role query.
+      // Call 1: ProtocolsQuery returns definition.
+      // Call 2: Ancestor query for `of: "message"` — the actor-based branch also
+      //         fires, returning carol as recipient of the ancestor (same record).
       const processStub = sinon.stub();
       processStub.onFirstCall().resolves({
         status  : { code: 200 },
         entries : [{ descriptor: { definition: protocolDef } }],
+      });
+      processStub.onSecondCall().resolves({
+        status  : { code: 200 },
+        entries : [ancestorEntry({ author: tenant, recipient })],
       });
 
       const dwn = mockDwn(processStub);
@@ -1215,6 +1254,448 @@ describe('DeliveryService — coverage', () => {
       }), 202);
       await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
 
+      expect(fetchStub.callCount).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Actor-based delivery (who: "author"/"recipient" + of)
+  // -----------------------------------------------------------------------
+
+  describe('actor-based delivery', () => {
+    it('should deliver to the author of the ancestor record (who: "author", of: "friend")', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+        new Response(null, { status: 200 }),
+      );
+
+      const tenant = 'did:test:alice';
+      const friendAuthor = 'did:test:bob';
+
+      // A social protocol where "friend/post" records are delivered to the
+      // author of the parent "friend" record.
+      const protocolDef: ProtocolDefinition = {
+        protocol  : 'http://example.com/social',
+        published : true,
+        types     : { friend: {}, post: {} },
+        structure : {
+          friend: {
+            post: {
+              $delivery : 'direct',
+              $actions  : [{ who: 'author', of: 'friend', can: ['read'] }],
+            },
+          },
+        },
+      };
+
+      // Call 1: ProtocolsQuery returns the protocol definition.
+      // Call 2: RecordsQuery for the ancestor "friend" record returns Bob as author.
+      const processStub = sinon.stub();
+      processStub.onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { definition: protocolDef } }],
+      });
+      processStub.onSecondCall().resolves({
+        status  : { code: 200 },
+        entries : [ancestorEntry({ author: friendAuthor })],
+      });
+
+      const dwn = mockDwn(processStub);
+      const resolver = fakeResolver({
+        [friendAuthor]: didDocWithDwnService(friendAuthor, ['http://bob-dwn.example.com']),
+      });
+
+      const svc = DeliveryService.create(dwn, resolver, testConfig({
+        forwardingEnabled : false,
+        deliveryEnabled   : true,
+      }));
+
+      svc.dispatchIfNeeded(tenant, protocolWriteMessage({
+        protocol     : 'http://example.com/social',
+        protocolPath : 'friend/post',
+        contextId    : 'ctx-friend-1/ctx-post-1',
+        recordId     : 'actor-author-1',
+      }), 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      expect(fetchStub.callCount).toBe(1);
+      expect(fetchStub.firstCall.args[0]).toBe('http://bob-dwn.example.com');
+    });
+
+    it('should deliver to the recipient of the ancestor record (who: "recipient", of: "request")', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+        new Response(null, { status: 200 }),
+      );
+
+      const tenant = 'did:test:alice';
+      const requestRecipient = 'did:test:carol';
+
+      const protocolDef: ProtocolDefinition = {
+        protocol  : 'http://example.com/request',
+        published : true,
+        types     : { request: {}, response: {} },
+        structure : {
+          request: {
+            response: {
+              $delivery : 'direct',
+              $actions  : [{ who: 'recipient', of: 'request', can: ['read'] }],
+            },
+          },
+        },
+      };
+
+      const processStub = sinon.stub();
+      processStub.onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { definition: protocolDef } }],
+      });
+      processStub.onSecondCall().resolves({
+        status  : { code: 200 },
+        entries : [ancestorEntry({ author: 'did:test:alice', recipient: requestRecipient })],
+      });
+
+      const dwn = mockDwn(processStub);
+      const resolver = fakeResolver({
+        [requestRecipient]: didDocWithDwnService(requestRecipient, ['http://carol-dwn.example.com']),
+      });
+
+      const svc = DeliveryService.create(dwn, resolver, testConfig({
+        forwardingEnabled : false,
+        deliveryEnabled   : true,
+      }));
+
+      svc.dispatchIfNeeded(tenant, protocolWriteMessage({
+        protocol     : 'http://example.com/request',
+        protocolPath : 'request/response',
+        contextId    : 'ctx-req/ctx-resp',
+        recordId     : 'actor-recipient-1',
+      }), 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      expect(fetchStub.callCount).toBe(1);
+      expect(fetchStub.firstCall.args[0]).toBe('http://carol-dwn.example.com');
+    });
+
+    it('should combine actor-based and role-based targets without duplicates', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+        new Response(null, { status: 200 }),
+      );
+
+      const tenant = 'did:test:alice';
+      const friendAuthor = 'did:test:bob';
+      const roleMember = 'did:test:carol';
+
+      const protocolDef: ProtocolDefinition = {
+        protocol  : 'http://example.com/social',
+        published : true,
+        types     : { friend: {}, moderator: {}, post: {} },
+        structure : {
+          friend: {
+            moderator : {},
+            post      : {
+              $delivery : 'direct',
+              $actions  : [
+                { who: 'author', of: 'friend', can: ['read'] },
+                { role: 'friend/moderator', can: ['read'] },
+              ],
+            },
+          },
+        },
+      };
+
+      // Rules are processed in order: first the role-based rule resolves, then
+      // the actor-based rule resolves. But within each rule, the code checks
+      // `rule.role` first, then `rule.who`/`rule.of`. Since the role rule is
+      // listed second in $actions, the actor rule (first in $actions) is processed
+      // first — it skips role (undefined) and enters actor branch.
+      //
+      // Actual call order:
+      // Call 1: ProtocolsQuery returns definition.
+      // Call 2: RecordsQuery for ancestor "friend" (actor-based, processed first).
+      // Call 3: RecordsQuery for role recipients (moderator, processed second).
+      const processStub = sinon.stub();
+      processStub.onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { definition: protocolDef } }],
+      });
+      processStub.onSecondCall().resolves({
+        status  : { code: 200 },
+        entries : [ancestorEntry({ author: friendAuthor })],
+      });
+      processStub.onThirdCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { recipient: roleMember } }],
+      });
+
+      const dwn = mockDwn(processStub);
+      const resolver = fakeResolver({
+        [friendAuthor] : didDocWithDwnService(friendAuthor, ['http://bob-dwn.example.com']),
+        [roleMember]   : didDocWithDwnService(roleMember, ['http://carol-dwn.example.com']),
+      });
+
+      const svc = DeliveryService.create(dwn, resolver, testConfig({
+        forwardingEnabled : false,
+        deliveryEnabled   : true,
+      }));
+
+      svc.dispatchIfNeeded(tenant, protocolWriteMessage({
+        protocol     : 'http://example.com/social',
+        protocolPath : 'friend/post',
+        contextId    : 'ctx-friend-1/ctx-post-1',
+        recordId     : 'actor-combined-1',
+      }), 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      // Both bob (author of friend) and carol (moderator role) should receive.
+      expect(fetchStub.callCount).toBe(2);
+      const calledUrls = [fetchStub.firstCall.args[0], fetchStub.secondCall.args[0]];
+      expect(calledUrls).toContain('http://bob-dwn.example.com');
+      expect(calledUrls).toContain('http://carol-dwn.example.com');
+    });
+
+    it('should deduplicate when actor-based target matches role-based target', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+        new Response(null, { status: 200 }),
+      );
+
+      const tenant = 'did:test:alice';
+      const bob = 'did:test:bob'; // bob is both the author AND a role member
+
+      const protocolDef: ProtocolDefinition = {
+        protocol  : 'http://example.com/social',
+        published : true,
+        types     : { friend: {}, moderator: {}, post: {} },
+        structure : {
+          friend: {
+            moderator : {},
+            post      : {
+              $delivery : 'direct',
+              $actions  : [
+                { who: 'author', of: 'friend', can: ['read'] },
+                { role: 'friend/moderator', can: ['read'] },
+              ],
+            },
+          },
+        },
+      };
+
+      // Actor rule is listed first in $actions, so it resolves first:
+      // Call 1: ProtocolsQuery → definition
+      // Call 2: Ancestor query (actor-based) → bob as author
+      // Call 3: Role query (role-based) → bob as role recipient
+      const processStub = sinon.stub();
+      processStub.onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { definition: protocolDef } }],
+      });
+      processStub.onSecondCall().resolves({
+        status  : { code: 200 },
+        entries : [ancestorEntry({ author: bob })],
+      });
+      processStub.onThirdCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { recipient: bob } }],
+      });
+
+      const dwn = mockDwn(processStub);
+      const resolver = fakeResolver({
+        [bob]: didDocWithDwnService(bob, ['http://bob-dwn.example.com']),
+      });
+
+      const svc = DeliveryService.create(dwn, resolver, testConfig({
+        forwardingEnabled : false,
+        deliveryEnabled   : true,
+      }));
+
+      svc.dispatchIfNeeded(tenant, protocolWriteMessage({
+        protocol     : 'http://example.com/social',
+        protocolPath : 'friend/post',
+        contextId    : 'ctx-friend-1/ctx-post-1',
+        recordId     : 'actor-dedup-1',
+      }), 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      // Bob should only receive once, not twice.
+      expect(fetchStub.callCount).toBe(1);
+      expect(fetchStub.firstCall.args[0]).toBe('http://bob-dwn.example.com');
+    });
+
+    it('should not deliver when ancestor record is not found', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      const tenant = 'did:test:alice';
+
+      const protocolDef: ProtocolDefinition = {
+        protocol  : 'http://example.com/social',
+        published : true,
+        types     : { friend: {}, post: {} },
+        structure : {
+          friend: {
+            post: {
+              $delivery : 'direct',
+              $actions  : [{ who: 'author', of: 'friend', can: ['read'] }],
+            },
+          },
+        },
+      };
+
+      const processStub = sinon.stub();
+      processStub.onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { definition: protocolDef } }],
+      });
+      // Ancestor query returns empty — the friend record was deleted or not found.
+      processStub.onSecondCall().resolves({
+        status  : { code: 200 },
+        entries : [],
+      });
+
+      const dwn = mockDwn(processStub);
+      const resolver = fakeResolver({});
+      const svc = DeliveryService.create(dwn, resolver, testConfig({
+        forwardingEnabled : false,
+        deliveryEnabled   : true,
+      }));
+
+      svc.dispatchIfNeeded(tenant, protocolWriteMessage({
+        protocol     : 'http://example.com/social',
+        protocolPath : 'friend/post',
+        contextId    : 'ctx-friend-1/ctx-post-1',
+        recordId     : 'actor-no-ancestor',
+      }), 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      expect(fetchStub.callCount).toBe(0);
+    });
+
+    it('should handle ancestor query failure gracefully', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      const tenant = 'did:test:alice';
+
+      const protocolDef: ProtocolDefinition = {
+        protocol  : 'http://example.com/social',
+        published : true,
+        types     : { friend: {}, post: {} },
+        structure : {
+          friend: {
+            post: {
+              $delivery : 'direct',
+              $actions  : [{ who: 'author', of: 'friend', can: ['read'] }],
+            },
+          },
+        },
+      };
+
+      const processStub = sinon.stub();
+      processStub.onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { definition: protocolDef } }],
+      });
+      // Ancestor query throws.
+      processStub.onSecondCall().rejects(new Error('query failed'));
+
+      const dwn = mockDwn(processStub);
+      const resolver = fakeResolver({});
+      const svc = DeliveryService.create(dwn, resolver, testConfig({
+        forwardingEnabled : false,
+        deliveryEnabled   : true,
+      }));
+
+      svc.dispatchIfNeeded(tenant, protocolWriteMessage({
+        protocol     : 'http://example.com/social',
+        protocolPath : 'friend/post',
+        contextId    : 'ctx-friend-1/ctx-post-1',
+        recordId     : 'actor-query-fail',
+      }), 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      // Should not crash; no delivery attempted.
+      expect(fetchStub.callCount).toBe(0);
+    });
+
+    it('should skip cross-protocol of references (deferred)', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      const tenant = 'did:test:alice';
+
+      const protocolDef: ProtocolDefinition = {
+        protocol  : 'http://example.com/composed',
+        published : true,
+        types     : { message: {} },
+        structure : {
+          message: {
+            $delivery : 'direct',
+            $actions  : [{ who: 'author', of: 'threads:thread', can: ['read'] }],
+          },
+        },
+      };
+
+      const processStub = sinon.stub();
+      processStub.onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { definition: protocolDef } }],
+      });
+      // No second call should happen — cross-protocol refs are skipped.
+
+      const dwn = mockDwn(processStub);
+      const resolver = fakeResolver({});
+      const svc = DeliveryService.create(dwn, resolver, testConfig({
+        forwardingEnabled : false,
+        deliveryEnabled   : true,
+      }));
+
+      svc.dispatchIfNeeded(tenant, protocolWriteMessage({
+        protocol     : 'http://example.com/composed',
+        protocolPath : 'message',
+        contextId    : 'ctx-1',
+        recordId     : 'cross-proto-skip',
+      }), 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      // Only the ProtocolsQuery should have been called, not an ancestor query.
+      expect(processStub.callCount).toBe(1);
+      expect(fetchStub.callCount).toBe(0);
+    });
+
+    it('should not trigger actor resolution for who: "anyone" rules', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      const tenant = 'did:test:alice';
+
+      const protocolDef: ProtocolDefinition = {
+        protocol  : 'http://example.com/public',
+        published : true,
+        types     : { post: {} },
+        structure : {
+          post: {
+            $delivery : 'direct',
+            $actions  : [{ who: 'anyone', can: ['read'] }],
+          },
+        },
+      };
+
+      const processStub = sinon.stub();
+      processStub.onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { definition: protocolDef } }],
+      });
+
+      const dwn = mockDwn(processStub);
+      const resolver = fakeResolver({});
+      const svc = DeliveryService.create(dwn, resolver, testConfig({
+        forwardingEnabled : false,
+        deliveryEnabled   : true,
+      }));
+
+      svc.dispatchIfNeeded(tenant, protocolWriteMessage({
+        protocol     : 'http://example.com/public',
+        protocolPath : 'post',
+        recordId     : 'anyone-skip',
+      }), 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      // Only the ProtocolsQuery — no ancestor query, no delivery.
+      expect(processStub.callCount).toBe(1);
       expect(fetchStub.callCount).toBe(0);
     });
   });


### PR DESCRIPTION
## Summary

- Implement delivery target resolution **Method 3**: for `$actions` rules with `who: "author"/"recipient"` and an `of` path, query the ancestor record at that protocol path within the same context and extract its author or recipient as a delivery target.
- This complements the existing role-based (Method 2) and explicit recipient (Method 1) target resolution, covering simpler protocols like the social graph where roles would be overkill.
- Cross-protocol `of` references (e.g., `"threads:thread"`) are detected and skipped — deferred to a follow-up.

## Changes

| File | Change |
|------|--------|
| `packages/dwn-server/src/delivery-service.ts` | Add `#queryActorFromAncestor()` helper + actor-based branch in `#resolveDeliveryTargets()`. Import `Message` from dwn-sdk-js for author extraction. |
| `packages/dwn-server/tests/delivery-service-coverage.test.ts` | 8 new tests + update to existing explicit-recipient test. Add `base64UrlEncode()` and `ancestorEntry()` test helpers. |

## How it works

For a rule like `{ who: "author", of: "friend", can: ["read"] }` on a `friend/post` record:

1. Build a RecordsQuery filter: `{ protocol, protocolPath: "friend", contextId: <scoped> }`
2. Query the tenant's DWN for the ancestor record
3. Extract the author DID via `Message.getAuthor()` (reads the JWS authorization)
4. Add to delivery targets (deduplicated via `Set<string>`)

For `who: "recipient"` + `of`, extract `descriptor.recipient` from the ancestor instead.

## Testing

- Full dwn-server test suite: **530 tests pass, 0 failures**
- Lint: clean
- 8 new test scenarios:
  - `who: "author"` delivers to ancestor author
  - `who: "recipient"` delivers to ancestor recipient
  - Combined actor + role targets (both receive)
  - Deduplication when actor matches role target
  - Ancestor not found → graceful no-op
  - Ancestor query failure → graceful no-op
  - Cross-protocol `of` → skipped (deferred)
  - `who: "anyone"` → no actor resolution triggered

## Related

- Closes #522
- Builds on PR #529 (explicit recipient delivery, merged)