### PR TITLE
feat(dwn-server): add dataRetention field to ServerInfo /info response

### DIFF
--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -225,6 +225,7 @@ export class HttpDwnRpcClient implements DwnRpc {
         const results = await response.json() as ServerInfo;
 
         const serverInfo: ServerInfo = {
+          dataRetention            : results.dataRetention,
           maxFileSize              : results.maxFileSize,
           registrationRequirements : results.registrationRequirements,
           server                   : results.server,

--- a/packages/dwn-clients/src/server-info-types.ts
+++ b/packages/dwn-clients/src/server-info-types.ts
@@ -17,6 +17,11 @@ export type ProviderAuthInfo = {
 };
 
 export type ServerInfo = {
+  /**
+   * Indicates whether the server retains all record data (`"full"`, the default
+   * when absent) or operates as a best-effort relay/cache (`"cache"`).
+   */
+  dataRetention?: 'full' | 'cache',
   /** the maximum file size the user can request to store */
   maxFileSize: number,
   /**

--- a/packages/dwn-server/src/config.ts
+++ b/packages/dwn-server/src/config.ts
@@ -56,6 +56,14 @@ export const config = {
    */
   maxInFlight: parseInt(process.env.DWN_MAX_IN_FLIGHT || '32'),
 
+  /**
+   * Data retention mode advertised in the `/info` response.
+   * `"full"` (default) means the server retains all record data indefinitely.
+   * `"cache"` means the server is a best-effort relay/cache that may evict data.
+   * When absent from the response, clients assume `"full"`.
+   */
+  dataRetention: (process.env.DWN_DATA_RETENTION as 'full' | 'cache' | undefined) || undefined,
+
   // whether to enable 'ws:'
   webSocketSupport: { on: true, off: false }[process.env.DS_WEBSOCKET_SERVER] ?? true,
 

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -501,6 +501,10 @@ export class HttpApi {
       webSocketSupport         : config.webSocketSupport,
     };
 
+    if (config.dataRetention) {
+      serverInfo.dataRetention = config.dataRetention;
+    }
+
     if (config.providerAuthEnabled) {
       serverInfo.providerAuth = {
         authorizeUrl  : config.providerAuthAuthorizeUrl,

--- a/packages/dwn-server/tests/http-api.test.ts
+++ b/packages/dwn-server/tests/http-api.test.ts
@@ -1030,6 +1030,33 @@ describe('http api', function () {
       // restore server name config
       config.serverName = serverName;
     });
+
+    it('verify /info omits dataRetention by default (full node)', async function () {
+      const resp = await fetch(`${baseUrl}/info`);
+      expect(resp.status).toBe(200);
+
+      const info = await resp.json();
+      expect(info['dataRetention']).toBeUndefined();
+    });
+
+    it('verify /info returns dataRetention when configured as cache', async function () {
+      await httpApi.close();
+
+      const originalDataRetention = config.dataRetention;
+      (config as any).dataRetention = 'cache';
+      httpApi = await HttpApi.create(config, dwn, registrationManager);
+      await httpApi.start(0);
+      baseUrl = `http://localhost:${httpApi.server.port}`;
+
+      const resp = await fetch(`${baseUrl}/info`);
+      expect(resp.status).toBe(200);
+
+      const info = await resp.json();
+      expect(info['dataRetention']).toBe('cache');
+
+      // restore
+      (config as any).dataRetention = originalDataRetention;
+    });
   });
 
   describe('getter accessors', () => {


### PR DESCRIPTION
## Summary

- Add optional `dataRetention` field (`"full"` | `"cache"`) to the `ServerInfo` type and `/info` endpoint response, allowing clients to distinguish full DWN nodes from relay/cache nodes
- When absent from the response, clients assume `"full"` (the default) — only cache nodes need to advertise `"cache"`
- Configurable via the `DWN_DATA_RETENTION` env var on the server

## Changes

| File | Change |
|------|--------|
| `packages/dwn-clients/src/server-info-types.ts` | Add `dataRetention?: 'full' \| 'cache'` to `ServerInfo` type |
| `packages/dwn-server/src/config.ts` | Add `dataRetention` config field (env: `DWN_DATA_RETENTION`) |
| `packages/dwn-server/src/http-api.ts` | Conditionally include `dataRetention` in `/info` response |
| `packages/dwn-clients/src/http-dwn-rpc-client.ts` | Pass through `dataRetention` in `getServerInfo()` |
| `packages/dwn-server/tests/http-api.test.ts` | 2 new tests: absent by default, present when configured as `"cache"` |

## Design

Per the spec and project conventions:
- Bare string `serviceEndpoint` entries and servers without `dataRetention` are implicitly "full" nodes
- Only cache/relay nodes annotate with `"cache"` — full nodes never need to set this
- The field is omitted entirely from the response when not configured (rather than defaulting to `"full"`)