### PR TITLE
feat(auth): built-in registration token persistence (#690)

### DIFF
--- a/packages/auth/src/flows/dwn-registration.ts
+++ b/packages/auth/src/flows/dwn-registration.ts
@@ -15,9 +15,12 @@ import type { EnboxUserAgent } from '@enbox/agent';
 
 import { DwnRegistrar } from '@enbox/dwn-clients';
 
+import { STORAGE_KEYS } from '../types.js';
+
 import type {
   RegistrationOptions,
   RegistrationTokenData,
+  StorageAdapter,
 } from '../types.js';
 
 /** @internal */
@@ -33,6 +36,12 @@ export interface RegistrationContext {
 
   /** The connected DID URI (the identity's DID). */
   connectedDid: string;
+
+  /**
+   * Storage adapter for automatic token persistence.
+   * Only used when `registration.persistTokens` is `true`.
+   */
+  storage?: StorageAdapter;
 }
 
 /**
@@ -51,11 +60,19 @@ export async function registerWithDwnEndpoints(
   ctx: RegistrationContext,
   registration: RegistrationOptions,
 ): Promise<void> {
-  const { userAgent, dwnEndpoints, agentDid, connectedDid } = ctx;
+  const { userAgent, dwnEndpoints, agentDid, connectedDid, storage } = ctx;
 
-  const updatedTokens: Record<string, RegistrationTokenData> = {
-    ...(registration.registrationTokens ?? {}),
-  };
+  // Load initial tokens: when persistTokens is enabled, load from storage
+  // (ignoring any explicit registrationTokens). Otherwise use the explicit map.
+  let seedTokens: Record<string, RegistrationTokenData> = {};
+
+  if (registration.persistTokens && storage) {
+    seedTokens = await loadTokensFromStorage(storage);
+  } else {
+    seedTokens = registration.registrationTokens ?? {};
+  }
+
+  const updatedTokens: Record<string, RegistrationTokenData> = { ...seedTokens };
 
   try {
     for (const dwnEndpoint of dwnEndpoints) {
@@ -145,7 +162,12 @@ export async function registerWithDwnEndpoints(
       }
     }
 
-    // Notify app of updated tokens for persistence.
+    // Persist tokens to storage when auto-persistence is enabled.
+    if (registration.persistTokens && storage) {
+      await saveTokensToStorage(storage, updatedTokens);
+    }
+
+    // Notify app of updated tokens (always, even when auto-persisting).
     if (registration.onRegistrationTokens) {
       registration.onRegistrationTokens(updatedTokens);
     }
@@ -154,4 +176,37 @@ export async function registerWithDwnEndpoints(
   } catch (error: unknown) {
     registration.onFailure(error);
   }
+}
+
+// ─── Storage helpers ──────────────────────────────────────────────
+
+/**
+ * Load registration tokens from a `StorageAdapter`.
+ *
+ * Returns an empty record if no tokens are stored or the stored value
+ * is corrupt (best-effort — never throws).
+ *
+ * @internal
+ */
+export async function loadTokensFromStorage(
+  storage: StorageAdapter,
+): Promise<Record<string, RegistrationTokenData>> {
+  try {
+    const raw = await storage.get(STORAGE_KEYS.REGISTRATION_TOKENS);
+    if (!raw) { return {}; }
+    return JSON.parse(raw) as Record<string, RegistrationTokenData>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Save registration tokens to a `StorageAdapter`.
+ * @internal
+ */
+export async function saveTokensToStorage(
+  storage: StorageAdapter,
+  tokens: Record<string, RegistrationTokenData>,
+): Promise<void> {
+  await storage.set(STORAGE_KEYS.REGISTRATION_TOKENS, JSON.stringify(tokens));
 }

--- a/packages/auth/src/flows/import-identity.ts
+++ b/packages/auth/src/flows/import-identity.ts
@@ -105,6 +105,7 @@ export async function importFromPhrase(
         dwnEndpoints,
         agentDid  : userAgent.agentDid.uri,
         connectedDid,
+        storage   : storage,
       },
       ctx.registration,
     );
@@ -174,6 +175,7 @@ export async function importFromPortable(
         dwnEndpoints,
         agentDid  : userAgent.agentDid.uri,
         connectedDid,
+        storage   : storage,
       },
       ctx.registration,
     );

--- a/packages/auth/src/flows/local-connect.ts
+++ b/packages/auth/src/flows/local-connect.ts
@@ -134,6 +134,7 @@ export async function localConnect(
         dwnEndpoints,
         agentDid  : userAgent.agentDid.uri,
         connectedDid,
+        storage   : storage,
       },
       ctx.registration,
     );

