### PR TITLE
fix: include dwn-server in publish pipeline and resolve workspace:* deps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,8 +10,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "@enbox/dwn-server",
-    "@enbox/dwn-relay"
-  ]
+  "ignore": []
 }

--- a/packages/dwn-server/package.json
+++ b/packages/dwn-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enbox/dwn-server",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "files": [
     "dist",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -31,6 +31,7 @@ PACKAGES=(
   "packages/protocols"
   "packages/browser"
   "packages/dwn-sql-store"
+  "packages/dwn-server"
 )
 
 # resolve_workspace_deps <package.json path>


### PR DESCRIPTION
## Summary

- Remove `@enbox/dwn-server` and `@enbox/dwn-relay` from the changeset `ignore` list so `changeset version` can bump their versions
- Add `packages/dwn-server` to the `PACKAGES` array in `scripts/publish.sh` so it gets workspace:* resolution and proper publishing
- Bump `@enbox/dwn-server` to `0.0.4` for republish

## Problem

The published `@enbox/dwn-server@0.0.3` on npm has literal `workspace:*` strings in its dependencies:

```json
"@enbox/common": "workspace:*",
"@enbox/dwn-sdk-js": "workspace:*",
...
```

This makes it impossible for any external consumer (including the standalone `@enbox/dwn-relay` repo) to install it from npm.

**Root cause:** `dwn-server` was excluded from both the changeset ignore list AND the publish.sh PACKAGES array. It was published via `changeset publish` before the custom `publish.sh` script existed, which doesn't resolve `workspace:*`.

## After merge

Once merged, run `bun run release` (or let the release workflow handle it) to publish `@enbox/dwn-server@0.0.4` with correctly resolved dependencies.