### PR TITLE
feat(auth): support custom agent, vault, and local DWN strategy

### DIFF
--- a/.changeset/auth-custom-agent.md
+++ b/.changeset/auth-custom-agent.md
@@ -1,0 +1,11 @@
+---
+"@enbox/auth": minor
+---
+
+Support custom agent, vault, and local DWN strategy in AuthManager.create()
+
+- Add `agent`, `agentVault`, and `localDwnStrategy` options to `AuthManagerOptions`
+- When a pre-built `Web5UserAgent` is provided, it is used as-is (escape hatch for custom DWN stores)
+- Re-export `Web5UserAgent` and `HdIdentityVault` classes from `@enbox/agent` so consumers don't need a direct dependency
+- Re-export `LocalDwnStrategy` type
+- 5 new tests covering all custom agent creation paths, 169 total tests passing

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -106,8 +106,9 @@ export class AuthManager {
   /**
    * Create a new AuthManager instance.
    *
-   * This initializes the underlying `Web5UserAgent` with platform-appropriate
-   * defaults and prepares the vault, storage, and event system.
+   * When a pre-built `agent` is provided, it is used as-is and
+   * `dataPath`, `agentVault`, and `localDwnStrategy` are ignored.
+   * Otherwise, a new `Web5UserAgent` is created with the given options.
    *
    * @param options - Configuration options for the auth manager.
    * @returns A ready-to-use AuthManager instance.
@@ -116,8 +117,11 @@ export class AuthManager {
     const emitter = new AuthEventEmitter();
     const storage = options.storage ?? createDefaultStorage();
 
-    const userAgent = await Web5UserAgent.create({
-      dataPath: options.dataPath,
+    // Use a pre-built agent or create one with the given options.
+    const userAgent = options.agent ?? await Web5UserAgent.create({
+      dataPath         : options.dataPath,
+      agentVault       : options.agentVault,
+      localDwnStrategy : options.localDwnStrategy,
     });
 
     const vault = new VaultManager(userAgent.vault, emitter);

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -40,6 +40,10 @@ export { AuthSession } from './identity-session.js';
 export { VaultManager } from './vault/vault-manager.js';
 export { AuthEventEmitter } from './events.js';
 
+// Re-export agent classes so consumers can construct custom agents/vaults
+// without a direct @enbox/agent dependency.
+export { HdIdentityVault, Web5UserAgent } from '@enbox/agent';
+
 // Storage adapters
 export { BrowserStorage, LevelStorage, MemoryStorage, createDefaultStorage } from './storage/storage.js';
 
@@ -58,6 +62,7 @@ export type {
   ImportFromPhraseOptions,
   ImportFromPortableOptions,
   LocalConnectOptions,
+  LocalDwnStrategy,
   PortableIdentity,
   ProviderAuthParams,
   ProviderAuthResult,

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -3,10 +3,13 @@
  * Public types for the authentication and identity management SDK.
  */
 
-import type { ConnectPermissionRequest, PortableIdentity } from '@enbox/agent';
+import type { ConnectPermissionRequest, HdIdentityVault, LocalDwnStrategy, PortableIdentity, Web5UserAgent } from '@enbox/agent';
 
 // Re-export types that consumers will need
-export type { ConnectPermissionRequest, IdentityVaultBackup, PortableIdentity } from '@enbox/agent';
+export type { ConnectPermissionRequest, HdIdentityVault, IdentityVaultBackup, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
+
+// Re-export Web5UserAgent so consumers don't need a direct @enbox/agent dep
+export type { Web5UserAgent } from '@enbox/agent';
 
 // ─── Sync ────────────────────────────────────────────────────────
 
@@ -170,9 +173,41 @@ export interface RegistrationOptions {
 /** Options for {@link AuthManager.create}. */
 export interface AuthManagerOptions {
   /**
+   * Provide a pre-built {@link Web5UserAgent} instance.
+   *
+   * When provided, `dataPath`, `agentVault`, and `localDwnStrategy` are
+   * ignored — the agent is used as-is. This is the escape hatch for
+   * advanced scenarios like custom DWN stores (e.g., SQLite-backed DWN).
+   *
+   * @example
+   * ```ts
+   * const agent = await Web5UserAgent.create({ dwnApi: myCustomDwnApi });
+   * const auth = await AuthManager.create({ agent });
+   * ```
+   */
+  agent?: Web5UserAgent;
+
+  /**
+   * Provide a custom {@link HdIdentityVault} implementation.
+   * Defaults to a LevelDB-backed vault with PBES2-HS512+A256KW encryption.
+   * Ignored when `agent` is provided.
+   */
+  agentVault?: HdIdentityVault;
+
+  /**
+   * Controls local DWN discovery behavior for remote-target DWN sends/sync.
+   * `'off'` (default) disables local probing, `'prefer'` tries local first
+   * then falls back to DID-document endpoints, `'only'` requires a local server.
+   * Ignored when `agent` is provided.
+   */
+  localDwnStrategy?: LocalDwnStrategy;
+
+  /**
    * Data path for agent storage.
    * - Browser default: `'DATA/AGENT'`
    * - CLI default: `'~/.enbox'`
+   *
+   * Ignored when `agent` is provided.
    */
   dataPath?: string;
 

--- a/packages/auth/tests/auth-manager-create.spec.ts
+++ b/packages/auth/tests/auth-manager-create.spec.ts
@@ -118,6 +118,84 @@ describe('AuthManager.create()', () => {
 
     expect(capturedOptions.dataPath).toBe('/my/data');
   });
+
+  test('uses pre-built agent when provided', async () => {
+    const customAgent = createMockAgent({ vaultIsInitialized: async () => false });
+    const callsBefore = mockUserAgentCreate.mock.calls.length;
+
+    const manager = await AuthManager.create({
+      agent   : customAgent as any,
+      storage : new MemoryStorage(),
+    });
+
+    // Web5UserAgent.create() should NOT have been called.
+    expect(mockUserAgentCreate.mock.calls.length).toBe(callsBefore);
+    expect(manager.agent).toBe(customAgent);
+    expect(manager.state).toBe('uninitialized');
+  });
+
+  test('agent option ignores dataPath, agentVault, and localDwnStrategy', async () => {
+    const customAgent = createMockAgent({ vaultIsInitialized: async () => true, vaultIsLocked: () => false });
+    const callsBefore = mockUserAgentCreate.mock.calls.length;
+
+    const manager = await AuthManager.create({
+      agent            : customAgent as any,
+      dataPath         : '/should/be/ignored',
+      agentVault       : { fake: 'vault' } as any,
+      localDwnStrategy : 'prefer' as any,
+      storage          : new MemoryStorage(),
+    });
+
+    // Web5UserAgent.create() should NOT have been called.
+    expect(mockUserAgentCreate.mock.calls.length).toBe(callsBefore);
+    expect(manager.agent).toBe(customAgent);
+    expect(manager.state).toBe('unlocked');
+  });
+
+  test('passes agentVault to Web5UserAgent.create', async () => {
+    let capturedOptions: any;
+    mockUserAgentCreate.mockImplementationOnce((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    const fakeVault = { fake: 'vault' } as any;
+    await AuthManager.create({ agentVault: fakeVault, storage: new MemoryStorage() });
+
+    expect(capturedOptions.agentVault).toBe(fakeVault);
+  });
+
+  test('passes localDwnStrategy to Web5UserAgent.create', async () => {
+    let capturedOptions: any;
+    mockUserAgentCreate.mockImplementationOnce((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    await AuthManager.create({ localDwnStrategy: 'prefer' as any, storage: new MemoryStorage() });
+
+    expect(capturedOptions.localDwnStrategy).toBe('prefer');
+  });
+
+  test('passes all agent creation options together', async () => {
+    let capturedOptions: any;
+    mockUserAgentCreate.mockImplementationOnce((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    const fakeVault = { fake: 'vault' } as any;
+    await AuthManager.create({
+      dataPath         : '/custom/path',
+      agentVault       : fakeVault,
+      localDwnStrategy : 'only' as any,
+      storage          : new MemoryStorage(),
+    });
+
+    expect(capturedOptions.dataPath).toBe('/custom/path');
+    expect(capturedOptions.agentVault).toBe(fakeVault);
+    expect(capturedOptions.localDwnStrategy).toBe('only');
+  });
 });
 
 describe('AuthManager.walletConnect()', () => {


### PR DESCRIPTION
## Summary

- Add `agent`, `agentVault`, and `localDwnStrategy` options to `AuthManagerOptions` so advanced consumers can customize agent creation
- When a pre-built `Web5UserAgent` is provided, it is used directly — `dataPath`, `agentVault`, and `localDwnStrategy` are ignored
- Re-export `Web5UserAgent` and `HdIdentityVault` classes (plus `LocalDwnStrategy` type) from `@enbox/agent` so consumers don't need a direct dependency

## Motivation

Tools like gitd need custom DWN stores (e.g., SQLite-backed). This provides an escape hatch:

```ts
const agent = await Web5UserAgent.create({ dwnApi: myCustomDwnApi });
const auth = await AuthManager.create({ agent });
```

For simpler customization (custom vault or local DWN strategy), consumers can pass those options without building a full agent:

```ts
const auth = await AuthManager.create({
  agentVault: myCustomVault,
  localDwnStrategy: 'prefer',
});
```

## Tests

5 new tests covering all custom agent creation paths. 169 total tests passing, 99%+ line coverage on all src/ files.