### PR TITLE
refactor: replace rimraf with rm -rf across all packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,6 @@
         "eventemitter3": "5.0.4",
         "globals": "15.6.0",
         "playwright": "1.45.3",
-        "rimraf": "5.0.7",
         "turbo": "^2.8.13",
         "typescript": "5.5.4",
       },
@@ -76,7 +75,6 @@
         "@vitest/coverage-istanbul": "4.0.18",
         "bun-types": "latest",
         "eslint": "9.7.0",
-        "rimraf": "5.0.7",
         "sinon": "18.0.0",
         "typescript": "5.5.4",
         "vitest": "4.0.18",
@@ -103,7 +101,6 @@
         "@vitest/coverage-istanbul": "4.0.18",
         "bun-types": "latest",
         "eslint": "9.7.0",
-        "rimraf": "5.0.7",
         "sinon": "18.0.0",
         "typescript": "5.5.4",
         "vitest": "4.0.18",
@@ -122,7 +119,6 @@
       "devDependencies": {
         "@types/node": "20.14.8",
         "bun-types": "latest",
-        "rimraf": "5.0.7",
         "typescript": "5.5.4",
       },
     },
@@ -138,7 +134,6 @@
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-istanbul": "4.0.18",
         "eslint": "9.7.0",
-        "rimraf": "5.0.7",
         "typescript": "5.5.4",
         "vitest": "4.0.18",
       },
@@ -160,7 +155,6 @@
         "abstract-level": "1.0.4",
         "eslint": "9.7.0",
         "fast-check": "4.5.3",
-        "rimraf": "5.0.7",
         "typescript": "5.5.4",
         "vitest": "4.0.18",
       },
@@ -183,7 +177,6 @@
         "@vitest/coverage-istanbul": "4.0.18",
         "eslint": "9.7.0",
         "fast-check": "4.5.3",
-        "rimraf": "5.0.7",
         "typescript": "5.5.4",
         "vitest": "4.0.18",
       },
@@ -211,7 +204,6 @@
         "@vitest/coverage-istanbul": "4.0.18",
         "bun-types": "latest",
         "eslint": "9.7.0",
-        "rimraf": "5.0.7",
         "typescript": "5.5.4",
         "vitest": "4.0.18",
       },
@@ -233,7 +225,6 @@
         "@typescript-eslint/parser": "8.32.1",
         "bun-types": "latest",
         "eslint": "9.7.0",
-        "rimraf": "5.0.7",
         "sinon": "18.0.0",
         "typescript": "5.5.4",
       },
@@ -287,7 +278,6 @@
         "mkdirp": "1.0.4",
         "mockdate": "3.0.5",
         "ms": "2.1.3",
-        "rimraf": "5.0.7",
         "search-index": "3.4.0",
         "sinon": "18.0.0",
         "typescript": "5.5.4",
@@ -335,7 +325,6 @@
         "eslint": "9.7.0",
         "eslint-plugin-todo-plz": "^1.3.0",
         "multiformats": "11.0.2",
-        "rimraf": "5.0.7",
         "sinon": "18.0.0",
         "typescript": "5.5.4",
       },
@@ -353,7 +342,6 @@
       },
       "devDependencies": {
         "esbuild": "0.23.0",
-        "rimraf": "5.0.7",
       },
     },
     "packages/dwn-sql-store": {
@@ -386,7 +374,6 @@
         "mysql2": "3.9.8",
         "pg": "8.11.2",
         "pg-cursor": "2.10.2",
-        "rimraf": "5.0.7",
         "typescript": "5.5.4",
       },
     },
@@ -419,7 +406,6 @@
         "@typescript-eslint/parser": "8.32.1",
         "bun-types": "latest",
         "eslint": "9.7.0",
-        "rimraf": "5.0.7",
         "typescript": "5.5.4",
       },
     },
@@ -435,7 +421,6 @@
         "@typescript-eslint/parser": "8.32.1",
         "bun-types": "latest",
         "eslint": "9.7.0",
-        "rimraf": "5.0.7",
         "typescript": "5.5.4",
       },
     },
@@ -2539,8 +2524,6 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rimraf": ["rimraf@5.0.7", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg=="],
-
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -2908,8 +2891,6 @@
     "@enbox/docs/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@enbox/electrobun-dwn/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
-
-    "@enbox/protocol-codegen/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "eventemitter3": "5.0.4",
     "globals": "15.6.0",
     "playwright": "1.45.3",