--- a/packages/auth/src/flows/wallet-connect.ts
+++ b/packages/auth/src/flows/wallet-connect.ts
@@ -147,6 +147,7 @@ export async function walletConnect(
           dwnEndpoints,
           agentDid  : userAgent.agentDid.uri,
           connectedDid,
+          storage   : storage,
         },
         ctx.registration,
       );

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -51,6 +51,9 @@ export { EnboxUserAgent, HdIdentityVault } from '@enbox/agent';
 // Wallet-connect helpers
 export { processConnectedGrants } from './flows/wallet-connect.js';
 
+// Registration token storage helpers
+export { loadTokensFromStorage, saveTokensToStorage } from './flows/dwn-registration.js';
+
 // Local DWN discovery (browser dwn:// protocol integration)
 export {
   applyLocalDwnDiscovery,

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -168,14 +168,46 @@ export interface RegistrationOptions {
    * Pre-existing registration tokens from a previous session, keyed by
    * DWN endpoint URL. If a valid (non-expired) token exists for an
    * endpoint, it is used directly without re-running the auth flow.
+   *
+   * When {@link persistTokens} is `true`, this field is ignored —
+   * tokens are loaded automatically from the `StorageAdapter`.
    */
   registrationTokens?: Record<string, RegistrationTokenData>;
 
   /**
    * Called when new or refreshed registration tokens are obtained.
    * The app should persist these for future sessions.
+   *
+   * When {@link persistTokens} is `true`, tokens are saved automatically
+   * to the `StorageAdapter`. This callback is still invoked (if provided)
+   * **after** the automatic save, so consumers can observe token changes
+   * without handling persistence themselves.
    */
   onRegistrationTokens?: (tokens: Record<string, RegistrationTokenData>) => void;
+
+  /**
+   * Automatically persist and restore registration tokens using the
+   * auth manager's `StorageAdapter`.
+   *
+   * When `true`, tokens are loaded from storage before registration and
+   * saved back after new or refreshed tokens are obtained. This removes
+   * the need for consumers to implement their own token I/O via
+   * {@link registrationTokens} and {@link onRegistrationTokens}.
+   *
+   * Defaults to `false` for backward compatibility.
+   *
+   * @example
+   * ```ts
+   * const auth = await AuthManager.create({
+   *   registration: {
+   *     onSuccess: () => {},
+   *     onFailure: (err) => console.error(err),
+   *     persistTokens: true,
+   *   },
+   * });
+   * ```
+   */
+  persistTokens?: boolean;
 }
 
 /** Options for {@link AuthManager.create}. */
@@ -457,4 +489,13 @@ export const STORAGE_KEYS = {
    * @see https://github.com/enboxorg/enbox/issues/589
    */
   LOCAL_DWN_ENDPOINT: 'enbox:auth:localDwnEndpoint',
+
+  /**
+   * JSON-serialised `Record<string, RegistrationTokenData>` for DWN endpoint
+   * registration tokens. Automatically loaded before registration and saved
+   * after new/refreshed tokens are obtained when `persistTokens` is enabled.
+   *
+   * @see https://github.com/enboxorg/enbox/issues/690
+   */
+  REGISTRATION_TOKENS: 'enbox:auth:registrationTokens',
 } as const;

--- a/packages/auth/tests/dwn-registration.spec.ts
+++ b/packages/auth/tests/dwn-registration.spec.ts
@@ -1,7 +1,14 @@
 import { describe, expect, mock, test } from 'bun:test';
 
 import { createMockAgent } from './helpers/mock-agent.js';
-import { registerWithDwnEndpoints } from '../src/flows/dwn-registration.js';
+import { MemoryStorage } from '../src/storage/storage.js';
+import { STORAGE_KEYS } from '../src/types.js';
+
+import {
+  loadTokensFromStorage,
+  registerWithDwnEndpoints,
+  saveTokensToStorage,
+} from '../src/flows/dwn-registration.js';
 
 import type { RegistrationTokenData } from '../src/types.js';
 
@@ -559,5 +566,396 @@ describe('registerWithDwnEndpoints', () => {
     // Should use the existing token
     expect(mockRegisterTenantWithToken.mock.calls.length).toBe(1);
     expect(mockRegisterTenantWithToken.mock.calls[0][2]).toBe('no-expiry-token');
+  });
+});
+
+// ─── Token Storage Helpers ───────────────────────────────────────
+
+describe('loadTokensFromStorage', () => {
+  test('returns empty record when no tokens are stored', async () => {
+    const storage = new MemoryStorage();
+    const tokens = await loadTokensFromStorage(storage);
+    expect(tokens).toEqual({});
+  });
+
+  test('parses stored JSON tokens', async () => {
+    const storage = new MemoryStorage();
+    const expected: Record<string, RegistrationTokenData> = {
+      'https://dwn1.example.com': {
+        registrationToken : 'tok-1',
+        tokenUrl          : 'https://auth.example.com/token',
+        expiresAt         : Date.now() + 60_000,
+      },
+    };
+    await storage.set(STORAGE_KEYS.REGISTRATION_TOKENS, JSON.stringify(expected));
+
+    const tokens = await loadTokensFromStorage(storage);
+    expect(tokens).toEqual(expected);
+  });
+
+  test('returns empty record when stored value is corrupt JSON', async () => {
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.REGISTRATION_TOKENS, '{bad json!!!');
+
+    const tokens = await loadTokensFromStorage(storage);
+    expect(tokens).toEqual({});
+  });
+
+  test('returns empty record when storage.get throws', async () => {
+    const storage = new MemoryStorage();
+    storage.get = async (): Promise<string | null> => { throw new Error('disk error'); };
+
+    const tokens = await loadTokensFromStorage(storage);
+    expect(tokens).toEqual({});
+  });
+});
+
+describe('saveTokensToStorage', () => {
+  test('serialises tokens to JSON in storage', async () => {
+    const storage = new MemoryStorage();
+    const tokens: Record<string, RegistrationTokenData> = {
+      'https://dwn1.example.com': {
+        registrationToken : 'tok-1',
+        refreshToken      : 'ref-1',
+        tokenUrl          : 'https://auth.example.com/token',
+        refreshUrl        : 'https://auth.example.com/refresh',
+        expiresAt         : 1_700_000_000_000,
+      },
+    };
+
+    await saveTokensToStorage(storage, tokens);
+
+    const raw = await storage.get(STORAGE_KEYS.REGISTRATION_TOKENS);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toEqual(tokens);
+  });
+
+  test('overwrites previously stored tokens', async () => {
+    const storage = new MemoryStorage();
+    await saveTokensToStorage(storage, {
+      'https://old.example.com': {
+        registrationToken : 'old-tok',
+        tokenUrl          : 'https://old.example.com/token',
+      },
+    });
+
+    const newTokens: Record<string, RegistrationTokenData> = {
+      'https://new.example.com': {
+        registrationToken : 'new-tok',
+        tokenUrl          : 'https://new.example.com/token',
+      },
+    };
+    await saveTokensToStorage(storage, newTokens);
+
+    const raw = await storage.get(STORAGE_KEYS.REGISTRATION_TOKENS);
+    expect(JSON.parse(raw!)).toEqual(newTokens);
+  });
+});
+
+// ─── persistTokens Integration ───────────────────────────────────
+
+describe('registerWithDwnEndpoints with persistTokens', () => {
+  test('loads tokens from storage when persistTokens is true', async () => {
+    mockRegisterTenantWithToken.mockClear();
+    mockExchangeAuthCode.mockClear();
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['provider-auth-v0'],
+        providerAuth             : {
+          authorizeUrl : 'https://auth.example.com/authorize',
+          tokenUrl     : 'https://auth.example.com/token',
+        },
+        maxFileSize: 10_000_000,
+      }),
+    });
+
+    // Pre-populate storage with a valid token.
+    const storage = new MemoryStorage();
+    const storedTokens: Record<string, RegistrationTokenData> = {
+      'https://dwn1.example.com': {
+        registrationToken : 'stored-token',
+        tokenUrl          : 'https://auth.example.com/token',
+        expiresAt         : Date.now() + 60_000,
+      },
+    };
+    await storage.set(STORAGE_KEYS.REGISTRATION_TOKENS, JSON.stringify(storedTokens));
+
+    let successCalled = false;
+    const authCallCount = { value: 0 };
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        storage,
+      },
+      {
+        onSuccess              : () => { successCalled = true; },
+        onFailure              : () => {},
+        onProviderAuthRequired : async (params) => {
+          authCallCount.value++;
+          return { code: 'code', state: params.state };
+        },
+        persistTokens: true,
+      },
+    );
+
+    expect(successCalled).toBe(true);
+    // Should NOT have run the auth flow — used stored token
+    expect(authCallCount.value).toBe(0);
+    expect(mockExchangeAuthCode.mock.calls.length).toBe(0);
+    // Should have registered using the stored token
+    expect(mockRegisterTenantWithToken.mock.calls.length).toBe(2);
+    expect(mockRegisterTenantWithToken.mock.calls[0][2]).toBe('stored-token');
+  });
+
+  test('saves new tokens to storage after registration', async () => {
+    mockRegisterTenantWithToken.mockClear();
+    mockExchangeAuthCode.mockClear();
+    mockExchangeAuthCode.mockImplementation(async () => ({
+      registrationToken : 'fresh-token',
+      refreshToken      : 'fresh-refresh',
+      expiresIn         : 7200,
+    }));
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['provider-auth-v0'],
+        providerAuth             : {
+          authorizeUrl : 'https://auth.example.com/authorize',
+          tokenUrl     : 'https://auth.example.com/token',
+          refreshUrl   : 'https://auth.example.com/refresh',
+        },
+        maxFileSize: 10_000_000,
+      }),
+    });
+
+    const storage = new MemoryStorage();
+    let successCalled = false;
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        storage,
+      },
+      {
+        onSuccess              : () => { successCalled = true; },
+        onFailure              : () => {},
+        onProviderAuthRequired : async (params) => ({
+          code: 'auth-code', state: params.state,
+        }),
+        persistTokens: true,
+      },
+    );
+
+    expect(successCalled).toBe(true);
+
+    // Verify tokens were persisted to storage.
+    const raw = await storage.get(STORAGE_KEYS.REGISTRATION_TOKENS);
+    expect(raw).not.toBeNull();
+    const persisted = JSON.parse(raw!) as Record<string, RegistrationTokenData>;
+    expect(persisted['https://dwn1.example.com']).toBeDefined();
+    expect(persisted['https://dwn1.example.com'].registrationToken).toBe('fresh-token');
+    expect(persisted['https://dwn1.example.com'].refreshToken).toBe('fresh-refresh');
+    expect(persisted['https://dwn1.example.com'].tokenUrl).toBe('https://auth.example.com/token');
+    expect(persisted['https://dwn1.example.com'].refreshUrl).toBe('https://auth.example.com/refresh');
+  });
+
+  test('still invokes onRegistrationTokens callback when persistTokens is true', async () => {
+    mockRegisterTenant.mockClear();
+    mockRegisterTenant.mockImplementation(async () => {});
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['proof-of-work-sha256-v0'],
+        maxFileSize              : 10_000_000,
+      }),
+    });
+
+    const storage = new MemoryStorage();
+    let callbackTokens: Record<string, RegistrationTokenData> | undefined;
+    let successCalled = false;
+
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        storage,
+      },
+      {
+        onSuccess            : () => { successCalled = true; },
+        onFailure            : () => {},
+        onRegistrationTokens : (tokens) => { callbackTokens = tokens; },
+        persistTokens        : true,
+      },
+    );
+
+    expect(successCalled).toBe(true);
+    // The callback should still be invoked
+    expect(callbackTokens).toBeDefined();
+  });
+
+  test('ignores explicit registrationTokens when persistTokens is true', async () => {
+    mockRegisterTenantWithToken.mockClear();
+    mockExchangeAuthCode.mockClear();
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['provider-auth-v0'],
+        providerAuth             : {
+          authorizeUrl : 'https://auth.example.com/authorize',
+          tokenUrl     : 'https://auth.example.com/token',
+        },
+        maxFileSize: 10_000_000,
+      }),
+    });
+
+    // Storage has a different token than the explicit one.
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.REGISTRATION_TOKENS, JSON.stringify({
+      'https://dwn1.example.com': {
+        registrationToken : 'from-storage',
+        tokenUrl          : 'https://auth.example.com/token',
+        expiresAt         : Date.now() + 60_000,
+      },
+    }));
+
+    let successCalled = false;
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        storage,
+      },
+      {
+        onSuccess              : () => { successCalled = true; },
+        onFailure              : () => {},
+        onProviderAuthRequired : async (params) => ({
+          code: 'code', state: params.state,
+        }),
+        // This should be ignored when persistTokens is true
+        registrationTokens: {
+          'https://dwn1.example.com': {
+            registrationToken : 'from-explicit',
+            tokenUrl          : 'https://auth.example.com/token',
+            expiresAt         : Date.now() + 60_000,
+          },
+        },
+        persistTokens: true,
+      },
+    );
+
+    expect(successCalled).toBe(true);
+    // Should have used the token from storage, not the explicit one
+    expect(mockRegisterTenantWithToken.mock.calls[0][2]).toBe('from-storage');
+  });
+
+  test('does not save to storage when persistTokens is false', async () => {
+    mockRegisterTenant.mockClear();
+    mockRegisterTenant.mockImplementation(async () => {});
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['proof-of-work-sha256-v0'],
+        maxFileSize              : 10_000_000,
+      }),
+    });
+
+    const storage = new MemoryStorage();
+    let successCalled = false;
+
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        storage,
+      },
+      {
+        onSuccess     : () => { successCalled = true; },
+        onFailure     : () => {},
+        persistTokens : false,
+      },
+    );
+
+    expect(successCalled).toBe(true);
+    // Storage should be empty — no auto-save
+    const raw = await storage.get(STORAGE_KEYS.REGISTRATION_TOKENS);
+    expect(raw).toBeNull();
+  });
+
+  test('does not save to storage when persistTokens is true but no storage provided', async () => {
+    mockRegisterTenant.mockClear();
+    mockRegisterTenant.mockImplementation(async () => {});
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['proof-of-work-sha256-v0'],
+        maxFileSize              : 10_000_000,
+      }),
+    });
+
+    let successCalled = false;
+
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        // No storage provided
+      },
+      {
+        onSuccess     : () => { successCalled = true; },
+        onFailure     : () => {},
+        persistTokens : true,
+      },
+    );
+
+    // Should still succeed — just without persistence
+    expect(successCalled).toBe(true);
+  });
+
+  test('handles storage load failure gracefully during registration', async () => {
+    mockRegisterTenant.mockClear();
+    mockRegisterTenant.mockImplementation(async () => {});
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['proof-of-work-sha256-v0'],
+        maxFileSize              : 10_000_000,
+      }),
+    });
+
+    const storage = new MemoryStorage();
+    storage.get = async (): Promise<string | null> => { throw new Error('disk read error'); };
+
+    let successCalled = false;
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        storage,
+      },
+      {
+        onSuccess     : () => { successCalled = true; },
+        onFailure     : () => {},
+        persistTokens : true,
+      },
+    );
+
+    // Should still succeed — loadTokensFromStorage returns {} on error
+    expect(successCalled).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add `persistTokens` option to `RegistrationOptions` that automatically loads and saves registration tokens via the auth `StorageAdapter`, removing the need for consumers to implement their own token I/O
- Add `REGISTRATION_TOKENS` key to `STORAGE_KEYS` (`enbox:auth:registrationTokens`)
- Export `loadTokensFromStorage()` / `saveTokensToStorage()` helpers for advanced consumers

