### PR TITLE
fix(agent,electrobun-dwn): align local DWN discovery with transport spec

### DIFF
--- a/packages/agent/src/dwn-discovery-file.ts
+++ b/packages/agent/src/dwn-discovery-file.ts
@@ -18,12 +18,21 @@ import { normalizeBaseUrl } from './local-dwn.js';
 
 // ─── Types ────────────────────────────────────────────────────────
 
-/** The JSON shape persisted in the discovery file. */
+/**
+ * The JSON shape persisted in the discovery file.
+ *
+ * @see https://identity.foundation/dwn-transport/#discovery-file
+ */
 export interface DwnDiscoveryRecord {
-  /** Base URL of the running DWN server (e.g. `"http://127.0.0.1:55557"`). */
+  /** Base URL of the running DWN server (e.g. `"http://127.0.0.1:55500"`). */
   endpoint: string;
   /** OS process ID of the DWN server. Used for liveness checking. */
   pid: number;
+  /**
+   * Transport capabilities advertised by the server (e.g. `["http", "ws"]`).
+   * Optional per the DWN Transport Spec.
+   */
+  capabilities?: string[];
 }
 
 /**
@@ -59,7 +68,7 @@ export function createNodeDiscoveryFileFs(): DiscoveryFileFs | undefined {
     const nodeRequire = require;
     const fs = nodeRequire('node:fs/promises') as {
       readFile(path: string, encoding: string): Promise<string>;
-      writeFile(path: string, data: string, encoding: string): Promise<void>;
+      writeFile(path: string, data: string, options: { encoding: string; mode?: number }): Promise<void>;
       mkdir(path: string, options: { recursive: boolean }): Promise<string | undefined>;
       unlink(path: string): Promise<void>;
     };
@@ -82,7 +91,9 @@ export function createNodeDiscoveryFileFs(): DiscoveryFileFs | undefined {
 
       async writeFile(filePath: string, contents: string): Promise<void> {
         await fs.mkdir(path.dirname(filePath), { recursive: true });
-        await fs.writeFile(filePath, contents, 'utf-8');
+        // mode 0o600: owner read/write only — the file contains the PID
+        // and endpoint of a local DWN server.
+        await fs.writeFile(filePath, contents, { encoding: 'utf-8', mode: 0o600 });
       },
 
       async removeFile(filePath: string): Promise<void> {
@@ -220,7 +231,16 @@ export class DwnDiscoveryFile {
       return undefined;
     }
 
-    return { endpoint: normalizeBaseUrl(parsed.endpoint), pid: parsed.pid };
+    const result: DwnDiscoveryRecord = {
+      endpoint : normalizeBaseUrl(parsed.endpoint),
+      pid      : parsed.pid,
+    };
+
+    if (parsed.capabilities !== undefined) {
+      result.capabilities = parsed.capabilities;
+    }
+
+    return result;
   }
 
   /**
@@ -229,11 +249,16 @@ export class DwnDiscoveryFile {
    * @param record - The endpoint and PID to persist.
    */
   public async write(record: DwnDiscoveryRecord): Promise<void> {
-    const json = JSON.stringify(
-      { endpoint: normalizeBaseUrl(record.endpoint), pid: record.pid },
-      null,
-      2,
-    );
+    const serialized: Record<string, unknown> = {
+      endpoint : normalizeBaseUrl(record.endpoint),
+      pid      : record.pid,
+    };
+
+    if (record.capabilities !== undefined && record.capabilities.length > 0) {
+      serialized.capabilities = record.capabilities;
+    }
+
+    const json = JSON.stringify(serialized, null, 2);
     await this._fs.writeFile(this._filePath, json);
   }
 
