### PR TITLE
fix: replace rimraf with rm -rf and add clean:all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "apps/docs"
   ],
   "scripts": {
-    "clean": "bun run clean:modules && bun run clean:data && bun run --filter '*' clean",
+    "clean": "bun run --filter '*' clean && bun run clean:modules && bun run clean:data",
     "clean:modules": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
-    "clean:all": "bun run clean && bun pm cache rm && rm -rf .turbo packages/*/.turbo",
+    "clean:all": "find . -name dist -not -path '*/node_modules/*' -type d -exec rm -rf {} + && bun run clean:data && bun run clean:modules && bun pm cache rm && rm -rf .turbo packages/*/.turbo",
     "clean:data": "rm -rf data/ data-test/ __TESTDATA__/ TEST-DATASTORE TEST-MESSAGESTORE TEST-EVENTLOG TEST-RESUMABLE-TASK-STORE TEST-INDEX BENCHMARK-INDEX BENCHMARK-BLOCK DATASTORE MESSAGESTORE EVENTLOG RESOLVERCACHE RESUMABLE-TASK-STORE INDEX DATA/ && find . -name '*.sqlite' -o -name '*.db' -o -name 'dwn.db' | xargs rm -f",
     "build": "turbo run build --filter='!@enbox/docs'",
     "build:ci": "./scripts/ci-setup.sh",


### PR DESCRIPTION
## Summary

- **Replace `rimraf` with `rm -rf` across all 14 packages** — `rimraf` is a cross-platform `rm -rf` for Windows. This project targets Bun on macOS/Linux where `rm -rf` works natively. Removing it eliminates "command not found" errors when `node_modules` symlinks are stale or missing.
- **Fix `clean` script ordering** — the existing `clean` script deleted `node_modules` first, then tried to run each package's `rimraf dist` which failed. Now per-package clean runs before `node_modules` removal.
- **Add `clean:all` script** — full workspace reset: removes all `dist/` outputs, test data, `node_modules` (root + all packages), Bun install/bunx cache, and Turbo cache. Self-contained (no dependency on installed packages).

## Usage

```bash
bun run clean:all   # full reset (works even with no node_modules)
bun i               # fresh install
bun run build       # build from scratch
```
