### PR TITLE
fix(api): mutate original record in-place on successful update()

### DIFF
--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -506,8 +506,14 @@ export class Record implements RecordModel {
 
   /**
    * Update the current record on the DWN.
+   *
+   * On success, **both** a new `Record` instance is returned *and* the
+   * current instance (`this`) is mutated in-place to reflect the updated
+   * state. This means callers can safely continue using the original
+   * reference after an update without capturing the returned record.
+   *
    * @param params - Parameters to update the record.
-   * @returns the status of the update request
+   * @returns the status of the update request and the updated Record
    * @throws `Error` if the record has already been deleted.
    *
    * @beta
@@ -599,6 +605,23 @@ export class Record implements RecordModel {
       encodedData  : data !== undefined ? dataBlob : this._encodedData,
       ...responseMessage as DwnMessage[DwnInterface.RecordsWrite],
     }, this._permissionsApi);
+
+    // Also mutate *this* record's internal state so that the caller's
+    // original reference reflects the update without having to capture
+    // the returned record. This eliminates the common footgun where
+    // `await record.update({ data }); await record.data.json()` returns
+    // stale data because `update()` historically only returned a *new* Record.
+    const msg = responseMessage as DwnMessage[DwnInterface.RecordsWrite];
+    this._descriptor = msg.descriptor;
+    this._attestation = msg.attestation;
+    this._authorization = msg.authorization;
+    this._encryption = msg.encryption;
+    this._contextId = msg.contextId;
+    this._initialWrite = initialWrite;
+    this._protocolRole = protocolRole ?? this._protocolRole;
+    this._encodedData = data !== undefined ? dataBlob : this._encodedData;
+    this._readableStream = undefined; // Invalidate any consumed stream.
+    this._rawMessageDirty = true; // Force rawMessage cache rebuild.
 
     return { status, record: updatedRecord };
   }

--- a/packages/api/src/typed-record.ts
+++ b/packages/api/src/typed-record.ts
@@ -126,7 +126,8 @@ export type TypedRecordUpdateResult<T> = DwnResponseStatus & {
    * The updated record, carrying the same type parameter `T`.
    *
    * This is a **new** {@link TypedRecord} instance reflecting the post-update
-   * state; the original record instance is not mutated.
+   * state. The original record instance is also mutated in-place, so both
+   * references see the updated data.
    */
   record: TypedRecord<T>;
 };
