### PR TITLE
docs: replace remaining Web5 references with Enbox across JSDoc and metadata

### DIFF
--- a/.changeset/web5-jsdoc-cleanup.md
+++ b/.changeset/web5-jsdoc-cleanup.md
@@ -1,0 +1,15 @@
+---
+"@enbox/agent": patch
+"@enbox/api": patch
+"@enbox/auth": patch
+"@enbox/browser": patch
+"@enbox/crypto": patch
+"@enbox/dwn-server": patch
+---
+
+Update remaining Web5 references in JSDoc, comments, and package metadata to Enbox
+
+- Replace ~60 stale "Web5" references in JSDoc/comments across agent, api, auth, browser, crypto, and dwn-server packages
+- Update package.json descriptions for @enbox/crypto and @enbox/browser
+- Fix typo in dwn-server http-api.ts ("am enbox" → "an enbox")
+- Update code examples in @enbox/auth to use `Enbox.connect()` instead of `new Web5()`

--- a/packages/agent/src/agent-did-resolver-cache.ts
+++ b/packages/agent/src/agent-did-resolver-cache.ts
@@ -14,8 +14,8 @@ export class AgentDidResolverCache extends DidResolverCacheLevel implements DidR
 
   /**
    * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
-   * the `AgentDidApi`. This agent is used to interact with other Web5 agent components. It's vital
-   * to ensure this instance is set to correctly contextualize operations within the broader Web5
+   * the `AgentDidApi`. This agent is used to interact with other Enbox agent components. It's vital
+   * to ensure this instance is set to correctly contextualize operations within the broader Enbox
    * Agent framework.
    */
   private _agent?: EnboxPlatformAgent;

