### PR TITLE
fix(dwn-sql-store): convert prefix range filters to LIKE for collation safety

### DIFF
--- a/packages/dwn-sql-store/src/utils/filter.ts
+++ b/packages/dwn-sql-store/src/utils/filter.ts
@@ -2,7 +2,7 @@ import type { DwnDatabaseType } from '../types.js';
 import type { Filter } from '@enbox/dwn-sdk-js';
 import type { ExpressionBuilder, OperandExpression, SelectQueryBuilder, SqlBool } from 'kysely';
 
-import { DynamicModule } from 'kysely';
+import { DynamicModule, sql } from 'kysely';
 import { sanitizedValue, sanitizeFiltersAndSeparateTags } from './sanitize.js';
 
 /**
@@ -52,6 +52,16 @@ function processFilter<DB = DwnDatabaseType, TB extends keyof DB = keyof DB>(
     if (Array.isArray(value)) { // OneOfFilter
       andOperands.push(eb(column, 'in', value));
     } else if (typeof value === 'object') { // RangeFilter
+      // Detect prefix-style range filters created by `constructPrefixFilterAsRangeFilter`
+      // which uses `{ gte: prefix, lt: prefix + '\uffff' }`. The U+FFFF sentinel does not
+      // sort correctly under ICU/libc collation rules (e.g. PostgreSQL's en_US.UTF-8),
+      // so we convert these to a collation-safe SQL LIKE expression.
+      if (isPrefixRangeFilter(value)) {
+        const prefix = escapeLikePattern(value.gte as string);
+        andOperands.push(sql`${sql.ref(property)} LIKE ${prefix + '%'}`);
+        continue;
+      }
+
       if (value.gt) {
         andOperands.push(eb(column, '>', sanitizedValue(value.gt)));
       }
@@ -68,6 +78,30 @@ function processFilter<DB = DwnDatabaseType, TB extends keyof DB = keyof DB>(
       andOperands.push(eb(column, '=', sanitizedValue(value)));
     }
   }
+}
+
+/**
+ * Returns `true` if the given RangeFilter matches the pattern produced by
+ * `constructPrefixFilterAsRangeFilter`: `{ gte: <prefix>, lt: <prefix> + '\uffff' }`.
+ */
+function isPrefixRangeFilter(value: Record<string, unknown>): boolean {
+  if (typeof value.gte !== 'string' || typeof value.lt !== 'string') {
+    return false;
+  }
+  // Only two keys: gte and lt (no gt, lte, or other properties)
+  const keys = Object.keys(value);
+  if (keys.length !== 2 || !keys.includes('gte') || !keys.includes('lt')) {
+    return false;
+  }
+  return value.lt === value.gte + '\uffff';
+}
+
+/**
+ * Escapes SQL LIKE meta-characters (`%`, `_`) in the given string so that
+ * they are matched literally.
+ */
+function escapeLikePattern(input: string): string {
+  return input.replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
 
 /**

--- a/packages/dwn-sql-store/tests/filter.spec.ts
+++ b/packages/dwn-sql-store/tests/filter.spec.ts
@@ -37,6 +37,7 @@ describe('filterSelectQuery', () => {
       .addColumn('messageTimestamp', 'varchar(30)')
       .addColumn('dateCreated', 'varchar(30)')
       .addColumn('dataFormat', 'varchar(30)')
+      .addColumn('contextId', 'varchar(600)')
       .execute();
 
     await db.schema
@@ -73,6 +74,7 @@ describe('filterSelectQuery', () => {
     dataFormat?: string;
     messageTimestamp?: string;
     dateCreated?: string;
+    contextId?: string;
   }): Promise<number> {
     const result = await db
       .insertInto('messageStoreMessages')
@@ -88,6 +90,7 @@ describe('filterSelectQuery', () => {
         dataFormat          : values.dataFormat ?? null,
         messageTimestamp    : values.messageTimestamp ?? null,
         dateCreated         : values.dateCreated ?? null,
+        contextId           : values.contextId ?? null,
       })
       .returning('id as insertId')
       .executeTakeFirstOrThrow();
@@ -230,6 +233,63 @@ describe('filterSelectQuery', () => {
       await insertMessage({ tenant: 't1', messageCid: 'cid-3', dateCreated: '2024-12-01' });
 
       const filters: Filter[] = [{ dateCreated: { lte: '2024-06-01' } }];
+
+      let query = db
+        .selectFrom('messageStoreMessages')
+        .leftJoin('messageStoreRecordsTags', 'messageStoreRecordsTags.messageInsertId', 'messageStoreMessages.id')
+        .select('messageCid')
+        .distinct()
+        .where('tenant', '=', 't1');
+
+      query = filterSelectQuery(filters, query);
+      const results = await query.execute();
+
+      expect(results.length).toBe(2);
+      const cids = results.map((r) => r.messageCid).sort();
+      expect(cids).toEqual(['cid-1', 'cid-2']);
+    });
+  });
+
+  // ─── PrefixRangeFilter (collation-safe LIKE) ───────────────────────────
+
+  describe('PrefixRangeFilter (contextId prefix matching)', () => {
+    it('should match records whose contextId starts with the given prefix', async () => {
+      // Simulate a nested protocol: root record `bafkA` with children `bafkA/bafkB` and `bafkA/bafkC`
+      const rootContextId = 'bafkreiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const childContextId1 = rootContextId + '/bafkreibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      const childContextId2 = rootContextId + '/bafkreicccccccccccccccccccccccccccccccccccccccccccccccccc';
+      const unrelatedContextId = 'bafkreidddddddddddddddddddddddddddddddddddddddddddddddddd/bafkreieeee';
+
+      await insertMessage({ tenant: 't1', messageCid: 'cid-root', contextId: rootContextId });
+      await insertMessage({ tenant: 't1', messageCid: 'cid-child-1', contextId: childContextId1 });
+      await insertMessage({ tenant: 't1', messageCid: 'cid-child-2', contextId: childContextId2 });
+      await insertMessage({ tenant: 't1', messageCid: 'cid-unrelated', contextId: unrelatedContextId });
+
+      // This is the exact filter shape produced by constructPrefixFilterAsRangeFilter
+      const filters: Filter[] = [{ contextId: { gte: rootContextId, lt: rootContextId + '\uffff' } }];
+
+      let query = db
+        .selectFrom('messageStoreMessages')
+        .leftJoin('messageStoreRecordsTags', 'messageStoreRecordsTags.messageInsertId', 'messageStoreMessages.id')
+        .select('messageCid')
+        .distinct()
+        .where('tenant', '=', 't1');
+
+      query = filterSelectQuery(filters, query);
+      const results = await query.execute();
+
+      expect(results.length).toBe(3); // root + 2 children
+      const cids = results.map((r) => r.messageCid).sort();
+      expect(cids).toEqual(['cid-child-1', 'cid-child-2', 'cid-root']);
+    });
+
+    it('should NOT convert a range filter that does not use the \\uffff sentinel', async () => {
+      await insertMessage({ tenant: 't1', messageCid: 'cid-1', dateCreated: '2024-01-01' });
+      await insertMessage({ tenant: 't1', messageCid: 'cid-2', dateCreated: '2024-06-01' });
+      await insertMessage({ tenant: 't1', messageCid: 'cid-3', dateCreated: '2024-12-01' });
+
+      // Normal range filter (not a prefix filter) — should still work as gte + lt
+      const filters: Filter[] = [{ dateCreated: { gte: '2024-01-01', lt: '2024-12-01' } }];
 
       let query = db
         .selectFrom('messageStoreMessages')


### PR DESCRIPTION
## Summary

- Fixes nested protocol role authorization failing on PostgreSQL due to `U+FFFF` sentinel character sorting incorrectly under ICU/libc collation rules (`en_US.UTF-8`)
- Detects the `{ gte: prefix, lt: prefix + '\uffff' }` pattern from `constructPrefixFilterAsRangeFilter` and converts it to a SQL `LIKE` expression, which is collation-agnostic
- Adds 2 new tests: prefix matching with contextId hierarchy, and verification that normal range filters are unaffected

## Background

`constructPrefixFilterAsRangeFilter` in `dwn-sdk-js` uses `'\uffff'` as a sentinel to create upper bounds for prefix range queries. This works in LevelDB (bytewise comparison on UTF-8 bytes where `0xEF 0xBF 0xBF` sorts after ASCII), but fails in PostgreSQL with `en_US.UTF-8` collation where Unicode noncharacters may sort before regular ASCII characters.

This caused `ProtocolAuthorizationMatchingRoleRecordNotFound` errors when using nested roles (e.g., `network/member` under `network`) because the role record query filtered by contextId prefix and returned no results.

## Changes

**`packages/dwn-sql-store/src/utils/filter.ts`**:
- Added `isPrefixRangeFilter()` helper to detect the sentinel pattern
- Added `escapeLikePattern()` to safely escape LIKE meta-characters
- In `processFilter()`, prefix range filters are now converted to `column LIKE 'prefix%'` instead of `column >= prefix AND column < prefix\uffff`

**`packages/dwn-sql-store/tests/filter.spec.ts`**:
- Added `contextId` column to test schema and `insertMessage` helper
- Added test: prefix matching returns root + children, excludes unrelated records
- Added test: normal range filters (without sentinel) remain unaffected

Related: #528 ($squash Ajv bug), #526 (resolver cache lifecycle)