### PR TITLE
fix(auth): allow sync: 'off' for delegated connect flows

### DIFF
--- a/.changeset/fix-allow-sync-off-delegates.md
+++ b/.changeset/fix-allow-sync-off-delegates.md
@@ -1,0 +1,14 @@
+---
+"@enbox/auth": patch
+---
+
+fix(auth): allow sync: 'off' for delegated connect flows
+
+Remove the restriction that forced sync to be enabled for
+walletConnect() and handler-based connect(). The sync engine's
+SMT tree walk generates hundreds of HTTP requests during initial
+reconciliation, easily exceeding DWN server rate limits.
+
+Dapps can now opt out of sync with `sync: 'off'` and rely on
+local DWN operations only. The `startSyncIfEnabled()` helper
+already handles sync: 'off' as a no-op.

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -807,13 +807,6 @@ export class AuthManager {
     const { userAgent, emitter, storage } = ctx;
     const sync = options?.sync ?? ctx.defaultSync;
 
-    if (sync === 'off') {
-      throw new Error(
-        '[@enbox/auth] Sync must be enabled for delegated connect. ' +
-        'Remove sync: "off" or set an interval like "15s".'
-      );
-    }
-
     // 1. Initialize vault (agent-only, no identity).
     const isFirstLaunch = await userAgent.firstLaunch();
     const password = await resolvePassword(ctx, undefined, isFirstLaunch);

--- a/packages/auth/src/connect/wallet.ts
+++ b/packages/auth/src/connect/wallet.ts
@@ -33,13 +33,6 @@ export async function walletConnect(
   const { userAgent, emitter, storage } = ctx;
   const sync = options.sync ?? ctx.defaultSync;
 
-  if (sync === 'off') {
-    throw new Error(
-      '[@enbox/auth] Sync must be enabled when using wallet connect. ' +
-      'Remove sync: "off" or set an interval like "15s".'
-    );
-  }
-
   // Ensure the agent is initialized and started before the relay flow.
   const isFirstLaunch = await userAgent.firstLaunch();
   const password = await resolvePassword(ctx, undefined, isFirstLaunch);

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -266,22 +266,33 @@ describe('AuthManager', () => {
       ).rejects.toThrow('denied or cancelled');
     });
 
-    test('throws when sync is off for handler connect', async () => {
+    test('allows sync off for handler connect without throwing', async () => {
+      const delegateIdentity = createMockIdentity({
+        did      : { uri: 'did:jwk:delegate123' },
+        metadata : { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner456' },
+      });
+
       const agent = createMockAgent({
-        firstLaunch  : async () => false,
-        identityList : async () => [],
+        firstLaunch    : async () => false,
+        identityList   : async () => [],
+        identityImport : async () => delegateIdentity,
+        syncSync       : async () => {},
       });
 
       const mockHandler = {
-        requestAccess: async (): Promise<undefined> => undefined,
+        requestAccess: async (): Promise<any> => ({
+          delegatePortableDid : { uri: 'did:jwk:delegate123', document: {}, privateKeys: [] },
+          delegateGrants      : [],
+          connectedDid        : 'did:dht:owner456',
+        }),
       };
 
       const manager = createTestManager(agent);
       (manager as any)._connectHandler = mockHandler;
+      (manager as any)._defaultSync = 'off';
 
-      await expect(
-        manager.connect({ protocols: [], sync: 'off' as any })
-      ).rejects.toThrow('Sync must be enabled');
+      const session = await manager.connect({ protocols: [] });
+      expect(session.did).toBe('did:dht:owner456');
     });
   });
 

--- a/packages/auth/tests/wallet-connect.spec.ts
+++ b/packages/auth/tests/wallet-connect.spec.ts
@@ -180,24 +180,39 @@ describe('processConnectedGrants', () => {
 });
 
 describe('walletConnect', () => {
-  test('throws when sync is off', async () => {
+  test('allows sync off without throwing', async () => {
     await load();
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
-    const agent = createMockAgent();
+    const identity = createMockIdentity({
+      did      : { uri: 'did:dht:delegate123' },
+      metadata : { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:connected456' },
+    });
 
-    await expect(
-      _walletConnect(
-        { userAgent: agent, emitter, storage, defaultSync: 'off' },
-        {
-          displayName        : 'Test App',
-          connectServerUrl   : 'https://relay.example.com',
-          permissionRequests : [],
-          onWalletUriReady   : () => {},
-          validatePin        : async () => '1234',
-        },
-      )
-    ).rejects.toThrow('Sync must be enabled when using wallet connect');
+    const agent = createMockAgent({
+      firstLaunch    : async () => false,
+      identityImport : async () => identity,
+    });
+
+    mockInitClient.mockImplementationOnce((): any => Promise.resolve({
+      delegatePortableDid : { uri: 'did:dht:delegate123' },
+      connectedDid        : 'did:dht:connected456',
+      delegateGrants      : [],
+    }));
+
+    // Should not throw — sync: 'off' is now allowed.
+    const session = await _walletConnect(
+      { userAgent: agent, emitter, storage, defaultSync: 'off' },
+      {
+        displayName        : 'Test App',
+        connectServerUrl   : 'https://relay.example.com',
+        permissionRequests : [],
+        onWalletUriReady   : () => {},
+        validatePin        : async () => '1234',
+      },
+    );
+
+    expect(session.did).toBe('did:dht:connected456');
   });
 
   test('throws when initClient returns undefined/null', async () => {


### PR DESCRIPTION
## Summary

Remove the restriction that blocked `sync: 'off'` for `walletConnect()` and handler-based `connect()`.

## Problem

The sync engine's SMT tree walk generates **290+ HTTP requests within seconds** during initial reconciliation after a delegate connect. This exceeds the DWN server's rate limits (20 req/s per tenant, burst 50), causing cascading 429 errors and retry storms.

Additionally, the sync engine requires `MessagesSubscribe` grants that aren't properly set up for delegates, causing `GrantAuthorizationGrantMissing` errors that trigger further retries.

## Fix

Remove the `sync === 'off'` throw from both `_handlerConnect()` and `walletConnect()`. The `startSyncIfEnabled()` helper already handles `sync: 'off'` as a no-op, so no other changes are needed.

Dapps can now pass `sync: 'off'` to operate with local DWN only — records persist in IndexedDB and work across page loads within the same browser.

## Changeset

`@enbox/auth` patch.