### PR TITLE
fix(electrobun-dwn): remove prebuild:dwn from build script to fix CI race

### DIFF
--- a/packages/electrobun-dwn/package.json
+++ b/packages/electrobun-dwn/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prebuild:dwn": "bun run --filter @enbox/common build && bun run --filter @enbox/crypto build && bun run --filter @enbox/dids build && bun run --filter @enbox/dwn-sdk-js build && bun run --filter @enbox/dwn-clients build && bun run --filter @enbox/dwn-sql-store build && bun run --filter @enbox/dwn-server build",
     "dev": "bun run prebuild:dwn && electrobun dev",
-    "build": "bun run prebuild:dwn && electrobun build"
+    "build": "electrobun build"
   },
   "dependencies": {
     "@enbox/dwn-server": "workspace:*",


### PR DESCRIPTION
## Summary

- Fixes the Release workflow failure introduced by #544 merging `electrobun-dwn` into `main`.

## Root cause

The `electrobun-dwn` package's `build` script ran `prebuild:dwn` which sequentially rebuilds the entire dependency chain (`@enbox/common`, `@enbox/crypto`, `@enbox/dids`, `@enbox/dwn-sdk-js`, `@enbox/dwn-clients`, `@enbox/dwn-sql-store`, `@enbox/dwn-server`). Each rebuild starts with `rimraf dist`, deleting the package's compiled output.

When the root `bun run build` executes all workspace packages in parallel, this creates a race condition:

1. `@enbox/api` starts building and reaches its browser-bundle step (esbuild)
2. `@enbox/electrobun-dwn` starts `prebuild:dwn` which runs `rimraf dist` on `@enbox/common`
3. `@enbox/api`'s esbuild tries to resolve `@enbox/common/dist/esm/index.js` — file not found
4. 37 "Could not resolve" errors, build fails

## Fix

Change `build` from `bun run prebuild:dwn && electrobun build` to just `electrobun build`. In CI, the root `bun run build` already builds all packages in the correct dependency order, so the prebuild step is redundant and harmful. The `prebuild:dwn` script remains available for local development via `bun run dev`.