### PR TITLE
feat(dids): add DidWeb.create(), getSigningMethod(), and import()

### DIFF
--- a/packages/agent/src/did-api.ts
+++ b/packages/agent/src/did-api.ts
@@ -8,6 +8,7 @@ import type {
   DidResolutionResult,
   DidResolverCache,
   DidVerificationMethod,
+  DidWebCreateOptions,
   PortableDid,
 } from '@enbox/dids';
 
@@ -77,6 +78,7 @@ export interface DidCreateParams<
 export interface DidMethodCreateOptions<TKeyManager> {
   dht: DidDhtCreateOptions<TKeyManager>;
   jwk: DidJwkCreateOptions<TKeyManager>;
+  web: DidWebCreateOptions<TKeyManager>;
 }
 
 export interface DidApiParams {

--- a/packages/dids/src/methods/did-web.ts
+++ b/packages/dids/src/methods/did-web.ts
@@ -1,8 +1,30 @@
-import type { DidDocument, DidResolutionOptions, DidResolutionResult } from '../types/did-core.js';
+import type {
+  InferKeyGeneratorAlgorithm,
+  KeyIdentifier,
+  KeyImporterExporter,
+  KeyManager,
+  KmsExportKeyParams,
+  KmsImportKeyParams,
+} from '@enbox/crypto';
 
+import { LocalKeyManager } from '@enbox/crypto';
+
+import type { PortableDid } from '../types/portable-did.js';
+import type { DidCreateOptions, DidCreateVerificationMethod } from './did-method.js';
+import type {
+  DidDocument,
+  DidResolutionOptions,
+  DidResolutionResult,
+  DidService,
+  DidVerificationMethod,
+} from '../types/did-core.js';
+
+import { BearerDid } from '../bearer-did.js';
 import { Did } from '../did.js';
 import { DidMethod } from './did-method.js';
 import { EMPTY_DID_RESOLUTION_RESULT } from '../types/did-resolution.js';
+import { extractDidFragment } from '../utils.js';
+import { DidError, DidErrorCode } from '../did-error.js';
 
 /** Default fetch timeout for DID document retrieval (30 seconds). */
 const FETCH_TIMEOUT_MS = 30_000;
@@ -45,10 +67,74 @@ function isPrivateHostname(hostname: string): boolean {
 }
 
 /**
+ * Defines the set of options available when creating a new Decentralized Identifier (DID) with the
+ * 'did:web' method.
+ *
+ * Unlike self-certifying DID methods (e.g., `did:jwk`, `did:dht`), `did:web` requires external
+ * information — a domain and an optional path — to form the DID URI. The `create()` method
+ * generates keys locally and constructs a DID document, but does NOT publish it. Registration
+ * with a `did:web` hosting server is the caller's responsibility.
+ *
+ * @example
+ * ```ts
+ * // Create a did:web DID for enbox.id/users/alice
+ * const did = await DidWeb.create({
+ *   options: {
+ *     domain: 'enbox.id',
+ *     path:   'users:alice',
+ *   }
+ * });
+ * // did.uri === 'did:web:enbox.id:users:alice'
+ * ```
+ */
+export interface DidWebCreateOptions<TKms> extends DidCreateOptions<TKms> {
+  /**
+   * The domain (and optional port) that will host the DID document.
+   *
+   * Ports are percent-encoded per the did:web spec (e.g., `localhost%3A3000`).
+   * This value forms the first segment of the method-specific identifier.
+   *
+   * @example 'enbox.id'
+   * @example 'localhost%3A3000'
+   */
+  domain: string;
+
+  /**
+   * Optional colon-separated path segments appended after the domain.
+   *
+   * When present the DID document is served at `https://<domain>/<path>/did.json`.
+   * When absent the DID document is served at `https://<domain>/.well-known/did.json`.
+   *
+   * @example 'users:alice'   // → did:web:enbox.id:users:alice
+   * @example 'orgs:acme'     // → did:web:enbox.id:orgs:acme
+   */
+  path?: string;
+
+  /**
+   * Optionally specify the algorithm to be used for key generation of the primary
+   * verification method. Defaults to Ed25519. Mutually exclusive with
+   * `verificationMethods`.
+   */
+  algorithm?: TKms extends KeyManager
+    ? InferKeyGeneratorAlgorithm<TKms>
+    : InferKeyGeneratorAlgorithm<LocalKeyManager>;
+
+  /**
+   * Optional services to include in the DID document (e.g., DWN endpoints).
+   */
+  services?: DidService[];
+}
+
+/**
  * The `DidWeb` class provides an implementation of the `did:web` DID method.
  *
  * Features:
+ * - DID Creation: Create new `did:web` DIDs with local key generation.
+ * - DID Key Management: Instantiate a DID object from an existing verification method key set or
+ *                       a key in a Key Management System (KMS). If supported by the KMS, a DID's
+ *                       key can be exported to a portable DID format.
  * - DID Resolution: Resolve a `did:web` to its corresponding DID Document.
+ * - Signature Operations: Sign and verify messages using keys associated with a DID.
  *
  * @remarks
  * The `did:web` method uses a web domain's existing reputation and aims to integrate decentralized
@@ -56,12 +142,30 @@ function isPrivateHostname(hostname: string): boolean {
  * security models and domain ownership to provide accessible, interoperable digital identity
  * management.
  *
+ * Unlike self-certifying methods, `did:web` creation generates keys and a DID document locally
+ * but does NOT publish them. The caller is responsible for registering the DID document with
+ * the hosting server.
+ *
  * @see {@link https://w3c-ccg.github.io/did-method-web/ | DID Web Specification}
  *
  * @example
  * ```ts
+ * // DID Creation
+ * const did = await DidWeb.create({
+ *   options: { domain: 'enbox.id', path: 'users:alice' }
+ * });
+ *
  * // DID Resolution
- * const resolutionResult = await DidWeb.resolve({ did: did.uri });
+ * const resolutionResult = await DidWeb.resolve('did:web:enbox.id:users:alice');
+ *
+ * // Signature Operations
+ * const signer = await did.getSigner();
+ * const signature = await signer.sign({ data: new TextEncoder().encode('Message') });
+ * const isValid = await signer.verify({ data: new TextEncoder().encode('Message'), signature });
+ *
+ * // Import / Export
+ * const portableDid = await did.export();
+ * const imported = await DidWeb.import({ portableDid });
  * ```
  */
 export class DidWeb extends DidMethod {
@@ -70,6 +174,214 @@ export class DidWeb extends DidMethod {
    * Name of the DID method, as defined in the DID Web specification.
    */
   public static methodName = 'web';
+
+  /**
+   * Creates a new DID using the `did:web` method formed from a newly generated key.
+   *
+   * @remarks
+   * The DID URI is formed from the given `domain` and optional `path`, prefixed with `did:web:`.
+   * Keys are generated locally and a DID document is constructed, but the document is NOT
+   * published to any server. Registration with a `did:web` hosting server is the caller's
+   * responsibility.
+   *
+   * Notes:
+   * - If no `options.algorithm` or `options.verificationMethods` are given, a new Ed25519 key is
+   *   generated by default.
+   * - The `algorithm` and `verificationMethods` options are mutually exclusive.
+   * - The `domain` option is required.
+   *
+   * @example
+   * ```ts
+   * // DID Creation
+   * const did = await DidWeb.create({
+   *   options: { domain: 'enbox.id', path: 'users:alice' }
+   * });
+   * // did.uri === 'did:web:enbox.id:users:alice'
+   *
+   * // DID Creation with a KMS
+   * const keyManager = new LocalKeyManager();
+   * const did = await DidWeb.create({
+   *   keyManager,
+   *   options: { domain: 'enbox.id', path: 'users:alice' }
+   * });
+   * ```
+   *
+   * @param params - The parameters for the create operation.
+   * @param params.keyManager - Optionally specify a Key Management System (KMS) used to generate
+   *                            keys and sign data.
+   * @param params.options - Parameters that specify the domain, path, algorithm, verification
+   *                         methods, and services for the new DID.
+   * @returns A Promise resolving to a {@link BearerDid} object representing the new DID.
+   */
+  public static async create<TKms extends KeyManager | undefined = undefined>({
+    keyManager = new LocalKeyManager(),
+    options,
+  }: {
+    keyManager?: TKms;
+    options: DidWebCreateOptions<TKms>;
+  }): Promise<BearerDid> {
+    // Validate required options.
+    if (!options.domain) {
+      throw new DidError(DidErrorCode.InvalidDid, `The 'domain' option is required for did:web creation`);
+    }
+
+    // Validate that `algorithm` and `verificationMethods` are not both given.
+    if (options.algorithm && options.verificationMethods) {
+      throw new Error(`The 'algorithm' and 'verificationMethods' options are mutually exclusive`);
+    }
+
+    // Build the DID URI from the domain and optional path.
+    const identifier = options.path
+      ? `${options.domain}:${options.path}`
+      : options.domain;
+    const didUri = `did:${DidWeb.methodName}:${identifier}`;
+
+    // Validate the constructed DID URI.
+    const parsedDid = Did.parse(didUri);
+    if (!parsedDid) {
+      throw new DidError(DidErrorCode.InvalidDid, `The constructed DID URI is invalid: ${didUri}`);
+    }
+
+    // Determine verification methods to create.
+    const verificationMethodsToAdd: DidCreateVerificationMethod<TKms>[] =
+      options.verificationMethods ?? [{
+        algorithm : (options.algorithm ?? 'Ed25519') as DidCreateVerificationMethod<TKms>['algorithm'],
+        purposes  : ['authentication', 'assertionMethod', 'capabilityDelegation', 'capabilityInvocation'],
+      }];
+
+    // Begin constructing the DID Document.
+    const document: DidDocument = {
+      '@context' : ['https://www.w3.org/ns/did/v1'],
+      id         : didUri,
+    };
+
+    // Generate key material for each verification method and add to the document.
+    for (let i = 0; i < verificationMethodsToAdd.length; i++) {
+      const vmOptions = verificationMethodsToAdd[i];
+
+      // Generate a random key.
+      const keyUri = await keyManager.generateKey({ algorithm: vmOptions.algorithm });
+      const publicKey = await keyManager.getPublicKey({ keyUri });
+
+      // Use the given ID or default to `key-N`.
+      const fragment = vmOptions.id?.split('#').pop() ?? `key-${i}`;
+      const methodId = `${didUri}#${fragment}`;
+
+      // Initialize the `verificationMethod` array if needed.
+      document.verificationMethod ??= [];
+
+      // Add the verification method to the DID document.
+      document.verificationMethod.push({
+        id           : methodId,
+        type         : 'JsonWebKey',
+        controller   : vmOptions.controller ?? didUri,
+        publicKeyJwk : publicKey,
+      });
+
+      // Add the verification method to the specified purpose properties.
+      for (const purpose of vmOptions.purposes ?? []) {
+        document[purpose] ??= [];
+        document[purpose]!.push(methodId);
+      }
+    }
+
+    // Add services, if any.
+    if (options.services) {
+      document.service = options.services.map(service => ({
+        ...service,
+        id: `${didUri}#${service.id.split('#').pop()}`,
+      }));
+    }
+
+    // Create the BearerDid object. Metadata indicates unpublished state.
+    const did = new BearerDid({
+      uri      : didUri,
+      document,
+      metadata : { published: false },
+      keyManager,
+    });
+
+    return did;
+  }
+
+  /**
+   * Given the W3C DID Document of a `did:web` DID, return the verification method that will be
+   * used for signing messages and credentials. If given, the `methodId` parameter is used to
+   * select the verification method. If not given, the first verification method referenced in
+   * `assertionMethod` is used, falling back to the first verification method in the document.
+   *
+   * @param params - The parameters for the `getSigningMethod` operation.
+   * @param params.didDocument - DID Document to get the verification method from.
+   * @param params.methodId - ID of the verification method to use for signing.
+   * @returns Verification method to use for signing.
+   */
+  public static async getSigningMethod({ didDocument, methodId }: {
+    didDocument: DidDocument;
+    methodId?: string;
+  }): Promise<DidVerificationMethod> {
+    // Verify the DID method is supported.
+    const parsedDid = Did.parse(didDocument.id);
+    if (parsedDid && parsedDid.method !== this.methodName) {
+      throw new DidError(DidErrorCode.MethodNotSupported, `Method not supported: ${parsedDid.method}`);
+    }
+
+    // Attempt to find a verification method that matches the given method ID, or if not given,
+    // find the first verification method intended for signing claims.
+    const targetFragment = extractDidFragment(methodId)
+      ?? extractDidFragment(didDocument.assertionMethod?.[0]);
+
+    const verificationMethod = targetFragment
+      ? didDocument.verificationMethod?.find(vm => extractDidFragment(vm.id) === targetFragment)
+      : didDocument.verificationMethod?.[0];
+
+    if (!(verificationMethod && verificationMethod.publicKeyJwk)) {
+      throw new DidError(
+        DidErrorCode.InternalError,
+        'A verification method intended for signing could not be determined from the DID Document'
+      );
+    }
+
+    return verificationMethod;
+  }
+
+  /**
+   * Instantiates a {@link BearerDid} object for the DID Web method from a given
+   * {@link PortableDid}.
+   *
+   * This method allows for the creation of a `BearerDid` object using a previously created DID's
+   * key material, DID document, and metadata.
+   *
+   * @example
+   * ```ts
+   * // Export an existing BearerDid to PortableDid format.
+   * const portableDid = await did.export();
+   * // Reconstruct a BearerDid object from the PortableDid.
+   * const did = await DidWeb.import({ portableDid });
+   * ```
+   *
+   * @param params - The parameters for the import operation.
+   * @param params.portableDid - The PortableDid object to import.
+   * @param params.keyManager - Optionally specify an external Key Management System (KMS) used to
+   *                            generate keys and sign data. If not given, a new
+   *                            {@link LocalKeyManager} instance will be created and used.
+   * @returns A Promise resolving to a `BearerDid` object representing the DID formed from the
+   *          provided keys.
+   */
+  public static async import({ portableDid, keyManager = new LocalKeyManager() }: {
+    keyManager?: KeyManager & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
+    portableDid: PortableDid;
+  }): Promise<BearerDid> {
+    // Verify the DID method is supported.
+    const parsedDid = Did.parse(portableDid.uri);
+    if (parsedDid?.method !== DidWeb.methodName) {
+      throw new DidError(DidErrorCode.MethodNotSupported, `Method not supported`);
+    }
+
+    // Use the given PortableDid to construct the BearerDid object.
+    const did = await BearerDid.import({ portableDid, keyManager });
+
+    return did;
+  }
 
   /**
    * Resolves a `did:web` identifier to a DID Document.

--- a/packages/dids/tests/methods/did-web.test.ts
+++ b/packages/dids/tests/methods/did-web.test.ts
@@ -3,6 +3,7 @@ import type { UnwrapPromise } from '@enbox/common';
 import DidWebResolveTestVector from '../fixtures/web5-spec-vectors/did_web/resolve.json' with { type: 'json' };
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
+import { DidErrorCode } from '../../src/did-error.js';
 import { DidWeb } from '../../src/methods/did-web.js';
 
 // Helper function to create a mocked fetch response that fails and returns a 404 Not Found.
@@ -39,6 +40,237 @@ describe('DidWeb', () => {
       expect(resolutionResult.didResolutionMetadata.error).toBe('notFound');
 
       fetchStub.mockRestore();
+    });
+  });
+
+  describe('create()', () => {
+    it('should create a DID with domain only', async () => {
+      const did = await DidWeb.create({
+        options: { domain: 'enbox.id' }
+      });
+
+      expect(did.uri).toBe('did:web:enbox.id');
+      expect(did.document.id).toBe('did:web:enbox.id');
+      expect(did.document['@context']).toEqual(['https://www.w3.org/ns/did/v1']);
+      expect(did.document.verificationMethod).toHaveLength(1);
+      expect(did.document.verificationMethod![0].publicKeyJwk).toBeDefined();
+      expect(did.document.verificationMethod![0].id).toBe('did:web:enbox.id#key-0');
+      expect(did.document.verificationMethod![0].type).toBe('JsonWebKey');
+      expect(did.document.verificationMethod![0].controller).toBe('did:web:enbox.id');
+      expect(did.metadata.published).toBe(false);
+    });
+
+    it('should create a DID with domain and path', async () => {
+      const did = await DidWeb.create({
+        options: { domain: 'enbox.id', path: 'users:alice' }
+      });
+
+      expect(did.uri).toBe('did:web:enbox.id:users:alice');
+      expect(did.document.id).toBe('did:web:enbox.id:users:alice');
+      expect(did.document.verificationMethod![0].id).toBe('did:web:enbox.id:users:alice#key-0');
+    });
+
+    it('should add default verification relationships', async () => {
+      const did = await DidWeb.create({
+        options: { domain: 'example.com', path: 'orgs:acme' }
+      });
+
+      const keyId = `${did.uri}#key-0`;
+      expect(did.document.authentication).toContain(keyId);
+      expect(did.document.assertionMethod).toContain(keyId);
+      expect(did.document.capabilityDelegation).toContain(keyId);
+      expect(did.document.capabilityInvocation).toContain(keyId);
+    });
+
+    it('should create a DID with custom verification methods', async () => {
+      const did = await DidWeb.create({
+        options: {
+          domain              : 'example.com',
+          verificationMethods : [
+            { algorithm: 'Ed25519', purposes: ['authentication', 'assertionMethod'] },
+            { algorithm: 'secp256k1', purposes: ['authentication'] },
+          ],
+        }
+      });
+
+      expect(did.document.verificationMethod).toHaveLength(2);
+      expect(did.document.verificationMethod![0].id).toBe('did:web:example.com#key-0');
+      expect(did.document.verificationMethod![1].id).toBe('did:web:example.com#key-1');
+      expect(did.document.authentication).toHaveLength(2);
+      expect(did.document.assertionMethod).toHaveLength(1);
+    });
+
+    it('should create a DID with services', async () => {
+      const did = await DidWeb.create({
+        options: {
+          domain   : 'enbox.id',
+          path     : 'users:alice',
+          services : [{
+            id              : 'dwn',
+            type            : 'DecentralizedWebNode',
+            serviceEndpoint : ['https://dwn.enbox.id'],
+          }],
+        }
+      });
+
+      expect(did.document.service).toHaveLength(1);
+      expect(did.document.service![0].id).toBe('did:web:enbox.id:users:alice#dwn');
+      expect(did.document.service![0].type).toBe('DecentralizedWebNode');
+    });
+
+    it('should support percent-encoded port in domain', async () => {
+      const did = await DidWeb.create({
+        options: { domain: 'localhost%3A3000', path: 'users:test' }
+      });
+
+      expect(did.uri).toBe('did:web:localhost%3A3000:users:test');
+    });
+
+    it('should throw when domain is empty', async () => {
+      await expect(
+        DidWeb.create({ options: { domain: '' } })
+      ).rejects.toThrow(DidErrorCode.InvalidDid);
+    });
+
+    it('should throw when algorithm and verificationMethods are both given', async () => {
+      await expect(
+        DidWeb.create({
+          options: {
+            domain              : 'example.com',
+            algorithm           : 'Ed25519',
+            verificationMethods : [{ algorithm: 'Ed25519' }],
+          }
+        })
+      ).rejects.toThrow('mutually exclusive');
+    });
+
+    it('should support export and import round-trip', async () => {
+      const did = await DidWeb.create({
+        options: { domain: 'enbox.id', path: 'users:roundtrip' }
+      });
+
+      // Export to PortableDid format.
+      const portableDid = await did.export();
+      expect(portableDid.uri).toBe(did.uri);
+      expect(portableDid.privateKeys).toBeDefined();
+      expect(portableDid.privateKeys!.length).toBeGreaterThan(0);
+
+      // Import back from PortableDid.
+      const imported = await DidWeb.import({ portableDid });
+      expect(imported.uri).toBe(did.uri);
+      expect(imported.document.id).toBe(did.document.id);
+    });
+
+    it('should support signing and verification', async () => {
+      const did = await DidWeb.create({
+        options: { domain: 'enbox.id', path: 'users:signer' }
+      });
+
+      const signer = await did.getSigner();
+      expect(signer.algorithm).toBeDefined();
+      expect(signer.keyId).toBe(`${did.uri}#key-0`);
+
+      const data = new TextEncoder().encode('test message');
+      const signature = await signer.sign({ data });
+      expect(signature).toBeInstanceOf(Uint8Array);
+      expect(signature.length).toBeGreaterThan(0);
+
+      const isValid = await signer.verify({ data, signature });
+      expect(isValid).toBe(true);
+
+      // Verification should fail with tampered data.
+      const tampered = new TextEncoder().encode('tampered message');
+      const isInvalid = await signer.verify({ data: tampered, signature });
+      expect(isInvalid).toBe(false);
+    });
+  });
+
+  describe('getSigningMethod()', () => {
+    it('should return the first assertionMethod verification method by default', async () => {
+      const did = await DidWeb.create({
+        options: { domain: 'example.com' }
+      });
+
+      const signingMethod = await DidWeb.getSigningMethod({ didDocument: did.document });
+      expect(signingMethod.id).toBe(`${did.uri}#key-0`);
+      expect(signingMethod.publicKeyJwk).toBeDefined();
+    });
+
+    it('should return a specific verification method by methodId', async () => {
+      const did = await DidWeb.create({
+        options: {
+          domain              : 'example.com',
+          verificationMethods : [
+            { algorithm: 'Ed25519', purposes: ['assertionMethod'], id: 'sig' },
+            { algorithm: 'Ed25519', purposes: ['authentication'], id: 'auth' },
+          ],
+        }
+      });
+
+      const signingMethod = await DidWeb.getSigningMethod({
+        didDocument : did.document,
+        methodId    : `${did.uri}#auth`,
+      });
+      expect(signingMethod.id).toBe(`${did.uri}#auth`);
+    });
+
+    it('should fall back to the first verification method when no assertionMethod exists', async () => {
+      const did = await DidWeb.create({
+        options: {
+          domain              : 'example.com',
+          verificationMethods : [
+            { algorithm: 'Ed25519', purposes: ['authentication'] },
+          ],
+        }
+      });
+
+      const signingMethod = await DidWeb.getSigningMethod({ didDocument: did.document });
+      expect(signingMethod.id).toBe(`${did.uri}#key-0`);
+    });
+
+    it('should throw for wrong DID method', async () => {
+      await expect(
+        DidWeb.getSigningMethod({
+          didDocument: {
+            id                 : 'did:jwk:test',
+            verificationMethod : [{ id: 'did:jwk:test#0', type: 'JsonWebKey', controller: 'did:jwk:test', publicKeyJwk: { kty: 'OKP' } }],
+          }
+        })
+      ).rejects.toThrow(DidErrorCode.MethodNotSupported);
+    });
+
+    it('should throw when no verification method is found', async () => {
+      await expect(
+        DidWeb.getSigningMethod({
+          didDocument: { id: 'did:web:example.com' }
+        })
+      ).rejects.toThrow(DidErrorCode.InternalError);
+    });
+  });
+
+  describe('import()', () => {
+    it('should import a PortableDid for did:web', async () => {
+      const did = await DidWeb.create({
+        options: { domain: 'enbox.id', path: 'users:importtest' }
+      });
+
+      const portableDid = await did.export();
+      const imported = await DidWeb.import({ portableDid });
+
+      expect(imported.uri).toBe(did.uri);
+      expect(imported.document).toEqual(did.document);
+    });
+
+    it('should throw for wrong DID method', async () => {
+      await expect(
+        DidWeb.import({
+          portableDid: {
+            uri      : 'did:jwk:test',
+            document : { id: 'did:jwk:test' },
+            metadata : {},
+          }
+        })
+      ).rejects.toThrow(DidErrorCode.MethodNotSupported);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds full lifecycle support to the `did:web` method in `@enbox/dids`, bringing it to parity with `DidJwk` and `DidDht`:

- **`DidWeb.create()`** — generates keys locally and constructs a DID document from a given `domain` and optional `path`. Does NOT publish; registration with a `did:web` hosting server is the caller's responsibility.
- **`DidWeb.getSigningMethod()`** — selects the verification method for signing, preferring `assertionMethod`, with fallback to the first VM in the document.
- **`DidWeb.import()`** — reconstructs a `BearerDid` from a `PortableDid`, enabling export/import round-trips.
- **`DidWebCreateOptions`** — typed options interface (`domain`, `path`, `algorithm`, `verificationMethods`, `services`).
- **Agent integration** — registers `DidWebCreateOptions` in `DidMethodCreateOptions` so `agent.did.create({ method: 'web', ... })` is properly typed.

## Motivation

This is the client-side counterpart to the new [`did-web-server`](https://github.com/enboxorg/did-web-server) — a standalone, crypto-authorized DID document hosting server for `enbox.id`. Together they enable the full `did:web` workflow: create keys locally → register with the server (Ed25519 proof-authorized) → resolve via standard `did:web` resolution.

## Changes

| File | Change |
|---|---|
| `packages/dids/src/methods/did-web.ts` | Added `create()`, `getSigningMethod()`, `import()`, `DidWebCreateOptions` interface |
| `packages/dids/tests/methods/did-web.test.ts` | Added 17 new tests (creation, signing, round-trip, error cases) |
| `packages/agent/src/did-api.ts` | Added `web: DidWebCreateOptions<TKeyManager>` to `DidMethodCreateOptions` |

## Testing

- 19 tests pass in `did-web.test.ts` (17 new + 2 existing resolve tests)
- Full monorepo lint passes
- `@enbox/dids` builds cleanly