### PR TITLE
fix(agent): send JSON for WalletConnect PAR request

### DIFF
--- a/.changeset/fix-par-content-type.md
+++ b/.changeset/fix-par-content-type.md
@@ -1,0 +1,9 @@
+---
+"@enbox/agent": patch
+---
+
+Fix WalletConnect PAR request to send JSON instead of form-urlencoded
+
+The dwn-server's /connect/par endpoint parses the request body with
+req.json(), so sending application/x-www-form-urlencoded would fail
+with a JSON parse error.

--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -68,21 +68,16 @@ async function initClient({
     encryptionKey,
   });
 
-  // Convert the encrypted Request Object to URLSearchParams for form encoding.
-  const formEncodedRequest = new URLSearchParams({
-    request: requestObjectJwe,
-  });
-
   const pushedAuthorizationRequestEndpoint = Oidc.buildOidcUrl({
     baseURL  : connectServerUrl,
     endpoint : 'pushedAuthorizationRequest',
   });
 
   const parResponse = await fetch(pushedAuthorizationRequestEndpoint, {
-    body    : formEncodedRequest,
+    body    : JSON.stringify({ request: requestObjectJwe }),
     method  : 'POST',
     headers : {
-      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Type': 'application/json',
     },
     signal: AbortSignal.timeout(30_000),
   });


### PR DESCRIPTION
## Summary

- Fixes the WalletConnect PAR (Pushed Authorization Request) to send `application/json` with `JSON.stringify()` instead of `application/x-www-form-urlencoded` with `URLSearchParams`
- The dwn-server's `/connect/par` endpoint parses the body with `req.json()`, which expects JSON — the old form-urlencoded format caused silent failures

Closes #657