### PR TITLE
feat(agent): add local DWN discovery with configurable strategy

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -33,6 +33,7 @@ import {
 import { CryptoUtils, X25519 } from '@enbox/crypto';
 import { DidDht, DidJwk, DidResolverCacheLevel, UniversalResolver } from '@enbox/dids';
 
+import type { LocalDwnStrategy } from './local-dwn.js';
 import type { Web5PlatformAgent } from './types/agent.js';
 import type {
   DwnMessage,
@@ -48,6 +49,7 @@ import type {
 } from './types/dwn.js';
 
 import { KeyDeliveryProtocolDefinition } from './store-data-protocols.js';
+import { LocalDwnDiscovery } from './local-dwn.js';
 import { DwnInterface, dwnMessageConstructors } from './types/dwn.js';
 import { getDwnServiceEndpointUrls, isRecordsWrite } from './utils.js';
 
@@ -101,6 +103,7 @@ type DwnMessageWithBlob<T extends DwnInterface> = {
 type DwnApiParams = {
   agent?: Web5PlatformAgent;
   dwn: Dwn;
+  localDwnStrategy?: LocalDwnStrategy;
 };
 
 interface DwnApiCreateDwnParams extends Partial<DwnConfig> {
@@ -148,12 +151,34 @@ export class AgentDwnApi {
     ttl: 30 * 60 * 1000
   });
 
-  constructor({ agent, dwn }: DwnApiParams) {
+  /**
+   * Cache of locally-managed DIDs (agent DID + identities). Used to decide
+   * whether a target DID should be routed through the local DWN server.
+   */
+  private _localManagedDidCache = new TtlCache<string, boolean>({
+    ttl: 30 * 60 * 1000
+  });
+
+  /** Controls local DWN discovery behavior ('prefer' | 'only' | 'off'). */
+  private _localDwnStrategy: LocalDwnStrategy;
+
+  /** Lazy-initialized local DWN discovery instance. */
+  private _localDwnDiscovery?: LocalDwnDiscovery;
+
+  constructor({ agent, dwn, localDwnStrategy = 'prefer' }: DwnApiParams) {
     // If an agent is provided, set it as the execution context for this API.
     this._agent = agent;
 
     // Set the DWN instance for this API.
     this._dwn = dwn;
+
+    // Set the local DWN discovery strategy.
+    this._localDwnStrategy = localDwnStrategy;
+
+    // If agent is already available, eagerly initialize the discovery instance.
+    if (agent) {
+      this._localDwnDiscovery = new LocalDwnDiscovery(agent.rpc);
+    }
   }
 
   /**
@@ -172,6 +197,114 @@ export class AgentDwnApi {
 
   set agent(agent: Web5PlatformAgent) {
     this._agent = agent;
+    // Re-initialize local DWN discovery with the new agent's RPC client.
+    this._localDwnDiscovery = new LocalDwnDiscovery(agent.rpc);
+    this._localManagedDidCache.clear();
+  }
+
+  get localDwnStrategy(): LocalDwnStrategy {
+    return this._localDwnStrategy;
+  }
+
+  public setLocalDwnStrategy(strategy: LocalDwnStrategy): void {
+    this._localDwnStrategy = strategy;
+  }
+
+  /**
+   * Resolves the DWN service endpoint URLs for the given target DID, optionally
+   * prepending a local DWN server endpoint when local discovery is enabled and
+   * the target is a locally-managed DID.
+   *
+   * @param targetDid - The DID whose DWN endpoints should be resolved.
+   * @returns An array of endpoint URLs.
+   * @throws When strategy is `'only'` and no local server is available.
+   */
+  public async getDwnEndpointUrlsForTarget(targetDid: string): Promise<string[]> {
+    const shouldUseLocalDwn = await this.shouldUseLocalDwnForTarget(targetDid);
+
+    if (!shouldUseLocalDwn) {
+      return getDwnServiceEndpointUrls(targetDid, this.agent.did);
+    }
+
+    const localDwnEndpoint = await this.getLocalDwnEndpoint();
+    if (this._localDwnStrategy === 'only') {
+      if (!localDwnEndpoint) {
+        throw new Error(
+          `AgentDwnApi: Local DWN strategy is 'only' but no local server is available ` +
+          `on localhost/127.0.0.1:{3000,55555-55559}`
+        );
+      }
+
+      return [localDwnEndpoint];
+    }
+
+    let dwnEndpointUrls: string[] = [];
+    try {
+      dwnEndpointUrls = await getDwnServiceEndpointUrls(targetDid, this.agent.did);
+    } catch (error) {
+      if (!localDwnEndpoint) {
+        throw error;
+      }
+    }
+
+    if (!localDwnEndpoint) {
+      return dwnEndpointUrls;
+    }
+
+    const uniqueEndpoints = new Set<string>([
+      localDwnEndpoint,
+      ...dwnEndpointUrls,
+    ]);
+
+    return [...uniqueEndpoints];
+  }
+
+  /** Lazily retrieves the local DWN server endpoint via discovery probing. */
+  private async getLocalDwnEndpoint(): Promise<string | undefined> {
+    this._localDwnDiscovery ??= new LocalDwnDiscovery(this.agent.rpc);
+    return this._localDwnDiscovery.getEndpoint();
+  }
+
+  /**
+   * Determines whether the given target DID should be routed through the
+   * local DWN server. Returns `true` if the DID is the agent DID or one
+   * of the locally-managed identity DIDs.
+   */
+  private async shouldUseLocalDwnForTarget(targetDid: string): Promise<boolean> {
+    if (this._localDwnStrategy === 'off') {
+      return false;
+    }
+
+    const cached = this._localManagedDidCache.get(targetDid);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    if (targetDid === this.agent.agentDid.uri) {
+      this._localManagedDidCache.set(targetDid, true);
+      return true;
+    }
+
+    const identities = await this.agent.identity.list();
+    const localManagedDids = new Set<string>();
+
+    for (const identity of identities) {
+      localManagedDids.add(identity.did.uri);
+      if (identity.metadata.connectedDid) {
+        localManagedDids.add(identity.metadata.connectedDid);
+      }
+    }
+
+    for (const localDid of localManagedDids) {
+      this._localManagedDidCache.set(localDid, true);
+    }
+
+    const isLocalManaged = localManagedDids.has(targetDid);
+    if (!isLocalManaged) {
+      this._localManagedDidCache.set(targetDid, false);
+    }
+
+    return isLocalManaged;
   }
 
   /**
@@ -252,8 +385,8 @@ export class AgentDwnApi {
   public async sendRequest<T extends DwnInterface>(
     request: SendDwnRequest<T>
   ): Promise<DwnResponse<T>> {
-    // First, confirm the target DID can be dereferenced and extract the DWN service endpoint URLs.
-    const dwnEndpointUrls = await getDwnServiceEndpointUrls(request.target, this.agent.did);
+    // Resolve DWN service endpoint URLs, with local DWN discovery if enabled.
+    const dwnEndpointUrls = await this.getDwnEndpointUrlsForTarget(request.target);
     if (dwnEndpointUrls.length === 0) {
       throw new Error(`AgentDwnApi: DID Service is missing or malformed: ${request.target}#dwn`);
     }
@@ -997,7 +1130,7 @@ export class AgentDwnApi {
     protocolUri: string,
   ): Promise<ProtocolDefinition> {
     return fetchRemoteProtocolDefinitionFn(
-      targetDid, protocolUri, this.agent.did,
+      targetDid, protocolUri, this.getDwnEndpointUrlsForTarget.bind(this),
       this.sendDwnRpcRequest.bind(this), this._protocolDefinitionCache,
     );
   }
@@ -1022,7 +1155,7 @@ export class AgentDwnApi {
   ): Promise<{ rootKeyId: string; derivedPublicKey: PublicKeyJwk } | undefined> {
     return extractDerivedPublicKeyFn(
       targetDid, protocolUri, rootContextId, requesterDid,
-      this.agent.did, this.getSigner.bind(this),
+      this.getDwnEndpointUrlsForTarget.bind(this), this.getSigner.bind(this),
       this.sendDwnRpcRequest.bind(this),
     );
   }
@@ -1139,6 +1272,7 @@ export class AgentDwnApi {
       this.agent, tenantDid, contextKeyMessage,
       this.getDwnMessage.bind(this),
       this.sendDwnRpcRequest.bind(this),
+      this.getDwnEndpointUrlsForTarget.bind(this),
     );
   }
 
@@ -1160,6 +1294,7 @@ export class AgentDwnApi {
       this.processRequest.bind(this),
       this.getSigner.bind(this),
       this.sendDwnRpcRequest.bind(this),
+      this.getDwnEndpointUrlsForTarget.bind(this),
     );
   }
 }

--- a/packages/agent/src/dwn-key-delivery.ts
+++ b/packages/agent/src/dwn-key-delivery.ts
@@ -22,7 +22,6 @@ import {
   Records,
 } from '@enbox/dwn-sdk-js';
 
-import { getDwnServiceEndpointUrls } from './utils.js';
 import { KeyDeliveryProtocolDefinition } from './store-data-protocols.js';
 import { buildEncryptionInput, encryptAndComputeCid, getEncryptionKeyDeriver, getKeyDecrypter, ivLength } from './dwn-encryption.js';
 import { DwnInterface, dwnMessageConstructors } from './types/dwn.js';
@@ -219,6 +218,7 @@ export async function writeContextKeyRecord(
  * @param contextKeyMessage - The context key message to send
  * @param getDwnMessage - Function to read a full message from local DWN
  * @param sendDwnRpcRequest - Function to send a DWN RPC request
+ * @param getDwnEndpointUrlsForTarget - Function to resolve DWN endpoint URLs (with local discovery)
  */
 export async function eagerSendContextKeyRecord(
   agent: Web5PlatformAgent,
@@ -226,10 +226,11 @@ export async function eagerSendContextKeyRecord(
   contextKeyMessage: DwnMessage[DwnInterface.RecordsWrite],
   getDwnMessage: (params: { author: string; messageType: DwnInterface; messageCid: string }) => Promise<{ message: any; data?: Blob }>,
   sendDwnRpcRequest: (params: { targetDid: string; dwnEndpointUrls: string[]; message: any; data?: Blob }) => Promise<any>,
+  getDwnEndpointUrlsForTarget: (targetDid: string) => Promise<string[]>,
 ): Promise<void> {
   let dwnEndpointUrls: string[];
   try {
-    dwnEndpointUrls = await getDwnServiceEndpointUrls(tenantDid, agent.did);
+    dwnEndpointUrls = await getDwnEndpointUrlsForTarget(tenantDid);
   } catch {
     // DID resolution or endpoint lookup failed — not fatal, sync will handle it.
     return;
@@ -266,6 +267,7 @@ export async function eagerSendContextKeyRecord(
  * @param processRequest - The agent's processRequest method (bound)
  * @param getSigner - Function to get a signer for a DID
  * @param sendDwnRpcRequest - Function to send a DWN RPC request
+ * @param getDwnEndpointUrlsForTarget - Function to resolve DWN endpoint URLs (with local discovery)
  * @returns The decrypted `DerivedPrivateJwk`, or `undefined` if no matching record found
  */
 export async function fetchContextKeyRecord(
@@ -274,6 +276,7 @@ export async function fetchContextKeyRecord(
   processRequest: ProcessRequestFn,
   getSigner: (author: string) => Promise<any>,
   sendDwnRpcRequest: (params: { targetDid: string; dwnEndpointUrls: string[]; message: any; data?: Blob }) => Promise<any>,
+  getDwnEndpointUrlsForTarget: (targetDid: string) => Promise<string[]>,
 ): Promise<DerivedPrivateJwk | undefined> {
   const { ownerDid, requesterDid, sourceProtocol, sourceContextId } = params;
   const protocolUri = KeyDeliveryProtocolDefinition.protocol;
@@ -323,7 +326,7 @@ export async function fetchContextKeyRecord(
   } else {
     // Remote query: participant queries the context owner's DWN
     const signer = await getSigner(requesterDid);
-    const dwnEndpointUrls = await getDwnServiceEndpointUrls(ownerDid, agent.did);
+    const dwnEndpointUrls = await getDwnEndpointUrlsForTarget(ownerDid);
 
     const recordsQuery = await dwnMessageConstructors[DwnInterface.RecordsQuery].create({
       signer,

--- a/packages/agent/src/dwn-protocol-cache.ts
+++ b/packages/agent/src/dwn-protocol-cache.ts
@@ -7,7 +7,6 @@
  * @module
  */
 
-import type { DidUrlDereferencer } from '@enbox/dids';
 import type { PublicKeyJwk } from '@enbox/crypto';
 import type { TtlCache } from '@enbox/common';
 import type {
@@ -26,12 +25,14 @@ import type {
 
 import { KeyDerivationScheme } from '@enbox/dwn-sdk-js';
 
-import { getDwnServiceEndpointUrls } from './utils.js';
 import { DwnInterface as DwnInterfaceEnum, dwnMessageConstructors } from './types/dwn.js';
 
 // ---------------------------------------------------------------------------
 // Dependency signatures — keep the extracted code free of `this` references.
 // ---------------------------------------------------------------------------
+
+/** Callback to resolve DWN endpoint URLs for a target DID (with local discovery). */
+type GetDwnEndpointUrlsFn = (targetDid: string) => Promise<string[]>;
 
 /** Callback to obtain a DWN signer for a given DID. */
 type GetSignerFn = (author: string) => Promise<DwnSigner>;
@@ -106,7 +107,7 @@ export async function getProtocolDefinition(
  *
  * @param targetDid - The remote DWN owner
  * @param protocolUri - The protocol URI to look up
- * @param didDereferencer - A DID URL dereferencer for resolving service endpoints
+ * @param getDwnEndpointUrls - Callback to resolve DWN endpoint URLs (with local discovery)
  * @param sendDwnRpcRequest - Callback to send the RPC query
  * @param cache - The shared protocol definition cache
  * @returns The protocol definition
@@ -115,7 +116,7 @@ export async function getProtocolDefinition(
 export async function fetchRemoteProtocolDefinition(
   targetDid: string,
   protocolUri: string,
-  didDereferencer: DidUrlDereferencer,
+  getDwnEndpointUrls: GetDwnEndpointUrlsFn,
   sendDwnRpcRequest: SendDwnRpcRequestFn,
   cache: TtlCache<string, ProtocolDefinition>,
 ): Promise<ProtocolDefinition> {
@@ -131,7 +132,7 @@ export async function fetchRemoteProtocolDefinition(
 
   const reply = await sendDwnRpcRequest({
     targetDid,
-    dwnEndpointUrls : await getDwnServiceEndpointUrls(targetDid, didDereferencer),
+    dwnEndpointUrls : await getDwnEndpointUrls(targetDid),
     message         : protocolsQuery.message,
   }) as ProtocolsQueryReply;
 
@@ -158,7 +159,7 @@ export async function fetchRemoteProtocolDefinition(
  * @param protocolUri    - The protocol URI to search
  * @param rootContextId  - The root context ID
  * @param requesterDid   - The DID of the requester (used for signing the query)
- * @param didDereferencer - A DID URL dereferencer for resolving service endpoints
+ * @param getDwnEndpointUrls - Callback to resolve DWN endpoint URLs (with local discovery)
  * @param getSigner      - Callback to obtain the signer for `requesterDid`
  * @param sendDwnRpcRequest - Callback to send the RPC query
  * @returns The rootKeyId and derivedPublicKey, or `undefined` if no
@@ -169,7 +170,7 @@ export async function extractDerivedPublicKey(
   protocolUri: string,
   rootContextId: string,
   requesterDid: string,
-  didDereferencer: DidUrlDereferencer,
+  getDwnEndpointUrls: GetDwnEndpointUrlsFn,
   getSigner: GetSignerFn,
   sendDwnRpcRequest: SendDwnRpcRequestFn,
 ): Promise<{ rootKeyId: string; derivedPublicKey: PublicKeyJwk } | undefined> {
@@ -184,7 +185,7 @@ export async function extractDerivedPublicKey(
     },
   });
 
-  const dwnEndpointUrls = await getDwnServiceEndpointUrls(targetDid, didDereferencer);
+  const dwnEndpointUrls = await getDwnEndpointUrls(targetDid);
   const queryReply = await sendDwnRpcRequest<DwnInterfaceEnum.RecordsQuery>({
     targetDid,
     dwnEndpointUrls,

--- a/packages/agent/src/identity-api.ts
+++ b/packages/agent/src/identity-api.ts
@@ -9,7 +9,6 @@ import type { IdentityMetadata, PortableIdentity } from './types/identity.js';
 import { isPortableDid } from '@enbox/dids';
 
 import { BearerIdentity } from './bearer-identity.js';
-import { getDwnServiceEndpointUrls } from './utils.js';
 import { InMemoryIdentityStore } from './store-identity.js';
 
 export interface IdentityApiParams<TKeyManager extends AgentKeyManager> {
@@ -226,7 +225,7 @@ export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyMana
    * @throws An error if the DID is not found, or no DWN service exists.
    */
   public getDwnEndpoints({ didUri }: { didUri: string; }): Promise<string[]> {
-    return getDwnServiceEndpointUrls(didUri, this.agent.did);
+    return this.agent.dwn.getDwnEndpointUrlsForTarget(didUri);
   }
 
   /**

--- a/packages/agent/src/local-dwn.ts
+++ b/packages/agent/src/local-dwn.ts
@@ -1,40 +1,72 @@
+/**
+ * Local DWN discovery — probes well-known localhost ports for a running
+ * `@enbox/dwn-server` instance so the agent can route traffic to it.
+ *
+ * @module
+ */
+
 import type { Web5Rpc } from '@enbox/dwn-clients';
 
+/** Well-known ports the local DWN desktop app may bind to. */
 export const localDwnPortCandidates = [3000, 55555, 55556, 55557, 55558, 55559] as const;
-const localDwnHostCandidates = ['127.0.0.1', 'localhost'] as const;
 
+/** Hosts probed when discovering a local DWN server. */
+export const localDwnHostCandidates = ['127.0.0.1', 'localhost'] as const;
+
+/**
+ * Controls how the agent discovers and routes to a local DWN server.
+ *
+ * - `'prefer'` — probe localhost first; fall back to DID-document endpoints.
+ * - `'only'`   — require a local server; throw if none is found.
+ * - `'off'`    — skip local discovery entirely.
+ */
 export type LocalDwnStrategy = 'prefer' | 'only' | 'off';
 
-const localDwnServerName = '@enbox/dwn-server';
+/** The `server` field returned by `GET /info` on `@enbox/dwn-server`. */
+export const localDwnServerName = '@enbox/dwn-server';
 
+/** Strips a trailing slash from a URL so endpoint comparisons are consistent. */
 function normalizeBaseUrl(url: string): string {
   return url.endsWith('/') ? url.slice(0, -1) : url;
 }
 
+/**
+ * Probes well-known localhost ports for a running `@enbox/dwn-server` instance.
+ *
+ * Results are cached for {@link _cacheTtlMs} milliseconds (default 10 s) to
+ * avoid repeated HTTP round-trips on hot paths such as sync.
+ *
+ * TODO: Replace sequential port probing with an `enbox://` protocol-handler
+ *       handshake (https://github.com/enboxorg/enbox/issues/287).
+ */
 export class LocalDwnDiscovery {
-  private cachedEndpoint?: string;
-  private cacheExpiry = 0;
+  private _cachedEndpoint?: string;
+  private _cacheExpiry = 0;
 
   constructor(
-    private rpcClient: Web5Rpc,
-    private cacheTtlMs = 10_000
+    private _rpcClient: Web5Rpc,
+    private _cacheTtlMs = 10_000
   ) {}
 
+  /**
+   * Returns the base URL of a local DWN server, or `undefined` if none is
+   * reachable on the well-known port candidates.
+   */
   public async getEndpoint(): Promise<string | undefined> {
     const now = Date.now();
-    if (now < this.cacheExpiry) {
-      return this.cachedEndpoint;
+    if (now < this._cacheExpiry) {
+      return this._cachedEndpoint;
     }
 
     for (const port of localDwnPortCandidates) {
       for (const host of localDwnHostCandidates) {
         const endpoint = `http://${host}:${port}`;
         try {
-          const serverInfo = await this.rpcClient.getServerInfo(endpoint);
+          const serverInfo = await this._rpcClient.getServerInfo(endpoint);
           if (serverInfo.server === localDwnServerName) {
-            this.cachedEndpoint = normalizeBaseUrl(endpoint);
-            this.cacheExpiry = now + this.cacheTtlMs;
-            return this.cachedEndpoint;
+            this._cachedEndpoint = normalizeBaseUrl(endpoint);
+            this._cacheExpiry = now + this._cacheTtlMs;
+            return this._cachedEndpoint;
           }
         } catch {
           // keep probing candidate endpoints
@@ -42,8 +74,8 @@ export class LocalDwnDiscovery {
       }
     }
 
-    this.cachedEndpoint = undefined;
-    this.cacheExpiry = now + this.cacheTtlMs;
+    this._cachedEndpoint = undefined;
+    this._cacheExpiry = now + this._cacheTtlMs;
     return undefined;
   }
 }

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -12,7 +12,6 @@ import type { Web5Agent, Web5PlatformAgent } from './types/agent.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
-import { getDwnServiceEndpointUrls } from './utils.js';
 import { isRecordsWrite } from './utils.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { pullMessages, pushMessages } from './sync-messages.js';
@@ -1063,7 +1062,7 @@ export class SyncEngineLevel implements SyncEngine {
       }
       const { protocols, delegateDid } = parsed;
 
-      const dwnEndpointUrls = await getDwnServiceEndpointUrls(did, this.agent.did);
+      const dwnEndpointUrls = await this.agent.dwn.getDwnEndpointUrlsForTarget(did);
       if (dwnEndpointUrls.length === 0) {
         continue;
       }

--- a/packages/agent/src/test-harness.ts
+++ b/packages/agent/src/test-harness.ts
@@ -277,7 +277,8 @@ export class PlatformAgentTestHarness {
     });
 
     // Instantiate Agent's DWN API using the custom DWN instance.
-    const dwnApi = new AgentDwnApi({ dwn });
+    // Disable local DWN discovery so tests don't accidentally probe localhost.
+    const dwnApi = new AgentDwnApi({ dwn, localDwnStrategy: 'off' });
 
     // Instantiate Agent's Sync API using a custom LevelDB-backed store.
     const syncStore = new Level(testDataPath('SYNC_STORE'));

--- a/packages/agent/src/web5-user-agent.ts
+++ b/packages/agent/src/web5-user-agent.ts
@@ -1,11 +1,11 @@
 import type { AgentKeyManager } from './types/key-manager.js';
 import type { BearerDid } from '@enbox/dids';
+import type { LocalDwnStrategy } from './local-dwn.js';
 import type { Web5PlatformAgent } from './types/agent.js';
 import type { Web5Rpc } from '@enbox/dwn-clients';
 import type { DidInterface, DidRequest, DidResponse } from './did-api.js';
 import type { DwnInterface, DwnResponse, ProcessDwnRequest, SendDwnRequest } from './types/dwn.js';
 import type { ProcessVcRequest, SendVcRequest, VcResponse } from './types/vc.js';
-import type { LocalDwnStrategy } from './local-dwn.js';
 
 import { AgentCryptoApi } from './crypto-api.js';
 import { AgentDidApi } from './did-api.js';

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -105,23 +105,23 @@ describe('AgentDwnApi', () => {
   describe('getDwnEndpointUrlsForTarget()', () => {
     const localDid = 'did:jwk:local';
 
-    function createDerefResult(did: string, serviceEndpoint: string | string[]) {
+    function createDerefResult(did: string, serviceEndpoint: string | string[]): object {
       return {
-        dereferencingMetadata: {},
-        contentStream: {
-          id: `${did}#dwn`,
-          type: 'DecentralizedWebNode',
-          serviceEndpoint,
-          enc: `${did}#enc`,
-          sig: `${did}#sig`,
+        dereferencingMetadata : {},
+        contentStream         : {
+          id              : `${did}#dwn`,
+          type            : 'DecentralizedWebNode',
+          serviceEndpoint : serviceEndpoint,
+          enc             : `${did}#enc`,
+          sig             : `${did}#sig`,
         },
       };
     }
 
     function createMockAgent(): any {
       return {
-        agentDid: { uri: 'did:jwk:agent' },
-        did: {
+        agentDid : { uri: 'did:jwk:agent' },
+        did      : {
           dereference: sinon.stub().resolves(createDerefResult(localDid, 'https://remote.example')),
         },
         identity: {
@@ -135,15 +135,15 @@ describe('AgentDwnApi', () => {
       };
     }
 
-    it('uses the local DWN endpoint if available even when DID #dwn dereference fails', async () => {
+    it('should use the local DWN endpoint if available even when DID #dwn dereference fails', async () => {
       const mockAgent = createMockAgent();
       mockAgent.did.dereference.rejects(new Error('DID dereference failed'));
       mockAgent.rpc.getServerInfo.onFirstCall().resolves({ server: '@enbox/dwn-server' });
 
       const dwnApi = new AgentDwnApi({
-        agent: mockAgent,
-        dwn: {} as Dwn,
-        localDwnStrategy: 'prefer',
+        agent            : mockAgent,
+        dwn              : {} as Dwn,
+        localDwnStrategy : 'prefer',
       });
 
       const endpoints = await dwnApi.getDwnEndpointUrlsForTarget(localDid);
@@ -153,13 +153,13 @@ describe('AgentDwnApi', () => {
       expect(mockAgent.did.dereference.callCount).toBe(1);
     });
 
-    it('throws when strategy is only and local DWN is unavailable', async () => {
+    it('should throw when strategy is only and local DWN is unavailable', async () => {
       const mockAgent = createMockAgent();
 
       const dwnApi = new AgentDwnApi({
-        agent: mockAgent,
-        dwn: {} as Dwn,
-        localDwnStrategy: 'only',
+        agent            : mockAgent,
+        dwn              : {} as Dwn,
+        localDwnStrategy : 'only',
       });
 
       await expect(dwnApi.getDwnEndpointUrlsForTarget(localDid))
@@ -167,13 +167,13 @@ describe('AgentDwnApi', () => {
       expect(mockAgent.did.dereference.callCount).toBe(0);
     });
 
-    it('returns DID endpoints and skips local probing when strategy is off', async () => {
+    it('should return DID endpoints and skip local probing when strategy is off', async () => {
       const mockAgent = createMockAgent();
 
       const dwnApi = new AgentDwnApi({
-        agent: mockAgent,
-        dwn: {} as Dwn,
-        localDwnStrategy: 'off',
+        agent            : mockAgent,
+        dwn              : {} as Dwn,
+        localDwnStrategy : 'off',
       });
 
       const endpoints = await dwnApi.getDwnEndpointUrlsForTarget(localDid);
@@ -183,7 +183,7 @@ describe('AgentDwnApi', () => {
       expect(mockAgent.did.dereference.callCount).toBe(1);
     });
 
-    it('prepends local endpoint ahead of DID endpoints when strategy is prefer', async () => {
+    it('should prepend local endpoint ahead of DID endpoints when strategy is prefer', async () => {
       const mockAgent = createMockAgent();
       mockAgent.did.dereference.resolves(
         createDerefResult(localDid, ['https://remote-a.example', 'https://remote-b.example'])
@@ -191,9 +191,9 @@ describe('AgentDwnApi', () => {
       mockAgent.rpc.getServerInfo.onFirstCall().resolves({ server: '@enbox/dwn-server' });
 
       const dwnApi = new AgentDwnApi({
-        agent: mockAgent,
-        dwn: {} as Dwn,
-        localDwnStrategy: 'prefer',
+        agent            : mockAgent,
+        dwn              : {} as Dwn,
+        localDwnStrategy : 'prefer',
       });
 
       const endpoints = await dwnApi.getDwnEndpointUrlsForTarget(localDid);
@@ -204,6 +204,26 @@ describe('AgentDwnApi', () => {
         'https://remote-b.example',
       ]);
       expect(mockAgent.rpc.getServerInfo.callCount).toBe(1);
+      expect(mockAgent.did.dereference.callCount).toBe(1);
+    });
+
+    it('should skip local probing for a DID not managed by this agent', async () => {
+      const mockAgent = createMockAgent();
+      mockAgent.identity.list.resolves([
+        { did: { uri: 'did:jwk:other' }, metadata: {} },
+      ]);
+
+      const dwnApi = new AgentDwnApi({
+        agent            : mockAgent,
+        dwn              : {} as Dwn,
+        localDwnStrategy : 'prefer',
+      });
+
+      const endpoints = await dwnApi.getDwnEndpointUrlsForTarget(localDid);
+
+      expect(endpoints).toEqual(['https://remote.example']);
+      // No localhost probing should have occurred for an unmanaged DID.
+      expect(mockAgent.rpc.getServerInfo.callCount).toBe(0);
       expect(mockAgent.did.dereference.callCount).toBe(1);
     });
   });

--- a/packages/agent/tests/dwn-key-delivery.spec.ts
+++ b/packages/agent/tests/dwn-key-delivery.spec.ts
@@ -218,62 +218,35 @@ describe('dwn-key-delivery', () => {
 
   describe('eagerSendContextKeyRecord', () => {
     it('should return early when DWN endpoint lookup fails', async () => {
-      const mockAgent = {
-        did: {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : undefined,
-          }),
-        },
-      } as any;
+      const mockAgent = {} as any;
       const getDwnMessage = sinon.stub();
       const sendDwnRpcRequest = sinon.stub();
+      const getDwnEndpointUrls = sinon.stub().rejects(new Error('endpoint lookup failed'));
 
       await eagerSendContextKeyRecord(
         mockAgent, 'did:example:alice', { recordId: 'rec' } as any,
-        getDwnMessage, sendDwnRpcRequest,
+        getDwnMessage, sendDwnRpcRequest, getDwnEndpointUrls,
       );
 
       expect(getDwnMessage.called).toBe(false);
     });
 
     it('should return early when no DWN endpoints found', async () => {
-      const mockAgent = {
-        did: {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : {
-              id              : 'did:example:alice#dwn',
-              type            : 'DecentralizedWebNode',
-              serviceEndpoint : [],
-            },
-          }),
-        },
-      } as any;
+      const mockAgent = {} as any;
       const getDwnMessage = sinon.stub();
       const sendDwnRpcRequest = sinon.stub();
+      const getDwnEndpointUrls = sinon.stub().resolves([]);
 
       await eagerSendContextKeyRecord(
         mockAgent, 'did:example:alice', { recordId: 'rec' } as any,
-        getDwnMessage, sendDwnRpcRequest,
+        getDwnMessage, sendDwnRpcRequest, getDwnEndpointUrls,
       );
 
       expect(getDwnMessage.called).toBe(false);
     });
 
     it('should read message and send to remote DWN', async () => {
-      const mockAgent = {
-        did: {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : {
-              id              : 'did:example:alice#dwn',
-              type            : 'DecentralizedWebNode',
-              serviceEndpoint : ['https://dwn.example.com'],
-            },
-          }),
-        },
-      } as any;
+      const mockAgent = {} as any;
 
       const contextKeyMessage = {
         recordId   : 'rec-send',
@@ -282,10 +255,11 @@ describe('dwn-key-delivery', () => {
 
       const getDwnMessage = sinon.stub().resolves({ message: contextKeyMessage, data: new Blob(['test']) });
       const sendDwnRpcRequest = sinon.stub().resolves({ status: { code: 202 } });
+      const getDwnEndpointUrls = sinon.stub().resolves(['https://dwn.example.com']);
 
       await eagerSendContextKeyRecord(
         mockAgent, 'did:example:alice', contextKeyMessage,
-        getDwnMessage, sendDwnRpcRequest,
+        getDwnMessage, sendDwnRpcRequest, getDwnEndpointUrls,
       );
 
       expect(getDwnMessage.calledOnce).toBe(true);
@@ -334,6 +308,7 @@ describe('dwn-key-delivery', () => {
         processRequest,
         sinon.stub(),
         sinon.stub(),
+        sinon.stub(), // getDwnEndpointUrlsForTarget — not called in local path
       );
 
       expect(result).toBeDefined();
@@ -356,6 +331,7 @@ describe('dwn-key-delivery', () => {
         processRequest,
         sinon.stub(),
         sinon.stub(),
+        sinon.stub(), // getDwnEndpointUrlsForTarget — not called in local path
       );
 
       expect(result).toBeUndefined();
@@ -387,6 +363,7 @@ describe('dwn-key-delivery', () => {
         processRequest,
         sinon.stub(),
         sinon.stub(),
+        sinon.stub(), // getDwnEndpointUrlsForTarget — not called in local path
       );
 
       expect(result).toBeUndefined();
@@ -403,14 +380,6 @@ describe('dwn-key-delivery', () => {
 
       const mockAgent = {
         did: {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : {
-              id              : 'did:example:alice#dwn',
-              type            : 'DecentralizedWebNode',
-              serviceEndpoint : ['https://dwn.example.com'],
-            },
-          }),
           resolve: sinon.stub().resolves({
             didDocument: {
               id                 : 'did:example:bob',
@@ -470,6 +439,8 @@ describe('dwn-key-delivery', () => {
       const plainStream = DataStream.fromBytes(encoded);
       const decryptStub = sinon.stub(Records, 'decrypt').resolves(plainStream);
 
+      const getDwnEndpointUrls = sinon.stub().resolves(['https://dwn.example.com']);
+
       const result = await fetchContextKeyRecord(
         mockAgent,
         {
@@ -481,6 +452,7 @@ describe('dwn-key-delivery', () => {
         sinon.stub(), // processRequest not used in remote path
         getSigner,
         sendDwnRpcRequest,
+        getDwnEndpointUrls,
       );
 
       expect(result).toBeDefined();
@@ -491,18 +463,7 @@ describe('dwn-key-delivery', () => {
     });
 
     it('should return undefined when remote query finds no entries', async () => {
-      const mockAgent = {
-        did: {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : {
-              id              : 'did:example:alice#dwn',
-              type            : 'DecentralizedWebNode',
-              serviceEndpoint : ['https://dwn.example.com'],
-            },
-          }),
-        },
-      } as any;
+      const mockAgent = {} as any;
 
       const mockSigner = { keyId: 'did:example:bob#sig', sign: sinon.stub().resolves(new Uint8Array(64)) };
       const getSigner = sinon.stub().resolves(mockSigner);
@@ -511,6 +472,8 @@ describe('dwn-key-delivery', () => {
         status  : { code: 200, detail: 'OK' },
         entries : [],
       } as RecordsQueryReply);
+
+      const getDwnEndpointUrls = sinon.stub().resolves(['https://dwn.example.com']);
 
       const result = await fetchContextKeyRecord(
         mockAgent,
@@ -523,24 +486,14 @@ describe('dwn-key-delivery', () => {
         sinon.stub(),
         getSigner,
         sendDwnRpcRequest,
+        getDwnEndpointUrls,
       );
 
       expect(result).toBeUndefined();
     });
 
     it('should return undefined when remote read returns no data', async () => {
-      const mockAgent = {
-        did: {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : {
-              id              : 'did:example:alice#dwn',
-              type            : 'DecentralizedWebNode',
-              serviceEndpoint : ['https://dwn.example.com'],
-            },
-          }),
-        },
-      } as any;
+      const mockAgent = {} as any;
 
       const mockSigner = { keyId: 'did:example:bob#sig', sign: sinon.stub().resolves(new Uint8Array(64)) };
       const getSigner = sinon.stub().resolves(mockSigner);
@@ -555,6 +508,8 @@ describe('dwn-key-delivery', () => {
         entry  : { data: undefined, recordsWrite: undefined },
       } as RecordsReadReply);
 
+      const getDwnEndpointUrls = sinon.stub().resolves(['https://dwn.example.com']);
+
       const result = await fetchContextKeyRecord(
         mockAgent,
         {
@@ -566,6 +521,7 @@ describe('dwn-key-delivery', () => {
         sinon.stub(),
         getSigner,
         sendDwnRpcRequest,
+        getDwnEndpointUrls,
       );
 
       expect(result).toBeUndefined();

--- a/packages/agent/tests/dwn-protocol-cache.spec.ts
+++ b/packages/agent/tests/dwn-protocol-cache.spec.ts
@@ -111,10 +111,10 @@ describe('dwn-protocol-cache', () => {
       const cache = new TtlCache<string, ProtocolDefinition>({ ttl: 60_000 });
       cache.set(`remote~${targetDid}~${protocolUri}`, mockDefinition);
       const sendDwnRpcRequest = sinon.stub();
-      const didDereferencer = { dereference: sinon.stub() };
+      const getDwnEndpointUrls = sinon.stub();
 
       const result = await fetchRemoteProtocolDefinition(
-        targetDid, protocolUri, didDereferencer as any, sendDwnRpcRequest, cache,
+        targetDid, protocolUri, getDwnEndpointUrls, sendDwnRpcRequest, cache,
       );
       expect(result).toBe(mockDefinition);
       expect(sendDwnRpcRequest.callCount).toBe(0);
@@ -126,19 +126,10 @@ describe('dwn-protocol-cache', () => {
         status  : { code: 200 },
         entries : [{ descriptor: { definition: mockDefinition } }],
       } as ProtocolsQueryReply);
-      const didDereferencer = {
-        dereference: sinon.stub().resolves({
-          dereferencingMetadata : {},
-          contentStream         : {
-            id              : `${targetDid}#dwn`,
-            type            : 'DecentralizedWebNode',
-            serviceEndpoint : ['https://dwn.example.com'],
-          },
-        }),
-      };
+      const getDwnEndpointUrls = sinon.stub().resolves(['https://dwn.example.com']);
 
       const result = await fetchRemoteProtocolDefinition(
-        targetDid, protocolUri, didDereferencer as any, sendDwnRpcRequest, cache,
+        targetDid, protocolUri, getDwnEndpointUrls, sendDwnRpcRequest, cache,
       );
       expect(result).toEqual(mockDefinition);
       expect(cache.get(`remote~${targetDid}~${protocolUri}`)).toEqual(mockDefinition);
@@ -150,19 +141,10 @@ describe('dwn-protocol-cache', () => {
         status  : { code: 404 },
         entries : [],
       } as unknown as ProtocolsQueryReply);
-      const didDereferencer = {
-        dereference: sinon.stub().resolves({
-          dereferencingMetadata : {},
-          contentStream         : {
-            id              : `${targetDid}#dwn`,
-            type            : 'DecentralizedWebNode',
-            serviceEndpoint : ['https://dwn.example.com'],
-          },
-        }),
-      };
+      const getDwnEndpointUrls = sinon.stub().resolves(['https://dwn.example.com']);
 
       await expect(fetchRemoteProtocolDefinition(
-        targetDid, protocolUri, didDereferencer as any, sendDwnRpcRequest, cache,
+        targetDid, protocolUri, getDwnEndpointUrls, sendDwnRpcRequest, cache,
       )).rejects.toThrow('Failed to fetch protocol');
     });
 
@@ -172,19 +154,10 @@ describe('dwn-protocol-cache', () => {
         status  : { code: 200 },
         entries : [],
       } as unknown as ProtocolsQueryReply);
-      const didDereferencer = {
-        dereference: sinon.stub().resolves({
-          dereferencingMetadata : {},
-          contentStream         : {
-            id              : `${targetDid}#dwn`,
-            type            : 'DecentralizedWebNode',
-            serviceEndpoint : ['https://dwn.example.com'],
-          },
-        }),
-      };
+      const getDwnEndpointUrls = sinon.stub().resolves(['https://dwn.example.com']);
 
       await expect(fetchRemoteProtocolDefinition(
-        targetDid, protocolUri, didDereferencer as any, sendDwnRpcRequest, cache,
+        targetDid, protocolUri, getDwnEndpointUrls, sendDwnRpcRequest, cache,
       )).rejects.toThrow('Failed to fetch protocol');
     });
   });
@@ -209,16 +182,7 @@ describe('dwn-protocol-cache', () => {
       return sinon.stub().resolves(persona.signer);
     }
 
-    const dwnDereferencer = (did: string): any => ({
-      dereference: sinon.stub().resolves({
-        dereferencingMetadata : {},
-        contentStream         : {
-          id              : `${did}#dwn`,
-          type            : 'DecentralizedWebNode',
-          serviceEndpoint : ['https://dwn.example.com'],
-        },
-      }),
-    });
+    const getDwnEndpointUrls = sinon.stub().resolves(['https://dwn.example.com']);
 
     it('should return undefined when query returns non-200', async () => {
       const getSigner = await createRealSigner();
@@ -229,7 +193,7 @@ describe('dwn-protocol-cache', () => {
 
       const result = await extractDerivedPublicKey(
         targetDid, protocolUri, rootContextId, requesterDid,
-        dwnDereferencer(targetDid) as any, getSigner, sendDwnRpcRequest,
+        getDwnEndpointUrls, getSigner, sendDwnRpcRequest,
       );
       expect(result).toBeUndefined();
     });
@@ -243,7 +207,7 @@ describe('dwn-protocol-cache', () => {
 
       const result = await extractDerivedPublicKey(
         targetDid, protocolUri, rootContextId, requesterDid,
-        dwnDereferencer(targetDid) as any, getSigner, sendDwnRpcRequest,
+        getDwnEndpointUrls, getSigner, sendDwnRpcRequest,
       );
       expect(result).toBeUndefined();
     });
@@ -267,7 +231,7 @@ describe('dwn-protocol-cache', () => {
 
       const result = await extractDerivedPublicKey(
         targetDid, protocolUri, rootContextId, requesterDid,
-        dwnDereferencer(targetDid) as any, getSigner, sendDwnRpcRequest,
+        getDwnEndpointUrls, getSigner, sendDwnRpcRequest,
       );
       expect(result).toBeDefined();
       expect(result!.rootKeyId).toBe('root-key-1');
@@ -292,7 +256,7 @@ describe('dwn-protocol-cache', () => {
 
       const result = await extractDerivedPublicKey(
         targetDid, protocolUri, rootContextId, requesterDid,
-        dwnDereferencer(targetDid) as any, getSigner, sendDwnRpcRequest,
+        getDwnEndpointUrls, getSigner, sendDwnRpcRequest,
       );
       expect(result).toBeUndefined();
     });
@@ -306,7 +270,7 @@ describe('dwn-protocol-cache', () => {
 
       const result = await extractDerivedPublicKey(
         targetDid, protocolUri, rootContextId, requesterDid,
-        dwnDereferencer(targetDid) as any, getSigner, sendDwnRpcRequest,
+        getDwnEndpointUrls, getSigner, sendDwnRpcRequest,
       );
       expect(result).toBeUndefined();
     });

--- a/packages/agent/tests/local-dwn.spec.ts
+++ b/packages/agent/tests/local-dwn.spec.ts
@@ -1,0 +1,114 @@
+import type { Web5Rpc } from '@enbox/dwn-clients';
+
+import sinon from 'sinon';
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import {
+  LocalDwnDiscovery,
+  localDwnHostCandidates,
+  localDwnPortCandidates,
+  localDwnServerName,
+} from '../src/local-dwn.js';
+
+describe('LocalDwnDiscovery', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return the endpoint when a local DWN server is found on the first candidate', async () => {
+    const rpcClient = {
+      getServerInfo: sinon.stub().resolves({ server: localDwnServerName }),
+    } as unknown as Web5Rpc;
+
+    const discovery = new LocalDwnDiscovery(rpcClient);
+    const endpoint = await discovery.getEndpoint();
+
+    expect(endpoint).toBe(`http://${localDwnHostCandidates[0]}:${localDwnPortCandidates[0]}`);
+    expect((rpcClient.getServerInfo as sinon.SinonStub).callCount).toBe(1);
+  });
+
+  it('should return undefined when no local DWN server is reachable', async () => {
+    const rpcClient = {
+      getServerInfo: sinon.stub().rejects(new Error('connection refused')),
+    } as unknown as Web5Rpc;
+
+    const discovery = new LocalDwnDiscovery(rpcClient);
+    const endpoint = await discovery.getEndpoint();
+
+    expect(endpoint).toBeUndefined();
+    // Should have probed all host/port combinations.
+    const expectedCalls = localDwnPortCandidates.length * localDwnHostCandidates.length;
+    expect((rpcClient.getServerInfo as sinon.SinonStub).callCount).toBe(expectedCalls);
+  });
+
+  it('should skip servers that do not identify as @enbox/dwn-server', async () => {
+    const rpcClient = {
+      getServerInfo: sinon.stub().resolves({ server: 'some-other-server' }),
+    } as unknown as Web5Rpc;
+
+    const discovery = new LocalDwnDiscovery(rpcClient);
+    const endpoint = await discovery.getEndpoint();
+
+    expect(endpoint).toBeUndefined();
+  });
+
+  it('should cache a positive result and return it without re-probing', async () => {
+    const rpcClient = {
+      getServerInfo: sinon.stub().resolves({ server: localDwnServerName }),
+    } as unknown as Web5Rpc;
+
+    const discovery = new LocalDwnDiscovery(rpcClient);
+    const first = await discovery.getEndpoint();
+    const second = await discovery.getEndpoint();
+
+    expect(first).toBe(second);
+    // Only one getServerInfo call — the second call was served from cache.
+    expect((rpcClient.getServerInfo as sinon.SinonStub).callCount).toBe(1);
+  });
+
+  it('should cache a negative result and return undefined without re-probing', async () => {
+    const rpcClient = {
+      getServerInfo: sinon.stub().rejects(new Error('connection refused')),
+    } as unknown as Web5Rpc;
+
+    const discovery = new LocalDwnDiscovery(rpcClient);
+    const first = await discovery.getEndpoint();
+    const second = await discovery.getEndpoint();
+
+    expect(first).toBeUndefined();
+    expect(second).toBeUndefined();
+    // Only probed once — the second call was served from cache.
+    const expectedCalls = localDwnPortCandidates.length * localDwnHostCandidates.length;
+    expect((rpcClient.getServerInfo as sinon.SinonStub).callCount).toBe(expectedCalls);
+  });
+
+  it('should re-probe after the cache TTL expires', async () => {
+    const rpcClient = {
+      getServerInfo: sinon.stub().resolves({ server: localDwnServerName }),
+    } as unknown as Web5Rpc;
+
+    // Use a 0ms TTL so the cache expires immediately.
+    const discovery = new LocalDwnDiscovery(rpcClient, 0);
+    await discovery.getEndpoint();
+    await discovery.getEndpoint();
+
+    // Both calls triggered a probe because the cache expired immediately.
+    expect((rpcClient.getServerInfo as sinon.SinonStub).callCount).toBe(2);
+  });
+
+  it('should strip trailing slashes from the discovered endpoint', async () => {
+    // Simulate a port where the endpoint might logically have a trailing slash.
+    // The normalizeBaseUrl function inside LocalDwnDiscovery handles this.
+    // Since getServerInfo doesn't return the URL (we construct it), the trailing
+    // slash only matters if someone appends one manually — but we verify the
+    // returned URL is clean.
+    const rpcClient = {
+      getServerInfo: sinon.stub().resolves({ server: localDwnServerName }),
+    } as unknown as Web5Rpc;
+
+    const discovery = new LocalDwnDiscovery(rpcClient);
+    const endpoint = await discovery.getEndpoint();
+
+    expect(endpoint).not.toMatch(/\/$/);
+  });
+});

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -203,7 +203,7 @@ describe('SyncEngineLevel — private methods', () => {
     it('should return empty array when no identities registered', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
-        did      : { dereference: sinon.stub() },
+        dwn      : { getDwnEndpointUrlsForTarget: sinon.stub() },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
 
@@ -214,11 +214,8 @@ describe('SyncEngineLevel — private methods', () => {
     it('should skip identities whose DID has no DWN endpoints', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
-        did      : {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : undefined,
-          }),
+        dwn      : {
+          getDwnEndpointUrlsForTarget: sinon.stub().resolves([]),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
@@ -231,15 +228,8 @@ describe('SyncEngineLevel — private methods', () => {
     it('should produce one target per DWN URL when protocols is empty', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
-        did      : {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : {
-              id              : 'did:example:alice#dwn',
-              type            : 'DecentralizedWebNode',
-              serviceEndpoint : ['https://dwn.example.com'],
-            },
-          }),
+        dwn      : {
+          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
@@ -255,15 +245,8 @@ describe('SyncEngineLevel — private methods', () => {
     it('should produce one target per protocol per DWN URL', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
-        did      : {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : {
-              id              : 'did:example:bob#dwn',
-              type            : 'DecentralizedWebNode',
-              serviceEndpoint : ['https://dwn.example.com'],
-            },
-          }),
+        dwn      : {
+          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
@@ -281,15 +264,8 @@ describe('SyncEngineLevel — private methods', () => {
     it('should include delegateDid from identity options', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
-        did      : {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : {
-              id              : 'did:example:carol#dwn',
-              type            : 'DecentralizedWebNode',
-              serviceEndpoint : ['https://dwn.example.com'],
-            },
-          }),
+        dwn      : {
+          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
@@ -306,15 +282,8 @@ describe('SyncEngineLevel — private methods', () => {
     it('should handle invalid JSON in identity options gracefully', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
-        did      : {
-          dereference: sinon.stub().resolves({
-            dereferencingMetadata : {},
-            contentStream         : {
-              id              : 'did:example:broken#dwn',
-              type            : 'DecentralizedWebNode',
-              serviceEndpoint : ['https://dwn.example.com'],
-            },
-          }),
+        dwn      : {
+          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });


### PR DESCRIPTION
## Summary

Builds on Daniel's initial `local-dwn` implementation in `electrobun-dwn` to ensure **all** DWN endpoint resolution goes through `getDwnEndpointUrlsForTarget()`, which handles local DWN discovery for locally-managed DIDs.

## Changes

### Production code (8 files)

- **`local-dwn.ts`** — JSDoc, `_` prefix conventions per CLAUDE.md, export `localDwnHostCandidates` and `localDwnServerName` for test use
- **`dwn-api.ts`** — Add full local DWN infrastructure (fields, constructor, getter/setter, `getDwnEndpointUrlsForTarget()`, `shouldUseLocalDwnForTarget()`, `getLocalDwnEndpoint()`); update `sendRequest()` and protocol cache/key delivery wrappers to use new method
- **`dwn-key-delivery.ts`** — Accept `getDwnEndpointUrlsForTarget` callback instead of calling `getDwnServiceEndpointUrls` directly (2 functions)
- **`dwn-protocol-cache.ts`** — Replace `didDereferencer` parameter with `getDwnEndpointUrlsForTarget` callback (2 functions)
- **`identity-api.ts`** — Route `getDwnEndpoints()` through `agent.dwn.getDwnEndpointUrlsForTarget()`
- **`sync-engine-level.ts`** — Route `getSyncTargets()` through `agent.dwn.getDwnEndpointUrlsForTarget()`
- **`test-harness.ts`** — Set `localDwnStrategy: 'off'` to prevent test interference
- **`web5-user-agent.ts`** — Fix import ordering (lint)

### Test code (5 files)

- **`local-dwn.spec.ts`** — NEW: 7 unit tests for `LocalDwnDiscovery` (cache hit/miss, TTL expiry, server name validation, negative caching)
- **`dwn-api.spec.ts`** — Add 5th test: "should skip local probing for unmanaged DID"; fix key-spacing alignment in test helpers
- **`dwn-key-delivery.spec.ts`** — Update all mock agents to use `getDwnEndpointUrlsForTarget` callback stubs
- **`dwn-protocol-cache.spec.ts`** — Replace `didDereferencer` stubs with `getDwnEndpointUrls` callback stubs
- **`sync-engine-private.spec.ts`** — Replace `did.dereference` mocks with `dwn.getDwnEndpointUrlsForTarget` stubs

## Call sites updated (7 of 8)

| File | Call site | Status |
|---|---|---|
| `dwn-api.ts` | `sendRequest()` | Updated |
| `dwn-api.ts` | `fetchRemoteProtocolDefinition()` wrapper | Updated |
| `dwn-api.ts` | `extractDerivedPublicKey()` wrapper | Updated |
| `dwn-key-delivery.ts` | `eagerSendContextKeyRecord()` | Updated |
| `dwn-key-delivery.ts` | `fetchContextKeyRecord()` | Updated |
| `identity-api.ts` | `getDwnEndpoints()` | Updated |
| `sync-engine-level.ts` | `getSyncTargets()` | Updated |
| `anonymous-dwn-api.ts` | `sendRequest()` | **Not updated** (handles foreign DIDs only) |

## Verification

- Lint: all packages pass
- Build: agent + api pass
- Tests: 1004 tests, 949 pass, 51 fail (identical to `electrobun-dwn` base), 4 skip
- Zero new failures introduced