-    "rimraf": "5.0.7",
     "turbo": "^2.8.13",
     "typescript": "5.5.4"
   },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -6,9 +6,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
-    "build:browser": "rimraf dist/browser.mjs && bun ../../build/browser-bundle.js --node-shims",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "build:browser": "rm -rf dist/browser.mjs && bun ../../build/browser-bundle.js --node-shims",
     "build": "bun run clean && bun run build:esm && bun run build:browser",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -93,7 +93,6 @@
     "@vitest/coverage-istanbul": "4.0.18",
     "bun-types": "latest",
     "eslint": "9.7.0",
-    "rimraf": "5.0.7",
     "sinon": "18.0.0",
     "typescript": "5.5.4",
     "vitest": "4.0.18"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,9 +7,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
-    "build:browser": "rimraf dist/browser.mjs && bun ../../build/browser-bundle.js --node-shims --metafile",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "build:browser": "rm -rf dist/browser.mjs && bun ../../build/browser-bundle.js --node-shims --metafile",
     "build": "bun run clean && bun run build:esm && bun run build:browser",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -98,7 +98,6 @@
     "@vitest/coverage-istanbul": "4.0.18",
     "bun-types": "latest",
     "eslint": "9.7.0",
-    "rimraf": "5.0.7",
     "sinon": "18.0.0",
     "typescript": "5.5.4",
     "vitest": "4.0.18"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -7,8 +7,8 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
     "build": "bun run clean && bun run build:esm",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -65,7 +65,6 @@
   "devDependencies": {
     "@types/node": "20.14.8",
     "bun-types": "latest",
-    "rimraf": "5.0.7",
     "typescript": "5.5.4"
   }
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -7,8 +7,8 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
     "build:browser": "bun run build:esm",
     "build": "bun run clean && bun run build:esm",
     "lint": "eslint . --max-warnings 0",
@@ -63,7 +63,6 @@
     "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-istanbul": "4.0.18",
     "eslint": "9.7.0",
-    "rimraf": "5.0.7",
     "typescript": "5.5.4",
     "vitest": "4.0.18"
   }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,9 +6,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
-    "build:browser": "rimraf dist/browser.mjs && bun ../../build/browser-bundle.js",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "build:browser": "rm -rf dist/browser.mjs && bun ../../build/browser-bundle.js",
     "build": "bun run clean && bun run build:esm && bun run build:browser",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -85,7 +85,6 @@
     "abstract-level": "1.0.4",
     "eslint": "9.7.0",
     "fast-check": "4.5.3",
-    "rimraf": "5.0.7",
     "typescript": "5.5.4",
     "vitest": "4.0.18"
   }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -7,9 +7,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
-    "build:browser": "rimraf dist/browser.mjs && bun ../../build/browser-bundle.js --extra-entry src/utils.ts:dist/utils.js",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "build:browser": "rm -rf dist/browser.mjs && bun ../../build/browser-bundle.js --extra-entry src/utils.ts:dist/utils.js",
     "build": "bun run clean && bun run build:esm && bun run build:browser",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -84,7 +84,6 @@
     "@vitest/coverage-istanbul": "4.0.18",
     "eslint": "9.7.0",
     "fast-check": "4.5.3",
-    "rimraf": "5.0.7",
     "typescript": "5.5.4",
     "vitest": "4.0.18"
   }

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -7,9 +7,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
-    "build:browser": "rimraf dist/browser.mjs && bun ../../build/browser-bundle.js --extra-entry src/utils.ts:dist/utils.js",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "build:browser": "rm -rf dist/browser.mjs && bun ../../build/browser-bundle.js --extra-entry src/utils.ts:dist/utils.js",
     "build": "bun run clean && bun run build:esm && bun run build:browser",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -97,7 +97,6 @@
     "@vitest/coverage-istanbul": "4.0.18",
     "bun-types": "latest",
     "eslint": "9.7.0",
-    "rimraf": "5.0.7",
     "typescript": "5.5.4",
     "vitest": "4.0.18"
   }

--- a/packages/dwn-clients/package.json
+++ b/packages/dwn-clients/package.json
@@ -6,8 +6,8 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
     "build": "bun run clean && bun run build:esm",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -59,7 +59,6 @@
     "@typescript-eslint/parser": "8.32.1",
     "bun-types": "latest",
     "eslint": "9.7.0",