@@ -261,6 +286,17 @@ function isValidRecord(value: unknown): value is DwnDiscoveryRecord {
 
   if (typeof record.pid !== 'number' || !Number.isInteger(record.pid) || record.pid <= 0) {
     return false;
+  }
+
+  // `capabilities` is optional, but when present must be a string array.
+  if (record.capabilities !== undefined) {
+    if (!Array.isArray(record.capabilities)) {
+      return false;
+    }
+
+    if (!record.capabilities.every((item: unknown) => typeof item === 'string')) {
+      return false;
+    }
   }
 
   return true;

--- a/packages/agent/src/dwn-discovery-payload.ts
+++ b/packages/agent/src/dwn-discovery-payload.ts
@@ -170,7 +170,16 @@ export function readDwnDiscoveryPayloadFromUrl(url: string): DwnDiscoveryPayload
 
 // ─── Internal helpers ─────────────────────────────────────────────
 
-/** Type guard for a valid {@link DwnDiscoveryPayload}. */
+/**
+ * Type guard for a valid {@link DwnDiscoveryPayload}.
+ *
+ * The endpoint MUST point to a loopback address (`127.0.0.1`, `[::1]`,
+ * or `localhost`) because the `dwn://register` payload is only intended
+ * for local DWN discovery. Accepting arbitrary hostnames would allow a
+ * malicious payload to redirect agent traffic to a remote server.
+ *
+ * @see https://github.com/enboxorg/enbox/issues/633
+ */
 function isValidPayload(value: unknown): value is DwnDiscoveryPayload {
   if (typeof value !== 'object' || value === null) {
     return false;
@@ -182,17 +191,65 @@ function isValidPayload(value: unknown): value is DwnDiscoveryPayload {
     return false;
   }
 
+  if (!isLoopbackEndpoint(record.endpoint)) {
+    return false;
+  }
+
   return true;
+}
+
+/**
+ * Returns `true` if the endpoint URL's hostname resolves to a loopback
+ * address.  Accepts `127.0.0.1`, `::1` (with or without brackets), and
+ * `localhost` (bare or with any subdomain suffix, per RFC 6761 §6.3).
+ *
+ * This is a security boundary: the `dwn://register` redirect flow MUST
+ * NOT allow payloads that point to non-local servers.
+ */
+function isLoopbackEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint);
+    const hostname = url.hostname.toLowerCase();
+
+    // IPv4 loopback: 127.0.0.1
+    if (hostname === '127.0.0.1') {
+      return true;
+    }
+
+    // IPv6 loopback: [::1] — URL.hostname strips the brackets.
+    if (hostname === '::1' || hostname === '[::1]') {
+      return true;
+    }
+
+    // `localhost` or any subdomain (e.g. `foo.localhost`).
+    if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Encode a UTF-8 string as unpadded base64url (RFC 4648 §5).
  *
- * Uses the standard `btoa` global available in all target runtimes
- * (browser, Bun, Node 16+).
+ * Uses `TextEncoder` to correctly handle all Unicode code points
+ * (including those above U+00FF that `btoa` cannot represent).
+ *
+ * This module MUST remain dependency-free — no imports from
+ * `@enbox/common` or any other package.
  */
 function stringToBase64Url(input: string): string {
-  return btoa(input)
+  const bytes = new TextEncoder().encode(input);
+  // Build a binary string from the UTF-8 byte array so `btoa` can
+  // consume it (btoa only accepts Latin-1 / code points ≤ U+00FF).
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/, '');
@@ -202,7 +259,8 @@ function stringToBase64Url(input: string): string {
  * Decode an unpadded base64url string back to a UTF-8 string.
  *
  * Re-adds padding and swaps base64url characters back to standard
- * base64 before calling the standard `atob` global.
+ * base64 before calling `atob`, then feeds the resulting bytes through
+ * `TextDecoder` for correct UTF-8 handling.
  */
 function base64UrlToString(input: string): string {
   // Restore standard base64 alphabet and padding.
@@ -213,5 +271,10 @@ function base64UrlToString(input: string): string {
   } else if (remainder === 3) {
     base64 += '=';
   }
-  return atob(base64);
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
 }

--- a/packages/agent/src/local-dwn.ts
+++ b/packages/agent/src/local-dwn.ts
@@ -18,11 +18,25 @@ import type { EnboxRpc } from '@enbox/dwn-clients';
 
 import type { DwnDiscoveryFile } from './dwn-discovery-file.js';
 
-/** Well-known ports the local DWN desktop app may bind to. */
-export const localDwnPortCandidates = [3000, 55555, 55556, 55557, 55558, 55559] as const;
+/**
+ * Well-known ports the local DWN desktop app may bind to.
+ *
+ * Per the DWN Transport Spec, clients probe ports `55500` through `55509`
+ * (inclusive). Port `3000` is included as a development convenience.
+ *
+ * @see https://identity.foundation/dwn-transport/#port-probing
+ */
+export const localDwnPortCandidates = [3000, 55500, 55501, 55502, 55503, 55504, 55505, 55506, 55507, 55508, 55509] as const;
 
-/** Hosts probed when discovering a local DWN server. */
-export const localDwnHostCandidates = ['127.0.0.1', 'localhost'] as const;
+/**
+ * Hosts probed when discovering a local DWN server.
+ *
+ * Per the DWN Transport Spec, clients MUST use `127.0.0.1` rather than
+ * `localhost` to avoid DNS resolution ambiguity.
+ *
+ * @see https://identity.foundation/dwn-transport/#port-probing
+ */
+export const localDwnHostCandidates = ['127.0.0.1'] as const;
 
 /**
  * Controls how the agent discovers and routes to a local DWN server.

--- a/packages/agent/tests/dwn-discovery-file.spec.ts
+++ b/packages/agent/tests/dwn-discovery-file.spec.ts
@@ -282,12 +282,106 @@ describe('DwnDiscoveryFile', () => {
     });
   });
 
+  describe('capabilities', () => {
+    it('should round-trip a record with capabilities', async () => {
+      const fs = createMemoryFs({ isProcessAlive: () => true });
+      const file = new DwnDiscoveryFile(fs, testFilePath);
+
+      const record: DwnDiscoveryRecord = {
+        endpoint     : 'http://127.0.0.1:55500',
+        pid          : 42,
+        capabilities : ['http', 'ws'],
+      };
+      await file.write(record);
+      const result = await file.read();
+
+      expect(result).toEqual(record);
+    });
+
+    it('should omit capabilities from the file when the array is empty', async () => {
+      const fs = createMemoryFs({ isProcessAlive: () => true });
+      const file = new DwnDiscoveryFile(fs, testFilePath);
+
+      await file.write({ endpoint: 'http://127.0.0.1:55500', pid: 42, capabilities: [] });
+
+      const raw = JSON.parse(fs.files.get(testFilePath)!);
+      expect(raw.capabilities).toBeUndefined();
+    });
+
+    it('should omit capabilities from the file when undefined', async () => {
+      const fs = createMemoryFs({ isProcessAlive: () => true });
+      const file = new DwnDiscoveryFile(fs, testFilePath);
+
+      await file.write({ endpoint: 'http://127.0.0.1:55500', pid: 42 });
+
+      const raw = JSON.parse(fs.files.get(testFilePath)!);
+      expect(raw.capabilities).toBeUndefined();
+    });
+
+    it('should read a record without capabilities (backward compatible)', async () => {
+      const fs = createMemoryFs({ isProcessAlive: () => true });
+      fs.files.set(testFilePath, JSON.stringify({ endpoint: 'http://127.0.0.1:55500', pid: 42 }));
+
+      const file = new DwnDiscoveryFile(fs, testFilePath);
+      const result = await file.read();
+
+      expect(result).toBeDefined();
+      expect(result!.endpoint).toBe('http://127.0.0.1:55500');
+      expect(result!.capabilities).toBeUndefined();
+    });
+
+    it('should reject a record with a non-array capabilities field', async () => {
+      const fs = createMemoryFs({ isProcessAlive: () => true });
+      fs.files.set(testFilePath, JSON.stringify({
+        endpoint     : 'http://127.0.0.1:55500',
+        pid          : 42,
+        capabilities : 'http',
+      }));
+
+      const file = new DwnDiscoveryFile(fs, testFilePath);
+      const result = await file.read();
+
+      expect(result).toBeUndefined();
+      expect(fs.files.has(testFilePath)).toBe(false);
+    });
+
+    it('should reject a record with non-string elements in capabilities', async () => {
+      const fs = createMemoryFs({ isProcessAlive: () => true });
+      fs.files.set(testFilePath, JSON.stringify({
+        endpoint     : 'http://127.0.0.1:55500',
+        pid          : 42,
+        capabilities : ['http', 123],
+      }));
+
+      const file = new DwnDiscoveryFile(fs, testFilePath);
+      const result = await file.read();
+
+      expect(result).toBeUndefined();
+      expect(fs.files.has(testFilePath)).toBe(false);
+    });
+  });
+
   describe('round-trip', () => {
     it('should write and then read the same record', async () => {
       const fs = createMemoryFs({ isProcessAlive: () => true });
       const file = new DwnDiscoveryFile(fs, testFilePath);
 
-      const record: DwnDiscoveryRecord = { endpoint: 'http://127.0.0.1:55557', pid: 42 };
+      const record: DwnDiscoveryRecord = { endpoint: 'http://127.0.0.1:55500', pid: 42 };
+      await file.write(record);
+      const result = await file.read();
+
+      expect(result).toEqual(record);
+    });
+
+    it('should round-trip a record with capabilities', async () => {
+      const fs = createMemoryFs({ isProcessAlive: () => true });
+      const file = new DwnDiscoveryFile(fs, testFilePath);
+
+      const record: DwnDiscoveryRecord = {
+        endpoint     : 'http://127.0.0.1:55500',
+        pid          : 42,
+        capabilities : ['http', 'ws'],
+      };
       await file.write(record);
       const result = await file.read();
 
@@ -298,7 +392,7 @@ describe('DwnDiscoveryFile', () => {
       const fs = createMemoryFs({ isProcessAlive: () => true });
       const file = new DwnDiscoveryFile(fs, testFilePath);
 
-      await file.write({ endpoint: 'http://127.0.0.1:55557', pid: 42 });
+      await file.write({ endpoint: 'http://127.0.0.1:55500', pid: 42 });
       await file.remove();
       const result = await file.read();
 

--- a/packages/agent/tests/dwn-discovery-payload.spec.ts
+++ b/packages/agent/tests/dwn-discovery-payload.spec.ts
@@ -60,13 +60,20 @@ describe('DwnDiscoveryPayload', () => {
       expect(decoded).toEqual(payload);
     });
 
-    it('should round-trip a payload with an https endpoint', () => {
-      const payload: DwnDiscoveryPayload = { endpoint: 'https://dwn.example.com' };
+    it('should round-trip a payload with an https localhost endpoint', () => {
+      const payload: DwnDiscoveryPayload = { endpoint: 'https://localhost:55500' };
 
       const encoded = encodeDwnDiscoveryPayload(payload);
       const decoded = decodeDwnDiscoveryPayload(encoded);
 
       expect(decoded).toEqual(payload);
+    });
+
+    it('should reject a payload with a non-loopback endpoint', () => {
+      const encoded = encodeDwnDiscoveryPayload({ endpoint: 'https://dwn.example.com' });
+      const decoded = decodeDwnDiscoveryPayload(encoded);
+
+      expect(decoded).toBeUndefined();
     });
 
     it('should round-trip a payload with unicode in the endpoint path', () => {
@@ -128,6 +135,85 @@ describe('DwnDiscoveryPayload', () => {
       const decoded = decodeDwnDiscoveryPayload(encoded);
 
       expect(decoded).toBeUndefined();
+    });
+
+    it('should round-trip a payload containing multi-byte UTF-8 characters', () => {
+      const payload: DwnDiscoveryPayload = { endpoint: 'http://127.0.0.1:3000/caf\u00e9' };
+
+      const encoded = encodeDwnDiscoveryPayload(payload);
+      const decoded = decodeDwnDiscoveryPayload(encoded);
+
+      expect(decoded).toEqual(payload);
+    });
+
+    it('should round-trip a payload containing emoji (4-byte UTF-8)', () => {
+      // Emoji is U+1F680 which is above U+FFFF and requires a surrogate
+      // pair in JavaScript — tests the TextEncoder/TextDecoder path.
+      const payload: DwnDiscoveryPayload = { endpoint: 'http://127.0.0.1:3000/\u{1F680}' };
+
+      const encoded = encodeDwnDiscoveryPayload(payload);
+      const decoded = decodeDwnDiscoveryPayload(encoded);
+
+      expect(decoded).toEqual(payload);
+    });
+
+    it('should round-trip a payload containing CJK characters', () => {
+      const payload: DwnDiscoveryPayload = { endpoint: 'http://127.0.0.1:3000/\u4F60\u597D' };
+
+      const encoded = encodeDwnDiscoveryPayload(payload);
+      const decoded = decodeDwnDiscoveryPayload(encoded);
+
+      expect(decoded).toEqual(payload);
+    });
+  });
+
+  describe('loopback validation', () => {
+    it('should accept 127.0.0.1 endpoints', () => {
+      const encoded = toBase64Url(JSON.stringify({ endpoint: 'http://127.0.0.1:55500' }));
+
+      expect(decodeDwnDiscoveryPayload(encoded)).toBeDefined();
+    });
+
+    it('should accept localhost endpoints', () => {
+      const encoded = toBase64Url(JSON.stringify({ endpoint: 'http://localhost:3000' }));
+
+      expect(decodeDwnDiscoveryPayload(encoded)).toBeDefined();
+    });
+
+    it('should accept [::1] (IPv6 loopback) endpoints', () => {
+      const encoded = toBase64Url(JSON.stringify({ endpoint: 'http://[::1]:55500' }));
+
+      expect(decodeDwnDiscoveryPayload(encoded)).toBeDefined();
+    });
+
+    it('should accept subdomain of localhost', () => {
+      const encoded = toBase64Url(JSON.stringify({ endpoint: 'http://foo.localhost:3000' }));
+
+      expect(decodeDwnDiscoveryPayload(encoded)).toBeDefined();
+    });
+
+    it('should reject a remote hostname', () => {
+      const encoded = toBase64Url(JSON.stringify({ endpoint: 'https://evil.com:55500' }));
+
+      expect(decodeDwnDiscoveryPayload(encoded)).toBeUndefined();
+    });
+
+    it('should reject a private network IP', () => {
+      const encoded = toBase64Url(JSON.stringify({ endpoint: 'http://192.168.1.1:55500' }));
+
+      expect(decodeDwnDiscoveryPayload(encoded)).toBeUndefined();
+    });
+
+    it('should reject a hostname that contains localhost but is not localhost', () => {
+      const encoded = toBase64Url(JSON.stringify({ endpoint: 'http://notlocalhost:3000' }));
+
+      expect(decodeDwnDiscoveryPayload(encoded)).toBeUndefined();
+    });
+
+    it('should reject an endpoint with no scheme', () => {
+      const encoded = toBase64Url(JSON.stringify({ endpoint: '127.0.0.1:3000' }));
+
+      expect(decodeDwnDiscoveryPayload(encoded)).toBeUndefined();
     });
   });
 

--- a/packages/electrobun-dwn/src/bun/index.ts
+++ b/packages/electrobun-dwn/src/bun/index.ts
@@ -1,17 +1,12 @@
 import type { DwnServerConfig } from '@enbox/dwn-server';
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import {
   buildDwnDiscoveryRedirectUrl,
-  DISCOVERY_DIR,
-  DISCOVERY_FILENAME,
+  DwnDiscoveryFile,
   localDwnPortCandidates,
   parseDwnRegisterUrl,
 } from '@enbox/agent';
 import Electrobun, { BrowserWindow, Utils } from 'electrobun/bun';
-import { mkdir, unlink, writeFile } from 'node:fs/promises';
 
 function selectPortCandidates(): number[] {
   const envPort = Bun.env.DS_PORT;
@@ -51,7 +46,7 @@ function resolveDwnServerPackageJsonPath(): string {
 function createDwnServerConfig(port: number): DwnServerConfig {
   return {
     serverName            : process.env.DWN_SERVER_PACKAGE_NAME || '@enbox/dwn-server',
-    baseUrl               : process.env.DWN_BASE_URL || `http://localhost:${port}`,
+    baseUrl               : process.env.DWN_BASE_URL || `http://127.0.0.1:${port}`,
     port,
     ttlCacheUrl           : process.env.DWN_TTL_CACHE_URL || 'sqlite://',
     packageJsonPath       : resolveDwnServerPackageJsonPath(),
@@ -79,26 +74,11 @@ function createDwnServerConfig(port: number): DwnServerConfig {
 // ─── Discovery file ──────────────────────────────────────────────
 //
 // Write ~/.enbox/dwn.json on startup so CLI/native apps can discover
-// the local DWN server without port probing.
+// the local DWN server without port probing.  Uses the shared
+// `DwnDiscoveryFile` class from `@enbox/agent` for consistent
+// validation, permissions (0600), and path resolution.
 
-const discoveryDir = join(homedir(), DISCOVERY_DIR);
-const discoveryFilePath = join(discoveryDir, DISCOVERY_FILENAME);
-
-async function writeDiscoveryFile(endpoint: string): Promise<void> {
-  const record = { endpoint, pid: process.pid };
-  await mkdir(discoveryDir, { recursive: true });
-  await writeFile(discoveryFilePath, JSON.stringify(record, null, 2), 'utf-8');
-  console.log(`[electrobun-dwn] Discovery file written: ${discoveryFilePath}`);
-}
-
-async function removeDiscoveryFile(): Promise<void> {
-  try {
-    await unlink(discoveryFilePath);
-    console.log(`[electrobun-dwn] Discovery file removed: ${discoveryFilePath}`);
-  } catch {
-    // File was already gone — nothing to clean up.
-  }
-}
+const discoveryFile = new DwnDiscoveryFile();
 
 // ─── Port selection ──────────────────────────────────────────────
 
@@ -165,13 +145,15 @@ if (!dwnServer || selectedPort === undefined) {
   );
 }
 
-const serverEndpoint = `http://localhost:${selectedPort}`;
+const serverEndpoint = `http://127.0.0.1:${selectedPort}`;
 console.log(
   `[electrobun-dwn] DWN server listening on ${serverEndpoint}`,
 );
 
 // Write the discovery file so CLI/native apps can find us.
-await writeDiscoveryFile(serverEndpoint);
+const capabilities = webSocketSupport ? ['http', 'ws'] : ['http'];
+await discoveryFile.write({ endpoint: serverEndpoint, pid: process.pid, capabilities });
+console.log(`[electrobun-dwn] Discovery file written: ${discoveryFile.path}`);
 
 const mainWindow = new BrowserWindow({
   title : 'Enbox DWN Server',
@@ -210,7 +192,12 @@ async function shutdown(): Promise<void> {
   isShuttingDown = true;
 
   // Remove the discovery file before stopping the server.
-  await removeDiscoveryFile();
+  try {
+    await discoveryFile.remove();
+    console.log(`[electrobun-dwn] Discovery file removed: ${discoveryFile.path}`);
+  } catch {
+    // Best-effort cleanup — the file may already be gone.
+  }
 
   try {
     await dwnServer.stop();
@@ -224,3 +211,7 @@ async function shutdown(): Promise<void> {
 mainWindow.on('close', () => {
   void shutdown();
 });
+
+// Clean up the discovery file on signal-based termination (e.g. `kill`).
+process.on('SIGTERM', () => { void shutdown(); });
+process.on('SIGINT', () => { void shutdown(); });

--- a/packages/electrobun-dwn/src/mainview/index.ts
+++ b/packages/electrobun-dwn/src/mainview/index.ts
@@ -8,8 +8,8 @@
  * pass the resolved endpoint to the mainview via Electrobun RPC/IPC.
  * The mainview runs in a BrowserWindow and cannot import `@enbox/agent`.
  */
-const candidatePorts = [3000, 55555, 55556, 55557, 55558, 55559];
-const candidateHosts = ['127.0.0.1', 'localhost'];
+const candidatePorts = [3000, 55500, 55501, 55502, 55503, 55504, 55505, 55506, 55507, 55508, 55509];
+const candidateHosts = ['127.0.0.1'];
 
 async function detectLocalDwnBaseUrl(): Promise<string> {
   for (const port of candidatePorts) {
@@ -23,7 +23,7 @@ async function detectLocalDwnBaseUrl(): Promise<string> {
 
         const serverInfo = await response.json();
         if (serverInfo?.server === '@enbox/dwn-server') {
-          return `http://localhost:${port}`;
+          return `http://127.0.0.1:${port}`;
         }
       } catch {
         // Keep probing candidate endpoints.
@@ -31,7 +31,7 @@ async function detectLocalDwnBaseUrl(): Promise<string> {
     }
   }
 
-  return 'http://localhost:3000';
+  return 'http://127.0.0.1:3000';
 }
 
 async function renderServerUrl(): Promise<void> {


### PR DESCRIPTION
## Summary

Aligns the local DWN discovery implementation with the merged [DWN Transport Specification](https://identity.foundation/dwn-transport/) (Local Transport section) and fixes several security/correctness issues identified during code review.

## Changes

### Spec alignment (#634)
- **Port range**: Changed from `55555–55559` to `55500–55509` per spec §Port Probing
- **Host probing**: Restricted to `127.0.0.1` only, removed `localhost` (spec MUST requirement to avoid DNS ambiguity)
- **`capabilities` field**: Added optional `capabilities?: string[]` to `DwnDiscoveryRecord` per spec §Discovery File
- **electrobun-dwn**: Now writes `capabilities: ['http', 'ws']` (or `['http']`) based on WebSocket config
- **electrobun-dwn**: `serverEndpoint` changed from `http://localhost:${port}` to `http://127.0.0.1:${port}`
- **mainview**: Updated hardcoded port/host lists to match

### Security (#633)
- **Loopback validation**: `decodeDwnDiscoveryPayload()` now rejects endpoints that don't resolve to a loopback address (`127.0.0.1`, `[::1]`, `localhost`). This prevents a malicious `dwn://register` payload from redirecting agent traffic to a remote server.
- **File permissions**: Discovery file now written with mode `0600` (owner read/write only)

### Bug fixes
- **UTF-8 base64url** (#637): `stringToBase64Url`/`base64UrlToString` now use `TextEncoder`/`TextDecoder` for correct UTF-8 handling, fixing silent data corruption for characters above U+00FF (e.g., emoji, CJK)
- **Shared DwnDiscoveryFile** (#635): electrobun-dwn now uses the `DwnDiscoveryFile` class from `@enbox/agent` instead of raw `fs.writeFile`/`unlink`, ensuring consistent validation, permissions, and path resolution
- **Signal handlers** (#636): Added `SIGTERM`/`SIGINT` handlers in electrobun-dwn for discovery file cleanup on signal-based termination

### Tests
- Added capability field tests (read, write, round-trip, validation of non-array/non-string values)
- Added loopback validation tests (accept `127.0.0.1`, `localhost`, `[::1]`, `foo.localhost`; reject `evil.com`, `192.168.1.1`, `notlocalhost`)
- Added UTF-8 round-trip tests (café, emoji 🚀, CJK 你好)
- All existing tests updated for new port/host values

## Verification

```
bun run lint                    # ✅ all packages pass
bun run --filter @enbox/agent build  # ✅
bun test (agent)                # ✅ 1109 pass, 0 fail
bun test (auth)                 # ✅ 187 pass, 0 fail
```

Closes #633, #634, #635, #636, #637