### PR TITLE
docs: improve content — landing page, intro, and per-package docs

### DIFF
--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -1,28 +1,28 @@
 ---
 title: API Reference
-description: Auto-generated API documentation for all Enbox SDK packages.
+description: API documentation for all Enbox SDK packages.
 ---
 
 ## API Reference
 
-The API reference is auto-generated from TypeScript source using TypeDoc. Each package has its own reference page documenting all exported classes, interfaces, functions, and types.
+For detailed documentation on each package — including usage examples, configuration tables, and type reference — see the individual package pages:
 
 ### Core packages
 
 <Cards>
-  <Card title="@enbox/api" href="/docs/api/enbox-api" />
-  <Card title="@enbox/auth" href="/docs/api/enbox-auth" />
-  <Card title="@enbox/agent" href="/docs/api/enbox-agent" />
-  <Card title="@enbox/protocols" href="/docs/api/enbox-protocols" />
+  <Card title="@enbox/api" href="/docs/packages/api" />
+  <Card title="@enbox/dwn-server" href="/docs/packages/dwn-server" />
 </Cards>
 
 ### Infrastructure packages
 
 <Cards>
-  <Card title="@enbox/dids" href="/docs/api/enbox-dids" />
-  <Card title="@enbox/crypto" href="/docs/api/enbox-crypto" />
-  <Card title="@enbox/common" href="/docs/api/enbox-common" />
-  <Card title="@enbox/dwn-sdk-js" href="/docs/api/enbox-dwn-sdk-js" />
+  <Card title="@enbox/agent" href="/docs/packages/agent" />
+  <Card title="@enbox/protocols" href="/docs/packages/protocols" />
+  <Card title="@enbox/dids" href="/docs/packages/dids" />
+  <Card title="@enbox/crypto" href="/docs/packages/crypto" />
+  <Card title="@enbox/common" href="/docs/packages/common" />
+  <Card title="@enbox/dwn-sdk-js" href="/docs/packages/dwn-sdk-js" />
 </Cards>
 
