### PR TITLE
feat(agent): enforce cross-protocol role record closure via filter-based resolution

### DIFF
--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -352,7 +352,11 @@ function extractProtocolAwareDeps(
             // Mirrors verifyInvokedRole() from protocol-authorization-action.ts:
             // queries by protocol + protocolPath + recipient + contextId prefix.
             const roleProtocolPath = protocolRole.substring(roleColonIdx + 1);
-            const messageAuthor = decoded.authorDid ?? decoded.author;
+            // Derive author from the message's JWS signature, not from the
+            // payload. The payload does NOT contain an author field — the
+            // DWN SDK extracts it from the signature's `kid` header via
+            // Message.getAuthor().
+            const messageAuthor = Message.getAuthor(message);
             const messageContextId = (message as any).contextId as string | undefined;
 
             if (messageAuthor) {
@@ -380,10 +384,14 @@ function extractProtocolAwareDeps(
                 }
               }
 
+              // Cache key must include the context prefix to prevent false
+              // positives across different contexts (e.g., different threads).
+              const contextPrefix = roleFilter.contextId
+                ? JSON.stringify(roleFilter.contextId) : 'no-context';
               edges.push({
                 dependencyClass : 6,
                 label           : 'crossProtocolRoleRecord',
-                identifier      : `${roleProtocol}|${roleProtocolPath}|${messageAuthor}`,
+                identifier      : `${roleProtocol}|${roleProtocolPath}|${messageAuthor}|${contextPrefix}`,
                 identifierType  : 'filter',
                 filter          : roleFilter,
               });

--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -718,7 +718,7 @@ async function resolveDependency(
     case 'messageCid': {
       // Special case: contextKeyRecord uses messageCid type but requires a
       // tag-based query against the key-delivery protocol, not a CID lookup.
-      // Identifier format is "sourceProtocol:rootContextId".
+      // Identifier format is "sourceProtocol|rootContextId".
       if (edge.label === 'contextKeyRecord') {
         const separatorIdx = edge.identifier.indexOf('|');
         if (separatorIdx > 0) {

--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -113,8 +113,9 @@ function extractAuthorizationDeps(message: GenericMessage): ClosureDependencyEdg
   const auth = (message as any).authorization;
   if (!auth) { return []; }
 
-  // Check for permissionGrantId in the signature payload.
-  const payload = auth.authorSignature?.payload ?? auth.payload;
+  // The signature payload is at authorization.signature.payload (GeneralJws).
+  // This is the base64url-encoded JSON containing permissionGrantId, protocolRole, etc.
+  const payload = auth.signature?.payload;
   if (payload) {
     try {
       // Payload is base64url-encoded JSON.
@@ -327,7 +328,8 @@ function extractProtocolAwareDeps(
   // This is extracted from the authorization payload regardless of $ref presence.
   const auth = (message as any).authorization;
   if (auth && protocolDef?.uses) {
-    const payload = auth.authorSignature?.payload ?? auth.payload;
+    // Same payload path as class 3: authorization.signature.payload
+    const payload = auth.signature?.payload;
     if (payload) {
       try {
         const decoded = JSON.parse(

--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -347,16 +347,47 @@ function extractProtocolAwareDeps(
               identifier      : roleProtocol,
               identifierType  : 'protocol',
             });
-            // Note: The actual role record (e.g., the participant record in the
-            // threads protocol) would require querying by protocol + protocolPath +
-            // recipient + contextId prefix. That query depends on the message's
-            // author and context, which is available here. However, the role record's
-            // recordId is not known from the message alone — it requires a query.
-            // For now, the ProtocolsConfigure dependency ensures the protocol
-            // definition is available for authorization evaluation. Full role-record
-            // closure (querying for the actual participant record) is deferred as it
-            // requires the resolveDependency infrastructure to support tag/filter-based
-            // queries, not just recordId lookups.
+
+            // The actual role record in the referenced protocol.
+            // Mirrors verifyInvokedRole() from protocol-authorization-action.ts:
+            // queries by protocol + protocolPath + recipient + contextId prefix.
+            const roleProtocolPath = protocolRole.substring(roleColonIdx + 1);
+            const messageAuthor = decoded.authorDid ?? decoded.author;
+            const messageContextId = (message as any).contextId as string | undefined;
+
+            if (messageAuthor) {
+              // Build the role record query filter.
+              const roleFilter: Record<string, unknown> = {
+                interface         : 'Records',
+                method            : 'Write',
+                protocol          : roleProtocol,
+                protocolPath      : roleProtocolPath,
+                recipient         : messageAuthor,
+                isLatestBaseState : true,
+              };
+
+              // Context scoping: the role record must be within the same context.
+              // The ancestor segment count determines how many contextId segments
+              // to use as the prefix filter (matching verifyInvokedRole logic).
+              if (messageContextId) {
+                const ancestorCount = roleProtocolPath.split('/').length - 1;
+                if (ancestorCount > 0) {
+                  const contextSegments = messageContextId.split('/');
+                  const contextPrefix = contextSegments.slice(0, ancestorCount).join('/');
+                  if (contextPrefix) {
+                    roleFilter.contextId = { gte: contextPrefix, lt: contextPrefix + '\uffff' };
+                  }
+                }
+              }
+
+              edges.push({
+                dependencyClass : 6,
+                label           : 'crossProtocolRoleRecord',
+                identifier      : `${roleProtocol}|${roleProtocolPath}|${messageAuthor}`,
+                identifierType  : 'filter',
+                filter          : roleFilter,
+              });
+            }
           }
         }
       } catch {
@@ -702,6 +733,17 @@ async function resolveDependency(
         }
       }
       return await messageStore.get(context.tenantDid, edge.identifier) ?? null;
+    }
+
+    case 'filter': {
+      // Filter-based resolution: query the MessageStore with the structured
+      // filter carried in edge.filter. Used for dependencies that require
+      // multi-field queries (e.g., cross-protocol role records).
+      if (!edge.filter) { return null; }
+      const { messages: filterResults } = await messageStore.query(
+        context.tenantDid, [edge.filter as any]
+      );
+      return filterResults.length > 0 ? filterResults[0] : null;
     }
 
     default:

--- a/packages/agent/src/sync-closure-types.ts
+++ b/packages/agent/src/sync-closure-types.ts
@@ -52,7 +52,14 @@ export type ClosureDependencyEdge = {
    */
   identifier: string;
   /** The type of identifier — determines the fetch strategy. */
-  identifierType: 'messageCid' | 'recordId' | 'protocol' | 'grantId';
+  identifierType: 'messageCid' | 'recordId' | 'protocol' | 'grantId' | 'filter';
+  /**
+   * When `identifierType` is `'filter'`, this carries the full query filter
+   * as a structured object. Used for dependencies that require multi-field
+   * queries (e.g., cross-protocol role records queried by protocol +
+   * protocolPath + recipient + contextId prefix).
+   */
+  filter?: Record<string, unknown>;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/sync-closure-types.ts
+++ b/packages/agent/src/sync-closure-types.ts
@@ -185,12 +185,53 @@ export function invalidateClosureCache(
     }
   }
 
-  // Any Records message → invalidate recordId-based satisfied/missing entries.
+  // Any Records message → invalidate all dep keys that could be affected.
+  // This includes:
+  //   - plain recordId entries (class 2 parent/context/initialWrite)
+  //   - composite protocol|recordId entries (class 6 crossProtocolParent)
+  //   - filter-based entries (class 6 crossProtocolRoleRecord)
+  //   - contextKeyRecord entries (class 5)
+  // Rather than parsing every composite key format, we iterate and remove
+  // any entry whose key contains the recordId or the message's protocol.
+  // This is safe because the caches are per-tenant per-session — aggressive
+  // invalidation just causes re-queries on the next evaluation.
   if (desc.interface === 'Records') {
     const recordId = (message as any).recordId as string | undefined;
+    const protocol = desc.protocol as string | undefined;
+    const protocolPath = desc.protocolPath as string | undefined;
+
     if (recordId) {
-      context.satisfiedDeps.delete(`recordId:${recordId}`);
-      context.missingDeps.delete(`recordId:${recordId}`);
+      // Invalidate any dep key containing this recordId.
+      for (const key of context.satisfiedDeps) {
+        if (key.includes(recordId)) { context.satisfiedDeps.delete(key); }
+      }
+      for (const key of context.missingDeps) {
+        if (key.includes(recordId)) { context.missingDeps.delete(key); }
+      }
+    }
+
+    // Invalidate filter-based role record deps that match this protocol + protocolPath.
+    // These are keyed like "filter:protocol|protocolPath|author|context".
+    if (protocol && protocolPath) {
+      const filterPrefix = `filter:${protocol}|${protocolPath}`;
+      for (const key of context.satisfiedDeps) {
+        if (key.startsWith(filterPrefix)) { context.satisfiedDeps.delete(key); }
+      }
+      for (const key of context.missingDeps) {
+        if (key.startsWith(filterPrefix)) { context.missingDeps.delete(key); }
+      }
+    }
+
+    // Invalidate contextKeyRecord deps for this protocol.
+    // These are keyed like "messageCid:protocol|contextId".
+    if (protocol) {
+      const ctxKeyPrefix = `messageCid:${protocol}|`;
+      for (const key of context.satisfiedDeps) {
+        if (key.startsWith(ctxKeyPrefix)) { context.satisfiedDeps.delete(key); }
+      }
+      for (const key of context.missingDeps) {
+        if (key.startsWith(ctxKeyPrefix)) { context.missingDeps.delete(key); }
+      }
     }
   }
 }

--- a/packages/agent/src/sync-closure-types.ts
+++ b/packages/agent/src/sync-closure-types.ts
@@ -185,16 +185,15 @@ export function invalidateClosureCache(
     }
   }
 
-  // Any Records message → invalidate all dep keys that could be affected.
-  // This includes:
+  // Any Records message → invalidate dep keys that could be affected.
+  // Handles multiple key formats:
   //   - plain recordId entries (class 2 parent/context/initialWrite)
   //   - composite protocol|recordId entries (class 6 crossProtocolParent)
-  //   - filter-based entries (class 6 crossProtocolRoleRecord)
-  //   - contextKeyRecord entries (class 5)
-  // Rather than parsing every composite key format, we iterate and remove
-  // any entry whose key contains the recordId or the message's protocol.
-  // This is safe because the caches are per-tenant per-session — aggressive
-  // invalidation just causes re-queries on the next evaluation.
+  //   - filter-based entries keyed by protocol+protocolPath (class 6 role records)
+  //   - contextKeyRecord entries keyed by source protocol from tags (class 5)
+  // Uses boundary-aware matching for recordId to avoid substring collisions,
+  // prefix matching for filter/contextKey entries, and tag-based source
+  // protocol extraction for key-delivery records.
   if (desc.interface === 'Records') {
     const recordId = (message as any).recordId as string | undefined;
     const protocol = desc.protocol as string | undefined;

--- a/packages/agent/src/sync-closure-types.ts
+++ b/packages/agent/src/sync-closure-types.ts
@@ -201,12 +201,23 @@ export function invalidateClosureCache(
     const protocolPath = desc.protocolPath as string | undefined;
 
     if (recordId) {
-      // Invalidate any dep key containing this recordId.
+      // Invalidate dep keys that reference this exact recordId.
+      // Check for recordId at a key boundary (preceded by ':' or '|')
+      // to avoid substring false matches (e.g., 'thread-1' matching 'thread-10').
+      const matchesRecordId = (key: string): boolean => {
+        const idx = key.indexOf(recordId);
+        if (idx === -1) { return false; }
+        const charBefore = idx > 0 ? key[idx - 1] : ':';
+        const charAfter = idx + recordId.length < key.length ? key[idx + recordId.length] : '|';
+        const validBefore = charBefore === ':' || charBefore === '|';
+        const validAfter = charAfter === '|' || charAfter === undefined;
+        return validBefore && (idx + recordId.length === key.length || validAfter);
+      };
       for (const key of context.satisfiedDeps) {
-        if (key.includes(recordId)) { context.satisfiedDeps.delete(key); }
+        if (matchesRecordId(key)) { context.satisfiedDeps.delete(key); }
       }
       for (const key of context.missingDeps) {
-        if (key.includes(recordId)) { context.missingDeps.delete(key); }
+        if (matchesRecordId(key)) { context.missingDeps.delete(key); }
       }
     }
 
@@ -222,9 +233,27 @@ export function invalidateClosureCache(
       }
     }
 
-    // Invalidate contextKeyRecord deps for this protocol.
-    // These are keyed like "messageCid:protocol|contextId".
-    if (protocol) {
+    // Invalidate contextKeyRecord deps.
+    // Context key records are in the key-delivery protocol, but their closure
+    // cache keys use the SOURCE protocol (from tags.protocol), not the
+    // key-delivery protocol URI. So when a key-delivery record arrives, we
+    // must extract the source protocol from the record's tags.
+    if (protocol === 'https://identity.foundation/protocols/key-delivery') {
+      // Real key-delivery writes have tags: { protocol: sourceProtocol, contextId: ... }
+      const tags = (message as any).descriptor?.tags as Record<string, string> | undefined;
+      const sourceProtocol = tags?.protocol;
+      if (sourceProtocol) {
+        const ctxKeyPrefix = `messageCid:${sourceProtocol}|`;
+        for (const key of context.satisfiedDeps) {
+          if (key.startsWith(ctxKeyPrefix)) { context.satisfiedDeps.delete(key); }
+        }
+        for (const key of context.missingDeps) {
+          if (key.startsWith(ctxKeyPrefix)) { context.missingDeps.delete(key); }
+        }
+      }
+    } else if (protocol) {
+      // For non-key-delivery protocols, invalidate contextKeyRecord entries
+      // keyed by this protocol (e.g., if a record write changes the context).
       const ctxKeyPrefix = `messageCid:${protocol}|`;
       for (const key of context.satisfiedDeps) {
         if (key.startsWith(ctxKeyPrefix)) { context.satisfiedDeps.delete(key); }

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -780,6 +780,164 @@ describe('evaluateClosure', () => {
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.CrossProtocolReferenceMissing);
     });
+
+    it('should require cross-protocol role record when protocolRole is invoked', async () => {
+      const composingDef = {
+        protocol  : 'https://comments.example.com',
+        published : true,
+        uses      : { threads: 'https://threads.example.com' },
+        types     : { comment: {} },
+        structure : {
+          thread: {
+            $ref    : 'threads:thread',
+            comment : {
+              $actions: [
+                { role: 'threads:thread/participant', can: ['create', 'read'] },
+              ],
+            },
+          },
+        },
+      };
+      const composingConfig = {
+        descriptor: { interface: 'Protocols', method: 'Configure', definition: composingDef },
+      } as any;
+      const referencedConfig = {
+        descriptor: { interface: 'Protocols', method: 'Configure', definition: { protocol: 'https://threads.example.com' } },
+      } as any;
+
+      // Message with cross-protocol role invocation in authorization.
+      const rolePayload = Buffer.from(JSON.stringify({
+        protocolRole : 'threads:thread/participant',
+        authorDid    : 'did:example:bob',
+      })).toString('base64url');
+
+      const msg = mockMessage({
+        protocol     : 'https://comments.example.com',
+        protocolPath : 'thread/comment',
+        parentId     : 'thread-1',
+        dateCreated  : '2025-01-01T00:00:00.000000Z',
+      });
+      (msg as any).recordId = 'comment-1';
+      (msg as any).contextId = 'thread-1/comment-1';
+      (msg as any).authorization = { authorSignature: { payload: rolePayload } };
+
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
+      (parentThread as any).recordId = 'thread-1';
+
+      // The role record (participant) in the referenced protocol.
+      const roleRecord = mockMessage({
+        interface    : 'Records',
+        method       : 'Write',
+        protocol     : 'https://threads.example.com',
+        protocolPath : 'thread/participant',
+      });
+      (roleRecord as any).recordId = 'participant-1';
+
+      const store = mockMessageStore({
+        queryResults: new Map([
+          ['protocol:https://comments.example.com', [composingConfig]],
+          ['protocol:https://threads.example.com', [referencedConfig]],
+          ['recordId:thread-1', [parentThread]],
+          ['protocol+recordId:https://threads.example.com|thread-1', [parentThread]],
+        ]),
+      });
+
+      // Override query to handle the filter-based role record query.
+      (store.query as sinon.SinonStub).callsFake(
+        async (_tenant: string, filters: any[]): Promise<{ messages: GenericMessage[] }> => {
+          const filter = filters[0] ?? {};
+          if (filter.interface === 'Protocols' && filter.protocol) {
+            const key = `protocol:${filter.protocol}`;
+            if (key === 'protocol:https://comments.example.com') { return { messages: [composingConfig] }; }
+            if (key === 'protocol:https://threads.example.com') { return { messages: [referencedConfig] }; }
+          }
+          if (filter.recordId && filter.protocol && filter.interface === 'Records') {
+            if (filter.protocol === 'https://threads.example.com' && filter.recordId === 'thread-1') {
+              return { messages: [parentThread] };
+            }
+          }
+          if (filter.recordId) {
+            if (filter.recordId === 'thread-1') { return { messages: [parentThread] }; }
+          }
+          // Filter-based role record query.
+          if (filter.protocol === 'https://threads.example.com' &&
+              filter.protocolPath === 'thread/participant' &&
+              filter.recipient === 'did:example:bob') {
+            return { messages: [roleRecord] };
+          }
+          return { messages: [] };
+        }
+      );
+
+      const result = await evaluateClosure(msg, store, {
+        kind: 'protocol', protocol: 'https://comments.example.com',
+      }, createClosureContext('did:example:alice'));
+
+      expect(result.complete).toBe(true);
+      expect(result.edges.some(e => e.label === 'crossProtocolRoleRecord')).toBe(true);
+      expect(result.edges.some(e => e.label === 'crossProtocolRoleConfig')).toBe(true);
+    });
+
+    it('should fail closure when cross-protocol role record is absent', async () => {
+      const composingDef = {
+        protocol  : 'https://comments.example.com',
+        published : true,
+        uses      : { threads: 'https://threads.example.com' },
+        types     : { comment: {} },
+        structure : {
+          thread: {
+            $ref    : 'threads:thread',
+            comment : {
+              $actions: [
+                { role: 'threads:thread/participant', can: ['create', 'read'] },
+              ],
+            },
+          },
+        },
+      };
+      const composingConfig = {
+        descriptor: { interface: 'Protocols', method: 'Configure', definition: composingDef },
+      } as any;
+      const referencedConfig = {
+        descriptor: { interface: 'Protocols', method: 'Configure', definition: { protocol: 'https://threads.example.com' } },
+      } as any;
+
+      const rolePayload = Buffer.from(JSON.stringify({
+        protocolRole : 'threads:thread/participant',
+        authorDid    : 'did:example:bob',
+      })).toString('base64url');
+
+      const msg = mockMessage({
+        protocol     : 'https://comments.example.com',
+        protocolPath : 'thread/comment',
+        parentId     : 'thread-1',
+        dateCreated  : '2025-01-01T00:00:00.000000Z',
+      });
+      (msg as any).recordId = 'comment-1';
+      (msg as any).contextId = 'thread-1/comment-1';
+      (msg as any).authorization = { authorSignature: { payload: rolePayload } };
+
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
+      (parentThread as any).recordId = 'thread-1';
+
+      const store = mockMessageStore({
+        queryResults: new Map([
+          ['protocol:https://comments.example.com', [composingConfig]],
+          ['protocol:https://threads.example.com', [referencedConfig]],
+          ['recordId:thread-1', [parentThread]],
+          ['protocol+recordId:https://threads.example.com|thread-1', [parentThread]],
+          // No role record in the store!
+        ]),
+      });
+
+      const result = await evaluateClosure(msg, store, {
+        kind: 'protocol', protocol: 'https://comments.example.com',
+      }, createClosureContext('did:example:alice'));
+
+      expect(result.complete).toBe(false);
+      expect(result.failure!.code).toBe(ClosureFailureCode.CrossProtocolReferenceMissing);
+      expect(result.failure!.edge.label).toBe('crossProtocolRoleRecord');
+    });
   });
 
   describe('traversal limits', () => {

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -1133,5 +1133,78 @@ describe('evaluateClosure', () => {
       expect(ctx.protocolCache.has('https://example.com/other')).toBe(true);
       expect(ctx.grantCache.has('grant-2')).toBe(true);
     });
+
+    it('should invalidate composite crossProtocolParent dep keys containing the recordId', () => {
+      const ctx = createClosureContext('did:example:alice');
+      // Composite key format: "recordId:referencedProtocol|parentId"
+      ctx.missingDeps.add('recordId:https://threads.example.com|thread-1');
+      ctx.satisfiedDeps.add('recordId:https://threads.example.com|thread-2');
+
+      const parentMsg = mockMessage({ interface: 'Records', method: 'Write' });
+      (parentMsg as any).recordId = 'thread-1';
+
+      invalidateClosureCache(ctx, parentMsg);
+
+      // thread-1 composite key should be cleared.
+      expect(ctx.missingDeps.has('recordId:https://threads.example.com|thread-1')).toBe(false);
+      // thread-2 should remain (different recordId).
+      expect(ctx.satisfiedDeps.has('recordId:https://threads.example.com|thread-2')).toBe(true);
+    });
+
+    it('should invalidate filter-based role record dep keys matching protocol+protocolPath', () => {
+      const ctx = createClosureContext('did:example:alice');
+      const roleKey = 'filter:https://threads.example.com|thread/participant|did:example:bob|{"gte":"t1","lt":"t1\\uffff"}';
+      ctx.missingDeps.add(roleKey);
+
+      // A participant record arrives in the referenced protocol.
+      const roleMsg = mockMessage({
+        interface    : 'Records',
+        method       : 'Write',
+        protocol     : 'https://threads.example.com',
+        protocolPath : 'thread/participant',
+      });
+      (roleMsg as any).recordId = 'participant-1';
+
+      invalidateClosureCache(ctx, roleMsg);
+
+      expect(ctx.missingDeps.has(roleKey)).toBe(false);
+    });
+
+    it('should invalidate contextKeyRecord dep keys matching the protocol', () => {
+      const ctx = createClosureContext('did:example:alice');
+      // contextKeyRecord key format: "messageCid:protocol|contextId"
+      ctx.missingDeps.add('messageCid:https://example.com/chat|thread-1');
+
+      // A key-delivery record arrives for this protocol.
+      const keyMsg = mockMessage({
+        interface : 'Records',
+        method    : 'Write',
+        protocol  : 'https://example.com/chat',
+      });
+      (keyMsg as any).recordId = 'key-record-1';
+
+      invalidateClosureCache(ctx, keyMsg);
+
+      expect(ctx.missingDeps.has('messageCid:https://example.com/chat|thread-1')).toBe(false);
+    });
+
+    it('should clear stale missingDeps so re-evaluation can succeed', () => {
+      const ctx = createClosureContext('did:example:alice');
+
+      // Simulate a previously-missing parent record.
+      ctx.missingDeps.add('recordId:parent-1');
+      ctx.missingDeps.add('recordId:https://threads.example.com|parent-1');
+
+      // The parent record arrives.
+      const parentMsg = mockMessage({ interface: 'Records', method: 'Write' });
+      (parentMsg as any).recordId = 'parent-1';
+
+      invalidateClosureCache(ctx, parentMsg);
+
+      // Both plain and composite keys should be cleared.
+      expect(ctx.missingDeps.has('recordId:parent-1')).toBe(false);
+      expect(ctx.missingDeps.has('recordId:https://threads.example.com|parent-1')).toBe(false);
+      // Next closure evaluation will re-query and find the record present.
+    });
   });
 });

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -1170,22 +1170,39 @@ describe('evaluateClosure', () => {
       expect(ctx.missingDeps.has(roleKey)).toBe(false);
     });
 
-    it('should invalidate contextKeyRecord dep keys matching the protocol', () => {
+    it('should invalidate contextKeyRecord dep keys when real key-delivery record arrives', () => {
       const ctx = createClosureContext('did:example:alice');
-      // contextKeyRecord key format: "messageCid:protocol|contextId"
+      // contextKeyRecord cache key uses the SOURCE protocol, not the key-delivery protocol.
       ctx.missingDeps.add('messageCid:https://example.com/chat|thread-1');
 
-      // A key-delivery record arrives for this protocol.
+      // Real key-delivery record: protocol is the key-delivery protocol URI,
+      // with tags pointing to the source protocol and contextId.
       const keyMsg = mockMessage({
         interface : 'Records',
         method    : 'Write',
-        protocol  : 'https://example.com/chat',
+        protocol  : 'https://identity.foundation/protocols/key-delivery',
+        tags      : { protocol: 'https://example.com/chat', contextId: 'thread-1' },
       });
-      (keyMsg as any).recordId = 'key-record-1';
+      (keyMsg as any).recordId = 'context-key-1';
 
       invalidateClosureCache(ctx, keyMsg);
 
       expect(ctx.missingDeps.has('messageCid:https://example.com/chat|thread-1')).toBe(false);
+    });
+
+    it('should not false-match recordId substrings (thread-1 vs thread-10)', () => {
+      const ctx = createClosureContext('did:example:alice');
+      ctx.missingDeps.add('recordId:thread-1');
+      ctx.missingDeps.add('recordId:thread-10');
+
+      const msg = mockMessage({ interface: 'Records', method: 'Write' });
+      (msg as any).recordId = 'thread-1';
+
+      invalidateClosureCache(ctx, msg);
+
+      // thread-1 should be cleared, thread-10 should remain.
+      expect(ctx.missingDeps.has('recordId:thread-1')).toBe(false);
+      expect(ctx.missingDeps.has('recordId:thread-10')).toBe(true);
     });
 
     it('should clear stale missingDeps so re-evaluation can succeed', () => {

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -805,10 +805,13 @@ describe('evaluateClosure', () => {
         descriptor: { interface: 'Protocols', method: 'Configure', definition: { protocol: 'https://threads.example.com' } },
       } as any;
 
-      // Message with cross-protocol role invocation in authorization.
+      // Build proper JWS authorization structure.
+      // Message.getAuthor extracts DID from authorization.signature.signatures[0].protected.kid
+      const protectedHeader = Buffer.from(JSON.stringify({
+        kid: 'did:example:bob#key-1',
+      })).toString('base64url');
       const rolePayload = Buffer.from(JSON.stringify({
-        protocolRole : 'threads:thread/participant',
-        authorDid    : 'did:example:bob',
+        protocolRole: 'threads:thread/participant',
       })).toString('base64url');
 
       const msg = mockMessage({
@@ -819,7 +822,12 @@ describe('evaluateClosure', () => {
       });
       (msg as any).recordId = 'comment-1';
       (msg as any).contextId = 'thread-1/comment-1';
-      (msg as any).authorization = { authorSignature: { payload: rolePayload } };
+      // Proper JWS authorization: signature has kid in protected header,
+      // authorSignature has protocolRole in payload.
+      (msg as any).authorization = {
+        signature       : { signatures: [{ protected: protectedHeader, signature: 'fake' }] },
+        authorSignature : { payload: rolePayload },
+      };
 
       const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
       (parentThread as any).recordId = 'thread-1';
@@ -902,9 +910,11 @@ describe('evaluateClosure', () => {
         descriptor: { interface: 'Protocols', method: 'Configure', definition: { protocol: 'https://threads.example.com' } },
       } as any;
 
-      const rolePayload = Buffer.from(JSON.stringify({
-        protocolRole : 'threads:thread/participant',
-        authorDid    : 'did:example:bob',
+      const absentProtectedHeader = Buffer.from(JSON.stringify({
+        kid: 'did:example:bob#key-1',
+      })).toString('base64url');
+      const absentRolePayload = Buffer.from(JSON.stringify({
+        protocolRole: 'threads:thread/participant',
       })).toString('base64url');
 
       const msg = mockMessage({
@@ -915,7 +925,10 @@ describe('evaluateClosure', () => {
       });
       (msg as any).recordId = 'comment-1';
       (msg as any).contextId = 'thread-1/comment-1';
-      (msg as any).authorization = { authorSignature: { payload: rolePayload } };
+      (msg as any).authorization = {
+        signature       : { signatures: [{ protected: absentProtectedHeader, signature: 'fake' }] },
+        authorSignature : { payload: absentRolePayload },
+      };
 
       const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
       (parentThread as any).recordId = 'thread-1';

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -256,7 +256,7 @@ describe('evaluateClosure', () => {
         protocol    : 'https://example.com/proto',
         dateCreated : '2025-01-01T00:00:00.000000Z',
       });
-      (msg as any).authorization = { authorSignature: { payload } };
+      (msg as any).authorization = { signature: { payload, signatures: [{ protected: payload, signature: 'fake' }] } };
 
       const protocolConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
       const grantRecord = mockMessage({ interface: 'Records', method: 'Write' });
@@ -282,7 +282,7 @@ describe('evaluateClosure', () => {
         protocol    : 'https://example.com/proto',
         dateCreated : '2025-01-01T00:00:00.000000Z',
       });
-      (msg as any).authorization = { authorSignature: { payload } };
+      (msg as any).authorization = { signature: { payload, signatures: [{ protected: payload, signature: 'fake' }] } };
 
       const protocolConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
 
@@ -822,11 +822,15 @@ describe('evaluateClosure', () => {
       });
       (msg as any).recordId = 'comment-1';
       (msg as any).contextId = 'thread-1/comment-1';
-      // Proper JWS authorization: signature has kid in protected header,
-      // authorSignature has protocolRole in payload.
+      // Real DWN authorization structure:
+      // authorization.signature is a GeneralJws with:
+      //   - payload: base64url JSON with protocolRole
+      //   - signatures[0].protected: base64url JSON with kid (for author extraction)
       (msg as any).authorization = {
-        signature       : { signatures: [{ protected: protectedHeader, signature: 'fake' }] },
-        authorSignature : { payload: rolePayload },
+        signature: {
+          payload    : rolePayload,
+          signatures : [{ protected: protectedHeader, signature: 'fake' }],
+        },
       };
 
       const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
@@ -926,8 +930,10 @@ describe('evaluateClosure', () => {
       (msg as any).recordId = 'comment-1';
       (msg as any).contextId = 'thread-1/comment-1';
       (msg as any).authorization = {
-        signature       : { signatures: [{ protected: absentProtectedHeader, signature: 'fake' }] },
-        authorSignature : { payload: absentRolePayload },
+        signature: {
+          payload    : absentRolePayload,
+          signatures : [{ protected: absentProtectedHeader, signature: 'fake' }],
+        },
       };
 
       const parentThread = mockMessage({ interface: 'Records', method: 'Write' });


### PR DESCRIPTION
## Summary

Completes class 6 level 3: cross-protocol role records are now queried and enforced via filter-based resolution. Also fixes author derivation, cache key completeness, and cache invalidation for all new dependency shapes.

**3 commits, 3 files changed**

## What's new

### Filter-based dependency resolution
- New `filter` identifierType on `ClosureDependencyEdge` carries a structured query object
- `resolveDependency` dispatches `filter` type to `messageStore.query(tenantDid, [edge.filter])`
- General-purpose infrastructure for any multi-field dependency query

### Cross-protocol role record enforcement
When `protocolRole` is `alias:path` format, emits `crossProtocolRoleRecord` edge with:
- `protocol`: from `uses[alias]`
- `protocolPath`: from the role path
- `recipient`: message author (from `Message.getAuthor()` — JWS `kid` header, NOT fabricated payload fields)
- `contextId` prefix: ancestor segment count matching `verifyInvokedRole()` logic

### Author derivation fix
Uses `Message.getAuthor(message)` which extracts the DID from the JWS signature's `kid` header. The previous version fabricated `authorDid`/`author` fields that don't exist in DWN signature payloads.

### Cache key completeness
Role record identifier includes serialized contextId filter to prevent cross-context false positives (e.g., same author with role in thread-1 but not thread-2).

### Cache invalidation for composite keys
`invalidateClosureCache` now clears ALL dep key formats when a Records message arrives:
- Plain `recordId:X` entries
- Composite `recordId:protocol|recordId` (crossProtocolParent)
- `messageCid:protocol|contextId` (contextKeyRecord)
- `filter:protocol|protocolPath|...` (crossProtocolRoleRecord)

## Class 6 enforcement matrix (final)

| Level | Edge | Enforced? |
|-------|------|-----------|
| 1 | `crossProtocolConfig` | Yes |
| 2 | `crossProtocolParent` | Yes (protocol-scoped) |
| 3 | `crossProtocolRoleConfig` | Yes |
| 3 | `crossProtocolRoleRecord` | **Yes (filter-based)** |

## Tests (34 total, 6 new)
- Role record present → closure succeeds
- Role record absent → `CrossProtocolReferenceMissing`
- Composite crossProtocolParent key invalidated on parent arrival
- Filter-based role record key invalidated on role record arrival
- contextKeyRecord key invalidated on key-delivery arrival
- Stale missingDeps cleared so re-evaluation succeeds

Tracks: enboxorg/enbox-internal#17
