### PR TITLE
fix(api): skip encryption key derivation for delegates in TypedEnbox

### DIFF
--- a/.changeset/fix-auto-encryption-delegate.md
+++ b/.changeset/fix-auto-encryption-delegate.md
@@ -1,0 +1,14 @@
+---
+"@enbox/api": patch
+---
+
+fix(api): skip encryption key derivation for delegates in TypedEnbox configure
+
+When operating as a delegate, `TypedEnbox.configure()` and
+`_autoConfigureOnce()` no longer attempt to derive encryption keys
+from the connected DID. The delegate doesn't have the owner's private
+keys, so encryption key derivation fails with "Key not found".
+
+The wallet already configures the protocol with encryption keys during
+the connect flow — the delegate only needs the protocol definition
+installed locally without re-deriving keys.

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -259,6 +259,11 @@ export class DwnApi {
     this.permissionsApi = new AgentPermissionsApi({ agent: this.agent });
   }
 
+  /** Whether this DWN API instance is operating as a delegate. */
+  get isDelegate(): boolean {
+    return this.delegateDid !== undefined;
+  }
+
   /**
    * API to interact with Grants
    *

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -639,7 +639,9 @@ export class TypedEnbox<
 
     // Not installed or definition has changed — configure the new version.
     // Auto-enable encryption if any type in the definition requires it.
-    const needsEncryption = Object.values(this._definition.types)
+    // Skip encryption key derivation when operating as a delegate — the
+    // wallet already configured the protocol with encryption keys.
+    const needsEncryption = !this._dwn.isDelegate && Object.values(this._definition.types)
       .some((type) => (type as ProtocolType)?.encryptionRequired === true);
 
     const result = await this._dwn.protocols.configure({
@@ -730,7 +732,10 @@ export class TypedEnbox<
 
     // Not installed — configure it now.
     // Auto-enable encryption if any type in the definition requires it.
-    const needsEncryption = Object.values(this._definition.types)
+    // Skip encryption key derivation when operating as a delegate — the
+    // wallet already configured the protocol with encryption keys. The
+    // delegate can't derive the owner's keys.
+    const needsEncryption = !this._dwn.isDelegate && Object.values(this._definition.types)
       .some((type) => (type as ProtocolType)?.encryptionRequired === true);
 
     const result = await this._dwn.protocols.configure({


### PR DESCRIPTION
## Summary

Fix "Key not found" error when a delegate dapp tries to use a protocol with `encryptionRequired: true`.

## Problem

After PR #730 added auto-encryption to `TypedEnbox`, `_autoConfigureOnce()` passes `encryption: true` when any protocol type has `encryptionRequired`. This triggers `getEncryptionKeyDeriverFn(agent, connectedDid)` which tries to derive encryption keys using the **wallet owner's** private key. But the dapp only has the **delegate's** `did:jwk` key — it doesn't have the owner's private key.

Result: `Key not found: urn:jwk:...` on every protocol init after a delegated connect.

## Fix

- Add `DwnApi.isDelegate` getter
- Skip `encryption: true` in `configure()` and `_autoConfigureOnce()` when `this._dwn.isDelegate` is true
- The wallet already configured the protocol with encryption keys during the connect flow — the delegate only needs the protocol definition installed locally without re-deriving keys

## Changeset

`@enbox/api` patch version bump.