-    "rimraf": "5.0.7",
     "sinon": "18.0.0",
     "typescript": "5.5.4"
   }

--- a/packages/dwn-sdk-js/package.json
+++ b/packages/dwn-sdk-js/package.json
@@ -109,7 +109,6 @@
     "mkdirp": "1.0.4",
     "mockdate": "3.0.5",
     "ms": "2.1.3",
-    "rimraf": "5.0.7",
     "search-index": "3.4.0",
     "sinon": "18.0.0",
     "typescript": "5.5.4",
@@ -122,8 +121,8 @@
   "scripts": {
     "build:esm": "tsc",
     "build": "bun run clean && bun run compile-validators && bun run build:esm && bun run bundle",
-    "bundle": "rimraf dist/browser.mjs && bun ../../build/browser-bundle.js --node-shims --metafile",
-    "clean": "rimraf dist && rimraf generated/*",
+    "bundle": "rm -rf dist/browser.mjs && bun ../../build/browser-bundle.js --node-shims --metafile",
+    "clean": "rm -rf dist && rm -rf generated/*",
     "compile-validators": "bun ./build/compile-validators.js",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",

--- a/packages/dwn-server-admin-ui/package.json
+++ b/packages/dwn-server-admin-ui/package.json
@@ -20,7 +20,7 @@
     "./dist/*": "./dist/*"
   },
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rm -rf dist",
     "build": "bun run clean && bun run build:bundle",
     "build:bundle": "bun run scripts/build.ts",
     "lint": "echo 'no lint configured'",
@@ -32,7 +32,6 @@
     "preact-router": "^4.1.2"
   },
   "devDependencies": {
-    "esbuild": "0.23.0",
-    "rimraf": "5.0.7"
+    "esbuild": "0.23.0"
   }
 }

--- a/packages/dwn-server/package.json
+++ b/packages/dwn-server/package.json
@@ -66,14 +66,13 @@
     "eslint": "9.7.0",
     "eslint-plugin-todo-plz": "^1.3.0",
     "multiformats": "11.0.2",
-    "rimraf": "5.0.7",
     "sinon": "18.0.0",
     "typescript": "5.5.4"
   },
   "scripts": {
     "build:esm": "bun run clean && tsc",
     "build": "bun run clean && bun run build:esm",
-    "clean": "rimraf dist && rimraf generated/*",
+    "clean": "rm -rf dist && rm -rf generated/*",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test:node": "bun test .test.ts",

--- a/packages/dwn-sql-store/package.json
+++ b/packages/dwn-sql-store/package.json
@@ -49,13 +49,12 @@
     "mysql2": "3.9.8",
     "pg": "8.11.2",
     "pg-cursor": "2.10.2",
-    "rimraf": "5.0.7",
     "typescript": "5.5.4"
   },
   "scripts": {
     "build:esm": "bun run clean && tsc",
     "build": "bun run clean && bun run build:esm",
-    "clean": "rimraf dist compiled",
+    "clean": "rm -rf dist compiled",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test": "bun test --timeout 10000 .spec.ts",

--- a/packages/protocol-codegen/package.json
+++ b/packages/protocol-codegen/package.json
@@ -10,8 +10,8 @@
     "protocol-codegen": "./dist/esm/cli.js"
   },
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
     "build": "bun run clean && bun run build:esm",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -60,7 +60,6 @@
     "@typescript-eslint/parser": "8.32.1",
     "bun-types": "latest",
     "eslint": "9.7.0",
-    "rimraf": "5.0.7",
     "typescript": "5.5.4"
   }
 }

--- a/packages/protocols/package.json
+++ b/packages/protocols/package.json
@@ -7,8 +7,8 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist",
-    "build:esm": "rimraf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
     "build": "bun run clean && bun run build:esm",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -55,7 +55,6 @@
     "@typescript-eslint/parser": "8.32.1",
     "bun-types": "latest",
     "eslint": "9.7.0",
-    "rimraf": "5.0.7",
     "typescript": "5.5.4"
   }
 }


### PR DESCRIPTION
## Summary

- **Replace `rimraf` with `rm -rf` in all 14 packages** — `rimraf` exists for Windows compatibility. This project targets Bun on macOS/Linux where `rm -rf` works natively. Removes a devDependency that caused "command not found" errors when `node_modules` symlinks were stale or missing.
- **Remove `rimraf` from all `devDependencies`** (root + every package)