### PR TITLE
fix(agent): sync engine audit cleanup — cursor safety, push retry, dead code removal

### DIFF
--- a/.changeset/fix-sync-audit-cleanup.md
+++ b/.changeset/fix-sync-audit-cleanup.md
@@ -1,0 +1,29 @@
+---
+"@enbox/agent": patch
+---
+
+fix(agent): sync engine audit cleanup — cursor safety, push retry, dead code removal
+
+1. Live pull cursor only advances on successful processRawMessage.
+   Previously the cursor advanced even when processing failed,
+   permanently losing the event.
+
+2. Failed push CIDs are re-queued for retry on the next debounce
+   cycle (1s backoff). Previously they were permanently lost until
+   the SMT integrity check.
+
+3. Removed ~180 lines of dead code: walkTreeDiff, Semaphore,
+   getRemoteSubtreeHash, getRemoteLeaves, REMOTE_CONCURRENCY.
+   These were replaced by the batched diff mechanism.
+
+4. Simplified openLivePullSubscription grant lookup — removed
+   redundant try/catch fallback (unified scope matching handles it).
+
+5. Fixed openLocalPushSubscription to request MessagesSubscribe
+   grant instead of MessagesRead (semantically correct).
+
+6. Cached getSyncPermissionGrantId result in diffWithRemote to
+   avoid redundant lookup.
+
+7. flushPendingPushes now pushes to all endpoints in parallel
+   instead of sequentially.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -40,56 +40,6 @@ const MAX_DIFF_DEPTH = 16;
 const BATCHED_DIFF_DEPTH = 8;
 
 /**
- * Maximum number of concurrent remote HTTP requests during a tree diff.
- * The binary tree walk fans out in parallel — without a limit, depth N
- * produces 2^N concurrent requests, which can exhaust server rate limits.
- */
-const REMOTE_CONCURRENCY = 4;
-
-/**
- * Counting semaphore for bounding concurrent async operations.
- * Used by the tree walk to limit in-flight remote HTTP requests.
- */
-class Semaphore {
-  private _permits: number;
-  private readonly _waiting: (() => void)[] = [];
-
-  constructor(permits: number) {
-    this._permits = permits;
-  }
-
-  /** Wait until a permit is available, then consume one. */
-  async acquire(): Promise<void> {
-    if (this._permits > 0) {
-      this._permits--;
-      return;
-    }
-    return new Promise<void>((resolve) => {
-      this._waiting.push(resolve);
-    });
-  }
-
-  /** Release a permit, waking the next waiter if any. */
-  release(): void {
-    const next = this._waiting.shift();
-    if (next) {
-      next();
-    } else {
-      this._permits++;
-    }
-  }
-
-  /** Acquire a permit, run the task, then release regardless of outcome. */
-  async run<T>(fn: () => Promise<T>): Promise<T> {
-    await this.acquire();
-    try {
-      return await fn();
-    } finally {
-      this.release();
-    }
-  }
-}
-
 /**
  * Key for the subscription cursor sublevel. Cursors are keyed by
  * `{did}^{dwnUrl}[^{protocol}]` and store an opaque EventLog cursor string.
@@ -572,28 +522,19 @@ export class SyncEngineLevel implements SyncEngine {
     const filters = protocol ? [{ protocol }] : [];
 
     // Look up permission grant for MessagesSubscribe if using a delegate.
+    // The unified scope matching in AgentPermissionsApi accepts a
+    // Messages.Read grant for MessagesSubscribe requests, so a single
+    // lookup is sufficient.
     let permissionGrantId: string | undefined;
     if (delegateDid) {
-      try {
-        const grant = await this._permissionsApi.getPermissionForRequest({
-          connectedDid : did,
-          messageType  : DwnInterface.MessagesSubscribe,
-          delegateDid,
-          protocol,
-          cached       : true
-        });
-        permissionGrantId = grant.grant.id;
-      } catch {
-        // Fall back to trying MessagesRead which is a unified scope.
-        const grant = await this._permissionsApi.getPermissionForRequest({
-          connectedDid : did,
-          messageType  : DwnInterface.MessagesRead,
-          delegateDid,
-          protocol,
-          cached       : true
-        });
-        permissionGrantId = grant.grant.id;
-      }
+      const grant = await this._permissionsApi.getPermissionForRequest({
+        connectedDid : did,
+        messageType  : DwnInterface.MessagesSubscribe,
+        delegateDid,
+        protocol,
+        cached       : true
+      });
+      permissionGrantId = grant.grant.id;
     }
 
     // Define the subscription handler that processes incoming events.
@@ -627,12 +568,14 @@ export class SyncEngineLevel implements SyncEngine {
           }
 
           await this.agent.dwn.processRawMessage(did, event.message, { dataStream });
+
+          // Only advance the cursor after successful processing.
+          // If processing fails, the event will be re-delivered on
+          // reconnection (cursor-based resume from the last good point).
+          await this.setCursor(cursorKey, subMessage.cursor);
         } catch (error: any) {
           console.error(`SyncEngineLevel: Error processing live-pull event for ${did}`, error);
         }
-
-        // Persist cursor for resume on reconnect.
-        await this.setCursor(cursorKey, subMessage.cursor);
       }
     };
 
@@ -719,7 +662,7 @@ export class SyncEngineLevel implements SyncEngine {
     if (delegateDid) {
       const grant = await this._permissionsApi.getPermissionForRequest({
         connectedDid : did,
-        messageType  : DwnInterface.MessagesRead,
+        messageType  : DwnInterface.MessagesSubscribe,
         delegateDid,
         protocol,
         cached       : true,
@@ -790,10 +733,11 @@ export class SyncEngineLevel implements SyncEngine {
     const entries = [...this._pendingPushCids.entries()];
     this._pendingPushCids.clear();
 
-    for (const [, pending] of entries) {
+    // Push to all endpoints in parallel — each target is independent.
+    await Promise.all(entries.map(async ([, pending]) => {
       const { did, dwnUrl, delegateDid, protocol, cids } = pending;
       if (cids.length === 0) {
-        continue;
+        return;
       }
 
       try {
@@ -805,8 +749,25 @@ export class SyncEngineLevel implements SyncEngine {
         });
       } catch (error: any) {
         console.error(`SyncEngineLevel: Push-on-write failed for ${did} -> ${dwnUrl}`, error);
+
+        // Re-queue the failed CIDs so they are retried on the next
+        // debounce cycle (or picked up by the SMT integrity check).
+        const targetKey = this.buildCursorKey(did, dwnUrl, protocol);
+        let requeued = this._pendingPushCids.get(targetKey);
+        if (!requeued) {
+          requeued = { did, dwnUrl, delegateDid, protocol, cids: [] };
+          this._pendingPushCids.set(targetKey, requeued);
+        }
+        requeued.cids.push(...cids);
+
+        // Schedule a retry after a short delay.
+        if (!this._pushDebounceTimer) {
+          this._pushDebounceTimer = setTimeout((): void => {
+            void this.flushPendingPushes();
+          }, PUSH_DEBOUNCE_MS * 4); // Back off: 1 second instead of 250ms.
+        }
       }
-    }
+    }));
   }
 
   // ---------------------------------------------------------------------------
@@ -869,8 +830,6 @@ export class SyncEngineLevel implements SyncEngine {
 
     return undefined;
   }
-
-
 
   // ---------------------------------------------------------------------------
   // Default Hash Cache
@@ -987,97 +946,6 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   // ---------------------------------------------------------------------------
-  // Tree Diff — walk the SMT to find divergent leaf sets
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Walks the local and remote SMTs in parallel, recursing into subtrees whose
-   * hashes differ, until reaching `MAX_DIFF_DEPTH` where leaves are enumerated.
-   *
-   * Returns the sets of messageCids that exist only locally or only remotely.
-   */
-  private async walkTreeDiff({ did, dwnUrl, delegateDid, protocol }: {
-    did: string;
-    dwnUrl: string;
-    delegateDid?: string;
-    protocol?: string;
-  }): Promise<{ onlyLocal: string[]; onlyRemote: string[] }> {
-    const onlyLocal: string[] = [];
-    const onlyRemote: string[] = [];
-
-    // Hoist permission grant lookup — resolved once and reused for all subtree/leaf requests.
-    const permissionGrantId = await this.getSyncPermissionGrantId(did, delegateDid, protocol);
-
-    // Gate remote HTTP requests through a semaphore so the binary tree walk
-    // doesn't produce an exponential burst of concurrent requests.  Local
-    // DWN requests (in-process) are not gated.
-    const remoteSemaphore = new Semaphore(REMOTE_CONCURRENCY);
-
-    const walk = async (prefix: string): Promise<void> => {
-      // Get subtree hashes for this prefix from local and remote.
-      // Only the remote request is gated by the semaphore.
-      const [localHash, remoteHash] = await Promise.all([
-        this.getLocalSubtreeHash(did, prefix, delegateDid, protocol, permissionGrantId),
-        remoteSemaphore.run(() => this.getRemoteSubtreeHash(did, dwnUrl, prefix, delegateDid, protocol, permissionGrantId)),
-      ]);
-
-      // If hashes match, this subtree is identical — skip.
-      if (localHash === remoteHash) {
-        return;
-      }
-
-      // Short-circuit: if one side is the default (empty-subtree) hash, all entries
-      // on the other side are unique.  Enumerate leaves directly instead of recursing
-      // further into the tree — this avoids an exponential walk when one DWN has
-      // entries that the other lacks entirely in this subtree.
-      const emptyHash = await this.getDefaultHashHex(prefix.length);
-      if (remoteHash === emptyHash && localHash !== emptyHash) {
-        const localLeaves = await this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantId);
-        onlyLocal.push(...localLeaves);
-        return;
-      }
-      if (localHash === emptyHash && remoteHash !== emptyHash) {
-        const remoteLeaves = await remoteSemaphore.run(
-          () => this.getRemoteLeaves(did, dwnUrl, prefix, delegateDid, protocol, permissionGrantId),
-        );
-        onlyRemote.push(...remoteLeaves);
-        return;
-      }
-
-      // If we've reached the maximum diff depth, enumerate leaves.
-      if (prefix.length >= MAX_DIFF_DEPTH) {
-        const [localLeaves, remoteLeaves] = await Promise.all([
-          this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantId),
-          remoteSemaphore.run(() => this.getRemoteLeaves(did, dwnUrl, prefix, delegateDid, protocol, permissionGrantId)),
-        ]);
-
-        const localSet = new Set(localLeaves);
-        const remoteSet = new Set(remoteLeaves);
-
-        for (const cid of localLeaves) {
-          if (!remoteSet.has(cid)) {
-            onlyLocal.push(cid);
-          }
-        }
-        for (const cid of remoteLeaves) {
-          if (!localSet.has(cid)) {
-            onlyRemote.push(cid);
-          }
-        }
-        return;
-      }
-
-      // Recurse into left (0) and right (1) children in parallel.
-      await Promise.all([
-        walk(prefix + '0'),
-        walk(prefix + '1'),
-      ]);
-    };
-
-    await walk('');
-    return { onlyLocal, onlyRemote };
-  }
-
   // ---------------------------------------------------------------------------
   // Batched Diff — single round-trip set reconciliation
   // ---------------------------------------------------------------------------
