### PR TITLE
fix(browser): read connectedDid from wallet response in DWeb Connect

### DIFF
--- a/.changeset/fix-dweb-connect-connected-did.md
+++ b/.changeset/fix-dweb-connect-connected-did.md
@@ -1,0 +1,9 @@
+---
+"@enbox/browser": patch
+---
+
+fix(browser): read connectedDid from wallet response in DWeb Connect
+
+The dapp client was falling back to `delegateDid.uri` (a `did:jwk` with no DWN endpoints) as the `connectedDid` when the wallet didn't explicitly send one. This caused "Failed to dereference `did:jwk:...#dwn`: notFound" errors during identity import after a successful wallet approval.
+
+Now reads `connectedDid` from the wallet's authorization response, which contains the actual wallet owner's identity DID (e.g., `did:dht:...`).

--- a/packages/browser/src/dweb-connect-client.ts
+++ b/packages/browser/src/dweb-connect-client.ts
@@ -126,7 +126,7 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
         clearInterval(pollClosed);
         cleanup();
 
-        const { delegateDid, grants } = event.data;
+        const { delegateDid, connectedDid: walletConnectedDid, grants } = event.data;
 
         if (!delegateDid || !grants) {
           // User denied the request.
@@ -134,10 +134,11 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
           return;
         }
 
+        // connectedDid priority: wallet response > dapp-provided > delegate DID
         resolve({
           delegatePortableDid : delegateDid as PortableDid,
           delegateGrants      : grants as DwnDataEncodedRecordsWriteMessage[],
-          connectedDid        : did ?? delegateDid.uri,
+          connectedDid        : walletConnectedDid ?? did ?? delegateDid.uri,
         });
       }
     };


### PR DESCRIPTION
## Summary

Fix the DWeb Connect flow failing with "Failed to dereference `did:jwk:...#dwn`: notFound" after the wallet approves the connection.

## Problem

The dapp client (`dweb-connect-client.ts`) was falling back to `delegateDid.uri` as the `connectedDid` when the wallet didn't explicitly send one in the response. Since `did:jwk` delegate DIDs are bare key DIDs with no DWN service endpoints, the subsequent `importDelegateAndSetupSync()` in `@enbox/auth` failed when trying to resolve DWN endpoints from the DID document.

## Fix

Read `connectedDid` from the wallet's `dweb-connect-authorization-response` message, which contains the actual wallet owner's identity DID (e.g., `did:dht:...`) that the user selected in the wallet's identity picker.

Priority chain: `walletConnectedDid` > `dapp-provided did` > `delegateDid.uri`

## Changeset

`@enbox/browser` patch version bump.

## Related

The web-wallet was also updated (separate commit) to include `connectedDid: selectedDid` in its response message.