### PR TITLE
fix(dwn-server): compute storage from messageStoreMessages instead of dataRefs

### DIFF
--- a/packages/dwn-server/src/admin/admin-store.ts
+++ b/packages/dwn-server/src/admin/admin-store.ts
@@ -161,10 +161,14 @@ export class AdminStore {
 
   /**
    * Returns the total data storage in bytes for a tenant.
+   *
+   * Uses `messageStoreMessages.dataSize` rather than `dataRefs.dataSize` so that
+   * **all** data is accounted for — including small payloads (<=30 KB) that the
+   * DWN SDK stores inline as `encodedData` and never writes to the data store.
    */
   public async getTenantStorageSize(did: string): Promise<number> {
     const result = await this.db
-      .selectFrom('dataRefs')
+      .selectFrom('messageStoreMessages')
       .select(this.db.fn.sum<number>('dataSize').as('totalBytes'))
       .where('tenant', '=', did)
       .executeTakeFirstOrThrow();
@@ -212,7 +216,7 @@ export class AdminStore {
         .select(this.db.fn.countAll<number>().as('count'))
         .executeTakeFirstOrThrow(),
       this.db
-        .selectFrom('dataRefs')
+        .selectFrom('messageStoreMessages')
         .select(this.db.fn.sum<number>('dataSize').as('totalBytes'))
         .executeTakeFirstOrThrow(),
       this.db

--- a/packages/dwn-server/tests/admin/admin-store.test.ts
+++ b/packages/dwn-server/tests/admin/admin-store.test.ts
@@ -23,9 +23,9 @@ import { runServerMigrations } from '../../src/server-migration-runner.js';
 
 /**
  * Minimal Kysely type for direct SQL verification queries.
- * Matches the `dataRefs` and `dataBlocks` tables created by `DataStoreSql`.
  */
 interface TestDatabase {
+  messageStoreMessages: { tenant: string; dataSize: number | null };
   dataRefs: { tenant: string; recordId: string; dataCid: string; dataSize: number };
   dataBlocks: { rootDataCid: string; blockCid: string; data: Uint8Array };
 }
@@ -423,16 +423,17 @@ describe('AdminStore', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // getTenantStorageSize() — content-addressed datastore
+  // getTenantStorageSize() — uses messageStoreMessages.dataSize
   // ---------------------------------------------------------------------------
 
   // Data must exceed DwnConstant.maxDataSizeAllowedToBeEncoded (30_000 bytes) to be
   // stored in the DataStore (dataRefs/dataBlocks). Smaller data is stored inline in
   // messageStoreMessages.encodedData and never touches dataRefs.
   const LARGE_DATA_SIZE = 40_000;
+  const SMALL_DATA_SIZE = 1_000;
 
   describe('getTenantStorageSize()', () => {
-    it('should return the correct byte total for a tenant with data records', async () => {
+    it('should return the correct byte total for a tenant with large data records', async () => {
       const persona = await TestDataGenerator.generateDidKeyPersona();
       await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
 
@@ -441,6 +442,25 @@ describe('AdminStore', () => {
       const result = await dwn.processMessage(persona.did, recordsWrite.message, { dataStream });
       expect(result.status.code).toBe(202);
 
+      const storageSize = await adminStore.getTenantStorageSize(persona.did);
+      expect(storageSize).toBe(data.length);
+    });
+
+    it('should include small inline data that never reaches the data store', async () => {
+      const persona = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, persona);
+
+      // Small data is stored inline in encodedData, NOT in dataRefs.
+      const data = TestDataGenerator.randomBytes(SMALL_DATA_SIZE);
+      const { recordsWrite, dataStream } = await TestDataGenerator.generateRecordsWrite({ author: persona, data });
+      const result = await dwn.processMessage(persona.did, recordsWrite.message, { dataStream });
+      expect(result.status.code).toBe(202);
+
+      // Verify no rows in dataRefs — the data is inline.
+      const refs = await rawDb.selectFrom('dataRefs').select('dataCid').where('tenant', '=', persona.did).execute();
+      expect(refs.length).toBe(0);
+
+      // Storage size should still reflect the small data.
       const storageSize = await adminStore.getTenantStorageSize(persona.did);
       expect(storageSize).toBe(data.length);
     });
@@ -554,10 +574,11 @@ describe('AdminStore', () => {
       expect(stats.tenantCount).toBeGreaterThan(0);
     });
 
-    it('should return correct totalDataBytes from dataRefs', async () => {
-      // Sum all dataSize values from dataRefs as ground truth.
+    it('should return correct totalDataBytes from messageStoreMessages', async () => {
+      // Sum all dataSize values from messageStoreMessages as ground truth
+      // (includes both inline and data-store-backed records).
       const groundTruth = await rawDb
-        .selectFrom('dataRefs')
+        .selectFrom('messageStoreMessages')
         .select(rawDb.fn.sum<number>('dataSize').as('total'))
         .executeTakeFirstOrThrow();
 
@@ -605,7 +626,7 @@ describe('AdminStore', () => {
 
       await adminStore.purgeTenantData(persona.did);
 
-      // dataRefs should be empty for this tenant.
+      // Storage should be 0 after purge (messages deleted).
       expect(await adminStore.getTenantStorageSize(persona.did)).toBe(0);
     });
 


### PR DESCRIPTION
## Summary

- **Bug**: Admin panel storage showed 0 bytes because `getTenantStorageSize()` and `getGlobalStats()` summed `dataSize` from `dataRefs`, which only contains records > 30 KB. Small payloads (≤30 KB) are stored inline in `messageStoreMessages.encodedData` and never touch `dataRefs`, so they were never counted.
- **Fix**: Switch both methods to sum `dataSize` from `messageStoreMessages` instead, which has the declared data size for all records regardless of storage backend. This also fixes the storage quota enforcement, which calls `getTenantStorageSize()`.
- **Test**: Added a new test verifying that small inline data (1 KB, no `dataRefs` rows) is correctly counted in storage. Updated ground-truth verification to use `messageStoreMessages`.