### PR TITLE
chore: add changeset for grant endpoint fix

### DIFF
--- a/.changeset/fix-grants-all-endpoints.md
+++ b/.changeset/fix-grants-all-endpoints.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+fix(agent): send permission grants to all DWN endpoints during connect


### PR DESCRIPTION
Adds the missing changeset for #745 (send permission grants to all DWN endpoints).