### PR TITLE
feat(api): cache TypedWeb5 instances by protocol URI

### DIFF
--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -323,6 +323,15 @@ export class Web5 {
   /** Internal DWN API instance. Use {@link Web5.using} for protocol-scoped access. */
   private _dwn: DwnApi;
 
+  /**
+   * Cache of {@link TypedWeb5} instances keyed by protocol URI.
+   *
+   * Ensures that `web5.using(Protocol)` returns the **same** `TypedWeb5`
+   * instance for a given protocol across multiple call sites, avoiding
+   * redundant protocol installations and duplicated internal state.
+   */
+  private _typedInstances = new Map<string, TypedWeb5<ProtocolDefinition, SchemaMap>>();
+
   /** Exposed instance to the VC APIs, allow users to issue, present and verify VCs */
   vc: VcApi;
 
@@ -340,6 +349,10 @@ export class Web5 {
    * protocol-backed records. It auto-injects the protocol URI, protocolPath,
    * and schema into every operation, and provides compile-time path
    * autocompletion plus typed data payloads via the schema map.
+   *
+   * Instances are **cached by protocol URI** — calling `using()` multiple
+   * times with the same protocol returns the same `TypedWeb5` instance,
+   * so auto-configure only runs once and all call sites share state.
    *
    * @param protocol - A typed protocol created via `defineProtocol()`.
    * @returns A `TypedWeb5` instance bound to the given protocol.
@@ -360,7 +373,18 @@ export class Web5 {
   public using<D extends ProtocolDefinition, M extends SchemaMap>(
     protocol: TypedProtocol<D, M>,
   ): TypedWeb5<D, M> {
-    return new TypedWeb5<D, M>(this._dwn, protocol);
+    const uri = protocol.definition.protocol;
+    const cached = this._typedInstances.get(uri);
+
+    if (cached) {
+      // The map stores a type-erased instance; restore the caller's generics.
+      return cached as unknown as TypedWeb5<D, M>;
+    }
+
+    const instance = new TypedWeb5<D, M>(this._dwn, protocol);
+    // Store with erased generics so the map value type stays uniform.
+    this._typedInstances.set(uri, instance as unknown as TypedWeb5<ProtocolDefinition, SchemaMap>);
+    return instance;
   }
 
   /**

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -14,7 +14,11 @@ import {
 
 import { Convert } from '@enbox/common';
 import { DidJwk } from '@enbox/dids';
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+
+import { defineProtocol } from '../src/define-protocol.js';
 import { testDwnUrl } from './utils/test-config.js';
+import { TypedWeb5 } from '../src/typed-web5.js';
 import { Web5 } from '../src/web5.js';
 import { DwnInterfaceName, DwnMethodName, Jws, Time } from '@enbox/dwn-sdk-js';
 
@@ -97,6 +101,104 @@ describe('web5 api', () => {
           connectedDid : socialIdentity.did.uri,
         });
         expect(web5Social).toBeDefined();
+      });
+    });
+
+    describe('using()', () => {
+      const TestProtocolDef = {
+        protocol  : 'https://example.com/protocols/test',
+        published : true,
+        types     : {
+          item: {
+            schema      : 'https://example.com/schemas/item',
+            dataFormats : ['application/json'],
+          },
+        },
+        structure: {
+          item: {},
+        },
+      } as const satisfies ProtocolDefinition;
+
+      type TestSchemaMap = { item: { name: string } };
+
+      const TestProtocol = defineProtocol(TestProtocolDef, {} as TestSchemaMap);
+
+      it('returns the same TypedWeb5 instance for repeated calls with the same protocol', async () => {
+        const identity = await testHarness.agent.identity.create({
+          metadata  : { name: 'CacheTest' },
+          didMethod : 'jwk',
+        });
+
+        const web5 = new Web5({
+          agent        : testHarness.agent,
+          connectedDid : identity.did.uri,
+        });
+
+        const first = web5.using(TestProtocol);
+        const second = web5.using(TestProtocol);
+
+        expect(first).toBeInstanceOf(TypedWeb5);
+        expect(first).toBe(second); // same reference
+      });
+
+      it('returns different TypedWeb5 instances for different protocols', async () => {
+        const OtherProtocolDef = {
+          protocol  : 'https://example.com/protocols/other',
+          published : true,
+          types     : {
+            thing: {
+              schema      : 'https://example.com/schemas/thing',
+              dataFormats : ['application/json'],
+            },
+          },
+          structure: { thing: {} },
+        } as const satisfies ProtocolDefinition;
+
+        type OtherSchemaMap = { thing: { value: number } };
+        const OtherProtocol = defineProtocol(OtherProtocolDef, {} as OtherSchemaMap);
+
+        const identity = await testHarness.agent.identity.create({
+          metadata  : { name: 'CacheTest2' },
+          didMethod : 'jwk',
+        });
+
+        const web5 = new Web5({
+          agent        : testHarness.agent,
+          connectedDid : identity.did.uri,
+        });
+
+        const test = web5.using(TestProtocol);
+        const other = web5.using(OtherProtocol);
+
+        expect(test).not.toBe(other);
+        expect(test.protocol).toBe('https://example.com/protocols/test');
+        expect(other.protocol).toBe('https://example.com/protocols/other');
+      });
+
+      it('caches per Web5 instance, not globally', async () => {
+        const identity1 = await testHarness.agent.identity.create({
+          metadata  : { name: 'User1' },
+          didMethod : 'jwk',
+        });
+        const identity2 = await testHarness.agent.identity.create({
+          metadata  : { name: 'User2' },
+          didMethod : 'jwk',
+        });
+
+        const web5a = new Web5({
+          agent        : testHarness.agent,
+          connectedDid : identity1.did.uri,
+        });
+        const web5b = new Web5({
+          agent        : testHarness.agent,
+          connectedDid : identity2.did.uri,
+        });
+
+        const fromA = web5a.using(TestProtocol);
+        const fromB = web5b.using(TestProtocol);
+
+        // Different Web5 instances must NOT share cached TypedWeb5 instances.
+        expect(fromA).not.toBe(fromB);
       });
     });
 


### PR DESCRIPTION
## Summary

- `Web5.using()` now caches `TypedWeb5` instances in a per-`Web5` `Map<string, TypedWeb5>` keyed by protocol URI
- Repeated calls with the same protocol return the **same** `TypedWeb5` reference, so auto-configure only runs once and all call sites share state
- Different `Web5` instances maintain independent caches (no global singleton)

## Problem

`Web5.using()` returned `new TypedWeb5(...)` on every call (line 362). This was the #1 footgun in the SDK — calling `web5.using(Protocol)` in multiple places (e.g., a repository class and a React hook) created separate instances, each with its own `_configured = false` flag, leading to:
- Redundant protocol installations on the DWN
- Race conditions between concurrent `_ensureReady()` calls from different instances
- Confusing behavior where configuring one instance had no effect on another

## Changes

- **`packages/api/src/web5.ts`**: Added `_typedInstances` map and cache-lookup logic in `using()`. Updated JSDoc to document caching behavior.
- **`packages/api/tests/web5.spec.ts`**: Added 3 tests:
  1. Same protocol → same instance (referential equality)
  2. Different protocols → different instances
  3. Different `Web5` instances → independent caches

## Testing

- All 52 typed-protocol tests pass
- All 33 web5 tests pass (1 pre-existing wallet connect 401 failure unrelated)
- Lint clean