### PR TITLE
fix(dwn-sdk-js): prevent prototype pollution in getRuleSetAtPath

### DIFF
--- a/packages/dwn-sdk-js/src/utils/protocols.ts
+++ b/packages/dwn-sdk-js/src/utils/protocols.ts
@@ -62,10 +62,10 @@ export function getRuleSetAtPath(protocolPath: string, structure: { [key: string
   let currentLevel: { [key: string]: ProtocolRuleSet } = structure;
 
   for (const segment of segments) {
-    current = currentLevel[segment];
-    if (current === undefined) {
+    if (!Object.hasOwn(currentLevel, segment)) {
       return undefined;
     }
+    current = currentLevel[segment];
     currentLevel = current as { [key: string]: ProtocolRuleSet };
   }
 

--- a/packages/dwn-sdk-js/tests/fuzz/get-rule-set-at-path.fuzz.spec.ts
+++ b/packages/dwn-sdk-js/tests/fuzz/get-rule-set-at-path.fuzz.spec.ts
@@ -1,26 +1,22 @@
+import type { ProtocolRuleSet } from '../../src/types/protocols-types.js';
+
 import { describe, expect, it } from 'bun:test';
 
 import fc from 'fast-check';
 
 import { getRuleSetAtPath } from '../../src/utils/protocols.js';
 
-import type { ProtocolRuleSet } from '../../src/types/protocols-types.js';
-
 const numRuns = Number(process.env.FAST_CHECK_NUM_RUNS) || 100;
 
 describe('getRuleSetAtPath — fuzz', () => {
 
   /**
-   * Strings that exist on Object.prototype and would collide with structure lookups.
-   */
-  const prototypeNames = new Set(Object.getOwnPropertyNames(Object.prototype));
-
-  /**
-   * Arbitrary for a valid type name segment (no slashes, non-empty, no $ prefix,
-   * no Object.prototype collisions like "toString", "valueOf", "constructor").
+   * Arbitrary for a valid type name segment (no slashes, non-empty, no $ prefix).
+   * Deliberately includes Object.prototype names like "toString" and "valueOf"
+   * to verify that the function is immune to prototype pollution.
    */
   const arbTypeName = fc.string({ minLength: 1, maxLength: 10 })
-    .filter((s) => !s.includes('/') && !s.startsWith('$') && !prototypeNames.has(s));
+    .filter((s) => !s.includes('/') && !s.startsWith('$'));
 
   describe('single-level path resolution', () => {
     it('should return the rule set for a root-level type', () => {
@@ -105,6 +101,20 @@ describe('getRuleSetAtPath — fuzz', () => {
         ),
         { numRuns }
       );
+    });
+  });
+
+  describe('prototype pollution immunity', () => {
+    it('should return undefined for Object.prototype property names not in the structure', () => {
+      const prototypeNames = Object.getOwnPropertyNames(Object.prototype)
+        .filter((name) => /^[a-zA-Z]+$/.test(name)); // only names valid as protocolPath segments
+
+      const structure = { message: { $size: { min: 0 } } as ProtocolRuleSet };
+
+      for (const name of prototypeNames) {
+        const result = getRuleSetAtPath(name, structure);
+        expect(result).toBeUndefined();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes `getRuleSetAtPath` to use `Object.hasOwn()` instead of bare property lookup, preventing `Object.prototype` method names from bypassing the missing-rule-set check
- Updates fuzz test to remove the prototype name workaround and adds explicit regression test

## Bug

`getRuleSetAtPath` used `currentLevel[segment]` to walk protocol structures. When `segment` matched an `Object.prototype` property (e.g. `"toString"`, `"valueOf"`, `"constructor"`), the lookup returned the inherited prototype method instead of `undefined`.

The caller `ProtocolAuthorization.getRuleSet()` checks `if (ruleSet === undefined)` — since a function is truthy, the check passed and the function was returned as a `ProtocolRuleSet`. Downstream code reads `$actions`, `$size`, `$tags` etc. from it — all `undefined` on a function — meaning no protocol constraints would be enforced.

The `protocolPath` JSON Schema pattern `^[a-zA-Z]+(\/[a-zA-Z]+)*$` accepts all of: `toString`, `valueOf`, `constructor`, `hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable`, `toLocaleString`.

## Fix

```diff
  for (const segment of segments) {
-   current = currentLevel[segment];
-   if (current === undefined) {
+   if (!Object.hasOwn(currentLevel, segment)) {
      return undefined;
    }
+   current = currentLevel[segment];
    currentLevel = current as { [key: string]: ProtocolRuleSet };
  }
```

## Test changes

- Removed the `prototypeNames` filter from `arbTypeName` — the fuzz arbitrary now deliberately generates prototype property names, verifying the function handles them correctly
- Added explicit `prototype pollution immunity` test that checks all `Object.prototype` property names return `undefined`

Fixes #632