### PR TITLE
fix(auth): remove redundant sync pull from delegate connect

### DIFF
--- a/.changeset/fix-remove-redundant-sync-pull.md
+++ b/.changeset/fix-remove-redundant-sync-pull.md
@@ -1,0 +1,10 @@
+---
+"@enbox/auth": patch
+---
+
+fix(auth): remove redundant sync pull from importDelegateAndSetupSync
+
+The manual `sync('pull')` call was immediately followed by
+`startSyncIfEnabled()` which runs its own immediate sync cycle.
+This doubled the startup burst and could trigger 429 rate limits
+on the remote DWN server.

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -343,7 +343,10 @@ export async function importDelegateAndSetupSync(params: {
       },
     });
 
-    await userAgent.sync.sync('pull');
+    // No explicit sync('pull') here — startSyncIfEnabled() in the caller
+    // runs an immediate sync cycle (both pull and push) when it starts.
+    // Doing a manual pull first would double the startup burst and can
+    // trigger rate limits on the remote DWN.
 
     return identity;
   } catch (error: unknown) {

--- a/packages/auth/tests/wallet-connect.spec.ts
+++ b/packages/auth/tests/wallet-connect.spec.ts
@@ -620,11 +620,11 @@ describe('walletConnect', () => {
     expect(syncCalls[0].interval).toBe('45s');
   });
 
-  test('calls sync.sync pull after registering identity', async () => {
+  test('does not call sync.sync pull after registering identity (deferred to startSync)', async () => {
     await load();
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
-    const syncPulls: string[] = [];
+    const syncCalls: string[] = [];
     const identity = createMockIdentity({
       did      : { uri: 'did:dht:delegate123' },
       metadata : { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:connected456' },
@@ -633,7 +633,7 @@ describe('walletConnect', () => {
     const agent = createMockAgent({
       firstLaunch    : async () => false,
       identityImport : async () => identity,
-      syncSync       : async (dir: string) => { syncPulls.push(dir); },
+      syncSync       : async (dir: string) => { syncCalls.push(dir); },
     });
 
     mockInitClient.mockImplementationOnce((): any => Promise.resolve({
@@ -653,7 +653,9 @@ describe('walletConnect', () => {
       },
     );
 
-    expect(syncPulls).toContain('pull');
+    // sync('pull') is no longer called in importDelegateAndSetupSync —
+    // startSyncIfEnabled() handles the initial sync cycle instead.
+    expect(syncCalls).not.toContain('pull');
   });
 
   test('calls registration when registration options are provided', async () => {


### PR DESCRIPTION
## Summary

Remove the manual `sync('pull')` call from `importDelegateAndSetupSync()` that doubled the startup burst and triggered 429 rate limits.

## Problem

The delegate connect lifecycle was:
1. `importDelegateAndSetupSync()` → `sync.registerIdentity()` → **`sync.sync('pull')`** ← redundant
2. `finalizeDelegateSession()` → `startSyncIfEnabled()` → **immediate `sync()`** ← already does pull + push

This caused ~160 HTTP requests on startup (two full sync cycles back-to-back) which easily exceeded the DWN server's per-tenant rate limit (20 req/s, burst 50).

## Fix

Remove the manual `sync('pull')` from step 1. The `startSyncIfEnabled()` in step 2 already runs an immediate sync that covers both pull and push.

## Changeset

`@enbox/auth` patch.