### PR TITLE
docs: design system alignment, bun-first, API-focused quick start

### DIFF
--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -17,12 +17,10 @@ The SDK handles:
 ## Installation
 
 ```bash
-npm install @enbox/api @enbox/auth
+bun add @enbox/api
 ```
 
 ## Quick start
-
-The main workflow is: **authenticate** with `@enbox/auth`, then **use protocols** with `@enbox/api`.
 
 ### 1. Define a protocol
 
@@ -46,23 +44,25 @@ const TaskProtocol = defineProtocol({
 });
 ```
 
-### 2. Authenticate and connect
+### 2. Connect and use
 
 ```ts
-import { AuthManager } from '@enbox/auth';
 import { Enbox } from '@enbox/api';
 
-const auth = await AuthManager.create();
-const session = await auth.connect();
+const enbox = Enbox.connect({ agent, connectedDid: did });
+const tasks = enbox.using(TaskProtocol);
+await tasks.configure();
+```
+
+`Enbox.connect()` takes an `agent` and `connectedDid` — the agent manages signing keys and DWN sync, while `connectedDid` is the user's DID. If you use `@enbox/auth`, you can pass the session directly:
+
+```ts
 const enbox = Enbox.connect({ session });
 ```
 
 ### 3. CRUD operations
 
 ```ts
