### PR TITLE
fix: pin bun-types to 1.2.14 to match packageManager version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
         "@typescript-eslint/parser": "8.32.1",
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-istanbul": "4.0.18",
-        "bun-types": "latest",
+        "bun-types": "1.2.14",
         "eslint": "9.7.0",
         "sinon": "18.0.0",
         "typescript": "5.5.4",
@@ -99,7 +99,7 @@
         "@typescript-eslint/parser": "8.32.1",
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-istanbul": "4.0.18",
-        "bun-types": "latest",
+        "bun-types": "1.2.14",
         "eslint": "9.7.0",
         "sinon": "18.0.0",
         "typescript": "5.5.4",
@@ -118,7 +118,7 @@
       },
       "devDependencies": {
         "@types/node": "20.14.8",
-        "bun-types": "latest",
+        "bun-types": "1.2.14",
         "typescript": "5.5.4",
       },
     },
@@ -202,7 +202,7 @@
         "@typescript-eslint/parser": "8.32.1",
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-istanbul": "4.0.18",
-        "bun-types": "latest",
+        "bun-types": "1.2.14",
         "eslint": "9.7.0",
         "typescript": "5.5.4",
         "vitest": "4.0.18",
@@ -223,7 +223,7 @@
         "@types/sinon": "17.0.3",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "latest",
+        "bun-types": "1.2.14",
         "eslint": "9.7.0",
         "sinon": "18.0.0",
         "typescript": "5.5.4",
@@ -269,7 +269,7 @@
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-istanbul": "4.0.18",
         "blockstore-core": "4.2.0",
-        "bun-types": "^1.2.4",
+        "bun-types": "1.2.14",
         "dependency-cruiser": "^16.3.7",
         "eslint": "9.7.0",
         "eslint-plugin-todo-plz": "1.3.0",
@@ -321,7 +321,7 @@
         "@types/ws": "8.5.10",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "^1.2.4",
+        "bun-types": "1.2.14",
         "eslint": "9.7.0",
         "eslint-plugin-todo-plz": "^1.3.0",
         "multiformats": "11.0.2",
@@ -368,7 +368,7 @@
         "@types/supertest": "2.0.12",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "latest",
+        "bun-types": "1.2.14",
         "esbuild": "0.23.0",
         "eslint": "9.7.0",
         "mysql2": "3.9.8",
@@ -404,7 +404,7 @@
         "@types/yargs": "^17.0.35",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "latest",
+        "bun-types": "1.2.14",
         "eslint": "9.7.0",
         "typescript": "5.5.4",
       },
@@ -419,7 +419,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "latest",
+        "bun-types": "1.2.14",
         "eslint": "9.7.0",
         "typescript": "5.5.4",
       },
@@ -1424,7 +1424,7 @@
 
     "buffer-writer": ["buffer-writer@2.0.0", "", {}, "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.2.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-Kuh4Ub28ucMRWeiUUWMHsT9Wcbr4H3kLIO72RZZElSDxSu7vpetRvxIUDUaW6QtaIeixIpm7OXtNnZPf82EzwA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -2948,6 +2948,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
     "@types/pg/pg-types": ["pg-types@4.1.0", "", { "dependencies": { "pg-int8": "1.0.1", "pg-numeric": "1.0.2", "postgres-array": "~3.0.1", "postgres-bytea": "~3.0.0", "postgres-date": "~2.1.0", "postgres-interval": "^3.0.0", "postgres-range": "^1.1.1" } }, "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg=="],
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/utils": ["@typescript-eslint/utils@8.32.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.32.1", "@typescript-eslint/types": "8.32.1", "@typescript-eslint/typescript-estree": "8.32.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA=="],
@@ -2977,6 +2979,8 @@
     "boxen/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "boxen/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
+
+    "bun-types/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
 
     "cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
@@ -3143,6 +3147,8 @@
     "boxen/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "boxen/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -91,7 +91,7 @@
     "@typescript-eslint/parser": "8.32.1",
     "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-istanbul": "4.0.18",
-    "bun-types": "latest",
+    "bun-types": "1.2.14",
     "eslint": "9.7.0",
     "sinon": "18.0.0",
     "typescript": "5.5.4",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/parser": "8.32.1",
     "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-istanbul": "4.0.18",
-    "bun-types": "latest",
+    "bun-types": "1.2.14",
     "eslint": "9.7.0",
     "sinon": "18.0.0",
     "typescript": "5.5.4",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "20.14.8",
-    "bun-types": "latest",
+    "bun-types": "1.2.14",
     "typescript": "5.5.4"
   }
 }

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/parser": "8.32.1",
     "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-istanbul": "4.0.18",
-    "bun-types": "latest",
+    "bun-types": "1.2.14",
     "eslint": "9.7.0",
     "typescript": "5.5.4",
     "vitest": "4.0.18"

--- a/packages/dwn-clients/package.json
+++ b/packages/dwn-clients/package.json
@@ -57,7 +57,7 @@
     "@types/sinon": "17.0.3",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "latest",
+    "bun-types": "1.2.14",
     "eslint": "9.7.0",
     "sinon": "18.0.0",
     "typescript": "5.5.4"

--- a/packages/dwn-sdk-js/package.json
+++ b/packages/dwn-sdk-js/package.json
@@ -100,7 +100,7 @@
     "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-istanbul": "4.0.18",
     "blockstore-core": "4.2.0",
-    "bun-types": "^1.2.4",
+    "bun-types": "1.2.14",
     "dependency-cruiser": "^16.3.7",
     "eslint": "9.7.0",
     "eslint-plugin-todo-plz": "1.3.0",

--- a/packages/dwn-server/package.json
+++ b/packages/dwn-server/package.json
@@ -62,7 +62,7 @@
     "@types/ws": "8.5.10",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "^1.2.4",
+    "bun-types": "1.2.14",
     "eslint": "9.7.0",
     "eslint-plugin-todo-plz": "^1.3.0",
     "multiformats": "11.0.2",

--- a/packages/dwn-sql-store/package.json
+++ b/packages/dwn-sql-store/package.json
@@ -43,7 +43,7 @@
     "@types/supertest": "2.0.12",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "latest",
+    "bun-types": "1.2.14",
     "esbuild": "0.23.0",
     "eslint": "9.7.0",
     "mysql2": "3.9.8",

--- a/packages/protocol-codegen/package.json
+++ b/packages/protocol-codegen/package.json
@@ -58,7 +58,7 @@
     "@types/yargs": "^17.0.35",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "latest",
+    "bun-types": "1.2.14",
     "eslint": "9.7.0",
     "typescript": "5.5.4"
   }

--- a/packages/protocols/package.json
+++ b/packages/protocols/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "latest",
+    "bun-types": "1.2.14",
     "eslint": "9.7.0",
     "typescript": "5.5.4"
   }


### PR DESCRIPTION
## Summary

- Pin `bun-types` from `"latest"` / `"^1.2.4"` to `"1.2.14"` across all 10 packages that depend on it
- Matches the `packageManager: "bun@1.2.14"` field in root `package.json`
- Fixes build failures (`ArrayBufferLike` not assignable to `ArrayBuffer`) that occur after `bun pm cache rm` + fresh install, which resolves `latest` to a newer incompatible `bun-types` version