## How it works

When `persistTokens: true` is set in registration options:

1. **Before registration:** tokens are loaded from `StorageAdapter.get('enbox:auth:registrationTokens')` (ignoring any explicit `registrationTokens` map)
2. **After registration:** updated tokens are saved via `StorageAdapter.set()` with JSON serialisation
3. The `onRegistrationTokens` callback is still invoked after the automatic save, so consumers can observe changes without handling persistence

```ts
const auth = await AuthManager.create({
  registration: {
    onSuccess: () => {},
    onFailure: (err) => console.error(err),
    persistTokens: true, // uses auth's StorageAdapter automatically
  },
});
```

## Changes

| File | Change |
|---|---|
| `types.ts` | Add `persistTokens` to `RegistrationOptions`, add `REGISTRATION_TOKENS` to `STORAGE_KEYS` |
| `dwn-registration.ts` | Auto-load/save tokens via `StorageAdapter`, add `storage` to `RegistrationContext`, export `loadTokensFromStorage`/`saveTokensToStorage` |
| `local-connect.ts` | Pass `storage` through to `RegistrationContext` |
| `wallet-connect.ts` | Pass `storage` through to `RegistrationContext` |
| `import-identity.ts` | Pass `storage` through to `RegistrationContext` (both flows) |
| `index.ts` | Export storage helpers |
| `dwn-registration.spec.ts` | 13 new tests for storage helpers + `persistTokens` integration |

## Testing

- 302 tests pass, 0 failures
- 98.5% line coverage (threshold: 98%)
- `dwn-registration.ts` at 100% coverage
- Lint clean

Closes #690