@@ -266,8 +267,9 @@ export class TypedRecord<T> {
    * Update the current record's data and/or metadata on the DWN.
    *
    * The `data` field accepts `Partial<T>`, so you only need to provide
-   * the fields you want to change. A new {@link TypedRecord} is returned;
-   * the original instance is not mutated.
+   * the fields you want to change. A new {@link TypedRecord} is returned
+   * **and** the original instance is mutated in-place, so both the returned
+   * record and the original reference reflect the updated state.
    *
    * @param params - Update parameters. `data` is type-checked as `Partial<T>`.
    *   Other fields like `tags`, `published`, and `datePublished` can also be
@@ -290,6 +292,10 @@ export class TypedRecord<T> {
    */
   public async update(params: TypedRecordUpdateParams<T>): Promise<TypedRecordUpdateResult<T>> {
     const { status, record } = await this._record.update(params as RecordUpdateParams);
+    // The underlying Record.update() now also mutates `this._record` in-place,
+    // so the original TypedRecord reference already reflects the new data.
+    // We still return a new TypedRecord wrapping the returned record for callers
+    // that use the destructured result.
     return { status, record: new TypedRecord<T>(record) };
   }
 

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -2897,6 +2897,37 @@ describe('Record', () => {
       expect(firstUpdateTimestamp).not.toBe(secondUpdateTimestamp);
     });
 
+    it('mutates the original record in-place on successful update', async () => {
+      const { status, record } = await dwnAlice.records.write({
+        data         : 'original',
+        protocol     : 'http://free-for-all.xyz',
+        protocolPath : 'post',
+        schema       : 'foo/bar',
+        dataFormat   : 'text/plain'
+      });
+
+      expect(status.code).toBe(202);
+
+      // Read original data.
+      const originalData = await record!.data.text();
+      expect(originalData).toBe('original');
+
+      // Update the record.
+      const { status: updateStatus, record: updatedRecord } = await record!.update({ data: 'updated' });
+      expect(updateStatus.code).toBe(202);
+
+      // The returned record should have the new data.
+      const returnedData = await updatedRecord!.data.text();
+      expect(returnedData).toBe('updated');
+
+      // The ORIGINAL record should also reflect the new data (in-place mutation).
+      const mutatedData = await record!.data.text();
+      expect(mutatedData).toBe('updated');
+
+      // Timestamps should be in sync.
+      expect(record!.timestamp).toBe(updatedRecord!.timestamp);
+    });
+
     it('throws an exception when an immutable property is modified', async () => {
       const { status, record } = await dwnAlice.records.write({
         data         : 'Hello, world!',

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -759,6 +759,35 @@ describe('TypedProtocol API', () => {
         expect(data.description).toBe('Now with description');
       });
 
+      it('should mutate the original record in-place on successful update', async () => {
+        const { record: original } = await typed.records.create('list', {
+          data: { name: 'Before' },
+        });
+
+        // Verify initial data.
+        const dataBefore = await original.data.json();
+        expect(dataBefore.name).toBe('Before');
+
+        // Perform update — the original reference should reflect the new data.
+        const { status, record: returned } = await original.update({
+          data: { name: 'After', description: 'Added description' },
+        });
+
+        expect(status.code).toBe(202);
+
+        // The returned record should have the new data (existing behavior).
+        const returnedData = await returned.data.json();
+        expect(returnedData.name).toBe('After');
+
+        // The ORIGINAL record should also reflect the new data (new behavior).
+        const originalData = await original.data.json();
+        expect(originalData.name).toBe('After');
+        expect(originalData.description).toBe('Added description');
+
+        // Timestamps should match between original and returned.
+        expect(original.timestamp).toBe(returned.timestamp);
+      });
+
       it('should delete a record via TypedRecord.delete()', async () => {
         const { record } = await typed.records.create('list', {
           data: { name: 'Delete Me' },


### PR DESCRIPTION
## Summary

- `Record.update()` now mutates the original record instance in-place on success, in addition to returning a new Record
- `TypedRecord.update()` inherits this behavior automatically — the original `TypedRecord` reference also reflects updated data
- JSDoc updated on `Record.update()`, `TypedRecord.update()`, and `TypedRecordUpdateResult` to document the new behavior

## Problem

`Record.update()` returned a new `Record` but left the original reference stale. This was the #2 SDK footgun:

```ts
// Common developer pattern — BROKEN before this fix:
await record.update({ data: { name: 'New Name' } });
const data = await record.data.json(); // Still returns OLD data!

// Correct but unintuitive pattern that was required:
const { record: updated } = await record.update({ data: { name: 'New Name' } });
const data = await updated.data.json(); // New data
```

## Changes

- **`packages/api/src/record.ts`**: After constructing the new Record on success, also sync `this._descriptor`, `_attestation`, `_authorization`, `_encryption`, `_contextId`, `_initialWrite`, `_protocolRole`, `_encodedData` from the response message. Clear `_readableStream` and set `_rawMessageDirty = true`.
- **`packages/api/src/typed-record.ts`**: Added comments explaining the underlying Record is now self-mutating. Updated JSDoc on `update()` and `TypedRecordUpdateResult`.
- **`packages/api/tests/typed-protocol.spec.ts`**: New test verifying original TypedRecord reflects updated data after `update()`.
- **`packages/api/tests/record.spec.ts`**: New test verifying original Record reflects updated data after `update()`.

## Testing

- 53/53 typed-protocol tests pass (1 new)
- record.spec.ts tests that don't require remote DWN pass (remote DWN tests have pre-existing 401 failures on main)
- Lint clean