### PR TITLE
fix(api): re-publish with correct @enbox/auth dependency

### DIFF
--- a/.changeset/fix-api-auth-dep.md
+++ b/.changeset/fix-api-auth-dep.md
@@ -1,0 +1,5 @@
+---
+"@enbox/api": patch
+---
+
+Fix @enbox/auth dependency version (0.2.0 was never published, now points to 0.3.1)


### PR DESCRIPTION
## Summary

- `@enbox/api@0.4.1` was published to npm with `@enbox/auth@0.2.0` as a dependency, but `@enbox/auth@0.2.0` was never published (auth was missing from the publish script)
- Now that `@enbox/auth@0.3.1` is published and the publish script includes auth (PR #663), this changeset triggers a patch bump for `@enbox/api` so it gets re-published with the correct resolved dependency version
- This unblocks consumers (gitd, notesd) from installing `@enbox/api` from npm

Root cause: Bun's lockfile cached the stale auth version (0.2.0), and since auth wasn't in the publish script's `PACKAGES` array, the manual workspace resolution didn't run for it.