### PR TITLE
fix: build packages in topological dependency order

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "bun run clean:modules && bun run clean:data && bun run --filter '*' clean",
     "clean:modules": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
     "clean:data": "rm -rf data/ data-test/ __TESTDATA__/ TEST-DATASTORE TEST-MESSAGESTORE TEST-EVENTLOG TEST-RESUMABLE-TASK-STORE TEST-INDEX BENCHMARK-INDEX BENCHMARK-BLOCK DATASTORE MESSAGESTORE EVENTLOG RESOLVERCACHE RESUMABLE-TASK-STORE INDEX DATA/ && find . -name '*.sqlite' -o -name '*.db' -o -name 'dwn.db' | xargs rm -f",
-    "build": "bun run --filter '!@enbox/docs' build",
+    "build": "./scripts/build.sh",
     "build:ci": "./scripts/ci-setup.sh",
     "test:node": "bun run --filter '!@enbox/docs' test:node",
     "lint": "bun run --filter '!@enbox/docs' lint",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+# Topological build script for the Enbox monorepo.
+#
+# Builds packages in dependency order. Packages at the same level of the
+# dependency graph are built in parallel via `bun run --filter`.
+#
+# Dependency graph (each level depends only on previous levels):
+#
+#   L0: common, protocol-codegen, dwn-server-admin-ui  (no workspace deps)
+#   L1: crypto                                          (common)
+#   L2: dids                                            (common, crypto)
+#   L3: browser, dwn-sdk-js                             (dids | crypto, dids)
+#   L4: dwn-sql-store, dwn-clients                      (dwn-sdk-js | common, crypto, dwn-sdk-js)
+#   L5: agent, dwn-server                               (common, crypto, dids, dwn-clients, dwn-sdk-js | + dwn-sql-store, dwn-server-admin-ui)
+#   L6: auth                                            (agent, common, dids, dwn-clients)
+#   L7: api                                             (agent, auth, common, dwn-clients)
+#   L8: protocols, electrobun-dwn                       (api, dwn-sdk-js | agent, dwn-server)
+
+echo "=== Building packages in dependency order ==="
+
+echo "[L0] common, protocol-codegen, dwn-server-admin-ui"
+bun run --filter '@enbox/common' --filter '@enbox/protocol-codegen' --filter '@enbox/dwn-server-admin-ui' build
+
+echo "[L1] crypto"
+bun run --filter '@enbox/crypto' build
+
+echo "[L2] dids"
+bun run --filter '@enbox/dids' build
+
+echo "[L3] browser, dwn-sdk-js"
+bun run --filter '@enbox/browser' --filter '@enbox/dwn-sdk-js' build
+
+echo "[L4] dwn-sql-store, dwn-clients"
+bun run --filter '@enbox/dwn-sql-store' --filter '@enbox/dwn-clients' build
+
+echo "[L5] agent, dwn-server"
+bun run --filter '@enbox/agent' --filter '@enbox/dwn-server' build
+
+echo "[L6] auth"
+bun run --filter '@enbox/auth' build
+
+echo "[L7] api"
+bun run --filter '@enbox/api' build
+
+echo "[L8] protocols, electrobun-dwn"
+bun run --filter '@enbox/protocols' --filter '@enbox/electrobun-dwn' build
+
+echo "=== All packages built successfully ==="


### PR DESCRIPTION
## Summary

- **`bun run build` was broken** because `bun run --filter` runs all matching packages concurrently without respecting inter-package dependencies, so downstream packages (e.g. `agent`, `api`) would start building before their dependencies (`dwn-sdk-js`, `crypto`, etc.) had finished.
- **Added `scripts/build.sh`** — a topological build script that builds packages in 9 dependency levels. Packages at the same level build in parallel for speed, but each level waits for the previous one to complete:

| Level | Packages |
|-------|----------|
| L0 | `common`, `protocol-codegen`, `dwn-server-admin-ui` |
| L1 | `crypto` |
| L2 | `dids` |
| L3 | `browser`, `dwn-sdk-js` |
| L4 | `dwn-sql-store`, `dwn-clients` |
| L5 | `agent`, `dwn-server` |
| L6 | `auth` |
| L7 | `api` |
| L8 | `protocols`, `electrobun-dwn` |

- **Updated root `package.json`** to point the `build` script at `./scripts/build.sh`.