### PR TITLE
fix(agent): correct stale port range in local DWN error message

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -258,7 +258,7 @@ export class AgentDwnApi {
       if (!localDwnEndpoint) {
         throw new Error(
           `AgentDwnApi: Local DWN strategy is 'only' but no local server is available ` +
-          `on localhost/127.0.0.1:{3000,55555-55559}`
+          `on 127.0.0.1:{3000,55500-55509}`
         );
       }
 


### PR DESCRIPTION
## Summary

- Fix stale port range in `AgentDwnApi` error message: `55555-55559` -> `55500-55509`
- Remove `localhost/` prefix from error message since clients use `127.0.0.1` per the transport spec

One-line string change, no behavioral impact. Found during alignment audit between the transport spec and implementation.