-const tasks = enbox.using(TaskProtocol);
-await tasks.configure();
-
 // Create
 const { record } = await tasks.records.create('task', {
   data: { title: 'Buy milk', done: false },

--- a/apps/docs/content/docs/packages/api.mdx
+++ b/apps/docs/content/docs/packages/api.mdx
@@ -8,28 +8,25 @@ description: The high-level TypeScript SDK for decentralised identity and data â
 ## Installation
 
 ```bash
-npm install @enbox/api @enbox/auth
+bun add @enbox/api
 ```
 
 ## Core concepts
 
 ### Enbox
 
-The `Enbox` class is the entry point. You create an instance by connecting with an `AuthSession` from `@enbox/auth`:
+The `Enbox` class is the entry point. You create an instance with `Enbox.connect()`:
 
 ```ts
-import { AuthManager } from '@enbox/auth';
 import { Enbox } from '@enbox/api';
 
-const auth = await AuthManager.create({ sync: '15s' });
-const session = await auth.connect();
-const enbox = Enbox.connect({ session });
+const enbox = Enbox.connect({ agent, connectedDid: did });
 ```
 
-`Enbox.connect()` also accepts raw parameters if you manage the agent yourself:
+The `agent` manages signing keys, DWN sync, and identity storage. The `connectedDid` is the user's DID. If you use `@enbox/auth` for authentication, you can pass the session directly:
 
 ```ts
-const enbox = Enbox.connect({ agent, connectedDid: did });
+const enbox = Enbox.connect({ session });
 ```
 
 The `Enbox` instance exposes:

--- a/apps/docs/content/docs/packages/dwn-server.mdx
+++ b/apps/docs/content/docs/packages/dwn-server.mdx
@@ -24,7 +24,7 @@ docker run -d \
 git clone https://github.com/enboxorg/enbox.git
 cd enbox
 bun install
-bun run --filter @enbox/dwn-server start
+bun --filter @enbox/dwn-server start
 ```
 
 ### Verify

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -1,94 +1,319 @@
-import Link from 'next/link';
+'use client';
 
-function EnboxMark() {
+import Link from 'next/link';
+import { useState } from 'react';
+
+/* ------------------------------------------------------------------ */
+/* Enbox mark — three overlapping rounded rects + central node        */
+/* ------------------------------------------------------------------ */
+function EnboxMark({ size = 56 }: { size?: number }) {
   return (
     <svg
-      width="56"
-      height="56"
+      width={size}
+      height={size}
       viewBox="0 0 40 40"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       aria-label="Enbox"
     >
-      <rect x="4" y="4" width="20" height="20" rx="4" stroke="#545d69" strokeWidth="1.5" fill="none" />
-      <rect x="10" y="10" width="20" height="20" rx="4" stroke="#78828f" strokeWidth="1.5" fill="none" />
+      <rect x="4" y="4" width="20" height="20" rx="4" stroke="var(--enbox-gray-600)" strokeWidth="1.5" fill="none" />
+      <rect x="10" y="10" width="20" height="20" rx="4" stroke="var(--enbox-gray-400)" strokeWidth="1.5" fill="none" />
       <rect x="16" y="16" width="20" height="20" rx="4" stroke="currentColor" strokeWidth="1.5" fill="none" />
       <circle cx="26" cy="26" r="2.5" fill="currentColor" />
     </svg>
   );
 }
 
-function FeatureCard({ title, description }: { title: string; description: string }) {
+/* ------------------------------------------------------------------ */
+/* Bun logo — small inline SVG                                        */
+/* ------------------------------------------------------------------ */
+function BunLogo({ size = 16 }: { size?: number }) {
   return (
-    <div className="flex flex-col gap-2 p-5 rounded-xl border border-fd-border bg-fd-card text-left">
-      <h3 className="text-sm font-semibold text-fd-card-foreground">{title}</h3>
-      <p className="text-sm text-fd-muted-foreground leading-relaxed">{description}</p>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 80 70"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="Bun"
+    >
+      <path
+        d="M71.1 32.2C71.1 52 55.2 68.2 35.8 68.2S.5 52 .5 32.2c0-6.4 1.7-12.4 4.6-17.6C9.3 6.5 17.3 1 26.6 1c3.5 0 6.8.8 9.7 2.3a26 26 0 0 1 9.7-2.3c9.3 0 17.3 5.5 21.5 13.6 2.3 4.3 3.6 9.2 3.6 14.3v3.3Z"
+        fill="#fbf0df"
+        stroke="#000"
+        strokeWidth="1.5"
+      />
+      <ellipse cx="22.5" cy="37.5" rx="4.5" ry="5.5" fill="#000" />
+      <ellipse cx="40" cy="37.5" rx="4.5" ry="5.5" fill="#000" />
+      <ellipse cx="23" cy="36" rx="1.5" ry="2" fill="#fff" />
+      <ellipse cx="40.5" cy="36" rx="1.5" ry="2" fill="#fff" />
+      <path d="M28 48c2.5 3 7.5 3 10 0" stroke="#000" strokeWidth="2" strokeLinecap="round" fill="none" />
+      <path d="M27 14c-2-6 3-12 8-10M38 14c2-6-3-12-8-10M32.5 12c0-7 5-11 5-11" stroke="#3b6e2c" strokeWidth="2.5" strokeLinecap="round" fill="none" />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Copy button with check animation                                    */
+/* ------------------------------------------------------------------ */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      onClick={copy}
+      className="inline-flex items-center justify-center w-8 h-8 rounded-lg shrink-0 transition-colors cursor-pointer"
+      style={{
+        background: 'var(--enbox-gray-800)',
+        color: copied ? 'var(--enbox-gray-50)' : 'var(--enbox-gray-400)',
+      }}
+      aria-label={copied ? 'Copied' : 'Copy to clipboard'}
+    >
+      {copied ? (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      ) : (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Install bar — pill shape, mono font, accent prompt, copy button    */
+/* ------------------------------------------------------------------ */
+function InstallBar({ command }: { command: string }) {
+  return (
+    <div
+      className="inline-flex items-center gap-3 px-3 py-2 rounded-full font-mono text-sm max-w-full"
+      style={{
+        background: 'var(--enbox-gray-900)',
+        border: '1px solid rgba(255, 255, 255, 0.10)',
+        color: 'var(--enbox-gray-100)',
+      }}
+    >
+      <span className="select-none" style={{ color: 'var(--enbox-white)' }}>$</span>
+      <span className="flex-1 min-w-0 whitespace-nowrap overflow-hidden text-ellipsis">{command}</span>
+      <CopyButton text={command} />
     </div>
   );
 }
 
-export default function HomePage() {
+/* ------------------------------------------------------------------ */
+/* Code block — terminal-style with dots and language badge            */
+/* ------------------------------------------------------------------ */
+function CodeBlock({ language, filename, children }: { language: string; filename?: string; children: string }) {
   return (
-    <div className="flex flex-col items-center flex-1 px-6">
-      {/* Hero */}
-      <div className="flex flex-col items-center text-center gap-6 pt-24 pb-16 max-w-2xl">
-        <EnboxMark />
-        <h1 className="text-4xl sm:text-5xl font-bold tracking-tight">
-          en<span className="font-extrabold">b</span>ox
-        </h1>
-        <p className="text-fd-muted-foreground max-w-lg text-lg leading-relaxed">
-          A TypeScript SDK for decentralised identity and personal data storage.
-          Your users own their data. You build the experience.
-        </p>
-        <div className="flex flex-row gap-3">
-          <Link
-            href="/docs"
-            className="inline-flex items-center justify-center rounded-lg bg-fd-primary text-fd-primary-foreground px-6 py-2.5 text-sm font-medium transition-colors hover:opacity-90"
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{
+        background: 'var(--enbox-gray-900)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+      }}
+    >
+      <div
+        className="flex items-center justify-between px-4 py-3"
+        style={{
+          borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
+          background: 'var(--enbox-gray-850)',
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1.5">
+            <span className="w-2.5 h-2.5 rounded-full" style={{ background: '#ff5f57' }} />
+            <span className="w-2.5 h-2.5 rounded-full" style={{ background: '#febc2e' }} />
+            <span className="w-2.5 h-2.5 rounded-full" style={{ background: '#28c840' }} />
+          </div>
+          {filename && (
+            <span className="ml-2 font-mono text-xs" style={{ color: 'var(--enbox-gray-400)' }}>
+              {filename}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className="font-mono text-xs uppercase tracking-wider"
+            style={{ color: 'var(--enbox-gray-500)', letterSpacing: '0.04em' }}
           >
-            Get Started
-          </Link>
-          <a
-            href="https://github.com/enboxorg/enbox"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center rounded-lg border border-fd-border px-6 py-2.5 text-sm font-medium transition-colors hover:bg-fd-accent"
-          >
-            GitHub
-          </a>
+            {language}
+          </span>
+          <CopyButton text={children} />
         </div>
       </div>
-
-      {/* Install */}
-      <div className="w-full max-w-lg pb-12">
-        <pre className="rounded-xl border border-fd-border bg-fd-card px-5 py-4 text-sm font-mono text-fd-card-foreground overflow-x-auto">
-          <span className="text-fd-muted-foreground select-none">$ </span>npm install @enbox/api @enbox/auth
+      <div className="p-6 overflow-x-auto">
+        <pre
+          className="font-mono text-sm leading-relaxed m-0"
+          style={{ background: 'transparent', border: 'none', color: 'var(--enbox-gray-100)' }}
+        >
+          {children}
         </pre>
       </div>
+    </div>
+  );
+}
 
-      {/* Code example */}
-      <div className="w-full max-w-2xl pb-16">
-        <div className="rounded-xl border border-fd-border bg-fd-card overflow-hidden">
-          <div className="px-5 py-3 border-b border-fd-border">
-            <span className="text-xs font-mono text-fd-muted-foreground">example.ts</span>
+/* ------------------------------------------------------------------ */
+/* Feature card — design system card pattern                           */
+/* ------------------------------------------------------------------ */
+function FeatureCard({ title, description }: { title: string; description: string }) {
+  return (
+    <div
+      className="flex flex-col gap-4 p-8 rounded-2xl transition-all duration-200"
+      style={{
+        background: 'var(--enbox-gray-900)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.borderColor = 'rgba(255, 255, 255, 0.10)';
+        e.currentTarget.style.boxShadow = '0 4px 24px rgba(0, 0, 0, 0.3)';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.borderColor = 'rgba(255, 255, 255, 0.06)';
+        e.currentTarget.style.boxShadow = 'none';
+      }}
+    >
+      <h3 className="text-lg font-semibold" style={{ color: 'var(--enbox-gray-50)' }}>{title}</h3>
+      <p className="text-base leading-relaxed" style={{ color: 'var(--enbox-gray-300)' }}>{description}</p>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Main page                                                           */
+/* ------------------------------------------------------------------ */
+export default function HomePage() {
+  return (
+    <div className="flex flex-col items-center flex-1">
+
+      {/* ---- Hero ---- */}
+      <section className="relative w-full flex flex-col items-center text-center pt-4 pb-8">
+        <div className="flex flex-col items-center gap-6 w-full" style={{ maxWidth: '1080px', padding: '0 clamp(1.25rem, 5vw, 3rem)' }}>
+
+          {/* Mark */}
+          <div className="flex justify-center mb-4 pt-12">
+            <EnboxMark size={64} />
           </div>
-          <pre className="px-5 py-4 text-sm font-mono text-fd-card-foreground overflow-x-auto leading-relaxed">
-{`import { AuthManager } from '@enbox/auth';
-import { Enbox, defineProtocol } from '@enbox/api';
+
+          {/* Title */}
+          <h1
+            className="font-bold tracking-tight"
+            style={{
+              fontSize: 'clamp(3rem, 6vw, 3.75rem)',
+              lineHeight: '1.15',
+              color: 'var(--enbox-gray-50)',
+              maxWidth: '16ch',
+              margin: '0 auto',
+            }}
+          >
+            en<span className="font-extrabold">b</span>ox
+          </h1>
+
+          {/* Subtitle */}
+          <p
+            className="leading-snug"
+            style={{
+              fontSize: 'clamp(1.125rem, 2.5vw, 1.3125rem)',
+              color: 'var(--enbox-gray-300)',
+              maxWidth: '52ch',
+              margin: '0 auto',
+            }}
+          >
+            A TypeScript SDK for decentralised identity and personal data storage.
+            Your users own their data. You build the experience.
+          </p>
+
+          {/* Actions */}
+          <div className="flex items-center justify-center gap-4 flex-wrap mt-2">
+            <Link
+              href="/docs"
+              className="inline-flex items-center justify-center gap-2 rounded-full text-sm font-medium no-underline whitespace-nowrap transition-all duration-200"
+              style={{
+                padding: '12px 32px',
+                background: 'var(--enbox-white)',
+                color: 'var(--enbox-gray-950)',
+                border: '1px solid var(--enbox-white)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.transform = 'translateY(-1px)';
+                e.currentTarget.style.boxShadow = '0 4px 16px rgba(255, 255, 255, 0.15)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = 'translateY(0)';
+                e.currentTarget.style.boxShadow = 'none';
+              }}
+            >
+              Get Started
+            </Link>
+            <a
+              href="https://github.com/enboxorg/enbox"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 rounded-full text-sm font-medium no-underline whitespace-nowrap transition-all duration-200"
+              style={{
+                padding: '12px 32px',
+                background: 'transparent',
+                color: 'var(--enbox-gray-50)',
+                border: '1px solid rgba(255, 255, 255, 0.16)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'var(--enbox-gray-850)';
+                e.currentTarget.style.transform = 'translateY(-1px)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'transparent';
+                e.currentTarget.style.transform = 'translateY(0)';
+              }}
+            >
+              GitHub
+            </a>
+          </div>
+
+          {/* Install bar */}
+          <div className="mt-4">
+            <InstallBar command="bun add @enbox/api" />
+          </div>
+
+          {/* Bun note */}
+          <p className="flex items-center gap-1.5 text-xs" style={{ color: 'var(--enbox-gray-500)' }}>
+            Built with <BunLogo size={14} /> Bun
+          </p>
+        </div>
+      </section>
+
+      {/* ---- Code example ---- */}
+      <section
+        className="w-full flex justify-center"
+        style={{ padding: 'var(--enbox-section-padding, 48px) clamp(1.25rem, 5vw, 3rem)' }}
+      >
+        <div className="w-full" style={{ maxWidth: '720px' }}>
+          <CodeBlock language="ts" filename="example.ts">
+{`import { Enbox, defineProtocol } from '@enbox/api';
 
 // Define a typed protocol
 const Notes = defineProtocol({
   protocol:  'https://example.com/notes',
   published: true,
-  types:     { note: { schema: 'https://example.com/note', dataFormats: ['application/json'] } },
+  types: {
+    note: {
+      schema:      'https://example.com/note',
+      dataFormats: ['application/json'],
+    },
+  },
   structure: { note: {} },
 });
 
-// Authenticate and connect
-const auth = await AuthManager.create();
-const session = await auth.connect();
-const enbox = Enbox.connect({ session });
-
-// Full CRUD with type safety
+// Connect to an Enbox instance
+const enbox = Enbox.connect({ agent, connectedDid: did });
 const notes = enbox.using(Notes);
 await notes.configure();
 
@@ -98,49 +323,62 @@ const { record } = await notes.records.create('note', {
 });
 
 // Read
-const text = await record.data.json();
+const data = await record.data.json();
 
 // Update
-await record.update({ data: { title: 'Updated note', body: 'Changed.' } });
+await record.update({
+  data: { title: 'Updated note', body: 'Changed.' },
+});
 
 // Query
 const { records } = await notes.records.query('note');
 
 // Delete
 await record.delete();`}
-          </pre>
+          </CodeBlock>
         </div>
+      </section>
+
+      {/* ---- Section divider ---- */}
+      <div className="w-full" style={{ maxWidth: '1080px', padding: '0 clamp(1.25rem, 5vw, 3rem)' }}>
+        <div style={{ borderTop: '1px solid rgba(255, 255, 255, 0.06)' }} />
       </div>
 
-      {/* Features */}
-      <div className="w-full max-w-3xl pb-24">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          <FeatureCard
-            title="Decentralised Identity"
-            description="DID-based identity that users own. No central account server. Supports did:dht, did:jwk, did:key, and did:web."
-          />
-          <FeatureCard
-            title="Personal Data Vaults"
-            description="Data stored in Decentralized Web Nodes. Users choose where their data lives. Sync across devices automatically."
-          />
-          <FeatureCard
-            title="Type-Safe Protocols"
-            description="Define DWN protocols with TypeScript types. Compile-time checks for paths, schemas, and record data."
-          />
-          <FeatureCard
-            title="End-to-End Encryption"
-            description="Records encrypted with ECDH-ES+A256KW key agreement and AES-256-GCM content encryption. Per-protocol encryption policies."
-          />
-          <FeatureCard
-            title="Multi-Identity"
-            description="Multiple identities in a single vault. Switch between them, export for backup, recover from a 12-word phrase."
-          />
-          <FeatureCard
-            title="Self-Hostable Server"
-            description="Run your own DWN server with PostgreSQL, MySQL, or SQLite. Rate limiting, quotas, admin dashboard included."
-          />
+      {/* ---- Features ---- */}
+      <section
+        className="w-full flex justify-center"
+        style={{ padding: '80px clamp(1.25rem, 5vw, 3rem)' }}
+      >
+        <div className="w-full" style={{ maxWidth: '1080px' }}>
+          <div className="grid gap-6" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))' }}>
+            <FeatureCard
+              title="Decentralised Identity"
+              description="DID-based identity that users own. No central account server. Supports did:dht, did:jwk, did:key, and did:web."
+            />
+            <FeatureCard
+              title="Personal Data Vaults"
+              description="Data stored in Decentralised Web Nodes. Users choose where their data lives. Sync across devices automatically."
+            />
+            <FeatureCard
+              title="Type-Safe Protocols"
+              description="Define DWN protocols with TypeScript types. Compile-time checks for paths, schemas, and record data."
+            />
+            <FeatureCard
+              title="End-to-End Encryption"
+              description="Records encrypted with ECDH key agreement and AES-256-GCM content encryption. Per-protocol encryption policies."
+            />
+            <FeatureCard
+              title="Real-Time Subscriptions"
+              description="LiveQuery provides an initial snapshot plus deduplicated change events. Connection lifecycle built in."
+            />
+            <FeatureCard
+              title="Self-Hostable Server"
+              description="Run your own DWN server with PostgreSQL, MySQL, or SQLite. Rate limiting, quotas, and admin dashboard included."
+            />
+          </div>
         </div>
