### PR TITLE
chore: add changeset for @enbox/auth

### DIFF
--- a/.changeset/feat-auth-package.md
+++ b/.changeset/feat-auth-package.md
@@ -1,0 +1,15 @@
+---
+"@enbox/auth": minor
+---
+
+feat: introduce @enbox/auth — headless authentication & identity SDK
+
+New package providing composable, multi-identity-aware authentication that replaces `Web5.connect()`. Depends only on `@enbox/agent`, `@enbox/common`, and `@enbox/dids` with zero dependency on `@enbox/api`.
+
+Key capabilities:
+- `AuthManager` orchestrator with local connect, wallet connect, import, and session restore flows
+- `AuthSession` exposing `agent`, `did`, `delegateDid` primitives (no `web5` getter — that's `@enbox/api`'s layer)
+- Multi-identity support: list, switch, delete, export identities
+- `VaultManager` wrapping `HdIdentityVault` with typed events
+- Platform-agnostic `StorageAdapter` with browser and memory implementations
+- `processConnectedGrants()` reimplemented using agent primitives


### PR DESCRIPTION
## Summary

- Adds the missing changeset for `@enbox/auth` (minor bump) that was not included in #578