### PR TITLE
docs(api): add comprehensive JSDoc to TypedWeb5 and TypedRecord

### DIFF
--- a/packages/api/src/typed-record.ts
+++ b/packages/api/src/typed-record.ts
@@ -11,14 +11,29 @@
  * - `.data.json()` returns `Promise<T>` instead of `Promise<unknown>`.
  * - `.update({ data })` accepts `Partial<T>` for the data payload.
  *
+ * You never construct `TypedRecord` directly — instances are returned by
+ * {@link TypedWeb5} methods such as `records.create()`, `records.query()`,
+ * `records.read()`, and `records.subscribe()`.
+ *
+ * @typeParam T - The TypeScript type of the record's data payload, resolved
+ *   from the protocol's schema map at the given protocol path.
+ *
  * @example
  * ```ts
- * const { record } = await typed.records.write('friend', {
+ * const { record } = await proto.records.create('friend', {
  *   data: { did: 'did:example:alice', alias: 'Alice' },
  * });
  *
  * // record is TypedRecord<FriendData>
  * const data = await record.data.json(); // FriendData — no manual cast
+ *
+ * // Update preserves the type
+ * const { record: updated } = await record.update({
+ *   data: { alias: 'Ali' },   // Partial<FriendData>
+ * });
+ *
+ * // Send to the remote DWN
+ * await updated.send();
  * ```
  */
 
@@ -39,9 +54,28 @@ import type { DwnInterface } from '@enbox/agent';
  *
  * All other methods (`blob`, `bytes`, `text`, `stream`, `then`, `catch`)
  * are forwarded unchanged from the underlying {@link RecordData}.
+ *
+ * @typeParam T - The TypeScript type returned by {@link TypedRecordData.json | json()}.
+ *
+ * @example
+ * ```ts
+ * const { record } = await proto.records.read('notebook', {
+ *   filter: { recordId: notebookId },
+ * });
+ *
+ * const payload = await record.data.json();   // Promise<NotebookData>
+ * const raw     = await record.data.text();   // Promise<string>
+ * const blob    = await record.data.blob();   // Promise<Blob>
+ * const stream  = await record.data.stream(); // Promise<ReadableStream>
+ * ```
  */
 export type TypedRecordData<T> = Omit<RecordData, 'json'> & {
-  /** Parse the data as JSON, returning the typed data shape `T`. */
+  /**
+   * Parse the record's data as JSON, returning the typed data shape `T`.
+   *
+   * @returns A promise resolving to the record's data payload typed as `T`.
+   * @throws If the data is not valid JSON or the record has been deleted.
+   */
   json: () => Promise<T>;
 };
 
