### PR TITLE
fix(api): batch ergonomics improvements — caching, types, JSDoc, disconnect

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -44,3 +44,4 @@ export * from './web5.js';
 
 import * as utils from './utils.js';
 export { utils };
+export { isOk } from './utils.js';

--- a/packages/api/src/protocol.ts
+++ b/packages/api/src/protocol.ts
@@ -26,17 +26,17 @@ export type ProtocolMetadata = {
 /**
  * Encapsulates a DWN Protocol with its associated metadata and configuration.
  *
- * This class primarly exists to provide developers with a convenient way to configure/install
+ * This class primarily exists to provide developers with a convenient way to configure/install
  * protocols on remote DWNs.
  */
 export class Protocol {
   /** The {@link Web5Agent} instance that handles DWNs requests. */
   private _agent: Web5Agent;
 
-  /** The ProtocolsConfigureMessage containing the detailed configuration for the protocol. */
+  /** Metadata associated with the protocol, including the author and optional message CID. */
   private _metadata: ProtocolMetadata;
 
-  /** Metadata associated with the protocol, including the author and optional message CID. */
+  /** The ProtocolsConfigureMessage containing the detailed configuration for the protocol. */
   private _protocolsConfigureMessage: DwnMessage[DwnInterface.ProtocolsConfigure];
 
   /**

--- a/packages/api/src/record-data.ts
+++ b/packages/api/src/record-data.ts
@@ -5,6 +5,10 @@
  * evaluated `stream()` function with convenience accessors that mirror the
  * Fetch `Response` API (`blob()`, `bytes()`, `json()`, `text()`).
  *
+ * Data is **cached after first read** so that subsequent calls to any accessor
+ * return the same data without re-fetching. Concurrent calls are safe — only
+ * one fetch is performed and all callers share the result.
+ *
  * Extracted from `record.ts` so the convenience-method boilerplate lives in
  * its own module while the stream-resolution logic (which is tightly coupled
  * to `Record` internals) stays inside the `Record` class.
@@ -15,11 +19,22 @@
 import { Stream } from '@enbox/common';
 
 /**
+ * Maximum data size (in bytes) that will be cached in-memory after the first
+ * read. Payloads larger than this threshold are not cached and will be
+ * re-fetched on every access.
+ */
+const DATA_CACHE_LIMIT = 10 * 1024 * 1024; // 10 MB
+
+/**
  * A thenable data accessor returned by {@link Record.data}.
  *
  * Provides convenience methods for consuming the record's data in various
  * formats, plus `then`/`catch` so the object can be awaited directly to
  * obtain the underlying `ReadableStream`.
+ *
+ * Data is cached after the first read so that repeated calls (e.g.,
+ * `data.json()` followed by `data.text()`) do not trigger redundant
+ * network requests.
  *
  * @beta
  */
@@ -46,6 +61,15 @@ export type RecordData = {
 /**
  * Create a {@link RecordData} wrapper around a `stream` provider function.
  *
+ * The first call to any accessor (`blob`, `bytes`, `json`, `text`, `stream`)
+ * consumes the underlying stream and caches the raw bytes (up to
+ * {@link DATA_CACHE_LIMIT}). Subsequent calls reconstruct a fresh stream
+ * from the cache, preventing the common footgun of stale data after stream
+ * consumption.
+ *
+ * Concurrent calls are safe: if multiple accessors are called simultaneously,
+ * only one stream fetch is performed and all callers share the result.
+ *
  * @param streamFn   - A function that returns a `Promise<ReadableStream>` for the record data.
  * @param dataFormat - The MIME type used when constructing Blobs.
  * @returns A {@link RecordData} object with convenience accessors.
@@ -53,6 +77,46 @@ export type RecordData = {
  * @beta
  */
 export function createRecordData(streamFn: () => Promise<ReadableStream>, dataFormat: string | undefined): RecordData {
+  // In-memory byte cache. Populated after the first successful read.
+  let cachedBytes: Uint8Array | undefined;
+  // In-flight read promise. Ensures concurrent callers share a single fetch.
+  let inflight: Promise<Uint8Array> | undefined;
+
+  /**
+   * Returns the record data as raw bytes, using the cache when available.
+   * If a read is already in-flight, waits for it instead of starting a new one.
+   */
+  async function getBytes(): Promise<Uint8Array> {
+    // Fast path: cache hit.
+    if (cachedBytes) {
+      return cachedBytes;
+    }
+
+    // If another call is already fetching, wait for it.
+    if (inflight) {
+      return inflight;
+    }
+
+    // Start a new fetch and share the promise.
+    inflight = (async (): Promise<Uint8Array> => {
+      const readableStream = await streamFn();
+      const bytes = await Stream.consumeToBytes({ readableStream });
+
+      // Cache only if within the size limit.
+      if (bytes.byteLength <= DATA_CACHE_LIMIT) {
+        cachedBytes = bytes;
+      }
+
+      return bytes;
+    })();
+
+    try {
+      return await inflight;
+    } finally {
+      inflight = undefined;
+    }
+  }
+
   const dataObj: RecordData = {
 
     /**
@@ -64,7 +128,7 @@ export function createRecordData(streamFn: () => Promise<ReadableStream>, dataFo
      * @beta
      */
     async blob(): Promise<Blob> {
-      return new Blob([await Stream.consumeToBytes({ readableStream: await this.stream() })], { type: dataFormat });
+      return new Blob([await getBytes()], { type: dataFormat });
     },
 
     /**
@@ -76,7 +140,7 @@ export function createRecordData(streamFn: () => Promise<ReadableStream>, dataFo
      * @beta
      */
     async bytes(): Promise<Uint8Array> {
-      return await Stream.consumeToBytes({ readableStream: await this.stream() });
+      return await getBytes();
     },
 
     /**
@@ -88,7 +152,8 @@ export function createRecordData(streamFn: () => Promise<ReadableStream>, dataFo
      * @beta
      */
     async json<T = unknown>(): Promise<T> {
-      return await Stream.consumeToJson({ readableStream: await this.stream() }) as T;
+      const bytes = await getBytes();
+      return JSON.parse(new TextDecoder().decode(bytes)) as T;
     },
 
     /**
@@ -100,7 +165,8 @@ export function createRecordData(streamFn: () => Promise<ReadableStream>, dataFo
      * @beta
      */
     async text(): Promise<string> {
-      return await Stream.consumeToText({ readableStream: await this.stream() });
+      const bytes = await getBytes();
+      return new TextDecoder().decode(bytes);
     },
 
     /**
@@ -109,12 +175,27 @@ export function createRecordData(streamFn: () => Promise<ReadableStream>, dataFo
      * Uses the standard Web Streams API for cross-platform compatibility across
      * browsers, Node.js, Bun, and Deno.
      *
+     * If the data has already been read and cached, returns a fresh stream
+     * reconstructed from the cache.
+     *
      * @returns A promise that resolves to a Web `ReadableStream` of the record's data.
      * @throws If the record data is not available in-memory and cannot be fetched.
      *
      * @beta
      */
-    stream: streamFn,
+    async stream(): Promise<ReadableStream> {
+      // If we have cached bytes, reconstruct a fresh stream from them.
+      if (cachedBytes) {
+        return new ReadableStream({
+          start(controller): void {
+            controller.enqueue(cachedBytes);
+            controller.close();
+          },
+        });
+      }
+      // Otherwise delegate to the original stream provider.
+      return streamFn();
+    },
 
     /**
      * Attaches callbacks for the resolution and/or rejection of the `Promise` returned by

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -215,10 +215,10 @@ export class Record implements RecordModel {
   /** Record's encryption */
   get encryption(): DwnMessage[DwnInterface.RecordsWrite]['encryption'] { return this._encryption; }
 
-  /** Record's signatures attestation */
+  /** Record's authorization signature(s). */
   get authorization(): DwnMessage[DwnInterface.RecordsWrite | DwnInterface.RecordsDelete]['authorization'] { return this._authorization; }
 
-  /** Record's signatures attestation */
+  /** Record's attestation signature. */
   get attestation(): DwnMessage[DwnInterface.RecordsWrite]['attestation'] | undefined { return this._attestation; }
 
   /** Role under which the author is writing the record */
@@ -324,7 +324,7 @@ export class Record implements RecordModel {
   get data(): RecordData {
     return createRecordData(async (): Promise<ReadableStream> => {
       if (this.deleted) {
-        throw new Error('404: Not Found');
+        throw new Error('Cannot access data of a deleted record.');
       }
 
       if (this._encodedData) {
@@ -381,15 +381,18 @@ export class Record implements RecordModel {
   }
 
   /**
-   * Send the current record to a remote DWN by specifying their DID
+   * Send the current record to a remote DWN by specifying their DID.
    * If no DID is specified, the target is assumed to be the owner (connectedDID).
    *
-   * If an initial write is present and the Record class send cache has no awareness of it, the initial write is sent first
-   * (vs waiting for the regular DWN sync)
+   * If the record is in a deleted state, a `RecordsDelete` message is sent
+   * so the remote DWN reflects the deletion.
+   *
+   * If an initial write is present and the Record class send cache has no
+   * awareness of it, the initial write is sent first (vs waiting for the
+   * regular DWN sync).
    *
    * @param target - the optional DID to send the record to, if none is set it is sent to the connectedDid
    * @returns the status of the send record request
-   * @throws `Error` if the record has already been deleted.
    *
    * @beta
    */
@@ -628,6 +631,11 @@ export class Record implements RecordModel {
 
   /**
    * Delete the current record on the DWN.
+   *
+   * On success, **both** a new `Record` instance is returned *and* the
+   * current instance (`this`) is mutated in-place to reflect the deleted
+   * state (the {@link Record.deleted | deleted} getter will return `true`).
+   *
    * @param params - Parameters to delete the record.
    * @returns the status and a new Record instance reflecting the deleted state
    */
@@ -697,6 +705,16 @@ export class Record implements RecordModel {
       initialWrite,
       ...message as DwnMessage[DwnInterface.RecordsDelete],
     }, this._permissionsApi);
+
+    // Also mutate *this* record so the caller's original reference reflects
+    // the deletion without having to capture the returned record.
+    const deleteMsg = message as DwnMessage[DwnInterface.RecordsDelete];
+    this._descriptor = deleteMsg.descriptor;
+    this._authorization = deleteMsg.authorization;
+    this._protocolRole = deleteParams?.protocolRole ?? this._protocolRole;
+    this._encodedData = undefined;
+    this._readableStream = undefined;
+    this._rawMessageDirty = true;
 
     return { status, record: deletedRecord };
   }

--- a/packages/api/src/typed-record.ts
+++ b/packages/api/src/typed-record.ts
@@ -136,7 +136,8 @@ export type TypedRecordUpdateResult<T> = DwnResponseStatus & {
  * Result of a {@link TypedRecord.delete} operation.
  *
  * Includes the DWN response status and the record in its deleted state.
- * After deletion, calling data accessors on the returned record will throw.
+ * The original record instance is also mutated in-place, so both
+ * references reflect the deletion.
  *
  * @typeParam T - The data type of the record.
  */
@@ -302,8 +303,9 @@ export class TypedRecord<T> {
   /**
    * Delete the current record from the DWN.
    *
-   * After deletion, the returned record's {@link TypedRecord.deleted | deleted}
-   * property will be `true` and calling data accessors will throw.
+   * After deletion, **both** the returned record and the original instance's
+   * {@link TypedRecord.deleted | deleted} property will be `true`, and
+   * calling data accessors on either will throw.
    *
    * @param params - Optional delete parameters:
    *   - `store` — whether to persist the delete message (defaults to `true`).

--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -1,4 +1,31 @@
+import type { DwnResponseStatus } from '@enbox/agent';
 import { Convert, universalTypeOf } from '@enbox/common';
+
+/**
+ * Returns `true` if the DWN response status indicates success (2xx code).
+ *
+ * Use this instead of manually checking `status.code >= 200 && status.code <= 299`
+ * on every API call.
+ *
+ * @param response - Any object that conforms to {@link DwnResponseStatus}.
+ * @returns `true` for 2xx status codes, `false` otherwise.
+ *
+ * @example
+ * ```ts
+ * const result = await proto.records.create('note', { data: { text: 'hello' } });
+ * if (!isOk(result)) {
+ *   console.error('Create failed:', result.status.detail);
+ *   return;
+ * }
+ * // result.record is safe to use here
+ * ```
+ *
+ * @beta
+ */
+export function isOk(response: DwnResponseStatus): boolean {
+  const code = response.status.code;
+  return code >= 200 && code <= 299;
+}
 
 /**
  * Converts various data types to a `Blob` object, automatically detecting the data type or using

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -129,6 +129,16 @@ export type RegistrationTokenData = {
   refreshUrl?: string;
 };
 
+/**
+ * Controls DWN sync mode.
+ *
+ * - `'off'`   — Sync disabled entirely.
+ * - An interval string such as `'30s'`, `'2m'`, `'1h'` — Poll mode at the
+ *   specified interval.
+ * - `undefined` (omitted) — Live WebSocket sync (default).
+ */
+export type SyncOption = 'off' | `${number}${'s' | 'm' | 'h'}`;
+
 /** Optional overrides that can be provided when calling {@link Web5.connect}. */
 export type Web5ConnectOptions = {
   /**
@@ -213,7 +223,7 @@ export type Web5ConnectOptions = {
    *   SMT set-reconciliation sync at the specified interval.
    * - **`'off'`**: Sync is disabled entirely.
    */
-  sync?: string;
+  sync?: SyncOption;
 
   /**
    * Override defaults configured during the technical preview phase.
@@ -385,6 +395,33 @@ export class Web5 {
     // Store with erased generics so the map value type stays uniform.
     this._typedInstances.set(uri, instance as unknown as TypedWeb5<ProtocolDefinition, SchemaMap>);
     return instance;
+  }
+
+  /**
+   * Stops DWN sync and clears the cached {@link TypedWeb5} instances.
+   *
+   * Call this when the application is shutting down or the user is
+   * disconnecting to cleanly release background resources. After calling
+   * `disconnect()`, the `Web5` instance should not be reused.
+   *
+   * @param timeout - Maximum milliseconds to wait for an in-progress sync
+   *   cycle to finish before force-stopping. Defaults to `2000`.
+   *
+   * @example
+   * ```ts
+   * await web5.disconnect();
+   * ```
+   *
+   * @beta
+   */
+  public async disconnect(timeout?: number): Promise<void> {
+    // Stop any active sync.
+    if ('sync' in this.agent && typeof (this.agent as any).sync?.stopSync === 'function') {
+      await (this.agent as any).sync.stopSync(timeout);
+    }
+
+    // Clear cached TypedWeb5 instances so they are not accidentally reused.
+    this._typedInstances.clear();
   }
 
   /**

--- a/packages/api/tests/record-coverage.spec.ts
+++ b/packages/api/tests/record-coverage.spec.ts
@@ -490,7 +490,7 @@ describe('Record — coverage gaps (stubbed)', () => {
       const record = new Record(agentStub as unknown as Web5Agent, options);
       expect(record.deleted).toBe(true);
 
-      await expect(record.data.text()).rejects.toThrow('404');
+      await expect(record.data.text()).rejects.toThrow('Cannot access data of a deleted record.');
     });
   });
 });

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -3853,7 +3853,7 @@ describe('Record', () => {
         await deletedRecord.data.text();
         throw new Error('Expected an exception to be thrown');
       } catch (error:any) {
-        expect(error.message).toContain('Not Found');
+        expect(error.message).toContain('Cannot access data of a deleted record.');
       }
     });
 

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -800,6 +800,27 @@ describe('TypedProtocol API', () => {
         expect(deletedRecord.deleted).toBe(true);
       });
 
+      it('should mutate the original record in-place on successful delete', async () => {
+        const { record: original } = await typed.records.create('list', {
+          data: { name: 'Will be deleted' },
+        });
+
+        // Verify not deleted before.
+        expect(original.deleted).toBe(false);
+
+        const { status, record: returned } = await original.delete();
+        expect(status.code).toBe(202);
+
+        // The returned record should be in a deleted state (existing behavior).
+        expect(returned.deleted).toBe(true);
+
+        // The ORIGINAL record should also reflect the deletion (new behavior).
+        expect(original.deleted).toBe(true);
+
+        // Both timestamps should match.
+        expect(original.timestamp).toBe(returned.timestamp);
+      });
+
       it('should forward toJSON() from the underlying Record', async () => {
         const { record } = await typed.records.create('list', {
           data: { name: 'JSON Test' },


### PR DESCRIPTION
## Summary

Batch of API ergonomics improvements discovered while building [notesd](https://notesd.pages.dev/). All changes are in `@enbox/api`.

## Changes

### New features
- **Data stream caching** — `record-data.ts` rewritten so that `blob()`, `bytes()`, `json()`, `text()`, and `stream()` all go through a cached `getBytes()` path. First read caches the raw bytes (up to 10 MB); subsequent reads serve from cache. Concurrent calls share a single inflight promise instead of racing on the stream.
- **`Web5.disconnect()`** — New method that stops sync polling and clears the internal `TypedWeb5` cache. Accepts optional timeout (ms) for graceful shutdown.
- **`SyncOption` type** — Replaces bare `string` on `connect({ sync })` with `'off' | \`${number}${'s' | 'm' | 'h'}\``. Exported from package index.
- **`isOk()` utility** — `isOk(response: DwnResponseStatus): boolean` for checking 2xx status codes. Exported as both `utils.isOk()` and top-level `isOk()`.

### Bug fixes
- **Delete in-place mutation** — `Record.delete()` now mutates the original record (clears encoded data, updates descriptor/authorization, marks dirty), mirroring the existing `update()` behavior from #566.
- **Improved error message** — Accessing data of a deleted record now says `"Cannot access data of a deleted record."` instead of `"404: Not Found"`.

### JSDoc fixes
- **Protocol field docs swapped** — `_metadata` and `_protocolsConfigureMessage` had each other's JSDoc comments.
- **`authorization` getter** — Was copy-pasted from `attestation` ("Record's signatures attestation"). Now says "Record's authorization signature(s)."
- **`send()` method** — Removed incorrect `@throws` tag; documented that deleted records are handled gracefully (returns status, doesn't throw).
- **`TypedRecord.delete()` / `TypedRecordDeleteResult`** — Updated docs to reflect in-place mutation.
- **Protocol typo** — "primarly" → "primarily".

## Testing
- `typed-protocol.spec.ts`: **54 pass** (includes 1 new test for delete mutation)
- `record-data.spec.ts`: **15 pass**
- Build: **passes**
- Lint: **passes**

## Not included in this PR
- **Record type lies** (#1 from audit) — Making `record` optional in response types is a breaking change; deferred to a separate PR.
- **Error cause chaining** (#7 from audit) — Deferred pending spec review.