### PR TITLE
feat(dwn-relay): forward original RecordsRead auth for non-published proxy reads

### DIFF
--- a/packages/dwn-relay/src/relay-server.ts
+++ b/packages/dwn-relay/src/relay-server.ts
@@ -9,6 +9,7 @@ import { getRelayConfig } from './config.js';
 import { IpfsResolver } from './proxy/ipfs-resolver.js';
 import { MetadataStore } from './stores/metadata-store.js';
 import { RelayDataStore } from './stores/relay-data-store.js';
+import { requestContext } from './request-context.js';
 import { ServerSyncEngine } from './sync/server-sync-engine.js';
 import { defaultDwnServerConfig, DwnServer, getDwnConfig } from '@enbox/dwn-server';
 import { Dwn, DwnInterfaceName, DwnMethodName, EventEmitterEventLog } from '@enbox/dwn-sdk-js';
@@ -98,6 +99,23 @@ export class RelayServer {
       dataStore: relayDataStore,
       eventLog,
     });
+
+    // Wrap dwn.processMessage to thread the original signed message through
+    // AsyncLocalStorage for RecordsRead requests. This lets RelayDataStore.get()
+    // forward the client's authorization when proxying to a peer DWN, enabling
+    // proxy reads of non-published records.
+    const originalProcessMessage = dwn.processMessage.bind(dwn);
+    (dwn as any).processMessage = (tenant: string, rawMessage: any, options?: any): Promise<any> => {
+      const descriptor = rawMessage?.descriptor;
+      if (
+        descriptor?.interface === DwnInterfaceName.Records &&
+        descriptor?.method === DwnMethodName.Read &&
+        rawMessage?.authorization !== undefined
+      ) {
+        return requestContext.run(rawMessage, () => originalProcessMessage(tenant, rawMessage, options));
+      }
+      return originalProcessMessage(tenant, rawMessage, options);
+    };
 
     // Create the connection pool (shared between sync engine and read proxy).
     const connectionPool = new ConnectionPool();

--- a/packages/dwn-relay/src/request-context.ts
+++ b/packages/dwn-relay/src/request-context.ts
@@ -1,0 +1,19 @@
+import type { GenericMessage } from '@enbox/dwn-sdk-js';
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Request-scoped context that threads the original DWN message through the
+ * call stack without modifying the `DataStore` interface.
+ *
+ * When a `RecordsRead` is processed, `RelayServer` wraps the
+ * `dwn.processMessage()` call in `requestContext.run(message, ...)`.
+ * Inside the call, `RelayDataStore.get()` can retrieve the original signed
+ * message via `requestContext.getStore()` and forward it to a peer DWN for
+ * proxy reads of non-published records.
+ *
+ * Background operations (sync, eviction) run without a request context,
+ * so `getStore()` returns `undefined` — the proxy falls back to an
+ * anonymous (unsigned) RecordsRead, which only works for published records.
+ */
+export const requestContext = new AsyncLocalStorage<GenericMessage>();

--- a/packages/dwn-relay/src/stores/relay-data-store.ts
+++ b/packages/dwn-relay/src/stores/relay-data-store.ts
@@ -3,6 +3,7 @@ import type { IpfsResolver } from '../proxy/ipfs-resolver.js';
 import log from 'loglevel';
 import type { MetadataStore } from './metadata-store.js';
 import type { RelayConfig } from '../config.js';
+import { requestContext } from '../request-context.js';
 import { resolveEndpoints } from '../endpoint-resolver.js';
 import { Cid, DataStream, Time } from '@enbox/dwn-sdk-js';
 import type { DataStore, DataStoreGetResult, DataStorePutResult } from '@enbox/dwn-sdk-js';
@@ -220,8 +221,14 @@ export class RelayDataStore implements DataStore {
       return undefined;
     }
 