--- a/packages/agent/src/bearer-identity.ts
+++ b/packages/agent/src/bearer-identity.ts
@@ -2,7 +2,7 @@ import type { BearerDid } from '@enbox/dids';
 import type { IdentityMetadata, PortableIdentity } from './types/identity.js';
 
 /**
- * Represents a Web5 Identity with its DID and metadata.
+ * Represents an Enbox Identity with its DID and metadata.
  */
 export class BearerIdentity {
   /** {@inheritDoc BearerDid} */

--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -93,8 +93,8 @@ async function initClient({
 
   const parData: PushedAuthResponse = await parResponse.json();
 
-  // a deeplink to a web5 compatible wallet. if the wallet scans this link it should receive
-  // a route to its web5 connect provider flow and the params of where to fetch the auth request.
+  // a deeplink to a compatible wallet. if the wallet scans this link it should receive
+  // a route to its Connect provider flow and the params of where to fetch the auth request.
   logger.log(`Wallet URI: ${walletUri}`);
   const generatedWalletUri = new URL(walletUri);
   generatedWalletUri.searchParams.set('request_uri', parData.request_uri);
@@ -159,20 +159,20 @@ export type WalletConnectOptions = {
   permissionRequests: ConnectPermissionRequest[];
 
   /**
-   * The Web5 API provides a URI to the wallet based on the `walletUri` plus a query params payload valid for 5 minutes.
+   * The Connect API provides a URI to the wallet based on the `walletUri` plus a query params payload valid for 5 minutes.
    * The link can either be used as a deep link on the same device or a QR code for cross device or both.
    * The query params are `{ request_uri: string; encryption_key: string; }`
    * The wallet will use the `request_uri to contact the intermediary server's `authorize` endpoint
    * and pull down the {@link EnboxConnectAuthRequest} and use the `encryption_key` to decrypt it.
    *
-   * @param uri - The URI returned by the web5 connect API to be passed to a provider.
+   * @param uri - The URI returned by the Connect API to be passed to a provider.
    */
   onWalletUriReady: (uri: string) => void;
 
   /**
    * Function that must be provided to submit the pin entered by the user on the client.
    * The pin is used to decrypt the {@link EnboxConnectAuthResponse} that was retrieved from the
-   * token endpoint by the client inside of web5 connect.
+   * token endpoint by the client inside of Connect.
    *
    * @returns A promise that resolves to the PIN as a string.
    */

--- a/packages/agent/src/did-api.ts
+++ b/packages/agent/src/did-api.ts
@@ -107,7 +107,7 @@ export function isDidRequest<T extends DidInterface>(
 }
 
 /**
- * This API is used to manage and interact with DIDs within the Web5 Agent framework.
+ * This API is used to manage and interact with DIDs within the Enbox Agent framework.
  *
  * If a DWN Data Store is used, the DID information is stored under DID's own tenant by default.
  * If a tenant property is passed, that tenant will be used to store the DID information.
@@ -115,8 +115,8 @@ export function isDidRequest<T extends DidInterface>(
 export class AgentDidApi<TKeyManager extends AgentKeyManager = AgentKeyManager> extends UniversalResolver {
   /**
    * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
-   * the `AgentDidApi`. This agent is used to interact with other Web5 agent components. It's vital
-   * to ensure this instance is set to correctly contextualize operations within the broader Web5
+   * the `AgentDidApi`. This agent is used to interact with other Enbox agent components. It's vital
+   * to ensure this instance is set to correctly contextualize operations within the broader Enbox
    * Agent framework.
    */
   private _agent?: EnboxPlatformAgent;

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -114,8 +114,8 @@ interface DwnApiCreateDwnParams extends Partial<DwnConfig> {
 export class AgentDwnApi {
   /**
    * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
-   * the `AgentDwnApi`. This agent is used to interact with other Web5 agent components. It's vital
-   * to ensure this instance is set to correctly contextualize operations within the broader Web5
+   * the `AgentDwnApi`. This agent is used to interact with other Enbox agent components. It's vital
+   * to ensure this instance is set to correctly contextualize operations within the broader Enbox
    * Agent framework.
    */
   private _agent?: EnboxPlatformAgent;

--- a/packages/agent/src/enbox-user-agent.ts
+++ b/packages/agent/src/enbox-user-agent.ts
@@ -64,7 +64,7 @@ export type AgentStartParams = {
  };
 
 export type AgentParams<TKeyManager extends AgentKeyManager = LocalKeyManager> = {
-  /** Optional. The Decentralized Identifier (DID) representing this Web5 User Agent. */
+  /** Optional. The Decentralized Identifier (DID) representing this Enbox User Agent. */
   agentDid?: BearerDid;
   /** Encrypted vault used for managing the Agent's DID and associated keys. */
   agentVault: HdIdentityVault;
@@ -82,7 +82,7 @@ export type AgentParams<TKeyManager extends AgentKeyManager = LocalKeyManager> =
   keyManager: TKeyManager;
   /** Facilitates fetching, requesting, creating, revoking and validating revocation status of permissions */
   permissionsApi: AgentPermissionsApi;
-  /** Remote procedure call (RPC) client used to communicate with other Web5 services. */
+  /** Remote procedure call (RPC) client used to communicate with other Enbox services. */
   rpcClient: EnboxRpc;
   /** Facilitates data synchronization of DWN records between nodes. */
   syncApi: AgentSyncApi;
@@ -206,7 +206,7 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
    *
    * This method is typically called once, the first time the Agent is launched, and is responsible
    * for setting up the agent's operational environment, cryptographic key material, and readiness
-   * for processing Web5 requests.
+   * for processing requests.
    *
    * The password is used to secure the Agent vault, and the recovery phrase is used to derive the
    * cryptographic keys for the vault. If a recovery phrase is not provided, a new recovery phrase

--- a/packages/agent/src/identity-api.ts
+++ b/packages/agent/src/identity-api.ts
@@ -36,7 +36,7 @@ export function isPortableIdentity(obj: unknown): obj is PortableIdentity {
 }
 
 /**
- * This API is used to manage and interact with Identities within the Web5 Agent framework.
+ * This API is used to manage and interact with Identities within the Enbox Agent framework.
  * An Identity is a DID that is associated with metadata that describes the Identity.
  * Metadata includes A name(label), and whether or not the Identity is connected (delegated to act on the behalf of another DID).
  *
@@ -48,9 +48,9 @@ export function isPortableIdentity(obj: unknown): obj is PortableIdentity {
 export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyManager> {
   /**
    * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
-   * the `AgentIdentityApi`. This agent is used to interact with other Web5 agent components. It's
+   * the `AgentIdentityApi`. This agent is used to interact with other Enbox agent components. It's
    * vital to ensure this instance is set to correctly contextualize operations within the broader
-   * Web5 Agent framework.
+   * Enbox Agent framework.
    */
   private _agent?: EnboxPlatformAgent<TKeyManager>;
 

--- a/packages/agent/src/local-key-manager.ts
+++ b/packages/agent/src/local-key-manager.ts
@@ -165,9 +165,9 @@ export interface LocalKmsUnwrapKeyParams extends KmsUriUnwrapKeyParams {
 export class LocalKeyManager implements AgentKeyManager {
   /**
    * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
-   * the `LocalKeyManager`. This agent is used to interact with other Web5 agent components. It's
+   * the `LocalKeyManager`. This agent is used to interact with other Enbox agent components. It's
    * vital to ensure this instance is set to correctly contextualize operations within the broader
-   * Web5 Agent framework.
+   * Enbox Agent framework.
    */
   private _agent?: EnboxPlatformAgent;
 

--- a/packages/agent/src/sync-api.ts
+++ b/packages/agent/src/sync-api.ts
@@ -9,8 +9,8 @@ export type SyncApiParams = {
 export class AgentSyncApi implements SyncEngine {
   /**
    * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
-   * the `AgentSyncApi`. This agent is used to interact with other Web5 agent components. It's vital
-   * to ensure this instance is set to correctly contextualize operations within the broader Web5
+   * the `AgentSyncApi`. This agent is used to interact with other Enbox agent components. It's vital
+   * to ensure this instance is set to correctly contextualize operations within the broader Enbox
    * Agent framework.
    */
   private _agent?: EnboxPlatformAgent;

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -62,9 +62,9 @@ type LocalSubscription = {
 export class SyncEngineLevel implements SyncEngine {
   /**
    * Holds the instance of a `EnboxPlatformAgent` that represents the current execution context for
-   * the `SyncEngineLevel`. This agent is used to interact with other Web5 agent components. It's
+   * the `SyncEngineLevel`. This agent is used to interact with other Enbox agent components. It's
    * vital to ensure this instance is set to correctly contextualize operations within the broader
-   * Web5 Agent framework.
+   * Enbox Agent framework.
    */
   private _agent?: EnboxPlatformAgent;
 

--- a/packages/agent/src/types/agent.ts
+++ b/packages/agent/src/types/agent.ts
@@ -16,7 +16,7 @@ import type { ProcessVcRequest, SendVcRequest, VcResponse } from './vc.js';
 
 /**
  * Defines the structure for response status in the context of an Agent's interaction within the
- * Web5 framework.
+ * Enbox framework.
  *
  * This type is utilized to convey the success or failure of an operation performed by the Agent,
  * providing feedback that can be programmatically interpreted and acted upon.
@@ -55,18 +55,18 @@ export type ResponseStatus = {
 };
 
 /**
- * Defines the interface for a Web5 Agent, encapsulating the core functionality all implementations
+ * Defines the interface for an Enbox Agent, encapsulating the core functionality all implementations
  * must include.
  *
  * The Agent is responsible for handling decentralized identifier (DID) requests, decentralized web
  * node (DWN) requests, and verifiable credential (VC) requests.
  *
- * The `AgentDid` property represents the Web5 Agent's own DID, while the various process and send
+ * The `AgentDid` property represents the Enbox Agent's own DID, while the various process and send
  * methods enable the Agent to handle and initiate requests pertaining to DIDs, DWNs, and VCs.
  */
 export interface EnboxAgent {
   /**
-   * The Decentralized Identifier (DID) of this Web5 Agent.
+   * The Decentralized Identifier (DID) of this Enbox Agent.
    */
   agentDid: BearerDid;
 
@@ -109,14 +109,14 @@ export interface EnboxAgent {
 }
 
 /**
- * Represents a Web5 Platform Agent, an extended and more feature-rich implementation of a
+ * Represents an Enbox Platform Agent, an extended and more feature-rich implementation of a
  * {@link EnboxAgent}.
  *
  * This Agent integrates a comprehensive set of APIs and functionalities, including cryptographic
  * operations, DID management, DWN interaction, identity handling, and data synchronization.
  *
  * The platform agent provides a higher-level abstraction over the core EnboxAgent functionalities,
- * facilitating a robust platform for developing Web5 applications. It includes lifecycle management
+ * facilitating a robust platform for developing Enbox applications. It includes lifecycle management
  * methods like initialization and startup, alongside a suite of specialized APIs and utilities.
  *
  * @typeParam TKeyManager - The type of Key Manager used to manage cryptographic keys.
@@ -125,7 +125,7 @@ export interface EnboxPlatformAgent<TKeyManager extends AgentKeyManager = AgentK
   /**
    * The cryptography API, essential for performing various cryptographic operations such
    * as encryption, decryption, signing, and verification, ensuring secure data handling and
-   * communication within the Web5 Platform.
+   * communication within the Enbox platform.
    */
   crypto: AgentCryptoApi;
 
@@ -137,13 +137,13 @@ export interface EnboxPlatformAgent<TKeyManager extends AgentKeyManager = AgentK
 
   /**
    * The DWN API, enabling the Agent to interact with Decentralized Web Nodes (DWNs) and handle
-   * requests from Web5 applications.
+   * requests from Enbox applications.
    */
   dwn: AgentDwnApi;
 
   /**
    * The identity management API, handling identity-related operations and allowing the agent to
-   * manage Web5 identities, supporting operations like identity creation and update.
+   * manage Enbox identities, supporting operations like identity creation and update.
    */
   identity: AgentIdentityApi<TKeyManager>;
 
@@ -159,8 +159,8 @@ export interface EnboxPlatformAgent<TKeyManager extends AgentKeyManager = AgentK
   permissions: AgentPermissionsApi;
 
   /**
-   * The RPC (Remote Procedure Call) client interface, facilitating communication with other Web5
-   * Agents and services.
+   * The RPC (Remote Procedure Call) client interface, facilitating communication with other Enbox
+   * agents and services.
    */
   rpc: EnboxRpc;
 
@@ -171,7 +171,7 @@ export interface EnboxPlatformAgent<TKeyManager extends AgentKeyManager = AgentK
   sync: AgentSyncApi;
 
   /**
-   * An instance of {@link IdentityVault}, providing secure storage and management of a Web5 Agent's
+   * An instance of {@link IdentityVault}, providing secure storage and management of an Enbox Agent's
    * DID and cryptographic keys.
    */
   vault: IdentityVault;
@@ -184,7 +184,7 @@ export interface EnboxPlatformAgent<TKeyManager extends AgentKeyManager = AgentK
 
   /**
    * Initializes the agent with essential parameters (e.g., a passphrase) and prepares it for
-   * processing Web5 requests.
+   * processing requests.
    */
   initialize(params: unknown): Promise<unknown>;
 

--- a/packages/agent/src/types/identity.ts
+++ b/packages/agent/src/types/identity.ts
@@ -1,7 +1,7 @@
 import type { PortableDid } from '@enbox/dids';
 
 /**
- * Represents metadata about a Web5 Identity.
+ * Represents metadata about an Enbox Identity.
  */
 export interface IdentityMetadata {
   name: string;

--- a/packages/agent/src/utils-internal.ts
+++ b/packages/agent/src/utils-internal.ts
@@ -5,7 +5,7 @@ import { computeJwkThumbprint, Ed25519, LocalKeyManager } from '@enbox/crypto';
 import type { EnboxPlatformAgent } from './types/agent.js';
 
 /**
- * Internal utility functions used by the Web5 platform agent that are not intended for public use
+ * Internal utility functions used by the Enbox platform agent that are not intended for public use
  * and are not exported in the public API.
  */
 
@@ -121,7 +121,7 @@ export class DeterministicKeyGenerator extends LocalKeyManager {
  * This approach ensures operations are isolated by DID, supporting multi-tenancy.
  *
  * @param params - The parameters for determining the tenant.
- * @param params.agent - The Web5 platform agent instance.
+ * @param params.agent - The Enbox platform agent instance.
  * @param [params.tenant] - An optional tenant DID. If provided, it takes precedence.
  * @param [params.didUri] - An optional DID URI to use if no tenant DID or agent DID is available.
  * @returns A promise that resolves to the tenant DID.

--- a/packages/api/src/advanced.ts
+++ b/packages/api/src/advanced.ts
@@ -2,7 +2,7 @@
  * Advanced API surface for power users who need direct access to
  * the underlying {@link DwnApi}.
  *
- * Most applications should use `web5.using(protocol)` instead.
+ * Most applications should use `enbox.using(protocol)` instead.
  * Import from `@enbox/api/advanced` to access these exports.
  *
  * @packageDocumentation

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -496,7 +496,7 @@ export class DwnApi {
 
         const agentRequest: ProcessDwnRequest<DwnInterface.RecordsDelete> = {
           /**
-           * The `author` is the DID that will sign the message and must be the DID the Web5 app is
+           * The `author` is the DID that will sign the message and must be the DID the Enbox app is
            * connected with and is authorized to access the signing private key of.
            */
           author      : this.connectedDid,
@@ -548,7 +548,7 @@ export class DwnApi {
 
         const agentRequest: ProcessDwnRequest<DwnInterface.RecordsQuery> = {
           /**
-           * The `author` is the DID that will sign the message and must be the DID the Web5 app is
+           * The `author` is the DID that will sign the message and must be the DID the Enbox app is
            * connected with and is authorized to access the signing private key of.
            */
           author      : this.connectedDid,
@@ -640,7 +640,7 @@ export class DwnApi {
 
         const agentRequest: ProcessDwnRequest<DwnInterface.RecordsRead> = {
           /**
-           * The `author` is the DID that will sign the message and must be the DID the Web5 app is
+           * The `author` is the DID that will sign the message and must be the DID the Enbox app is
            * connected with and is authorized to access the signing private key of.
            */
           author      : this.connectedDid,

--- a/packages/api/src/repository.ts
+++ b/packages/api/src/repository.ts
@@ -12,7 +12,7 @@
  *
  * @example
  * ```ts
- * const social = repository(web5.using(SocialGraphProtocol));
+ * const social = repository(enbox.using(SocialGraphProtocol));
  * await social.configure();
  *
  * // Root collection
@@ -334,12 +334,12 @@ function buildNode(
  * - Singletons: `repo.profile.set()`, `repo.profile.get()`
  * - Protocol install: `repo.configure()`
  *
- * @param typed - A `TypedEnbox` instance from `web5.using(protocol)`.
+ * @param typed - A `TypedEnbox` instance from `enbox.using(protocol)`.
  * @returns A typed repository object.
  *
  * @example
  * ```ts
- * const social = repository(web5.using(SocialGraphProtocol));
+ * const social = repository(enbox.using(SocialGraphProtocol));
  * await social.configure();
  *
  * const rec = await social.friend.create({

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -12,7 +12,7 @@
  *
  * @example
  * ```ts
- * const social = web5.using(SocialProtocol);
+ * const social = enbox.using(SocialProtocol);
  *
  * // Install the protocol
  * await social.configure();
@@ -525,11 +525,11 @@ export type TypedSubscribeResponse<T = unknown> = DwnResponseStatus & {
  * the data type `T` (resolved from the schema map) flows end-to-end — from
  * write through read, query, update, and subscribe — without manual casts.
  *
- * Obtain an instance via `web5.using(typedProtocol)`.
+ * Obtain an instance via `enbox.using(typedProtocol)`.
  *
  * @example
  * ```ts
- * const social = web5.using(SocialProtocol);
+ * const social = enbox.using(SocialProtocol);
  *
  * await social.configure();
  *
@@ -564,7 +564,7 @@ export class TypedEnbox<
   private _records?: TypedEnbox<D, M>['records'];
 
   /**
-   * @internal Create a new `TypedEnbox` instance. Use `web5.using(protocol)` instead.
+   * @internal Create a new `TypedEnbox` instance. Use `enbox.using(protocol)` instead.
    * @param dwn - The underlying DWN API instance.
    * @param protocol - The typed protocol containing the definition and schema map.
    */
@@ -614,7 +614,7 @@ export class TypedEnbox<
    *
    * @example
    * ```ts
-   * const proto = web5.using(NotebookProtocol);
+   * const proto = enbox.using(NotebookProtocol);
    *
    * const { status, protocol } = await proto.configure();
    * console.log(status.code); // 202 (first install) or 200 (already installed)

--- a/packages/api/vitest.browser.config.ts
+++ b/packages/api/vitest.browser.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
   },
   test: {
     // Only utils.spec.ts is browser-safe.
-    // All other test files depend on PlatformAgentTestHarness / Web5UserAgent (LevelDB).
+    // All other test files depend on PlatformAgentTestHarness / EnboxUserAgent (LevelDB).
     include: [
       'tests/utils.spec.ts',
     ],

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -1,8 +1,8 @@
 /**
  * AuthManager — the primary entry point for `@enbox/auth`.
  *
- * Replaces `Web5.connect()` with a composable, multi-identity-aware
- * auth system that works in both browser and CLI environments.
+ * Replaces `Enbox.connect()` (formerly `Web5.connect()`) with a composable,
+ * multi-identity-aware auth system that works in both browser and CLI environments.
  * @module
  */
 
@@ -38,7 +38,7 @@ import { importFromPhrase, importFromPortable } from './flows/import-identity.js
 /**
  * The primary entry point for authentication and identity management.
  *
- * `AuthManager` replaces `Web5.connect()` with a composable, multi-identity-aware
+ * `AuthManager` replaces `Enbox.connect()` (formerly `Web5.connect()`) with a composable, multi-identity-aware
  * system. It manages vault lifecycle, identity CRUD, session persistence,
  * and all connection flows (local DID, wallet connect, import, restore).
  *
@@ -52,7 +52,7 @@ import { importFromPhrase, importFromPortable } from './flows/import-identity.js
  * // Subsequent times: restores the previous session
  * const session = await auth.restoreSession() ?? await auth.connect();
  *
- * // session.agent  — the authenticated Web5 agent
+ * // session.agent  — the authenticated Enbox agent
  * // session.did    — the connected DID URI
  * // session.identity — metadata about the connected identity
  * ```

--- a/packages/auth/src/flows/dwn-registration.ts
+++ b/packages/auth/src/flows/dwn-registration.ts
@@ -6,7 +6,7 @@
  * 1. Provider auth (`provider-auth-v0`) — OAuth-style with tokens
  * 2. Proof of Work (default) — PoW challenge-response
  *
- * This matches the registration logic from `Web5.connect()` but as a
+ * This matches the registration logic from `Enbox.connect()` but as a
  * standalone, reusable function.
  * @module
  */

--- a/packages/auth/src/flows/local-connect.ts
+++ b/packages/auth/src/flows/local-connect.ts
@@ -2,7 +2,7 @@
  * Local DID connect flow.
  *
  * Creates or reconnects a local identity with vault-protected keys.
- * This replaces the "Mode D/E" paths in Web5.connect().
+ * This replaces the "Mode D/E" paths in Enbox.connect().
  * @module
  */
 

--- a/packages/auth/src/flows/wallet-connect.ts
+++ b/packages/auth/src/flows/wallet-connect.ts
@@ -3,7 +3,7 @@
  *
  * Connects to an external wallet via the WalletConnect relay protocol,
  * importing a delegated DID with permission grants.
- * This replaces the "Mode B/C" paths in Web5.connect().
+ * This replaces the "Mode B/C" paths in Enbox.connect().
  * @module
  */
 
@@ -31,7 +31,7 @@ export interface WalletConnectContext {
 /**
  * Process connected grants by storing them in the local DWN as the owner.
  *
- * This is the agent-level equivalent of `Web5.processConnectedGrants()`.
+ * This is the agent-level equivalent of `Enbox.processConnectedGrants()`.
  * It stores each grant, signed as owner, and returns the deduplicated
  * list of protocol URIs represented by the grants.
  *

--- a/packages/auth/src/identity-session.ts
+++ b/packages/auth/src/identity-session.ts
@@ -12,14 +12,14 @@ import type { IdentityInfo } from './types.js';
  *
  * The session exposes the authenticated **agent**, **did**, and
  * **delegateDid** — the primitives needed to interact with the DWN
- * network. Consumers that use `@enbox/api` can construct a `Web5`
+ * network. Consumers that use `@enbox/api` can construct an `Enbox`
  * instance from these properties:
  *
  * ```ts
- * import { Web5 } from '@enbox/api';
+ * import { Enbox } from '@enbox/api';
  *
  * const session = await auth.connect();
- * const web5 = new Web5({
+ * const enbox = Enbox.connect({
  *   agent: session.agent,
  *   connectedDid: session.did,
  *   delegateDid: session.delegateDid,
@@ -27,7 +27,7 @@ import type { IdentityInfo } from './types.js';
  * ```
  */
 export class AuthSession {
-  /** The authenticated Web5 agent managing keys, DIDs, and DWN access. */
+  /** The authenticated Enbox agent managing keys, DIDs, and DWN access. */
   readonly agent: EnboxAgent;
 
   /** The DID URI of the connected identity. */

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -12,19 +12,19 @@
  * const auth = await AuthManager.create({ sync: '15s' });
  * const session = await auth.restoreSession() ?? await auth.connect();
  *
- * // session.agent — the authenticated Web5 agent
+ * // session.agent — the authenticated Enbox agent
  * // session.did   — the connected DID URI
  * ```
  *
  * @example With @enbox/api
  * ```ts
  * import { AuthManager } from '@enbox/auth';
- * import { Web5 } from '@enbox/api';
+ * import { Enbox } from '@enbox/api';
  *
  * const auth = await AuthManager.create({ sync: '15s' });
  * const session = await auth.connect();
  *
- * const web5 = new Web5({
+ * const enbox = Enbox.connect({
  *   agent: session.agent,
  *   connectedDid: session.did,
  *   delegateDid: session.delegateDid,

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enbox/browser",
   "version": "0.1.1",
-  "description": "Web5 tools and features to use in the browser",
+  "description": "Enbox tools and features to use in the browser",
   "type": "module",
   "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/browser/src/web-features.ts
+++ b/packages/browser/src/web-features.ts
@@ -545,7 +545,7 @@ async function resetContextMenuTarget(e?: Event): Promise<void> {
 }
 
 /**
- * Activates various polyfills to enable Web5 features in Web environments.
+ * Activates various polyfills to enable Enbox features in Web environments.
  *
  * @param options - Configuration options to control the activation of polyfills.
  *

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enbox/crypto",
   "version": "0.0.7",
-  "description": "Web5 cryptographic library",
+  "description": "Enbox cryptographic library",
   "type": "module",
   "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -353,7 +353,7 @@ export class HttpApi {
 
     if (method === 'GET' && path === '/') {
       return new Response(
-        'please use am enbox client, for example: https://github.com/enboxorg/enbox ',
+        'please use an enbox client, for example: https://github.com/enboxorg/enbox ',
         { headers: { 'content-type': 'text/plain' } },
       );
     }


### PR DESCRIPTION
## Summary

Follow-up to the Web5 → Enbox rename (PRs #615, #628, #642). Sweeps ~60 stale "Web5" references in JSDoc comments, code comments, and package metadata that were missed during the symbol rename.

**No runtime code changes** — JSDoc, comments, and metadata only.

## Changes by package

### `@enbox/agent` (32 edits across 13 files)
- `types/agent.ts` — 12 JSDoc updates ("Web5 Agent" → "Enbox Agent", "Web5 Platform" → "Enbox platform", etc.)
- `enbox-user-agent.ts` — 3 JSDoc updates
- `identity-api.ts`, `did-api.ts`, `dwn-api.ts`, `sync-api.ts`, `sync-engine-level.ts`, `local-key-manager.ts`, `agent-did-resolver-cache.ts` — "Web5 Agent framework" → "Enbox Agent framework"
- `connect.ts` — "web5 connect" → "Connect" (protocol references)
- `bearer-identity.ts`, `types/identity.ts` — "Web5 Identity" → "Enbox Identity"
- `utils-internal.ts` — "Web5 platform agent" → "Enbox platform agent"

### `@enbox/api` (13 edits across 5 files)
- `typed-enbox.ts` — 5x `web5.using(...)` → `enbox.using(...)` in JSDoc examples
- `dwn-api.ts` — 3x "the DID the Web5 app is" → "the DID the Enbox app is"
- `repository.ts` — 3x `web5.using(...)` → `enbox.using(...)` in JSDoc
- `advanced.ts` — 1x `web5.using(protocol)` → `enbox.using(protocol)`
- `vitest.browser.config.ts` — comment: `Web5UserAgent` → `EnboxUserAgent`

### `@enbox/auth` (12 edits across 6 files)
- `identity-session.ts` — Code example updated from `new Web5(...)` to `Enbox.connect(...)`
- `auth-manager.ts` — "Replaces Web5.connect()" → "Replaces Enbox.connect() (formerly Web5.connect())"
- `index.ts` — Code example updated to use `Enbox`
- Flow files — `Web5.connect()` → `Enbox.connect()` in comments

### Miscellaneous
- `@enbox/crypto` package.json — "Web5 cryptographic library" → "Enbox cryptographic library"
- `@enbox/browser` package.json — "Web5 tools and features..." → "Enbox tools and features..."
- `@enbox/browser` web-features.ts — "Web5 features" → "Enbox features"
- `@enbox/dwn-server` http-api.ts — fix pre-existing typo "am enbox" → "an enbox"

## Verification

- All 15 packages build successfully
- Lint passes for agent, api, auth
- 187/187 auth tests pass, 208/208 api unit tests pass