### PR TITLE
fix(changeset): remove non-workspace @enbox/dweb-wallet changeset

### DIFF
--- a/.changeset/web-wallet-security-fixes.md
+++ b/.changeset/web-wallet-security-fixes.md
@@ -1,5 +1,0 @@
----
-"@enbox/dweb-wallet": patch
----
-
-Remove plaintext password and recovery phrase from localStorage (security), fix keyAgreement curve from secp256k1 to X25519, fix `craetedIdentity` typo, and rename Web5 symbols to Enbox throughout.


### PR DESCRIPTION
## Summary

- Removes the `web-wallet-security-fixes` changeset that references `@enbox/dweb-wallet`, which is a git submodule — not a workspace package
- This was causing the Release workflow to fail with: `Found changeset web-wallet-security-fixes for package @enbox/dweb-wallet which is not in the workspace`
- The web-wallet has its own versioning in its own repo; no changeset is needed in the monorepo for submodule pointer updates

Unblocks the Release workflow so `@enbox/auth` and other pending packages can be published.