### PR TITLE
chore: add changeset for sync perf batched diff

### DIFF
--- a/.changeset/sync-perf-batched-diff.md
+++ b/.changeset/sync-perf-batched-diff.md
@@ -1,6 +1,6 @@
 ---
-"@enbox/dwn-sdk-js": minor
-"@enbox/agent": minor
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
 ---
 
 feat(sync): batched diff protocol and direct StateIndex access


### PR DESCRIPTION
## Summary

- Adds the missing changeset for PR #740 (feat(sync): batched diff protocol and direct StateIndex access)
- `@enbox/dwn-sdk-js`: minor (new `MessagesSync` `action: 'diff'`)
- `@enbox/agent`: minor (direct StateIndex access, `diffWithRemote()`, stream-aware retry)