### PR TITLE
fix(release): add @enbox/auth to publish script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -27,6 +27,7 @@ PACKAGES=(
   "packages/dwn-sdk-js"
   "packages/dwn-clients"
   "packages/agent"
+  "packages/auth"
   "packages/api"
   "packages/protocols"
   "packages/browser"


### PR DESCRIPTION
## Summary

- Adds `packages/auth` to the `PACKAGES` array in `scripts/publish.sh`
- Without this, `@enbox/auth` was never published to npm despite being version-bumped by changesets
- Placed between `agent` and `api` to match the dependency order (auth depends on agent, api depends on auth)

Once merged, the Release workflow will publish `@enbox/auth@0.3.1` to npm.