### PR TITLE
feat(agent): deepen closure classes 5/6 — key-delivery records, $ref parent, cross-protocol roles

### DIFF
--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -248,18 +248,28 @@ function extractProtocolAwareDeps(
         identifierType  : 'protocol',
       });
 
-      // If the record has a contextId (multi-party context), a contextKey record
-      // tagged with this protocol and contextId must be locally present for decryption.
+      // Context key lookup (non-enforcing scaffolding):
+      // For records with a contextId, a contextKey record in the key-delivery
+      // protocol would be needed for multi-party decryption. However, determining
+      // whether a context is actually multi-party requires evaluating the protocol's
+      // action rules ($role descendants, relational who/of rules) — which is complex
+      // rule-set tree analysis not yet implemented here.
+      //
+      // For now, this edge is emitted as a diagnostic marker but does NOT fail
+      // closure when the context key is absent (the resolver returns a synthetic
+      // sentinel). This avoids false failures for single-party contexts where
+      // ProtocolPath encryption is used and no context key exists.
+      //
+      // Full enforcement requires: multi-party detection → if multi-party, require
+      // contextKey; if single-party, skip. Deferred to follow-up.
       const contextId = (message as any).contextId as string | undefined;
       if (contextId) {
-        // Context root is the first segment of contextId — context keys are tagged
-        // with the root contextId, not the full path.
         const rootContextId = contextId.split('/')[0];
         edges.push({
           dependencyClass : 5,
           label           : 'contextKeyRecord',
           identifier      : `${desc.protocol}:${rootContextId}`,
-          identifierType  : 'messageCid', // Resolved via tag-based query, not CID lookup (see resolveDependency)
+          identifierType  : 'messageCid',
         });
       }
     }
@@ -293,14 +303,16 @@ function extractProtocolAwareDeps(
         // Level 2: $ref parent record in the referenced protocol.
         // When path depth is 2 (e.g., "thread/comment"), the parent is the $ref node
         // itself, which lives in the referenced protocol. The parent's recordId is
-        // the message's parentId.
+        // the message's parentId. The query MUST be scoped to the referenced
+        // protocol URI to prevent false matches from the composing protocol.
+        // Identifier format: "referencedProtocol|parentId"
         const pathSegments = protocolPath.split('/');
         const parentId = desc.parentId as string | undefined;
         if (pathSegments.length === 2 && parentId) {
           edges.push({
             dependencyClass : 6,
             label           : 'crossProtocolParent',
-            identifier      : parentId,
+            identifier      : `${referencedProtocol}|${parentId}`,
             identifierType  : 'recordId',
           });
         }
@@ -590,7 +602,25 @@ async function resolveDependency(
         return byRecordId.length > 0 ? byRecordId[0] : null;
       }
 
-      // For parentRecord or other recordId lookups, query latest state.
+      // crossProtocolParent: identifier is "referencedProtocol|parentId"
+      // Query MUST be scoped to the referenced protocol URI.
+      if (edge.label === 'crossProtocolParent') {
+        const pipeIdx = edge.identifier.indexOf('|');
+        if (pipeIdx > 0) {
+          const refProtocol = edge.identifier.substring(0, pipeIdx);
+          const refParentId = edge.identifier.substring(pipeIdx + 1);
+          const { messages: refParents } = await messageStore.query(context.tenantDid, [{
+            interface         : 'Records',
+            method            : 'Write',
+            protocol          : refProtocol,
+            recordId          : refParentId,
+            isLatestBaseState : true,
+          }]);
+          return refParents.length > 0 ? refParents[0] : null;
+        }
+      }
+
+      // For parentRecord, contextRoot, or other recordId lookups, query latest state.
       const { messages } = await messageStore.query(context.tenantDid, [{
         interface         : 'Records',
         recordId          : edge.identifier,

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -37,6 +37,13 @@ function mockMessageStore(options: {
       if (filter.interface === 'Protocols' && filter.protocol) {
         return { messages: queryResults.get(`protocol:${filter.protocol}`) ?? [] };
       }
+      // Match by protocol + recordId (Class 6 cross-protocol parent)
+      if (filter.recordId && filter.protocol && filter.interface === 'Records') {
+        const key = `protocol+recordId:${filter.protocol}|${filter.recordId}`;
+        const result = queryResults.get(key);
+        if (result) { return { messages: result }; }
+        // Fall through to bare recordId match below.
+      }
       // Match by recordId (Class 2/3)
       if (filter.recordId) {
         return { messages: queryResults.get(`recordId:${filter.recordId}`) ?? [] };
@@ -574,6 +581,7 @@ describe('evaluateClosure', () => {
           ['protocol:https://comments.example.com', [composingConfig]],
           ['protocol:https://threads.example.com', [referencedConfig]],
           ['recordId:thread-1', [parentThread]],
+          ['protocol+recordId:https://threads.example.com|thread-1', [parentThread]],
         ]),
       });
 


### PR DESCRIPTION
## Summary

Deepens closure classes 5 and 6 with actual dependency extraction that reflects DWN runtime mechanics. Honest about what's enforced vs scaffolding.

**2 commits, 2 files changed**

## Class 5: Encryption / key-delivery

| Level | Edge label | Enforced? | What it does |
|-------|-----------|-----------|-------------|
| 1 | `encryptionKeyMaterial` | Yes | Requires ProtocolsConfigure with `$encryption` (via class 1) |
| 2 | `keyDeliveryProtocol` | Yes | Requires key-delivery protocol ProtocolsConfigure installed locally |
| 3 | `contextKeyRecord` | **No — diagnostic scaffolding** | Emits edge for multi-party context keys but returns synthetic sentinel on absence |

**Why Level 3 is non-enforcing:** Determining whether a context is multi-party requires evaluating the protocol's action rules (`$role` descendants, relational `who`/`of` rules) — complex rule-set tree analysis not yet implemented. Single-party contexts use ProtocolPath encryption and have no context key. Without multi-party detection, enforcing presence would cause false failures.

**Follow-up needed:** Multi-party detection function → if multi-party, require contextKey; if single-party, skip.

## Class 6: Cross-protocol `$ref`

| Level | Edge label | Enforced? | What it does |
|-------|-----------|-----------|-------------|
| 1 | `crossProtocolConfig` | Yes | Requires referenced protocol's ProtocolsConfigure |
| 2 | `crossProtocolParent` | **Yes — protocol-scoped** | Requires parent record in the referenced protocol (2-segment paths) |
| 3 | `crossProtocolRoleConfig` | Yes (config only) | Requires ProtocolsConfigure for cross-protocol role resolution |

**Level 2 correctness:** The `crossProtocolParent` edge now uses composite identifier `referencedProtocol|parentId` and the resolution query is scoped to `{ protocol: refProtocol, recordId: refParentId }`. This prevents false matches from records in the composing protocol.

**What remains for Level 3:** The actual role RECORD (e.g., participant record) requires filter-based queries (protocol + protocolPath + recipient + contextId prefix) not yet supported by `resolveDependency`.

## Tests (26 total)
- Class 5: key-delivery protocol + context key scaffolding edges
- Class 6: crossProtocolConfig + crossProtocolParent (protocol-scoped) + missing config failure
- Mock store updated with `protocol+recordId` composite key handling

Tracks: enboxorg/enbox-internal#17
