### PR TITLE
chore: add changeset for remote DWN mode

### DIFF
--- a/.changeset/remove-port-probing.md
+++ b/.changeset/remove-port-probing.md
@@ -1,0 +1,21 @@
+---
+"@enbox/agent": minor
+"@enbox/auth": minor
+---
+
+Remove port probing and add remote DWN mode
+
+**@enbox/agent:**
+- Add remote DWN mode: when `localDwnEndpoint` is provided, skip creating an in-process DWN and route all operations through RPC to the local DWN server.
+- Add `processRawMessage()` for the sync engine to store pre-constructed messages via RPC.
+- Add `isRemoteMode` getter on `AgentDwnApi`.
+- Remove `localDwnPortCandidates` and `localDwnHostCandidates` exports (port probing removed).
+- Remove `dwn-record-upgrade` export (disabled, kept as reference).
+- `node` getter now throws in remote mode with a clear error message.
+
+**@enbox/auth:**
+- Add `discoverLocalDwn()` standalone function that runs before agent creation with zero vault/DWN dependencies.
+- `AuthManager.create()` now runs local DWN discovery before creating the agent, enabling remote mode when a local server is available.
+- Add `localDwnEndpoint` getter on `AuthManager`.
+- Remove `probeLocalDwn()` export (port probing removed).
+- Skip `applyLocalDwnDiscovery()` in connect/restore flows when already in remote mode.


### PR DESCRIPTION
## Summary

Adds a changeset to trigger version bumps after PR #712 (remove port probing, add remote DWN mode) was merged.

### Version bumps

| Package | Current | New | Reason |
|---------|---------|-----|--------|
| `@enbox/agent` | 0.3.1 | 0.4.0 (minor) | New remote mode API, removed port probing exports |
| `@enbox/auth` | 0.4.0 | 0.5.0 (minor) | New `discoverLocalDwn()`, `localDwnEndpoint` getter, removed `probeLocalDwn()` |
| `@enbox/api` | patch | auto | Depends on `@enbox/agent` |
| `@enbox/protocols` | patch | auto | Depends on `@enbox/agent` |
| `@enbox/electrobun-dwn` | patch | auto | Depends on `@enbox/agent` |

### What happens next

1. Merge this PR → changeset lands on main
2. Release workflow creates a "Version Packages" PR with bumped versions
3. Merge the Version PR → packages are published to npm
4. Update `web-wallet` to use the new versions