### PR TITLE
docs: fix Bun contrast, widen layout, auto-configure

### DIFF
--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -51,10 +51,9 @@ import { Enbox } from '@enbox/api';
 
 const enbox = Enbox.connect({ agent, connectedDid: did });
 const tasks = enbox.using(TaskProtocol);
-await tasks.configure();
 ```
 
-`Enbox.connect()` takes an `agent` and `connectedDid` — the agent manages signing keys and DWN sync, while `connectedDid` is the user's DID. If you use `@enbox/auth`, you can pass the session directly:
+`Enbox.connect()` takes an `agent` and `connectedDid` — the agent manages signing keys and DWN sync, while `connectedDid` is the user's DID. The protocol is automatically configured on the first operation. If you use `@enbox/auth`, you can pass the session directly:
 
 ```ts
 const enbox = Enbox.connect({ session });

--- a/apps/docs/content/docs/packages/api.mdx
+++ b/apps/docs/content/docs/packages/api.mdx
@@ -82,14 +82,14 @@ const tasks = enbox.using(TaskProtocol);
 
 Instances are **cached by protocol URI** — calling `using()` multiple times with the same protocol returns the same instance.
 
-Before performing record operations, call `configure()` to install the protocol on the local DWN:
+`TypedEnbox` **auto-configures** the protocol on the first record operation — it queries the local DWN for an existing installation and installs one if needed. You can start using records immediately without any setup step.
+
+If you need explicit control (for example, to check the status code or to pre-install before any reads), call `configure()` manually:
 
 ```ts
 const { status } = await tasks.configure();
 // status.code: 200 (already installed) or 202 (newly installed)
 ```
-
-If you skip `configure()`, `TypedEnbox` will **auto-configure** on the first record operation by querying for an existing installation and installing if needed.
 
 ### TypedEnbox.records
 
@@ -387,7 +387,6 @@ const NotebookProtocol = defineProtocol({
 });
 
 const notebooks = enbox.using(NotebookProtocol);
-await notebooks.configure();
 
 // Create a parent
 const { record: notebook } = await notebooks.records.create('notebook', {

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -284,8 +284,8 @@ export default function HomePage() {
           </div>
 
           {/* Bun note */}
-          <p className="flex items-center gap-1.5 text-xs" style={{ color: 'var(--enbox-gray-500)' }}>
-            Built with <BunLogo size={14} /> Bun
+          <p className="flex items-center gap-2 text-sm font-medium" style={{ color: 'var(--enbox-gray-300)' }}>
+            Built with <BunLogo size={20} /> Bun
           </p>
         </div>
       </section>
@@ -312,10 +312,9 @@ const Notes = defineProtocol({
   structure: { note: {} },
 });
 
-// Connect to an Enbox instance
+// Connect and use the protocol
 const enbox = Enbox.connect({ agent, connectedDid: did });
 const notes = enbox.using(Notes);
-await notes.configure();
 
 // Create
 const { record } = await notes.records.create('note', {

--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -73,9 +73,9 @@
   --color-fd-ring: var(--enbox-gray-400);
 }
 
-/* ---- Layout width (match Enbox content-width) ---- */
+/* ---- Layout width ---- */
 :root {
-  --fd-layout-width: 1080px;
+  --fd-layout-width: 1400px;
 }
 
 /* ---- Selection ---- */

--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
     },
     "packages/api": {
       "name": "@enbox/api",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@enbox/agent": "workspace:*",
         "@enbox/auth": "workspace:*",
@@ -110,7 +110,7 @@
     },
     "packages/auth": {
       "name": "@enbox/auth",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@enbox/agent": "workspace:*",
         "@enbox/common": "workspace:*",
@@ -424,7 +424,7 @@
     },
     "packages/protocols": {
       "name": "@enbox/protocols",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@enbox/api": "workspace:*",
         "@enbox/dwn-sdk-js": "workspace:*",


### PR DESCRIPTION
## Summary

- Fix "Built with Bun" text contrast: changed from `--gray-500` (text-ghost — design system violation) to `--gray-300` (text-secondary), increased size from `text-xs` to `text-sm`
- Widen `--fd-layout-width` from `1080px` to `1400px` to fix excessive left margin on wider screens
- Remove `configure()` from landing page, introduction quick start, and `@enbox/api` hierarchical records example — `TypedEnbox` auto-configures on the first record operation
- Rewrite the `configure()` section in `@enbox/api` docs to lead with auto-configure as the default behaviour, with explicit `configure()` as an optional escape hatch