### PR TITLE
fix(auth): add 'configure' to DEFAULT_PERMISSIONS

### DIFF
--- a/.changeset/fix-default-permissions-configure.md
+++ b/.changeset/fix-default-permissions-configure.md
@@ -1,0 +1,11 @@
+---
+"@enbox/auth": patch
+---
+
+fix(auth): add 'configure' to DEFAULT_PERMISSIONS
+
+Include `ProtocolsConfigure` in the default permission set requested
+during `connect()`. Without this, dapps using the standard `TypedEnbox`
+API fail with "No permissions found for ProtocolsConfigure" because
+`_autoConfigureOnce()` needs a configure grant to install the protocol
+on the delegate's local DWN.

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -423,7 +423,7 @@ export type ProtocolRequest =
 export type Permission = 'write' | 'read' | 'delete' | 'query' | 'subscribe' | 'configure';
 
 /** Default permissions granted when only a protocol definition is provided. */
-export const DEFAULT_PERMISSIONS: Permission[] = ['read', 'write', 'query', 'subscribe'];
+export const DEFAULT_PERMISSIONS: Permission[] = ['read', 'write', 'query', 'subscribe', 'configure'];
 
 /**
  * Options for a handler-based (delegated) connect flow.

--- a/packages/auth/src/wallet-connect-client.ts
+++ b/packages/auth/src/wallet-connect-client.ts
@@ -197,8 +197,10 @@ async function initClient({
 /**
  * Creates a set of Dwn Permission Scopes to request for a given protocol.
  *
- * If no permissions are provided, the default is to request all relevant record permissions (write, read, delete, query, subscribe).
- * 'configure' is not included by default, as this gives the application a lot of control over the protocol.
+ * If no permissions are provided, the default permissions from
+ * {@link DEFAULT_PERMISSIONS} are used (read, write, query, subscribe, configure).
+ * The 'configure' permission is included because dapps using the TypedEnbox API
+ * need it to auto-install the protocol on their local DWN via _autoConfigureOnce().
  */
 function createPermissionRequestForProtocol({ definition, permissions }: ProtocolPermissionOptions): ConnectPermissionRequest {
   const requests: DwnPermissionScope[] = [];


### PR DESCRIPTION
## Summary

Add `'configure'` to `DEFAULT_PERMISSIONS` so that dapps using the standard `TypedEnbox` API work out of the box with delegated connect.

## Problem

When a dapp calls `auth.connect({ protocols: [MyProtocol] })`, the default permissions requested are `['read', 'write', 'query', 'subscribe']`. After connecting, the dapp uses `enbox.using(MyProtocol)` which triggers `_autoConfigureOnce()` to install the protocol on the local DWN. This calls `protocols.configure()` which requires a `ProtocolsConfigure` grant — but no such grant was requested during connect.

**Result:** Every dapp using the simple `protocols: [MyProtocol]` syntax fails with "No permissions found for ProtocolsConfigure".

## Fix

```diff
- export const DEFAULT_PERMISSIONS: Permission[] = ['read', 'write', 'query', 'subscribe'];
+ export const DEFAULT_PERMISSIONS: Permission[] = ['read', 'write', 'query', 'subscribe', 'configure'];
```

The wallet already validates and installs the exact protocol definition during connect (via `prepareProtocol()`), so granting `ProtocolsConfigure` to the delegate only allows it to install the same protocol it already declared.

## Changeset

`@enbox/auth` patch version bump.