@@ -1133,7 +1001,8 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     // Step 3: Enumerate local leaves for prefixes the remote reported as onlyLocal.
-    const permissionGrantIdForLeaves = await this.getSyncPermissionGrantId(did, delegateDid, protocol);
+    // Reuse the same grant ID from step 2 (avoids redundant lookup).
+    const permissionGrantIdForLeaves = permissionGrantId;
     const onlyLocalCids: string[] = [];
     for (const prefix of reply.onlyLocal ?? []) {
       const leaves = await this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantIdForLeaves);
@@ -1234,32 +1103,6 @@ export class SyncEngineLevel implements SyncEngine {
     return reply.hash ?? '';
   }
 
-  private async getRemoteSubtreeHash(
-    did: string, dwnUrl: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantId?: string
-  ): Promise<string> {
-    const syncMessage = await this.agent.dwn.processRequest({
-      store         : false,
-      author        : did,
-      target        : did,
-      messageType   : DwnInterface.MessagesSync,
-      granteeDid    : delegateDid,
-      messageParams : {
-        action: 'subtree',
-        prefix,
-        protocol,
-        permissionGrantId
-      }
-    });
-
-    const reply = await this.agent.rpc.sendDwnRequest({
-      dwnUrl,
-      targetDid : did,
-      message   : syncMessage.message,
-    }) as MessagesSyncReply;
-
-    return reply.hash ?? '';
-  }
-
   /**
    * Get all leaf messageCids under a given prefix from the local DWN.
    *
@@ -1291,32 +1134,6 @@ export class SyncEngineLevel implements SyncEngine {
       }
     });
     const reply = response.reply as MessagesSyncReply;
-    return reply.entries ?? [];
-  }
-
-  private async getRemoteLeaves(
-    did: string, dwnUrl: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantId?: string
-  ): Promise<string[]> {
-    const syncMessage = await this.agent.dwn.processRequest({
-      store         : false,
-      author        : did,
-      target        : did,
-      messageType   : DwnInterface.MessagesSync,
-      granteeDid    : delegateDid,
-      messageParams : {
-        action: 'leaves',
-        prefix,
-        protocol,
-        permissionGrantId
-      }
-    });
-
-    const reply = await this.agent.rpc.sendDwnRequest({
-      dwnUrl,
-      targetDid : did,
-      message   : syncMessage.message,
-    }) as MessagesSyncReply;
-
     return reply.entries ?? [];
   }
 

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -708,29 +708,7 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._liveSubscriptions = [];
     });
 
-    it('should fall back to MessagesRead grant when MessagesSubscribe grant not found', async () => {
-      const permStub = sinon.stub()
-        .onFirstCall().rejects(new Error('no subscribe grant'))
-        .onSecondCall().resolves({ grant: { id: 'read-grant-1' } });
-      const { agent } = createPullMockAgent();
-      const engine = new SyncEngineLevel({ db, agent });
-      (engine as any)._permissionsApi = {
-        getPermissionForRequest : permStub,
-        clear                   : sinon.stub(),
-      };
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
-
-      await (engine as any).openLivePullSubscription({
-        did         : 'did:example:alice',
-        dwnUrl      : 'https://dwn.example.com',
-        delegateDid : 'did:example:delegate',
-      });
-
-      expect(permStub.callCount).toBe(2);
-      (engine as any)._liveSubscriptions = [];
-    });
-
-    it('should throw when both permission grant lookups fail', async () => {
+    it('should throw when permission grant lookup fails', async () => {
       const permStub = sinon.stub().rejects(new Error('no grant'));
       const { agent, rpcStub } = createPullMockAgent();
       const engine = new SyncEngineLevel({ db, agent });
@@ -1024,30 +1002,6 @@ describe('SyncEngineLevel — private methods', () => {
       expect(typeof hash).toBe('string');
     });
 
-    it('getRemoteSubtreeHash should return hash from remote DWN', async () => {
-      const mockAgent = {
-        agentDid : 'did:example:agent',
-        dwn      : {
-          processRequest: sinon.stub().resolves({
-            message : {},
-            reply   : { status: { code: 200 } },
-          }),
-        },
-        rpc: {
-          sendDwnRequest: sinon.stub().resolves({
-            status : { code: 200 },
-            hash   : 'subtree-hash-remote',
-          }),
-        },
-      } as any;
-      const engine = new SyncEngineLevel({ db, agent: mockAgent });
-
-      const hash = await (engine as any).getRemoteSubtreeHash(
-        'did:example:alice', 'https://dwn.example.com', '01',
-      );
-      expect(hash).toBe('subtree-hash-remote');
-    });
-
     it('getLocalLeaves should query StateIndex directly and return CIDs', async () => {
       const mockStateIndex = {
         getLeaves         : sinon.stub().resolves(['cid-a', 'cid-b']),
@@ -1079,140 +1033,6 @@ describe('SyncEngineLevel — private methods', () => {
       expect(leaves).toEqual([]);
     });
 
-    it('getRemoteLeaves should return entries from remote DWN', async () => {
-      const mockAgent = {
-        agentDid : 'did:example:agent',
-        dwn      : {
-          processRequest: sinon.stub().resolves({
-            message : {},
-            reply   : { status: { code: 200 } },
-          }),
-        },
-        rpc: {
-          sendDwnRequest: sinon.stub().resolves({
-            status  : { code: 200 },
-            entries : ['cid-x', 'cid-y'],
-          }),
-        },
-      } as any;
-      const engine = new SyncEngineLevel({ db, agent: mockAgent });
-
-      const leaves = await (engine as any).getRemoteLeaves(
-        'did:example:alice', 'https://dwn.example.com', '01',
-      );
-      expect(leaves).toEqual(['cid-x', 'cid-y']);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // walkTreeDiff
-  // ---------------------------------------------------------------------------
-
-  describe('walkTreeDiff', () => {
-    it('should return empty diff when all subtrees match', async () => {
-      const mockAgent = { agentDid: 'did:example:agent' } as any;
-      const engine = new SyncEngineLevel({ db, agent: mockAgent });
-      (engine as any)._permissionsApi = { getPermissionForRequest: sinon.stub(), clear: sinon.stub() };
-
-      // All subtrees match
-      sinon.stub(engine as any, 'getLocalSubtreeHash').resolves('same-hash');
-      sinon.stub(engine as any, 'getRemoteSubtreeHash').resolves('same-hash');
-      sinon.stub(engine as any, 'getSyncPermissionGrantId').resolves(undefined);
-
-      const diff = await (engine as any).walkTreeDiff({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com',
-      });
-
-      expect(diff.onlyLocal).toEqual([]);
-      expect(diff.onlyRemote).toEqual([]);
-    });
-
-    it('should enumerate leaves when reaching MAX_DIFF_DEPTH', async () => {
-      const mockAgent = { agentDid: 'did:example:agent' } as any;
-      const engine = new SyncEngineLevel({ db, agent: mockAgent });
-      (engine as any)._permissionsApi = { getPermissionForRequest: sinon.stub(), clear: sinon.stub() };
-
-      // Root level differs, all intermediate levels differ, leaf level has different CIDs
-      const localSubtreeStub = sinon.stub(engine as any, 'getLocalSubtreeHash');
-      const remoteSubtreeStub = sinon.stub(engine as any, 'getRemoteSubtreeHash');
-      const localLeavesStub = sinon.stub(engine as any, 'getLocalLeaves');
-      const remoteLeavesStub = sinon.stub(engine as any, 'getRemoteLeaves');
-      sinon.stub(engine as any, 'getSyncPermissionGrantId').resolves(undefined);
-
-      // For all prefixes shorter than 16, return different hashes and non-default hashes
-      localSubtreeStub.callsFake(async (_did: string, prefix: string): Promise<string> => {
-        if (prefix.length >= 16) { return 'local-leaf-hash'; }
-        // Only the leftmost child (all zeros) differs
-        if (prefix === '' || prefix.split('').every((c: string): boolean => c === '0')) {
-          return 'local-' + prefix;
-        }
-        return 'matching-' + prefix;
-      });
-      remoteSubtreeStub.callsFake(async (_did: string, _url: string, prefix: string): Promise<string> => {
-        if (prefix.length >= 16) { return 'remote-leaf-hash'; }
-        if (prefix === '' || prefix.split('').every((c: string): boolean => c === '0')) {
-          return 'remote-' + prefix;
-        }
-        return 'matching-' + prefix;
-      });
-
-      // Override getDefaultHashHex to return a unique value that won't match
-      sinon.stub(engine as any, 'getDefaultHashHex').resolves('default-empty');
-
-      // At leaf level (prefix of length 16), return different CID sets
-      localLeavesStub.resolves(['cid-local-only', 'cid-shared']);
-      remoteLeavesStub.resolves(['cid-remote-only', 'cid-shared']);
-
-      const diff = await (engine as any).walkTreeDiff({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com',
-      });
-
-      expect(diff.onlyLocal).toContain('cid-local-only');
-      expect(diff.onlyRemote).toContain('cid-remote-only');
-      // The shared CID should not appear in either
-      expect(diff.onlyLocal).not.toContain('cid-shared');
-      expect(diff.onlyRemote).not.toContain('cid-shared');
-    });
-
-    it('should short-circuit when remote is empty subtree', async () => {
-      const mockAgent = { agentDid: 'did:example:agent' } as any;
-      const engine = new SyncEngineLevel({ db, agent: mockAgent });
-      (engine as any)._permissionsApi = { getPermissionForRequest: sinon.stub(), clear: sinon.stub() };
-      sinon.stub(engine as any, 'getSyncPermissionGrantId').resolves(undefined);
-
-      // Remote returns default (empty) hash, local has data
-      sinon.stub(engine as any, 'getLocalSubtreeHash').resolves('local-has-data');
-      sinon.stub(engine as any, 'getRemoteSubtreeHash').resolves('default-empty');
-      sinon.stub(engine as any, 'getDefaultHashHex').resolves('default-empty');
-      sinon.stub(engine as any, 'getLocalLeaves').resolves(['cid-1', 'cid-2']);
-
-      const diff = await (engine as any).walkTreeDiff({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com',
-      });
-
-      expect(diff.onlyLocal).toEqual(['cid-1', 'cid-2']);
-      expect(diff.onlyRemote).toEqual([]);
-    });
-
-    it('should short-circuit when local is empty subtree', async () => {
-      const mockAgent = { agentDid: 'did:example:agent' } as any;
-      const engine = new SyncEngineLevel({ db, agent: mockAgent });
-      (engine as any)._permissionsApi = { getPermissionForRequest: sinon.stub(), clear: sinon.stub() };
-      sinon.stub(engine as any, 'getSyncPermissionGrantId').resolves(undefined);
-
-      // Local returns default (empty) hash, remote has data
-      sinon.stub(engine as any, 'getLocalSubtreeHash').resolves('default-empty');
-      sinon.stub(engine as any, 'getRemoteSubtreeHash').resolves('remote-has-data');
-      sinon.stub(engine as any, 'getDefaultHashHex').resolves('default-empty');
-      sinon.stub(engine as any, 'getRemoteLeaves').resolves(['cid-r1', 'cid-r2']);
-
-      const diff = await (engine as any).walkTreeDiff({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com',
-      });
-
-      expect(diff.onlyLocal).toEqual([]);
-      expect(diff.onlyRemote).toEqual(['cid-r1', 'cid-r2']);
-    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Comprehensive sync engine audit cleanup. Net: **-334 lines** (70 added, 404 removed).

## Changes

### Critical fixes

1. **Cursor safety**: Live pull cursor only advances after `processRawMessage` succeeds. Previously it advanced even on failure, permanently losing the event until the next SMT integrity check.

2. **Push retry**: Failed push CIDs are re-queued into `_pendingPushCids` with a 1-second backoff timer. Previously they were cleared from the accumulator on failure and permanently lost.

### Dead code removal (-180 lines)

3. Removed `walkTreeDiff()`, `Semaphore` class, `getRemoteSubtreeHash()`, `getRemoteLeaves()`, and `REMOTE_CONCURRENCY` constant. All replaced by the batched diff mechanism (`diffWithRemote`). Corresponding tests removed.

### Cleanup

4. **Simplified grant lookup**: Removed redundant try/catch fallback in `openLivePullSubscription` — the unified scope matching in `AgentPermissionsApi` already handles `MessagesSubscribe` → `MessagesRead` grant mapping.

5. **Semantic correctness**: `openLocalPushSubscription` now requests a `MessagesSubscribe` grant instead of `MessagesRead`.

6. **Redundant lookup**: Cached `getSyncPermissionGrantId` result in `diffWithRemote` (was called twice for the same args).

7. **Parallel push**: `flushPendingPushes` now pushes to all DWN endpoints in parallel via `Promise.all` instead of sequentially.

## Testing

- 1077 pass, 0 fail (7 dead code tests removed)
- Lint: pass