### PR TITLE
fix(dwn-clients): include providerAuth and maxInFlight in getServerInfo response

### DIFF
--- a/packages/dwn-clients/package.json
+++ b/packages/dwn-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enbox/dwn-clients",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -226,6 +226,8 @@ export class HttpDwnRpcClient implements DwnRpc {
 
         const serverInfo: ServerInfo = {
           maxFileSize              : results.maxFileSize,
+          maxInFlight              : results.maxInFlight,
+          providerAuth             : results.providerAuth,
           registrationRequirements : results.registrationRequirements,
           server                   : results.server,
           sdkVersion               : results.sdkVersion,


### PR DESCRIPTION
## Summary

`HttpDwnRpcClient.getServerInfo()` explicitly maps fields from the `/info` JSON response into a `ServerInfo` object, but omitted `providerAuth` and `maxInFlight`. This caused `serverInfo.providerAuth` to always be `undefined`, so any code checking for provider-auth-v0 support (e.g. `registerDidWithEndpoint` in the web-wallet) would never detect it and fall through to the PoW registration path — which 404s on servers that only support `provider-auth-v0`.

## Changes

- **`packages/dwn-clients/src/http-dwn-rpc-client.ts`** — Add `providerAuth` and `maxInFlight` to the `ServerInfo` field mapping in `getServerInfo()`
- **`packages/dwn-clients/package.json`** — Bump version to `0.0.9`