### PR TITLE
docs: auto-generated API reference with TypeDoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Generate API Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/*/src/**'
+      - 'typedoc.json'
+      - 'packages/*/typedoc.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    name: Generate API Reference
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build packages
+        run: bun run build
+
+      - name: Generate API docs
+        run: bun run docs:clean
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git add docs/api/
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "docs: regenerate API reference [skip ci]"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ CLAUDE.local.md
 
 # AI agent working directories
 .opencode/
+
+# Generated API documentation (regenerated via `bun run docs`)
+docs/api/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,53 @@ Use `bunx changeset status` to verify the changeset is valid before committing.
 feat: add provider-auth-v0 client methods and Web5.connect() integration
 ```
 
+## API Documentation
+
+Auto-generated API reference lives in `docs/api/` (git-ignored). It is produced by [TypeDoc](https://typedoc.org/) with the `typedoc-plugin-markdown` plugin, configured in `typedoc.json`.
+
+### Generating docs locally
+
+```bash
+# Build packages first (TypeDoc needs the compiled .d.ts files):
+bun run build
+
+# Generate Markdown API reference into docs/api/:
+bun run docs
+
+# Clean and regenerate from scratch:
+bun run docs:clean
+```
+
+### How it works
+
+- `typedoc.json` at the repo root uses `entryPointStrategy: "packages"` to document 13 library packages.
+- Each package page is generated from its `src/index.ts` entry point (except `dwn-sql-store` which uses `src/main.ts` via a local `typedoc.json` override).
+- Output goes to `docs/api/` with one Markdown file per package, organized under `docs/api/@enbox/`.
+- Source links point to the GitHub repo at the current git revision.
+- `excludeInternal`, `excludePrivate`, and `excludeProtected` are enabled — only the public API surface is documented.
+- Two packages are excluded: `electrobun-dwn` (private desktop app) and `dwn-server-admin-ui` (Preact UI, not a library).
+
+### CI auto-regeneration
+
+The `.github/workflows/docs.yml` workflow runs on every push to `main` that touches `packages/*/src/**`. It builds all packages, runs TypeDoc, and commits any changes back to `main` with `[skip ci]` to avoid retriggering. It can also be triggered manually via `workflow_dispatch`.
+
+### Adding a new package to the docs
+
+1. Add the package directory to the `entryPoints` array in `typedoc.json`.
+2. If the package entry point is NOT `src/index.ts`, create a `typedoc.json` in the package directory with `{ "entryPoints": ["src/your-entry.ts"] }`.
+3. Run `bun run docs` to verify.
+
+### JSDoc conventions for TypeDoc
+
+TypeDoc reads JSDoc/TSDoc comments from source. Keep these conventions for good output:
+
+- `@param name - Description` for parameters (do NOT include the type in braces — TypeScript provides it).
+- `@returns Description` for return values.
+- `@throws Description` for thrown errors.
+- `@example` for code examples (fenced code blocks).
+- `@internal` on symbols that should be excluded from public docs.
+- `{@link ClassName.methodName}` for cross-references within the same package.
+
 ## Coding Style
 
 Style is derived from `dwn-sdk-js` (gold standard). ESLint enforces most rules.
@@ -358,7 +405,7 @@ throw new Error(`AgentDwnApi: DID '${didUri}' does not have a keyAgreement verif
 
 ### JSDoc
 
-Brief JSDoc on public methods and complex private methods. Use `@param`, `@returns`, `@throws` where appropriate.
+Brief JSDoc on public methods and complex private methods. Use `@param`, `@returns`, `@throws` where appropriate. These comments are consumed by TypeDoc to generate the API reference in `docs/api/` — see [API Documentation](#api-documentation) above.
 
 ```typescript
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -17,11 +17,13 @@
         "eventemitter3": "5.0.4",
         "globals": "15.6.0",
         "playwright": "1.45.3",
+        "typedoc": "^0.28.17",
+        "typedoc-plugin-markdown": "^4.10.0",
       },
     },
     "packages/agent": {
       "name": "@enbox/agent",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "dependencies": {
         "@enbox/common": "workspace:*",
         "@enbox/crypto": "workspace:*",
@@ -55,7 +57,7 @@
     },
     "packages/api": {
       "name": "@enbox/api",
-      "version": "0.3.2",
+      "version": "0.4.2",
       "dependencies": {
         "@enbox/agent": "workspace:*",
         "@enbox/auth": "workspace:*",
@@ -83,7 +85,7 @@
     },
     "packages/auth": {
       "name": "@enbox/auth",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "@enbox/agent": "workspace:*",
         "@enbox/common": "workspace:*",
@@ -100,7 +102,7 @@
     },
     "packages/browser": {
       "name": "@enbox/browser",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@enbox/dids": "workspace:*",
       },
@@ -117,7 +119,7 @@
     },
     "packages/common": {
       "name": "@enbox/common",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@isaacs/ttlcache": "1.4.1",
         "level": "8.0.1",
@@ -139,7 +141,7 @@
     },
     "packages/crypto": {
       "name": "@enbox/crypto",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "@enbox/common": "workspace:*",
         "@noble/ciphers": "0.5.3",
@@ -162,7 +164,7 @@
     },
     "packages/dids": {
       "name": "@enbox/dids",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.4",
         "@dnsquery/dns-packet": "6.1.1",
@@ -190,7 +192,7 @@
     },
     "packages/dwn-clients": {
       "name": "@enbox/dwn-clients",
-      "version": "0.0.9",
+      "version": "0.1.0",
       "dependencies": {
         "@enbox/common": "workspace:*",
         "@enbox/crypto": "workspace:*",
@@ -212,7 +214,7 @@
     },
     "packages/dwn-sdk-js": {
       "name": "@enbox/dwn-sdk-js",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@enbox/crypto": "workspace:*",
         "@enbox/dids": "workspace:*",
@@ -269,7 +271,7 @@
     },
     "packages/dwn-server": {
       "name": "@enbox/dwn-server",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "bin": {
         "dwn-server": "./dist/esm/src/main.js",
       },
@@ -330,7 +332,7 @@
     },
     "packages/dwn-sql-store": {
       "name": "@enbox/dwn-sql-store",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/lib-storage": "^3.700.0",
@@ -364,7 +366,7 @@
     },
     "packages/electrobun-dwn": {
       "name": "@enbox/electrobun-dwn",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "dependencies": {
         "@enbox/agent": "workspace:*",
         "@enbox/dwn-server": "workspace:*",
@@ -397,7 +399,7 @@
     },
     "packages/protocols": {
       "name": "@enbox/protocols",
-      "version": "0.2.9",
+      "version": "0.2.12",
       "dependencies": {
         "@enbox/api": "workspace:*",
         "@enbox/dwn-sdk-js": "workspace:*",
@@ -671,6 +673,8 @@
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
+    "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
+
     "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
 
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
@@ -827,6 +831,16 @@
 
     "@scure/bip39": ["@scure/bip39@1.2.2", "", { "dependencies": { "@noble/hashes": "~1.3.2", "@scure/base": "~1.1.4" } }, "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA=="],
 
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@simplewebauthn/browser": ["@simplewebauthn/browser@13.2.2", "", {}, "sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA=="],
 
     "@simplewebauthn/server": ["@simplewebauthn/server@13.2.3", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-ZhcVBOw63birYx9jVfbhK6rTehckVes8PeWV324zpmdxr0BUfylospwMzcrxrdMcOi48MHWj2LCA+S528LnGvg=="],
@@ -975,6 +989,8 @@
 
     "@types/flat": ["@types/flat@5.0.5", "", {}, "sha512-nPLljZQKSnac53KDUDzuzdRfGI0TDb5qPrb+SrQyN3MtdQrOnGsKniHN1iYZsJEBIVQve94Y6gNz22sgISZq+Q=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
 
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
@@ -1010,6 +1026,8 @@
     "@types/superagent": ["@types/superagent@8.1.9", "", { "dependencies": { "@types/cookiejar": "^2.1.5", "@types/methods": "^1.1.4", "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ=="],
 
     "@types/supertest": ["@types/supertest@2.0.12", "", { "dependencies": { "@types/superagent": "*" } }, "sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/uuid": ["@types/uuid@9.0.8", "", {}, "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="],
 
@@ -1262,6 +1280,8 @@
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "eol": ["eol@0.9.1", "", {}, "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg=="],
 
@@ -1629,6 +1649,8 @@
 
     "license-report": ["license-report@6.3.0", "", { "dependencies": { "@kessler/tableify": "^1.0.2", "debug": "^4.3.4", "eol": "^0.9.1", "got": "^12.5.2", "rc": "^1.2.8", "semver": "^7.3.8", "tablemark": "^3.0.0", "text-table": "^0.2.0", "visit-values": "^2.0.0" }, "bin": { "license-report": "index.js" } }, "sha512-BAECqr4ets2Uio+lfMvp4oVuf+rJyE/+EBMkVbn4vKAy08MRYjpDeGP9BUHKZ1uC1sIbb6z0esgAiU2Aygcp8Q=="],
 
+    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
@@ -1651,13 +1673,19 @@
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
+    "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
+    "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
     "memoize": ["memoize@10.2.0", "", { "dependencies": { "mimic-function": "^5.0.1" } }, "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA=="],
 
@@ -1854,6 +1882,8 @@
     "protons-runtime": ["protons-runtime@5.6.0", "", { "dependencies": { "uint8-varint": "^2.0.2", "uint8arraylist": "^2.4.3", "uint8arrays": "^5.0.1" } }, "sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
 
@@ -2083,7 +2113,13 @@
 
     "typedarray.prototype.slice": ["typedarray.prototype.slice@1.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "math-intrinsics": "^1.1.0", "typed-array-buffer": "^1.0.3", "typed-array-byte-offset": "^1.0.4" } }, "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg=="],
 
+    "typedoc": ["typedoc@0.28.17", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.17.0", "lunr": "^2.3.9", "markdown-it": "^14.1.0", "minimatch": "^9.0.5", "yaml": "^2.8.1" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ=="],
+
+    "typedoc-plugin-markdown": ["typedoc-plugin-markdown@4.10.0", "", { "peerDependencies": { "typedoc": "0.28.x" } }, "sha512-psrg8Rtnv4HPWCsoxId+MzEN8TVK5jeKCnTbnGAbTBqcDapR9hM41bJT/9eAyKn9C2MDG9Qjh3MkltAYuLDoXg=="],
+
     "typescript": ["typescript@5.5.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "uint8-util": ["uint8-util@2.2.6", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-r+ZjS8CzPhtPF771ROOadUoqC40OVdiMKBI8lTfJQWb4W7+73sMBwMYmai/uvNcmZ7tBJJyZSad03yMWIt3RQg=="],
 
@@ -2385,6 +2421,8 @@
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
+    "typedoc/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
     "vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -2528,6 +2566,8 @@
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "typedoc/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "lint:fix": "bun run --filter '*' lint:fix",
     "changeset": "changeset",
     "version": "changeset version && bun install",
-    "release": "bun run build && ./scripts/publish.sh"
+    "release": "bun run build && ./scripts/publish.sh",
+    "docs": "typedoc",
+    "docs:clean": "rm -rf docs/api && typedoc"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",
@@ -41,10 +43,12 @@
     "@typescript-eslint/parser": "8.32.1",
     "esbuild": "0.23.0",
     "eslint": "9.7.0",
-    "eventemitter3": "5.0.4",
     "eslint-plugin-mocha": "10.4.3",
+    "eventemitter3": "5.0.4",
     "globals": "15.6.0",
-    "playwright": "1.45.3"
+    "playwright": "1.45.3",
+    "typedoc": "^0.28.17",
+    "typedoc-plugin-markdown": "^4.10.0"
   },
   "engines": {
     "bun": ">=1.0.0"

--- a/packages/dwn-sql-store/typedoc.json
+++ b/packages/dwn-sql-store/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src/main.ts"]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPointStrategy": "packages",
+  "entryPoints": [
+    "packages/common",
+    "packages/crypto",
+    "packages/dids",
+    "packages/dwn-sdk-js",
+    "packages/dwn-clients",
+    "packages/agent",
+    "packages/api",
+    "packages/auth",
+    "packages/protocols",
+    "packages/browser",
+    "packages/protocol-codegen",
+    "packages/dwn-sql-store",
+    "packages/dwn-server"
+  ],
+  "packageOptions": {
+    "entryPoints": ["src/index.ts"],
+    "excludeInternal": true,
+    "excludePrivate": true,
+    "excludeProtected": true
+  },
+  "plugin": ["typedoc-plugin-markdown"],
+  "out": "docs/api",
+  "name": "Enbox SDK",
+  "includeVersion": true,
+  "categorizeByGroup": true,
+  "excludeExternals": true,
+  "sourceLinkTemplate": "https://github.com/enboxorg/enbox/blob/{gitRevision}/{path}#L{line}",
+  "readme": "none",
+  "outputFileStrategy": "modules",
+  "hidePageHeader": false,
+  "hideGroupHeadings": false
+}


### PR DESCRIPTION
## Summary

Sets up TypeDoc with the `typedoc-plugin-markdown` plugin to auto-generate per-package API reference documentation as Markdown.

## What's included

- **`typedoc.json`** — Root config using `entryPointStrategy: "packages"` covering all 13 library packages (excludes `electrobun-dwn` and `dwn-server-admin-ui`)
- **`packages/dwn-sql-store/typedoc.json`** — Override for non-standard entry point (`src/main.ts`)
- **`bun run docs`** / **`bun run docs:clean`** — npm scripts for local generation
- **`.github/workflows/docs.yml`** — CI workflow that regenerates `docs/api/` on every push to `main` that touches source files, and commits changes back with `[skip ci]`
- **`.gitignore`** — `docs/api/` added (generated output)
- **`CLAUDE.md`** — New "API Documentation" section with usage instructions, JSDoc conventions, and how to add new packages

## How it works

1. TypeDoc reads each package's `src/index.ts` exports and JSDoc comments
2. Outputs Markdown files to `docs/api/@enbox/<package>.md` with classes, methods, types, source links
3. CI auto-commits regenerated docs after source changes on `main`
4. `docs/api/` is git-ignored — generated on demand locally, committed only by CI

## Output structure

```
docs/api/
  README.md                    # Package index
  @enbox/
    agent.md                   # @enbox/agent API reference
    api/
      README.md                # @enbox/api API reference
      namespaces/utils.md
    auth.md                    # @enbox/auth API reference
    common/
      README.md
      namespaces/TtlCache.md
    crypto.md
    dids/
      README.md
      namespaces/utils.md
    dwn-clients.md
    dwn-server.md
    dwn-sql-store.md
    browser.md
    protocols.md
    protocol-codegen.md
  DWN-SDK-Documentation.md
```

## Local usage

```bash
bun run build       # Build packages first
bun run docs        # Generate API docs
bun run docs:clean  # Clean and regenerate
```