### PR TITLE
fix(electrobun-dwn): correct port range, config field, and endpoint passthrough

### DIFF
--- a/.changeset/fix-electrobun-bugs.md
+++ b/.changeset/fix-electrobun-bugs.md
@@ -1,0 +1,5 @@
+---
+"@enbox/electrobun-dwn": patch
+---
+
+Fix port range documentation and config field name

--- a/packages/electrobun-dwn/src/bun/index.ts
+++ b/packages/electrobun-dwn/src/bun/index.ts
@@ -52,7 +52,7 @@ function createDwnServerConfig(port: number): DwnServerConfig {
     packageJsonPath       : resolveDwnServerPackageJsonPath(),
     maxRecordDataSize     : 1_073_741_824, // 1 GB
     webSocketSupport,
-    eventStreamPluginPath : process.env.DWN_EVENT_STREAM_PLUGIN_PATH,
+    eventLogPluginPath    : process.env.DWN_EVENT_LOG_PLUGIN_PATH || process.env.DWN_EVENT_STREAM_PLUGIN_PATH,
     messageStore          : process.env.DWN_STORAGE_MESSAGES || process.env.DWN_STORAGE || 'level://data',
     dataStore             : process.env.DWN_STORAGE_DATA || process.env.DWN_STORAGE || 'level://data',
     stateIndex            : process.env.DWN_STORAGE_STATE_INDEX || process.env.DWN_STORAGE || 'level://data',
@@ -157,7 +157,7 @@ console.log(`[electrobun-dwn] Discovery file written: ${discoveryFile.path}`);
 
 const mainWindow = new BrowserWindow({
   title : 'Enbox DWN Server',
-  url   : 'views://mainview/index.html',
+  url   : `views://mainview/index.html?endpoint=${encodeURIComponent(serverEndpoint)}`,
   frame : {
     width  : 860,
     height : 620,

--- a/packages/electrobun-dwn/src/mainview/index.html
+++ b/packages/electrobun-dwn/src/mainview/index.html
@@ -21,7 +21,7 @@
       <h2>Notes</h2>
       <ul>
         <li>Close this window to stop the local server process.</li>
-        <li>Uses port <code>3000</code> first, then <code>55555-55559</code>.</li>
+        <li>Uses port <code>3000</code> first, then <code>55500-55509</code>.</li>
         <li>Use your client against this local JSON-RPC endpoint.</li>
       </ul>
     </section>

--- a/packages/electrobun-dwn/src/mainview/index.ts
+++ b/packages/electrobun-dwn/src/mainview/index.ts
@@ -1,16 +1,39 @@
 /**
- * Well-known ports and hosts for local DWN detection (browser context).
+ * Mainview UI for the Electrobun DWN desktop app.
  *
- * Keep in sync with `localDwnPortCandidates` and `localDwnHostCandidates`
- * in `@enbox/agent/src/local-dwn.ts`.
+ * The bun process passes the resolved server endpoint via the `endpoint`
+ * query parameter when constructing the BrowserWindow URL. This avoids
+ * duplicate port-probing that was previously needed.
  *
- * TODO(#590): Eliminate this duplicate port-probing by having the bun side
- * pass the resolved endpoint to the mainview via Electrobun RPC/IPC.
- * The mainview runs in a BrowserWindow and cannot import `@enbox/agent`.
+ * A fallback probe is retained for defensive robustness in case the query
+ * parameter is ever missing.
+ *
+ * Keep fallback port list in sync with `localDwnPortCandidates` and
+ * `localDwnHostCandidates` in `@enbox/agent/src/local-dwn.ts`.
  */
+
 const candidatePorts = [3000, 55500, 55501, 55502, 55503, 55504, 55505, 55506, 55507, 55508, 55509];
 const candidateHosts = ['127.0.0.1'];
 
+/**
+ * Try to read the endpoint from the query string set by the bun process.
+ */
+function getEndpointFromQueryParam(): string | null {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const endpoint = params.get('endpoint');
+    if (endpoint && endpoint.startsWith('http')) {
+      return endpoint;
+    }
+  } catch {
+    // Defensive: if URL parsing fails, fall through to probing.
+  }
+  return null;
+}
+
+/**
+ * Fallback: probe well-known ports to find the running DWN server.
+ */
 async function detectLocalDwnBaseUrl(): Promise<string> {
   for (const port of candidatePorts) {
     for (const host of candidateHosts) {
@@ -34,13 +57,23 @@ async function detectLocalDwnBaseUrl(): Promise<string> {
   return 'http://127.0.0.1:3000';
 }
 
+async function resolveServerEndpoint(): Promise<string> {
+  const fromParam = getEndpointFromQueryParam();
+  if (fromParam) {
+    return fromParam;
+  }
+
+  // Fallback: probe ports (should rarely be needed).
+  return detectLocalDwnBaseUrl();
+}
+
 async function renderServerUrl(): Promise<void> {
   const serverUrlEl = document.querySelector<HTMLAnchorElement>('#server-url');
   if (!serverUrlEl) {
     return;
   }
 
-  const baseUrl = await detectLocalDwnBaseUrl();
+  const baseUrl = await resolveServerEndpoint();
   serverUrlEl.href = baseUrl;
   serverUrlEl.textContent = baseUrl;
 }


### PR DESCRIPTION
## Summary

- Fixed port range in UI from `55555-55559` to `55500-55509` to match the actual DWN server port range
- Fixed stale config field `eventStreamPluginPath` → `eventLogPluginPath`
- Main process now passes the `?endpoint=` query param to the mainview URL so it reads the endpoint directly instead of always probing ports
- Mainview reads endpoint from query param first, falls back to port probing only when needed

Closes #656