### PR TITLE
feat(dwn-sdk-js,agent): include data in live sync events and handle incomplete records

### DIFF
--- a/.changeset/feat-live-sync-data-completeness.md
+++ b/.changeset/feat-live-sync-data-completeness.md
@@ -1,0 +1,29 @@
+---
+"@enbox/dwn-sdk-js": minor
+"@enbox/agent": patch
+---
+
+feat(dwn-sdk-js): include encodedData in EventLog emit for live sync
+
+fix(agent): handle inline encodedData in live pull and fetch data for large records
+
+Three changes that make live WebSocket sync deliver complete records:
+
+1. RecordsWriteHandler now emits `messageWithOptionalEncodedData` (with
+   inline `encodedData` for records <= 30 KB) to the EventLog instead of
+   the raw message. WebSocket subscribers receive complete small records
+   without a separate MessagesRead round-trip.
+
+2. The sync engine's `extractDataStream` now decodes inline `encodedData`
+   from WebSocket events into a ReadableStream. For large records (no
+   inline data), it fetches the data from the remote DWN via MessagesRead
+   before storing locally.
+
+3. RecordsWriteHandler now allows re-processing of the same message when
+   the existing copy was stored as an incomplete initial write (204, no
+   data) and the incoming message supplies data. This repairs records
+   that were previously "poisoned" by live sync storing them without data.
+
+4. MessagesSyncHandler diff inline threshold lowered from 256 KB to 30 KB
+   to match the MessageStore's encodedData threshold, keeping diff
+   responses lightweight.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -6,7 +6,7 @@ import type { GenericMessage, MessageEvent, MessagesSubscribeReply, MessagesSync
 import ms from 'ms';
 
 import { Level } from 'level';
-import { hashToHex, initDefaultHashes, Message } from '@enbox/dwn-sdk-js';
+import { Encoder, hashToHex, initDefaultHashes, Message } from '@enbox/dwn-sdk-js';
 
 import type { PermissionsApi } from './types/permissions.js';
 import type { EnboxAgent, EnboxPlatformAgent } from './types/agent.js';
@@ -16,7 +16,7 @@ import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
 import { isRecordsWrite } from './utils.js';
 import { topologicalSort } from './sync-topological-sort.js';
-import { pullMessages, pushMessages } from './sync-messages.js';
+import { fetchRemoteMessages, pullMessages, pushMessages } from './sync-messages.js';
 
 export type SyncEngineLevelParams = {
   agent?: EnboxPlatformAgent;
@@ -608,8 +608,24 @@ export class SyncEngineLevel implements SyncEngine {
       if (subMessage.type === 'event') {
         const event: MessageEvent = subMessage.event;
         try {
-          // Process the message locally.
-          const dataStream = this.extractDataStream(event);
+          // Extract inline data from the event (available for records <= 30 KB).
+          let dataStream = this.extractDataStream(event);
+
+          // For large RecordsWrite messages (no inline data), fetch the data
+          // from the remote DWN via MessagesRead before storing locally.
+          if (!dataStream && isRecordsWrite(event) && (event.message.descriptor as any).dataCid) {
+            const messageCid = await Message.getCid(event.message);
+            const fetched = await fetchRemoteMessages({
+              did, dwnUrl, delegateDid, protocol,
+              messageCids    : [messageCid],
+              agent          : this.agent,
+              permissionsApi : this._permissionsApi,
+            });
+            if (fetched.length > 0 && fetched[0].dataStream) {
+              dataStream = fetched[0].dataStream;
+            }
+          }
+
           await this.agent.dwn.processRawMessage(did, event.message, { dataStream });
         } catch (error: any) {
           console.error(`SyncEngineLevel: Error processing live-pull event for ${did}`, error);
@@ -825,23 +841,36 @@ export class SyncEngineLevel implements SyncEngine {
   // ---------------------------------------------------------------------------
 
   /**
-   * Extracts a ReadableStream from a MessageEvent if it contains a RecordsWrite with data.
+   * Extracts a ReadableStream from a MessageEvent if it contains a
+   * RecordsWrite with data — either as an inline `encodedData` field
+   * (for records <= 30 KB) or as a pre-existing data stream.
    */
   private extractDataStream(event: MessageEvent): ReadableStream<Uint8Array> | undefined {
-    if (isRecordsWrite(event) && (event as any).data) {
+    if (!isRecordsWrite(event)) {
+      return undefined;
+    }
+
+    // Check for inline base64url-encoded data (small records from EventLog).
+    const encodedData = (event.message as any).encodedData as string | undefined;
+    if (encodedData) {
+      const bytes = Encoder.base64UrlToBytes(encodedData);
+      return new ReadableStream<Uint8Array>({
+        start(controller): void {
+          controller.enqueue(bytes);
+          controller.close();
+        }
+      });
+    }
+
+    // Check for a pre-existing data stream (e.g. from a direct message read).
+    if ((event as any).data) {
       return (event as any).data;
     }
+
     return undefined;
   }
 
-  /**
-   * Synchronously attempts to get a message CID. Returns undefined on failure.
-   * This is used in the synchronous EventLog callback; the actual CID computation
-   * is fast for already-constructed messages.
-   */
-  // tryGetCidSync was removed — it tried to return a CID synchronously
-  // from an async SHA-256 computation, which always returned undefined.
-  // The local push handler now awaits Message.getCid() directly.
+
 
   // ---------------------------------------------------------------------------
   // Default Hash Cache

--- a/packages/dwn-sdk-js/src/handlers/messages-sync.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-sync.ts
@@ -4,6 +4,7 @@ import type { HandlerDependencies, MethodHandler } from '../types/method-handler
 import type { MessagesSyncDiffEntry, MessagesSyncMessage, MessagesSyncReply } from '../types/messages-types.js';
 
 import { authenticate } from '../core/auth.js';
+import { DwnConstant } from '../core/dwn-constant.js';
 import { Encoder } from '../utils/encoder.js';
 import { hashToHex } from '../smt/smt-utils.js';
 import { messageReplyFromError } from '../core/message-reply.js';
@@ -13,11 +14,13 @@ import { PermissionsProtocol } from '../protocols/permissions.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
 /**
- * Default maximum inline data size for diff responses (256 KB).
+ * Maximum inline data size for diff responses — aligned with the
+ * {@link DwnConstant.maxDataSizeAllowedToBeEncoded} threshold (30 KB).
  * RecordsWrite data payloads smaller than this are base64url-encoded and
- * included directly in the diff reply, avoiding a separate MessagesRead round-trip.
+ * included directly in the diff reply.  Larger payloads must be fetched
+ * separately via MessagesRead.
  */
-const DEFAULT_MAX_INLINE_DATA_SIZE = 262_144;
+const DEFAULT_MAX_INLINE_DATA_SIZE = DwnConstant.maxDataSizeAllowedToBeEncoded;
 
 
 export class MessagesSyncHandler implements MethodHandler {

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -91,9 +91,32 @@ export class RecordsWriteHandler implements MethodHandler {
     }
 
     if (!incomingMessageIsNewest) {
-      return {
-        status: { code: 409, detail: 'Conflict' }
-      };
+      // Allow re-processing when the existing record was stored as an
+      // initial write without data (isLatestBaseState = false, status 204)
+      // and the incoming message now supplies data.  This happens during
+      // sync when a live pull initially stores the message without data
+      // and a subsequent poll or retry delivers the same message with data.
+      //
+      // We detect the incomplete state by checking whether the existing
+      // message is an initial write that lacks both inline encodedData and
+      // DataStore data — indicating it was stored without data.
+      let existingLacksData = false;
+      if (newestExistingMessage !== undefined && dataStream !== undefined) {
+        const isInitial = await RecordsWrite.isInitialWrite(newestExistingMessage);
+        if (isInitial) {
+          const hasInlineData = !!(newestExistingMessage as any).encodedData;
+          const hasStoredData = this.deps.dataStore
+            ? !!(await this.deps.dataStore.get(tenant, recordsWrite.message.recordId, message.descriptor.dataCid!))
+            : false;
+          existingLacksData = !hasInlineData && !hasStoredData;
+        }
+      }
+
+      if (!existingLacksData) {
+        return {
+          status: { code: 409, detail: 'Conflict' }
+        };
+      }
     }
 
     // Look up the core protocol (if any) for the incoming message so that lifecycle hooks
@@ -147,8 +170,13 @@ export class RecordsWriteHandler implements MethodHandler {
       // NOTE: We only emit a `RecordsWrite` when the message is the latest base state.
       // Because we allow a `RecordsWrite` which is not the latest state to be written, but not queried, we shouldn't emit it either.
       // It will be emitted as a part of a subsequent next write, if it is the latest base state.
+      //
+      // We emit `messageWithOptionalEncodedData` (not the raw `message`) so
+      // that WebSocket subscribers receive inline `encodedData` for small
+      // records (<= 30 KB).  This allows live sync to store the record
+      // immediately without a separate MessagesRead round-trip.
       if (this.deps.eventLog !== undefined && isLatestBaseState) {
-        await this.deps.eventLog.emit(tenant, { message, initialWrite }, indexes);
+        await this.deps.eventLog.emit(tenant, { message: messageWithOptionalEncodedData, initialWrite }, indexes);
       }
     } catch (error) {
       if (error instanceof DwnError) {


### PR DESCRIPTION
## Summary

Makes live WebSocket sync deliver **complete** records instead of data-less 204s.

## Problem

WebSocket events from the EventLog contained the RecordsWrite message metadata but NOT the record data. The live pull handler called `processRawMessage` without data, which stored the record as an incomplete initial write (`isLatestBaseState = false`, status 204). This caused:

1. The record was not queryable (queries filter on `isLatestBaseState = true`)
2. The SMT state index included the message CID, so subsequent poll sync saw matching roots and thought everything was in sync
3. Even refreshing the page didn't fix it — the "poisoned" CID prevented the diff from detecting the missing data

## Changes

### 1. Include `encodedData` in EventLog emit (`dwn-sdk-js`)
`RecordsWriteHandler` now emits `messageWithOptionalEncodedData` (with inline base64url data for records <= 30KB) instead of the raw message. WebSocket subscribers receive complete small records without a separate `MessagesRead` round-trip.

### 2. Handle inline `encodedData` in live pull (`agent`)
`extractDataStream` now checks `event.message.encodedData` and decodes it into a ReadableStream. For large records (no inline data, has `dataCid`), the handler fetches data from the remote DWN via `MessagesRead` before storing locally.

### 3. Repair incomplete 204 records (`dwn-sdk-js`)
`RecordsWriteHandler` now allows re-processing of the same message when the existing copy is an incomplete initial write (no `encodedData`, no DataStore data) and the incoming message supplies data. This repairs previously "poisoned" 204 records on the next sync cycle.

### 4. Lower diff inline threshold to 30KB (`dwn-sdk-js`)
`MessagesSyncHandler` diff inline threshold lowered from 256KB to 30KB to match `DwnConstant.maxDataSizeAllowedToBeEncoded`. Keeps diff responses lightweight — records > 30KB are fetched individually via `MessagesRead`.

## Testing

- dwn-sdk-js: 1350 pass, 0 fail
- agent: 1084 pass, 0 fail
- Lint: all 27 tasks pass