### PR TITLE
fix: move admin-ui to optionalDependencies, publish admin-ui package

### DIFF
--- a/packages/dwn-server-admin-ui/package.json
+++ b/packages/dwn-server-admin-ui/package.json
@@ -1,9 +1,19 @@
 {
   "name": "@enbox/dwn-server-admin-ui",
   "version": "0.1.0",
-  "private": true,
   "license": "Apache-2.0",
   "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/enboxorg/enbox.git",
+    "directory": "packages/dwn-server-admin-ui"
+  },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/dwn-server/package.json
+++ b/packages/dwn-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enbox/dwn-server",
   "type": "module",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "Apache-2.0",
   "files": [
     "dist",
@@ -35,7 +35,6 @@
     "@enbox/dids": "workspace:*",
     "@enbox/dwn-clients": "workspace:*",
     "@enbox/dwn-sdk-js": "workspace:*",
-    "@enbox/dwn-server-admin-ui": "workspace:*",
     "@enbox/dwn-sql-store": "workspace:*",
     "@nats-io/jetstream": "^3.3.1",
     "@nats-io/transport-node": "^3.3.1",
@@ -50,6 +49,9 @@
     "prom-client": "14.2.0",
     "uuid": "9.0.0",
     "ws": "8.18.0"
+  },
+  "optionalDependencies": {
+    "@enbox/dwn-server-admin-ui": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "^1.3.9",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -31,6 +31,7 @@ PACKAGES=(
   "packages/protocols"
   "packages/browser"
   "packages/dwn-sql-store"
+  "packages/dwn-server-admin-ui"
   "packages/dwn-server"
 )
 


### PR DESCRIPTION
## Summary

- Move `@enbox/dwn-server-admin-ui` from `dependencies` to `optionalDependencies` in `@enbox/dwn-server` — the import is already guarded by try/catch and gracefully degrades when not installed
- Remove `private: true` from admin-ui package so it can be published to npm
- Add `packages/dwn-server-admin-ui` to `publish.sh` PACKAGES array
- Bump `@enbox/dwn-server` to `0.0.5` for republish

## Problem

`@enbox/dwn-server@0.0.4` lists `@enbox/dwn-server-admin-ui@0.1.0` as a hard dependency, but the admin-ui package was never published to npm (`private: true`). This causes `bun install` to fail for any external consumer of `@enbox/dwn-server`.

## After merge

The release workflow will:
1. Publish `@enbox/dwn-server-admin-ui@0.1.0` to npm (first time)
2. Republish `@enbox/dwn-server@0.0.5` with admin-ui as optional