### PR TITLE
fix(dwn-clients): include providerAuth and maxInFlight in getServerInfo response

### DIFF
--- a/.changeset/fix-server-info-provider-auth.md
+++ b/.changeset/fix-server-info-provider-auth.md
@@ -1,0 +1,7 @@
+---
+"@enbox/dwn-clients": patch
+---
+
+fix: include providerAuth and maxInFlight in getServerInfo response
+
+`HttpDwnRpcClient.getServerInfo()` explicitly mapped fields from the `/info` JSON response but omitted `providerAuth` and `maxInFlight`, causing provider-auth-v0 registration to silently fall through to the PoW path.

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -226,6 +226,8 @@ export class HttpDwnRpcClient implements DwnRpc {
 
         const serverInfo: ServerInfo = {
           maxFileSize              : results.maxFileSize,
+          maxInFlight              : results.maxInFlight,
+          providerAuth             : results.providerAuth,
           registrationRequirements : results.registrationRequirements,
           server                   : results.server,
           sdkVersion               : results.sdkVersion,


### PR DESCRIPTION
## Summary

`HttpDwnRpcClient.getServerInfo()` explicitly maps fields from the `/info` JSON response into a `ServerInfo` object, but omitted `providerAuth` and `maxInFlight`. This caused `serverInfo.providerAuth` to always be `undefined`, so any code checking for provider-auth-v0 support would never detect it and fall through to the PoW registration path — which 404s on servers that only require `provider-auth-v0`.

## Changes

- **`packages/dwn-clients/src/http-dwn-rpc-client.ts`** — Add `providerAuth` and `maxInFlight` to the `ServerInfo` field mapping in `getServerInfo()`

## Changeset

Included — `@enbox/dwn-clients` patch bump. Dependents (`agent`, `api`, `dwn-server`, `protocols`, `electrobun-dwn`) auto-bump per `updateInternalDependencies: "patch"`.