### PR TITLE
fix(api): auto-enable encryption in TypedEnbox when protocol types require it

### DIFF
--- a/.changeset/fix-auto-encryption.md
+++ b/.changeset/fix-auto-encryption.md
@@ -1,0 +1,13 @@
+---
+"@enbox/api": patch
+---
+
+fix(api): auto-enable encryption in TypedEnbox when protocol types require it
+
+When a protocol type has `encryptionRequired: true`, TypedEnbox now
+automatically passes `encryption: true` to the underlying DWN API for
+`create()`, `query()`, `read()`, `configure()`, and `_autoConfigureOnce()`.
+
+This eliminates the need for dapp developers to manually pass
+`encryption: true` on every record operation — the protocol definition
+is the single source of truth.

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -638,9 +638,13 @@ export class TypedEnbox<
     }
 
     // Not installed or definition has changed — configure the new version.
+    // Auto-enable encryption if any type in the definition requires it.
+    const needsEncryption = Object.values(this._definition.types)
+      .some((type) => (type as ProtocolType)?.encryptionRequired === true);
+
     const result = await this._dwn.protocols.configure({
       definition : this._definition,
-      encryption : options?.encryption,
+      encryption : options?.encryption ?? (needsEncryption || undefined),
     });
 
     if (result.status.code === 202) {
@@ -725,8 +729,13 @@ export class TypedEnbox<
     }
 
     // Not installed — configure it now.
+    // Auto-enable encryption if any type in the definition requires it.
+    const needsEncryption = Object.values(this._definition.types)
+      .some((type) => (type as ProtocolType)?.encryptionRequired === true);
+
     const result = await this._dwn.protocols.configure({
-      definition: this._definition,
+      definition : this._definition,
+      encryption : needsEncryption || undefined,
     });
 
     if (result.status.code === 202) {
@@ -823,7 +832,7 @@ export class TypedEnbox<
         const { status, record } = await this._dwn.records.write({
           data            : request.data,
           store           : request.store,
-          encryption      : request.encryption,
+          encryption      : request.encryption ?? (typeEntry?.encryptionRequired === true ? true : undefined),
           parentContextId : request.parentContextId,
           published       : request.published,
           datePublished   : request.datePublished,
@@ -890,7 +899,7 @@ export class TypedEnbox<
 
         const { status, records, cursor } = await this._dwn.records.query({
           from       : request?.from,
-          encryption : request?.encryption,
+          encryption : request?.encryption ?? (typeEntry?.encryptionRequired === true ? true : undefined),
           filter     : {
             ...queryFilter,
             protocol     : this._definition.protocol,
@@ -944,7 +953,7 @@ export class TypedEnbox<
 
         const { status, record } = await this._dwn.records.read({
           from       : request.from,
-          encryption : request.encryption,
+          encryption : request.encryption ?? (typeEntry?.encryptionRequired === true ? true : undefined),
           protocol   : this._definition.protocol,
           filter     : {
             ...readFilter,


### PR DESCRIPTION
## Summary

When a protocol type has `encryptionRequired: true`, `TypedEnbox` now automatically passes `encryption: true` to the underlying DWN API. Dapp developers no longer need to manually add `encryption: true` to every record operation.

## Problem

Protocol definitions can declare `encryptionRequired: true` on types, but the `TypedEnbox` API layer passed the `encryption` flag straight through without checking the protocol definition. This meant dapp developers had to manually pass `encryption: true` on every `create()`, `query()`, `read()`, and `configure()` call — otherwise the DWN rejected writes with `ProtocolAuthorizationEncryptionRequired`.

## Fix

In `TypedEnbox` (`typed-enbox.ts`), auto-set `encryption: true` when the caller doesn't explicitly set it and the protocol type has `encryptionRequired === true`:

```ts
encryption: request.encryption ?? (typeEntry?.encryptionRequired === true ? true : undefined),
```

Applied to:
- `records.create()` — auto-encrypt writes
- `records.query()` — auto-decrypt query results
- `records.read()` — auto-decrypt reads
- `configure()` — auto-enable encryption keys during protocol installation
- `_autoConfigureOnce()` — same for lazy auto-configuration

## Changeset

`@enbox/api` patch version bump.