@@ -52,11 +86,25 @@ export type TypedRecordData<T> = Omit<RecordData, 'json'> & {
 /**
  * Update parameters for a {@link TypedRecord}.
  *
- * Extends the base `RecordUpdateParams` but narrows `data` from `unknown`
- * to `Partial<T>`.
+ * Extends the base {@link RecordUpdateParams} but narrows `data` from
+ * `unknown` to `Partial<T>`, providing compile-time type safety when
+ * updating record payloads.
+ *
+ * @typeParam T - The full data type of the record being updated.
+ *
+ * @example
+ * ```ts
+ * await record.update({
+ *   data: { title: 'Updated title' },  // Partial<NotebookData>
+ *   tags: { category: 'work' },
+ * });
+ * ```
  */
 export type TypedRecordUpdateParams<T> = Omit<RecordUpdateParams, 'data'> & {
-  /** The new data for the record. Type-checked against the schema map. */
+  /**
+   * The new data for the record. Type-checked against the schema map as
+   * `Partial<T>`, so you only need to supply the fields you want to change.
+   */
   data?: Partial<T>;
 };
 
@@ -66,17 +114,36 @@ export type TypedRecordUpdateParams<T> = Omit<RecordUpdateParams, 'data'> & {
 
 /**
  * Result of a {@link TypedRecord.update} operation.
+ *
+ * Includes the DWN response status (`status.code` / `status.detail`) and
+ * the updated record, which carries the same type parameter `T` so
+ * subsequent reads remain type-safe.
+ *
+ * @typeParam T - The data type of the record.
  */
 export type TypedRecordUpdateResult<T> = DwnResponseStatus & {
-  /** The updated record, carrying the same type parameter. */
+  /**
+   * The updated record, carrying the same type parameter `T`.
+   *
+   * This is a **new** {@link TypedRecord} instance reflecting the post-update
+   * state; the original record instance is not mutated.
+   */
   record: TypedRecord<T>;
 };
 
 /**
  * Result of a {@link TypedRecord.delete} operation.
+ *
+ * Includes the DWN response status and the record in its deleted state.
+ * After deletion, calling data accessors on the returned record will throw.
+ *
+ * @typeParam T - The data type of the record.
  */
 export type TypedRecordDeleteResult<T> = DwnResponseStatus & {
-  /** The deleted record, carrying the same type parameter. */
+  /**
+   * The record in its deleted state. The {@link TypedRecord.deleted} getter
+   * will return `true`, and data accessors will throw.
+   */
   record: TypedRecord<T>;
 };
 
@@ -87,13 +154,45 @@ export type TypedRecordDeleteResult<T> = DwnResponseStatus & {
 /**
  * A type-safe wrapper around {@link Record} that preserves the data type `T`.
  *
- * Obtain instances through `TypedWeb5.records.write()`, `.query()`, `.read()`,
- * or `.subscribe()` — never construct directly.
+ * Obtain instances through {@link TypedWeb5} methods — `records.create()`,
+ * `records.query()`, `records.read()`, or `records.subscribe()` — never
+ * construct directly.
+ *
+ * @typeParam T - The TypeScript type of the record's data payload. This type
+ *   is inferred automatically from the protocol's schema map and the protocol
+ *   path used when creating or querying the record.
+ *
+ * @example
+ * ```ts
+ * // TypedRecord instances are returned by TypedWeb5 methods:
+ * const { record } = await proto.records.create('notebook', {
+ *   data: { name: 'My Notebook' },
+ * });
+ *
+ * // Access metadata
+ * console.log(record.id);          // unique record ID
+ * console.log(record.contextId);   // context ID for hierarchical grouping
+ * console.log(record.dateCreated); // ISO 8601 creation timestamp
+ * console.log(record.timestamp);   // ISO 8601 last-update timestamp
+ * console.log(record.tags);        // key-value metadata tags
+ *
+ * // Type-safe data access
+ * const data = await record.data.json(); // NotebookData
+ *
+ * // Lifecycle
+ * await record.send();                   // push to remote DWN
+ * await record.update({ data: { name: 'Renamed' } });
+ * await record.delete();
+ * ```
  */
 export class TypedRecord<T> {
-  /** The underlying untyped Record instance. */
+  /** @internal The underlying untyped Record instance. */
   private _record: Record;
 
+  /**
+   * @internal Wrap an untyped {@link Record} in a type-safe shell.
+   * @param record - The underlying `Record` instance to wrap.
+   */
   constructor(record: Record) {
     this._record = record;
   }
@@ -102,7 +201,14 @@ export class TypedRecord<T> {
   // Escape hatch
   // -------------------------------------------------------------------------
 
-  /** Access the underlying untyped {@link Record} for advanced use cases. */
+  /**
+   * Access the underlying untyped {@link Record} for advanced use cases.
+   *
+   * Use this escape hatch when you need to call `Record` methods or access
+   * properties that are not surfaced by the typed wrapper.
+   *
+   * @returns The wrapped {@link Record} instance.
+   */
   public get rawRecord(): Record {
     return this._record;
   }
@@ -112,11 +218,32 @@ export class TypedRecord<T> {
   // -------------------------------------------------------------------------
 
   /**
-   * Returns the data of the current record with type-safe accessors.
+   * Returns the record's data with type-safe accessors.
    *
-   * The `json()` method returns `Promise<T>` — no manual generic needed.
+   * The returned object provides multiple ways to consume the data:
    *
+   * | Method     | Return type              | Description                          |
+   * |------------|--------------------------|--------------------------------------|
+   * | `json()`   | `Promise<T>`             | Parse as JSON with full type safety   |
+   * | `text()`   | `Promise<string>`        | Raw UTF-8 text                        |
+   * | `blob()`   | `Promise<Blob>`          | Binary blob (respects `dataFormat`)   |
+   * | `bytes()`  | `Promise<Uint8Array>`    | Raw bytes                             |
+   * | `stream()` | `Promise<ReadableStream>`| Web `ReadableStream` for streaming    |
+   *
+   * The object is also directly awaitable (returns the stream).
+   *
+   * @returns A {@link TypedRecordData} accessor whose `json()` returns `Promise<T>`.
    * @throws `Error` if the record has been deleted.
+   *
+   * @example
+   * ```ts
+   * const { record } = await proto.records.read('notebook', {
+   *   filter: { recordId },
+   * });
+   *
+   * const notebook = await record.data.json(); // NotebookData
+   * const raw      = await record.data.text(); // string
+   * ```
    */
   public get data(): TypedRecordData<T> {
     const underlying = this._record.data;
@@ -136,11 +263,30 @@ export class TypedRecord<T> {
   // -------------------------------------------------------------------------
 
   /**
-   * Update the current record on the DWN.
+   * Update the current record's data and/or metadata on the DWN.
    *
-   * @param params - Parameters including the typed `data` payload.
-   * @returns The status and an updated {@link TypedRecord}.
+   * The `data` field accepts `Partial<T>`, so you only need to provide
+   * the fields you want to change. A new {@link TypedRecord} is returned;
+   * the original instance is not mutated.
+   *
+   * @param params - Update parameters. `data` is type-checked as `Partial<T>`.
+   *   Other fields like `tags`, `published`, and `datePublished` can also be
+   *   updated.
+   * @returns A {@link TypedRecordUpdateResult} containing the DWN response
+   *   `status` and the updated {@link TypedRecord}.
    * @throws `Error` if the record has been deleted.
+   *
+   * @example
+   * ```ts
+   * const { status, record: updated } = await record.update({
+   *   data: { title: 'New Title' },  // Partial<PageData>
+   *   tags: { priority: 'high' },
+   * });
+   *
+   * if (status.code === 202) {
+   *   await updated.send(); // push update to remote
+   * }
+   * ```
    */
   public async update(params: TypedRecordUpdateParams<T>): Promise<TypedRecordUpdateResult<T>> {
     const { status, record } = await this._record.update(params as RecordUpdateParams);
@@ -148,10 +294,25 @@ export class TypedRecord<T> {
   }
 
   /**
-   * Delete the current record on the DWN.
+   * Delete the current record from the DWN.
    *
-   * @param params - Delete parameters.
-   * @returns The status and a {@link TypedRecord} reflecting the deleted state.
+   * After deletion, the returned record's {@link TypedRecord.deleted | deleted}
+   * property will be `true` and calling data accessors will throw.
+   *
+   * @param params - Optional delete parameters:
+   *   - `store` — whether to persist the delete message (defaults to `true`).
+   *   - `prune` — whether to also delete child records.
+   *   - `signAsOwner` — sign the delete as the DWN owner (for imports).
+   * @returns A {@link TypedRecordDeleteResult} containing the DWN response
+   *   `status` and the record in its deleted state.
+   *
+   * @example
+   * ```ts
+   * const { status } = await record.delete({ prune: true });
+   * if (status.code === 202) {
+   *   console.log('Record and children deleted');
+   * }
+   * ```
    */
   public async delete(params?: RecordDeleteParams): Promise<TypedRecordDeleteResult<T>> {
     const { status, record } = await this._record.delete(params);
@@ -163,49 +324,95 @@ export class TypedRecord<T> {
   // -------------------------------------------------------------------------
 
   /**
-   * Stores the current record state to the owner's DWN.
+   * Stores the current record state to the local DWN.
    *
-   * @param importRecord - If true, sign as owner before storing. Defaults to false.
+   * Call this after creating a record with `store: false` or after
+   * receiving a record from a remote DWN that you want to persist locally.
+   *
+   * @param importRecord - If `true`, sign the record as the DWN owner
+   *   before storing (useful for importing records authored by others).
+   *   Defaults to `false`.
+   * @returns The DWN response status.
    */
   public async store(importRecord: boolean = false): Promise<DwnResponseStatus> {
     return this._record.store(importRecord);
   }
 
   /**
-   * Signs and optionally stores the record to the owner's DWN.
-   * Useful when importing a record signed by someone else.
+   * Signs the record as the DWN owner and optionally stores it.
    *
-   * @param store - If true, store after signing. Defaults to true.
+   * Use this when importing a record authored/signed by another DID into
+   * your own DWN. The record will be re-signed under your identity.
+   *
+   * @param store - If `true`, persist the record after signing.
+   *   Defaults to `true`.
+   * @returns The DWN response status.
    */
   public async import(store: boolean = true): Promise<DwnResponseStatus> {
     return this._record.import(store);
   }
 
   /**
-   * Send the current record to a remote DWN.
+   * Push the current record to a remote DWN.
    *
-   * @param target - Optional DID of the target DWN. Defaults to the connected DID.
+   * This sends the record (including its data) to the specified remote
+   * DWN. Use this after `create`, `update`, or `delete` to sync changes
+   * with the remote node.
+   *
+   * @param target - The DID of the remote DWN to send to. If omitted,
+   *   defaults to the DID of the currently connected identity.
+   * @returns The DWN response status from the remote node.
+   *
+   * @example
+   * ```ts
+   * const { record } = await proto.records.create('notebook', {
+   *   data: { name: 'Travel Notes' },
+   * });
+   *
+   * // Push to your own remote DWN
+   * await record.send();
+   *
+   * // Or push to another user's DWN
+   * await record.send('did:example:bob');
+   * ```
    */
   public async send(target?: string): Promise<DwnResponseStatus> {
     return this._record.send(target);
   }
 
   /**
-   * Returns a JSON representation of the Record instance.
+   * Returns a JSON-serializable representation of the record's metadata.
+   *
+   * Useful for logging, debugging, or serializing the record's state.
+   * Does **not** include the record's data payload — use {@link TypedRecord.data | data}
+   * accessors for that.
+   *
+   * @returns A {@link RecordModel} containing the record's metadata fields.
    */
   public toJSON(): RecordModel {
     return this._record.toJSON();
   }
 
   /**
-   * Returns a string representation of the Record instance.
+   * Returns a human-readable string representation of the record.
+   *
+   * @returns A string summary of the record (delegates to the underlying Record).
    */
   public toString(): string {
     return this._record.toString();
   }
 
   /**
-   * Returns a pagination cursor for the current record given a sort order.
+   * Returns a pagination cursor anchored at this record for the given sort
+   * order.
+   *
+   * Pass the returned cursor to a subsequent `query()` call's
+   * `pagination.cursor` to resume pagination from this record.
+   *
+   * @param sort - The date-sort order to use for cursor positioning
+   *   (e.g. `DateSort.CreatedAscending`).
+   * @returns A pagination cursor, or `undefined` if the record cannot
+   *   produce one.
    */
   public async paginationCursor(sort: DwnDateSort): Promise<DwnPaginationCursor | undefined> {
     return this._record.paginationCursor(sort);
@@ -215,50 +422,149 @@ export class TypedRecord<T> {
   // Forwarded immutable property getters
   // -------------------------------------------------------------------------
 
-  /** Record's ID. */
+  /**
+   * The record's unique identifier.
+   *
+   * This is a stable, globally unique ID assigned when the record is first
+   * created. It does not change across updates or deletes.
+   */
   public get id(): string { return this._record.id; }
 
-  /** Record's context ID. */
+  /**
+   * The context ID used to group hierarchical records.
+   *
+   * When a record is created as a child (using `parentContextId`), the DWN
+   * assigns a `contextId` that links all records in the same hierarchy.
+   * Use this value as the `parentContextId` when creating child records,
+   * or as a `parentId` filter when querying for children.
+   *
+   * @returns The context ID string, or `undefined` if the record is not
+   *   part of a hierarchical context.
+   *
+   * @example
+   * ```ts
+   * const { record: notebook } = await proto.records.create('notebook', {
+   *   data: { name: 'My Notebook' },
+   * });
+   *
+   * // Create a child page under the notebook's context
+   * const { record: page } = await proto.records.create('notebook/page', {
+   *   data: { title: 'Page 1' },
+   *   parentContextId: notebook.contextId,
+   * });
+   * ```
+   */
   public get contextId(): string | undefined { return this._record.contextId; }
 
-  /** Record's creation date. */
+  /**
+   * ISO 8601 timestamp of when the record was first created.
+   *
+   * This value is immutable and never changes, even when the record is
+   * updated or deleted. For the timestamp of the most recent mutation,
+   * use {@link TypedRecord.timestamp | timestamp}.
+   */
   public get dateCreated(): string { return this._record.dateCreated; }
 
-  /** Record's parent ID. */
+  /**
+   * The parent record's ID, if this record was created as a child.
+   *
+   * @returns The parent's record ID, or `undefined` for top-level records.
+   */
   public get parentId(): string | undefined { return this._record.parentId; }
 
-  /** Record's protocol. */
+  /**
+   * The protocol URI this record belongs to.
+   *
+   * @returns The protocol URI string (e.g. `'https://example.com/social'`),
+   *   or `undefined` if the record is not protocol-scoped.
+   */
   public get protocol(): string | undefined { return this._record.protocol; }
 
-  /** Record's protocol path. */
+  /**
+   * The protocol path of this record within the protocol's structure.
+   *
+   * For example, `'notebook'` or `'notebook/page'`. This identifies which
+   * type definition in the protocol structure governs this record.
+   */
   public get protocolPath(): string | undefined { return this._record.protocolPath; }
 
-  /** Record's recipient. */
+  /**
+   * The DID of the intended recipient of this record.
+   *
+   * @returns The recipient's DID string, or `undefined` if no specific
+   *   recipient was set.
+   */
   public get recipient(): string | undefined { return this._record.recipient; }
 
-  /** Record's schema. */
+  /**
+   * The schema URI associated with this record's type in the protocol
+   * definition.
+   *
+   * @returns The schema URI string, or `undefined` if the type has no schema.
+   */
   public get schema(): string | undefined { return this._record.schema; }
 
   // -------------------------------------------------------------------------
   // Forwarded mutable property getters
   // -------------------------------------------------------------------------
 
-  /** Record's data format. */
+  /**
+   * The MIME type / data format of the record's payload.
+   *
+   * Typically `'application/json'` for structured data, but can be any
+   * MIME type supported by the protocol definition's `dataFormats` array.
+   */
   public get dataFormat(): string | undefined { return this._record.dataFormat; }
 
-  /** Record's data CID. */
+  /**
+   * The Content Identifier (CID) of the record's data.
+   *
+   * This is a content-addressable hash of the data payload, useful for
+   * verifying data integrity.
+   */
   public get dataCid(): string | undefined { return this._record.dataCid; }
 
-  /** Record's data size. */
+  /**
+   * The size of the record's data payload in bytes.
+   */
   public get dataSize(): number | undefined { return this._record.dataSize; }
 
-  /** Record's published date. */
+  /**
+   * ISO 8601 timestamp of when the record was published.
+   *
+   * Only present if the record has been explicitly published
+   * (i.e. `published: true` was set during create or update).
+   */
   public get datePublished(): string | undefined { return this._record.datePublished; }
 
-  /** Record's published status. */
+  /**
+   * Whether the record is publicly published.
+   *
+   * Published records can be read by anyone without authorization.
+   * `undefined` if the published state was never explicitly set.
+   */
   public get published(): boolean | undefined { return this._record.published; }
 
-  /** Tags of the record. */
+  /**
+   * Key-value metadata tags attached to the record.
+   *
+   * Tags are indexed by the DWN and can be used in query filters for
+   * efficient lookups. Values can be strings, numbers, booleans, or
+   * arrays of strings/numbers.
+   *
+   * @returns The tags object, or `undefined` if no tags are set.
+   *
+   * @example
+   * ```ts
+   * // Query records by tag
+   * const { records } = await proto.records.query('notebook', {
+   *   filter: { tags: { category: 'work' } },
+   * });
+   *
+   * // Read tags from a record
+   * const tags = record.tags; // { category: 'work', priority: 1 }
+   * ```
+   */
   public get tags(): DwnMessage[DwnInterface.RecordsWrite]['descriptor']['tags'] | undefined {
     return this._record.tags;
   }
@@ -267,42 +573,106 @@ export class TypedRecord<T> {
   // Forwarded state-dependent property getters
   // -------------------------------------------------------------------------
 
-  /** DID that is the logical author of the Record. */
+  /**
+   * The DID of the logical author of this record.
+   *
+   * For records you create, this is your own DID. For records written by
+   * others (e.g. received via a protocol role), this is the signer's DID.
+   */
   public get author(): string { return this._record.author; }
 
-  /** DID that is the original creator of the Record. */
+  /**
+   * The DID of the original creator of this record.
+   *
+   * Unlike {@link TypedRecord.author | author}, which reflects the current
+   * message signer (and may change on updates), `creator` always refers
+   * to the DID that authored the initial write.
+   */
   public get creator(): string { return this._record.creator; }
 
-  /** Record's message timestamp. */
+  /**
+   * ISO 8601 timestamp of the record's most recent message (create, update,
+   * or delete).
+   *
+   * This value changes with every mutation. For the original creation time,
+   * use {@link TypedRecord.dateCreated | dateCreated}.
+   *
+   * **Note:** There is no `.dateModified` property — use `timestamp` to
+   * determine when the record was last changed.
+   */
   public get timestamp(): string { return this._record.timestamp; }
 
-  /** Record's encryption details. */
+  /**
+   * Encryption metadata for the record, if it was encrypted.
+   *
+   * Contains the algorithm, key encryption details, and initialization
+   * vectors used to encrypt the record's data. `undefined` for
+   * unencrypted records.
+   */
   public get encryption(): DwnMessage[DwnInterface.RecordsWrite]['encryption'] {
     return this._record.encryption;
   }
 
-  /** Record's authorization. */
+  /**
+   * The authorization signature(s) for the current record message.
+   *
+   * Contains the JWS (JSON Web Signature) proving the message was
+   * authorized by the author.
+   */
   public get authorization(): DwnMessage[DwnInterface.RecordsWrite | DwnInterface.RecordsDelete]['authorization'] {
     return this._record.authorization;
   }
 
-  /** Record's attestation. */
+  /**
+   * Optional attestation signature(s) for the record.
+   *
+   * Attestations are additional signatures (beyond the author's
+   * authorization) that vouch for the record's content.
+   *
+   * @returns The attestation JWS, or `undefined` if none is present.
+   */
   public get attestation(): DwnMessage[DwnInterface.RecordsWrite]['attestation'] | undefined {
     return this._record.attestation;
   }
 
-  /** Role under which the author is writing the record. */
+  /**
+   * The protocol role under which this record was written.
+   *
+   * When a record is created with a `protocolRole`, the DWN checks that
+   * the author is authorized to write under that role per the protocol's
+   * `$actions` rules.
+   *
+   * @returns The role string (e.g. `'admin'`, `'member'`), or `undefined`
+   *   if no role was specified.
+   */
   public get protocolRole(): string | undefined { return this._record.protocolRole; }
 
-  /** Record's deleted state. */
+  /**
+   * Whether the record has been deleted.
+   *
+   * Once `true`, data accessors (`data.json()`, etc.) will throw. The
+   * record's metadata (ID, timestamps, etc.) remains accessible.
+   */
   public get deleted(): boolean { return this._record.deleted; }
 
-  /** Record's initial write if the record has been updated. */
+  /**
+   * The initial `RecordsWrite` message for this record, if it has been
+   * updated at least once.
+   *
+   * The DWN preserves the initial write message to allow other nodes to
+   * verify the full history chain. For records that have never been
+   * updated, this is `undefined`.
+   */
   public get initialWrite(): DwnMessage[DwnInterface.RecordsWrite] | undefined {
     return this._record.initialWrite;
   }
 
-  /** The raw DWN message backing this record. */
+  /**
+   * The raw DWN message backing this record's current state.
+   *
+   * This is the full, unprocessed DWN message — either a `RecordsWrite`
+   * or `RecordsDelete` message depending on the record's state.
+   */
   public get rawMessage(): DwnMessage[DwnInterface.RecordsWrite] | DwnMessage[DwnInterface.RecordsDelete] {
     return this._record.rawMessage;
   }

--- a/packages/api/src/typed-web5.ts
+++ b/packages/api/src/typed-web5.ts
@@ -91,100 +91,406 @@ type DataFormatForPath<
 // Request / response types
 // ---------------------------------------------------------------------------
 
-/** Options for {@link TypedWeb5} `records.create()`. */
+/**
+ * Options for {@link TypedWeb5} `records.create()`.
+ *
+ * The `data` field is type-checked against the protocol's schema map for
+ * the given path, providing compile-time safety for record payloads.
+ *
+ * @typeParam D - The protocol definition type.
+ * @typeParam M - The schema map mapping type names to TypeScript types.
+ * @typeParam Path - The protocol path string literal.
+ *
+ * @example
+ * ```ts
+ * await proto.records.create('notebook/page', {
+ *   data: { title: 'My Page', body: '...' },       // type-checked as PageData
+ *   parentContextId: notebook.contextId,             // link to parent
+ *   tags: { category: 'draft' },
+ * });
+ * ```
+ */
 export type TypedCreateRequest<
   D extends ProtocolDefinition,
   M extends SchemaMap,
   Path extends string,
 > = {
-  /** The data payload. Type-checked against the schema map. */
+  /** The data payload. Type-checked against the schema map for the given path. */
   data: DataForPath<D, M, Path>;
 
+  /**
+   * The context ID of the parent record.
+   *
+   * Required when creating a child record under a parent in a hierarchical
+   * protocol structure. Use the parent record's {@link TypedRecord.contextId | contextId}
+   * as this value.
+   *
+   * @example
+   * ```ts
+   * const { record: notebook } = await proto.records.create('notebook', {
+   *   data: { name: 'My Notebook' },
+   * });
+   *
+   * // Create a page under the notebook
+   * await proto.records.create('notebook/page', {
+   *   data: { title: 'Page 1' },
+   *   parentContextId: notebook.contextId,
+   * });
+   * ```
+   */
   parentContextId?: string;
+
+  /**
+   * Whether the record should be publicly published.
+   *
+   * Published records can be read by anyone without authorization.
+   */
   published?: boolean;
+
+  /**
+   * ISO 8601 timestamp for when the record is considered published.
+   * Only meaningful when `published` is `true`.
+   */
   datePublished?: string;
+
+  /**
+   * The DID of the intended recipient.
+   *
+   * Sets the recipient for permission-scoped records. The recipient may
+   * have special read/write permissions as defined by the protocol's
+   * `$actions` rules.
+   */
   recipient?: string;
+
+  /**
+   * The protocol role under which to create this record.
+   *
+   * The DWN will verify that the author is authorized to write under
+   * this role per the protocol's `$actions` configuration.
+   */
   protocolRole?: string;
+
+  /**
+   * The MIME type / data format for the record.
+   *
+   * If omitted, defaults to the first entry in the protocol type's
+   * `dataFormats` array (typically `'application/json'`).
+   */
   dataFormat?: DataFormatForPath<D, Path>;
+
+  /**
+   * Key-value metadata tags to attach to the record.
+   *
+   * Tags are indexed by the DWN and can be used in query filters for
+   * efficient lookups. Values can be strings, numbers, booleans, or
+   * arrays of strings/numbers.
+   */
   tags?: globalThis.Record<string, string | number | boolean | string[] | number[]>;
 
-  /** Whether to persist immediately (defaults to `true`). */
+  /**
+   * Whether to persist the record to the local DWN immediately.
+   *
+   * Defaults to `true`. Set to `false` to create the record in memory
+   * only — you can call {@link TypedRecord.store | record.store()} later.
+   */
   store?: boolean;
 
-  /** Whether to auto-encrypt (follows protocol definition if omitted). */
+  /**
+   * Whether to auto-encrypt the record.
+   *
+   * If omitted, encryption follows the protocol definition. Set to `true`
+   * to force encryption or `false` to skip it.
+   */
   encryption?: boolean;
 };
 
-/** Response from {@link TypedWeb5} `records.create()`. */
+/**
+ * Response from {@link TypedWeb5} `records.create()`.
+ *
+ * @typeParam T - The data type of the created record.
+ */
 export type TypedCreateResponse<T = unknown> = DwnResponseStatus & {
+  /**
+   * The created record, typed as `TypedRecord<T>`.
+   *
+   * Access `record.id`, `record.contextId`, and `record.data.json()` for
+   * the most commonly needed values after creation.
+   */
   record: TypedRecord<T>;
 };
 
-/** Filter options for {@link TypedWeb5} `records.query()`. */
+/**
+ * Filter options for {@link TypedWeb5} `records.query()` and `records.subscribe()`.
+ *
+ * The `protocol`, `protocolPath`, and `schema` fields are automatically
+ * injected by {@link TypedWeb5} — you only need to supply additional
+ * filter criteria.
+ *
+ * Common filter fields inherited from `RecordsFilter`:
+ *
+ * - **`parentId`** — Filter by parent context ID. Despite the name, this
+ *   filters on the parent record's **context ID** (i.e. pass
+ *   `parent.contextId`, not `parent.id`). Use this to find child records
+ *   under a specific parent in a hierarchical protocol.
+ * - **`recordId`** — Match a specific record by its unique ID.
+ * - **`recipient`** — Filter by recipient DID.
+ * - **`dataFormat`** — Filter by MIME type.
+ * - **`dateCreated`** — Range filter on creation date.
+ * - **`contextId`** — Filter by context ID directly.
+ *
+ * @example
+ * ```ts
+ * // Find pages under a specific notebook
+ * const { records } = await proto.records.query('notebook/page', {
+ *   filter: {
+ *     parentId: notebook.contextId,  // filters by parent's context ID
+ *     tags: { status: 'published' },
+ *   },
+ * });
+ * ```
+ */
 export type TypedQueryFilter = Omit<RecordsFilter, 'protocol' | 'protocolPath' | 'schema'> & {
+  /**
+   * Filter records by tag values.
+   *
+   * Only records whose tags match **all** specified key-value pairs are
+   * returned. Array values match if the record's tag contains any of the
+   * specified values.
+   */
   tags?: globalThis.Record<string, string | number | boolean | (string | number)[]>;
 };
 
-/** Options for {@link TypedWeb5} `records.query()`. */
+/**
+ * Options for {@link TypedWeb5} `records.query()`.
+ *
+ * All fields are optional — calling `query(path)` with no request object
+ * returns all records at that path.
+ *
+ * @example
+ * ```ts
+ * const { records, cursor } = await proto.records.query('notebook', {
+ *   filter: { tags: { archived: false } },
+ *   dateSort: DateSort.CreatedDescending,
+ *   pagination: { limit: 25 },
+ * });
+ *
+ * // Paginate for more
+ * if (cursor) {
+ *   const { records: next } = await proto.records.query('notebook', {
+ *     pagination: { limit: 25, cursor },
+ *   });
+ * }
+ * ```
+ */
 export type TypedQueryRequest = {
-  /** Optional remote DWN DID to query from. */
+  /**
+   * A remote DWN DID to query from.
+   *
+   * When set, the query is sent to the specified DID's remote DWN instead
+   * of the local DWN.
+   */
   from?: string;
 
-  /** Query filter (protocol, protocolPath, schema are injected). */
+  /**
+   * Filter criteria for the query.
+   *
+   * The `protocol`, `protocolPath`, and `schema` fields are auto-injected.
+   * See {@link TypedQueryFilter} for available filter fields.
+   */
   filter?: TypedQueryFilter;
+
+  /**
+   * Sort order for the returned records.
+   *
+   * Use `DateSort.CreatedAscending`, `DateSort.CreatedDescending`,
+   * `DateSort.PublishedAscending`, or `DateSort.PublishedDescending`.
+   */
   dateSort?: DateSort;
+
+  /**
+   * Pagination options.
+   *
+   * - `limit` — Maximum number of records to return.
+   * - `cursor` — A pagination cursor from a previous query response to
+   *   resume from where the last page left off.
+   */
   pagination?: { limit?: number; cursor?: DwnPaginationCursor };
+
+  /**
+   * The protocol role under which to execute the query.
+   *
+   * Required when the protocol's `$actions` rules restrict read access
+   * to specific roles.
+   */
   protocolRole?: string;
 
-  /** When true, automatically decrypts encrypted records. */
+  /**
+   * When `true`, automatically decrypts encrypted records in the results.
+   *
+   * If omitted, encrypted records are returned as-is (data accessors will
+   * return encrypted bytes).
+   */
   encryption?: boolean;
 };
 
-/** Response from {@link TypedWeb5} `records.query()`. */
+/**
+ * Response from {@link TypedWeb5} `records.query()`.
+ *
+ * @typeParam T - The data type of the queried records.
+ */
 export type TypedQueryResponse<T = unknown> = DwnResponseStatus & {
+  /**
+   * The matching records, each wrapped as {@link TypedRecord | TypedRecord<T>}.
+   *
+   * The array is empty if no records match the filter criteria.
+   */
   records: TypedRecord<T>[];
+
+  /**
+   * A pagination cursor for fetching the next page of results.
+   *
+   * Pass this to a subsequent `query()` call's `pagination.cursor` to
+   * continue from where this page ended. `undefined` when there are no
+   * more results.
+   */
   cursor?: DwnPaginationCursor;
 };
 
-/** Options for {@link TypedWeb5} `records.read()`. */
+/**
+ * Options for {@link TypedWeb5} `records.read()`.
+ *
+ * A `filter` is required to identify which record to read. The most common
+ * approach is to filter by `recordId`.
+ *
+ * @example
+ * ```ts
+ * // Read a specific record by ID
+ * const { record } = await proto.records.read('notebook', {
+ *   filter: { recordId: notebookId },
+ * });
+ *
+ * // Read from a remote DWN
+ * const { record: remote } = await proto.records.read('notebook', {
+ *   from: 'did:example:alice',
+ *   filter: { recordId: notebookId },
+ * });
+ * ```
+ */
 export type TypedReadRequest = {
-  /** Optional remote DWN DID to read from. */
+  /**
+   * A remote DWN DID to read from.
+   *
+   * When set, the read is performed against the specified DID's remote
+   * DWN instead of the local DWN.
+   */
   from?: string;
 
-  /** Filter to identify the record (protocol and protocolPath are injected). */
+  /**
+   * Filter to identify the record to read.
+   *
+   * The `protocol`, `protocolPath`, and `schema` fields are auto-injected.
+   * Typically you filter by `recordId` to read a specific record. Other
+   * fields from `RecordsFilter` (like `contextId`, `parentId`, `recipient`)
+   * are also available.
+   */
   filter: Omit<RecordsFilter, 'protocol' | 'protocolPath' | 'schema'>;
 
-  /** When true, automatically decrypts the record. */
+  /**
+   * When `true`, automatically decrypts the record if it is encrypted.
+   *
+   * If omitted, encrypted records are returned as-is.
+   */
   encryption?: boolean;
 };
 
-/** Response from {@link TypedWeb5} `records.read()`. */
+/**
+ * Response from {@link TypedWeb5} `records.read()`.
+ *
+ * @typeParam T - The data type of the read record.
+ */
 export type TypedReadResponse<T = unknown> = DwnResponseStatus & {
+  /** The record matching the filter, typed as {@link TypedRecord | TypedRecord<T>}. */
   record: TypedRecord<T>;
 };
 
-/** Options for {@link TypedWeb5} `records.delete()`. */
+/**
+ * Options for {@link TypedWeb5} `records.delete()`.
+ *
+ * @example
+ * ```ts
+ * const { status } = await proto.records.delete('notebook', {
+ *   recordId: notebook.id,
+ * });
+ * ```
+ */
 export type TypedDeleteRequest = {
-  /** Optional remote DWN DID to delete from. */
+  /**
+   * A remote DWN DID to delete from.
+   *
+   * When set, the delete is performed on the specified DID's remote DWN.
+   */
   from?: string;
 
-  /** The `recordId` of the record to delete. */
+  /**
+   * The unique `recordId` of the record to delete.
+   *
+   * Use {@link TypedRecord.id | record.id} to obtain this value.
+   */
   recordId: string;
 };
 
-/** Options for {@link TypedWeb5} `records.subscribe()`. */
+/**
+ * Options for {@link TypedWeb5} `records.subscribe()`.
+ *
+ * @example
+ * ```ts
+ * const { liveQuery } = await proto.records.subscribe('notebook/page', {
+ *   filter: { parentId: notebook.contextId },
+ * });
+ *
+ * liveQuery.on('create', (record) => {
+ *   console.log('New page:', await record.data.json());
+ * });
+ * ```
+ */
 export type TypedSubscribeRequest = {
-  /** Optional remote DWN DID to subscribe to. */
+  /**
+   * A remote DWN DID to subscribe to.
+   *
+   * When set, the subscription listens to the specified DID's remote DWN.
+   */
   from?: string;
 
-  /** Subscription filter (protocol, protocolPath, schema are injected). */
+  /**
+   * Filter criteria for the subscription.
+   *
+   * The `protocol`, `protocolPath`, and `schema` fields are auto-injected.
+   * See {@link TypedQueryFilter} for available filter fields.
+   */
   filter?: TypedQueryFilter;
+
+  /**
+   * The protocol role under which to subscribe.
+   *
+   * Required when the protocol's `$actions` rules restrict read access
+   * to specific roles.
+   */
   protocolRole?: string;
 };
 
-/** Response from {@link TypedWeb5} `records.subscribe()`. */
+/**
+ * Response from {@link TypedWeb5} `records.subscribe()`.
+ *
+ * @typeParam T - The data type of records in the subscription.
+ */
 export type TypedSubscribeResponse<T = unknown> = DwnResponseStatus & {
-  /** The typed live query instance, or `undefined` if the request failed. */
+  /**
+   * The typed live query instance for receiving real-time record changes.
+   *
+   * `undefined` if the subscription request failed (check `status.code`).
+   * When defined, use `liveQuery.on('create' | 'update' | 'delete', callback)`
+   * to react to changes. Call `liveQuery.close()` to stop the subscription.
+   */
   liveQuery?: TypedLiveQuery<T>;
 };
 
@@ -225,24 +531,44 @@ export class TypedWeb5<
   D extends ProtocolDefinition = ProtocolDefinition,
   M extends SchemaMap = SchemaMap,
 > {
+  /** @internal */
   private _dwn: DwnApi;
+  /** @internal */
   private _definition: D;
+  /** @internal */
   private _configured: boolean = false;
+  /** @internal */
   private _validPaths: Set<string>;
+  /** @internal */
   private _records?: TypedWeb5<D, M>['records'];
 
+  /**
+   * @internal Create a new `TypedWeb5` instance. Use `web5.using(protocol)` instead.
+   * @param dwn - The underlying DWN API instance.
+   * @param protocol - The typed protocol containing the definition and schema map.
+   */
   constructor(dwn: DwnApi, protocol: TypedProtocol<D, M>) {
     this._dwn = dwn;
     this._definition = protocol.definition;
     this._validPaths = collectPaths(this._definition.structure);
   }
 
-  /** The protocol URI. */
+  /**
+   * The protocol URI string (e.g. `'https://example.com/social'`).
+   *
+   * This is the globally unique identifier for the protocol and is
+   * auto-injected into every record operation.
+   */
   public get protocol(): string {
     return this._definition.protocol;
   }
 
-  /** The raw protocol definition. */
+  /**
+   * The raw protocol definition object.
+   *
+   * Contains the full `protocol`, `types`, and `structure` that define
+   * the protocol's schema and permission rules.
+   */
   public get definition(): D {
     return this._definition;
   }
@@ -251,11 +577,29 @@ export class TypedWeb5<
    * Configures (installs) this protocol on the local DWN.
    *
    * If the protocol is already installed with an identical definition,
-   * this is a no-op and returns the existing protocol. If the definition
-   * has changed (e.g. new types, modified structure), the protocol is
-   * re-configured with the updated definition.
+   * this is a no-op and returns the existing protocol with status `200`.
+   * If the definition has changed (e.g. new types, modified structure),
+   * the protocol is re-configured with the updated definition and returns
+   * status `202`.
    *
-   * @param options - Optional overrides like `encryption`.
+   * **Must be called before any record operations.** Methods like
+   * `records.create()`, `records.query()`, etc. will throw if the protocol
+   * has not been configured.
+   *
+   * @param options - Optional configuration overrides.
+   * @param options.encryption - Whether to enable auto-encryption for the
+   *   protocol. If omitted, follows the protocol definition defaults.
+   * @returns The DWN response status and the installed protocol object.
+   *
+   * @example
+   * ```ts
+   * const proto = web5.using(NotebookProtocol);
+   *
+   * const { status, protocol } = await proto.configure();
+   * console.log(status.code); // 202 (first install) or 200 (already installed)
+   *
+   * // Now you can use records.create(), records.query(), etc.
+   * ```
    */
   public async configure(options?: { encryption?: boolean }): Promise<DwnResponseStatus & { protocol?: Protocol }> {
     // Query for an existing installation of this protocol.
@@ -285,7 +629,12 @@ export class TypedWeb5<
     return result;
   }
 
-  /** Whether the protocol has been configured (installed) on the local DWN. */
+  /**
+   * Whether the protocol has been configured (installed) on the local DWN.
+   *
+   * Returns `true` after a successful call to {@link TypedWeb5.configure | configure()}.
+   * Record operations will throw if this is `false`.
+   */
   public get isConfigured(): boolean {
     return this._configured;
   }
@@ -313,12 +662,21 @@ export class TypedWeb5<
   /**
    * Protocol-scoped record operations.
    *
-   * Every method auto-injects the protocol URI, protocolPath, and schema
-   * from the protocol definition. Path parameters provide compile-time
-   * autocompletion via `ProtocolPaths<D>`.
+   * Every method auto-injects the `protocol`, `protocolPath`, and `schema`
+   * from the protocol definition — you never need to specify them manually.
+   * Path parameters provide **compile-time autocompletion** via
+   * `ProtocolPaths<D>`, and data types are resolved from the schema map.
    *
    * All methods return {@link TypedRecord} or {@link TypedLiveQuery} instances
-   * that carry the resolved data type from the schema map.
+   * that carry the resolved data type from the schema map, providing
+   * end-to-end type safety.
+   *
+   * Available methods:
+   * - {@link TypedWeb5.records.create | create(path, request)} — Create a new record
+   * - {@link TypedWeb5.records.query | query(path, request?)} — Query records with filters
+   * - {@link TypedWeb5.records.read | read(path, request)} — Read a single record
+   * - {@link TypedWeb5.records.delete | delete(path, request)} — Delete a record by ID
+   * - {@link TypedWeb5.records.subscribe | subscribe(path, request?)} — Real-time subscription
    */
   public get records(): {
     create: <Path extends ProtocolPaths<D> & string>(
@@ -354,8 +712,29 @@ export class TypedWeb5<
       /**
        * Create a new record at the given protocol path.
        *
-       * @param path - The protocol path (e.g. `'friend'`, `'group/member'`).
-       * @param request - Create options including typed `data`.
+       * The `protocol`, `protocolPath`, and `schema` are auto-injected from
+       * the protocol definition. The `data` field is type-checked against
+       * the schema map for the given path.
+       *
+       * @param path - The protocol path (e.g. `'notebook'`, `'notebook/page'`).
+       *   Provides compile-time autocompletion for valid paths.
+       * @param request - Create options including the typed `data` payload
+       *   and optional fields like `parentContextId`, `tags`, `recipient`.
+       * @returns A {@link TypedCreateResponse} containing the DWN response
+       *   `status` and the created {@link TypedRecord}.
+       *
+       * @example
+       * ```ts
+       * const { status, record } = await proto.records.create('notebook', {
+       *   data: { name: 'My Notebook' },
+       * });
+       *
+       * // Create a child page under the notebook's context
+       * const { record: page } = await proto.records.create('notebook/page', {
+       *   data: { title: 'First Page', body: '' },
+       *   parentContextId: record.contextId,
+       * });
+       * ```
        */
       create: async <Path extends ProtocolPaths<D> & string>(
         path: Path,
@@ -391,8 +770,37 @@ export class TypedWeb5<
       /**
        * Query records at the given protocol path.
        *
-       * @param path - The protocol path to query.
-       * @param request - Optional filter, sort, and pagination.
+       * Returns all matching records as an array of typed records, with
+       * an optional pagination cursor for fetching additional pages.
+       *
+       * @param path - The protocol path to query (e.g. `'notebook'`,
+       *   `'notebook/page'`).
+       * @param request - Optional filter, sort, and pagination options.
+       *   Omit entirely to return all records at the path.
+       * @returns A {@link TypedQueryResponse} containing `status`, `records`
+       *   (as {@link TypedRecord | TypedRecord<T>[]}), and an optional
+       *   `cursor` for pagination.
+       *
+       * @example
+       * ```ts
+       * // Query all notebooks
+       * const { records } = await proto.records.query('notebook');
+       *
+       * // Query pages under a specific notebook
+       * const { records: pages } = await proto.records.query('notebook/page', {
+       *   filter: { parentId: notebook.contextId },
+       * });
+       *
+       * for (const page of pages) {
+       *   const data = await page.data.json(); // PageData
+       * }
+       *
+       * // Paginated query
+       * const { records: batch, cursor } = await proto.records.query('notebook', {
+       *   pagination: { limit: 10 },
+       *   dateSort: DateSort.CreatedDescending,
+       * });
+       * ```
        */
       query: async <Path extends ProtocolPaths<D> & string>(
         path: Path,
@@ -427,8 +835,24 @@ export class TypedWeb5<
       /**
        * Read a single record at the given protocol path.
        *
+       * Unlike `query()`, which returns an array, `read()` returns exactly
+       * one record. Use `filter.recordId` to target a specific record.
+       *
        * @param path - The protocol path to read from.
-       * @param request - Read options including a filter to identify the record.
+       * @param request - Read options including a `filter` to identify the
+       *   record. See {@link TypedReadRequest} for details.
+       * @returns A {@link TypedReadResponse} containing `status` and the
+       *   matching {@link TypedRecord}.
+       *
+       * @example
+       * ```ts
+       * const { record } = await proto.records.read('notebook', {
+       *   filter: { recordId: notebookId },
+       * });
+       *
+       * const data = await record.data.json(); // NotebookData
+       * console.log(data.name);
+       * ```
        */
       read: async <Path extends ProtocolPaths<D> & string>(
         path: Path,
@@ -460,8 +884,25 @@ export class TypedWeb5<
       /**
        * Delete a record at the given protocol path.
        *
-       * @param path - The protocol path (used for permission scoping).
-       * @param request - Delete options including the `recordId`.
+       * The path is used for protocol validation and permission scoping,
+       * while the actual record is identified by `recordId`.
+       *
+       * @param path - The protocol path (used for permission scoping and
+       *   path validation).
+       * @param request - Delete options. `recordId` is required; `from` is
+       *   optional for remote deletes.
+       * @returns The DWN response status.
+       *
+       * @example
+       * ```ts
+       * const { status } = await proto.records.delete('notebook', {
+       *   recordId: notebook.id,
+       * });
+       *
+       * if (status.code === 202) {
+       *   console.log('Notebook deleted');
+       * }
+       * ```
        */
       delete: async <Path extends ProtocolPaths<D> & string>(
         _path: Path,
@@ -476,14 +917,40 @@ export class TypedWeb5<
       },
 
       /**
-       * Subscribe to records at the given protocol path.
+       * Subscribe to real-time changes at the given protocol path.
        *
        * Returns a {@link TypedLiveQuery} that atomically provides an initial
        * snapshot and a real-time stream of deduplicated change events, with
        * all records typed as `TypedRecord<T>`.
        *
        * @param path - The protocol path to subscribe to.
-       * @param request - Optional filter and role.
+       * @param request - Optional filter and role. Use `filter.parentId`
+       *   to scope the subscription to children of a specific parent.
+       * @returns A {@link TypedSubscribeResponse} containing `status` and
+       *   a {@link TypedLiveQuery} for receiving events.
+       *
+       * @example
+       * ```ts
+       * const { liveQuery } = await proto.records.subscribe('notebook/page', {
+       *   filter: { parentId: notebook.contextId },
+       * });
+       *
+       * liveQuery.on('create', (record) => {
+       *   // record is TypedRecord<PageData>
+       *   console.log('New page created');
+       * });
+       *
+       * liveQuery.on('update', (record) => {
+       *   const data = await record.data.json(); // PageData
+       * });
+       *
+       * liveQuery.on('delete', (record) => {
+       *   console.log('Page deleted:', record.id);
+       * });
+       *
+       * // Stop listening
+       * liveQuery.close();
+       * ```
        */
       subscribe: async <Path extends ProtocolPaths<D> & string>(
         path: Path,


### PR DESCRIPTION
## Summary

- Adds comprehensive JSDoc to every public method, property, and type in `TypedWeb5` and `TypedRecord`
- Documents the full CRUD lifecycle with practical `@example` blocks
- Clarifies common confusion points:
  - `record.timestamp` is the last update time (there is no `.dateModified`)
  - `filter.parentId` actually filters by context ID (not record ID)
  - `record.send()` is needed after mutations to push to remote DWN
  - `record.update()` returns a new `TypedRecord` (immutable pattern)

## Files changed

- `packages/api/src/typed-web5.ts` — JSDoc on all request/response types and all 5 record methods
- `packages/api/src/typed-record.ts` — JSDoc on the `TypedRecord` class, all 20+ property getters, data accessors, and lifecycle methods