### PR TITLE
feat(auth): make identity creation opt-in during connect()

### DIFF
--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -185,10 +185,17 @@ export class AuthManager {
   /**
    * Create or reconnect a local identity.
    *
-   * On first use, this creates a new vault, agent DID, and user identity.
-   * On subsequent uses, it unlocks the vault and reconnects.
+   * On first use, this creates a new vault and agent DID. By default,
+   * **no user identity is created** — the session uses the agent DID.
+   * Pass `{ createIdentity: true }` to also create a default identity
+   * during vault setup (useful when vault init and identity creation
+   * are combined into a single step, e.g. Electrobun's create wizard).
    *
-   * @param options - Optional overrides for password, sync, DWN endpoints.
+   * On subsequent uses, it unlocks the vault and reconnects to the
+   * existing identity (or agent DID if no identities exist).
+   *
+   * @param options - Optional overrides for password, sync, DWN endpoints,
+   *   and identity creation behaviour.
    * @returns An active AuthSession.
    * @throws If a connection attempt is already in progress.
    */

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -267,7 +267,7 @@ export async function finalizeSession(params: {
   connectedDid: string;
   delegateDid?: string;
   recoveryPhrase?: string;
-  identityName: string;
+  identityName?: string;
   identityConnectedDid?: string;
   emitIdentityAdded?: boolean;
   extraStorageKeys?: Record<string, string>;
@@ -295,9 +295,11 @@ export async function finalizeSession(params: {
     }
   }
 
+  // When identityName is undefined, no user identity exists (agent-only session).
+  // Build an IdentityInfo with the agent DID as a fallback.
   const identityInfo: IdentityInfo = {
     didUri       : connectedDid,
-    name         : identityName,
+    name         : identityName ?? 'Agent',
     connectedDid : identityConnectedDid,
   };
 
@@ -309,7 +311,7 @@ export async function finalizeSession(params: {
     identity : identityInfo,
   });
 
-  if (emitIdentityAdded) {
+  if (emitIdentityAdded && identityName !== undefined) {
     emitter.emit('identity-added', { identity: identityInfo });
   }
 

--- a/packages/auth/src/connect/local.ts
+++ b/packages/auth/src/connect/local.ts
@@ -18,8 +18,13 @@ import { createDefaultIdentity, ensureVaultReady, finalizeSession, resolveIdenti
 /**
  * Execute the local connect flow.
  *
- * - On first launch: initializes the vault, creates a new DID, returns recovery phrase.
+ * - On first launch: initializes the vault. Identity creation is opt-in via
+ *   `options.createIdentity: true`.
  * - On subsequent launches: unlocks the vault and reconnects to the existing identity.
+ *
+ * When no identities exist and `createIdentity` is not `true`, the session
+ * is returned with the **agent DID** as the connected DID. This allows apps to
+ * manage identity creation separately from vault setup.
  */
 export async function localConnect(
   ctx: FlowContext,
@@ -33,6 +38,7 @@ export async function localConnect(
 
   const sync = options.sync ?? ctx.defaultSync;
   const dwnEndpoints = options.dwnEndpoints ?? ctx.defaultDwnEndpoints ?? DEFAULT_DWN_ENDPOINTS;
+  const shouldCreateIdentity = options.createIdentity === true;
 
   // Initialize vault on first launch and start the agent.
   const recoveryPhrase = await ensureVaultReady({
@@ -55,12 +61,21 @@ export async function localConnect(
   let identity = identities[0];
   let isNewIdentity = false;
 
-  if (!identity) {
+  if (!identity && shouldCreateIdentity) {
     isNewIdentity = true;
     identity = await createDefaultIdentity(userAgent, dwnEndpoints, options.metadata?.name ?? 'Default');
   }
 
-  const { connectedDid, delegateDid } = resolveIdentityDids(identity);
+  // When no identity exists (createIdentity: false on first launch), use the
+  // agent DID as the session's connected DID. The session is still valid but
+  // operates in the agent's context rather than a user identity's context.
+  const connectedDid = identity
+    ? resolveIdentityDids(identity).connectedDid
+    : userAgent.agentDid.uri;
+
+  const delegateDid = identity
+    ? resolveIdentityDids(identity).delegateDid
+    : undefined;
 
   // Register with DWN endpoints (if registration options are provided).
   if (ctx.registration) {
@@ -95,7 +110,7 @@ export async function localConnect(
     connectedDid,
     delegateDid,
     recoveryPhrase,
-    identityName         : identity.metadata.name,
-    identityConnectedDid : identity.metadata.connectedDid,
+    identityName         : identity?.metadata.name,
+    identityConnectedDid : identity?.metadata.connectedDid,
   });
 }

--- a/packages/auth/src/connect/restore.ts
+++ b/packages/auth/src/connect/restore.ts
@@ -86,21 +86,37 @@ export async function restoreSession(
     }
   }
 
+  // Start sync.
+  startSyncIfEnabled(userAgent, ctx.defaultSync);
+
   if (!identity) {
-    // No identity found — clean up stale session data.
-    await storage.remove(STORAGE_KEYS.PREVIOUSLY_CONNECTED);
-    await storage.remove(STORAGE_KEYS.ACTIVE_IDENTITY);
-    await storage.remove(STORAGE_KEYS.DELEGATE_DID);
-    await storage.remove(STORAGE_KEYS.CONNECTED_DID);
-    return undefined;
+    // No identity found — this is valid for agent-only sessions created
+    // with `createIdentity: false`. Restore a session using the agent DID.
+    // If the active identity stored was the agent DID, this is an
+    // intentional agent-only session rather than stale data.
+    const isAgentOnlySession = activeIdentityDid === userAgent.agentDid.uri;
+
+    if (!isAgentOnlySession) {
+      // Truly stale session data — clean up and bail.
+      await storage.remove(STORAGE_KEYS.PREVIOUSLY_CONNECTED);
+      await storage.remove(STORAGE_KEYS.ACTIVE_IDENTITY);
+      await storage.remove(STORAGE_KEYS.DELEGATE_DID);
+      await storage.remove(STORAGE_KEYS.CONNECTED_DID);
+      return undefined;
+    }
+
+    return finalizeSession({
+      userAgent,
+      emitter,
+      storage,
+      connectedDid      : userAgent.agentDid.uri,
+      emitIdentityAdded : false,
+    });
   }
 
   const { connectedDid, delegateDid } = resolveIdentityDids(
     identity, storedDelegateDid ?? undefined,
   );
-
-  // Start sync.
-  startSyncIfEnabled(userAgent, ctx.defaultSync);
 
   // Persist session info, build AuthSession, and emit lifecycle events.
   // Session restore does not emit `identity-added` (identity was already added in the original flow).

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -316,6 +316,24 @@ export interface LocalConnectOptions {
 
   /** Identity metadata. */
   metadata?: { name?: string };
+
+  /**
+   * Whether to create a default identity if none exist.
+   *
+   * - `false` (default) — Skip automatic identity creation. The session is
+   *   returned with the **agent DID** as the connected DID and no identity
+   *   metadata. Use this when the app manages identity creation separately
+   *   (e.g. a web wallet with an explicit "Create Identity" flow after
+   *   vault setup).
+   *
+   * - `true` — If no identities exist after vault initialisation, a new
+   *   `did:dht` identity is created automatically. Use this when vault
+   *   setup and identity creation are combined into a single step (e.g.
+   *   Electrobun's create wizard).
+   *
+   * @default false
+   */
+  createIdentity?: boolean;
 }
 
 /** Options for {@link AuthManager.walletConnect}. */

--- a/packages/auth/tests/local-connect.spec.ts
+++ b/packages/auth/tests/local-connect.spec.ts
@@ -7,7 +7,7 @@ import { createMockAgent, createMockIdentity } from './helpers/mock-agent.js';
 import { INSECURE_DEFAULT_PASSWORD, STORAGE_KEYS } from '../src/types.js';
 
 describe('localConnect', () => {
-  test('first launch: initializes vault, creates identity, returns recovery phrase', async () => {
+  test('first launch: initializes vault, creates identity when createIdentity is true', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
     const initCalls: any[] = [];
@@ -23,7 +23,7 @@ describe('localConnect', () => {
 
     const session = await localConnect(
       { userAgent: agent, emitter, storage },
-      { password: 'test-pass' },
+      { password: 'test-pass', createIdentity: true },
     );
 
     // Vault was initialized with the password
@@ -138,7 +138,7 @@ describe('localConnect', () => {
 
     await localConnect(
       { userAgent: agent, emitter, storage, defaultSync: '15s' },
-      {},
+      { createIdentity: true },
     );
 
     expect(syncCalls).toHaveLength(1);
@@ -161,7 +161,7 @@ describe('localConnect', () => {
 
     await localConnect(
       { userAgent: agent, emitter, storage, defaultSync: 'off' },
-      {},
+      { createIdentity: true },
     );
 
     expect(syncCalls).toHaveLength(0);
@@ -181,7 +181,7 @@ describe('localConnect', () => {
 
     await localConnect(
       { userAgent: agent, emitter, storage },
-      { dwnEndpoints: ['https://custom-dwn.example.com'] },
+      { createIdentity: true, dwnEndpoints: ['https://custom-dwn.example.com'] },
     );
 
     expect(initCalls[0].dwnEndpoints).toEqual(['https://custom-dwn.example.com']);
@@ -239,7 +239,7 @@ describe('localConnect', () => {
 
     await localConnect(
       { userAgent: agent, emitter, storage },
-      { metadata: { name: 'My Custom Name' } },
+      { createIdentity: true, metadata: { name: 'My Custom Name' } },
     );
 
     expect(createCalls[0].metadata.name).toBe('My Custom Name');
@@ -295,5 +295,104 @@ describe('localConnect', () => {
     );
 
     expect(registrationSucceeded).toBe(true);
+  });
+
+  test('createIdentity: false skips identity creation and uses agent DID', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const createCalls: any[] = [];
+
+    const agent = createMockAgent({
+      firstLaunch    : async () => true,
+      initialize     : async () => 'recovery phrase words',
+      identityList   : async () => [],
+      identityCreate : async (params) => { createCalls.push(params); return createMockIdentity(); },
+    });
+
+    const session = await localConnect(
+      { userAgent: agent, emitter, storage },
+      { password: 'test-pass', createIdentity: false },
+    );
+
+    // Identity was NOT created
+    expect(createCalls).toHaveLength(0);
+
+    // Session uses the agent DID instead
+    expect(session.did).toBe('did:dht:testagent');
+    expect(session.agent).toBe(agent);
+    expect(session.recoveryPhrase).toBe('recovery phrase words');
+
+    // Session identity info uses the agent DID with fallback name
+    expect(session.identity.didUri).toBe('did:dht:testagent');
+    expect(session.identity.name).toBe('Agent');
+
+    // Storage was updated with agent DID
+    expect(await storage.get(STORAGE_KEYS.ACTIVE_IDENTITY)).toBe('did:dht:testagent');
+  });
+
+  test('createIdentity: false with existing identities uses the existing identity', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const identity = createMockIdentity();
+
+    const agent = createMockAgent({
+      firstLaunch  : async () => false,
+      identityList : async () => [identity],
+    });
+
+    const session = await localConnect(
+      { userAgent: agent, emitter, storage },
+      { password: 'test-pass', createIdentity: false },
+    );
+
+    // Existing identity is used, not the agent DID
+    expect(session.did).toBe('did:dht:testuser123');
+    expect(session.identity.name).toBe('Default');
+  });
+
+  test('createIdentity: false does not emit identity-added event', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const events: string[] = [];
+
+    emitter.on('vault-unlocked', () => { events.push('vault-unlocked'); });
+    emitter.on('identity-added', () => { events.push('identity-added'); });
+    emitter.on('session-start', () => { events.push('session-start'); });
+
+    const agent = createMockAgent({
+      firstLaunch  : async () => true,
+      initialize   : async () => 'phrase',
+      identityList : async () => [],
+    });
+
+    await localConnect(
+      { userAgent: agent, emitter, storage },
+      { createIdentity: false },
+    );
+
+    // identity-added should NOT be emitted since no identity was created
+    expect(events).toEqual(['vault-unlocked', 'session-start']);
+  });
+
+  test('default (no createIdentity) skips identity creation', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const createCalls: any[] = [];
+
+    const agent = createMockAgent({
+      firstLaunch    : async () => true,
+      initialize     : async () => 'phrase',
+      identityList   : async () => [],
+      identityCreate : async (params) => { createCalls.push(params); return createMockIdentity(); },
+    });
+
+    const session = await localConnect(
+      { userAgent: agent, emitter, storage },
+      { password: 'test-pass' },
+    );
+
+    // Identity was NOT created (default is false)
+    expect(createCalls).toHaveLength(0);
+    expect(session.did).toBe('did:dht:testagent');
   });
 });

--- a/packages/auth/tests/session-restore.spec.ts
+++ b/packages/auth/tests/session-restore.spec.ts
@@ -30,7 +30,7 @@ describe('restoreSession', () => {
     expect(await storage.get(STORAGE_KEYS.PREVIOUSLY_CONNECTED)).toBeNull();
   });
 
-  test('returns undefined when no identity found', async () => {
+  test('returns undefined when no identity found and not an agent-only session', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
     await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
@@ -50,6 +50,25 @@ describe('restoreSession', () => {
     expect(await storage.get(STORAGE_KEYS.ACTIVE_IDENTITY)).toBeNull();
     expect(await storage.get(STORAGE_KEYS.DELEGATE_DID)).toBeNull();
     expect(await storage.get(STORAGE_KEYS.CONNECTED_DID)).toBeNull();
+  });
+
+  test('restores agent-only session when active identity is the agent DID', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
+    await storage.set(STORAGE_KEYS.ACTIVE_IDENTITY, 'did:dht:testagent');
+
+    const agent = createMockAgent({
+      firstLaunch               : async () => false,
+      identityConnectedIdentity : async () => undefined,
+      identityGet               : async () => undefined,
+      identityList              : async () => [],
+    });
+
+    const session = await restoreSession({ userAgent: agent, emitter, storage });
+    expect(session).toBeDefined();
+    expect(session!.did).toBe('did:dht:testagent');
+    expect(session!.identity.name).toBe('Agent');
   });
 
   test('restores session from connected identity', async () => {


### PR DESCRIPTION
## Summary

Makes identity creation opt-in during `AuthManager.connect()` by adding a `createIdentity` option to `LocalConnectOptions` (default: `false`).

### Problem

`localConnect()` unconditionally creates a default identity when none exist. This is wrong for apps like the web-wallet that manage identity creation separately from vault setup — the auto-created identity has no protocols installed, causing `ProtocolAuthorizationProtocolNotFound` errors when the user tries to edit profile data.

### Solution

- **`createIdentity: false` (default)** — Skip automatic identity creation. The session uses the **agent DID** as the connected DID. Apps manage identity creation in their own UI flow.
- **`createIdentity: true`** — Create a default identity on first launch. Used by Electrobun's wizard where vault setup and identity creation are a single step.

### Changes

| File | Change |
|------|--------|
| `src/types.ts` | Added `createIdentity?: boolean` to `LocalConnectOptions` |
| `src/connect/local.ts` | Skip identity creation when `createIdentity` is not `true` |
| `src/connect/lifecycle.ts` | `identityName` optional; fallback to `'Agent'`; skip `identity-added` event for agent-only sessions |
| `src/connect/restore.ts` | Detect and restore agent-only sessions (active identity = agent DID) |
| `src/auth-manager.ts` | Updated JSDoc |
| `tests/local-connect.spec.ts` | 4 new tests, updated existing tests to pass `createIdentity: true` where identity creation is intended |
| `tests/session-restore.spec.ts` | 1 new test for agent-only session restore |

### Migration

- **Electrobun**: Add `createIdentity: true` to `connect()` call
- **Web-wallet**: No change needed — default `false` is the desired behavior
- **Existing consumers that relied on auto-identity creation**: Add `createIdentity: true`

### Tests

All 129 tests pass (5 new, 0 failures).