### PR TITLE
feat(agent,dwn-clients)!: rename Web5-prefixed symbols to Enbox-prefixed

### DIFF
--- a/.changeset/rename-web5-agent-symbols.md
+++ b/.changeset/rename-web5-agent-symbols.md
@@ -1,0 +1,15 @@
+---
+"@enbox/agent": major
+"@enbox/dwn-clients": major
+"@enbox/api": patch
+"@enbox/auth": patch
+---
+
+BREAKING: Rename Web5-prefixed symbols to Enbox-prefixed across agent and dwn-clients
+
+- `Web5Agent` → `EnboxAgent`, `Web5UserAgent` → `EnboxUserAgent`, `Web5PlatformAgent` → `EnboxPlatformAgent`
+- `Web5RpcClient` → `EnboxRpcClient`, `Web5Rpc` → `EnboxRpc`, `HttpWeb5RpcClient` → `HttpEnboxRpcClient`, `WebSocketWeb5RpcClient` → `WebSocketEnboxRpcClient`
+- `Web5ConnectAuthRequest` → `EnboxConnectAuthRequest`, `Web5ConnectAuthResponse` → `EnboxConnectAuthResponse`
+- Deprecated aliases preserved for all renamed symbols
+- File renamed: `web5-user-agent.ts` → `enbox-user-agent.ts`
+- All downstream packages updated: @enbox/api, @enbox/auth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,7 +366,7 @@ Brief JSDoc on public methods and complex private methods. Use `@param`, `@retur
  * When any type in the protocol definition has `encryptionRequired: true`,
  * `$encryption` keys are derived and injected into the protocol definition.
  */
-private async installProtocol(tenant: string, agent: Web5PlatformAgent): Promise<void> {
+private async installProtocol(tenant: string, agent: EnboxPlatformAgent): Promise<void> {
 ```
 
 ### ESLint Rules Summary
@@ -463,13 +463,13 @@ describe('ComponentName', () => {
 });
 ```
 
-For full agent lifecycle tests (vault + DWN stores), use `Web5UserAgent` instead of `TestAgent`:
+For full agent lifecycle tests (vault + DWN stores), use `EnboxUserAgent` instead of `TestAgent`:
 
 ```typescript
-import { Web5UserAgent } from '../src/web5-user-agent.js';
+import { EnboxUserAgent } from '../src/enbox-user-agent.js';
 
 const harness = await PlatformAgentTestHarness.setup({
-  agentClass  : Web5UserAgent,
+  agentClass  : EnboxUserAgent,
   agentStores : 'dwn',
 });
 await harness.agent.initialize({ password: 'test' });

--- a/packages/agent/src/agent-did-resolver-cache.ts
+++ b/packages/agent/src/agent-did-resolver-cache.ts
@@ -1,6 +1,6 @@
 import type { DidResolutionResult, DidResolverCache, DidResolverCacheLevelParams } from '@enbox/dids';
 
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 
 import { DidResolverCacheLevel } from '@enbox/dids';
 import { logger } from '@enbox/common';
