### PR TITLE
fix(api)!: make record optional in write/read responses, add discriminated union types

### DIFF
--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -161,10 +161,13 @@ export type RecordsReadRequest = Omit<DwnMessageParams[DwnInterface.RecordsRead]
 /**
  * Encapsulates the response from a record read operation, combining the general operation status
  * with the specific record that was retrieved.
+ *
+ * When the status code is not in the 2xx range (e.g. 401, 404), `record` will be `undefined`.
+ * Always check `status.code` before accessing the record.
  */
 export type RecordsReadResponse = DwnResponseStatus & {
-  /** The record retrieved by the read operation. */
-  record: Record;
+  /** The record retrieved by the read operation, or `undefined` if the request failed. */
+  record?: Record;
 };
 
 /**
@@ -223,9 +226,11 @@ export type RecordsWriteRequest = Omit<Partial<DwnMessageParams[DwnInterface.Rec
 export type RecordsWriteResponse = DwnResponseStatus & {
   /**
    * The `Record` instance representing the record that was successfully written to the
-   * DWN as a result of the write operation.
+   * DWN as a result of the write operation, or `undefined` if the write failed.
+   *
+   * Always check `status.code` before accessing the record.
    */
-  record: Record;
+  record?: Record;
 };
 
 /**
@@ -688,7 +693,7 @@ export class DwnApi {
 
         const { reply: { entry, status } } = agentResponse;
 
-        let record: Record;
+        let record: Record | undefined;
         if (200 <= status.code && status.code <= 299) {
           const recordOptions = {
             /**
@@ -883,7 +888,7 @@ export class DwnApi {
 
         const { message: responseMessage, reply: { status } } = agentResponse;
 
-        let record: Record;
+        let record: Record | undefined;
         if (200 <= status.code && status.code <= 299) {
           const recordOptions = {
             /**

--- a/packages/api/src/repository-types.ts
+++ b/packages/api/src/repository-types.ts
@@ -108,9 +108,12 @@ export type CollectionCRUD<
   M extends SchemaMap,
   Path extends string,
 > = {
-  create(options: CollectionCreateOptions<D, M, Path>): Promise<DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> }>;
+  create(options: CollectionCreateOptions<D, M, Path>): Promise<
+    | (DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> })
+    | (DwnResponseStatus & { record: undefined })
+  >;
   query(options?: TypedQueryRequest): Promise<DwnResponseStatus & { records: TypedRecord<DataAt<D, M, Path>>[]; cursor?: DwnPaginationCursor }>;
-  get(recordId: string): Promise<TypedRecord<DataAt<D, M, Path>>>;
+  get(recordId: string): Promise<TypedRecord<DataAt<D, M, Path>> | undefined>;
   delete(recordId: string): Promise<DwnResponseStatus>;
   subscribe(options?: TypedSubscribeRequest): Promise<TypedLiveQuery<DataAt<D, M, Path>> | undefined>;
 };
@@ -121,7 +124,10 @@ export type SingletonCRUD<
   M extends SchemaMap,
   Path extends string,
 > = {
-  set(options: SingletonSetOptions<D, M, Path>): Promise<DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> }>;
+  set(options: SingletonSetOptions<D, M, Path>): Promise<
+    | (DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> })
+    | (DwnResponseStatus & { record: undefined })
+  >;
   get(): Promise<TypedRecord<DataAt<D, M, Path>> | undefined>;
   delete(recordId: string): Promise<DwnResponseStatus>;
 };
@@ -135,12 +141,15 @@ export type NestedCollectionCRUD<
   create(
     parentContextId: string,
     options: CollectionCreateOptions<D, M, Path>,
-  ): Promise<DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> }>;
+  ): Promise<
+    | (DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> })
+    | (DwnResponseStatus & { record: undefined })
+  >;
   query(
     parentContextId: string,
     options?: TypedQueryRequest,
   ): Promise<DwnResponseStatus & { records: TypedRecord<DataAt<D, M, Path>>[]; cursor?: DwnPaginationCursor }>;
-  get(recordId: string): Promise<TypedRecord<DataAt<D, M, Path>>>;
+  get(recordId: string): Promise<TypedRecord<DataAt<D, M, Path>> | undefined>;
   delete(recordId: string): Promise<DwnResponseStatus>;
   subscribe(
     parentContextId: string,
@@ -157,7 +166,10 @@ export type NestedSingletonCRUD<
   set(
     parentContextId: string,
     options: SingletonSetOptions<D, M, Path>,
-  ): Promise<DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> }>;
+  ): Promise<
+    | (DwnResponseStatus & { record: TypedRecord<DataAt<D, M, Path>> })
+    | (DwnResponseStatus & { record: undefined })
+  >;
   get(parentContextId: string): Promise<TypedRecord<DataAt<D, M, Path>> | undefined>;
   delete(recordId: string): Promise<DwnResponseStatus>;
 };

--- a/packages/api/src/repository.ts
+++ b/packages/api/src/repository.ts
@@ -110,7 +110,7 @@ function buildRootCollectionMethods(
       const { record } = await typed.records.read(path, {
         filter: { recordId },
       });
-      return record;
+      return record; // undefined when the read fails (e.g. 404)
     },
 
     async delete(recordId: string): Promise<DwnResponseStatus> {
@@ -198,7 +198,7 @@ function buildNestedCollectionMethods(
       const { record } = await typed.records.read(path, {
         filter: { recordId },
       });
-      return record;
+      return record; // undefined when the read fails (e.g. 404)
     },
 
     async delete(recordId: string): Promise<DwnResponseStatus> {

--- a/packages/api/src/typed-web5.ts
+++ b/packages/api/src/typed-web5.ts
@@ -207,17 +207,22 @@ export type TypedCreateRequest<
 /**
  * Response from {@link TypedWeb5} `records.create()`.
  *
+ * Uses a discriminated union so that TypeScript narrows `record` to
+ * `TypedRecord<T>` after a `status.code` check:
+ *
+ * ```ts
+ * const result = await proto.records.create('notebook', { data });
+ * if (result.record) {
+ *   // TypeScript knows `record` is TypedRecord<NotebookData> here
+ *   console.log(result.record.id);
+ * }
+ * ```
+ *
  * @typeParam T - The data type of the created record.
  */