-    // Build a minimal RecordsRead message for the peer
-    const readMessage = {
+    // Use the original signed RecordsRead message if available (threaded via
+    // AsyncLocalStorage from the request handler). This forwards the client's
+    // authorization to the peer, enabling proxy reads of non-published records.
+    // Falls back to an anonymous (unsigned) RecordsRead for background operations
+    // (sync, eviction) where no client request is in-flight — only works for
+    // published records.
+    const originalMessage = requestContext.getStore();
+    const readMessage = originalMessage ?? {
       descriptor: {
         interface        : 'Records',
         method           : 'Read',

--- a/packages/dwn-relay/tests/relay-data-store.test.ts
+++ b/packages/dwn-relay/tests/relay-data-store.test.ts
@@ -1,3 +1,5 @@
+import type { GenericMessage } from '@enbox/dwn-sdk-js';
+
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
@@ -5,7 +7,8 @@ import { mkdtempSync, rmSync } from 'fs';
 
 import { MetadataStore } from '../src/stores/metadata-store.js';
 import { RelayDataStore } from '../src/stores/relay-data-store.js';
-import { createMockDataStore, randomBytes, streamFromBytes } from './test-utils.js';
+import { requestContext } from '../src/request-context.js';
+import { createDidDocument, createMockDataStore, createMockDidResolver, createMockRpcClient, getTestRelayConfig, randomBytes, streamFromBytes } from './test-utils.js';
 
 describe('RelayDataStore', () => {
   let innerStore: ReturnType<typeof createMockDataStore>;
@@ -370,6 +373,116 @@ describe('RelayDataStore', () => {
       expect(candidates.every(c => c.synced)).toBe(true);
 
       await storeB.close();
+    });
+  });
+
+  // ─── Read proxy auth forwarding ───────────────────────────────────
+
+  describe('read proxy auth forwarding', () => {
+    it('should forward the original signed RecordsRead message when available in request context', async () => {
+      const rpcClient = createMockRpcClient();
+      const tenant = 'did:test:alice';
+
+      // The peer returns 404 (no data) — we're testing what message gets sent, not the response.
+      rpcClient.pushResponse({ status: { code: 404, detail: 'Not Found' } });
+
+      const proxyStore = new RelayDataStore(createMockDataStore());
+      await proxyStore.open();
+
+      proxyStore.setProxy({
+        didResolver: createMockDidResolver({
+          [tenant]: createDidDocument(tenant, ['https://peer.example.com']),
+        }),
+        rpcClient,
+        config       : getTestRelayConfig(),
+        ipfsResolver : undefined,
+      });
+
+      const signedMessage = {
+        descriptor: {
+          interface        : 'Records',
+          method           : 'Read',
+          messageTimestamp : '2026-01-01T00:00:00.000000Z',
+          filter           : { recordId: 'rec-private' },
+        },
+        authorization: {
+          signature: {
+            signatures: [{ protected: 'signed-header', signature: 'signed-sig' }],
+          },
+        },
+      } as unknown as GenericMessage;
+
+      // Run within request context — the proxy should forward the signed message.
+      await requestContext.run(signedMessage, async () => {
+        await proxyStore.get(tenant, 'rec-private', 'cid-private');
+      });
+
+      // Verify the RPC request used the original signed message, not an anonymous one.
+      expect(rpcClient.requests).toHaveLength(1);
+      const sentMessage = rpcClient.requests[0].message as any;
+      expect(sentMessage.authorization).toBeDefined();
+      expect(sentMessage.authorization.signature.signatures[0].protected).toBe('signed-header');
+
+      await proxyStore.close();
+    });
+
+    it('should use an anonymous RecordsRead when no request context is available', async () => {
+      const rpcClient = createMockRpcClient();
+      const tenant = 'did:test:alice';
+
+      rpcClient.pushResponse({ status: { code: 404, detail: 'Not Found' } });
+
+      const proxyStore = new RelayDataStore(createMockDataStore());
+      await proxyStore.open();
+
+      proxyStore.setProxy({
+        didResolver: createMockDidResolver({
+          [tenant]: createDidDocument(tenant, ['https://peer.example.com']),
+        }),
+        rpcClient,
+        config       : getTestRelayConfig(),
+        ipfsResolver : undefined,
+      });
+
+      // No requestContext.run() — simulates a background operation.
+      await proxyStore.get(tenant, 'rec-published', 'cid-published');
+
+      // Verify the RPC request used an anonymous message (no authorization).
+      expect(rpcClient.requests).toHaveLength(1);
+      const sentMessage = rpcClient.requests[0].message as any;
+      expect(sentMessage.authorization).toBeUndefined();
+      expect(sentMessage.descriptor.filter.recordId).toBe('rec-published');
+
+      await proxyStore.close();
+    });
+
+    it('should not forward auth for non-RecordsRead contexts', async () => {
+      const rpcClient = createMockRpcClient();
+      const tenant = 'did:test:alice';
+
+      rpcClient.pushResponse({ status: { code: 404, detail: 'Not Found' } });
+
+      const proxyStore = new RelayDataStore(createMockDataStore());
+      await proxyStore.open();
+
+      proxyStore.setProxy({
+        didResolver: createMockDidResolver({
+          [tenant]: createDidDocument(tenant, ['https://peer.example.com']),
+        }),
+        rpcClient,
+        config       : getTestRelayConfig(),
+        ipfsResolver : undefined,
+      });
+
+      // No requestContext — the relay server wrapper only stores RecordsRead
+      // messages in the context, so background calls get anonymous reads.
+      await proxyStore.get(tenant, 'rec-test', 'cid-test');
+
+      expect(rpcClient.requests).toHaveLength(1);
+      const sentMessage = rpcClient.requests[0].message as any;
+      expect(sentMessage.authorization).toBeUndefined();
+
+      await proxyStore.close();
     });
   });
 });

--- a/packages/dwn-relay/tests/request-context.test.ts
+++ b/packages/dwn-relay/tests/request-context.test.ts
@@ -1,0 +1,51 @@
+import type { GenericMessage } from '@enbox/dwn-sdk-js';
+
+import { describe, expect, it } from 'bun:test';
+
+import { requestContext } from '../src/request-context.js';
+
+describe('requestContext', () => {
+  it('should return undefined outside of a run scope', () => {
+    expect(requestContext.getStore()).toBeUndefined();
+  });
+
+  it('should store and retrieve the message within a run scope', async () => {
+    const message = {
+      descriptor: {
+        interface        : 'Records',
+        method           : 'Read',
+        messageTimestamp : '2026-01-01T00:00:00.000000Z',
+        filter           : { recordId: 'test-record' },
+      },
+      authorization: { signature: { signatures: [{ protected: 'test', signature: 'test' }] } },
+    } as unknown as GenericMessage;
+
+    await requestContext.run(message, async () => {
+      expect(requestContext.getStore()).toBe(message);
+    });
+  });
+
+  it('should isolate contexts between concurrent runs', async () => {
+    const msg1 = { descriptor: { method: 'msg1' } } as unknown as GenericMessage;
+    const msg2 = { descriptor: { method: 'msg2' } } as unknown as GenericMessage;
+
+    await Promise.all([
+      requestContext.run(msg1, async () => {
+        await new Promise(r => setTimeout(r, 10));
+        expect(requestContext.getStore()).toBe(msg1);
+      }),
+      requestContext.run(msg2, async () => {
+        await new Promise(r => setTimeout(r, 10));
+        expect(requestContext.getStore()).toBe(msg2);
+      }),
+    ]);
+  });
+
+  it('should return undefined after the run scope ends', async () => {
+    const message = { descriptor: { method: 'test' } } as unknown as GenericMessage;
+    await requestContext.run(message, async () => {
+      // inside scope
+    });
+    expect(requestContext.getStore()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Forward the original signed `RecordsRead` message when proxying to peer DWNs on cache miss, enabling proxy reads of **non-published records** (DMs, private channels, protocol-governed data).
- Use `AsyncLocalStorage` to thread the original message from the request handler through to `RelayDataStore.get()` without changing the `DataStore` interface.
- Background operations (sync, eviction) fall back to anonymous reads — only works for published records, which is expected.

## Approach: Option A from #525

The issue analyzed four options. This implements **Option A (forward original auth)** — the simplest approach that covers the interactive case (client → relay → peer). The client already has valid auth; the relay just passes it through.

### Architecture

```
Client → [signed RecordsRead] → RelayServer
  └─ processMessage wrapper stores message in AsyncLocalStorage
     └─ DWN engine: RecordsReadHandler → DataStore.get()
        └─ RelayDataStore.get(): cache miss → #proxyFromPeer()
           └─ reads original message from AsyncLocalStorage
              └─ forwards signed message to peer DWN
                 └─ peer validates auth → returns data
```

## Changes

| File | Change |
|------|--------|
| `packages/dwn-relay/src/request-context.ts` | **New**: `AsyncLocalStorage<GenericMessage>` singleton |
| `packages/dwn-relay/src/relay-server.ts` | Wrap `dwn.processMessage()` to store signed RecordsRead in context |
| `packages/dwn-relay/src/stores/relay-data-store.ts` | Read original message from context in `#proxyFromPeer()` |
| `packages/dwn-relay/tests/request-context.test.ts` | **New**: 4 tests for AsyncLocalStorage behavior |
| `packages/dwn-relay/tests/relay-data-store.test.ts` | 3 new tests for auth forwarding vs anonymous fallback |

## Testing

- Full dwn-relay test suite: **170 tests pass, 0 failures**
- Lint: clean
- New test scenarios:
  - Signed message forwarded when request context is available
  - Anonymous fallback when no request context (background ops)
  - Context isolation between concurrent requests
  - Context cleanup after scope ends

## Limitations (documented in #525)

- Does not cover background operations (sync engine re-fetching, eviction re-hydration) — those would need **Option B (delegated grants)**, deferred to a future milestone.
- The `DataStore` interface is unchanged — the async context is transparent to the DWN engine.

## Related

- Closes #525
- Builds on PR #519 (read proxy bugs, merged)