### PR TITLE
feat(api): auto-configure protocol on first record operation

### DIFF
--- a/packages/api/src/typed-web5.ts
+++ b/packages/api/src/typed-web5.ts
@@ -538,6 +538,8 @@ export class TypedWeb5<
   /** @internal */
   private _configured: boolean = false;
   /** @internal */
+  private _ensureReadyPromise: Promise<void> | null = null;
+  /** @internal */
   private _validPaths: Set<string>;
   /** @internal */
   private _records?: TypedWeb5<D, M>['records'];
@@ -640,22 +642,76 @@ export class TypedWeb5<
   }
 
   /**
-   * Validates that the protocol has been configured and that the path is
-   * recognized. Throws a descriptive error if either check fails.
+   * Validates that the path is recognized.
+   * Throws a descriptive error if the path is not a valid protocol path.
    */
-  private _assertReady(path: string): void {
-    if (!this._configured) {
-      throw new Error(
-        `TypedWeb5: protocol '${this._definition.protocol}' has not been configured. ` +
-        'Call configure() before performing record operations.',
-      );
-    }
-
+  private _assertValidPath(path: string): void {
     if (!this._validPaths.has(path)) {
       throw new Error(
         `TypedWeb5: invalid protocol path '${path}'. ` +
         `Valid paths are: ${[...this._validPaths].join(', ')}.`,
       );
+    }
+  }
+
+  /**
+   * Ensures the protocol is configured before performing record operations.
+   *
+   * On first call, queries for an existing protocol installation:
+   * - If found with an identical definition → marks as configured.
+   * - If found with a different definition → marks as configured but warns
+   *   that the local definition differs from the installed one.
+   * - If not found → installs the protocol via `protocols.configure()`.
+   *
+   * Concurrent calls are deduplicated via a shared Promise so the network
+   * call only happens once.
+   */
+  private async _ensureReady(path: string): Promise<void> {
+    if (this._configured) {
+      this._assertValidPath(path);
+      return;
+    }
+
+    if (this._ensureReadyPromise === null) {
+      this._ensureReadyPromise = this._autoConfigureOnce();
+    }
+
+    await this._ensureReadyPromise;
+    this._assertValidPath(path);
+  }
+
+  /**
+   * Performs the one-time auto-configuration check. Called at most once;
+   * subsequent calls reuse the same Promise via `_ensureReadyPromise`.
+   */
+  private async _autoConfigureOnce(): Promise<void> {
+    const { protocols } = await this._dwn.protocols.query({
+      filter: { protocol: this._definition.protocol },
+    });
+
+    if (protocols.length > 0) {
+      const existing = protocols[0];
+      if (definitionsEqual(existing.definition, this._definition)) {
+        this._configured = true;
+        return;
+      }
+
+      // Installed but definitions differ — allow operations but warn.
+      console.warn(
+        `TypedWeb5: installed protocol '${this._definition.protocol}' differs from the provided definition. ` +
+        'Call configure() to update it.',
+      );
+      this._configured = true;
+      return;
+    }
+
+    // Not installed — configure it now.
+    const result = await this._dwn.protocols.configure({
+      definition: this._definition,
+    });
+
+    if (result.status.code === 202) {
+      this._configured = true;
     }
   }
 
@@ -741,7 +797,7 @@ export class TypedWeb5<
         request: TypedCreateRequest<D, M, Path>,
       ): Promise<TypedCreateResponse<DataForPath<D, M, Path>>> => {
         const normalizedPath = normalizePath(path);
-        this._assertReady(normalizedPath);
+        await this._ensureReady(normalizedPath);
         const typeName = lastSegment(normalizedPath);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
@@ -807,7 +863,7 @@ export class TypedWeb5<
         request?: TypedQueryRequest,
       ): Promise<TypedQueryResponse<DataForPath<D, M, Path>>> => {
         const normalizedPath = normalizePath(path);
-        this._assertReady(normalizedPath);
+        await this._ensureReady(normalizedPath);
         const typeName = lastSegment(normalizedPath);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
@@ -859,7 +915,7 @@ export class TypedWeb5<
         request: TypedReadRequest,
       ): Promise<TypedReadResponse<DataForPath<D, M, Path>>> => {
         const normalizedPath = normalizePath(path);
-        this._assertReady(normalizedPath);
+        await this._ensureReady(normalizedPath);
         const typeName = lastSegment(normalizedPath);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 
@@ -908,7 +964,7 @@ export class TypedWeb5<
         _path: Path,
         request: TypedDeleteRequest,
       ): Promise<DwnResponseStatus> => {
-        this._assertReady(normalizePath(_path));
+        await this._ensureReady(normalizePath(_path));
         return this._dwn.records.delete({
           from     : request.from,
           protocol : this._definition.protocol,
@@ -957,7 +1013,7 @@ export class TypedWeb5<
         request?: TypedSubscribeRequest,
       ): Promise<TypedSubscribeResponse<DataForPath<D, M, Path>>> => {
         const normalizedPath = normalizePath(path);
-        this._assertReady(normalizedPath);
+        await this._ensureReady(normalizedPath);
         const typeName = lastSegment(normalizedPath);
         const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
 

--- a/packages/api/tests/repository.spec.ts
+++ b/packages/api/tests/repository.spec.ts
@@ -571,59 +571,87 @@ describe('repository()', () => {
     });
   });
 
-  describe('error paths', () => {
-    it('should throw when calling create() before configure()', async () => {
+  describe('auto-configure on first operation', () => {
+    it('should auto-configure and succeed when calling create() before configure()', async () => {
       const typed = new TypedWeb5(dwnAlice, TodoProtocol);
       const repo = repository(typed);
 
-      await expect(
-        repo.list.create({ data: { name: 'Fail' } }),
-      ).rejects.toThrow('has not been configured');
+      const result = await repo.list.create({ data: { name: 'Auto-configured' } });
+
+      expect(result.status.code).toBe(202);
+      expect(result.record).toBeInstanceOf(TypedRecord);
+      expect(typed.isConfigured).toBe(true);
     });
 
-    it('should throw when calling query() before configure()', async () => {
+    it('should auto-configure and succeed when calling query() before configure()', async () => {
       const typed = new TypedWeb5(dwnAlice, TodoProtocol);
       const repo = repository(typed);
 
-      await expect(
-        repo.list.query(),
-      ).rejects.toThrow('has not been configured');
+      const result = await repo.list.query();
+
+      expect(result.status.code).toBe(200);
+      expect(result.records).toBeDefined();
+      expect(typed.isConfigured).toBe(true);
     });
 
-    it('should throw when calling singleton set() before configure()', async () => {
+    it('should auto-configure and succeed when calling singleton set() before configure()', async () => {
       const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
       const repo = repository(typed);
 
-      await expect(
-        repo.profile.set({ data: { displayName: 'Fail' } }),
-      ).rejects.toThrow('has not been configured');
+      const result = await repo.profile.set({ data: { displayName: 'Auto-configured' } });
+
+      expect(result.status.code).toBe(202);
+      expect(result.record).toBeInstanceOf(TypedRecord);
+      expect(typed.isConfigured).toBe(true);
     });
 
-    it('should throw when calling singleton get() before configure()', async () => {
+    it('should auto-configure and succeed when calling singleton get() before configure()', async () => {
       const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
       const repo = repository(typed);
 
-      await expect(
-        repo.profile.get(),
-      ).rejects.toThrow('has not been configured');
+      // get() on an empty singleton should return undefined or a record
+      const _result = await repo.profile.get();
+
+      // Protocol should be auto-configured regardless of whether a record exists
+      expect(typed.isConfigured).toBe(true);
     });
 
-    it('should throw when calling nested create() before configure()', async () => {
+    it('should auto-configure and succeed when calling nested create() before configure()', async () => {
       const typed = new TypedWeb5(dwnAlice, TodoProtocol);
       const repo = repository(typed);
 
-      await expect(
-        repo.list.task.create('ctx-123', { data: { title: 'Fail', completed: false } }),
-      ).rejects.toThrow('has not been configured');
+      // Create a parent list first (this will auto-configure)
+      const { record: listRecord } = await repo.list.create({
+        data: { name: 'Parent List' },
+      });
+
+      // Create a nested task
+      const result = await repo.list.task.create(listRecord.contextId, {
+        data: { title: 'Nested Task', completed: false },
+      });
+
+      expect(result.status.code).toBe(202);
+      expect(result.record).toBeInstanceOf(TypedRecord);
+      expect(typed.isConfigured).toBe(true);
     });
 
-    it('should throw when calling nested singleton set() before configure()', async () => {
+    it('should auto-configure and succeed when calling nested singleton set() before configure()', async () => {
       const typed = new TypedWeb5(dwnAlice, ProfileProtocol);
       const repo = repository(typed);
 
-      await expect(
-        repo.group.settings.set('ctx-123', { data: { theme: 'dark', notifications: true } }),
-      ).rejects.toThrow('has not been configured');
+      // Create a parent group first (this will auto-configure)
+      const { record: groupRecord } = await repo.group.create({
+        data: { name: 'Test Group' },
+      });
+
+      // Set the nested singleton settings
+      const result = await repo.group.settings.set(groupRecord.contextId, {
+        data: { theme: 'dark', notifications: true },
+      });
+
+      expect(result.status.code).toBe(202);
+      expect(result.record).toBeInstanceOf(TypedRecord);
+      expect(typed.isConfigured).toBe(true);
     });
   });
 

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -454,57 +454,90 @@ describe('TypedProtocol API', () => {
       });
     });
 
+    describe('auto-configure on first operation', () => {
+      it('should auto-configure and succeed when calling create() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        const { status, record } = await unconfigured.records.create('list', {
+          data: { name: 'Auto-configured' },
+        });
+
+        expect(status.code).toBe(202);
+        expect(record).toBeInstanceOf(TypedRecord);
+        expect(unconfigured.isConfigured).toBe(true);
+      });
+
+      it('should auto-configure and succeed when calling query() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        const { status, records } = await unconfigured.records.query('list');
+
+        expect(status.code).toBe(200);
+        expect(records).toBeDefined();
+        expect(unconfigured.isConfigured).toBe(true);
+      });
+
+      it('should auto-configure and succeed when calling read() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        // Create a record first via auto-configure, then read it back
+        const { record: created } = await unconfigured.records.create('list', {
+          data: { name: 'Read Test' },
+        });
+
+        const { status, record } = await unconfigured.records.read('list', {
+          filter: { recordId: created.id },
+        });
+
+        expect(status.code).toBe(200);
+        expect(record).toBeInstanceOf(TypedRecord);
+        expect(unconfigured.isConfigured).toBe(true);
+      });
+
+      it('should auto-configure and succeed when calling delete() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        // Create a record first via auto-configure, then delete it
+        const { record: created } = await unconfigured.records.create('list', {
+          data: { name: 'Delete Test' },
+        });
+
+        const { status } = await unconfigured.records.delete('list', {
+          recordId: created.id,
+        });
+
+        expect(status.code).toBe(202);
+        expect(unconfigured.isConfigured).toBe(true);
+      });
+
+      it('should auto-configure and succeed when calling subscribe() before configure()', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        const { status, liveQuery } = await unconfigured.records.subscribe('list');
+
+        expect(status.code).toBe(200);
+        expect(liveQuery).toBeDefined();
+        expect(unconfigured.isConfigured).toBe(true);
+
+        await liveQuery.close();
+      });
+
+      it('should install the protocol transparently on first operation', async () => {
+        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
+
+        // Perform an operation without explicit configure()
+        await unconfigured.records.create('list', { data: { name: 'Transparent' } });
+
+        // Verify the protocol was installed
+        const { protocols } = await dwnAlice.protocols.query({
+          filter: { protocol: TodoProtocol.definition.protocol },
+        });
+        expect(protocols.length).toBe(1);
+      });
+    });
+
     describe('error paths', () => {
-      it('should throw when calling create() before configure()', async () => {
-        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
-
-        await expect(
-          unconfigured.records.create('list', { data: { name: 'Fail' } }),
-        ).rejects.toThrow('has not been configured');
-      });
-
-      it('should throw when calling query() before configure()', async () => {
-        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
-
-        await expect(
-          unconfigured.records.query('list'),
-        ).rejects.toThrow('has not been configured');
-      });
-
-      it('should throw when calling read() before configure()', async () => {
-        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
-
-        await expect(
-          unconfigured.records.read('list', { filter: { recordId: 'abc' } }),
-        ).rejects.toThrow('has not been configured');
-      });
-
-      it('should throw when calling delete() before configure()', async () => {
-        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
-
-        await expect(
-          unconfigured.records.delete('list', { recordId: 'abc' }),
-        ).rejects.toThrow('has not been configured');
-      });
-
-      it('should throw when calling subscribe() before configure()', async () => {
-        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
-
-        await expect(
-          unconfigured.records.subscribe('list'),
-        ).rejects.toThrow('has not been configured');
-      });
-
-      it('should include the protocol URI in the not-configured error message', async () => {
-        const unconfigured = new TypedWeb5(dwnAlice, TodoProtocol);
-
-        await expect(
-          unconfigured.records.create('list', { data: { name: 'Fail' } }),
-        ).rejects.toThrow('https://example.com/protocols/todo');
-      });
-
       it('should throw on invalid protocol path', async () => {
-        // Configure first so the not-configured guard passes
         await expect(
           typed.records.create('nonexistent' as any, { data: {} }),
         ).rejects.toThrow('invalid protocol path');


### PR DESCRIPTION
## Summary

- TypedWeb5 now **automatically configures the protocol on first record operation** if it hasn't been configured yet, eliminating the need for explicit `configure()` calls
- If the protocol is already installed with an **identical** definition, it's a no-op
- If installed with a **different** definition, operations proceed but a `console.warn` is emitted advising the developer to call `configure()` explicitly to update
- If **not installed**, the protocol is auto-installed
- Concurrent calls are deduplicated via a shared Promise — no redundant network requests
- The explicit `configure()` method is preserved for developers who want manual control

## Motivation

Every app using `TypedWeb5` had to call `configure()` before any record operation. Worse, `web5.using()` returns a new instance each time with its own `_configured` flag, so configuring one instance didn't help another. This was the #1 footgun discovered while building [notesd](https://github.com/enboxorg/notesd).

## Changes

- `_assertReady()` → `_assertValidPath()` (sync, path-only validation)
- New `_ensureReady()` (async, auto-configures if needed)
- New `_autoConfigureOnce()` (one-time configuration logic with definition comparison)
- All 5 record methods (create, query, read, delete, subscribe) now await `_ensureReady()`

Closes #560 (to be created — or link to relevant issue)