-export type TypedCreateResponse<T = unknown> = DwnResponseStatus & {
-  /**
-   * The created record, typed as `TypedRecord<T>`.
-   *
-   * Access `record.id`, `record.contextId`, and `record.data.json()` for
-   * the most commonly needed values after creation.
-   */
-  record: TypedRecord<T>;
-};
+export type TypedCreateResponse<T = unknown> =
+  | (DwnResponseStatus & { record: TypedRecord<T> })
+  | (DwnResponseStatus & { record: undefined });
 
 /**
  * Filter options for {@link TypedWeb5} `records.query()` and `records.subscribe()`.
@@ -411,12 +416,21 @@ export type TypedReadRequest = {
 /**
  * Response from {@link TypedWeb5} `records.read()`.
  *
+ * Uses a discriminated union so that TypeScript narrows `record` to
+ * `TypedRecord<T>` after a truthiness check:
+ *
+ * ```ts
+ * const result = await proto.records.read('notebook', { filter: { recordId } });
+ * if (result.record) {
+ *   const data = await result.record.data.json(); // NotebookData
+ * }
+ * ```
+ *
  * @typeParam T - The data type of the read record.
  */
-export type TypedReadResponse<T = unknown> = DwnResponseStatus & {
-  /** The record matching the filter, typed as {@link TypedRecord | TypedRecord<T>}. */
-  record: TypedRecord<T>;
-};
+export type TypedReadResponse<T = unknown> =
+  | (DwnResponseStatus & { record: TypedRecord<T> })
+  | (DwnResponseStatus & { record: undefined });
 
 /**
  * Options for {@link TypedWeb5} `records.delete()`.
@@ -824,7 +838,7 @@ export class TypedWeb5<
 
         return {
           status,
-          record: new TypedRecord<DataForPath<D, M, Path>>(record),
+          record: record ? new TypedRecord<DataForPath<D, M, Path>>(record) : undefined,
         };
       },
 
@@ -942,7 +956,7 @@ export class TypedWeb5<
 
         return {
           status,
-          record: new TypedRecord<DataForPath<D, M, Path>>(record),
+          record: record ? new TypedRecord<DataForPath<D, M, Path>>(record) : undefined,
         };
       },
 

--- a/packages/api/tests/record-coverage.spec.ts
+++ b/packages/api/tests/record-coverage.spec.ts
@@ -493,4 +493,139 @@ describe('Record — coverage gaps (stubbed)', () => {
       await expect(record.data.text()).rejects.toThrow('Cannot access data of a deleted record.');
     });
   });
+
+  describe('DwnApi record type safety', () => {
+    it('write() should return record: undefined when status is non-2xx', async () => {
+      // Simulate a 400 response from the agent
+      agentStub.processDwnRequest.resolves({
+        reply   : { status: { code: 400, detail: 'Bad Request' } },
+        message : {},
+      });
+
+      const { DwnApi } = await import('../src/dwn-api.js');
+      const dwnApi = new DwnApi({
+        agent        : agentStub as unknown as Web5Agent,
+        connectedDid : 'did:example:alice',
+      });
+
+      const result = await dwnApi.records.write({
+        data         : { test: true },
+        protocol     : 'https://example.com/protocol',
+        protocolPath : 'test',
+      });
+
+      expect(result.status.code).toBe(400);
+      expect(result.record).toBeUndefined();
+    });
+
+    it('write() should return record when status is 2xx', async () => {
+      // Create a valid write message for a success response
+      const validDescriptor = {
+        interface        : DwnInterface.RecordsWrite,
+        method           : 'Write',
+        protocol         : 'https://example.com/protocol',
+        protocolPath     : 'test',
+        schema           : 'https://example.com/schema',
+        dataFormat       : 'application/json',
+        dataCid          : 'bafyreicid',
+        dataSize         : 13,
+        dateCreated      : '2024-01-01T00:00:00.000000Z',
+        messageTimestamp : '2024-01-01T00:00:00.000000Z',
+        recordId         : 'rec-success',
+      };
+
+      agentStub.processDwnRequest.resolves({
+        reply   : { status: { code: 202, detail: 'Accepted' } },
+        message : {
+          recordId      : 'rec-success',
+          descriptor    : validDescriptor,
+          authorization : createValidAuthorization(),
+        },
+      });
+
+      const { DwnApi } = await import('../src/dwn-api.js');
+      const dwnApi = new DwnApi({
+        agent        : agentStub as unknown as Web5Agent,
+        connectedDid : 'did:example:alice',
+      });
+
+      const result = await dwnApi.records.write({
+        data         : { test: true },
+        protocol     : 'https://example.com/protocol',
+        protocolPath : 'test',
+      });
+
+      expect(result.status.code).toBe(202);
+      expect(result.record).toBeDefined();
+      expect(result.record).toBeInstanceOf(Record);
+    });
+
+    it('read() should return record: undefined when status is non-2xx', async () => {
+      agentStub.processDwnRequest.resolves({
+        reply: {
+          status : { code: 404, detail: 'Not Found' },
+          entry  : {},
+        },
+        message: {},
+      });
+
+      const { DwnApi } = await import('../src/dwn-api.js');
+      const dwnApi = new DwnApi({
+        agent        : agentStub as unknown as Web5Agent,
+        connectedDid : 'did:example:alice',
+      });
+
+      const result = await dwnApi.records.read({
+        filter: { recordId: 'nonexistent' },
+      });
+
+      expect(result.status.code).toBe(404);
+      expect(result.record).toBeUndefined();
+    });
+
+    it('read() should return record when status is 2xx', async () => {
+      const validDescriptor = {
+        interface        : DwnInterface.RecordsWrite,
+        method           : 'Write',
+        protocol         : 'https://example.com/protocol',
+        protocolPath     : 'test',
+        schema           : 'https://example.com/schema',
+        dataFormat       : 'application/json',
+        dataCid          : 'bafyreicid',
+        dataSize         : 13,
+        dateCreated      : '2024-01-01T00:00:00.000000Z',
+        messageTimestamp : '2024-01-01T00:00:00.000000Z',
+        recordId         : 'rec-read',
+      };
+
+      agentStub.processDwnRequest.resolves({
+        reply: {
+          status : { code: 200, detail: 'OK' },
+          entry  : {
+            recordsWrite: {
+              recordId      : 'rec-read',
+              descriptor    : validDescriptor,
+              authorization : createValidAuthorization(),
+            },
+            data: new Blob(['{"test":true}']),
+          },
+        },
+        message: {},
+      });
+
+      const { DwnApi } = await import('../src/dwn-api.js');
+      const dwnApi = new DwnApi({
+        agent        : agentStub as unknown as Web5Agent,
+        connectedDid : 'did:example:alice',
+      });
+
+      const result = await dwnApi.records.read({
+        filter: { recordId: 'rec-read' },
+      });
+
+      expect(result.status.code).toBe(200);
+      expect(result.record).toBeDefined();
+      expect(result.record).toBeInstanceOf(Record);
+    });
+  });
 });

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -836,9 +836,116 @@ describe('TypedProtocol API', () => {
           data: { name: 'String Test' },
         });
 
-        const str = record.toString();
+        const str = record!.toString();
         expect(str).toContain('Record:');
-        expect(str).toContain(record.id);
+        expect(str).toContain(record!.id);
+      });
+    });
+
+    describe('record type safety (discriminated union)', () => {
+      it('create() should return record on success', async () => {
+        const result = await typed.records.create('list', {
+          data: { name: 'Type Safety Test' },
+        });
+
+        expect(result.status.code).toBe(202);
+        expect(result.record).toBeDefined();
+
+        // After a truthiness check, record should be narrowed to TypedRecord
+        if (result.record) {
+          expect(result.record.id).toBeDefined();
+          const data = await result.record.data.json();
+          expect(data.name).toBe('Type Safety Test');
+        }
+      });
+
+      it('create() should return undefined record on failure', async () => {
+        // Stub the agent to return a non-2xx status for the write operation.
+        // DwnApi.records is a getter that returns a fresh object, so we stub
+        // at the agent level instead.
+        const processStub = sinon.stub(testHarness.agent, 'processDwnRequest').resolves({
+          reply   : { status: { code: 400, detail: 'Bad Request' } },
+          message : {} as never,
+        } as never);
+
+        const result = await typed.records.create('list', {
+          data: { name: 'Should Fail' },
+        });
+
+        expect(result.status.code).toBe(400);
+        expect(result.record).toBeUndefined();
+
+        processStub.restore();
+      });
+
+      it('read() should return record on success', async () => {
+        // First create a record
+        const { record: created } = await typed.records.create('list', {
+          data: { name: 'Read Target' },
+        });
+
+        const result = await typed.records.read('list', {
+          filter: { recordId: created!.id },
+        });
+
+        expect(result.status.code).toBe(200);
+        expect(result.record).toBeDefined();
+
+        if (result.record) {
+          const data = await result.record.data.json();
+          expect(data.name).toBe('Read Target');
+        }
+      });
+
+      it('read() should return undefined record on failure', async () => {
+        // Stub at the agent level — DwnApi.records is a getter that
+        // returns a fresh object, so direct stubbing doesn't work.
+        const processStub = sinon.stub(testHarness.agent, 'processDwnRequest').resolves({
+          reply   : { status: { code: 404, detail: 'Not Found' }, entry: {} },
+          message : {} as never,
+        } as never);
+
+        const result = await typed.records.read('list', {
+          filter: { recordId: 'nonexistent-id' },
+        });
+
+        expect(result.status.code).toBe(404);
+        expect(result.record).toBeUndefined();
+
+        processStub.restore();
+      });
+
+      it('record should be narrowable via truthiness check', async () => {
+        const result = await typed.records.create('list', {
+          data: { name: 'Narrowing Test' },
+        });
+
+        // This is the pattern users should use:
+        if (!result.record) {
+          // In this branch, TypeScript knows record is undefined
+          expect(result.status.code).not.toBe(202);
+          return;
+        }
+
+        // In this branch, TypeScript knows record is TypedRecord<ListData>
+        expect(result.record.id).toBeDefined();
+        expect(result.record.contextId).toBeDefined();
+      });
+
+      it('destructured record should be TypedRecord | undefined', async () => {
+        const { status, record } = await typed.records.create('list', {
+          data: { name: 'Destructure Test' },
+        });
+
+        expect(status.code).toBe(202);
+
+        // After destructuring, `record` is `TypedRecord | undefined`
+        // The user must check before using it
+        if (record) {
+          expect(record.id).toBeDefined();
+          const data = await record.data.json();
+          expect(data.name).toBe('Destructure Test');
+        }
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes the "record type lie" where `RecordsWriteResponse.record`, `RecordsReadResponse.record`, `TypedCreateResponse.record`, and `TypedReadResponse.record` were declared as non-optional but were `undefined` at runtime on non-2xx status codes. This caused null pointer errors that TypeScript could not catch.

**This is a breaking change** — consumers that destructure `{ record }` without a null check will now get TypeScript errors, which is the intended behavior.

## Changes

### DwnApi layer — simple optional
- `RecordsWriteResponse.record` → `record?: Record`
- `RecordsReadResponse.record` → `record?: Record`
- Implementation uses `let record: Record | undefined` instead of `let record: Record`

### TypedWeb5 layer — discriminated union
- `TypedCreateResponse<T>` → `(DwnResponseStatus & { record: TypedRecord<T> }) | (DwnResponseStatus & { record: undefined })`
- `TypedReadResponse<T>` → same pattern
- Implementation guards `new TypedRecord()` wrapping: `record ? new TypedRecord(record) : undefined`
- TypeScript narrows `record` after a truthiness check:
  ```ts
  const result = await proto.records.create('notebook', { data });
  if (result.record) {
    // TypeScript knows record is TypedRecord<NotebookData> here
    console.log(result.record.id);
  }
  ```

### Repository layer
- `CollectionCRUD.create()`, `SingletonCRUD.set()`, `NestedCollectionCRUD.create()`, `NestedSingletonCRUD.set()` — return types updated to match discriminated union
- `CollectionCRUD.get()`, `NestedCollectionCRUD.get()` — now return `TypedRecord | undefined`

### What's NOT affected
- `update()` and `delete()` always return a record (returns `this` on failure) — types were already correct
- `query()` always returns `records: Record[]` (defaults to `[]`) — already correct
- `subscribe()` already had `liveQuery?:` optional — already correct

## Testing
- **6 new tests** in `typed-protocol.spec.ts`: create success/failure, read success/failure, narrowing via truthiness check, destructured record handling
- **4 new tests** in `record-coverage.spec.ts`: DwnApi `write()` and `read()` returning `record: undefined` on non-2xx, and `Record` instance on 2xx
- All existing tests pass (94 total across 3 local test files)
- Build: passes
- Lint: passes