@@ -13,29 +13,29 @@ import { logger } from '@enbox/common';
 export class AgentDidResolverCache extends DidResolverCacheLevel implements DidResolverCache {
 
   /**
-   * Holds the instance of a `Web5PlatformAgent` that represents the current execution context for
+   * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
    * the `AgentDidApi`. This agent is used to interact with other Web5 agent components. It's vital
    * to ensure this instance is set to correctly contextualize operations within the broader Web5
    * Agent framework.
    */
-  private _agent?: Web5PlatformAgent;
+  private _agent?: EnboxPlatformAgent;
 
   /** A map of DIDs that are currently in-flight. This helps avoid going into an infinite loop */
   private _resolving: Map<string, boolean> = new Map();
 
-  constructor({ agent, db, location, ttl }: DidResolverCacheLevelParams & { agent?: Web5PlatformAgent }) {
+  constructor({ agent, db, location, ttl }: DidResolverCacheLevelParams & { agent?: EnboxPlatformAgent }) {
     super ({ db, location, ttl });
     this._agent = agent;
   }
 
-  get agent(): Web5PlatformAgent {
+  get agent(): EnboxPlatformAgent {
     if (!this._agent) {
       throw new Error('Agent not initialized');
     }
     return this._agent;
   }
 
-  set agent(agent: Web5PlatformAgent) {
+  set agent(agent: EnboxPlatformAgent) {
     this._agent = agent;
   }
 

--- a/packages/agent/src/anonymous-dwn-api.ts
+++ b/packages/agent/src/anonymous-dwn-api.ts
@@ -13,7 +13,7 @@ import type {
   RecordsSubscribeReply,
   SubscriptionListener,
 } from '@enbox/dwn-sdk-js';
-import type { DwnRpcRequest, Web5Rpc } from '@enbox/dwn-clients';
+import type { DwnRpcRequest, EnboxRpc } from '@enbox/dwn-clients';
 
 import { ProtocolsQuery, RecordsCount, RecordsQuery, RecordsRead, RecordsSubscribe } from '@enbox/dwn-sdk-js';
 
@@ -26,7 +26,7 @@ export type AnonymousDwnApiParams = {
   /** A DID URL dereferencer for resolving target DID service endpoints. */
   didResolver: DidUrlDereferencer;
   /** An RPC client for sending messages to remote DWNs. */
-  rpcClient: Web5Rpc;
+  rpcClient: EnboxRpc;
 };
 
 /**
@@ -89,7 +89,7 @@ export type AnonymousProtocolsQueryParams = {
  * @example
  * ```ts
  * const resolver = new UniversalResolver({ didResolvers: [DidDht, DidJwk] });
- * const rpcClient = new Web5RpcClient();
+ * const rpcClient = new EnboxRpcClient();
  * const anonymousDwn = new AnonymousDwnApi({ didResolver: resolver, rpcClient });
  *
  * const reply = await anonymousDwn.recordsQuery('did:dht:alice...', {
@@ -99,7 +99,7 @@ export type AnonymousProtocolsQueryParams = {
  */
 export class AnonymousDwnApi {
   private _didResolver: DidUrlDereferencer;
-  private _rpcClient: Web5Rpc;
+  private _rpcClient: EnboxRpc;
 
   constructor({ didResolver, rpcClient }: AnonymousDwnApiParams) {
     this._didResolver = didResolver;

--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -1,6 +1,6 @@
 
 import type { PushedAuthResponse } from './oidc.js';
-import type { DwnPermissionScope, DwnProtocolDefinition, Web5ConnectAuthResponse } from './index.js';
+import type { DwnPermissionScope, DwnProtocolDefinition, EnboxConnectAuthResponse } from './index.js';
 
 import { CryptoUtils } from '@enbox/crypto';
 import { DidJwk } from '@enbox/dids';
@@ -21,8 +21,8 @@ async function initClient({
   onWalletUriReady,
   validatePin,
 }: WalletConnectOptions): Promise<{
-  delegateGrants: Web5ConnectAuthResponse['delegateGrants'];
-  delegatePortableDid: Web5ConnectAuthResponse['delegatePortableDid'];
+  delegateGrants: EnboxConnectAuthResponse['delegateGrants'];
+  delegatePortableDid: EnboxConnectAuthResponse['delegatePortableDid'];
   connectedDid: string;
 } | undefined> {
   // ephemeral client did for ECDH, signing, verification
@@ -112,7 +112,7 @@ async function initClient({
     tokenParam : request.state,
   });
 
-  // subscribe to receiving a response from the wallet with default TTL. receive ciphertext of {@link Web5ConnectAuthResponse}
+  // subscribe to receiving a response from the wallet with default TTL. receive ciphertext of {@link EnboxConnectAuthResponse}
   const authResponse = await pollWithTtl(() => fetch(tokenUrl, { signal: AbortSignal.timeout(30_000) }));
 
   if (authResponse) {
@@ -123,7 +123,7 @@ async function initClient({
     const jwt = await Oidc.decryptAuthResponse(clientDid, jwe, pin);
     const verifiedAuthResponse = (await Oidc.verifyJwt({
       jwt,
-    })) as Web5ConnectAuthResponse;
+    })) as EnboxConnectAuthResponse;
 
     return {
       delegateGrants      : verifiedAuthResponse.delegateGrants,
@@ -163,7 +163,7 @@ export type WalletConnectOptions = {
    * The link can either be used as a deep link on the same device or a QR code for cross device or both.
    * The query params are `{ request_uri: string; encryption_key: string; }`
    * The wallet will use the `request_uri to contact the intermediary server's `authorize` endpoint
-   * and pull down the {@link Web5ConnectAuthRequest} and use the `encryption_key` to decrypt it.
+   * and pull down the {@link EnboxConnectAuthRequest} and use the `encryption_key` to decrypt it.
    *
    * @param uri - The URI returned by the web5 connect API to be passed to a provider.
    */
@@ -171,7 +171,7 @@ export type WalletConnectOptions = {
 
   /**
    * Function that must be provided to submit the pin entered by the user on the client.
-   * The pin is used to decrypt the {@link Web5ConnectAuthResponse} that was retrieved from the
+   * The pin is used to decrypt the {@link EnboxConnectAuthResponse} that was retrieved from the
    * token endpoint by the client inside of web5 connect.
    *
    * @returns A promise that resolves to the PIN as a string.

--- a/packages/agent/src/did-api.ts
+++ b/packages/agent/src/did-api.ts
@@ -16,7 +16,7 @@ import { BearerDid, Did, DidDht, UniversalResolver } from '@enbox/dids';
 
 import type { AgentDataStore } from './store-data.js';
 import type { AgentKeyManager } from './types/key-manager.js';
-import type { ResponseStatus, Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent, ResponseStatus } from './types/agent.js';
 
 import { AgentDidResolverCache } from './agent-did-resolver-cache.js';
 import { canonicalize } from '@enbox/crypto';
@@ -84,7 +84,7 @@ export interface DidMethodCreateOptions<TKeyManager> {
 export interface DidApiParams {
   didMethods: DidMethodApi[];
 
-  agent?: Web5PlatformAgent;
+  agent?: EnboxPlatformAgent;
 
   /**
    * An optional `DidResolverCache` instance used for caching resolved DID documents.
@@ -114,12 +114,12 @@ export function isDidRequest<T extends DidInterface>(
  */
 export class AgentDidApi<TKeyManager extends AgentKeyManager = AgentKeyManager> extends UniversalResolver {
   /**
-   * Holds the instance of a `Web5PlatformAgent` that represents the current execution context for
+   * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
    * the `AgentDidApi`. This agent is used to interact with other Web5 agent components. It's vital
    * to ensure this instance is set to correctly contextualize operations within the broader Web5
    * Agent framework.
    */
-  private _agent?: Web5PlatformAgent;
+  private _agent?: EnboxPlatformAgent;
 
   private _didMethods: Map<string, DidMethodApi> = new Map();
 
@@ -148,12 +148,12 @@ export class AgentDidApi<TKeyManager extends AgentKeyManager = AgentKeyManager> 
   }
 
   /**
-   * Retrieves the `Web5PlatformAgent` execution context.
+   * Retrieves the `EnboxPlatformAgent` execution context.
    *
-   * @returns The `Web5PlatformAgent` instance that represents the current execution context.
+   * @returns The `EnboxPlatformAgent` instance that represents the current execution context.
    * @throws Will throw an error if the `agent` instance property is undefined.
    */
-  get agent(): Web5PlatformAgent {
+  get agent(): EnboxPlatformAgent {
     if (this._agent === undefined) {
       throw new Error('AgentDidApi: Unable to determine agent execution context.');
     }
@@ -161,7 +161,7 @@ export class AgentDidApi<TKeyManager extends AgentKeyManager = AgentKeyManager> 
     return this._agent;
   }
 
-  set agent(agent: Web5PlatformAgent) {
+  set agent(agent: EnboxPlatformAgent) {
     this._agent = agent;
 
     // AgentDidResolverCache should set the agent if it is the type of cache being used

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -33,8 +33,8 @@ import {
 import { CryptoUtils, X25519 } from '@enbox/crypto';
 import { DidDht, DidJwk, DidResolverCacheLevel, UniversalResolver } from '@enbox/dids';
 
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type { LocalDwnStrategy } from './local-dwn.js';
-import type { Web5PlatformAgent } from './types/agent.js';
 import type {
   DwnMessage,
   DwnMessageInstance,
@@ -102,7 +102,7 @@ type DwnMessageWithBlob<T extends DwnInterface> = {
 };
 
 type DwnApiParams = {
-  agent?: Web5PlatformAgent;
+  agent?: EnboxPlatformAgent;
   dwn: Dwn;
   localDwnStrategy?: LocalDwnStrategy;
 };
@@ -113,12 +113,12 @@ interface DwnApiCreateDwnParams extends Partial<DwnConfig> {
 
 export class AgentDwnApi {
   /**
-   * Holds the instance of a `Web5PlatformAgent` that represents the current execution context for
+   * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
    * the `AgentDwnApi`. This agent is used to interact with other Web5 agent components. It's vital
    * to ensure this instance is set to correctly contextualize operations within the broader Web5
    * Agent framework.
    */
-  private _agent?: Web5PlatformAgent;
+  private _agent?: EnboxPlatformAgent;
 
   /**
    * The DWN instance to use for this API.
@@ -187,12 +187,12 @@ export class AgentDwnApi {
   }
 
   /**
-   * Retrieves the `Web5PlatformAgent` execution context.
+   * Retrieves the `EnboxPlatformAgent` execution context.
    *
-   * @returns The `Web5PlatformAgent` instance that represents the current execution context.
+   * @returns The `EnboxPlatformAgent` instance that represents the current execution context.
    * @throws Will throw an error if the `agent` instance property is undefined.
    */
-  get agent(): Web5PlatformAgent {
+  get agent(): EnboxPlatformAgent {
     if (this._agent === undefined) {
       throw new Error('AgentDwnApi: Unable to determine agent execution context.');
     }
@@ -200,7 +200,7 @@ export class AgentDwnApi {
     return this._agent;
   }
 
-  set agent(agent: Web5PlatformAgent) {
+  set agent(agent: EnboxPlatformAgent) {
     this._agent = agent;
     // Re-initialize local DWN discovery with the new agent's RPC client.
     this._localDwnDiscovery = new LocalDwnDiscovery(
@@ -360,7 +360,7 @@ export class AgentDwnApi {
    *   However, it is recommended to use the `processRequest` method to interact with the DWN
    *   instance to ensure that the DWN message is constructed correctly.
    * - The getter is named `node` to avoid confusion with the `dwn` property of the
-   *   `Web5PlatformAgent`. In other words, so that a developer can call `agent.dwn.node` to access
+   *   `EnboxPlatformAgent`. In other words, so that a developer can call `agent.dwn.node` to access
    *   the DWN instance and not `agent.dwn.dwn`.
    */
   get node(): Dwn {

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -9,7 +9,7 @@ import type {
 } from '@enbox/dwn-sdk-js';
 import type { KeyIdentifier, PublicKeyJwk } from '@enbox/crypto';
 
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type {
   DwnMessageReply,
   ProcessDwnRequest,
@@ -93,7 +93,7 @@ export async function encryptAndComputeCid(
  * @throws If the DID has no keyAgreement verification method or it's not X25519.
  */
 export async function getEncryptionKeyInfo(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   didUri: string,
 ): Promise<{
   keyId: string;
@@ -172,7 +172,7 @@ export async function getEncryptionKeyInfo(
  * @param iv - Initialization vector
  */
 export async function deriveContextEncryptionInput(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   didUri: string,
   contextId: string,
   dek: Uint8Array,
@@ -208,7 +208,7 @@ export async function deriveContextEncryptionInput(
  * @param derivationScheme - The key derivation scheme
  */
 export function buildKmsDecryptCallback(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   keyId: string,
   keyUri: KeyIdentifier,
   derivationScheme: typeof KeyDerivationScheme.ProtocolPath | typeof KeyDerivationScheme.ProtocolContext,
@@ -240,7 +240,7 @@ export function buildKmsDecryptCallback(
  * @returns An EncryptionKeyDeriver callback object
  */
 export async function getEncryptionKeyDeriver(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   didUri: string,
 ): Promise<EncryptionKeyDeriver> {
   const { keyId, keyUri } = await getEncryptionKeyInfo(agent, didUri);
@@ -266,7 +266,7 @@ export async function getEncryptionKeyDeriver(
  * @returns A KeyDecrypter callback object
  */
 export async function getKeyDecrypter(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   didUri: string,
 ): Promise<KeyDecrypter> {
   const { keyId, keyUri } = await getEncryptionKeyInfo(agent, didUri);
@@ -311,7 +311,7 @@ export function buildContextKeyDecrypter(
  * @param fetchContextKeyRecordFn - Function to fetch context key records from key-delivery protocol
  */
 export async function resolveKeyDecrypter(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   authorDid: string,
   recordsWrite: RecordsWriteMessage,
   targetDid: string | undefined,
@@ -409,7 +409,7 @@ export async function resolveKeyDecrypter(
 export async function maybeDecryptReply<T extends DwnInterface>(
   request: ProcessDwnRequest<T> | SendDwnRequest<T>,
   reply: DwnMessageReply[T],
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   contextDerivedKeyCache: { get(key: string): DerivedPrivateJwk | undefined; set(key: string, value: DerivedPrivateJwk): void },
   fetchContextKeyRecordFn: (params: {
     ownerDid: string;

--- a/packages/agent/src/dwn-key-delivery.ts
+++ b/packages/agent/src/dwn-key-delivery.ts
@@ -6,7 +6,7 @@ import type {
   RecordsReadReply,
 } from '@enbox/dwn-sdk-js';
 
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type {
   DwnMessage,
   DwnMessageReply,
@@ -65,7 +65,7 @@ type ProcessRequestFn = <T extends DwnInterface>(
  * @param installedCache - Cache for installation status
  */
 export async function ensureKeyDeliveryProtocol(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   tenantDid: string,
   processRequest: ProcessRequestFn,
   getProtocolDefinition: (tenantDid: string, protocolUri: string) => Promise<any>,
@@ -120,7 +120,7 @@ export async function ensureKeyDeliveryProtocol(
  * @returns The recordId of the written contextKey record
  */
 export async function writeContextKeyRecord(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   params: WriteContextKeyParams,
   processRequest: ProcessRequestFn,
   ensureProtocol: (tenantDid: string) => Promise<void>,
@@ -221,7 +221,7 @@ export async function writeContextKeyRecord(
  * @param getDwnEndpointUrlsForTarget - Function to resolve DWN endpoint URLs (with local discovery)
  */
 export async function eagerSendContextKeyRecord(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   tenantDid: string,
   contextKeyMessage: DwnMessage[DwnInterface.RecordsWrite],
   getDwnMessage: (params: { author: string; messageType: DwnInterface; messageCid: string }) => Promise<{ message: any; data?: Blob }>,
@@ -271,7 +271,7 @@ export async function eagerSendContextKeyRecord(
  * @returns The decrypted `DerivedPrivateJwk`, or `undefined` if no matching record found
  */
 export async function fetchContextKeyRecord(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   params: FetchContextKeyParams,
   processRequest: ProcessRequestFn,
   getSigner: (author: string) => Promise<any>,

--- a/packages/agent/src/dwn-record-upgrade.ts
+++ b/packages/agent/src/dwn-record-upgrade.ts
@@ -8,7 +8,7 @@ import type {
 } from '@enbox/dwn-sdk-js';
 
 import type { DwnSigner } from './types/dwn.js';
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 
 import {
   Encoder,
@@ -42,7 +42,7 @@ import { DwnInterface, dwnMessageConstructors } from './types/dwn.js';
  * @param contextKeyCache - Cache for context key info
  */
 export async function upgradeExternalRootRecord(
-  agent: Web5PlatformAgent,
+  agent: EnboxPlatformAgent,
   tenantDid: string,
   recordsWrite: RecordsWriteMessage,
   dwn: Dwn,

--- a/packages/agent/src/enbox-user-agent.ts
+++ b/packages/agent/src/enbox-user-agent.ts
@@ -1,8 +1,8 @@
 import type { AgentKeyManager } from './types/key-manager.js';
 import type { BearerDid } from '@enbox/dids';
+import type { EnboxPlatformAgent } from './types/agent.js';
+import type { EnboxRpc } from '@enbox/dwn-clients';
 import type { LocalDwnStrategy } from './local-dwn.js';
-import type { Web5PlatformAgent } from './types/agent.js';
-import type { Web5Rpc } from '@enbox/dwn-clients';
 import type { DidInterface, DidRequest, DidResponse } from './did-api.js';
 import type { DwnInterface, DwnResponse, ProcessDwnRequest, SendDwnRequest } from './types/dwn.js';
 import type { ProcessVcRequest, SendVcRequest, VcResponse } from './types/vc.js';
@@ -17,15 +17,15 @@ import { AgentSyncApi } from './sync-api.js';
 import { DwnDidStore } from './store-did.js';
 import { DwnIdentityStore } from './store-identity.js';
 import { DwnKeyStore } from './store-key.js';
+import { EnboxRpcClient } from '@enbox/dwn-clients';
 import { HdIdentityVault } from './hd-identity-vault.js';
 import { LevelStore } from '@enbox/common';
 import { LocalKeyManager } from './local-key-manager.js';
 import { SyncEngineLevel } from './sync-engine-level.js';
-import { Web5RpcClient } from '@enbox/dwn-clients';
 import { DidDht, DidJwk } from '@enbox/dids';
 
 /**
- * Initialization parameters for {@link Web5UserAgent}, including an optional recovery phrase that
+ * Initialization parameters for {@link EnboxUserAgent}, including an optional recovery phrase that
  * can be used to derive keys to encrypt the vault and generate a DID.
  */
 export type AgentInitializeParams = {
@@ -46,10 +46,10 @@ export type AgentInitializeParams = {
    recoveryPhrase?: string;
 
   /**
-   * Optional dwnEndpoints to register didService endpoints during Web5UserAgent initialization
+   * Optional dwnEndpoints to register didService endpoints during EnboxUserAgent initialization
    *
    * The dwnEndpoints are used to register DWN endpoints against the agent DID created during
-   * Web5UserAgent.initialize() =>  DidDht.create(). This allows the
+   * EnboxUserAgent.initialize() =>  DidDht.create(). This allows the
    * agent to properly recover connectedDids from DWN. Also, this pattern can be used on the server
    * side in place of the agentDid-->connectedDids pattern.
    */
@@ -83,7 +83,7 @@ export type AgentParams<TKeyManager extends AgentKeyManager = LocalKeyManager> =
   /** Facilitates fetching, requesting, creating, revoking and validating revocation status of permissions */
   permissionsApi: AgentPermissionsApi;
   /** Remote procedure call (RPC) client used to communicate with other Web5 services. */
-  rpcClient: Web5Rpc;
+  rpcClient: EnboxRpc;
   /** Facilitates data synchronization of DWN records between nodes. */
   syncApi: AgentSyncApi;
 };
@@ -92,14 +92,14 @@ export type CreateUserAgentParams = Partial<AgentParams> & {
   localDwnStrategy?: LocalDwnStrategy;
 };
 
-export class Web5UserAgent<TKeyManager extends AgentKeyManager = LocalKeyManager> implements Web5PlatformAgent<TKeyManager> {
+export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManager> implements EnboxPlatformAgent<TKeyManager> {
   public crypto: AgentCryptoApi;
   public did: AgentDidApi<TKeyManager>;
   public dwn: AgentDwnApi;
   public identity: AgentIdentityApi<TKeyManager>;
   public keyManager: TKeyManager;
   public permissions: AgentPermissionsApi;
-  public rpc: Web5Rpc;
+  public rpc: EnboxRpc;
   public sync: AgentSyncApi;
   public vault: HdIdentityVault;
 
@@ -129,7 +129,7 @@ export class Web5UserAgent<TKeyManager extends AgentKeyManager = LocalKeyManager
   get agentDid(): BearerDid {
     if (this._agentDid === undefined) {
       throw new Error(
-        'Web5UserAgent: The "agentDid" property is not set. Ensure the agent is properly ' +
+        'EnboxUserAgent: The "agentDid" property is not set. Ensure the agent is properly ' +
         'initialized and a DID is assigned.'
       );
     }
@@ -148,7 +148,7 @@ export class Web5UserAgent<TKeyManager extends AgentKeyManager = LocalKeyManager
     localDwnStrategy,
     agentDid, agentVault, cryptoApi, didApi, dwnApi, identityApi, keyManager, permissionsApi, rpcClient, syncApi
   }: CreateUserAgentParams = {}
-  ): Promise<Web5UserAgent> {
+  ): Promise<EnboxUserAgent> {
 
     agentVault ??= new HdIdentityVault({
       keyDerivationWorkFactor : 210_000,
@@ -177,12 +177,12 @@ export class Web5UserAgent<TKeyManager extends AgentKeyManager = LocalKeyManager
 
     permissionsApi ??= new AgentPermissionsApi();
 
-    rpcClient ??= new Web5RpcClient();
+    rpcClient ??= new EnboxRpcClient();
 
     syncApi ??= new AgentSyncApi({ syncEngine: new SyncEngineLevel({ dataPath }) });
 
     // Instantiate the Agent using the provided or default components.
-    return new Web5UserAgent({
+    return new EnboxUserAgent({
       agentDid,
       agentVault,
       cryptoApi,
@@ -261,3 +261,13 @@ export class Web5UserAgent<TKeyManager extends AgentKeyManager = LocalKeyManager
     this.agentDid = await this.vault.getDid();
   }
 }
+
+// ---------------------------------------------------------------------------
+// Deprecated aliases — migration aid
+// ---------------------------------------------------------------------------
+
+/** @deprecated Use {@link EnboxUserAgent} instead. Will be removed in a future version. */
+export const Web5UserAgent = EnboxUserAgent;
+
+/** @deprecated Use {@link EnboxUserAgent} instead. Will be removed in a future version. */
+export type Web5UserAgent = EnboxUserAgent;

--- a/packages/agent/src/identity-api.ts
+++ b/packages/agent/src/identity-api.ts
@@ -3,7 +3,7 @@ import type { RequireOnly } from '@enbox/common';
 import type { AgentDataStore } from './store-data.js';
 import type { AgentKeyManager } from './types/key-manager.js';
 import type { DidMethodCreateOptions } from './did-api.js';
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type { IdentityMetadata, PortableIdentity } from './types/identity.js';
 
 import { isPortableDid } from '@enbox/dids';
@@ -12,7 +12,7 @@ import { BearerIdentity } from './bearer-identity.js';
 import { InMemoryIdentityStore } from './store-identity.js';
 
 export interface IdentityApiParams<TKeyManager extends AgentKeyManager> {
-  agent?: Web5PlatformAgent<TKeyManager>;
+  agent?: EnboxPlatformAgent<TKeyManager>;
 
   store?: AgentDataStore<IdentityMetadata>;
 }
@@ -47,12 +47,12 @@ export function isPortableIdentity(obj: unknown): obj is PortableIdentity {
  */
 export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyManager> {
   /**
-   * Holds the instance of a `Web5PlatformAgent` that represents the current execution context for
+   * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
    * the `AgentIdentityApi`. This agent is used to interact with other Web5 agent components. It's
    * vital to ensure this instance is set to correctly contextualize operations within the broader
    * Web5 Agent framework.
    */
-  private _agent?: Web5PlatformAgent<TKeyManager>;
+  private _agent?: EnboxPlatformAgent<TKeyManager>;
 
   private _store: AgentDataStore<IdentityMetadata>;
 
@@ -64,12 +64,12 @@ export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyMana
   }
 
   /**
-   * Retrieves the `Web5PlatformAgent` execution context.
+   * Retrieves the `EnboxPlatformAgent` execution context.
    *
-   * @returns The `Web5PlatformAgent` instance that represents the current execution context.
+   * @returns The `EnboxPlatformAgent` instance that represents the current execution context.
    * @throws Will throw an error if the `agent` instance property is undefined.
    */
-  get agent(): Web5PlatformAgent<TKeyManager> {
+  get agent(): EnboxPlatformAgent<TKeyManager> {
     if (this._agent === undefined) {
       throw new Error('AgentIdentityApi: Unable to determine agent execution context.');
     }
@@ -77,7 +77,7 @@ export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyMana
     return this._agent;
   }
 
-  set agent(agent: Web5PlatformAgent<TKeyManager>) {
+  set agent(agent: EnboxPlatformAgent<TKeyManager>) {
     this._agent = agent;
   }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -35,4 +35,4 @@ export * from './test-harness.js';
 export * from './utils.js';
 export * from './connect.js';
 export * from './oidc.js';
-export * from './web5-user-agent.js';
+export * from './enbox-user-agent.js';

--- a/packages/agent/src/local-dwn.ts
+++ b/packages/agent/src/local-dwn.ts
@@ -14,7 +14,7 @@
  * @module
  */
 
-import type { Web5Rpc } from '@enbox/dwn-clients';
+import type { EnboxRpc } from '@enbox/dwn-clients';
 
 import type { DwnDiscoveryFile } from './dwn-discovery-file.js';
 
@@ -67,7 +67,7 @@ export class LocalDwnDiscovery {
   private _cacheExpiry = 0;
 
   constructor(
-    private _rpcClient: Web5Rpc,
+    private _rpcClient: EnboxRpc,
     private _cacheTtlMs = 10_000,
     private _discoveryFile?: DwnDiscoveryFile,
   ) {}

--- a/packages/agent/src/local-key-manager.ts
+++ b/packages/agent/src/local-key-manager.ts
@@ -48,7 +48,7 @@ import { Encryption, HdKey } from '@enbox/dwn-sdk-js';
 
 import type { AgentDataStore } from './store-data.js';
 import type { AgentKeyManager } from './types/key-manager.js';
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 
 import { InMemoryKeyStore } from './store-key.js';
 
@@ -121,7 +121,7 @@ type SupportedKeyGeneratorAlgorithm =
  * the application exits.
  */
 export type LocalKmsParams = {
-  agent?: Web5PlatformAgent;
+  agent?: EnboxPlatformAgent;
 
   /**
    * An optional property to specify a custom {@link AgentDataStore} instance for key management. If
@@ -164,12 +164,12 @@ export interface LocalKmsUnwrapKeyParams extends KmsUriUnwrapKeyParams {
 
 export class LocalKeyManager implements AgentKeyManager {
   /**
-   * Holds the instance of a `Web5PlatformAgent` that represents the current execution context for
+   * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
    * the `LocalKeyManager`. This agent is used to interact with other Web5 agent components. It's
    * vital to ensure this instance is set to correctly contextualize operations within the broader
    * Web5 Agent framework.
    */
-  private _agent?: Web5PlatformAgent;
+  private _agent?: EnboxPlatformAgent;
 
   /**
    * A private map that stores instances of cryptographic algorithm implementations. Each key in
@@ -196,12 +196,12 @@ export class LocalKeyManager implements AgentKeyManager {
   }
 
   /**
-   * Retrieves the `Web5PlatformAgent` execution context.
+   * Retrieves the `EnboxPlatformAgent` execution context.
    *
-   * @returns The `Web5PlatformAgent` instance that represents the current execution context.
+   * @returns The `EnboxPlatformAgent` instance that represents the current execution context.
    * @throws Will throw an error if the `agent` instance property is undefined.
    */
-  get agent(): Web5PlatformAgent {
+  get agent(): EnboxPlatformAgent {
     if (this._agent === undefined) {
       throw new Error('LocalKeyManager: Unable to determine agent execution context.');
     }
@@ -209,7 +209,7 @@ export class LocalKeyManager implements AgentKeyManager {
     return this._agent;
   }
 
-  set agent(agent: Web5PlatformAgent) {
+  set agent(agent: EnboxPlatformAgent) {
     this._agent = agent;
   }
 

--- a/packages/agent/src/oidc.ts
+++ b/packages/agent/src/oidc.ts
@@ -1,6 +1,6 @@
 import type { ConnectPermissionRequest } from './connect.js';
+import type { EnboxAgent } from './types/agent.js';
 import type { RequireOnly } from '@enbox/common';
-import type { Web5Agent } from './types/agent.js';
 import type { DidDocument, PortableDid } from '@enbox/dids';
 import type { DwnDataEncodedRecordsWriteMessage, DwnPermissionScope, DwnProtocolDefinition } from './types/dwn.js';
 import type {
@@ -34,7 +34,7 @@ import { isRecordPermissionScope } from './dwn-api.js';
  * @see {@link https://www.rfc-editor.org/rfc/rfc9126.html | OAuth 2.0 Pushed Authorization Requests}
  */
 export type PushedAuthRequest = {
-  /** The JWT which contains the {@link Web5ConnectAuthRequest} */
+  /** The JWT which contains the {@link EnboxConnectAuthRequest} */
   request: string;
 };
 
@@ -134,7 +134,7 @@ export type SIOPv2AuthRequest = {
  * An auth request that is compatible with both Web5 Connect and (hopefully, WIP) OIDC SIOPv2
  * The contents of this are inserted into a JWT inside of the {@link PushedAuthRequest}.
  */
-export type Web5ConnectAuthRequest = {
+export type EnboxConnectAuthRequest = {
   /** The user friendly name of the client/app to be displayed when prompting end-user with permission requests. */
   displayName: string;
 
@@ -168,16 +168,16 @@ export type SIOPv2AuthResponse = {
 };
 
 /** An auth response that is compatible with both Web5 Connect and (hopefully, WIP) OIDC SIOPv2 */
-export type Web5ConnectAuthResponse = {
+export type EnboxConnectAuthResponse = {
   delegateGrants: DwnDataEncodedRecordsWriteMessage[];
   delegatePortableDid: PortableDid;
 } & SIOPv2AuthResponse;
 
 /** Represents the different OIDC endpoint types.
  * 1. `pushedAuthorizationRequest`: client sends {@link PushedAuthRequest} receives {@link PushedAuthResponse}
- * 2. `authorize`: provider gets the {@link Web5ConnectAuthRequest} JWT that was stored by the PAR
- * 3. `callback`: provider sends {@link Web5ConnectAuthResponse} to this endpoint
- * 4. `token`: client gets {@link Web5ConnectAuthResponse} from this endpoint
+ * 2. `authorize`: provider gets the {@link EnboxConnectAuthRequest} JWT that was stored by the PAR
+ * 3. `callback`: provider sends {@link EnboxConnectAuthResponse} to this endpoint
+ * 4. `token`: client gets {@link EnboxConnectAuthResponse} from this endpoint
  */
 type OidcEndpoint =
   | 'pushedAuthorizationRequest'
@@ -210,17 +210,17 @@ function buildOidcUrl({
     /** 1. client sends {@link PushedAuthRequest} & client receives {@link PushedAuthResponse} */
     case 'pushedAuthorizationRequest':
       return concatenateUrl(baseURL, 'par');
-    /** 2. provider gets {@link Web5ConnectAuthRequest} */
+    /** 2. provider gets {@link EnboxConnectAuthRequest} */
     case 'authorize':
       if (!authParam)
       {throw new Error(
         `authParam must be providied when building a token URL`
       );}
       return concatenateUrl(baseURL, `authorize/${authParam}.jwt`);
-    /** 3. provider sends {@link Web5ConnectAuthResponse} */
+    /** 3. provider sends {@link EnboxConnectAuthResponse} */
     case 'callback':
       return concatenateUrl(baseURL, `callback`);
-    /**  4. client gets {@link Web5ConnectAuthResponse */
+    /**  4. client gets {@link EnboxConnectAuthResponse */
     case 'token':
       if (!tokenParam)
       {throw new Error(
@@ -248,20 +248,20 @@ async function generateCodeChallenge(): Promise<{ codeChallengeBytes: Uint8Array
   return { codeChallengeBytes, codeChallengeBase64Url };
 }
 
-/** Client creates the {@link Web5ConnectAuthRequest} */
+/** Client creates the {@link EnboxConnectAuthRequest} */
 async function createAuthRequest(
   options: RequireOnly<
-    Web5ConnectAuthRequest,
+    EnboxConnectAuthRequest,
     'client_id' | 'scope' | 'redirect_uri' | 'permissionRequests' | 'displayName'
   >
-): Promise<Web5ConnectAuthRequest> {
+): Promise<EnboxConnectAuthRequest> {
   // Generate a random state value to associate the authorization request with the response.
   const stateBytes = CryptoUtils.randomBytes(16);
 
   // Generate a random nonce value to associate the ID Token with the authorization request.
   const nonceBytes = CryptoUtils.randomBytes(16);
 
-  const requestObject: Web5ConnectAuthRequest = {
+  const requestObject: EnboxConnectAuthRequest = {
     ...options,
     nonce           : Convert.uint8Array(nonceBytes).toBase64Url(),
     response_type   : 'id_token',
@@ -313,13 +313,13 @@ async function encryptAuthRequest({
 /** Create a response object compatible with Web5 Connect and OIDC SIOPv2 */
 async function createResponseObject(
   options: RequireOnly<
-    Web5ConnectAuthResponse,
+    EnboxConnectAuthResponse,
     'iss' | 'sub' | 'aud' | 'delegateGrants' | 'delegatePortableDid'
   >
-): Promise<Web5ConnectAuthResponse> {
+): Promise<EnboxConnectAuthResponse> {
   const currentTimeInSeconds = Math.floor(Date.now() / 1000);
 
-  const responseObject: Web5ConnectAuthResponse = {
+  const responseObject: EnboxConnectAuthResponse = {
     ...options,
     iat : currentTimeInSeconds,
     exp : currentTimeInSeconds + 600, // Expires in 10 minutes.
@@ -406,10 +406,10 @@ async function verifyJwt({ jwt }: { jwt: string }): Promise<Record<string, unkno
 }
 
 /**
- * Fetches the {@Web5ConnectAuthRequest} from the authorize endpoint and decrypts it
+ * Fetches the {@EnboxConnectAuthRequest} from the authorize endpoint and decrypts it
  * using the encryption key passed via QR code.
  */
-const getAuthRequest = async (request_uri: string, encryption_key: string): Promise<Web5ConnectAuthRequest> => {
+const getAuthRequest = async (request_uri: string, encryption_key: string): Promise<EnboxConnectAuthRequest> => {
   const authRequest = await fetch(request_uri, { signal: AbortSignal.timeout(30_000) });
   const jwe = await authRequest.text();
   const jwt = await decryptAuthRequest({
@@ -418,7 +418,7 @@ const getAuthRequest = async (request_uri: string, encryption_key: string): Prom
   });
   const web5ConnectAuthRequest = (await verifyJwt({
     jwt,
-  })) as Web5ConnectAuthRequest;
+  })) as EnboxConnectAuthRequest;
 
   return web5ConnectAuthRequest;
 };
@@ -461,7 +461,7 @@ async function decryptAuthRequest({
 
 /**
  * The client uses to decrypt the jwe obtained from the auth server which contains
- * the {@link Web5ConnectAuthResponse} that was sent by the provider to the auth server.
+ * the {@link EnboxConnectAuthResponse} that was sent by the provider to the auth server.
  *
  * @async
  * @param {BearerDid} clientDid - The did that was initially used by the client for ECDH at connect init.
@@ -517,7 +517,7 @@ async function decryptAuthResponse(
   return jwt;
 }
 
-/** Derives a shared ECDH private key in order to encrypt the {@link Web5ConnectAuthResponse} */
+/** Derives a shared ECDH private key in order to encrypt the {@link EnboxConnectAuthResponse} */
 async function deriveSharedKey(
   privateKeyDid: BearerDid,
   publicKeyDid: DidDocument
@@ -616,12 +616,12 @@ function shouldUseDelegatePermission(scope: DwnPermissionScope): boolean {
 
 /**
  * Creates the permission grants that assign to the selectedDid the level of
- * permissions that the web app requested in the {@link Web5ConnectAuthRequest}
+ * permissions that the web app requested in the {@link EnboxConnectAuthRequest}
  */
 async function createPermissionGrants(
   selectedDid: string,
   delegateBearerDid: BearerDid,
-  agent: Web5Agent,
+  agent: EnboxAgent,
   scopes: DwnPermissionScope[],
 ): Promise<DwnDataEncodedRecordsWriteMessage[]> {
   const permissionsApi = new AgentPermissionsApi({ agent });
@@ -683,7 +683,7 @@ async function createPermissionGrants(
  */
 async function prepareProtocol(
   selectedDid: string,
-  agent: Web5Agent,
+  agent: EnboxAgent,
   protocolDefinition: DwnProtocolDefinition
 ): Promise<void> {
 
@@ -744,17 +744,17 @@ async function prepareProtocol(
 /**
  * Creates a delegate did which the web app will use as its future indentity.
  * Assigns to that DID the level of permissions that the web app requested in
- * the {@link Web5ConnectAuthRequest}. Encrypts via ECDH key that the web app
+ * the {@link EnboxConnectAuthRequest}. Encrypts via ECDH key that the web app
  * will have access to because the web app has the public key which it provided
- * in the {@link Web5ConnectAuthRequest}. Then sends the ciphertext of this
- * {@link Web5ConnectAuthResponse} to the callback endpoint. Which the
+ * in the {@link EnboxConnectAuthRequest}. Then sends the ciphertext of this
+ * {@link EnboxConnectAuthResponse} to the callback endpoint. Which the
  * web app will need to retrieve from the token endpoint and decrypt with the pin to access.
  */
 async function submitAuthResponse(
   selectedDid: string,
-  authRequest: Web5ConnectAuthRequest,
+  authRequest: EnboxConnectAuthRequest,
   randomPin: string,
-  agent: Web5Agent
+  agent: EnboxAgent
 ): Promise<void> {
   const delegateBearerDid = await DidJwk.create();
   const delegatePortableDid = await delegateBearerDid.export();
@@ -852,3 +852,13 @@ export const Oidc = {
   generateCodeChallenge,
   submitAuthResponse,
 };
+
+// ---------------------------------------------------------------------------
+// Deprecated aliases — migration aid
+// ---------------------------------------------------------------------------
+
+/** @deprecated Use {@link EnboxConnectAuthRequest} instead. */
+export type Web5ConnectAuthRequest = EnboxConnectAuthRequest;
+
+/** @deprecated Use {@link EnboxConnectAuthResponse} instead. */
+export type Web5ConnectAuthResponse = EnboxConnectAuthResponse;

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -1,4 +1,4 @@
-import type { Web5Agent } from './types/agent.js';
+import type { EnboxAgent } from './types/agent.js';
 import type { CreateGrantParams, CreateRequestParams, CreateRevocationParams, FetchPermissionRequestParams, FetchPermissionsParams, GetPermissionParams, IsGrantRevokedParams, PermissionGrantEntry, PermissionRequestEntry, PermissionRevocationEntry, PermissionsApi } from './types/permissions.js';
 import type { DwnDataEncodedRecordsWriteMessage, DwnMessageParams, DwnMessagesPermissionScope, DwnPermissionScope, DwnProtocolPermissionScope, DwnRecordsPermissionScope, ProcessDwnRequest } from './types/dwn.js';
 import type { PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData } from '@enbox/dwn-sdk-js';
@@ -13,20 +13,20 @@ export class AgentPermissionsApi implements PermissionsApi {
   /** cache for fetching a permission {@link PermissionGrant}, keyed by a specific MessageType and protocol */
   private _cachedPermissions: TtlCache<string, PermissionGrantEntry> = new TtlCache({ ttl: 60 * 1000 });
 
-  private _agent?: Web5Agent;
+  private _agent?: EnboxAgent;
 
-  get agent(): Web5Agent {
+  get agent(): EnboxAgent {
     if (!this._agent) {
       throw new Error('AgentPermissionsApi: Agent is not set');
     }
     return this._agent;
   }
 
-  set agent(agent:Web5Agent) {
+  set agent(agent:EnboxAgent) {
     this._agent = agent;
   }
 
-  constructor({ agent }: { agent?: Web5Agent } = {}) {
+  constructor({ agent }: { agent?: EnboxAgent } = {}) {
     this._agent = agent;
   }
 

--- a/packages/agent/src/store-data.ts
+++ b/packages/agent/src/store-data.ts
@@ -4,7 +4,7 @@ import ms from 'ms';
 import { Convert, Stream, TtlCache } from '@enbox/common';
 
 import type { DwnMessageParams } from './types/dwn.js';
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type { ProtocolDefinition, RecordsReadReplyEntry } from '@enbox/dwn-sdk-js';
 
 import { Protocols } from '@enbox/dwn-sdk-js';
@@ -13,7 +13,7 @@ import { DwnInterface } from './types/dwn.js';
 import { getDataStoreTenant, TENANT_SEPARATOR } from './utils-internal.js';
 
 export type DataStoreTenantParams = {
-  agent: Web5PlatformAgent;
+  agent: EnboxPlatformAgent;
   tenant?: string;
 };
 
@@ -269,7 +269,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
   }
 
   protected async getAllRecords(_params: {
-    agent: Web5PlatformAgent;
+    agent: EnboxPlatformAgent;
     tenantDid: string;
   }): Promise<TStoreObject[]> {
     throw new Error('Not implemented: Classes extending DwnDataStore must implement getAllRecords()');
@@ -278,7 +278,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
   private async getRecord({ recordId, tenantDid, agent, useCache }: {
     recordId: string;
     tenantDid: string;
-    agent: Web5PlatformAgent;
+    agent: EnboxPlatformAgent;
     useCache: boolean;
   }): Promise<TStoreObject | undefined> {
     // If caching is enabled, check the cache for the record ID.
@@ -322,7 +322,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
    * If the tenant DID lacks an X25519 keyAgreement key, the error propagates
    * — plaintext fallback is not allowed.
    */
-  private async installProtocol(tenant: string, agent: Web5PlatformAgent): Promise<void> {
+  private async installProtocol(tenant: string, agent: EnboxPlatformAgent): Promise<void> {
     let definition = this._recordProtocolDefinition;
     let encryptionActive = false;
 
@@ -353,7 +353,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
   private async lookupRecordId({ id, tenantDid, agent }: {
     id: string;
     tenantDid: string;
-    agent: Web5PlatformAgent;
+    agent: EnboxPlatformAgent;
   }): Promise<string | undefined> {
     // Check the index for a matching ID and extend the index TTL.
     let recordId = this._index.get(`${tenantDid}${TENANT_SEPARATOR}${id}`, { updateAgeOnGet: true });
@@ -373,7 +373,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
   private async getExistingRecordEntry({ id, tenantDid, agent }: {
     id: string;
     tenantDid: string;
-    agent: Web5PlatformAgent;
+    agent: EnboxPlatformAgent;
   }): Promise<RecordsReadReplyEntry | undefined> {
     // Look up the DWN record ID of the object in the store with the given `id`.
     const recordId = await this.lookupRecordId({ id, tenantDid, agent });

--- a/packages/agent/src/store-did.ts
+++ b/packages/agent/src/store-did.ts
@@ -3,7 +3,7 @@ import type { PortableDid } from '@enbox/dids';
 import { Convert } from '@enbox/common';
 import { isPortableDid } from '@enbox/dids';
 
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type { AgentDataStore, DataStoreDeleteParams, DataStoreGetParams, DataStoreListParams, DataStoreSetParams } from './store-data.js';
 
 import { DwnInterface } from './types/dwn.js';
@@ -43,7 +43,7 @@ export class DwnDidStore extends DwnDataStore<PortableDid> implements AgentDataS
   }
 
   protected async getAllRecords({ agent, tenantDid }: {
-    agent: Web5PlatformAgent;
+    agent: EnboxPlatformAgent;
     tenantDid: string;
   }): Promise<PortableDid[]> {
     // Clear the index since it will be rebuilt from the query results.

--- a/packages/agent/src/store-identity.ts
+++ b/packages/agent/src/store-identity.ts
@@ -1,7 +1,7 @@
 import { Convert } from '@enbox/common';
 
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type { IdentityMetadata } from './types/identity.js';
-import type { Web5PlatformAgent } from './types/agent.js';
 import type { AgentDataStore, DataStoreDeleteParams, DataStoreGetParams, DataStoreListParams, DataStoreSetParams } from './store-data.js';
 
 import { DwnInterface } from './types/dwn.js';
@@ -47,7 +47,7 @@ export class DwnIdentityStore extends DwnDataStore<IdentityMetadata> implements 
   }
 
   protected async getAllRecords({ agent, tenantDid }: {
-    agent: Web5PlatformAgent;
+    agent: EnboxPlatformAgent;
     tenantDid: string;
   }): Promise<IdentityMetadata[]> {
     // Clear the index since it will be rebuilt from the query results.

--- a/packages/agent/src/store-key.ts
+++ b/packages/agent/src/store-key.ts
@@ -5,7 +5,7 @@ import { isPrivateJwk, KEY_URI_PREFIX_JWK } from '@enbox/crypto';
 
 import type { RecordsReadReply } from '@enbox/dwn-sdk-js';
 
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 
 import { DwnInterface } from './types/dwn.js';
 import { JwkProtocolDefinition } from './store-data-protocols.js';
@@ -45,7 +45,7 @@ export class DwnKeyStore extends DwnDataStore<Jwk> implements AgentDataStore<Jwk
   }
 
   protected async getAllRecords({ agent, tenantDid }: {
-    agent: Web5PlatformAgent;
+    agent: EnboxPlatformAgent;
     tenantDid: string;
   }): Promise<Jwk[]> {
     // Clear the index since it will be rebuilt from the query results.

--- a/packages/agent/src/sync-api.ts
+++ b/packages/agent/src/sync-api.ts
@@ -1,19 +1,19 @@
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type { StartSyncParams, SyncConnectivityState, SyncEngine, SyncIdentityOptions } from './types/sync.js';
 
 export type SyncApiParams = {
-  agent?: Web5PlatformAgent;
+  agent?: EnboxPlatformAgent;
   syncEngine: SyncEngine;
 };
 
 export class AgentSyncApi implements SyncEngine {
   /**
-   * Holds the instance of a `Web5PlatformAgent` that represents the current execution context for
+   * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
    * the `AgentSyncApi`. This agent is used to interact with other Web5 agent components. It's vital
    * to ensure this instance is set to correctly contextualize operations within the broader Web5
    * Agent framework.
    */
-  private _agent?: Web5PlatformAgent;
+  private _agent?: EnboxPlatformAgent;
 
   private _syncEngine: SyncEngine;
 
@@ -23,12 +23,12 @@ export class AgentSyncApi implements SyncEngine {
   }
 
   /**
-   * Retrieves the `Web5PlatformAgent` execution context.
+   * Retrieves the `EnboxPlatformAgent` execution context.
    *
-   * @returns The `Web5PlatformAgent` instance that represents the current execution context.
+   * @returns The `EnboxPlatformAgent` instance that represents the current execution context.
    * @throws Will throw an error if the `agent` instance property is undefined.
    */
-  get agent(): Web5PlatformAgent {
+  get agent(): EnboxPlatformAgent {
     if (this._agent === undefined) {
       throw new Error('AgentSyncApi: Unable to determine agent execution context.');
     }
@@ -36,7 +36,7 @@ export class AgentSyncApi implements SyncEngine {
     return this._agent;
   }
 
-  set agent(agent: Web5PlatformAgent) {
+  set agent(agent: EnboxPlatformAgent) {
     this._agent = agent;
     this._syncEngine.agent = agent;
   }

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -7,8 +7,8 @@ import { Level } from 'level';
 import { hashToHex, initDefaultHashes, Message } from '@enbox/dwn-sdk-js';
 
 import type { PermissionsApi } from './types/permissions.js';
+import type { EnboxAgent, EnboxPlatformAgent } from './types/agent.js';
 import type { StartSyncParams, SyncConnectivityState, SyncEngine, SyncIdentityOptions, SyncMode } from './types/sync.js';
-import type { Web5Agent, Web5PlatformAgent } from './types/agent.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
@@ -17,7 +17,7 @@ import { topologicalSort } from './sync-topological-sort.js';
 import { pullMessages, pushMessages } from './sync-messages.js';
 
 export type SyncEngineLevelParams = {
-  agent?: Web5PlatformAgent;
+  agent?: EnboxPlatformAgent;
   dataPath?: string;
   db?: AbstractLevel<string | Buffer | Uint8Array>;
 };
@@ -61,12 +61,12 @@ type LocalSubscription = {
 
 export class SyncEngineLevel implements SyncEngine {
   /**
-   * Holds the instance of a `Web5PlatformAgent` that represents the current execution context for
+   * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
    * the `SyncEngineLevel`. This agent is used to interact with other Web5 agent components. It's
    * vital to ensure this instance is set to correctly contextualize operations within the broader
    * Web5 Agent framework.
    */
-  private _agent?: Web5PlatformAgent;
+  private _agent?: EnboxPlatformAgent;
 
   /**
    * An instance of the `AgentPermissionsApi` that is used to interact with permissions grants used during sync
@@ -117,17 +117,17 @@ export class SyncEngineLevel implements SyncEngine {
 
   constructor({ agent, dataPath, db }: SyncEngineLevelParams) {
     this._agent = agent;
-    this._permissionsApi = new AgentPermissionsApi({ agent: agent as Web5Agent });
+    this._permissionsApi = new AgentPermissionsApi({ agent: agent as EnboxAgent });
     this._db = (db) ? db : new Level<string, string>(dataPath ?? 'DATA/AGENT/SYNC_STORE');
   }
 
   /**
-   * Retrieves the `Web5PlatformAgent` execution context.
+   * Retrieves the `EnboxPlatformAgent` execution context.
    *
-   * @returns The `Web5PlatformAgent` instance that represents the current execution context.
+   * @returns The `EnboxPlatformAgent` instance that represents the current execution context.
    * @throws Will throw an error if the `agent` instance property is undefined.
    */
-  get agent(): Web5PlatformAgent {
+  get agent(): EnboxPlatformAgent {
     if (this._agent === undefined) {
       throw new Error('SyncEngineLevel: Unable to determine agent execution context.');
     }
@@ -135,9 +135,9 @@ export class SyncEngineLevel implements SyncEngine {
     return this._agent;
   }
 
-  set agent(agent: Web5PlatformAgent) {
+  set agent(agent: EnboxPlatformAgent) {
     this._agent = agent;
-    this._permissionsApi = new AgentPermissionsApi({ agent: agent as Web5Agent });
+    this._permissionsApi = new AgentPermissionsApi({ agent: agent as EnboxAgent });
   }
 
   get connectivityState(): SyncConnectivityState {

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -1,5 +1,5 @@
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
-import type { Web5PlatformAgent } from './types/agent.js';
 import type { GenericMessage, MessagesReadReply, UnionMessageReply } from '@enbox/dwn-sdk-js';
 
 import { DwnInterfaceName, DwnMethodName, Message } from '@enbox/dwn-sdk-js';
@@ -54,7 +54,7 @@ export async function pullMessages({ did, dwnUrl, delegateDid, protocol, message
   delegateDid?: string;
   protocol?: string;
   messageCids: string[];
-  agent: Web5PlatformAgent;
+  agent: EnboxPlatformAgent;
   permissionsApi: PermissionsApi;
 }): Promise<void> {
   // Step 1: Fetch all missing messages from the remote in parallel.
@@ -101,7 +101,7 @@ export async function fetchRemoteMessages({ did, dwnUrl, delegateDid, protocol, 
   delegateDid?: string;
   protocol?: string;
   messageCids: string[];
-  agent: Web5PlatformAgent;
+  agent: EnboxPlatformAgent;
   permissionsApi: PermissionsApi;
 }): Promise<SyncMessageEntry[]> {
   const results: SyncMessageEntry[] = [];
@@ -189,7 +189,7 @@ export async function pushMessages({ did, dwnUrl, delegateDid, protocol, message
   delegateDid?: string;
   protocol?: string;
   messageCids: string[];
-  agent: Web5PlatformAgent;
+  agent: EnboxPlatformAgent;
   permissionsApi: PermissionsApi;
 }): Promise<void> {
   // Step 1: Fetch all local messages (streams are pull-based, not yet consumed).
@@ -234,7 +234,7 @@ export async function getLocalMessage({ author, delegateDid, protocol, messageCi
   delegateDid?: string;
   protocol?: string;
   messageCid: string;
-  agent: Web5PlatformAgent;
+  agent: EnboxPlatformAgent;
   permissionsApi: PermissionsApi;
 }): Promise<SyncMessageEntry | undefined> {
   let permissionGrantId: string | undefined;

--- a/packages/agent/src/test-harness.ts
+++ b/packages/agent/src/test-harness.ts
@@ -2,8 +2,8 @@ import type { AbstractLevel } from 'abstract-level';
 import type { BearerIdentity } from './bearer-identity.js';
 import type { DidResolverCache } from '@enbox/dids';
 import type { Dwn } from '@enbox/dwn-sdk-js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 import type { KeyValueStore } from '@enbox/common';
-import type { Web5PlatformAgent } from './types/agent.js';
 
 import { Level } from 'level';
 import { DataStoreLevel, EventEmitterEventLog, MessageStoreLevel, ResumableTaskStoreLevel, StateIndexLevel } from '@enbox/dwn-sdk-js';
@@ -17,10 +17,10 @@ import { AgentDwnApi } from './dwn-api.js';
 import { AgentIdentityApi } from './identity-api.js';
 import { AgentPermissionsApi } from './permissions-api.js';
 import { AgentSyncApi } from './sync-api.js';
+import { EnboxRpcClient } from '@enbox/dwn-clients';
 import { HdIdentityVault } from './hd-identity-vault.js';
 import { LocalKeyManager } from './local-key-manager.js';
 import { SyncEngineLevel } from './sync-engine-level.js';
-import { Web5RpcClient } from '@enbox/dwn-clients';
 import { DwnDidStore, InMemoryDidStore } from './store-did.js';
 import { DwnIdentityStore, InMemoryIdentityStore } from './store-identity.js';
 import { DwnKeyStore, InMemoryKeyStore } from './store-key.js';
@@ -36,7 +36,7 @@ type StoreSetupResult = {
 };
 
 type PlatformAgentTestHarnessParams = {
-  agent: Web5PlatformAgent<LocalKeyManager>
+  agent: EnboxPlatformAgent<LocalKeyManager>
 
   agentStores: 'dwn' | 'memory';
   didResolverCache: DidResolverCache;
@@ -56,7 +56,7 @@ type PlatformAgentTestHarnessParams = {
 };
 
 export class PlatformAgentTestHarness {
-  public agent: Web5PlatformAgent<LocalKeyManager>;
+  public agent: EnboxPlatformAgent<LocalKeyManager>;
 
   public agentStores: 'dwn' | 'memory';
   public didResolverCache: DidResolverCache;
@@ -215,7 +215,7 @@ export class PlatformAgentTestHarness {
   }
 
   public static async setup({ agentClass, agentStores, testDataLocation }: {
-    agentClass: new (params: any) => Web5PlatformAgent<LocalKeyManager>
+    agentClass: new (params: any) => EnboxPlatformAgent<LocalKeyManager>
     agentStores?: 'dwn' | 'memory';
     testDataLocation?: string;
   }): Promise<PlatformAgentTestHarness> {
@@ -228,7 +228,7 @@ export class PlatformAgentTestHarness {
     const cryptoApi = new AgentCryptoApi();
 
     // Instantiate Agent's RPC Client.
-    const rpcClient = new Web5RpcClient();
+    const rpcClient = new EnboxRpcClient();
 
     const dwnStores = {
       keyStore      : new DwnKeyStore(),
@@ -285,7 +285,7 @@ export class PlatformAgentTestHarness {
     const syncEngine = new SyncEngineLevel({ db: syncStore });
     const syncApi = new AgentSyncApi({ syncEngine });
 
-    // Create Web5PlatformAgent instance
+    // Create EnboxPlatformAgent instance
     const agent = new agentClass({
       agentVault,
       cryptoApi,
@@ -314,7 +314,7 @@ export class PlatformAgentTestHarness {
   }
 
   private static useDiskStores({ agent, testDataLocation, stores }: {
-    agent?: Web5PlatformAgent<LocalKeyManager>;
+    agent?: EnboxPlatformAgent<LocalKeyManager>;
     stores: {
       keyStore: DwnKeyStore;
       identityStore: DwnIdentityStore;
@@ -350,7 +350,7 @@ export class PlatformAgentTestHarness {
     return { agentVault, didApi, didResolverCache, identityApi, keyManager, permissionsApi, vaultStore };
   }
 
-  private static useMemoryStores({ agent }: { agent?: Web5PlatformAgent<LocalKeyManager> } = {}): StoreSetupResult {
+  private static useMemoryStores({ agent }: { agent?: EnboxPlatformAgent<LocalKeyManager> } = {}): StoreSetupResult {
     const vaultStore = new MemoryStore<string, string>();
     const agentVault = new HdIdentityVault({ keyDerivationWorkFactor: 1, store: vaultStore });
 

--- a/packages/agent/src/types/agent.ts
+++ b/packages/agent/src/types/agent.ts
@@ -6,8 +6,9 @@ import type { AgentIdentityApi } from '../identity-api.js';
 import type { AgentKeyManager } from './key-manager.js';
 import type { AgentPermissionsApi } from '../permissions-api.js';
 import type { AgentSyncApi } from '../sync-api.js';
+import type { EnboxRpc } from '@enbox/dwn-clients';
 import type { IdentityVault } from './identity-vault.js';
-import type { Web5Rpc } from '@enbox/dwn-clients';
+import type { LocalKeyManager } from '../local-key-manager.js';
 import type { AgentDidApi, DidInterface, DidRequest, DidResponse } from '../did-api.js';
 import type { DwnInterface, DwnResponse, ProcessDwnRequest, SendDwnRequest } from './dwn.js';
 import type { ProcessVcRequest, SendVcRequest, VcResponse } from './vc.js';
@@ -63,7 +64,7 @@ export type ResponseStatus = {
  * The `AgentDid` property represents the Web5 Agent's own DID, while the various process and send
  * methods enable the Agent to handle and initiate requests pertaining to DIDs, DWNs, and VCs.
  */
-export interface Web5Agent {
+export interface EnboxAgent {
   /**
    * The Decentralized Identifier (DID) of this Web5 Agent.
    */
@@ -109,18 +110,18 @@ export interface Web5Agent {
 
 /**
  * Represents a Web5 Platform Agent, an extended and more feature-rich implementation of a
- * {@link Web5Agent}.
+ * {@link EnboxAgent}.
  *
  * This Agent integrates a comprehensive set of APIs and functionalities, including cryptographic
  * operations, DID management, DWN interaction, identity handling, and data synchronization.
  *
- * The platform agent provides a higher-level abstraction over the core Web5Agent functionalities,
+ * The platform agent provides a higher-level abstraction over the core EnboxAgent functionalities,
  * facilitating a robust platform for developing Web5 applications. It includes lifecycle management
  * methods like initialization and startup, alongside a suite of specialized APIs and utilities.
  *
  * @typeParam TKeyManager - The type of Key Manager used to manage cryptographic keys.
  */
-export interface Web5PlatformAgent<TKeyManager extends AgentKeyManager = AgentKeyManager> extends Web5Agent {
+export interface EnboxPlatformAgent<TKeyManager extends AgentKeyManager = AgentKeyManager> extends EnboxAgent {
   /**
    * The cryptography API, essential for performing various cryptographic operations such
    * as encryption, decryption, signing, and verification, ensuring secure data handling and
@@ -161,7 +162,7 @@ export interface Web5PlatformAgent<TKeyManager extends AgentKeyManager = AgentKe
    * The RPC (Remote Procedure Call) client interface, facilitating communication with other Web5
    * Agents and services.
    */
-  rpc: Web5Rpc;
+  rpc: EnboxRpc;
 
   /**
    * The synchronization API, responsible for managing the consistency and real-time update of the
@@ -193,3 +194,13 @@ export interface Web5PlatformAgent<TKeyManager extends AgentKeyManager = AgentKe
    */
   start(params: unknown): Promise<unknown>;
 }
+
+// ---------------------------------------------------------------------------
+// Deprecated aliases — migration aid
+// ---------------------------------------------------------------------------
+
+/** @deprecated Use {@link EnboxAgent} instead. Will be removed in a future version. */
+export type Web5Agent = EnboxAgent;
+
+/** @deprecated Use {@link EnboxPlatformAgent} instead. Will be removed in a future version. */
+export type Web5PlatformAgent<TKeyManager extends AgentKeyManager = LocalKeyManager> = EnboxPlatformAgent<TKeyManager>;

--- a/packages/agent/src/types/key-manager.ts
+++ b/packages/agent/src/types/key-manager.ts
@@ -16,7 +16,7 @@ import type {
   PublicKeyJwk,
 } from '@enbox/crypto';
 
-import type { Web5PlatformAgent } from './agent.js';
+import type { EnboxPlatformAgent } from './agent.js';
 
 export interface AgentKeyManager extends KeyManager,
   Cipher<KmsCipherParams, KmsCipherParams>,
@@ -25,7 +25,7 @@ export interface AgentKeyManager extends KeyManager,
   KeyDeleter<KmsDeleteKeyParams>,
   KeyWrapper<KmsUriWrapKeyParams, KmsUriUnwrapKeyParams> {
 
-  agent: Web5PlatformAgent;
+  agent: EnboxPlatformAgent;
 
   /**
    * Derives an HD child public key from a stored private key using HKDF-SHA256

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -1,4 +1,4 @@
-import type { Web5PlatformAgent } from './agent.js';
+import type { EnboxPlatformAgent } from './agent.js';
 
 /**
  * The SyncEngine is responsible for syncing messages between the agent and the platform.
@@ -58,7 +58,7 @@ export interface SyncEngine {
   /**
    * The agent that the SyncEngine is attached to.
    */
-  agent: Web5PlatformAgent;
+  agent: EnboxPlatformAgent;
 
   /**
    * Current connectivity state as observed by the sync engine.

--- a/packages/agent/src/utils-internal.ts
+++ b/packages/agent/src/utils-internal.ts
@@ -2,7 +2,7 @@ import type { Jwk, KeyIdentifier, KmsExportKeyParams, KmsGetPublicKeyParams, Kms
 
 import { computeJwkThumbprint, Ed25519, LocalKeyManager } from '@enbox/crypto';
 
-import type { Web5PlatformAgent } from './types/agent.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 
 /**
  * Internal utility functions used by the Web5 platform agent that are not intended for public use
@@ -128,7 +128,7 @@ export class DeterministicKeyGenerator extends LocalKeyManager {
  * @throws Throws an error if it fails to determine the tenant from the provided inputs.
  */
 export async function getDataStoreTenant({ agent, tenant, didUri }: {
-  agent: Web5PlatformAgent;
+  agent: EnboxPlatformAgent;
   tenant?: string;
   didUri?: string;
 }): Promise<string> {

--- a/packages/agent/tests/anonymous-dwn-api.spec.ts
+++ b/packages/agent/tests/anonymous-dwn-api.spec.ts
@@ -1,4 +1,4 @@
-import type { Web5Rpc } from '@enbox/dwn-clients';
+import type { EnboxRpc } from '@enbox/dwn-clients';
 import type { DidDereferencingResult, DidUrlDereferencer } from '@enbox/dids';
 
 import sinon from 'sinon';
@@ -9,7 +9,7 @@ import { AnonymousDwnApi } from '../src/anonymous-dwn-api.js';
 describe('AnonymousDwnApi', () => {
 
   let anonymousDwn: AnonymousDwnApi;
-  let rpcStub: sinon.SinonStubbedInstance<Web5Rpc>;
+  let rpcStub: sinon.SinonStubbedInstance<EnboxRpc>;
   let resolverStub: sinon.SinonStubbedInstance<DidUrlDereferencer>;
 
   const targetDid = 'did:example:alice';
@@ -34,9 +34,9 @@ describe('AnonymousDwnApi', () => {
   }
 
   /**
-   * Helper: create a stubbed Web5Rpc client.
+   * Helper: create a stubbed EnboxRpc client.
    */
-  function createRpcStub(): sinon.SinonStubbedInstance<Web5Rpc> {
+  function createRpcStub(): sinon.SinonStubbedInstance<EnboxRpc> {
     return {
       transportProtocols : [],
       sendDwnRequest     : sinon.stub(),
@@ -46,7 +46,7 @@ describe('AnonymousDwnApi', () => {
         maxFileSize              : 10_000_000,
         webSocketSupport         : false,
       }),
-    } as unknown as sinon.SinonStubbedInstance<Web5Rpc>;
+    } as unknown as sinon.SinonStubbedInstance<EnboxRpc>;
   }
 
   beforeEach(() => {

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -13,9 +13,9 @@ import { testDwnUrl } from './utils/test-config.js';
 import { type BearerDid, DidDht, DidJwk } from '@enbox/dids';
 import { DwnInterfaceName, DwnMethodName } from '@enbox/dwn-sdk-js';
 import {
+  type EnboxConnectAuthRequest,
+  type EnboxConnectAuthResponse,
   Oidc,
-  type Web5ConnectAuthRequest,
-  type Web5ConnectAuthResponse,
 } from '../src/oidc.js';
 
 import type { BearerIdentity, DwnMessage, DwnProtocolDefinition } from '../src/index.js';
@@ -163,11 +163,11 @@ describe('web5 connect', () => {
 
   let testHarness: PlatformAgentTestHarness;
 
-  let authRequest: Web5ConnectAuthRequest;
+  let authRequest: EnboxConnectAuthRequest;
   let authRequestJwt: string;
   let authRequestJwe: string;
 
-  let authResponse: Web5ConnectAuthResponse;
+  let authResponse: EnboxConnectAuthResponse;
   let authResponseJwt: string;
   let authResponseJwe: string;
 
@@ -445,7 +445,7 @@ describe('web5 connect', () => {
     it('should validate the jwt and parse it into an object', async () => {
       const result = (await Oidc.verifyJwt({
         jwt: authResponseJwt,
-      })) as Web5ConnectAuthResponse;
+      })) as EnboxConnectAuthResponse;
       expect(typeof result).toBe('object');
       expect(result.delegateGrants.length).toBeGreaterThan(0);
     });

--- a/packages/agent/tests/did-api.spec.ts
+++ b/packages/agent/tests/did-api.spec.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import type { BearerDid, PortableDid } from '@enbox/dids';
 import { DidDht, DidJwk } from '@enbox/dids';
 
-import type { Web5PlatformAgent } from '../src/types/agent.js';
+import type { EnboxPlatformAgent } from '../src/types/agent.js';
 
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { TestAgent } from './utils/test-agent.js';
@@ -30,7 +30,7 @@ describe('AgentDidApi', () => {
   describe('get agent', () => {
     it(`returns the 'agent' instance property`, async () => {
       // @ts-expect-error because we are only mocking a single property.
-      const mockAgent: Web5PlatformAgent = {
+      const mockAgent: EnboxPlatformAgent = {
         agentDid: { uri: 'did:method:abc123' } as BearerDid
       };
       const didApi = new AgentDidApi({ didMethods: [DidJwk], agent: mockAgent });

--- a/packages/agent/tests/e2e-encrypted-sync.spec.ts
+++ b/packages/agent/tests/e2e-encrypted-sync.spec.ts
@@ -6,11 +6,11 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 
 import { AgentSyncApi } from '../src/sync-api.js';
 import { DwnInterface } from '../src/types/dwn.js';
+import { EnboxUserAgent } from '../src/enbox-user-agent.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
-import { Web5UserAgent } from '../src/web5-user-agent.js';
 import { JwkProtocolDefinition, KeyDeliveryProtocolDefinition } from '../src/store-data-protocols.js';
 
 const testDwnUrls: string[] = [testDwnUrl];
@@ -276,15 +276,15 @@ describe('e2e: agent lifecycle with encrypted stores', () => {
 
     it('should initialize the agent with a vault and encrypted key store', async () => {
       harness = await PlatformAgentTestHarness.setup({
-        agentClass  : Web5UserAgent,
+        agentClass  : EnboxUserAgent,
         agentStores : 'dwn',
         testDataLocation,
       });
 
-      recoveryPhrase = await (harness.agent as Web5UserAgent).initialize({ password });
+      recoveryPhrase = await (harness.agent as EnboxUserAgent).initialize({ password });
       expect(recoveryPhrase.split(' ')).toHaveLength(12);
 
-      await (harness.agent as Web5UserAgent).start({ password });
+      await (harness.agent as EnboxUserAgent).start({ password });
       agentDidUri = harness.agent.agentDid.uri;
       expect(agentDidUri).toMatch(/^did:dht:/);
     }, 30_000);
@@ -334,13 +334,13 @@ describe('e2e: agent lifecycle with encrypted stores', () => {
 
     it('should restart the agent with the same password', async () => {
       harness = await PlatformAgentTestHarness.setup({
-        agentClass  : Web5UserAgent,
+        agentClass  : EnboxUserAgent,
         agentStores : 'dwn',
         testDataLocation,
       });
 
       // The vault is already initialized — just start with the password.
-      await (harness.agent as Web5UserAgent).start({ password });
+      await (harness.agent as EnboxUserAgent).start({ password });
       expect(harness.agent.agentDid.uri).toBe(agentDidUri);
     }, 30_000);
 

--- a/packages/agent/tests/e2e-two-layer-encryption.spec.ts
+++ b/packages/agent/tests/e2e-two-layer-encryption.spec.ts
@@ -4,9 +4,9 @@ import { Convert } from '@enbox/common';
 import { afterAll, describe, expect, it } from 'bun:test';
 
 import { DwnInterface } from '../src/types/dwn.js';
+import { EnboxUserAgent } from '../src/enbox-user-agent.js';
 import { JwkProtocolDefinition } from '../src/store-data-protocols.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
-import { Web5UserAgent } from '../src/web5-user-agent.js';
 
 /**
  * End-to-end test for two-layer encryption and recovery from seed phrase.
@@ -39,7 +39,7 @@ describe('e2e: two-layer encryption recovery', () => {
     // (e.g., when the entire suite was skipped due to DHT publish failures).
     try {
       const cleanupHarness = await PlatformAgentTestHarness.setup({
-        agentClass  : Web5UserAgent,
+        agentClass  : EnboxUserAgent,
         agentStores : 'dwn',
         testDataLocation,
       });
@@ -55,7 +55,7 @@ describe('e2e: two-layer encryption recovery', () => {
 
     it('should initialize the agent, returning a recovery phrase', async () => {
       harness = await PlatformAgentTestHarness.setup({
-        agentClass  : Web5UserAgent,
+        agentClass  : EnboxUserAgent,
         agentStores : 'dwn',
         testDataLocation,
       });
@@ -63,12 +63,12 @@ describe('e2e: two-layer encryption recovery', () => {
       // Initialize the vault — this creates the agent DID (did:dht with Ed25519 +
       // X25519) deterministically from a generated seed phrase, and encrypts
       // the PortableDid with the password (Layer 1).
-      recoveryPhrase = await (harness.agent as Web5UserAgent).initialize({ password });
+      recoveryPhrase = await (harness.agent as EnboxUserAgent).initialize({ password });
       expect(typeof recoveryPhrase).toBe('string');
       expect(recoveryPhrase.split(' ')).toHaveLength(12);
 
       // Start the agent (unlocks the vault).
-      await (harness.agent as Web5UserAgent).start({ password });
+      await (harness.agent as EnboxUserAgent).start({ password });
       originalAgentDidUri = harness.agent.agentDid.uri;
       expect(originalAgentDidUri).toMatch(/^did:dht:/);
     });
@@ -217,13 +217,13 @@ describe('e2e: two-layer encryption recovery', () => {
       // Create a fresh agent pointed at the same LevelDB paths. The DWN data is
       // still on disk; we need to unlock the vault and verify we can read it.
       harness = await PlatformAgentTestHarness.setup({
-        agentClass  : Web5UserAgent,
+        agentClass  : EnboxUserAgent,
         agentStores : 'dwn',
         testDataLocation,
       });
 
       // The vault should be locked since we just created a fresh agent instance.
-      expect((harness.agent as Web5UserAgent).vault.isLocked()).toBe(true);
+      expect((harness.agent as EnboxUserAgent).vault.isLocked()).toBe(true);
     });
 
     it('should recover the agent DID using the seed phrase (Layer 1)', async () => {
@@ -236,17 +236,17 @@ describe('e2e: two-layer encryption recovery', () => {
       // Re-initialize with the original recovery phrase but a NEW password.
       // The seed phrase deterministically re-derives the same agent DID, and the
       // new password re-encrypts the vault.
-      const returnedPhrase = await (harness.agent as Web5UserAgent).initialize({
+      const returnedPhrase = await (harness.agent as EnboxUserAgent).initialize({
         password: newPassword,
         recoveryPhrase,
       });
       expect(returnedPhrase).toBe(recoveryPhrase);
 
       // Verify the vault reports as initialized after recovery.
-      expect(await (harness.agent as Web5UserAgent).vault.isInitialized()).toBe(true);
+      expect(await (harness.agent as EnboxUserAgent).vault.isInitialized()).toBe(true);
 
       // Start the agent with the new password.
-      await (harness.agent as Web5UserAgent).start({ password: newPassword });
+      await (harness.agent as EnboxUserAgent).start({ password: newPassword });
 
       // The recovered agent DID should be identical to the original.
       expect(harness.agent.agentDid.uri).toBe(originalAgentDidUri);
@@ -258,10 +258,10 @@ describe('e2e: two-layer encryption recovery', () => {
       // re-encryption was effective.
 
       // Lock the vault first to simulate a fresh start attempt.
-      await (harness.agent as Web5UserAgent).vault.lock();
+      await (harness.agent as EnboxUserAgent).vault.lock();
 
       try {
-        await (harness.agent as Web5UserAgent).start({ password });
+        await (harness.agent as EnboxUserAgent).start({ password });
         throw new Error('Expected an error when using the old password');
       } catch (error: any) {
         // Re-throw Error from throw new Error() so it isn't swallowed.
@@ -270,7 +270,7 @@ describe('e2e: two-layer encryption recovery', () => {
       }
 
       // Re-unlock with the correct (new) password to continue the test.
-      await (harness.agent as Web5UserAgent).start({ password: newPassword });
+      await (harness.agent as EnboxUserAgent).start({ password: newPassword });
     });
 
     it('should read back all encrypted keys with exact match (Layer 2)', async () => {

--- a/packages/agent/tests/enbox-user-agent.spec.ts
+++ b/packages/agent/tests/enbox-user-agent.spec.ts
@@ -7,19 +7,19 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 
 import { DidInterface } from '../src/did-api.js';
 import { DwnInterface } from '../src/types/dwn.js';
+import { EnboxUserAgent } from '../src/enbox-user-agent.js';
 import freeForAllProtocolDefinition from './fixtures/protocol-definitions/free-for-all.json' with { type: 'json' };
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { testDwnUrl } from './utils/test-config.js';
-import { Web5UserAgent } from '../src/web5-user-agent.js';
 
 const testDwnUrls: string[] = [testDwnUrl];
 
-describe('Web5UserAgent', () => {
+describe('EnboxUserAgent', () => {
 
   describe('agentDid', () => {
     it('throws an error if accessed before the Agent is initialized', async () => {
       // @ts-expect-error - Initializing with empty object to test error.
-      const userAgent = new Web5UserAgent({ didApi: {}, dwnApi: {}, identityApi: {}, keyManager: {}, permissionsApi: {}, syncApi: {} });
+      const userAgent = new EnboxUserAgent({ didApi: {}, dwnApi: {}, identityApi: {}, keyManager: {}, permissionsApi: {}, syncApi: {} });
       try {
         userAgent.agentDid;
         throw new Error('Expected an error');
@@ -31,9 +31,9 @@ describe('Web5UserAgent', () => {
 
   describe('create()', () => {
     it('should create an instance with default parameters when none are provided', async () => {
-      const userAgent = await Web5UserAgent.create({ dataPath: '__TESTDATA__/USERAGENT' });
+      const userAgent = await EnboxUserAgent.create({ dataPath: '__TESTDATA__/USERAGENT' });
 
-      expect(userAgent).toBeInstanceOf(Web5UserAgent);
+      expect(userAgent).toBeInstanceOf(EnboxUserAgent);
       expect(userAgent.crypto).toBeDefined();
       expect(userAgent.did).toBeDefined();
       expect(userAgent.dwn).toBeDefined();
@@ -53,7 +53,7 @@ describe('Web5UserAgent', () => {
 
       beforeAll(async () => {
         testHarness = await PlatformAgentTestHarness.setup({
-          agentClass  : Web5UserAgent,
+          agentClass  : EnboxUserAgent,
           agentStores : agentStoreType
         });
       });
@@ -413,7 +413,7 @@ describe('Web5UserAgent', () => {
             // Simulate terminating and restarting an app.
             await testHarness.closeStorage();
             testHarness = await PlatformAgentTestHarness.setup({
-              agentClass  : Web5UserAgent,
+              agentClass  : EnboxUserAgent,
               agentStores : 'dwn'
             });
             await testHarness.agent.start({ password: 'test' });

--- a/packages/agent/tests/local-dwn.spec.ts
+++ b/packages/agent/tests/local-dwn.spec.ts
@@ -1,4 +1,4 @@
-import type { Web5Rpc } from '@enbox/dwn-clients';
+import type { EnboxRpc } from '@enbox/dwn-clients';
 
 import sinon from 'sinon';
 import { afterEach, describe, expect, it } from 'bun:test';
@@ -13,7 +13,7 @@ import {
 
 // ─── Helpers ─────────────────────────────────────────────────────
 
-function createRpcStub(behavior: 'valid' | 'invalid' | 'error' = 'valid'): Web5Rpc {
+function createRpcStub(behavior: 'valid' | 'invalid' | 'error' = 'valid'): EnboxRpc {
   const stub = sinon.stub();
 
   if (behavior === 'valid') {
@@ -24,7 +24,7 @@ function createRpcStub(behavior: 'valid' | 'invalid' | 'error' = 'valid'): Web5R
     stub.rejects(new Error('connection refused'));
   }
 
-  return { getServerInfo: stub } as unknown as Web5Rpc;
+  return { getServerInfo: stub } as unknown as EnboxRpc;
 }
 
 function createDiscoveryFileStub(record?: DwnDiscoveryRecord | null): DwnDiscoveryFile {
@@ -153,7 +153,7 @@ describe('LocalDwnDiscovery', () => {
       rpcStub.onFirstCall().rejects(new Error('connection refused'));
       rpcStub.resolves({ server: localDwnServerName });
 
-      const rpcClient = { getServerInfo: rpcStub } as unknown as Web5Rpc;
+      const rpcClient = { getServerInfo: rpcStub } as unknown as EnboxRpc;
       const discoveryFile = createDiscoveryFileStub({
         endpoint : 'http://127.0.0.1:55557',
         pid      : 12345,
@@ -263,7 +263,7 @@ describe('LocalDwnDiscovery', () => {
       rpcStub.onFirstCall().resolves({ server: localDwnServerName });
       rpcStub.rejects(new Error('connection refused'));
 
-      const rpcClient = { getServerInfo: rpcStub } as unknown as Web5Rpc;
+      const rpcClient = { getServerInfo: rpcStub } as unknown as EnboxRpc;
       const discovery = new LocalDwnDiscovery(rpcClient);
 
       const first = await discovery.getEndpoint();

--- a/packages/agent/tests/local-key-manager.spec.ts
+++ b/packages/agent/tests/local-key-manager.spec.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { CryptoErrorCode, CryptoUtils, Ed25519, X25519 } from '@enbox/crypto';
 import { Encryption, HdKey } from '@enbox/dwn-sdk-js';
 
-import type { Web5PlatformAgent } from '../src/types/agent.js';
+import type { EnboxPlatformAgent } from '../src/types/agent.js';
 
 import { isChrome } from './utils/runtimes.js';
 import { LocalKeyManager } from '../src/local-key-manager.js';
@@ -18,7 +18,7 @@ describe('LocalKeyManager', () => {
   describe('get agent', () => {
     it(`returns the 'agent' instance property`, async () => {
       // @ts-expect-error because we are only mocking a single property.
-      const mockAgent: Web5PlatformAgent = {
+      const mockAgent: EnboxPlatformAgent = {
         agentDid: { uri: 'did:method:abc123' } as BearerDid
       };
       const keyManager = new LocalKeyManager({ agent: mockAgent });

--- a/packages/agent/tests/managing-identities.spec.ts
+++ b/packages/agent/tests/managing-identities.spec.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
+import { EnboxUserAgent } from '../src/enbox-user-agent.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
-import { Web5UserAgent } from '../src/web5-user-agent.js';
 
 describe('Managing Identities', () => {
 
@@ -13,7 +13,7 @@ describe('Managing Identities', () => {
 
       beforeAll(async () => {
         testHarness = await PlatformAgentTestHarness.setup({
-          agentClass  : Web5UserAgent,
+          agentClass  : EnboxUserAgent,
           agentStores : agentStoreType
         });
       });

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -1,7 +1,7 @@
 import type { BearerDid } from '@enbox/dids';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
-import type { DwnPermissionScope, Web5PlatformAgent } from '../src/index.js';
+import type { DwnPermissionScope, EnboxPlatformAgent } from '../src/index.js';
 
 import { AgentPermissionsApi } from '../src/permissions-api.js';
 import { Convert } from '@enbox/common';
@@ -867,8 +867,8 @@ describe('AgentPermissionsApi', () => {
   describe('matchGrantFromArray', () => {
 
     const createRecordGrants = async ({ grantee, grantor, grantorAgent, protocol, protocolPath, contextId }:{
-      grantorAgent: Web5PlatformAgent;
-      granteeAgent: Web5PlatformAgent;
+      grantorAgent: EnboxPlatformAgent;
+      granteeAgent: EnboxPlatformAgent;
       grantor: string;
       grantee: string;
       protocol: string;
@@ -960,8 +960,8 @@ describe('AgentPermissionsApi', () => {
     };
 
     const createMessageGrants = async ({ grantee, grantor, grantorAgent, protocol }:{
-      grantorAgent: Web5PlatformAgent;
-      granteeAgent: Web5PlatformAgent;
+      grantorAgent: EnboxPlatformAgent;
+      granteeAgent: EnboxPlatformAgent;
       grantor: string;
       grantee: string;
       protocol?: string;
@@ -1027,8 +1027,8 @@ describe('AgentPermissionsApi', () => {
 
 
       const deviceXRecordGrantsFromAlice = await createRecordGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol
@@ -1051,8 +1051,8 @@ describe('AgentPermissionsApi', () => {
       expect(notFoundGrantee).toBeUndefined();
 
       const deviceYRecordGrantsFromDeviceX = await createRecordGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDeviceX.did.uri,
         grantee      : aliceDeviceY.did.uri,
         protocol
@@ -1082,8 +1082,8 @@ describe('AgentPermissionsApi', () => {
       });
 
       const messagesGrants = await createMessageGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
       });
@@ -1111,8 +1111,8 @@ describe('AgentPermissionsApi', () => {
       // create delegated record grants
       const protocol = 'http://example.com/protocol';
       const recordsGrants = await createRecordGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol
@@ -1143,8 +1143,8 @@ describe('AgentPermissionsApi', () => {
       });
 
       const messageGrants = await createMessageGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri
       });
@@ -1237,16 +1237,16 @@ describe('AgentPermissionsApi', () => {
       const otherProtocol = 'http://example.com/other-protocol';
 
       const protocolMessageGrants = await createMessageGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol
       });
 
       const otherProtocolMessageGrants = await createMessageGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol     : otherProtocol
@@ -1354,16 +1354,16 @@ describe('AgentPermissionsApi', () => {
       const protocol2 = 'http://example.com/other-protocol';
 
       const protocol1Grants = await createRecordGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol     : protocol1,
       });
 
       const otherProtocolGrants = await createRecordGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol     : protocol2,
@@ -1443,8 +1443,8 @@ describe('AgentPermissionsApi', () => {
       const protocol = 'http://example.com/protocol';
 
       const fooGrants = await createRecordGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol,
@@ -1452,8 +1452,8 @@ describe('AgentPermissionsApi', () => {
       });
 
       const barGrants = await createRecordGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol,
@@ -1540,8 +1540,8 @@ describe('AgentPermissionsApi', () => {
       const protocol = 'http://example.com/protocol';
 
       const abcGrants = await createRecordGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol,
@@ -1549,8 +1549,8 @@ describe('AgentPermissionsApi', () => {
       });
 
       const defGrants = await createRecordGrants({
-        grantorAgent : testHarness.agent as Web5PlatformAgent,
-        granteeAgent : testHarness.agent as Web5PlatformAgent,
+        grantorAgent : testHarness.agent as EnboxPlatformAgent,
+        granteeAgent : testHarness.agent as EnboxPlatformAgent,
         grantor      : aliceDid.uri,
         grantee      : aliceDeviceX.did.uri,
         protocol,

--- a/packages/agent/tests/prototyping/crypto/jose/jwe-compact.spec.ts
+++ b/packages/agent/tests/prototyping/crypto/jose/jwe-compact.spec.ts
@@ -2,7 +2,7 @@ import type { Jwk } from '@enbox/crypto';
 
 import { beforeEach, describe, expect, it } from 'bun:test';
 
-import type { Web5PlatformAgent } from '../../../../src/types/agent.js';
+import type { EnboxPlatformAgent } from '../../../../src/types/agent.js';
 
 import { AgentCryptoApi } from '../../../../src/crypto-api.js';
 import { CompactJwe } from '../../../../src/prototyping/crypto/jose/jwe-compact.js';
@@ -13,7 +13,7 @@ describe('CompactJwe', () => {
   let keyManager: LocalKeyManager;
 
   beforeEach(async () => {
-    keyManager = new LocalKeyManager({ agent: {} as Web5PlatformAgent });
+    keyManager = new LocalKeyManager({ agent: {} as EnboxPlatformAgent });
   });
 
   describe('decrypt()', () => {

--- a/packages/agent/tests/prototyping/crypto/jose/jwe-flattened.spec.ts
+++ b/packages/agent/tests/prototyping/crypto/jose/jwe-flattened.spec.ts
@@ -2,7 +2,7 @@ import type { Jwk } from '@enbox/crypto';
 
 import { beforeEach, describe, expect, it } from 'bun:test';
 
-import type { Web5PlatformAgent } from '../../../../src/types/agent.js';
+import type { EnboxPlatformAgent } from '../../../../src/types/agent.js';
 
 import { AgentCryptoApi } from '../../../../src/crypto-api.js';
 import { FlattenedJwe } from '../../../../src/prototyping/crypto/jose/jwe-flattened.js';
@@ -13,7 +13,7 @@ describe('FlattenedJwe', () => {
   let keyManager: LocalKeyManager;
 
   beforeEach(async () => {
-    keyManager = new LocalKeyManager({ agent: {} as Web5PlatformAgent });
+    keyManager = new LocalKeyManager({ agent: {} as EnboxPlatformAgent });
   });
 
   describe('decrypt()', () => {

--- a/packages/agent/tests/store-data.spec.ts
+++ b/packages/agent/tests/store-data.spec.ts
@@ -6,7 +6,7 @@ import type { ProtocolDefinition, RecordsDeleteMessage, RecordsWriteMessage } fr
 import { Convert } from '@enbox/common';
 import { DidJwk, isPortableDid } from '@enbox/dids';
 
-import type { Web5PlatformAgent } from '../src/types/agent.js';
+import type { EnboxPlatformAgent } from '../src/types/agent.js';
 import type { AgentDataStore, DataStoreDeleteParams, DataStoreGetParams, DataStoreListParams, DataStoreSetParams } from '../src/store-data.js';
 
 import { AgentDidApi } from '../src/did-api.js';
@@ -60,7 +60,7 @@ class DwnTestStore extends DwnDataStore<PortableDid> implements AgentDataStore<P
   }
 
   protected async getAllRecords({ agent, tenantDid }: {
-    agent: Web5PlatformAgent;
+    agent: EnboxPlatformAgent;
     tenantDid: string;
   }): Promise<PortableDid[]> {
     // Clear the index since it will be rebuilt from the query results.

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -58,7 +58,7 @@ describe('SyncEngineLevel', () => {
     });
   });
 
-  describe('with Web5 Platform Agent', () => {
+  describe('with Enbox Platform Agent', () => {
     let alice: BearerIdentity;
     let randomSchema: string;
     let syncEngine: SyncEngineLevel;

--- a/packages/agent/tests/utils/test-agent.ts
+++ b/packages/agent/tests/utils/test-agent.ts
@@ -6,9 +6,9 @@ import type { AgentIdentityApi } from '../../src/identity-api.js';
 import type { AgentKeyManager } from '../../src/types/key-manager.js';
 import type { AgentPermissionsApi } from '../../src/permissions-api.js';
 import type { AgentSyncApi } from '../../src/sync-api.js';
+import type { EnboxPlatformAgent } from '../../src/types/agent.js';
+import type { EnboxRpc } from '@enbox/dwn-clients';
 import type { IdentityVault } from '../../src/types/identity-vault.js';
-import type { Web5PlatformAgent } from '../../src/types/agent.js';
-import type { Web5Rpc } from '@enbox/dwn-clients';
 import type { AgentDidApi, DidInterface } from '../../src/did-api.js';
 import type { DidRequest, DidResponse } from '../../src/did-api.js';
 import type {
@@ -27,18 +27,18 @@ type TestAgentParams<TKeyManager extends AgentKeyManager> = {
   identityApi: AgentIdentityApi<TKeyManager>;
   keyManager: TKeyManager;
   permissionsApi: AgentPermissionsApi;
-  rpcClient: Web5Rpc;
+  rpcClient: EnboxRpc;
   syncApi: AgentSyncApi;
 };
 
-export class TestAgent<TKeyManager extends AgentKeyManager> implements Web5PlatformAgent<TKeyManager> {
+export class TestAgent<TKeyManager extends AgentKeyManager> implements EnboxPlatformAgent<TKeyManager> {
   public crypto: AgentCryptoApi;
   public did: AgentDidApi;
   public dwn: AgentDwnApi;
   public identity: AgentIdentityApi<TKeyManager>;
   public keyManager: TKeyManager;
   public permissions: AgentPermissionsApi;
-  public rpc: Web5Rpc;
+  public rpc: EnboxRpc;
   public sync: AgentSyncApi;
   public vault: IdentityVault;
 

--- a/packages/api/src/did-api.ts
+++ b/packages/api/src/did-api.ts
@@ -1,4 +1,4 @@
-import type { DidCreateParams, DidMessageResult, DidResolveParams, ResponseStatus, Web5Agent } from '@enbox/agent';
+import type { DidCreateParams, DidMessageResult, DidResolveParams, EnboxAgent, ResponseStatus } from '@enbox/agent';
 
 import { DidInterface } from '@enbox/agent';
 
@@ -37,15 +37,15 @@ export type DidResolveResponse = DidMessageResult[DidInterface.Resolve];
  */
 export class DidApi {
   /**
-   * Holds the instance of a {@link Web5Agent} that represents the current execution context for
+   * Holds the instance of a {@link EnboxAgent} that represents the current execution context for
    * the `DidApi`. This agent is used to process DID requests.
    */
-  private agent: Web5Agent;
+  private agent: EnboxAgent;
 
   /** The DID of the tenant under which DID operations are being performed. */
   private connectedDid: string;
 
-  constructor(options: { agent: Web5Agent, connectedDid: string }) {
+  constructor(options: { agent: EnboxAgent, connectedDid: string }) {
     this.agent = options.agent;
     this.connectedDid = options.connectedDid;
   }

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -12,10 +12,10 @@ import type {
   DwnPaginationCursor,
   DwnResponse,
   DwnResponseStatus,
+  EnboxAgent,
   FetchPermissionRequestParams,
   FetchPermissionsParams,
-  ProcessDwnRequest,
-  Web5Agent } from '@enbox/agent';
+  ProcessDwnRequest } from '@enbox/agent';
 
 import type { DwnSubscriptionMessage } from '@enbox/dwn-clients';
 
@@ -238,10 +238,10 @@ export type RecordsWriteResponse = DwnResponseStatus & {
  */
 export class DwnApi {
   /**
-   * Holds the instance of a {@link Web5Agent} that represents the current execution context for
+   * Holds the instance of a {@link EnboxAgent} that represents the current execution context for
    * the `DwnApi`. This agent is used to process DWN requests.
    */
-  private agent: Web5Agent;
+  private agent: EnboxAgent;
 
   /** The DID of the DWN tenant under which operations are being performed. */
   private connectedDid: string;
@@ -252,7 +252,7 @@ export class DwnApi {
   /** Holds the instance of {@link AgentPermissionsApi} that helps when dealing with permissions protocol records */
   private permissionsApi: AgentPermissionsApi;
 
-  constructor(options: { agent: Web5Agent, connectedDid: string, delegateDid?: string }) {
+  constructor(options: { agent: EnboxAgent, connectedDid: string, delegateDid?: string }) {
     this.agent = options.agent;
     this.connectedDid = options.connectedDid;
     this.delegateDid = options.delegateDid;

--- a/packages/api/src/enbox.ts
+++ b/packages/api/src/enbox.ts
@@ -6,13 +6,13 @@
 
 import type { AuthSession } from '@enbox/auth';
 import type { DidMethodResolver } from '@enbox/dids';
+import type { EnboxAgent } from '@enbox/agent';
 import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
-import type { Web5Agent } from '@enbox/agent';
 
 import type { SchemaMap, TypedProtocol } from './protocol-types.js';
 
 import { AnonymousDwnApi } from '@enbox/agent';
-import { Web5RpcClient } from '@enbox/dwn-clients';
+import { EnboxRpcClient } from '@enbox/dwn-clients';
 import { DidDht, DidJwk, DidKey, DidResolverCacheMemory, DidWeb, UniversalResolver } from '@enbox/dids';
 
 import { DidApi } from './did-api.js';
@@ -51,10 +51,10 @@ export type EnboxAnonymousApi = {
  */
 export type EnboxParams = {
   /**
-   * A {@link Web5Agent} instance that handles DIDs, DWNs and VCs requests. The agent manages the
+   * A {@link EnboxAgent} instance that handles DIDs, DWNs and VCs requests. The agent manages the
    * user keys and identities, and is responsible to sign and verify messages.
    */
-  agent: Web5Agent;
+  agent: EnboxAgent;
 
   /** The DID of the tenant under which all DID, DWN, and VC requests are being performed. */
   connectedDid: string;
@@ -86,10 +86,10 @@ export type EnboxParams = {
  */
 export class Enbox {
   /**
-   * A {@link Web5Agent} instance that handles DIDs, DWNs and VCs requests. The agent manages the
+   * A {@link EnboxAgent} instance that handles DIDs, DWNs and VCs requests. The agent manages the
    * user keys and identities, and is responsible to sign and verify messages.
    */
-  public agent: Web5Agent;
+  public agent: EnboxAgent;
 
   /** Exposed instance to the DID APIs, allow users to create and resolve DIDs. */
   public did: DidApi;
@@ -220,7 +220,7 @@ export class Enbox {
       cache        : new DidResolverCacheMemory(),
     });
 
-    const rpcClient = new Web5RpcClient();
+    const rpcClient = new EnboxRpcClient();
     const anonymousDwn = new AnonymousDwnApi({ didResolver, rpcClient });
 
     return {

--- a/packages/api/src/grant-revocation.ts
+++ b/packages/api/src/grant-revocation.ts
@@ -1,4 +1,4 @@
-import type { DwnDataEncodedRecordsWriteMessage, DwnResponseStatus, SendDwnRequest, Web5Agent } from '@enbox/agent';
+import type { DwnDataEncodedRecordsWriteMessage, DwnResponseStatus, EnboxAgent, SendDwnRequest } from '@enbox/agent';
 
 import { Convert } from '@enbox/common';
 import { AgentPermissionsApi, DwnInterface, getRecordAuthor } from '@enbox/agent';
@@ -53,7 +53,7 @@ export class PermissionGrantRevocation implements GrantRevocationModel {
   /** parses the grant revocation given am agent, connectedDid and data encoded records write message  */
   static async parse({ connectedDid, agent, message }:{
     connectedDid: string;
-    agent: Web5Agent;
+    agent: EnboxAgent;
     message: DwnDataEncodedRecordsWriteMessage;
   }): Promise<PermissionGrantRevocation> {
     const permissions = new AgentPermissionsApi({ agent });
@@ -61,7 +61,7 @@ export class PermissionGrantRevocation implements GrantRevocationModel {
   }
 
   /** The agent to use for this instantiation of the grant revocation */
-  private get agent(): Web5Agent {
+  private get agent(): EnboxAgent {
     return this._permissions.agent;
   }
 

--- a/packages/api/src/live-query.ts
+++ b/packages/api/src/live-query.ts
@@ -1,4 +1,4 @@
-import type { DwnMessageSubscription, PermissionsApi, Web5Agent } from '@enbox/agent';
+import type { DwnMessageSubscription, EnboxAgent, PermissionsApi } from '@enbox/agent';
 import type { PaginationCursor, RecordsQueryReplyEntry } from '@enbox/dwn-sdk-js';
 
 import { getRecordAuthor } from '@enbox/agent';
@@ -40,7 +40,7 @@ export class RecordChangeEvent extends CustomEvent<RecordChange> {
  */
 export type LiveQueryOptions = {
   /** The agent instance used to construct Record objects. */
-  agent: Web5Agent;
+  agent: EnboxAgent;
 
   /** The DID of the connected user. */
   connectedDid: string;

--- a/packages/api/src/permission-grant.ts
+++ b/packages/api/src/permission-grant.ts
@@ -3,8 +3,8 @@ import type {
   DwnPermissionConditions,
   DwnPermissionScope,
   DwnResponseStatus,
-  SendDwnRequest,
-  Web5Agent
+  EnboxAgent,
+  SendDwnRequest
 } from '@enbox/agent';
 
 import { Convert } from '@enbox/common';
@@ -80,7 +80,7 @@ export interface PermissionGrantOptions {
   /** The underlying DWN `RecordsWrite` message along with encoded data that represent the grant */
   message: DwnDataEncodedRecordsWriteMessage;
   /** The agent to use when interacting with the underlying DWN record representing the grant */
-  agent: Web5Agent;
+  agent: EnboxAgent;
 }
 
 /**
@@ -127,7 +127,7 @@ export class PermissionGrant implements PermissionGrantModel {
   }
 
   /** The agent to use for this instantiation of the grant */
-  private get agent(): Web5Agent {
+  private get agent(): EnboxAgent {
     return this._permissions.agent;
   }
 

--- a/packages/api/src/permission-request.ts
+++ b/packages/api/src/permission-request.ts
@@ -3,8 +3,8 @@ import type {
   DwnPermissionConditions,
   DwnPermissionScope,
   DwnResponseStatus,
+  EnboxAgent,
   SendDwnRequest,
-  Web5Agent,
 } from '@enbox/agent';
 
 import { Convert } from '@enbox/common';
@@ -86,7 +86,7 @@ export class PermissionRequest implements PermissionRequestModel {
   /** parses the request given an agent, connectedDid and data encoded records write message  */
   static parse({ connectedDid, agent, message }:{
     connectedDid: string;
-    agent: Web5Agent;
+    agent: EnboxAgent;
     message: DwnDataEncodedRecordsWriteMessage;
   }): PermissionRequest {
     const request = DwnPermissionRequest.parse(message);
@@ -95,7 +95,7 @@ export class PermissionRequest implements PermissionRequestModel {
   }
 
   /** The agent to use for this instantiation of the request */
-  private get agent(): Web5Agent {
+  private get agent(): EnboxAgent {
     return this._permissions.agent;
   }
 

--- a/packages/api/src/protocol.ts
+++ b/packages/api/src/protocol.ts
@@ -4,7 +4,7 @@
  */
 /// <reference types="@enbox/dwn-sdk-js" />
 
-import type { DwnMessage, DwnResponseStatus, Web5Agent } from '@enbox/agent';
+import type { DwnMessage, DwnResponseStatus, EnboxAgent } from '@enbox/agent';
 
 import { DwnInterface } from '@enbox/agent';
 
@@ -30,8 +30,8 @@ export type ProtocolMetadata = {
  * protocols on remote DWNs.
  */
 export class Protocol {
-  /** The {@link Web5Agent} instance that handles DWNs requests. */
-  private _agent: Web5Agent;
+  /** The {@link EnboxAgent} instance that handles DWNs requests. */
+  private _agent: EnboxAgent;
 
   /** Metadata associated with the protocol, including the author and optional message CID. */
   private _metadata: ProtocolMetadata;
@@ -42,11 +42,11 @@ export class Protocol {
   /**
    * Constructs a new instance of the Protocol class.
    *
-   * @param agent - The Web5Agent instance used for network interactions.
+   * @param agent - The EnboxAgent instance used for network interactions.
    * @param protocolsConfigureMessage - The configuration message containing the protocol details.
    * @param metadata - Metadata associated with the protocol, including the author and optional message CID.
    */
-  constructor(agent: Web5Agent, protocolsConfigureMessage: DwnMessage[DwnInterface.ProtocolsConfigure], metadata: ProtocolMetadata) {
+  constructor(agent: EnboxAgent, protocolsConfigureMessage: DwnMessage[DwnInterface.ProtocolsConfigure], metadata: ProtocolMetadata) {
     this._agent = agent;
     this._metadata = metadata;
     this._protocolsConfigureMessage = protocolsConfigureMessage;

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -11,10 +11,10 @@ import type {
   DwnMessageParams,
   DwnPaginationCursor,
   DwnResponseStatus,
+  EnboxAgent,
   PermissionsApi,
   ProcessDwnRequest,
   SendDwnRequest,
-  Web5Agent,
 } from '@enbox/agent';
 
 import type {
@@ -94,8 +94,8 @@ export class Record implements RecordModel {
 
   // Record instance metadata.
 
-  /** The {@link Web5Agent} instance that handles DWNs requests. */
-  private _agent: Web5Agent;
+  /** The {@link EnboxAgent} instance that handles DWNs requests. */
+  private _agent: EnboxAgent;
   /** The DID of the DWN tenant under which operations are being performed. */
   private _connectedDid: string;
   /** The optional DID that is delegated to act on behalf of the connectedDid */
@@ -264,7 +264,7 @@ export class Record implements RecordModel {
     return message;
   }
 
-  constructor(agent: Web5Agent, options: RecordOptions, permissionsApi?: PermissionsApi) {
+  constructor(agent: EnboxAgent, options: RecordOptions, permissionsApi?: PermissionsApi) {
 
     this._agent = agent;
 

--- a/packages/api/src/vc-api.ts
+++ b/packages/api/src/vc-api.ts
@@ -1,4 +1,4 @@
-import type { Web5Agent } from '@enbox/agent';
+import type { EnboxAgent } from '@enbox/agent';
 
 /**
  * The VC API is used to issue, present and verify VCs
@@ -7,15 +7,15 @@ import type { Web5Agent } from '@enbox/agent';
  */
 export class VcApi {
   /**
-   * Holds the instance of a {@link Web5Agent} that represents the current execution context for
+   * Holds the instance of a {@link EnboxAgent} that represents the current execution context for
    * the `VcApi`. This agent is used to process VC requests.
    */
-  private agent: Web5Agent;
+  private agent: EnboxAgent;
 
   /** The DID of the tenant under which DID operations are being performed. */
   private connectedDid: string;
 
-  constructor(options: { agent: Web5Agent, connectedDid: string }) {
+  constructor(options: { agent: EnboxAgent, connectedDid: string }) {
     this.agent = options.agent;
     this.connectedDid = options.connectedDid;
   }

--- a/packages/api/tests/did-api.spec.ts
+++ b/packages/api/tests/did-api.spec.ts
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { DidDht } from '@enbox/dids';
-import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent, PlatformAgentTestHarness } from '@enbox/agent';
 
 import { DidApi } from '../src/did-api.js';
 
@@ -12,7 +12,7 @@ describe('DidApi', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass  : Web5UserAgent,
+      agentClass  : EnboxUserAgent,
       agentStores : 'memory'
     });
 

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { processConnectedGrants } from '@enbox/auth';
-import { AgentPermissionsApi, DwnDateSort, DwnInterface, getRecordAuthor, Oidc, PlatformAgentTestHarness, WalletConnect, Web5UserAgent } from '@enbox/agent';
+import { AgentPermissionsApi, DwnDateSort, DwnInterface, EnboxUserAgent, getRecordAuthor, Oidc, PlatformAgentTestHarness, WalletConnect } from '@enbox/agent';
 import { DwnConstant, DwnInterfaceName, DwnMethodName, Jws, PermissionsProtocol, Poller, Time } from '@enbox/dwn-sdk-js';
 
 import emailProtocolDefinition from './fixtures/protocol-definitions/email.json' with { type: 'json' };
@@ -33,7 +33,7 @@ describe('DwnApi', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass  : Web5UserAgent,
+      agentClass  : EnboxUserAgent,
       agentStores : 'memory'
     });
 
@@ -91,7 +91,7 @@ describe('DwnApi', () => {
 
     beforeAll(async () => {
       delegateHarness = await PlatformAgentTestHarness.setup({
-        agentClass       : Web5UserAgent,
+        agentClass       : EnboxUserAgent,
         agentStores      : 'memory',
         testDataLocation : '__TESTDATA__/delegateDid'
       });
@@ -169,18 +169,18 @@ describe('DwnApi', () => {
 
       // Process the connected grants (stores them in the delegate agent's DWN).
       const connectedProtocols = await processConnectedGrants({
-        grants, delegateDid: delegateDid.uri, agent: delegateHarness.agent as Web5UserAgent,
+        grants, delegateDid: delegateDid.uri, agent: delegateHarness.agent as EnboxUserAgent,
       });
 
       // Register sync for Alice's DID and pull the protocol configuration.
-      await (delegateHarness.agent as Web5UserAgent).sync.registerIdentity({
+      await (delegateHarness.agent as EnboxUserAgent).sync.registerIdentity({
         did     : aliceDid.uri,
         options : {
           delegateDid : delegateDid.uri,
           protocols   : connectedProtocols,
         }
       });
-      await (delegateHarness.agent as Web5UserAgent).sync.sync('pull');
+      await (delegateHarness.agent as EnboxUserAgent).sync.sync('pull');
 
       // Construct the Enbox instance directly with delegate support.
       const enbox = new Enbox({ agent: delegateHarness.agent, connectedDid: aliceDid.uri, delegateDid: delegateDid.uri });
@@ -647,7 +647,7 @@ describe('DwnApi', () => {
           protocol  : protocolUri
         }]);
 
-        await processConnectedGrants({ grants, delegateDid: delegateDid.uri, agent: delegateHarness.agent as Web5UserAgent });
+        await processConnectedGrants({ grants, delegateDid: delegateDid.uri, agent: delegateHarness.agent as EnboxUserAgent });
 
         // now try again after processing the connected grant
         const { status, protocol } = await delegateDwn.protocols.configure({
@@ -695,7 +695,7 @@ describe('DwnApi', () => {
           method    : DwnMethodName.Query,
           protocol  : nonPublicProtocol.protocol
         }]);
-        await processConnectedGrants({ grants, delegateDid: delegateDid.uri, agent: delegateHarness.agent as Web5UserAgent });
+        await processConnectedGrants({ grants, delegateDid: delegateDid.uri, agent: delegateHarness.agent as EnboxUserAgent });
 
         // now query for the non-public protocol, should return the protocol
         const { status: nonPublicQueryStatus2, protocols: nonPublicProtocols2 } = await delegateDwn.protocols.query({

--- a/packages/api/tests/e2e-phase-create.ts
+++ b/packages/api/tests/e2e-phase-create.ts
@@ -10,7 +10,7 @@
  *   E2E_ADMIN_TOKEN — (Optional) DWN admin token for tenant registration
  */
 
-import { Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent } from '@enbox/agent';
 import { ProfileProtocol, SocialGraphProtocol } from '@enbox/protocols';
 
 import { Enbox, repository } from '../src/index.js';
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
   log('Connecting to create new agent + identity...');
 
   // Create the agent, initialize the vault, and start it.
-  const agent = await Web5UserAgent.create();
+  const agent = await EnboxUserAgent.create();
   const recoveryPhrase = await agent.initialize({ password, dwnEndpoints: [DWN_URL] });
   await agent.start({ password });
 

--- a/packages/api/tests/e2e-phase-recover.ts
+++ b/packages/api/tests/e2e-phase-recover.ts
@@ -18,8 +18,8 @@
  */
 
 import { DwnApi } from '../src/dwn-api.js';
+import { EnboxUserAgent } from '@enbox/agent';
 import { ProfileProtocol } from '@enbox/protocols';
-import { Web5UserAgent } from '@enbox/agent';
 import { repository, TypedEnbox } from '../src/index.js';
 
 const DWN_URL = process.env.E2E_DWN_URL!;
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
   log('Recovering agent from seed phrase...');
 
   // Create agent and recover the deterministic agent DID from the seed phrase
-  const agent = await Web5UserAgent.create();
+  const agent = await EnboxUserAgent.create();
 
   // Initialize with the original seed phrase — deterministically re-derives the agent DID
   await agent.initialize({

--- a/packages/api/tests/enbox.spec.ts
+++ b/packages/api/tests/enbox.spec.ts
@@ -5,8 +5,8 @@ import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
 
 import {
   DwnInterface,
+  EnboxUserAgent,
   PlatformAgentTestHarness,
-  Web5UserAgent,
 } from '@enbox/agent';
 
 import { defineProtocol } from '../src/define-protocol.js';
@@ -32,7 +32,7 @@ describe('Enbox API', () => {
 
     beforeAll(async () => {
       testHarness = await PlatformAgentTestHarness.setup({
-        agentClass  : Web5UserAgent,
+        agentClass  : EnboxUserAgent,
         agentStores : 'memory',
       });
     });
@@ -330,7 +330,7 @@ describe('Enbox API', () => {
 
     beforeAll(async () => {
       testHarness = await PlatformAgentTestHarness.setup({
-        agentClass  : Web5UserAgent,
+        agentClass  : EnboxUserAgent,
         agentStores : 'memory',
       });
     });

--- a/packages/api/tests/grant-revocation-coverage.spec.ts
+++ b/packages/api/tests/grant-revocation-coverage.spec.ts
@@ -1,4 +1,4 @@
-import type { DwnDataEncodedRecordsWriteMessage, Web5Agent } from '@enbox/agent';
+import type { DwnDataEncodedRecordsWriteMessage, EnboxAgent } from '@enbox/agent';
 
 import sinon from 'sinon';
 import { afterEach, describe, expect, it } from 'bun:test';
@@ -33,7 +33,7 @@ function createFakeMessage(overrides: Partial<DwnDataEncodedRecordsWriteMessage>
   };
 }
 
-function createFakeAgent(overrides: Record<string, unknown> = {}): Web5Agent {
+function createFakeAgent(overrides: Record<string, unknown> = {}): EnboxAgent {
   return {
     sendDwnRequest    : sinon.stub().resolves({ reply: { status: { code: 202, detail: 'Accepted' } } }),
     processDwnRequest : sinon.stub().resolves({

--- a/packages/api/tests/grant-revocation.spec.ts
+++ b/packages/api/tests/grant-revocation.spec.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { DwnInterfaceName, DwnMethodName, Time } from '@enbox/dwn-sdk-js';
-import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent, PlatformAgentTestHarness } from '@enbox/agent';
 
 import { DwnApi } from '../src/dwn-api.js';
 import { PermissionGrantRevocation } from '../src/grant-revocation.js';
@@ -22,7 +22,7 @@ describe('PermissionGrantRevocation', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass       : Web5UserAgent,
+      agentClass       : EnboxUserAgent,
       agentStores      : 'memory',
       testDataLocation : '__TESTDATA__/grant-revocation',
     });

--- a/packages/api/tests/live-query.spec.ts
+++ b/packages/api/tests/live-query.spec.ts
@@ -1,6 +1,6 @@
 import type { Record } from '../src/record.js';
 import type { RecordChange } from '../src/live-query.js';
-import type { DwnMessageSubscription, Web5Agent } from '@enbox/agent';
+import type { DwnMessageSubscription, EnboxAgent } from '@enbox/agent';
 
 import sinon from 'sinon';
 import { afterEach, describe, expect, it } from 'bun:test';
@@ -37,7 +37,7 @@ function createLiveQuery(options?: {
   subscription?: DwnMessageSubscription;
 }): LiveQuery {
   return new LiveQuery({
-    agent          : {} as Web5Agent,
+    agent          : {} as EnboxAgent,
     connectedDid   : 'did:test:alice',
     initialEntries : options?.initialEntries ?? [],
     subscription   : options?.subscription ?? createMockSubscription() as unknown as DwnMessageSubscription,

--- a/packages/api/tests/permission-grant.spec.ts
+++ b/packages/api/tests/permission-grant.spec.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { DwnErrorCode, DwnInterfaceName, DwnMethodName, TestDataGenerator, Time } from '@enbox/dwn-sdk-js';
-import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent, PlatformAgentTestHarness } from '@enbox/agent';
 
 import { DwnApi } from '../src/dwn-api.js';
 import { PermissionGrant } from '../src/permission-grant.js';
@@ -22,7 +22,7 @@ describe('PermissionGrant', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass  : Web5UserAgent,
+      agentClass  : EnboxUserAgent,
       agentStores : 'memory'
     });
 

--- a/packages/api/tests/permission-request-coverage.spec.ts
+++ b/packages/api/tests/permission-request-coverage.spec.ts
@@ -1,4 +1,4 @@
-import type { DwnDataEncodedRecordsWriteMessage, Web5Agent } from '@enbox/agent';
+import type { DwnDataEncodedRecordsWriteMessage, EnboxAgent } from '@enbox/agent';
 
 import sinon from 'sinon';
 import { afterEach, describe, expect, it } from 'bun:test';
@@ -58,7 +58,7 @@ function createRequestMessage(overrides: Partial<DwnDataEncodedRecordsWriteMessa
   };
 }
 
-function createFakeAgent(overrides: Record<string, unknown> = {}): Web5Agent {
+function createFakeAgent(overrides: Record<string, unknown> = {}): EnboxAgent {
   return {
     sendDwnRequest    : sinon.stub().resolves({ reply: { status: { code: 202, detail: 'Accepted' } } }),
     processDwnRequest : sinon.stub().resolves({

--- a/packages/api/tests/permission-request.spec.ts
+++ b/packages/api/tests/permission-request.spec.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { DwnErrorCode, DwnInterfaceName, DwnMethodName, Time } from '@enbox/dwn-sdk-js';
-import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent, PlatformAgentTestHarness } from '@enbox/agent';
 
 import { DwnApi } from '../src/dwn-api.js';
 import { PermissionRequest } from '../src/permission-request.js';
@@ -23,7 +23,7 @@ describe('PermissionRequest', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass  : Web5UserAgent,
+      agentClass  : EnboxUserAgent,
       agentStores : 'memory'
     });
 

--- a/packages/api/tests/protocol.spec.ts
+++ b/packages/api/tests/protocol.spec.ts
@@ -2,7 +2,7 @@ import type { BearerDid } from '@enbox/dids';
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
-import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent, PlatformAgentTestHarness } from '@enbox/agent';
 
 import { DwnApi } from '../src/dwn-api.js';
 import emailProtocolDefinition from './fixtures/protocol-definitions/email.json' with { type: 'json' };
@@ -18,7 +18,7 @@ describe('Protocol', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass  : Web5UserAgent,
+      agentClass  : EnboxUserAgent,
       agentStores : 'memory'
     });
 

--- a/packages/api/tests/protocols-integration.spec.ts
+++ b/packages/api/tests/protocols-integration.spec.ts
@@ -27,7 +27,7 @@ import {
   SocialGraphProtocol,
   StatusProtocol,
 } from '@enbox/protocols';
-import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent, PlatformAgentTestHarness } from '@enbox/agent';
 
 import { DwnApi } from '../src/dwn-api.js';
 import { repository } from '../src/repository.js';
@@ -48,7 +48,7 @@ describe('@enbox/protocols integration', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass       : Web5UserAgent,
+      agentClass       : EnboxUserAgent,
       agentStores      : 'memory',
       testDataLocation : '__TESTDATA__/protocols-integration',
     });

--- a/packages/api/tests/record-coverage.spec.ts
+++ b/packages/api/tests/record-coverage.spec.ts
@@ -11,7 +11,7 @@
  * - author/creator getters (lines 207-210)
  */
 
-import type { Web5Agent } from '@enbox/agent';
+import type { EnboxAgent } from '@enbox/agent';
 
 import sinon from 'sinon';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
@@ -24,11 +24,11 @@ import { Record } from '../src/record.js';
 // Helpers — create a minimal agent stub and Record constructor options
 // ---------------------------------------------------------------------------
 
-function createAgentStub(): sinon.SinonStubbedInstance<Web5Agent> {
+function createAgentStub(): sinon.SinonStubbedInstance<EnboxAgent> {
   return {
     processDwnRequest : sinon.stub(),
     sendDwnRequest    : sinon.stub(),
-  } as unknown as sinon.SinonStubbedInstance<Web5Agent>;
+  } as unknown as sinon.SinonStubbedInstance<EnboxAgent>;
 }
 
 function createValidAuthorization(did: string = 'did:example:alice'): any {
@@ -85,7 +85,7 @@ function createDeleteDescriptor(recordId: string): any {
 // ---------------------------------------------------------------------------
 
 describe('Record — coverage gaps (stubbed)', () => {
-  let agentStub: sinon.SinonStubbedInstance<Web5Agent>;
+  let agentStub: sinon.SinonStubbedInstance<EnboxAgent>;
 
   beforeEach(() => {
     agentStub = createAgentStub();
@@ -110,7 +110,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         encodedData : undefined,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
       expect(record.deleted).toBe(true);
 
       // Stub sendDwnRequest to succeed for all calls.
@@ -149,7 +149,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         initialWrite,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
       expect(record.deleted).toBe(false);
 
       agentStub.sendDwnRequest.resolves({
@@ -176,7 +176,7 @@ describe('Record — coverage gaps (stubbed)', () => {
   describe('send() — default target', () => {
     it('should default target to connectedDid when none is specified', async () => {
       const options = createRecordOptions({ connectedDid: 'did:example:myDid' });
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
 
       agentStub.sendDwnRequest.resolves({
         messageCid : 'cid-1',
@@ -194,7 +194,7 @@ describe('Record — coverage gaps (stubbed)', () => {
   describe('processRecord() — signAsOwner updates authorization', () => {
     it('should update authorization when signAsOwner is true (import)', async () => {
       const options = createRecordOptions();
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
 
       const newAuth = { signature: { payload: 'owner-sig', signatures: [{ protected: 'a', signature: 'b' }] } };
       agentStub.processDwnRequest.resolves({
@@ -226,7 +226,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         encodedData : undefined,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
       expect(record.deleted).toBe(true);
 
       agentStub.processDwnRequest.resolves({
@@ -254,7 +254,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         data         : undefined,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
 
       const mockStream = new ReadableStream({
         start(controller): void {
@@ -285,7 +285,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         data        : undefined,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
 
       const mockStream = new ReadableStream({
         start(controller): void {
@@ -322,7 +322,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         data        : undefined,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options, mockPermissionsApi as any);
+      const record = new Record(agentStub as unknown as EnboxAgent, options, mockPermissionsApi as any);
 
       const mockStream = new ReadableStream({
         start(controller): void {
@@ -357,7 +357,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         data        : undefined,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
 
       const mockStream = new ReadableStream({
         start(controller): void {
@@ -387,13 +387,13 @@ describe('Record — coverage gaps (stubbed)', () => {
   describe('author and creator getters', () => {
     it('should return the author from the constructor options', () => {
       const options = createRecordOptions({ author: 'did:example:alice' });
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
       expect(record.author).toBe('did:example:alice');
     });
 
     it('should return the creator from the constructor options', () => {
       const options = createRecordOptions({ author: 'did:example:alice' });
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
       // When no initialWrite, creator = author.
       expect(record.creator).toBe('did:example:alice');
     });
@@ -411,7 +411,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         encodedData: undefined,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
       expect(record.deleted).toBe(true);
 
       const cursor = await record.paginationCursor(DwnDateSort.CreatedAscending);
@@ -427,7 +427,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         encodedData: base64url,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
       const text = await record.data.text();
       expect(text).toBe('hello');
     });
@@ -447,7 +447,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         data        : stream,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
 
       // First access returns the stream.
       const text = await record.data.text();
@@ -487,7 +487,7 @@ describe('Record — coverage gaps (stubbed)', () => {
         encodedData: undefined,
       });
 
-      const record = new Record(agentStub as unknown as Web5Agent, options);
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
       expect(record.deleted).toBe(true);
 
       await expect(record.data.text()).rejects.toThrow('Cannot access data of a deleted record.');
@@ -504,7 +504,7 @@ describe('Record — coverage gaps (stubbed)', () => {
 
       const { DwnApi } = await import('../src/dwn-api.js');
       const dwnApi = new DwnApi({
-        agent        : agentStub as unknown as Web5Agent,
+        agent        : agentStub as unknown as EnboxAgent,
         connectedDid : 'did:example:alice',
       });
 
@@ -545,7 +545,7 @@ describe('Record — coverage gaps (stubbed)', () => {
 
       const { DwnApi } = await import('../src/dwn-api.js');
       const dwnApi = new DwnApi({
-        agent        : agentStub as unknown as Web5Agent,
+        agent        : agentStub as unknown as EnboxAgent,
         connectedDid : 'did:example:alice',
       });
 
@@ -571,7 +571,7 @@ describe('Record — coverage gaps (stubbed)', () => {
 
       const { DwnApi } = await import('../src/dwn-api.js');
       const dwnApi = new DwnApi({
-        agent        : agentStub as unknown as Web5Agent,
+        agent        : agentStub as unknown as EnboxAgent,
         connectedDid : 'did:example:alice',
       });
 
@@ -615,7 +615,7 @@ describe('Record — coverage gaps (stubbed)', () => {
 
       const { DwnApi } = await import('../src/dwn-api.js');
       const dwnApi = new DwnApi({
-        agent        : agentStub as unknown as Web5Agent,
+        agent        : agentStub as unknown as EnboxAgent,
         connectedDid : 'did:example:alice',
       });
 

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -9,8 +9,8 @@ import { processConnectedGrants } from '@enbox/auth';
 import { Stream } from '@enbox/common';
 import {
   DwnConstant, DwnContentEncryptionAlgorithm, DwnDateSort, DwnInterface, DwnKeyDerivationScheme,
-  dwnMessageConstructors, getRecordAuthor, getRecordProtocolRole, Oidc,
-  PlatformAgentTestHarness, WalletConnect, Web5UserAgent,
+  dwnMessageConstructors, EnboxUserAgent, getRecordAuthor, getRecordProtocolRole,
+  Oidc, PlatformAgentTestHarness, WalletConnect,
 } from '@enbox/agent';
 import { Jws, Message, Poller } from '@enbox/dwn-sdk-js';
 
@@ -45,7 +45,7 @@ describe('Record', () => {
     console.warn = (): void => {};
 
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass  : Web5UserAgent,
+      agentClass  : EnboxUserAgent,
       agentStores : 'memory'
     });
 
@@ -133,7 +133,7 @@ describe('Record', () => {
 
     beforeAll(async () => {
       delegateHarness = await PlatformAgentTestHarness.setup({
-        agentClass       : Web5UserAgent,
+        agentClass       : EnboxUserAgent,
         agentStores      : 'memory',
         testDataLocation : '__TESTDATA__/delegateDid'
       });
@@ -212,18 +212,18 @@ describe('Record', () => {
 
       // Process the connected grants (stores them in the delegate agent's DWN).
       const connectedProtocols = await processConnectedGrants({
-        grants, delegateDid: delegateDid.uri, agent: delegateHarness.agent as Web5UserAgent,
+        grants, delegateDid: delegateDid.uri, agent: delegateHarness.agent as EnboxUserAgent,
       });
 
       // Register sync for Alice's DID and pull the protocol configuration.
-      await (delegateHarness.agent as Web5UserAgent).sync.registerIdentity({
+      await (delegateHarness.agent as EnboxUserAgent).sync.registerIdentity({
         did     : aliceDid.uri,
         options : {
           delegateDid : delegateDid.uri,
           protocols   : connectedProtocols,
         }
       });
-      await (delegateHarness.agent as Web5UserAgent).sync.sync('pull');
+      await (delegateHarness.agent as EnboxUserAgent).sync.sync('pull');
 
       // Construct the Enbox instance directly with delegate support.
       const enbox = new Enbox({ agent: delegateHarness.agent, connectedDid: aliceDid.uri, delegateDid: delegateDid.uri });
@@ -1739,7 +1739,7 @@ describe('Record', () => {
       beforeAll(async () => {
         // Create a second `TestManagedAgent` that only Carol will use.
         testHarnessCarol = await PlatformAgentTestHarness.setup({
-          agentClass       : Web5UserAgent,
+          agentClass       : EnboxUserAgent,
           agentStores      : 'memory',
           testDataLocation : '__TESTDATA__/AGENT_BOB'
         });

--- a/packages/api/tests/repository.spec.ts
+++ b/packages/api/tests/repository.spec.ts
@@ -4,7 +4,7 @@ import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
 import sinon from 'sinon';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
-import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent, PlatformAgentTestHarness } from '@enbox/agent';
 
 import { defineProtocol } from '../src/define-protocol.js';
 import { DwnApi } from '../src/dwn-api.js';
@@ -145,7 +145,7 @@ describe('repository()', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass       : Web5UserAgent,
+      agentClass       : EnboxUserAgent,
       agentStores      : 'memory',
       testDataLocation : '__TESTDATA__/repository',
     });

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -4,7 +4,7 @@ import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
 import sinon from 'sinon';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
-import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent, PlatformAgentTestHarness } from '@enbox/agent';
 
 import { defineProtocol } from '../src/define-protocol.js';
 import { DwnApi } from '../src/dwn-api.js';
@@ -76,7 +76,7 @@ describe('TypedProtocol API', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass       : Web5UserAgent,
+      agentClass       : EnboxUserAgent,
       agentStores      : 'memory',
       testDataLocation : '__TESTDATA__/typed-protocol',
     });

--- a/packages/api/tests/vc-api.spec.ts
+++ b/packages/api/tests/vc-api.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 
-import { PlatformAgentTestHarness, Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent, PlatformAgentTestHarness } from '@enbox/agent';
 
 import { VcApi } from '../src/vc-api.js';
 
@@ -10,7 +10,7 @@ describe('VcApi', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass  : Web5UserAgent,
+      agentClass  : EnboxUserAgent,
       agentStores : 'memory'
     });
 

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -6,7 +6,7 @@
  * @module
  */
 
-import { Web5UserAgent } from '@enbox/agent';
+import { EnboxUserAgent } from '@enbox/agent';
 import type { BearerIdentity, PortableIdentity } from '@enbox/agent';
 
 import { AuthEventEmitter } from './events.js';
@@ -69,7 +69,7 @@ import { importFromPhrase, importFromPortable } from './flows/import-identity.js
  * ```
  */
 export class AuthManager {
-  private _userAgent: Web5UserAgent;
+  private _userAgent: EnboxUserAgent;
   private _emitter: AuthEventEmitter;
   private _storage: StorageAdapter;
   private _vault: VaultManager;
@@ -84,7 +84,7 @@ export class AuthManager {
   private _registration?: RegistrationOptions;
 
   private constructor(params: {
-    userAgent: Web5UserAgent;
+    userAgent: EnboxUserAgent;
     emitter: AuthEventEmitter;
     storage: StorageAdapter;
     vault: VaultManager;
@@ -108,7 +108,7 @@ export class AuthManager {
    *
    * When a pre-built `agent` is provided, it is used as-is and
    * `dataPath`, `agentVault`, and `localDwnStrategy` are ignored.
-   * Otherwise, a new `Web5UserAgent` is created with the given options.
+   * Otherwise, a new `EnboxUserAgent` is created with the given options.
    *
    * @param options - Configuration options for the auth manager.
    * @returns A ready-to-use AuthManager instance.
@@ -118,7 +118,7 @@ export class AuthManager {
     const storage = options.storage ?? createDefaultStorage();
 
     // Use a pre-built agent or create one with the given options.
-    const userAgent = options.agent ?? await Web5UserAgent.create({
+    const userAgent = options.agent ?? await EnboxUserAgent.create({
       dataPath         : options.dataPath,
       agentVault       : options.agentVault,
       localDwnStrategy : options.localDwnStrategy,
@@ -544,8 +544,8 @@ export class AuthManager {
     return this._isConnecting;
   }
 
-  /** The underlying Web5UserAgent (for advanced usage). */
-  get agent(): Web5UserAgent {
+  /** The underlying EnboxUserAgent (for advanced usage). */
+  get agent(): EnboxUserAgent {
     return this._userAgent;
   }
 

--- a/packages/auth/src/flows/dwn-discovery.ts
+++ b/packages/auth/src/flows/dwn-discovery.ts
@@ -15,7 +15,7 @@
  * @module
  */
 
-import type { Web5UserAgent } from '@enbox/agent';
+import type { EnboxUserAgent } from '@enbox/agent';
 
 import { readDwnDiscoveryPayloadFromUrl } from '@enbox/agent';
 
@@ -87,12 +87,12 @@ export async function clearLocalDwnEndpoint(
  * The endpoint is validated by the agent (via `GET /info`) before being
  * accepted. If validation fails, the stale entry is removed from storage.
  *
- * @param agent - The running Web5UserAgent.
+ * @param agent - The running EnboxUserAgent.
  * @param storage - The auth storage adapter.
  * @returns `true` if an endpoint was restored and validated, `false` otherwise.
  */
 export async function restoreLocalDwnEndpoint(
-  agent: Web5UserAgent,
+  agent: EnboxUserAgent,
   storage: StorageAdapter,
 ): Promise<boolean> {
   const endpoint = await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT);
@@ -121,12 +121,12 @@ export async function restoreLocalDwnEndpoint(
  * `agentDid` available) so that `setCachedLocalDwnEndpoint()` can
  * validate the endpoint.
  *
- * @param agent - The running Web5UserAgent.
+ * @param agent - The running EnboxUserAgent.
  * @param storage - The auth storage adapter.
  * @returns `true` if a local DWN endpoint was discovered and injected.
  */
 export async function applyLocalDwnDiscovery(
-  agent: Web5UserAgent,
+  agent: EnboxUserAgent,
   storage: StorageAdapter,
 ): Promise<boolean> {
   // Step 1: Check for a fresh payload in the URL fragment (redirect just happened).

--- a/packages/auth/src/flows/dwn-registration.ts
+++ b/packages/auth/src/flows/dwn-registration.ts
@@ -11,7 +11,7 @@
  * @module
  */
 
-import type { Web5UserAgent } from '@enbox/agent';
+import type { EnboxUserAgent } from '@enbox/agent';
 
 import { DwnRegistrar } from '@enbox/dwn-clients';
 
@@ -23,7 +23,7 @@ import type {
 /** @internal */
 export interface RegistrationContext {
   /** The user agent with RPC access for getServerInfo(). */
-  userAgent: Web5UserAgent;
+  userAgent: EnboxUserAgent;
 
   /** DWN endpoints to register with. */
   dwnEndpoints: string[];

--- a/packages/auth/src/flows/import-identity.ts
+++ b/packages/auth/src/flows/import-identity.ts
@@ -6,7 +6,7 @@
  * @module
  */
 
-import type { Web5UserAgent } from '@enbox/agent';
+import type { EnboxUserAgent } from '@enbox/agent';
 
 import type { AuthEventEmitter } from '../events.js';
 import { AuthSession } from '../identity-session.js';
@@ -22,7 +22,7 @@ import type {
 
 /** @internal */
 export interface ImportContext {
-  userAgent: Web5UserAgent;
+  userAgent: EnboxUserAgent;
   emitter: AuthEventEmitter;
   storage: StorageAdapter;
   defaultSync?: SyncOption;

--- a/packages/auth/src/flows/local-connect.ts
+++ b/packages/auth/src/flows/local-connect.ts
@@ -6,7 +6,7 @@
  * @module
  */
 
-import type { Web5UserAgent } from '@enbox/agent';
+import type { EnboxUserAgent } from '@enbox/agent';
 
 import type { AuthEventEmitter } from '../events.js';
 import type { LocalConnectOptions, RegistrationOptions, StorageAdapter, SyncOption } from '../types.js';
@@ -18,7 +18,7 @@ import { INSECURE_DEFAULT_PASSWORD, STORAGE_KEYS } from '../types.js';
 
 /** @internal */
 export interface LocalConnectContext {
-  userAgent: Web5UserAgent;
+  userAgent: EnboxUserAgent;
   emitter: AuthEventEmitter;
   storage: StorageAdapter;
   defaultPassword?: string;

--- a/packages/auth/src/flows/session-restore.ts
+++ b/packages/auth/src/flows/session-restore.ts
@@ -6,7 +6,7 @@
  * @module
  */
 
-import type { Web5UserAgent } from '@enbox/agent';
+import type { EnboxUserAgent } from '@enbox/agent';
 
 import type { AuthEventEmitter } from '../events.js';
 import type { RestoreSessionOptions, StorageAdapter, SyncOption } from '../types.js';
@@ -17,7 +17,7 @@ import { INSECURE_DEFAULT_PASSWORD, STORAGE_KEYS } from '../types.js';
 
 /** @internal */
 export interface SessionRestoreContext {
-  userAgent: Web5UserAgent;
+  userAgent: EnboxUserAgent;
   emitter: AuthEventEmitter;
   storage: StorageAdapter;
   defaultPassword?: string;

--- a/packages/auth/src/flows/wallet-connect.ts
+++ b/packages/auth/src/flows/wallet-connect.ts
@@ -9,7 +9,7 @@
 
 import { Convert } from '@enbox/common';
 import { WalletConnect } from '@enbox/agent';
-import type { DwnDataEncodedRecordsWriteMessage, DwnMessagesPermissionScope, DwnRecordsPermissionScope, Web5UserAgent } from '@enbox/agent';
+import type { DwnDataEncodedRecordsWriteMessage, DwnMessagesPermissionScope, DwnRecordsPermissionScope, EnboxUserAgent } from '@enbox/agent';
 import { DwnInterface, DwnPermissionGrant } from '@enbox/agent';
 
 import type { AuthEventEmitter } from '../events.js';
@@ -20,7 +20,7 @@ import type { RegistrationOptions, StorageAdapter, SyncOption, WalletConnectOpti
 
 /** @internal */
 export interface WalletConnectContext {
-  userAgent: Web5UserAgent;
+  userAgent: EnboxUserAgent;
   emitter: AuthEventEmitter;
   storage: StorageAdapter;
   defaultSync?: SyncOption;
@@ -38,7 +38,7 @@ export interface WalletConnectContext {
  * @internal
  */
 export async function processConnectedGrants(params: {
-  agent: Web5UserAgent;
+  agent: EnboxUserAgent;
   delegateDid: string;
   grants: DwnDataEncodedRecordsWriteMessage[];
 }): Promise<string[]> {

--- a/packages/auth/src/identity-session.ts
+++ b/packages/auth/src/identity-session.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-import type { Web5Agent } from '@enbox/agent';
+import type { EnboxAgent } from '@enbox/agent';
 
 import type { IdentityInfo } from './types.js';
 
@@ -28,7 +28,7 @@ import type { IdentityInfo } from './types.js';
  */
 export class AuthSession {
   /** The authenticated Web5 agent managing keys, DIDs, and DWN access. */
-  readonly agent: Web5Agent;
+  readonly agent: EnboxAgent;
 
   /** The DID URI of the connected identity. */
   readonly did: string;
@@ -50,7 +50,7 @@ export class AuthSession {
   readonly identity: IdentityInfo;
 
   constructor(params: {
-    agent: Web5Agent;
+    agent: EnboxAgent;
     did: string;
     delegateDid?: string;
     recoveryPhrase?: string;

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -42,7 +42,7 @@ export { AuthEventEmitter } from './events.js';
 
 // Re-export agent classes so consumers can construct custom agents/vaults
 // without a direct @enbox/agent dependency.
-export { HdIdentityVault, Web5UserAgent } from '@enbox/agent';
+export { EnboxUserAgent, HdIdentityVault } from '@enbox/agent';
 
 // Wallet-connect helpers
 export { processConnectedGrants } from './flows/wallet-connect.js';

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -3,13 +3,13 @@
  * Public types for the authentication and identity management SDK.
  */
 
-import type { ConnectPermissionRequest, HdIdentityVault, LocalDwnStrategy, PortableIdentity, Web5UserAgent } from '@enbox/agent';
+import type { ConnectPermissionRequest, EnboxUserAgent, HdIdentityVault, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
 
 // Re-export types that consumers will need
 export type { ConnectPermissionRequest, HdIdentityVault, IdentityVaultBackup, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
 
-// Re-export Web5UserAgent so consumers don't need a direct @enbox/agent dep
-export type { Web5UserAgent } from '@enbox/agent';
+// Re-export EnboxUserAgent so consumers don't need a direct @enbox/agent dep
+export type { EnboxUserAgent } from '@enbox/agent';
 
 // ─── Sync ────────────────────────────────────────────────────────
 
@@ -173,7 +173,7 @@ export interface RegistrationOptions {
 /** Options for {@link AuthManager.create}. */
 export interface AuthManagerOptions {
   /**
-   * Provide a pre-built {@link Web5UserAgent} instance.
+   * Provide a pre-built {@link EnboxUserAgent} instance.
    *
    * When provided, `dataPath`, `agentVault`, and `localDwnStrategy` are
    * ignored — the agent is used as-is. This is the escape hatch for
@@ -181,11 +181,11 @@ export interface AuthManagerOptions {
    *
    * @example
    * ```ts
-   * const agent = await Web5UserAgent.create({ dwnApi: myCustomDwnApi });
+   * const agent = await EnboxUserAgent.create({ dwnApi: myCustomDwnApi });
    * const auth = await AuthManager.create({ agent });
    * ```
    */
-  agent?: Web5UserAgent;
+  agent?: EnboxUserAgent;
 
   /**
    * Provide a custom {@link HdIdentityVault} implementation.

--- a/packages/auth/tests/auth-manager-create.spec.ts
+++ b/packages/auth/tests/auth-manager-create.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for AuthManager.create() and walletConnect() — the two uncovered methods.
  *
- * These need module-level mocking of Web5UserAgent.create() because the
+ * These need module-level mocking of EnboxUserAgent.create() because the
  * private constructor is not directly accessible. We use a dedicated test
  * file so mock.module() does not pollute other test files.
  */
@@ -11,7 +11,7 @@ import { MemoryStorage } from '../src/storage/storage.js';
 import { createMockAgent, createMockIdentity } from './helpers/mock-agent.js';
 
 // ── Module-level mocks ──────────────────────────────────────────
-// Preserve all actual agent exports, only mock Web5UserAgent.create and
+// Preserve all actual agent exports, only mock EnboxUserAgent.create and
 // WalletConnect.initClient.
 
 const actualAgent = await import('@enbox/agent');
@@ -27,8 +27,8 @@ const mockInitClient = mock((): any => Promise.resolve({
 
 mock.module('@enbox/agent', () => ({
   ...actualAgent,
-  Web5UserAgent: {
-    ...actualAgent.Web5UserAgent,
+  EnboxUserAgent: {
+    ...actualAgent.EnboxUserAgent,
     create: mockUserAgentCreate,
   },
   WalletConnect: {
@@ -107,7 +107,7 @@ describe('AuthManager.create()', () => {
     expect(manager.state).toBe('unlocked');
   });
 
-  test('passes dataPath to Web5UserAgent.create', async () => {
+  test('passes dataPath to EnboxUserAgent.create', async () => {
     let capturedOptions: any;
     mockUserAgentCreate.mockImplementationOnce((...args: any[]): any => {
       capturedOptions = args[0];
@@ -128,7 +128,7 @@ describe('AuthManager.create()', () => {
       storage : new MemoryStorage(),
     });
 
-    // Web5UserAgent.create() should NOT have been called.
+    // EnboxUserAgent.create() should NOT have been called.
     expect(mockUserAgentCreate.mock.calls.length).toBe(callsBefore);
     expect(manager.agent).toBe(customAgent);
     expect(manager.state).toBe('uninitialized');
@@ -146,13 +146,13 @@ describe('AuthManager.create()', () => {
       storage          : new MemoryStorage(),
     });
 
-    // Web5UserAgent.create() should NOT have been called.
+    // EnboxUserAgent.create() should NOT have been called.
     expect(mockUserAgentCreate.mock.calls.length).toBe(callsBefore);
     expect(manager.agent).toBe(customAgent);
     expect(manager.state).toBe('unlocked');
   });
 
-  test('passes agentVault to Web5UserAgent.create', async () => {
+  test('passes agentVault to EnboxUserAgent.create', async () => {
     let capturedOptions: any;
     mockUserAgentCreate.mockImplementationOnce((...args: any[]): any => {
       capturedOptions = args[0];
@@ -165,7 +165,7 @@ describe('AuthManager.create()', () => {
     expect(capturedOptions.agentVault).toBe(fakeVault);
   });
 
-  test('passes localDwnStrategy to Web5UserAgent.create', async () => {
+  test('passes localDwnStrategy to EnboxUserAgent.create', async () => {
     let capturedOptions: any;
     mockUserAgentCreate.mockImplementationOnce((...args: any[]): any => {
       capturedOptions = args[0];

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -1,4 +1,4 @@
-import type { Web5UserAgent } from '@enbox/agent';
+import type { EnboxUserAgent } from '@enbox/agent';
 import { describe, expect, test } from 'bun:test';
 
 import { AuthManager } from '../src/auth-manager.js';
@@ -10,11 +10,11 @@ import { createMockAgent, createMockIdentity } from './helpers/mock-agent.js';
  * Construct an AuthManager instance with a pre-built mock agent.
  *
  * We use `Object.create()` + manual assignment to bypass the private
- * constructor and `Web5UserAgent.create()` call, testing orchestration
+ * constructor and `EnboxUserAgent.create()` call, testing orchestration
  * logic in isolation.
  */
 function createTestManager(
-  agent: Web5UserAgent,
+  agent: EnboxUserAgent,
   overrides: {
     storage?: MemoryStorage;
     password?: string;
@@ -26,7 +26,7 @@ function createTestManager(
   const storage = overrides.storage ?? new MemoryStorage();
 
   // Use the static create path with a module mock — but that requires
-  // mocking Web5UserAgent.create. Instead, craft the instance manually.
+  // mocking EnboxUserAgent.create. Instead, craft the instance manually.
   const manager = Object.create(AuthManager.prototype) as any;
   manager._userAgent = agent;
   manager._emitter = new (require('../src/events.js').AuthEventEmitter)();

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -1,9 +1,9 @@
 /**
- * Shared mock factory for Web5UserAgent used across tests.
+ * Shared mock factory for EnboxUserAgent used across tests.
  * @module
  */
 
-import type { Web5UserAgent } from '@enbox/agent';
+import type { EnboxUserAgent } from '@enbox/agent';
 
 /** Minimal BearerIdentity-like object for testing. */
 export interface MockIdentity {
@@ -57,11 +57,11 @@ export interface MockAgentOverrides {
 }
 
 /**
- * Create a fully-mocked Web5UserAgent with sensible defaults.
+ * Create a fully-mocked EnboxUserAgent with sensible defaults.
  *
  * All methods are mocked with no-op defaults that can be overridden.
  */
-export function createMockAgent(overrides: MockAgentOverrides = {}): Web5UserAgent {
+export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAgent {
   const defaultIdentity = createMockIdentity();
 
   return {
@@ -122,5 +122,5 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): Web5UserAge
       backup         : overrides.vaultBackup ?? (async (): Promise<any> => ({ data: 'backup' })),
       restore        : overrides.vaultRestore ?? (async (): Promise<void> => {}),
     },
-  } as unknown as Web5UserAgent;
+  } as unknown as EnboxUserAgent;
 }

--- a/packages/dwn-clients/src/rpc-client.ts
+++ b/packages/dwn-clients/src/rpc-client.ts
@@ -8,7 +8,7 @@ import { HttpDwnRpcClient } from './http-dwn-rpc-client.js';
 import { WebSocketDwnRpcClient } from './web-socket-clients.js';
 
 /**
- * Interface that can be implemented to communicate with {@link Web5Agent | Web5 Agent}
+ * Interface that can be implemented to communicate with {@link EnboxAgent | Enbox Agent}
  * implementations via JSON-RPC.
  */
 export interface DidRpc {
@@ -38,20 +38,20 @@ export type RpcStatus = {
   message: string;
 };
 
-export interface Web5Rpc extends DwnRpc, DidRpc, DwnServerInfoRpc {}
+export interface EnboxRpc extends DwnRpc, DidRpc, DwnServerInfoRpc {}
 
 /**
  * Client used to communicate with Dwn Servers
  */
-export class Web5RpcClient implements Web5Rpc {
-  private transportClients: Map<string, Web5Rpc>;
+export class EnboxRpcClient implements EnboxRpc {
+  private transportClients: Map<string, EnboxRpc>;
 
-  constructor(clients: Web5Rpc[] = []) {
+  constructor(clients: EnboxRpc[] = []) {
     this.transportClients = new Map();
 
     // include http and socket clients as default.
     // can be overwritten for 'http:', 'https:', 'ws: or ':wss' if instantiated with other clients.
-    clients = [new HttpWeb5RpcClient(), new WebSocketWeb5RpcClient(), ...clients];
+    clients = [new HttpEnboxRpcClient(), new WebSocketEnboxRpcClient(), ...clients];
 
     for (const client of clients) {
       for (const transportScheme of client.transportProtocols) {
@@ -110,7 +110,7 @@ export class Web5RpcClient implements Web5Rpc {
   }
 }
 
-export class HttpWeb5RpcClient extends HttpDwnRpcClient implements Web5Rpc {
+export class HttpEnboxRpcClient extends HttpDwnRpcClient implements EnboxRpc {
   async sendDidRequest(request: DidRpcRequest): Promise<DidRpcResponse> {
     const requestId = CryptoUtils.randomUuid();
     const jsonRpcRequest = createJsonRpcRequest(requestId, request.method, {
@@ -149,7 +149,7 @@ export class HttpWeb5RpcClient extends HttpDwnRpcClient implements Web5Rpc {
   }
 }
 
-export class WebSocketWeb5RpcClient extends WebSocketDwnRpcClient implements Web5Rpc {
+export class WebSocketEnboxRpcClient extends WebSocketDwnRpcClient implements EnboxRpc {
   async sendDidRequest(_request: DidRpcRequest): Promise<DidRpcResponse> {
     throw new Error(`not implemented for transports [${this.transportProtocols.join(', ')}]`);
   }
@@ -158,3 +158,19 @@ export class WebSocketWeb5RpcClient extends WebSocketDwnRpcClient implements Web
     throw new Error(`not implemented for transports [${this.transportProtocols.join(', ')}]`);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Deprecated aliases — migration aid
+// ---------------------------------------------------------------------------
+
+/** @deprecated Use {@link EnboxRpc} instead. Will be removed in a future version. */
+export type Web5Rpc = EnboxRpc;
+
+/** @deprecated Use {@link EnboxRpcClient} instead. Will be removed in a future version. */
+export const Web5RpcClient = EnboxRpcClient;
+
+/** @deprecated Use {@link HttpEnboxRpcClient} instead. Will be removed in a future version. */
+export const HttpWeb5RpcClient = HttpEnboxRpcClient;
+
+/** @deprecated Use {@link WebSocketEnboxRpcClient} instead. Will be removed in a future version. */
+export const WebSocketWeb5RpcClient = WebSocketEnboxRpcClient;

--- a/packages/dwn-clients/tests/rpc-client.spec.ts
+++ b/packages/dwn-clients/tests/rpc-client.spec.ts
@@ -1,5 +1,5 @@
+import type { EnboxRpc } from '../src/rpc-client.js';
 import type { Persona } from '@enbox/dwn-sdk-js';
-import type { Web5Rpc } from '../src/rpc-client.js';
 
 import sinon from 'sinon';
 
@@ -10,7 +10,7 @@ import {
   createJsonRpcErrorResponse, createJsonRpcSuccessResponse,
   DwnServerInfoCacheMemory, HttpDwnRpcClient, JsonRpcErrorCodes,
 } from '../src/index.js';
-import { DidRpcMethod, HttpWeb5RpcClient, Web5RpcClient, WebSocketWeb5RpcClient } from '../src/rpc-client.js';
+import { DidRpcMethod, EnboxRpcClient, HttpEnboxRpcClient, WebSocketEnboxRpcClient } from '../src/rpc-client.js';
 
 const testDwnUrl = process.env.TEST_DWN_URL || 'http://localhost:3000';
 
@@ -65,7 +65,7 @@ describe('RPC Clients', () => {
     });
   });
 
-  describe('Web5RpcClient', () => {
+  describe('EnboxRpcClient', () => {
     let alice: Persona;
 
     beforeEach(async () => {
@@ -79,7 +79,7 @@ describe('RPC Clients', () => {
     });
 
     it('returns available transports', async () => {
-      const httpOnlyClient = new Web5RpcClient();
+      const httpOnlyClient = new EnboxRpcClient();
 
       expect(httpOnlyClient.transportProtocols).toEqual(expect.arrayContaining([
         'http:',
@@ -91,8 +91,8 @@ describe('RPC Clients', () => {
 
     describe('sendDidRequest', () => {
       it('should send to the client depending on transport', async () => {
-        const stubHttpClient = sinon.createStubInstance(HttpWeb5RpcClient);
-        const httpOnlyClient = new Web5RpcClient([ stubHttpClient ]);
+        const stubHttpClient = sinon.createStubInstance(HttpEnboxRpcClient);
+        const httpOnlyClient = new EnboxRpcClient([ stubHttpClient ]);
 
         // request with http
         const request = { method: DidRpcMethod.Resolve, url: 'http://127.0.0.1', data: 'some-data' };
@@ -102,7 +102,7 @@ describe('RPC Clients', () => {
       });
 
       it('should throw if transport client is not found', async () => {
-        const client = new Web5RpcClient();
+        const client = new EnboxRpcClient();
 
         // request with foo transport
         const request = { method: DidRpcMethod.Resolve, url: 'foo://127.0.0.1', data: 'some-data' };
@@ -115,7 +115,7 @@ describe('RPC Clients', () => {
       });
 
       it('should throw for a completely invalid URL', async () => {
-        const client = new Web5RpcClient();
+        const client = new EnboxRpcClient();
         const request = { method: DidRpcMethod.Resolve, url: 'not a valid url at all', data: 'some-data' };
         try {
           await client.sendDidRequest(request);
@@ -127,8 +127,8 @@ describe('RPC Clients', () => {
       });
 
       it('should throw if transport is sockets', async () => {
-        const socketClientSpy = sinon.spy(WebSocketWeb5RpcClient.prototype, 'sendDidRequest');
-        const client = new Web5RpcClient();
+        const socketClientSpy = sinon.spy(WebSocketEnboxRpcClient.prototype, 'sendDidRequest');
+        const client = new EnboxRpcClient();
 
         for (const transport of ['ws:', 'wss:']) {
         // request with ws transport
@@ -148,8 +148,8 @@ describe('RPC Clients', () => {
 
     describe('sendDwnRequest', () => {
       it('should send to the client depending on transport', async () => {
-        const stubHttpClient = sinon.createStubInstance(HttpWeb5RpcClient);
-        const httpOnlyClient = new Web5RpcClient([ stubHttpClient ]);
+        const stubHttpClient = sinon.createStubInstance(HttpEnboxRpcClient);
+        const httpOnlyClient = new EnboxRpcClient([ stubHttpClient ]);
         const { message } = await TestDataGenerator.generateRecordsQuery({
           author : alice,
           filter : {
@@ -169,7 +169,7 @@ describe('RPC Clients', () => {
       });
 
       it('should throw if transport client is not found', async () => {
-        const client = new Web5RpcClient();
+        const client = new EnboxRpcClient();
         const { message } = await TestDataGenerator.generateRecordsQuery({
           author : alice,
           filter : {
@@ -191,7 +191,7 @@ describe('RPC Clients', () => {
       });
 
       it('should throw for a completely invalid URL in sendDwnRequest', async () => {
-        const client = new Web5RpcClient();
+        const client = new EnboxRpcClient();
         const { message } = await TestDataGenerator.generateRecordsQuery({
           author : alice,
           filter : { schema: 'foo/bar' }
@@ -218,7 +218,7 @@ describe('RPC Clients', () => {
         };
 
         // Create a custom client that handles http: and returns a custom response
-        const customClient: Web5Rpc = {
+        const customClient: EnboxRpc = {
           get transportProtocols(): string[] { return ['http:', 'https:']; },
           sendDwnRequest : sinon.stub().resolves(customResponse),
           sendDidRequest : sinon.stub().resolves({ ok: true, status: { code: 200, message: 'OK' } }),
@@ -226,7 +226,7 @@ describe('RPC Clients', () => {
         };
 
         // Custom clients override the defaults since they're appended after defaults
-        const rpcClient = new Web5RpcClient([customClient as any]);
+        const rpcClient = new EnboxRpcClient([customClient as any]);
 
         const { message } = await TestDataGenerator.generateRecordsQuery({
           author : alice,
@@ -245,7 +245,7 @@ describe('RPC Clients', () => {
     });
 
     describe('getServerInfo',() => {
-      let client: Web5RpcClient;
+      let client: EnboxRpcClient;
 
       afterAll(() => {
         sinon.restore();
@@ -253,7 +253,7 @@ describe('RPC Clients', () => {
 
       beforeEach(async () => {
         sinon.restore();
-        client = new Web5RpcClient();
+        client = new EnboxRpcClient();
       });
 
       it('is able to get server info', async () => {
@@ -301,7 +301,7 @@ describe('RPC Clients', () => {
       });
 
       it('should throw if transport client is not found', async () => {
-        const client = new Web5RpcClient();
+        const client = new EnboxRpcClient();
 
         // request with foo transport
         try {
@@ -313,8 +313,8 @@ describe('RPC Clients', () => {
       });
 
       it('should throw if transport is sockets', async () => {
-        const socketClientSpy = sinon.spy(WebSocketWeb5RpcClient.prototype, 'getServerInfo');
-        const client = new Web5RpcClient();
+        const socketClientSpy = sinon.spy(WebSocketEnboxRpcClient.prototype, 'getServerInfo');
+        const client = new EnboxRpcClient();
 
         for (const transport of ['ws:', 'wss:']) {
         // request with ws transport
@@ -332,9 +332,9 @@ describe('RPC Clients', () => {
     });
   });
 
-  describe('HttpWeb5RpcClient', () => {
+  describe('HttpEnboxRpcClient', () => {
     let alice: Persona;
-    let client: HttpWeb5RpcClient;
+    let client: HttpEnboxRpcClient;
 
     afterAll(() => {
       sinon.restore();
@@ -343,7 +343,7 @@ describe('RPC Clients', () => {
     beforeEach(async () => {
       sinon.restore();
 
-      client = new HttpWeb5RpcClient();
+      client = new HttpEnboxRpcClient();
       alice = await TestDataGenerator.generateDidKeyPersona();
     });
 
@@ -423,9 +423,9 @@ describe('RPC Clients', () => {
     });
   });
 
-  describe('WebSocketWeb5RpcClient', () => {
+  describe('WebSocketEnboxRpcClient', () => {
     let alice: Persona;
-    const client = new WebSocketWeb5RpcClient();
+    const client = new WebSocketEnboxRpcClient();
     // we set the client to a websocket url
     const dwnUrl = new URL(testDwnUrl);
     dwnUrl.protocol = dwnUrl.protocol === 'http:' ? 'ws:' : 'wss:';


### PR DESCRIPTION
## Summary

Phase 2+3 of the Web5 → Enbox rename (#595). Renames all `Web5`-prefixed public symbols across `@enbox/agent` and `@enbox/dwn-clients`, with deprecated aliases preserved for migration.

### Symbols renamed

| Package | Old | New |
|---------|-----|-----|
| `@enbox/agent` | `Web5Agent` | `EnboxAgent` |
| `@enbox/agent` | `Web5UserAgent` | `EnboxUserAgent` |
| `@enbox/agent` | `Web5PlatformAgent` | `EnboxPlatformAgent` |
| `@enbox/agent` | `Web5ConnectAuthRequest` | `EnboxConnectAuthRequest` |
| `@enbox/agent` | `Web5ConnectAuthResponse` | `EnboxConnectAuthResponse` |
| `@enbox/dwn-clients` | `Web5Rpc` | `EnboxRpc` |
| `@enbox/dwn-clients` | `Web5RpcClient` | `EnboxRpcClient` |
| `@enbox/dwn-clients` | `HttpWeb5RpcClient` | `HttpEnboxRpcClient` |
| `@enbox/dwn-clients` | `WebSocketWeb5RpcClient` | `WebSocketEnboxRpcClient` |

### File renamed
- `packages/agent/src/web5-user-agent.ts` → `packages/agent/src/enbox-user-agent.ts`
- `packages/agent/tests/web5-user-agent.spec.ts` → `packages/agent/tests/enbox-user-agent.spec.ts`

### Downstream packages updated
- `@enbox/api` — all `Web5Agent` → `EnboxAgent`, `Web5RpcClient` → `EnboxRpcClient` references
- `@enbox/auth` — all `Web5UserAgent` → `EnboxUserAgent`, `Web5Agent` → `EnboxAgent` references
- `CLAUDE.md` — updated code examples

### Breaking changes
All old names are preserved as deprecated aliases — existing consumers will get deprecation warnings but won't break immediately.

## Verification

| Package | Tests | Result |
|---------|-------|--------|
| `@enbox/dwn-clients` | 141 | 0 fail |
| `@enbox/agent` | 1086 | 0 fail |
| `@enbox/api` | 516 | 0 fail |
| `@enbox/auth` | 169 | 0 fail |

All 4 packages: lint 0 errors, build passes.

**86 files changed**, +518 / -459 lines (net +59 from deprecated alias blocks).