### PR TITLE
feat(api): add protocol-wide subscribe() to TypedEnbox

### DIFF
--- a/.changeset/feat-protocol-wide-subscribe.md
+++ b/.changeset/feat-protocol-wide-subscribe.md
@@ -1,0 +1,10 @@
+---
+"@enbox/api": minor
+---
+
+feat(api): add protocol-wide subscribe() to TypedEnbox
+
+TypedEnbox now exposes a `subscribe()` method that listens for record
+changes across the entire protocol, regardless of protocolPath. Unlike
+`records.subscribe(path)` which scopes to a single level, this catches
+creates, updates, and deletes at every level of the protocol hierarchy.

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -38,6 +38,7 @@
  */
 
 import type { DwnApi } from './dwn-api.js';
+import type { LiveQuery } from './live-query.js';
 import type { Protocol } from './protocol.js';
 
 import type { DateSort, ProtocolDefinition, ProtocolType, RecordsFilter } from '@enbox/dwn-sdk-js';
@@ -664,6 +665,40 @@ export class TypedEnbox<
    */
   public get isConfigured(): boolean {
     return this._configured;
+  }
+
+  /**
+   * Subscribe to **all** record changes across the entire protocol,
+   * regardless of protocolPath.
+   *
+   * Unlike `records.subscribe(path)` which scopes to a single path
+   * (e.g. `'notebook'`), this method catches creates, updates, and
+   * deletes at every level of the protocol hierarchy — ideal for a
+   * "refresh everything" strategy when any record changes.
+   *
+   * Returns a {@link LiveQuery} (untyped, since events span multiple
+   * paths/types) or `undefined` if the subscription could not be created.
+   * Call `liveQuery.close()` to stop listening.
+   *
+   * @example
+   * ```ts
+   * const typed = enbox.using(NotebookProtocol);
+   * const liveQuery = await typed.subscribe();
+   *
+   * liveQuery?.on('change', () => {
+   *   // A record somewhere in the protocol changed — re-query as needed.
+   * });
+   * ```
+   */
+  public async subscribe(request?: { from?: string }): Promise<LiveQuery | undefined> {
+    await this._autoConfigureOnce();
+
+    const { liveQuery } = await this._dwn.records.subscribe({
+      from   : request?.from,
+      filter : { protocol: this._definition.protocol },
+    });
+
+    return liveQuery;
   }
 
   /**

--- a/packages/api/tests/repository.spec.ts
+++ b/packages/api/tests/repository.spec.ts
@@ -683,4 +683,38 @@ describe('repository()', () => {
       expect(nonExistent).toBeUndefined();
     });
   });
+
+  describe('protocol-wide subscribe', () => {
+    it('should catch events from all protocol paths via typed.subscribe()', async () => {
+      const typed = new TypedEnbox(dwnAlice, TodoProtocol);
+      const repo = repository(typed);
+      await repo.configure();
+
+      const liveQuery = await typed.subscribe();
+      expect(liveQuery).toBeDefined();
+
+      const changes: string[] = [];
+      liveQuery!.on('change', () => {
+        changes.push('change');
+      });
+
+      // Create a root record (list) — should fire an event.
+      const { record: listRecord } = await repo.list.create({
+        data: { name: 'Groceries' },
+      });
+
+      // Create a nested record (task) — should also fire an event.
+      await repo.list.task.create(listRecord.contextId, {
+        data: { title: 'Buy milk', completed: false },
+      });
+
+      // Give the event loop time to deliver events.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Both the root and nested record events should have been captured.
+      expect(changes.length).toBeGreaterThanOrEqual(2);
+
+      await liveQuery!.close();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `TypedEnbox.subscribe()` method that listens for record changes across the **entire** protocol, regardless of protocolPath
- Returns a `LiveQuery` (untyped, since events span multiple paths/types)

## Motivation

`records.subscribe(path)` scopes to a single protocolPath (e.g. `'notebook'`). Apps using hierarchical protocols (notebook -> page -> section) need to subscribe to all levels to catch sync-pulled changes. Previously this required N separate subscriptions. Now:

```ts
const typed = enbox.using(NotebookProtocol);
const liveQuery = await typed.subscribe();
liveQuery?.on('change', () => refreshAll());
```

## Testing

- New test in `repository.spec.ts` verifying events from both root and nested paths are captured
- Full API test suite passes