### PR TITLE
feat(api,agent): change local DWN discovery default to 'off'

### DIFF
--- a/packages/agent/src/local-dwn.ts
+++ b/packages/agent/src/local-dwn.ts
@@ -16,9 +16,9 @@ export const localDwnHostCandidates = ['127.0.0.1', 'localhost'] as const;
 /**
  * Controls how the agent discovers and routes to a local DWN server.
  *
+ * - `'off'`    — (default) skip local discovery entirely.
  * - `'prefer'` — probe localhost first; fall back to DID-document endpoints.
  * - `'only'`   — require a local server; throw if none is found.
- * - `'off'`    — skip local discovery entirely.
  */
 export type LocalDwnStrategy = 'prefer' | 'only' | 'off';
 

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -133,7 +133,8 @@ export type RegistrationTokenData = {
 export type Web5ConnectOptions = {
   /**
    * Controls local DWN discovery behavior for remote-target DWN sends/sync.
-   * `prefer` (default) tries local first, `only` requires local, `off` disables local probing.
+   * `'off'` (default) disables local probing, `'prefer'` tries local first
+   * then falls back to DID-document endpoints, `'only'` requires a local server.
    */
   localDwnStrategy?: LocalDwnStrategy;
 
@@ -416,7 +417,7 @@ export class Web5 {
   static async connect({
     agent,
     agentVault,
-    localDwnStrategy = 'prefer',
+    localDwnStrategy = 'off',
     connectedDid,
     password,
     recoveryPhrase,


### PR DESCRIPTION
## Summary

- Changes the default `localDwnStrategy` from `'prefer'` to `'off'`
- Local DWN discovery is now **opt-in** instead of opt-out

## Motivation

The agent probes `127.0.0.1:3000`, `localhost:55555`, etc. on every sync cycle to discover a local DWN server. For web apps deployed to production (e.g., Cloudflare Pages), these requests always fail with `ERR_BLOCKED_BY_CLIENT` and flood the console with noise. Since most web apps don't have a local DWN server, the default should be `'off'`.

Desktop apps (like Electrobun) that bundle a local DWN can explicitly set `localDwnStrategy: 'prefer'`.

## Changes

- `packages/api/src/web5.ts` — default changed from `'prefer'` to `'off'`, JSDoc updated
- `packages/agent/src/local-dwn.ts` — JSDoc on `LocalDwnStrategy` updated to reflect new default