### PR TITLE
fix(agent): prevent repair from continuing after teardown via generation guard

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -160,6 +160,14 @@ export class SyncEngineLevel implements SyncEngine {
   /** Current sync mode, set by `startSync`. */
   private _syncMode: SyncMode = 'poll';
 
+  /**
+   * Monotonic session generation counter. Incremented on every teardown.
+   * Async operations (repair, retry timers) capture the generation at start
+   * and bail if it has changed — this prevents stale work from mutating
+   * state after teardown or mode switch.
+   */
+  private _syncGeneration = 0;
+
   /** Active live pull subscriptions (remote -> local via MessagesSubscribe). */
   private _liveSubscriptions: LiveSubscription[] = [];
 
@@ -722,8 +730,12 @@ export class SyncEngineLevel implements SyncEngine {
     const backoff = SyncEngineLevel.REPAIR_BACKOFF_MS;
     const delayMs = backoff[Math.min(attempts - 1, backoff.length - 1)];
 
+    const timerGeneration = this._syncGeneration;
     const timer = setTimeout(async (): Promise<void> => {
       this._repairRetryTimers.delete(linkKey);
+
+      // Bail if teardown occurred since this timer was scheduled.
+      if (this._syncGeneration !== timerGeneration) { return; }
 
       // Verify link still exists and is still repairing.
       const currentLink = this._activeLinks.get(linkKey);
@@ -768,6 +780,11 @@ export class SyncEngineLevel implements SyncEngine {
     const link = this._activeLinks.get(linkKey);
     if (!link) { return; }
 
+    // Capture the sync generation at repair start. If teardown occurs during
+    // any await, the generation will have incremented and we bail before
+    // mutating state — preventing the race where repair continues after teardown.
+    const generation = this._syncGeneration;
+
     const { tenantDid: did, remoteEndpoint: dwnUrl, delegateDid, protocol } = link;
     const attempts = (this._repairAttempts.get(linkKey) ?? 0) + 1;
     this._repairAttempts.set(linkKey, attempts);
@@ -775,6 +792,7 @@ export class SyncEngineLevel implements SyncEngine {
     // Step 1: Close existing subscriptions FIRST to stop old events from
     // mutating local state while repair runs.
     await this.closeLinkSubscriptions(link);
+    if (this._syncGeneration !== generation) { return; } // Teardown occurred.
 
     // Step 2: Clear runtime ordinals immediately — stale state must not
     // persist across repair attempts (successful or failed).
@@ -786,10 +804,13 @@ export class SyncEngineLevel implements SyncEngine {
     try {
       // Step 3: Run SMT reconciliation for this link.
       const localRoot = await this.getLocalRoot(did, delegateDid, protocol);
+      if (this._syncGeneration !== generation) { return; }
       const remoteRoot = await this.getRemoteRoot(did, dwnUrl, delegateDid, protocol);
+      if (this._syncGeneration !== generation) { return; }
 
       if (localRoot !== remoteRoot) {
         const diff = await this.diffWithRemote({ did, dwnUrl, delegateDid, protocol });
+        if (this._syncGeneration !== generation) { return; }
 
         if (diff.onlyRemote.length > 0) {
           const prefetched: (MessagesSyncDiffEntry & { message: GenericMessage })[] = [];
@@ -804,10 +825,12 @@ export class SyncEngineLevel implements SyncEngine {
             }
           }
           await this.pullMessages({ did, dwnUrl, delegateDid, protocol, messageCids: needsFetchCids, prefetched });
+          if (this._syncGeneration !== generation) { return; }
         }
 
         if (diff.onlyLocal.length > 0) {
           await this.pushMessages({ did, dwnUrl, delegateDid, protocol, messageCids: diff.onlyLocal });
+          if (this._syncGeneration !== generation) { return; }
         }
       }
 
@@ -824,13 +847,12 @@ export class SyncEngineLevel implements SyncEngine {
       const resumeToken = repairCtx?.resumeToken ?? link.pull.contiguousAppliedToken;
       ReplicationLedger.resetCheckpoint(link.pull, resumeToken);
       await this.ledger.saveLink(link);
+      if (this._syncGeneration !== generation) { return; }
 
       // Step 5: Reopen subscriptions with the repaired checkpoints.
-      // Pull: resumeToken closes the remote→local race window.
-      // Push: push checkpoint closes the local→remote race window —
-      //   local writes during repair are replayed via catch-up.
       const target = { did, dwnUrl, delegateDid, protocol };
       await this.openLivePullSubscription(target);
+      if (this._syncGeneration !== generation) { return; }
       try {
         await this.openLocalPushSubscription({
           ...target,
@@ -846,22 +868,25 @@ export class SyncEngineLevel implements SyncEngine {
         }
         throw pushError;
       }
+      if (this._syncGeneration !== generation) { return; }
 
       // Step 6: Clean up repair context and transition to live.
       this._repairContext.delete(linkKey);
       this._repairAttempts.delete(linkKey);
-      // Clear any pending retry timer — repair succeeded.
       const retryTimer = this._repairRetryTimers.get(linkKey);
       if (retryTimer) { clearTimeout(retryTimer); this._repairRetryTimers.delete(linkKey); }
       await this.ledger.setStatus(link, 'live');
 
     } catch (error: any) {
+      // If teardown occurred during repair, don't retry or enter degraded_poll.
+      if (this._syncGeneration !== generation) { return; }
+
       console.error(`SyncEngineLevel: Repair failed for ${did} -> ${dwnUrl} (attempt ${attempts})`, error);
 
       if (attempts >= SyncEngineLevel.MAX_REPAIR_ATTEMPTS) {
         console.warn(`SyncEngineLevel: Max repair attempts reached for ${did} -> ${dwnUrl}, entering degraded_poll`);
         await this.enterDegradedPoll(linkKey);
-        return; // enterDegradedPoll handles further retries.
+        return;
       }
 
       // Re-throw so callers (degraded_poll timer) can handle retry scheduling.
@@ -915,7 +940,15 @@ export class SyncEngineLevel implements SyncEngine {
     const jitter = Math.floor(Math.random() * 15_000);
     const interval = baseInterval + jitter;
 
+    const pollGeneration = this._syncGeneration;
     const timer = setInterval(async (): Promise<void> => {
+      // Bail if teardown occurred since this timer was created.
+      if (this._syncGeneration !== pollGeneration) {
+        clearInterval(timer);
+        this._degradedPollTimers.delete(linkKey);
+        return;
+      }
+
       // If the link was transitioned out of degraded_poll externally (e.g.,
       // by teardown or manual intervention), stop polling.
       if (link.status !== 'degraded_poll') {
@@ -952,6 +985,11 @@ export class SyncEngineLevel implements SyncEngine {
    * Tears down all live subscriptions and push listeners.
    */
   private async teardownLiveSync(): Promise<void> {
+    // Increment generation to invalidate all in-flight async operations
+    // (repairs, retry timers, degraded-poll ticks). Any async work that
+    // captured the previous generation will bail on its next checkpoint.
+    this._syncGeneration++;
+
     // Clear the push debounce timer.
     if (this._pushDebounceTimer) {
       clearTimeout(this._pushDebounceTimer);

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -2138,5 +2138,44 @@ describe('SyncEngineLevel — private methods', () => {
       const pushTarget = pushSubStub.firstCall.args[0];
       expect(pushTarget.pushCursor).toEqual(pushToken);
     });
+
+    it('should bail if teardown occurs during repair (generation check)', async () => {
+      const engine = new SyncEngineLevel({ db });
+      const linkKey = 'did:example:alice^https://dwn.example.com';
+
+      const link = {
+        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
+        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
+        pull           : {}, push           : {},
+      } as any;
+      (engine as any)._activeLinks.set(linkKey, link);
+      (engine as any).getOrCreateRuntime(linkKey);
+
+      const closeStub = sinon.stub(engine as any, 'closeLinkSubscriptions').resolves();
+
+      // Stub getLocalRoot to simulate an async operation during which teardown occurs.
+      sinon.stub(engine as any, 'getLocalRoot').callsFake(async () => {
+        // Simulate teardown by incrementing the generation.
+        (engine as any)._syncGeneration++;
+        return 'root-a';
+      });
+
+      const openPullStub = sinon.stub(engine as any, 'openLivePullSubscription').resolves();
+
+      const saveStub = sinon.stub().resolves();
+      const setStatusStub = sinon.stub().resolves();
+      (engine as any)._ledger = { setStatus: setStatusStub, saveLink: saveStub };
+
+      await (engine as any).doRepairLink(linkKey);
+
+      // closeLinkSubscriptions should have been called (before the generation check).
+      expect(closeStub.calledOnce).toBe(true);
+
+      // But subscriptions should NOT be reopened — repair bailed after getLocalRoot.
+      expect(openPullStub.called).toBe(false);
+
+      // Link should NOT have been set to live.
+      expect(setStatusStub.calledWith(link, 'live')).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a lifecycle race where async repair work continues running after `teardownLiveSync()` clears all state, potentially reopening subscriptions and setting links back to `live` after sync was stopped.

**1 commit, 2 files changed, +82/-5**

## The problem

`doRepairLink()` is a multi-step async operation that captures `link` at the start. If `teardownLiveSync()` runs while repair is in-flight:
1. Teardown clears subscriptions, timers, `_activeLinks`, `_linkRuntimes`
2. Repair's next `await` resumes and continues with its captured `link` reference
3. Repair runs SMT, reopens subscriptions, sets link to `live`
4. Sync is now partially restarted after being torn down

This can happen during: stop/start mode switches, agent shutdown, test cleanup.

## The fix

A monotonic `_syncGeneration` counter incremented on every `teardownLiveSync()`. Async operations capture the generation at start and bail if it has changed.

**Why generation counter, not boolean `_stopped`:**
A boolean would incorrectly pass after a stop→restart cycle. The generation counter ensures a repair from session N fails its check even if session N+1 has already started.

**Checkpoints in `doRepairLink`** (after every `await`):
- After `closeLinkSubscriptions`
- After `getLocalRoot`, `getRemoteRoot`
- After `diffWithRemote`
- After `pullMessages`, `pushMessages`
- After `ledger.saveLink`
- After `openLivePullSubscription`, `openLocalPushSubscription`
- In `catch` block (don't retry or enter `degraded_poll` after teardown)

**Checkpoints in timers:**
- `scheduleRepairRetry` timer checks before executing
- `enterDegradedPoll` timer checks before each tick

## Test

- Simulates teardown by incrementing generation inside `getLocalRoot` stub
- Verifies subscriptions are NOT reopened after generation change
- Verifies link is NOT set to `live` after generation change

Tracks: enboxorg/enbox-internal#17