-> API reference pages are generated from the `main` branch of the [enbox monorepo](https://github.com/enboxorg/enbox). They update automatically when source code changes.
+> Auto-generated TypeDoc API reference is planned for a future release.

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,58 +1,132 @@
 ---
 title: Introduction
-description: Getting started with the Enbox SDK for decentralised identity, data, and authentication.
+description: Getting started with the Enbox SDK — decentralised identity, data, and authentication for TypeScript.
 ---
 
 ## What is Enbox?
 
-Enbox is a JavaScript/TypeScript SDK for building applications with **decentralised identity** and **personal data storage**. It gives your users:
+Enbox is a TypeScript SDK for building applications where **users own their data**. Instead of storing user data in your database, Enbox gives each user a [Decentralized Web Node](https://identity.foundation/decentralized-web-node/spec/) (DWN) — a personal data vault they control. Your app reads and writes to it with their permission.
 
-- **Self-sovereign identity** via Decentralized Identifiers (DIDs)
-- **Personal data vaults** powered by Decentralized Web Nodes (DWNs)
-- **Passwordless authentication** with the `@enbox/auth` manager
-- **End-to-end encryption** and selective data sharing
+The SDK handles:
 
-## Packages
+- **Identity** — Decentralized Identifiers (DIDs) that users own, not your server
+- **Storage** — Protocol-defined records in personal DWN vaults, synced across devices
+- **Authentication** — Passwordless auth with vault encryption, recovery phrases, and multi-identity
+- **Encryption** — End-to-end encrypted records with ECDH key agreement
 
-The SDK is published as a set of npm packages:
-
-| Package | Description |
-|---|---|
-| `@enbox/api` | High-level API — `Enbox.connect()`, records, protocols |
-| `@enbox/auth` | Authentication manager — connect, lock, disconnect flows |
-| `@enbox/agent` | Low-level agent runtime for DID and DWN operations |
-| `@enbox/protocols` | Protocol definitions and type-safe schema helpers |
-| `@enbox/dids` | DID creation, resolution, and key management |
-| `@enbox/crypto` | Cryptographic primitives (JOSE, key wrapping) |
-| `@enbox/common` | Shared utilities and types |
-| `@enbox/dwn-sdk-js` | Decentralized Web Node reference implementation |
-
-## Quick start
+## Installation
 
 ```bash
 npm install @enbox/api @enbox/auth
 ```
 
+## Quick start
+
+The main workflow is: **authenticate** with `@enbox/auth`, then **use protocols** with `@enbox/api`.
+
+### 1. Define a protocol
+
+A protocol describes the data your app works with — its schema, structure, and access rules.
+
 ```ts
-import { Enbox } from '@enbox/api';
+import { defineProtocol } from '@enbox/api';
 
-const enbox = new Enbox();
-await enbox.connect();
-
-// Write a record
-const { record } = await enbox.dwn.records.create({
-  data: 'Hello from Enbox!',
-  message: {
-    dataFormat: 'text/plain',
+const TaskProtocol = defineProtocol({
+  protocol:  'https://example.com/tasks',
+  published: true,
+  types: {
+    task: {
+      schema:      'https://example.com/schemas/task',
+      dataFormats: ['application/json'],
+    },
+  },
+  structure: {
+    task: {},
   },
 });
-
-console.log(await record.data.text());
 ```
+
+### 2. Authenticate and connect
+
+```ts
+import { AuthManager } from '@enbox/auth';
+import { Enbox } from '@enbox/api';
+
+const auth = await AuthManager.create();
+const session = await auth.connect();
+const enbox = Enbox.connect({ session });
+```
+
+### 3. CRUD operations
+
+```ts
+const tasks = enbox.using(TaskProtocol);
+await tasks.configure();
+
+// Create
+const { record } = await tasks.records.create('task', {
+  data: { title: 'Buy milk', done: false },
+});
+
+// Read
+const task = await record.data.json();    // { title: 'Buy milk', done: false }
+const raw  = await record.data.text();    // raw JSON string
+const blob = await record.data.blob();    // Blob
+const bytes = await record.data.bytes();  // Uint8Array
+
+// Update
+await record.update({
+  data: { title: 'Buy milk', done: true },
+});
+
+// Query all tasks
+const { records } = await tasks.records.query('task');
+for (const r of records) {
+  console.log(await r.data.json());
+}
+
+// Delete
+await record.delete();
+```
+
+### 4. Real-time subscriptions
+
+```ts
+const { liveQuery } = await tasks.records.subscribe('task');
+
+liveQuery.on('create', (record) => {
+  console.log('New task:', record.id);
+});
+
+liveQuery.on('update', (record) => {
+  console.log('Task updated:', record.id);
+});
+
+liveQuery.on('delete', (record) => {
+  console.log('Task deleted:', record.id);
+});
+```
+
+## Packages
+
+| Package | Description |
+|---|---|
+| [`@enbox/api`](/docs/packages/api) | High-level SDK — `Enbox.connect()`, typed protocols, records CRUD |
+| [`@enbox/auth`](/docs/guides/auth) | Authentication — connect, lock, disconnect, multi-identity |
+| [`@enbox/dwn-server`](/docs/packages/dwn-server) | Self-hostable DWN server with PostgreSQL, MySQL, SQLite |
+| [`@enbox/agent`](/docs/packages/agent) | Low-level agent runtime for DID and DWN operations |
+| [`@enbox/protocols`](/docs/packages/protocols) | Protocol definitions and type-safe schema helpers |
+| [`@enbox/dids`](/docs/packages/dids) | DID creation, resolution, and key management |
+| [`@enbox/crypto`](/docs/packages/crypto) | Cryptographic primitives (JOSE, key wrapping, ECDH) |
+| [`@enbox/common`](/docs/packages/common) | Shared utilities (TTL cache, LevelStore) |
+| [`@enbox/dwn-sdk-js`](/docs/packages/dwn-sdk-js) | Decentralized Web Node protocol engine |
+| `@enbox/dwn-sql-store` | SQL storage backends for the DWN |
+| `@enbox/dwn-clients` | HTTP and WebSocket DWN transport clients |
 
 ## Next steps
 
 <Cards>
+  <Card title="@enbox/api" href="/docs/packages/api" />
+  <Card title="DWN Server" href="/docs/packages/dwn-server" />
   <Card title="Authentication" href="/docs/guides/auth" />
-  <Card title="API Reference" href="/docs/api" />
 </Cards>

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -3,6 +3,8 @@
   "pages": [
     "---Introduction---",
     "index",
+    "---Packages---",
+    "packages",
     "---Guides---",
     "guides",
     "---API Reference---",

--- a/apps/docs/content/docs/packages/agent.mdx
+++ b/apps/docs/content/docs/packages/agent.mdx
@@ -1,0 +1,35 @@
+---
+title: "@enbox/agent"
+description: Low-level agent runtime for DID and DWN operations — identity management, key storage, message signing, and sync.
+---
+
+`@enbox/agent` is the low-level runtime that underpins `@enbox/api`. It manages identities, keys, DWN message signing/verification, and background sync with remote DWNs.
+
+## What it does
+
+- **Identity management** — Creates and stores DID-based identities in an encrypted vault. Each identity owns a set of cryptographic keys and is bound to one or more DWN endpoints.
+- **Message signing and verification** — Signs outbound DWN messages (RecordsWrite, RecordsQuery, etc.) using the active identity's keys, and verifies inbound messages.
+- **DWN sync** — Runs a background sync loop that pushes local changes to the user's remote DWN and pulls remote changes down. Sync interval is configurable (e.g. `'15s'`).
+- **Key storage** — Wraps cryptographic keys in an encrypted vault (backed by LevelDB or IndexedDB depending on the environment). Keys never leave the vault in plaintext.
+- **Permissions** — Manages permission grants and requests between DIDs, including delegated access patterns.
+- **Anonymous access** — Provides an `AnonymousDwnApi` for unsigned read-only queries against remote DWNs.
+
+## When to use it
+
+Most applications should use `@enbox/api` (which wraps the agent internally) rather than interacting with the agent directly. Use `@enbox/agent` when you need:
+
+- Direct control over the sync loop (start, stop, force-sync)
+- Custom identity or key management beyond what `@enbox/auth` provides
+- Low-level access to DWN message construction and signing
+- Building a custom SDK or framework on top of Enbox primitives
+
+## Key exports
+
+| Export | Description |
+|---|---|
+| `EnboxAgent` | The agent interface — identity, DWN, and VC operations |
+| `AnonymousDwnApi` | Read-only DWN API for unsigned queries |
+| `DwnInterface` | Enum of DWN message types (RecordsWrite, RecordsQuery, etc.) |
+| `DwnResponseStatus` | Standard `{ code, detail }` response from DWN operations |
+| `DwnPaginationCursor` | Cursor type for paginated queries |
+| `PermissionsApi` | Permission grant management |

--- a/apps/docs/content/docs/packages/api.mdx
+++ b/apps/docs/content/docs/packages/api.mdx
@@ -1,0 +1,420 @@
+---
+title: "@enbox/api"
+description: The high-level TypeScript SDK for decentralised identity and data — typed protocols, records CRUD, real-time subscriptions, and anonymous queries.
+---
+
+`@enbox/api` is the main package developers use to interact with the Enbox network. It provides a type-safe, protocol-scoped API for creating, reading, updating, deleting, and subscribing to records stored in Decentralised Web Nodes (DWNs).
+
+## Installation
+
+```bash
+npm install @enbox/api @enbox/auth
+```
+
+## Core concepts
+
+### Enbox
+
+The `Enbox` class is the entry point. You create an instance by connecting with an `AuthSession` from `@enbox/auth`:
+
+```ts
+import { AuthManager } from '@enbox/auth';
+import { Enbox } from '@enbox/api';
+
+const auth = await AuthManager.create({ sync: '15s' });
+const session = await auth.connect();
+const enbox = Enbox.connect({ session });
+```
+
+`Enbox.connect()` also accepts raw parameters if you manage the agent yourself:
+
+```ts
+const enbox = Enbox.connect({ agent, connectedDid: did });
+```
+
+The `Enbox` instance exposes:
+
+| Property / Method | Description |
+|---|---|
+| `enbox.using(protocol)` | Returns a `TypedEnbox` scoped to a protocol |
+| `enbox.did` | DID API — create and resolve DIDs |
+| `enbox.vc` | Verifiable Credentials API |
+| `enbox.agent` | The underlying `EnboxAgent` |
+| `enbox.disconnect()` | Stops sync and clears cached instances |
+
+There is **no public `dwn` property** on the `Enbox` instance. All DWN access goes through `enbox.using(protocol)`.
+
+### defineProtocol
+
+`defineProtocol()` creates a typed protocol definition that carries compile-time type metadata:
+
+```ts
+import { defineProtocol } from '@enbox/api';
+
+interface TaskData {
+  title: string;
+  done: boolean;
+}
+
+const TaskProtocol = defineProtocol({
+  protocol:  'https://example.com/tasks',
+  published: true,
+  types: {
+    task: {
+      schema:      'https://example.com/schemas/task',
+      dataFormats: ['application/json'],
+    },
+  },
+  structure: {
+    task: {},
+  },
+}, {} as {
+  task: TaskData;
+});
+```
+
+The second argument is a **phantom schema map** — it exists only at compile time to map protocol type names to TypeScript interfaces. The runtime value (`{}`) is ignored.
+
+### TypedEnbox
+
+`TypedEnbox` is the **primary developer interface**. You get one by calling `enbox.using(protocol)`:
+
+```ts
+const tasks = enbox.using(TaskProtocol);
+```
+
+Instances are **cached by protocol URI** — calling `using()` multiple times with the same protocol returns the same instance.
+
+Before performing record operations, call `configure()` to install the protocol on the local DWN:
+
+```ts
+const { status } = await tasks.configure();
+// status.code: 200 (already installed) or 202 (newly installed)
+```
+
+If you skip `configure()`, `TypedEnbox` will **auto-configure** on the first record operation by querying for an existing installation and installing if needed.
+
+### TypedEnbox.records
+
+All record methods auto-inject `protocol`, `protocolPath`, and `schema` — you only provide the path and your data:
+
+#### create
+
+```ts
+const { status, record } = await tasks.records.create('task', {
+  data: { title: 'Buy milk', done: false },
+});
+// record is TypedRecord<TaskData>
+```
+
+Create options:
+
+| Field | Type | Description |
+|---|---|---|
+| `data` | `T` (type-checked) | The record payload |
+| `parentContextId` | `string?` | Link to a parent record's `contextId` |
+| `published` | `boolean?` | Whether the record is publicly readable |
+| `recipient` | `string?` | DID of the intended recipient |
+| `protocolRole` | `string?` | Role for permission-scoped writes |
+| `tags` | `Record<string, ...>?` | Indexed key-value metadata |
+| `store` | `boolean?` | Persist locally (default `true`) |
+| `encryption` | `boolean?` | Force or skip encryption |
+| `dataFormat` | `string?` | MIME type override |
+
+#### query
+
+```ts
+const { records, cursor } = await tasks.records.query('task');
+
+for (const r of records) {
+  const data = await r.data.json(); // TaskData
+  console.log(data.title, data.done);
+}
+```
+
+Query with filters, sorting, and pagination:
+
+```ts
+import { DateSort } from '@enbox/dwn-sdk-js';
+
+const { records, cursor } = await tasks.records.query('task', {
+  filter: { tags: { done: false } },
+  dateSort: DateSort.CreatedDescending,
+  pagination: { limit: 25 },
+});
+
+// Fetch next page
+if (cursor) {
+  const { records: next } = await tasks.records.query('task', {
+    pagination: { limit: 25, cursor },
+  });
+}
+```
+
+#### read
+
+Read a specific record by ID:
+
+```ts
+const { record } = await tasks.records.read('task', {
+  filter: { recordId: taskId },
+});
+
+const data = await record.data.json(); // TaskData
+```
+
+Read from a remote DWN:
+
+```ts
+const { record } = await tasks.records.read('task', {
+  from: 'did:dht:alice...',
+  filter: { recordId: taskId },
+});
+```
+
+#### delete
+
+Delete via the `TypedEnbox` API:
+
+```ts
+const { status } = await tasks.records.delete('task', {
+  recordId: record.id,
+});
+```
+
+Or delete via the record instance:
+
+```ts
+await record.delete();
+```
+
+#### subscribe
+
+Subscribe to real-time changes:
+
+```ts
+const { liveQuery } = await tasks.records.subscribe('task');
+```
+
+See the [LiveQuery](#livequery) section below for event handling.
+
+## TypedRecord
+
+Every record returned by `TypedEnbox` is wrapped in `TypedRecord<T>`, which provides type-safe data access and lifecycle methods.
+
+### Data accessors
+
+```ts
+const task = await record.data.json();    // Promise<TaskData>
+const raw  = await record.data.text();    // Promise<string>
+const blob = await record.data.blob();    // Promise<Blob>
+const bytes = await record.data.bytes();  // Promise<Uint8Array>
+const stream = await record.data.stream(); // Promise<ReadableStream>
+```
+
+Data is cached in memory up to 10 MB — subsequent calls to any accessor return the cached value without re-reading from the DWN.
+
+### Metadata
+
+| Property | Type | Description |
+|---|---|---|
+| `record.id` | `string` | Unique, stable record ID |
+| `record.contextId` | `string?` | Hierarchical grouping ID |
+| `record.dateCreated` | `string` | ISO 8601 creation timestamp (immutable) |
+| `record.timestamp` | `string` | ISO 8601 timestamp of last mutation |
+| `record.author` | `string` | DID of the current message signer |
+| `record.creator` | `string` | DID of the original author |
+| `record.protocol` | `string?` | Protocol URI |
+| `record.protocolPath` | `string?` | Path within the protocol structure |
+| `record.schema` | `string?` | Schema URI from the protocol type |
+| `record.dataFormat` | `string?` | MIME type of the payload |
+| `record.dataSize` | `number?` | Payload size in bytes |
+| `record.tags` | `object?` | Indexed key-value metadata |
+| `record.published` | `boolean?` | Whether publicly readable |
+| `record.deleted` | `boolean` | Whether the record has been deleted |
+| `record.parentId` | `string?` | Parent record ID |
+| `record.recipient` | `string?` | Recipient DID |
+
+### Mutation methods
+
+#### update
+
+```ts
+const { status, record: updated } = await record.update({
+  data: { title: 'Buy oat milk', done: false },  // Partial<TaskData>
+  tags: { priority: 'high' },
+});
+```
+
+The `data` field accepts `Partial<T>` — only supply the fields you want to change. Both the returned record and the original instance reflect the updated state.
+
+#### delete
+
+```ts
+const { status } = await record.delete();
+// status.code: 202 on success
+```
+
+Delete with options:
+
+```ts
+await record.delete({ prune: true });  // also delete child records
+```
+
+### Lifecycle methods
+
+| Method | Description |
+|---|---|
+| `record.send(target?)` | Push the record to a remote DWN. Defaults to your own remote DWN. |
+| `record.store(importRecord?)` | Persist to local DWN (for records created with `store: false`) |
+| `record.import(store?)` | Re-sign under your identity and optionally store (for importing others' records) |
+| `record.rawRecord` | Escape hatch to the underlying untyped `Record` |
+
+## LiveQuery
+
+`LiveQuery` (and its typed wrapper `TypedLiveQuery<T>`) provides an initial snapshot plus a real-time stream of deduplicated change events.
+
+```ts
+const { liveQuery } = await tasks.records.subscribe('task');
+
+// Initial snapshot
+for (const record of liveQuery.records) {
+  console.log(await record.data.json());
+}
+
+// Real-time events
+liveQuery.on('create', (record) => {
+  console.log('New task:', record.id);
+});
+
+liveQuery.on('update', (record) => {
+  console.log('Updated:', record.id);
+});
+
+liveQuery.on('delete', (record) => {
+  console.log('Deleted:', record.id);
+});
+
+// Catch-all
+liveQuery.on('change', (change) => {
+  console.log(change.type, change.record.id);
+});
+```
+
+### Events
+
+| Event | Callback argument | Description |
+|---|---|---|
+| `create` | `TypedRecord<T>` | A new record was written |
+| `update` | `TypedRecord<T>` | An existing record was updated |
+| `delete` | `TypedRecord<T>` | A record was deleted |
+| `change` | `{ type, record }` | Catch-all for any of the above |
+| `disconnected` | *(none)* | Transport connection lost |
+| `reconnecting` | `{ attempt: number }` | Reconnection attempt in progress |
+| `reconnected` | *(none)* | Connection restored |
+| `eose` | *(none)* | End of stored events — catch-up complete, events are now live |
+
+The `.on()` method returns an unsubscribe function:
+
+```ts
+const off = liveQuery.on('create', handler);
+off(); // stop listening
+```
+
+Close the subscription when done:
+
+```ts
+await liveQuery.close();
+```
+
+### Connection lifecycle
+
+`liveQuery.isConnected` reflects the current transport state. Use the lifecycle events to show connection status in your UI:
+
+```ts
+liveQuery.on('disconnected', () => showOfflineBanner());
+liveQuery.on('reconnecting', ({ attempt }) => {
+  console.log(`Reconnection attempt ${attempt}...`);
+});
+liveQuery.on('reconnected', () => hideOfflineBanner());
+```
+
+## Anonymous queries
+
+`Enbox.anonymous()` creates a lightweight, read-only instance for querying **published** records without authentication:
+
+```ts
+const { dwn } = Enbox.anonymous();
+
+const { records } = await dwn.records.query({
+  from: 'did:dht:alice...',
+  filter: {
+    protocol: 'https://social.example/posts',
+    protocolPath: 'post',
+  },
+});
+
+for (const record of records) {
+  console.log(record.id, await record.data.text());
+}
+```
+
+No identity, vault, password, or signing keys are required. Only unsigned (anonymous) DWN messages are supported — you can query and read, but not write.
+
+## Hierarchical records
+
+Protocols can define nested structures. Use `parentContextId` to create child records:
+
+```ts
+const NotebookProtocol = defineProtocol({
+  protocol:  'https://example.com/notebooks',
+  published: true,
+  types: {
+    notebook: {
+      schema:      'https://example.com/schemas/notebook',
+      dataFormats: ['application/json'],
+    },
+    page: {
+      schema:      'https://example.com/schemas/page',
+      dataFormats: ['application/json'],
+    },
+  },
+  structure: {
+    notebook: {
+      page: {},
+    },
+  },
+}, {} as {
+  notebook: { name: string };
+  page: { title: string; body: string };
+});
+
+const notebooks = enbox.using(NotebookProtocol);
+await notebooks.configure();
+
+// Create a parent
+const { record: notebook } = await notebooks.records.create('notebook', {
+  data: { name: 'Travel Notes' },
+});
+
+// Create a child under the parent
+const { record: page } = await notebooks.records.create('notebook/page', {
+  data: { title: 'Day 1', body: 'Arrived in Tokyo...' },
+  parentContextId: notebook.contextId,
+});
+
+// Query children of a specific parent
+const { records: pages } = await notebooks.records.query('notebook/page', {
+  filter: { parentId: notebook.contextId },
+});
+```
+
+## Disconnecting
+
+When your application shuts down or the user signs out, call `disconnect()` to stop background sync and release resources:
+
+```ts
+await enbox.disconnect();
+```
+
+After calling `disconnect()`, the `Enbox` instance should not be reused. Create a new one with `Enbox.connect()` for the next session.

--- a/apps/docs/content/docs/packages/common.mdx
+++ b/apps/docs/content/docs/packages/common.mdx
@@ -1,0 +1,28 @@
+---
+title: "@enbox/common"
+description: Shared utilities used across the Enbox SDK — TTL cache, LevelStore, and common helpers.
+---
+
+`@enbox/common` contains shared utilities and abstractions used by multiple Enbox packages. It is an internal dependency — most applications do not need to import from it directly.
+
+## What it provides
+
+- **TTL cache** — A time-to-live cache implementation used for DID resolution caching, deduplication, and session state management.
+- **LevelStore** — A key-value store abstraction backed by LevelDB (Node.js) or IndexedDB (browser). Used by the agent for identity vaults, key storage, and local DWN data.
+- **Common helpers** — Shared utility functions for encoding, type checking, and data manipulation used across SDK packages.
+
+## When to use it
+
+This package is primarily an internal dependency. You might import from it if you are:
+
+- Building a custom storage backend that needs to implement the same store interfaces
+- Using the TTL cache for your own application-level caching
+- Extending or forking Enbox SDK packages
+
+## Key exports
+
+| Export | Description |
+|---|---|
+| `TtlCache` | Generic time-to-live cache |
+| `LevelStore` | Key-value store backed by LevelDB/IndexedDB |
+| Utility functions | Encoding, type checking, and data helpers |

--- a/apps/docs/content/docs/packages/crypto.mdx
+++ b/apps/docs/content/docs/packages/crypto.mdx
@@ -1,0 +1,33 @@
+---
+title: "@enbox/crypto"
+description: Cryptographic primitives — JOSE, key wrapping, ECDH key agreement, and signature algorithms.
+---
+
+`@enbox/crypto` provides the cryptographic building blocks used throughout the Enbox SDK. It implements JOSE (JSON Object Signing and Encryption) standards and the key agreement protocols needed for end-to-end encrypted DWN records.
+
+## What it does
+
+- **JOSE implementation** — JWS (JSON Web Signature) and JWE (JSON Web Encryption) operations for signing and encrypting DWN messages and record data.
+- **Key wrapping** — AES key wrapping for protecting content encryption keys within encrypted records.
+- **ECDH key agreement** — Elliptic Curve Diffie-Hellman key agreement for deriving shared secrets between DIDs, enabling end-to-end encryption where only the intended recipient can decrypt.
+- **Signature algorithms** — EdDSA (Ed25519) and ECDSA (secp256k1) signature schemes used for DWN message signing and DID authentication.
+- **Key generation** — Utilities for generating cryptographic key pairs in JWK (JSON Web Key) format.
+
+## When to use it
+
+Most applications never need to import from `@enbox/crypto` directly — encryption, signing, and key agreement are handled automatically by `@enbox/api` and `@enbox/agent`. Use this package when you need:
+
+- Standalone JOSE operations outside the Enbox SDK context
+- Custom encryption or signature logic
+- Direct key generation or manipulation
+- Building a cryptographic layer for a non-Enbox application
+
+## Key exports
+
+| Export | Description |
+|---|---|
+| JWS utilities | Sign and verify JSON Web Signatures |
+| JWE utilities | Encrypt and decrypt JSON Web Encryption payloads |
+| ECDH key agreement | Derive shared secrets from key pairs |
+| AES key wrapping | Wrap and unwrap content encryption keys |
+| Key generation | Generate Ed25519 and secp256k1 key pairs |

--- a/apps/docs/content/docs/packages/dids.mdx
+++ b/apps/docs/content/docs/packages/dids.mdx
@@ -1,0 +1,41 @@
+---
+title: "@enbox/dids"
+description: DID creation, resolution, and key management — supporting did:dht, did:jwk, did:key, and did:web methods.
+---
+
+`@enbox/dids` handles everything related to Decentralised Identifiers (DIDs) — creating them, resolving them, and managing the cryptographic keys they contain.
+
+## What it does
+
+- **DID creation** — Generates new DIDs using supported methods. Each method produces a DID document with verification methods (public keys) and service endpoints.
+- **DID resolution** — Resolves any DID URI to its DID document, discovering the subject's public keys, service endpoints, and authentication methods.
+- **Key management** — Manages the key pairs associated with DIDs, including key generation, export, and storage in encrypted vaults.
+- **Universal resolver** — A `UniversalResolver` that delegates to method-specific resolvers and caches results.
+
+## Supported DID methods
+
+| Method | Class | Description |
+|---|---|---|
+| `did:dht` | `DidDht` | DIDs anchored to the Mainline DHT network. Recommended for production use. |
+| `did:jwk` | `DidJwk` | Self-contained DIDs where the DID string encodes the public key directly. |
+| `did:key` | `DidKey` | Similar to `did:jwk` but uses the Multicodec encoding format. |
+| `did:web` | `DidWeb` | DIDs resolved via HTTPS from a web domain (e.g. `did:web:example.com`). |
+
+## When to use it
+
+Most applications interact with DIDs through `@enbox/api` and `@enbox/auth`, which handle DID creation and resolution internally. Use `@enbox/dids` directly when you need:
+
+- Custom DID method support or resolver configuration
+- Standalone DID resolution without the full Enbox SDK
+- Direct key management operations (export, rotation, etc.)
+- Building a DID-aware service or verifier
+
+## Key exports
+
+| Export | Description |
+|---|---|
+| `DidDht`, `DidJwk`, `DidKey`, `DidWeb` | Method-specific DID handlers |
+| `UniversalResolver` | Multi-method DID resolver with caching |
+| `DidResolverCacheMemory` | In-memory resolver cache |
+| `DidMethodResolver` | Interface for custom DID method resolvers |
+| `DidDocument` | The W3C DID Document type |

--- a/apps/docs/content/docs/packages/dwn-sdk-js.mdx
+++ b/apps/docs/content/docs/packages/dwn-sdk-js.mdx
@@ -1,0 +1,42 @@
+---
+title: "@enbox/dwn-sdk-js"
+description: The Decentralised Web Node protocol engine — message processing, storage interfaces, and protocol rule enforcement.
+---
+
+`@enbox/dwn-sdk-js` is the core DWN protocol engine. It implements the [DWN specification](https://identity.foundation/decentralized-web-node/spec/) — processing DWN messages, enforcing protocol rules, managing record storage, and handling subscriptions.
+
+## What it does
+
+- **Message processing** — Parses, validates, and processes all DWN message types: `RecordsWrite`, `RecordsQuery`, `RecordsRead`, `RecordsDelete`, `RecordsSubscribe`, `ProtocolsConfigure`, `ProtocolsQuery`, and more.
+- **Protocol rule enforcement** — Evaluates protocol definitions (types, structure, `$actions`) to determine whether a given message is authorised. This includes role-based access control, recipient scoping, and hierarchical record permissions.
+- **Storage interfaces** — Defines abstract interfaces (`MessageStore`, `DataStore`, `EventLog`, `ResumableTaskStore`) that storage backends implement. The DWN engine is storage-agnostic.
+- **Event system** — Produces events when records are created, updated, or deleted, enabling the subscription and sync mechanisms used by the agent and server.
+- **Encryption support** — Handles protocol-level encryption rules, key derivation paths, and encrypted record processing.
+
+## Relationship to other packages
+
+| Package | Uses dwn-sdk-js for... |
+|---|---|
+| `@enbox/dwn-server` | Running a DWN instance that processes incoming messages |
+| `@enbox/agent` | Processing local DWN operations and maintaining the local store |
+| `@enbox/api` | Type definitions (`ProtocolDefinition`, `DateSort`, `RecordsFilter`, etc.) |
+
+## When to use it
+
+Most applications do not import from `@enbox/dwn-sdk-js` directly. Use it when you need:
+
+- Access to DWN type definitions like `ProtocolDefinition`, `DateSort`, or `RecordsFilter`
+- To build a custom DWN implementation or storage backend
+- To understand or extend the protocol rule engine
+- Low-level message construction for testing or tooling
+
+## Key exports
+
+| Export | Description |
+|---|---|
+| `ProtocolDefinition` | Type describing a DWN protocol's types, structure, and rules |
+| `DateSort` | Enum for record sort ordering (`CreatedAscending`, `CreatedDescending`, etc.) |
+| `RecordsFilter` | Filter type for record queries |
+| `MessageStore`, `DataStore` | Storage backend interfaces |
+| `EventLog` | Event log interface for change tracking |
+| `Dwn` | The DWN engine class itself |

--- a/apps/docs/content/docs/packages/dwn-server.mdx
+++ b/apps/docs/content/docs/packages/dwn-server.mdx
@@ -1,0 +1,225 @@
+---
+title: "@enbox/dwn-server"
+description: Self-hostable Decentralised Web Node server with PostgreSQL, MySQL, SQLite, and LevelDB storage backends.
+---
+
+`@enbox/dwn-server` is a standalone HTTP + WebSocket server that hosts Decentralised Web Nodes (DWNs) for multiple tenants. It implements the [DWN specification](https://identity.foundation/decentralized-web-node/spec/) and is designed to run as a long-lived service — in Docker, on bare metal, or in a cloud environment.
+
+## Quick start
+
+### Docker (recommended)
+
+```bash
+docker run -d \
+  --name dwn-server \
+  -p 3000:3000 \
+  -e DWN_STORAGE=level://data \
+  -v dwn-data:/data \
+  ghcr.io/enboxorg/dwn-server:latest
+```
+
+### From source
+
+```bash
+git clone https://github.com/enboxorg/enbox.git
+cd enbox
+bun install
+bun run --filter @enbox/dwn-server start
+```
+
+### Verify
+
+```bash
+curl http://localhost:3000/health
+# {"ok":true}
+
+curl http://localhost:3000/info
+# {"server":"@enbox/dwn-server","version":"...","sdkVersion":"...","webSocketSupport":true,...}
+```
+
+## Configuration
+
+All configuration is via **environment variables**. There are no CLI flags.
+
+### Server
+
+| Variable | Default | Description |
+|---|---|---|
+| `DS_PORT` | `3000` | Port the server listens on |
+| `DWN_BASE_URL` | `http://localhost:3000` | External base URL (used in Connect flow URIs) |
+| `DWN_SERVER_PACKAGE_NAME` | `@enbox/dwn-server` | Name returned by `/info` |
+| `DWN_SERVER_LOG_LEVEL` | `INFO` | Log level: `trace`, `debug`, `info`, `warn`, `error` |
+| `DS_WEBSOCKET_SERVER` | `on` | Enable WebSocket support (`on` / `off`) |
+| `MAX_RECORD_DATA_SIZE` | `100mb` | Maximum payload size per `RecordsWrite` |
+| `DWN_MAX_IN_FLIGHT` | `32` | Max unacknowledged subscription events per subscription |
+
+### Storage
+
+Storage URLs use a scheme prefix to select the backend:
+
+| Scheme | Example | Description |
+|---|---|---|
+| `level://` | `level://data` | LevelDB (default, file-based) |
+| `sqlite://` | `sqlite://dwn.db` | SQLite (single file, good for dev) |
+| `postgres://` | `postgres://user:pass@host:5432/dwn` | PostgreSQL (recommended for production) |
+| `mysql://` | `mysql://user:pass@host:3306/dwn` | MySQL |
+
+| Variable | Default | Description |
+|---|---|---|
+| `DWN_STORAGE` | `level://data` | Default storage URL for all stores |
+| `DWN_STORAGE_MESSAGES` | `DWN_STORAGE` | Override for the message store |
+| `DWN_STORAGE_DATA` | `DWN_STORAGE` | Override for the data (blob) store |
+| `DWN_STORAGE_STATE_INDEX` | `DWN_STORAGE` | Override for the state/event index |
+| `DWN_STORAGE_RESUMABLE_TASKS` | `DWN_STORAGE` | Override for resumable task storage |
+| `DWN_TTL_CACHE_URL` | `sqlite://` | TTL cache (session/state). SQL only. |
+
+You can point different stores at different backends — for example, keep messages in PostgreSQL but store blobs on the filesystem with LevelDB.
+
+### PostgreSQL pool tuning
+
+When multiple stores share the same PostgreSQL connection URL, a single shared pool is used instead of one pool per store (which would be 4 pools x 10 connections = 40 connections by default).
+
+| Variable | Default | Description |
+|---|---|---|
+| `DWN_PG_POOL_MIN` | `5` | Minimum pool connections |
+| `DWN_PG_POOL_MAX` | `30` | Maximum pool connections |
+| `DWN_PG_POOL_IDLE_TIMEOUT` | `30000` | Idle connection timeout (ms) |
+
+### Tenant registration
+
+By default, any DID can use the server (open registration). You can require registration via Proof-of-Work, Provider Auth (OAuth), or both.
+
+| Variable | Default | Description |
+|---|---|---|
+| `DWN_REGISTRATION_STORE_URL` | `DWN_STORAGE` | Storage URL for registration data |
+| `DWN_REGISTRATION_PROOF_OF_WORK_ENABLED` | `false` | Enable Proof-of-Work registration |
+| `DWN_REGISTRATION_PROOF_OF_WORK_SEED` | *(none)* | Seed for PoW challenge generation |
+| `DWN_REGISTRATION_PROOF_OF_WORK_INITIAL_MAX_HASH` | *(none)* | Initial difficulty ceiling |
+| `DWN_TERMS_OF_SERVICE_FILE_PATH` | *(none)* | Path to a ToS file tenants must accept |
+
+#### Provider Auth (OAuth)
+
+For paid or managed DWN hosting, Provider Auth gates registration behind an OAuth flow:
+
+| Variable | Default | Description |
+|---|---|---|
+| `DWN_PROVIDER_AUTH_ENABLED` | `false` | Enable Provider Auth |
+| `DWN_PROVIDER_AUTH_AUTHORIZE_URL` | *(none)* | OAuth authorise endpoint |
+| `DWN_PROVIDER_AUTH_TOKEN_URL` | *(none)* | OAuth token endpoint |
+| `DWN_PROVIDER_AUTH_REFRESH_URL` | *(none)* | OAuth refresh endpoint |
+| `DWN_PROVIDER_AUTH_MANAGEMENT_URL` | *(none)* | Management portal URL |
+| `DWN_PROVIDER_AUTH_PLUGIN_PATH` | *(none)* | Path to a custom auth plugin |
+| `DWN_PROVIDER_AUTH_JWT_SECRET` | *(none)* | JWT signing secret |
+| `DWN_PROVIDER_AUTH_JWT_JWKS_URL` | *(none)* | JWKS URL for JWT verification |
+
+### Admin API
+
+The admin API is **disabled by default**. Set `DWN_ADMIN_TOKEN` to enable it.
+
+| Variable | Default | Description |
+|---|---|---|
+| `DWN_ADMIN_TOKEN` | *(none)* | Bearer token for admin endpoints. If unset, admin API is disabled. |
+| `DWN_ADMIN_TOKEN_FILE` | *(none)* | Read the admin token from a file (useful for Docker secrets) |
+| `DWN_ADMIN_ACTIVITY_LOG_CAPACITY` | `10000` | Max events in the admin activity ring buffer |
+| `DWN_ADMIN_METRICS_UPDATE_INTERVAL` | `30` | Prometheus gauge update interval (seconds) |
+| `DWN_ADMIN_WEBAUTHN_RP_ID` | *(from DWN_BASE_URL)* | WebAuthn Relying Party ID for passkey auth |
+| `DWN_ADMIN_WEBAUTHN_RP_NAME` | `DWN Admin` | WebAuthn Relying Party display name |
+| `DWN_ADMIN_SESSION_TTL` | `86400` | Passkey session TTL (seconds, default 24 hours) |
+
+### Quotas
+
+Per-tenant storage quotas limit resource usage. Defaults are unlimited; per-tenant overrides are managed via the admin API.
+
+| Variable | Default | Description |
+|---|---|---|
+| `DWN_QUOTA_MAX_MESSAGES` | `0` (unlimited) | Default max messages per tenant |
+| `DWN_QUOTA_MAX_STORAGE_BYTES` | `0` (unlimited) | Default max data storage per tenant (bytes) |
+
+### Rate limiting
+
+| Variable | Default | Description |
+|---|---|---|
+| `DWN_RATE_LIMIT_REQUESTS_PER_SECOND` | `30` | Max HTTP requests/sec per IP. `0` disables. |
+| `DWN_RATE_LIMIT_BURST` | `50` | Burst allowance per IP |
+| `DWN_RATE_LIMIT_TENANT_REQUESTS_PER_SECOND` | `20` | Max DWN requests/sec per tenant DID. `0` disables. |
+| `DWN_RATE_LIMIT_TENANT_BURST` | `50` | Burst allowance per tenant |
+
+### Audit log
+
+| Variable | Default | Description |
+|---|---|---|
+| `DWN_AUDIT_LOG_MAX_AGE_DAYS` | `90` | Max age of audit entries (days). `0` = no limit. |
+| `DWN_AUDIT_LOG_MAX_ROWS` | `100000` | Max number of audit rows. Oldest purged when exceeded. |
+
+### Record delivery and forwarding
+
+| Variable | Default | Description |
+|---|---|---|
+| `DWN_FORWARDING_ENABLED` | `false` | Forward signed messages to tenant's other DWN endpoints |
+| `DWN_DELIVERY_ENABLED` | `false` | Protocol-aware `$delivery` to participants' DWNs |
+| `DWN_DELIVERY_MAX_CONCURRENCY` | `10` | Max concurrent outbound delivery requests |
+| `DWN_DELIVERY_ENDPOINT_CACHE_TTL` | `300` | DID endpoint resolution cache TTL (seconds) |
+| `DWN_FORWARDING_DEDUP_TTL` | `60` | Deduplication cache TTL for forwarded messages (seconds) |
+
+## HTTP endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/health` | Health check. Returns `{ "ok": true }`. |
+| `GET` | `/info` | Server info: name, version, SDK version, registration requirements |
+| `POST` | `/` | JSON-RPC endpoint for all DWN messages |
+| `GET` | `/:did/read/records/:id` | Direct HTTP read for a specific record |
+
+### WebSocket
+
+When `DS_WEBSOCKET_SERVER=on` (the default), the server accepts WebSocket upgrades on the root path (`/`). The WebSocket transport supports:
+
+- JSON-RPC DWN messages (same as HTTP)
+- Real-time subscription events
+- Flow control via `rpc.ack` messages (controlled by `DWN_MAX_IN_FLIGHT`)
+
+### Registration routes
+
+When Proof-of-Work or Provider Auth is enabled, additional routes are exposed for tenant registration and terms-of-service acceptance.
+
+## Production deployment
+
+### PostgreSQL example
+
+```bash
+docker run -d \
+  --name dwn-server \
+  -p 3000:3000 \
+  -e DWN_STORAGE=postgres://dwn:secret@db:5432/dwn \
+  -e DWN_BASE_URL=https://dwn.example.com \
+  -e DWN_ADMIN_TOKEN=your-secret-token \
+  -e DWN_RATE_LIMIT_REQUESTS_PER_SECOND=30 \
+  -e DWN_QUOTA_MAX_STORAGE_BYTES=1073741824 \
+  ghcr.io/enboxorg/dwn-server:latest
+```
+
+### Split storage
+
+Store messages and state in PostgreSQL, but keep large binary data on the filesystem:
+
+```bash
+DWN_STORAGE_MESSAGES=postgres://dwn:secret@db:5432/dwn
+DWN_STORAGE_DATA=level:///mnt/blobs
+DWN_STORAGE_STATE_INDEX=postgres://dwn:secret@db:5432/dwn
+```
+
+### Health checks
+
+Use the `/health` endpoint for container orchestration liveness probes:
+
+```yaml
+# docker-compose.yml
+services:
+  dwn:
+    image: ghcr.io/enboxorg/dwn-server:latest
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+```

--- a/apps/docs/content/docs/packages/meta.json
+++ b/apps/docs/content/docs/packages/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "Packages",
+  "pages": [
+    "api",
+    "dwn-server",
+    "agent",
+    "protocols",
+    "dids",
+    "crypto",
+    "common",
+    "dwn-sdk-js"
+  ]
+}

--- a/apps/docs/content/docs/packages/protocols.mdx
+++ b/apps/docs/content/docs/packages/protocols.mdx
@@ -1,0 +1,30 @@
+---
+title: "@enbox/protocols"
+description: Protocol definitions and type-safe schema helpers for structuring data in Decentralised Web Nodes.
+---
+
+`@enbox/protocols` provides pre-built protocol definitions and utilities for defining the data structures, access rules, and schemas that govern records in a DWN.
+
+## What it does
+
+- **Protocol definitions** — Ships ready-to-use protocol definitions for common use cases (social graphs, messaging, profiles, etc.) that can be passed directly to `defineProtocol()` or used with the lower-level DWN API.
+- **Schema helpers** — Utilities for constructing well-formed protocol definitions with proper `types`, `structure`, and `$actions` configurations.
+- **Type generation** — TypeScript type utilities that derive compile-time types from protocol definitions, enabling the type-safe path autocompletion in `TypedEnbox`.
+
+## When to use it
+
+- When you want to reuse a well-tested protocol definition rather than writing one from scratch
+- When building protocol tooling or code generators
+- When you need the low-level protocol type utilities that power `defineProtocol()`
+
+## Relationship to @enbox/api
+
+`@enbox/api`'s `defineProtocol()` function uses the type utilities from this package internally. If you are using `defineProtocol()` with inline definitions, you typically do not need to import from `@enbox/protocols` directly.
+
+## Key exports
+
+| Export | Description |
+|---|---|
+| Protocol definitions | Pre-built definitions for common data patterns |
+| `ProtocolDefinition` | The core type describing a DWN protocol (re-exported from `@enbox/dwn-sdk-js`) |
+| Type utilities | Helpers for deriving TypeScript types from protocol structures |

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -1,30 +1,145 @@
 import Link from 'next/link';
 
+function EnboxMark() {
+  return (
+    <svg
+      width="56"
+      height="56"
+      viewBox="0 0 40 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="Enbox"
+    >
+      <rect x="4" y="4" width="20" height="20" rx="4" stroke="#545d69" strokeWidth="1.5" fill="none" />
+      <rect x="10" y="10" width="20" height="20" rx="4" stroke="#78828f" strokeWidth="1.5" fill="none" />
+      <rect x="16" y="16" width="20" height="20" rx="4" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <circle cx="26" cy="26" r="2.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+function FeatureCard({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="flex flex-col gap-2 p-5 rounded-xl border border-fd-border bg-fd-card text-left">
+      <h3 className="text-sm font-semibold text-fd-card-foreground">{title}</h3>
+      <p className="text-sm text-fd-muted-foreground leading-relaxed">{description}</p>
+    </div>
+  );
+}
+
 export default function HomePage() {
   return (
-    <div className="flex flex-col justify-center items-center text-center flex-1 gap-6 py-20 px-6">
-      <h1 className="text-4xl font-bold tracking-tight">
-        en<span className="font-extrabold">b</span>ox docs
-      </h1>
-      <p className="text-fd-muted-foreground max-w-lg text-lg">
-        Decentralised identity, data, and authentication for JavaScript and
-        TypeScript.
-      </p>
-      <div className="flex flex-row gap-3">
-        <Link
-          href="/docs"
-          className="inline-flex items-center justify-center rounded-lg bg-fd-primary text-fd-primary-foreground px-5 py-2.5 text-sm font-medium transition-colors hover:opacity-90"
-        >
-          Get Started
-        </Link>
-        <a
-          href="https://github.com/enboxorg/enbox"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center justify-center rounded-lg border border-fd-border px-5 py-2.5 text-sm font-medium transition-colors hover:bg-fd-accent"
-        >
-          GitHub
-        </a>
+    <div className="flex flex-col items-center flex-1 px-6">
+      {/* Hero */}
+      <div className="flex flex-col items-center text-center gap-6 pt-24 pb-16 max-w-2xl">
+        <EnboxMark />
+        <h1 className="text-4xl sm:text-5xl font-bold tracking-tight">
+          en<span className="font-extrabold">b</span>ox
+        </h1>
+        <p className="text-fd-muted-foreground max-w-lg text-lg leading-relaxed">
+          A TypeScript SDK for decentralised identity and personal data storage.
+          Your users own their data. You build the experience.
+        </p>
+        <div className="flex flex-row gap-3">
+          <Link
+            href="/docs"
+            className="inline-flex items-center justify-center rounded-lg bg-fd-primary text-fd-primary-foreground px-6 py-2.5 text-sm font-medium transition-colors hover:opacity-90"
+          >
+            Get Started
+          </Link>
+          <a
+            href="https://github.com/enboxorg/enbox"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center rounded-lg border border-fd-border px-6 py-2.5 text-sm font-medium transition-colors hover:bg-fd-accent"
+          >
+            GitHub
+          </a>
+        </div>
+      </div>
+
+      {/* Install */}
+      <div className="w-full max-w-lg pb-12">
+        <pre className="rounded-xl border border-fd-border bg-fd-card px-5 py-4 text-sm font-mono text-fd-card-foreground overflow-x-auto">
+          <span className="text-fd-muted-foreground select-none">$ </span>npm install @enbox/api @enbox/auth
+        </pre>
+      </div>
+
+      {/* Code example */}
+      <div className="w-full max-w-2xl pb-16">
+        <div className="rounded-xl border border-fd-border bg-fd-card overflow-hidden">
+          <div className="px-5 py-3 border-b border-fd-border">
+            <span className="text-xs font-mono text-fd-muted-foreground">example.ts</span>
+          </div>
+          <pre className="px-5 py-4 text-sm font-mono text-fd-card-foreground overflow-x-auto leading-relaxed">
+{`import { AuthManager } from '@enbox/auth';
+import { Enbox, defineProtocol } from '@enbox/api';
+
+// Define a typed protocol
+const Notes = defineProtocol({
+  protocol:  'https://example.com/notes',
+  published: true,
+  types:     { note: { schema: 'https://example.com/note', dataFormats: ['application/json'] } },
+  structure: { note: {} },
+});
+
+// Authenticate and connect
+const auth = await AuthManager.create();
+const session = await auth.connect();
+const enbox = Enbox.connect({ session });
+
+// Full CRUD with type safety
+const notes = enbox.using(Notes);
+await notes.configure();
+
+// Create
+const { record } = await notes.records.create('note', {
+  data: { title: 'First note', body: 'Hello from Enbox!' },
+});
+
+// Read
+const text = await record.data.json();
+
+// Update
+await record.update({ data: { title: 'Updated note', body: 'Changed.' } });
+
+// Query
+const { records } = await notes.records.query('note');
+
+// Delete
+await record.delete();`}
+          </pre>
+        </div>
+      </div>
+
+      {/* Features */}
+      <div className="w-full max-w-3xl pb-24">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <FeatureCard
+            title="Decentralised Identity"
+            description="DID-based identity that users own. No central account server. Supports did:dht, did:jwk, did:key, and did:web."
+          />
+          <FeatureCard
+            title="Personal Data Vaults"
+            description="Data stored in Decentralized Web Nodes. Users choose where their data lives. Sync across devices automatically."
+          />
+          <FeatureCard
+            title="Type-Safe Protocols"
+            description="Define DWN protocols with TypeScript types. Compile-time checks for paths, schemas, and record data."
+          />
+          <FeatureCard
+            title="End-to-End Encryption"
+            description="Records encrypted with ECDH-ES+A256KW key agreement and AES-256-GCM content encryption. Per-protocol encryption policies."
+          />
+          <FeatureCard
+            title="Multi-Identity"
+            description="Multiple identities in a single vault. Switch between them, export for backup, recover from a 12-word phrase."
+          />
+          <FeatureCard
+            title="Self-Hostable Server"
+            description="Run your own DWN server with PostgreSQL, MySQL, or SQLite. Rate limiting, quotas, admin dashboard included."
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Major docs content improvement for the Fumadocs site at `apps/docs/`.

- **Landing page** (`page.tsx`) — rewritten with inlined SVG logo, install snippet, 6 feature cards, and a full CRUD code example
- **Introduction** (`index.mdx`) — rewritten with accurate API usage: `defineProtocol`, `AuthManager.create()`, `Enbox.connect({ session })`, `enbox.using()`, CRUD + subscriptions, and a packages table linking to per-package pages
- **`@enbox/api` docs** — detailed coverage of `Enbox`, `defineProtocol`, `TypedEnbox`, `TypedRecord`, `LiveQuery`, anonymous queries, hierarchical records, and disconnection
- **`@enbox/dwn-server` docs** — quick start (Docker + source), complete env var configuration tables (server, storage, PostgreSQL pool, registration, admin API, quotas, rate limiting, audit, delivery/forwarding), HTTP endpoints, and production deployment examples
- **Library-style docs** for `@enbox/agent`, `@enbox/protocols`, `@enbox/dids`, `@enbox/crypto`, `@enbox/common`, `@enbox/dwn-sdk-js` — explanation of what each package does, when to use it, and key exports (no code examples per instructions)
- **Sidebar** updated with new "Packages" section
- **API Reference** page updated to link to the new per-package pages

Build verified: `bun run docs:build` passes (45 static pages generated).