-      </div>
+      </section>
+
     </div>
   );
 }

--- a/apps/docs/src/app/docs/layout.tsx
+++ b/apps/docs/src/app/docs/layout.tsx
@@ -4,7 +4,11 @@ import { baseOptions } from '@/lib/layout.shared';
 
 export default function Layout({ children }: LayoutProps<'/docs'>) {
   return (
-    <DocsLayout tree={source.getPageTree()} {...baseOptions()}>
+    <DocsLayout
+      tree={source.getPageTree()}
+      sidebar={{ collapsible: false }}
+      {...baseOptions()}
+    >
       {children}
     </DocsLayout>
   );

--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -105,3 +105,17 @@
 [data-theme="light"] ::-webkit-scrollbar-thumb {
   background: var(--enbox-gray-300);
 }
+
+/* ---- Sidebar refinements ---- */
+#nd-sidebar {
+  transition: width 250ms ease;
+}
+
+/* Reduce sidebar border weight to match design system --border-subtle */
+#nd-sidebar {
+  border-color: rgba(255, 255, 255, 0.06);
+}
+.light #nd-sidebar,
+[data-theme="light"] #nd-sidebar {
+  border-color: rgba(80, 60, 30, 0.06);
+}


### PR DESCRIPTION
## Summary

Follow-up to #672. Aligns the docs site more closely with the Enbox design system, switches to bun-first messaging, and refocuses the quick start on `@enbox/api`.

- **Landing page redesigned** to follow the design system strictly: pill-shaped install bar with copy button, terminal-style code block with window dots and language badge, feature cards with proper surface colours and hover transitions, pill-shaped buttons with hover lift, correct typography scale and spacing
- **Bun-first**: all install commands switched from `npm install` to `bun add`, Bun logo added to landing page
- **Quick start refocused on `@enbox/api`**: primary pattern is `Enbox.connect({ agent, connectedDid })`, `@enbox/auth` shown as optional alternative
- **Sidebar fix**: disabled collapsible mode to eliminate awkward margin and floating button positioning when collapsed; border refined to match `--border-subtle`

Build verified: `bun run docs:build` passes (45 static pages).