### PR TITLE
fix(agent): propagate permission errors in live sync subscription setup

### DIFF
--- a/.changeset/fix-live-sync-grant-errors.md
+++ b/.changeset/fix-live-sync-grant-errors.md
@@ -1,0 +1,10 @@
+---
+"@enbox/agent": patch
+---
+
+fix(agent): propagate permission errors in live sync subscription setup
+
+openLivePullSubscription and openLocalPushSubscription were silently
+returning when the delegate permission grant lookup failed, causing live
+WebSocket sync to silently do nothing. Errors now propagate to the
+startLiveSync catch block so they are visible in the console.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -583,19 +583,14 @@ export class SyncEngineLevel implements SyncEngine {
         permissionGrantId = grant.grant.id;
       } catch {
         // Fall back to trying MessagesRead which is a unified scope.
-        try {
-          const grant = await this._permissionsApi.getPermissionForRequest({
-            connectedDid : did,
-            messageType  : DwnInterface.MessagesRead,
-            delegateDid,
-            protocol,
-            cached       : true
-          });
-          permissionGrantId = grant.grant.id;
-        } catch (error: any) {
-          console.error('SyncEngineLevel: Could not find permission grant for live pull subscription', error);
-          return;
-        }
+        const grant = await this._permissionsApi.getPermissionForRequest({
+          connectedDid : did,
+          messageType  : DwnInterface.MessagesRead,
+          delegateDid,
+          protocol,
+          cached       : true
+        });
+        permissionGrantId = grant.grant.id;
       }
     }
 
@@ -673,19 +668,14 @@ export class SyncEngineLevel implements SyncEngine {
     // Look up permission grant for local subscription.
     let permissionGrantId: string | undefined;
     if (delegateDid) {
-      try {
-        const grant = await this._permissionsApi.getPermissionForRequest({
-          connectedDid : did,
-          messageType  : DwnInterface.MessagesRead,
-          delegateDid,
-          protocol,
-          cached       : true,
-        });
-        permissionGrantId = grant.grant.id;
-      } catch {
-        // No grant available — skip push-on-write for this target.
-        return;
-      }
+      const grant = await this._permissionsApi.getPermissionForRequest({
+        connectedDid : did,
+        messageType  : DwnInterface.MessagesRead,
+        delegateDid,
+        protocol,
+        cached       : true,
+      });
+      permissionGrantId = grant.grant.id;
     }
 
     // Subscribe to the local DWN's EventLog.

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -787,7 +787,7 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._liveSubscriptions = [];
     });
 
-    it('should return early when both permission grant lookups fail', async () => {
+    it('should throw when both permission grant lookups fail', async () => {
       const permStub = sinon.stub().rejects(new Error('no grant'));
       const sendRequestStub = sinon.stub();
       const mockAgent = {
@@ -800,15 +800,16 @@ describe('SyncEngineLevel — private methods', () => {
         clear                   : sinon.stub(),
       };
       sinon.stub(engine as any, 'getCursor').resolves(undefined);
-      sinon.stub(console, 'error');
 
-      await (engine as any).openLivePullSubscription({
-        did         : 'did:example:alice',
-        dwnUrl      : 'https://dwn.example.com',
-        delegateDid : 'did:example:delegate',
-      });
+      await expect(
+        (engine as any).openLivePullSubscription({
+          did         : 'did:example:alice',
+          dwnUrl      : 'https://dwn.example.com',
+          delegateDid : 'did:example:delegate',
+        })
+      ).rejects.toThrow('no grant');
 
-      // sendRequest should not have been called since we returned early
+      // sendRequest should not have been called since we threw
       expect(sendRequestStub.called).toBe(false);
     });
   });
@@ -865,7 +866,7 @@ describe('SyncEngineLevel — private methods', () => {
       expect((engine as any)._localSubscriptions.length).toBe(0);
     });
 
-    it('should return early when delegate permission lookup fails', async () => {
+    it('should throw when delegate permission lookup fails', async () => {
       const permStub = sinon.stub().rejects(new Error('no grant'));
       const processRequestStub = sinon.stub();
       const mockAgent = {
@@ -878,11 +879,13 @@ describe('SyncEngineLevel — private methods', () => {
         clear                   : sinon.stub(),
       };
 
-      await (engine as any).openLocalPushSubscription({
-        did         : 'did:example:alice',
-        dwnUrl      : 'https://dwn.example.com',
-        delegateDid : 'did:example:delegate',
-      });
+      await expect(
+        (engine as any).openLocalPushSubscription({
+          did         : 'did:example:alice',
+          dwnUrl      : 'https://dwn.example.com',
+          delegateDid : 'did:example:delegate',
+        })
+      ).rejects.toThrow('no grant');
 
       expect(processRequestStub.called).toBe(false);
     });


### PR DESCRIPTION
## Summary

- `openLivePullSubscription` and `openLocalPushSubscription` were silently returning when the delegate permission grant lookup failed
- This caused live WebSocket sync to establish a WebSocket connection but never actually subscribe or push any messages
- Errors now propagate to the `startLiveSync` catch block so they appear in the console

Same class of bug as #748 — silent error swallowing in delegate grant lookups — but in the live sync code path instead of the poll sync path.