### PR TITLE
feat(agent,auth): integrate dwn://register browser discovery with @enbox/auth

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -220,6 +220,24 @@ export class AgentDwnApi {
   }
 
   /**
+   * Inject a cached local DWN endpoint (e.g. from a `dwn://register`
+   * browser redirect or from persisted storage). The endpoint is validated
+   * via `GET /info` before being accepted.
+   *
+   * @param endpoint - The local DWN server base URL.
+   * @returns `true` if the endpoint was validated and cached, `false` otherwise.
+   * @see https://github.com/enboxorg/enbox/issues/589
+   */
+  public async setCachedLocalDwnEndpoint(endpoint: string): Promise<boolean> {
+    this._localDwnDiscovery ??= new LocalDwnDiscovery(
+      this.agent.rpc,
+      10_000,
+      AgentDwnApi._tryCreateDiscoveryFile(),
+    );
+    return this._localDwnDiscovery.setCachedEndpoint(endpoint);
+  }
+
+  /**
    * Resolves the DWN service endpoint URLs for the given target DID, optionally
    * prepending a local DWN server endpoint when local discovery is enabled and
    * the target is a locally-managed DID.

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -102,6 +102,53 @@ describe('AgentDwnApi', () => {
     });
   });
 
+  describe('setCachedLocalDwnEndpoint()', () => {
+    it('should return true and cache the endpoint when the server is valid', async () => {
+      const mockDwn = ({} as unknown) as Dwn;
+      const rpcStub = sinon.stub().resolves({ server: '@enbox/dwn-server' });
+      const mockAgent = { rpc: { getServerInfo: rpcStub } } as any;
+      const dwnApi = new AgentDwnApi({ agent: mockAgent, dwn: mockDwn });
+
+      const result = await dwnApi.setCachedLocalDwnEndpoint('http://127.0.0.1:55557');
+      expect(result).toBe(true);
+      expect(rpcStub.calledOnce).toBe(true);
+      expect(rpcStub.firstCall.args[0]).toBe('http://127.0.0.1:55557');
+    });
+
+    it('should return false when the server is not reachable', async () => {
+      const mockDwn = ({} as unknown) as Dwn;
+      const rpcStub = sinon.stub().rejects(new Error('connection refused'));
+      const mockAgent = { rpc: { getServerInfo: rpcStub } } as any;
+      const dwnApi = new AgentDwnApi({ agent: mockAgent, dwn: mockDwn });
+
+      const result = await dwnApi.setCachedLocalDwnEndpoint('http://127.0.0.1:9999');
+      expect(result).toBe(false);
+    });
+
+    it('should return false when the server is not @enbox/dwn-server', async () => {
+      const mockDwn = ({} as unknown) as Dwn;
+      const rpcStub = sinon.stub().resolves({ server: 'some-other-server' });
+      const mockAgent = { rpc: { getServerInfo: rpcStub } } as any;
+      const dwnApi = new AgentDwnApi({ agent: mockAgent, dwn: mockDwn });
+
+      const result = await dwnApi.setCachedLocalDwnEndpoint('http://127.0.0.1:55557');
+      expect(result).toBe(false);
+    });
+
+    it('should lazily initialize LocalDwnDiscovery when _localDwnDiscovery is undefined', async () => {
+      const mockDwn = ({} as unknown) as Dwn;
+      const rpcStub = sinon.stub().resolves({ server: '@enbox/dwn-server' });
+      const mockAgent = { rpc: { getServerInfo: rpcStub } } as any;
+      const dwnApi = new AgentDwnApi({ dwn: mockDwn });
+      dwnApi.agent = mockAgent;
+
+      // After setting agent, _localDwnDiscovery is initialized via the setter.
+      // Calling setCachedLocalDwnEndpoint should work without errors.
+      const result = await dwnApi.setCachedLocalDwnEndpoint('http://127.0.0.1:55557');
+      expect(result).toBe(true);
+    });
+  });
+
   describe('getDwnEndpointUrlsForTarget()', () => {
     const localDid = 'did:jwk:local';
 

--- a/packages/auth/src/flows/dwn-discovery.ts
+++ b/packages/auth/src/flows/dwn-discovery.ts
@@ -1,0 +1,146 @@
+/**
+ * Local DWN discovery integration for the `dwn://register` browser flow.
+ *
+ * This module bridges the `dwn://register` protocol handler (implemented in
+ * `@enbox/agent`) with the `@enbox/auth` storage and session lifecycle:
+ *
+ * 1. **On page load**: Check the URL fragment for a `DwnDiscoveryPayload`
+ *    delivered by the `dwn://register` redirect from electrobun-dwn.
+ * 2. **Persist the endpoint** in the auth storage so subsequent page loads
+ *    can restore it without re-triggering the redirect.
+ * 3. **Inject the endpoint** into the agent's `AgentDwnApi` so that
+ *    `LocalDwnDiscovery` uses it for routing.
+ *
+ * @see https://github.com/enboxorg/enbox/issues/589
+ * @module
+ */
+
+import type { Web5UserAgent } from '@enbox/agent';
+
+import { readDwnDiscoveryPayloadFromUrl } from '@enbox/agent';
+
+import { STORAGE_KEYS } from '../types.js';
+import type { StorageAdapter } from '../types.js';
+
+/**
+ * Check the current page URL for a `DwnDiscoveryPayload` in the fragment.
+ *
+ * This is called once at the start of a connection flow to detect whether
+ * the user was just redirected back from a `dwn://register` handler. If a
+ * valid payload is found, the endpoint is persisted and the fragment is
+ * cleared to prevent double-reads.
+ *
+ * @returns The discovered endpoint string, or `undefined` if no payload
+ *   was found in the URL.
+ */
+export function checkUrlForDwnDiscoveryPayload(): string | undefined {
+  if (typeof globalThis.location === 'undefined') {
+    return undefined;
+  }
+
+  const payload = readDwnDiscoveryPayloadFromUrl(globalThis.location.href);
+  if (!payload) {
+    return undefined;
+  }
+
+  // Clear the fragment to prevent re-reading on subsequent calls or
+  // if the user refreshes the page after the redirect.
+  if (typeof globalThis.history !== 'undefined' && globalThis.history.replaceState) {
+    const cleanUrl = globalThis.location.href.split('#')[0];
+    globalThis.history.replaceState(null, '', cleanUrl);
+  }
+
+  return payload.endpoint;
+}
+
+/**
+ * Persist a discovered local DWN endpoint in auth storage.
+ *
+ * @param storage - The auth storage adapter.
+ * @param endpoint - The local DWN server base URL.
+ */
+export async function persistLocalDwnEndpoint(
+  storage: StorageAdapter,
+  endpoint: string,
+): Promise<void> {
+  await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, endpoint);
+}
+
+/**
+ * Clear the persisted local DWN endpoint from auth storage.
+ *
+ * Call this when the cached endpoint is found to be stale (server no
+ * longer running).
+ *
+ * @param storage - The auth storage adapter.
+ */
+export async function clearLocalDwnEndpoint(
+  storage: StorageAdapter,
+): Promise<void> {
+  await storage.remove(STORAGE_KEYS.LOCAL_DWN_ENDPOINT);
+}
+
+/**
+ * Restore a previously persisted local DWN endpoint and inject it into the
+ * agent's discovery cache.
+ *
+ * The endpoint is validated by the agent (via `GET /info`) before being
+ * accepted. If validation fails, the stale entry is removed from storage.
+ *
+ * @param agent - The running Web5UserAgent.
+ * @param storage - The auth storage adapter.
+ * @returns `true` if an endpoint was restored and validated, `false` otherwise.
+ */
+export async function restoreLocalDwnEndpoint(
+  agent: Web5UserAgent,
+  storage: StorageAdapter,
+): Promise<boolean> {
+  const endpoint = await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT);
+  if (!endpoint) {
+    return false;
+  }
+
+  const accepted = await agent.dwn.setCachedLocalDwnEndpoint(endpoint);
+  if (!accepted) {
+    // The server is no longer running — remove the stale entry.
+    await clearLocalDwnEndpoint(storage);
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Run the full local DWN discovery sequence for a browser connection flow.
+ *
+ * 1. Check the URL fragment for a fresh `dwn://register` payload.
+ * 2. If not found, try to restore a previously persisted endpoint.
+ * 3. If a fresh payload is found, persist it and inject it into the agent.
+ *
+ * This should be called after the agent has been started (vault unlocked,
+ * `agentDid` available) so that `setCachedLocalDwnEndpoint()` can
+ * validate the endpoint.
+ *
+ * @param agent - The running Web5UserAgent.
+ * @param storage - The auth storage adapter.
+ * @returns `true` if a local DWN endpoint was discovered and injected.
+ */
+export async function applyLocalDwnDiscovery(
+  agent: Web5UserAgent,
+  storage: StorageAdapter,
+): Promise<boolean> {
+  // Step 1: Check for a fresh payload in the URL fragment (redirect just happened).
+  const freshEndpoint = checkUrlForDwnDiscoveryPayload();
+
+  if (freshEndpoint) {
+    const accepted = await agent.dwn.setCachedLocalDwnEndpoint(freshEndpoint);
+    if (accepted) {
+      await persistLocalDwnEndpoint(storage, freshEndpoint);
+      return true;
+    }
+    // Payload was in the URL but the server is not reachable — fall through.
+  }
+
+  // Step 2: Try restoring from storage.
+  return restoreLocalDwnEndpoint(agent, storage);
+}

--- a/packages/auth/src/flows/local-connect.ts
+++ b/packages/auth/src/flows/local-connect.ts
@@ -9,10 +9,12 @@
 import type { Web5UserAgent } from '@enbox/agent';
 
 import type { AuthEventEmitter } from '../events.js';
+import type { LocalConnectOptions, RegistrationOptions, StorageAdapter, SyncOption } from '../types.js';
+
+import { applyLocalDwnDiscovery } from './dwn-discovery.js';
 import { AuthSession } from '../identity-session.js';
 import { registerWithDwnEndpoints } from './dwn-registration.js';
 import { INSECURE_DEFAULT_PASSWORD, STORAGE_KEYS } from '../types.js';
-import type { LocalConnectOptions, RegistrationOptions, StorageAdapter, SyncOption } from '../types.js';
 
 /** @internal */
 export interface LocalConnectContext {
@@ -64,6 +66,9 @@ export async function localConnect(
   // Start the agent (unlocks vault if locked, sets agentDid).
   await userAgent.start({ password });
   emitter.emit('vault-unlocked', {});
+
+  // Apply local DWN discovery (browser redirect payload or persisted endpoint).
+  await applyLocalDwnDiscovery(userAgent, storage);
 
   // Find or create the user identity.
   const identities = await userAgent.identity.list();

--- a/packages/auth/src/flows/session-restore.ts
+++ b/packages/auth/src/flows/session-restore.ts
@@ -9,9 +9,11 @@
 import type { Web5UserAgent } from '@enbox/agent';
 
 import type { AuthEventEmitter } from '../events.js';
+import type { RestoreSessionOptions, StorageAdapter, SyncOption } from '../types.js';
+
+import { applyLocalDwnDiscovery } from './dwn-discovery.js';
 import { AuthSession } from '../identity-session.js';
 import { INSECURE_DEFAULT_PASSWORD, STORAGE_KEYS } from '../types.js';
-import type { RestoreSessionOptions, StorageAdapter, SyncOption } from '../types.js';
 
 /** @internal */
 export interface SessionRestoreContext {
@@ -60,6 +62,9 @@ export async function restoreSession(
 
   await userAgent.start({ password });
   emitter.emit('vault-unlocked', {});
+
+  // Apply local DWN discovery (browser redirect payload or persisted endpoint).
+  await applyLocalDwnDiscovery(userAgent, storage);
 
   // Determine which identity to reconnect.
   const activeIdentityDid = await storage.get(STORAGE_KEYS.ACTIVE_IDENTITY);

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -47,6 +47,15 @@ export { HdIdentityVault, Web5UserAgent } from '@enbox/agent';
 // Wallet-connect helpers
 export { processConnectedGrants } from './flows/wallet-connect.js';
 
+// Local DWN discovery (browser dwn:// protocol integration)
+export {
+  applyLocalDwnDiscovery,
+  checkUrlForDwnDiscoveryPayload,
+  clearLocalDwnEndpoint,
+  persistLocalDwnEndpoint,
+  restoreLocalDwnEndpoint,
+} from './flows/dwn-discovery.js';
+
 // Storage adapters
 export { BrowserStorage, LevelStorage, MemoryStorage, createDefaultStorage } from './storage/storage.js';
 

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -370,4 +370,13 @@ export const STORAGE_KEYS = {
 
   /** The connected DID (for wallet-connected sessions). */
   CONNECTED_DID: 'enbox:auth:connectedDid',
+
+  /**
+   * The base URL of the local DWN server discovered via the `dwn://register`
+   * browser redirect flow. Persisted so subsequent page loads can skip the
+   * redirect and inject the endpoint directly.
+   *
+   * @see https://github.com/enboxorg/enbox/issues/589
+   */
+  LOCAL_DWN_ENDPOINT: 'enbox:auth:localDwnEndpoint',
 } as const;

--- a/packages/auth/tests/dwn-discovery.spec.ts
+++ b/packages/auth/tests/dwn-discovery.spec.ts
@@ -1,0 +1,383 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { encodeDwnDiscoveryPayload } from '@enbox/agent';
+
+import { createMockAgent } from './helpers/mock-agent.js';
+import { MemoryStorage } from '../src/storage/storage.js';
+import { STORAGE_KEYS } from '../src/types.js';
+import {
+  applyLocalDwnDiscovery,
+  checkUrlForDwnDiscoveryPayload,
+  clearLocalDwnEndpoint,
+  persistLocalDwnEndpoint,
+  restoreLocalDwnEndpoint,
+} from '../src/flows/dwn-discovery.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+/** Build a fake page URL with a DWN discovery payload in the fragment. */
+function buildUrlWithPayload(endpoint: string): string {
+  const encoded = encodeDwnDiscoveryPayload({ endpoint });
+  return `https://myapp.example.com/callback#${encoded}`;
+}
+
+// ─── checkUrlForDwnDiscoveryPayload ─────────────────────────────────
+
+describe('checkUrlForDwnDiscoveryPayload', () => {
+  let originalLocation: Location | undefined;
+  let originalHistory: History | undefined;
+
+  beforeEach(() => {
+    originalLocation = globalThis.location;
+    originalHistory = globalThis.history;
+  });
+
+  afterEach(() => {
+    // Restore globalThis.location
+    if (originalLocation !== undefined) {
+      Object.defineProperty(globalThis, 'location', {
+        value        : originalLocation,
+        writable     : true,
+        configurable : true,
+      });
+    } else {
+      delete (globalThis as any).location;
+    }
+    // Restore globalThis.history
+    if (originalHistory !== undefined) {
+      Object.defineProperty(globalThis, 'history', {
+        value        : originalHistory,
+        writable     : true,
+        configurable : true,
+      });
+    } else {
+      delete (globalThis as any).history;
+    }
+  });
+
+  test('should return undefined when globalThis.location is undefined', () => {
+    // In Bun/Node, globalThis.location is typically undefined
+    delete (globalThis as any).location;
+    expect(checkUrlForDwnDiscoveryPayload()).toBeUndefined();
+  });
+
+  test('should return the endpoint from a valid payload in the URL fragment', () => {
+    const url = buildUrlWithPayload('http://127.0.0.1:55557');
+    const replaceStateCalls: any[] = [];
+
+    Object.defineProperty(globalThis, 'location', {
+      value        : { href: url },
+      writable     : true,
+      configurable : true,
+    });
+    Object.defineProperty(globalThis, 'history', {
+      value        : { replaceState: (...args: any[]): void => { replaceStateCalls.push(args); } },
+      writable     : true,
+      configurable : true,
+    });
+
+    const result = checkUrlForDwnDiscoveryPayload();
+    expect(result).toBe('http://127.0.0.1:55557');
+
+    // Should have cleared the fragment via history.replaceState
+    expect(replaceStateCalls).toHaveLength(1);
+    expect(replaceStateCalls[0][2]).toBe('https://myapp.example.com/callback');
+  });
+
+  test('should return undefined when URL has no fragment', () => {
+    Object.defineProperty(globalThis, 'location', {
+      value        : { href: 'https://myapp.example.com/page' },
+      writable     : true,
+      configurable : true,
+    });
+    Object.defineProperty(globalThis, 'history', {
+      value        : { replaceState: (): void => {} },
+      writable     : true,
+      configurable : true,
+    });
+
+    expect(checkUrlForDwnDiscoveryPayload()).toBeUndefined();
+  });
+
+  test('should return undefined when fragment contains invalid data', () => {
+    Object.defineProperty(globalThis, 'location', {
+      value        : { href: 'https://myapp.example.com/page#not-valid-base64url' },
+      writable     : true,
+      configurable : true,
+    });
+    Object.defineProperty(globalThis, 'history', {
+      value        : { replaceState: (): void => {} },
+      writable     : true,
+      configurable : true,
+    });
+
+    expect(checkUrlForDwnDiscoveryPayload()).toBeUndefined();
+  });
+
+  test('should not clear fragment when history.replaceState is unavailable', () => {
+    const url = buildUrlWithPayload('http://localhost:3000');
+
+    Object.defineProperty(globalThis, 'location', {
+      value        : { href: url },
+      writable     : true,
+      configurable : true,
+    });
+    // No history object
+    delete (globalThis as any).history;
+
+    const result = checkUrlForDwnDiscoveryPayload();
+    expect(result).toBe('http://localhost:3000');
+  });
+});
+
+// ─── persistLocalDwnEndpoint / clearLocalDwnEndpoint ────────────────
+
+describe('persistLocalDwnEndpoint / clearLocalDwnEndpoint', () => {
+  test('should persist and retrieve an endpoint', async () => {
+    const storage = new MemoryStorage();
+    await persistLocalDwnEndpoint(storage, 'http://127.0.0.1:55557');
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBe('http://127.0.0.1:55557');
+  });
+
+  test('should clear a persisted endpoint', async () => {
+    const storage = new MemoryStorage();
+    await persistLocalDwnEndpoint(storage, 'http://127.0.0.1:55557');
+    await clearLocalDwnEndpoint(storage);
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBeNull();
+  });
+});
+
+// ─── restoreLocalDwnEndpoint ────────────────────────────────────────
+
+describe('restoreLocalDwnEndpoint', () => {
+  test('should return false when no endpoint is stored', async () => {
+    const storage = new MemoryStorage();
+    const agent = createMockAgent();
+
+    const result = await restoreLocalDwnEndpoint(agent, storage);
+    expect(result).toBe(false);
+  });
+
+  test('should return true and inject endpoint when stored and agent accepts it', async () => {
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, 'http://127.0.0.1:55557');
+
+    const setCalls: string[] = [];
+    const agent = createMockAgent({
+      dwnSetCachedLocalDwnEndpoint: async (endpoint): Promise<boolean> => {
+        setCalls.push(endpoint);
+        return true;
+      },
+    });
+
+    const result = await restoreLocalDwnEndpoint(agent, storage);
+    expect(result).toBe(true);
+    expect(setCalls).toEqual(['http://127.0.0.1:55557']);
+
+    // Endpoint should still be in storage
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBe('http://127.0.0.1:55557');
+  });
+
+  test('should clear stale endpoint from storage when agent rejects it', async () => {
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, 'http://127.0.0.1:9999');
+
+    const agent = createMockAgent({
+      dwnSetCachedLocalDwnEndpoint: async (): Promise<boolean> => false,
+    });
+
+    const result = await restoreLocalDwnEndpoint(agent, storage);
+    expect(result).toBe(false);
+
+    // Stale endpoint should be removed
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBeNull();
+  });
+});
+
+// ─── applyLocalDwnDiscovery ─────────────────────────────────────────
+
+describe('applyLocalDwnDiscovery', () => {
+  let originalLocation: Location | undefined;
+  let originalHistory: History | undefined;
+
+  beforeEach(() => {
+    originalLocation = globalThis.location;
+    originalHistory = globalThis.history;
+  });
+
+  afterEach(() => {
+    if (originalLocation !== undefined) {
+      Object.defineProperty(globalThis, 'location', {
+        value        : originalLocation,
+        writable     : true,
+        configurable : true,
+      });
+    } else {
+      delete (globalThis as any).location;
+    }
+    if (originalHistory !== undefined) {
+      Object.defineProperty(globalThis, 'history', {
+        value        : originalHistory,
+        writable     : true,
+        configurable : true,
+      });
+    } else {
+      delete (globalThis as any).history;
+    }
+  });
+
+  test('should return false when no URL payload and no stored endpoint', async () => {
+    delete (globalThis as any).location;
+
+    const storage = new MemoryStorage();
+    const agent = createMockAgent();
+
+    const result = await applyLocalDwnDiscovery(agent, storage);
+    expect(result).toBe(false);
+  });
+
+  test('should inject and persist a fresh endpoint from the URL fragment', async () => {
+    const url = buildUrlWithPayload('http://127.0.0.1:55557');
+
+    Object.defineProperty(globalThis, 'location', {
+      value        : { href: url },
+      writable     : true,
+      configurable : true,
+    });
+    Object.defineProperty(globalThis, 'history', {
+      value        : { replaceState: (): void => {} },
+      writable     : true,
+      configurable : true,
+    });
+
+    const storage = new MemoryStorage();
+    const setCalls: string[] = [];
+    const agent = createMockAgent({
+      dwnSetCachedLocalDwnEndpoint: async (endpoint): Promise<boolean> => {
+        setCalls.push(endpoint);
+        return true;
+      },
+    });
+
+    const result = await applyLocalDwnDiscovery(agent, storage);
+    expect(result).toBe(true);
+    expect(setCalls).toEqual(['http://127.0.0.1:55557']);
+
+    // Endpoint should be persisted in storage
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBe('http://127.0.0.1:55557');
+  });
+
+  test('should fall back to stored endpoint when URL fragment has no payload', async () => {
+    delete (globalThis as any).location;
+
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, 'http://127.0.0.1:3000');
+
+    const setCalls: string[] = [];
+    const agent = createMockAgent({
+      dwnSetCachedLocalDwnEndpoint: async (endpoint): Promise<boolean> => {
+        setCalls.push(endpoint);
+        return true;
+      },
+    });
+
+    const result = await applyLocalDwnDiscovery(agent, storage);
+    expect(result).toBe(true);
+    expect(setCalls).toEqual(['http://127.0.0.1:3000']);
+  });
+
+  test('should prefer fresh URL payload over stored endpoint', async () => {
+    const url = buildUrlWithPayload('http://127.0.0.1:55557');
+
+    Object.defineProperty(globalThis, 'location', {
+      value        : { href: url },
+      writable     : true,
+      configurable : true,
+    });
+    Object.defineProperty(globalThis, 'history', {
+      value        : { replaceState: (): void => {} },
+      writable     : true,
+      configurable : true,
+    });
+
+    const storage = new MemoryStorage();
+    // Pre-populate with a different endpoint
+    await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, 'http://127.0.0.1:3000');
+
+    const setCalls: string[] = [];
+    const agent = createMockAgent({
+      dwnSetCachedLocalDwnEndpoint: async (endpoint): Promise<boolean> => {
+        setCalls.push(endpoint);
+        return true;
+      },
+    });
+
+    const result = await applyLocalDwnDiscovery(agent, storage);
+    expect(result).toBe(true);
+    // Should have used the fresh URL endpoint, not the stored one
+    expect(setCalls).toEqual(['http://127.0.0.1:55557']);
+    // Storage should be updated to the new endpoint
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBe('http://127.0.0.1:55557');
+  });
+
+  test('should fall through to stored endpoint when fresh URL endpoint is rejected', async () => {
+    const url = buildUrlWithPayload('http://127.0.0.1:55557');
+
+    Object.defineProperty(globalThis, 'location', {
+      value        : { href: url },
+      writable     : true,
+      configurable : true,
+    });
+    Object.defineProperty(globalThis, 'history', {
+      value        : { replaceState: (): void => {} },
+      writable     : true,
+      configurable : true,
+    });
+
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, 'http://127.0.0.1:3000');
+
+    let callCount = 0;
+    const agent = createMockAgent({
+      dwnSetCachedLocalDwnEndpoint: async (endpoint): Promise<boolean> => {
+        callCount++;
+        // Reject the first (fresh URL) call, accept the second (stored) call
+        if (endpoint === 'http://127.0.0.1:55557') { return false; }
+        return true;
+      },
+    });
+
+    const result = await applyLocalDwnDiscovery(agent, storage);
+    expect(result).toBe(true);
+    // Called twice: once for fresh URL, once for stored
+    expect(callCount).toBe(2);
+  });
+
+  test('should return false when both fresh URL and stored endpoints are rejected', async () => {
+    const url = buildUrlWithPayload('http://127.0.0.1:55557');
+
+    Object.defineProperty(globalThis, 'location', {
+      value        : { href: url },
+      writable     : true,
+      configurable : true,
+    });
+    Object.defineProperty(globalThis, 'history', {
+      value        : { replaceState: (): void => {} },
+      writable     : true,
+      configurable : true,
+    });
+
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, 'http://127.0.0.1:3000');
+
+    const agent = createMockAgent({
+      dwnSetCachedLocalDwnEndpoint: async (): Promise<boolean> => false,
+    });
+
+    const result = await applyLocalDwnDiscovery(agent, storage);
+    expect(result).toBe(false);
+
+    // The stale stored endpoint should be removed
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBeNull();
+  });
+});

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -40,6 +40,7 @@ export interface MockAgentOverrides {
   identityExport?: (params: any) => Promise<any>;
   identityConnectedIdentity?: () => Promise<MockIdentity | undefined>;
   didDelete?: (params: any) => Promise<void>;
+  dwnSetCachedLocalDwnEndpoint?: (endpoint: string) => Promise<boolean>;
   syncRegisterIdentity?: (params: any) => Promise<void>;
   syncStartSync?: (params: any) => Promise<void>;
   syncStopSync?: (timeout: number) => Promise<void>;
@@ -82,6 +83,11 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): Web5UserAge
 
     did: {
       delete: overrides.didDelete ?? (async (): Promise<void> => {}),
+    },
+
+    dwn: {
+      setCachedLocalDwnEndpoint: overrides.dwnSetCachedLocalDwnEndpoint
+        ?? (async (): Promise<boolean> => false),
     },
 
     sync: {

--- a/packages/auth/tests/local-connect.spec.ts
+++ b/packages/auth/tests/local-connect.spec.ts
@@ -245,6 +245,27 @@ describe('localConnect', () => {
     expect(createCalls[0].metadata.name).toBe('My Custom Name');
   });
 
+  test('applies local DWN discovery from stored endpoint', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const identity = createMockIdentity();
+
+    // Pre-populate a stored endpoint (simulating a previous dwn:// redirect).
+    await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, 'http://127.0.0.1:55557');
+
+    const setCalls: string[] = [];
+    const agent = createMockAgent({
+      firstLaunch                  : async () => false,
+      identityList                 : async () => [identity],
+      dwnSetCachedLocalDwnEndpoint : async (endpoint) => { setCalls.push(endpoint); return true; },
+    });
+
+    await localConnect({ userAgent: agent, emitter, storage }, {});
+
+    // The stored endpoint should have been injected into the agent.
+    expect(setCalls).toEqual(['http://127.0.0.1:55557']);
+  });
+
   test('calls registration when registration options are provided', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();

--- a/packages/auth/tests/session-restore.spec.ts
+++ b/packages/auth/tests/session-restore.spec.ts
@@ -132,6 +132,27 @@ describe('restoreSession', () => {
     expect(events).toEqual(['vault-unlocked', 'session-start']);
   });
 
+  test('applies local DWN discovery from stored endpoint', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
+
+    // Pre-populate a stored endpoint (simulating a previous dwn:// redirect).
+    await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, 'http://127.0.0.1:55557');
+
+    const setCalls: string[] = [];
+    const agent = createMockAgent({
+      firstLaunch                  : async () => false,
+      dwnSetCachedLocalDwnEndpoint : async (endpoint) => { setCalls.push(endpoint); return true; },
+    });
+
+    const session = await restoreSession({ userAgent: agent, emitter, storage });
+    expect(session).toBeDefined();
+
+    // The stored endpoint should have been injected into the agent.
+    expect(setCalls).toEqual(['http://127.0.0.1:55557']);
+  });
+
   test('uses insecure default password when none provided', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();


### PR DESCRIPTION
## Summary

Integrates the `dwn://register` browser protocol handler flow into `@enbox/auth`, completing issue #589. When a user's browser is redirected back from `dwn://register` with a discovery payload in the URL fragment, the auth flows now detect it, validate the endpoint, persist it, and inject it into the agent's local DWN discovery cache.

- **`AgentDwnApi.setCachedLocalDwnEndpoint(endpoint)`** — new public method that validates and injects a local DWN endpoint into `LocalDwnDiscovery`'s cache (lazy-initializes the discovery instance if needed)
- **`packages/auth/src/flows/dwn-discovery.ts`** — new module with `checkUrlForDwnDiscoveryPayload()`, `persistLocalDwnEndpoint()`, `clearLocalDwnEndpoint()`, `restoreLocalDwnEndpoint()`, and `applyLocalDwnDiscovery()` orchestrator
- **`localConnect()` and `restoreSession()`** — now call `applyLocalDwnDiscovery()` after `userAgent.start()` to detect fresh redirect payloads or restore previously persisted endpoints
- **`STORAGE_KEYS.LOCAL_DWN_ENDPOINT`** — new auth storage key for persisting the discovered endpoint across page loads

## How it works

1. Web app opens `dwn://register?callback=<url>` → electrobun-dwn starts the DWN server and redirects back to `<url>#<base64url_payload>`
2. On page load, `applyLocalDwnDiscovery()` reads the fragment, validates the endpoint via `GET /info`, persists it in auth storage, and clears the fragment
3. On subsequent page loads (no redirect), the persisted endpoint is restored from storage and re-validated

## Test plan

- 17 new tests in `packages/auth/tests/dwn-discovery.spec.ts` covering all functions
- 2 integration tests added to `local-connect.spec.ts` and `session-restore.spec.ts`
- 4 tests added to `packages/agent/tests/dwn-api.spec.ts` for `setCachedLocalDwnEndpoint()`
- All 187 auth tests pass, all 142 agent (dwn-api + local-dwn) tests pass
- Lint clean across all changed files

## Related

- Closes #589
- Part of the `dwn://` discovery epic (#585)
- Builds on #597 (file-based discovery) and #599 (protocol handler registration)