### PR TITLE
fix(agent): don't retry permanent push failures (400/401/403)

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1655,10 +1655,13 @@ export class SyncEngineLevel implements SyncEngine {
           await this.ledger.saveLink(link);
         }
 
-        // Re-queue failed entries so they are retried on the next debounce
-        // cycle (or picked up by the SMT integrity check).
+        // Re-queue only TRANSIENT failures for retry. Permanent failures (400/401/403)
+        // are dropped — they will never succeed regardless of retry.
         if (result.failed.length > 0) {
-          console.error(`SyncEngineLevel: Push-on-write failed for ${did} -> ${dwnUrl}: ${result.failed.length} of ${cids.length} messages failed`);
+          console.error(
+            `SyncEngineLevel: Push-on-write failed for ${did} -> ${dwnUrl}: ` +
+            `${result.failed.length} transient failures of ${cids.length} messages`
+          );
           const failedSet = new Set(result.failed);
           const failedEntries = pushEntries.filter(e => failedSet.has(e.cid));
           let requeued = this._pendingPushCids.get(targetKey);
@@ -1672,9 +1675,12 @@ export class SyncEngineLevel implements SyncEngine {
           if (!this._pushDebounceTimer) {
             this._pushDebounceTimer = setTimeout((): void => {
               void this.flushPendingPushes();
-            }, PUSH_DEBOUNCE_MS * 4); // Back off: 1 second instead of 250ms.
+            }, PUSH_DEBOUNCE_MS * 4);
           }
         }
+        // Permanent failures are logged by pushMessages but NOT re-queued.
+        // They will be rediscovered by the next SMT integrity check if the
+        // local/remote state has changed, but won't spin in a retry loop.
       } catch (error: any) {
         // Truly unexpected error (not per-message failure). Re-queue entire
         // batch so entries aren't silently dropped from the debounce queue.

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -38,6 +38,20 @@ export function syncMessageReplyIsSuccessful(reply: UnionMessageReply): boolean 
 }
 
 /**
+ * Determines whether a failed push reply represents a permanent failure that
+ * should NOT be retried. Permanent failures include protocol violations (400),
+ * authorization errors (401/403), and schema validation errors that will never
+ * succeed regardless of retry.
+ *
+ * Transient failures (5xx, network errors) are worth retrying.
+ */
+export function isPermanentPushFailure(reply: UnionMessageReply): boolean {
+  return reply.status.code === 400 ||
+    reply.status.code === 401 ||
+    reply.status.code === 403;
+}
+
+/**
  * Helper to get the CID of a message for logging purposes.
  */
 export async function getMessageCid(message: GenericMessage): Promise<string> {
@@ -313,6 +327,7 @@ export async function pushMessages({ did, dwnUrl, delegateDid, protocol, message
 }): Promise<PushResult> {
   const succeeded: string[] = [];
   const failed: string[] = [];
+  const permanentlyFailed: string[] = [];
 
   // Step 1: Fetch all local messages (streams are pull-based, not yet consumed).
   const fetched: SyncMessageEntry[] = [];
@@ -342,17 +357,25 @@ export async function pushMessages({ did, dwnUrl, delegateDid, protocol, message
 
       if (syncMessageReplyIsSuccessful(reply)) {
         succeeded.push(cid);
+      } else if (isPermanentPushFailure(reply)) {
+        // Permanent failures (400/401/403) will never succeed — do NOT retry.
+        // These include protocol violations (RecordLimitExceeded), auth errors,
+        // and schema validation failures.
+        console.warn(`SyncEngineLevel: push permanently failed for ${cid}: ${reply.status.code} ${reply.status.detail}`);
+        permanentlyFailed.push(cid);
       } else {
+        // Transient failures (5xx, etc.) — worth retrying.
         console.error(`SyncEngineLevel: push failed for ${cid}: ${reply.status.code} ${reply.status.detail}`);
         failed.push(cid);
       }
     } catch (error: any) {
+      // Network errors — transient, worth retrying.
       console.error(`SyncEngineLevel: push error for ${cid}: ${error.message ?? error}`);
       failed.push(cid);
     }
   }
 
-  return { succeeded, failed };
+  return { succeeded, failed, permanentlyFailed };
 }
 
 /**

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -194,8 +194,10 @@ export type ReplicationLinkState = {
 export type PushResult = {
   /** messageCids that were accepted (202/204/409 — idempotent success). */
   succeeded: string[];
-  /** messageCids that failed (retryable or hard error). */
+  /** messageCids that failed with a transient error (5xx, network) — worth retrying. */
   failed: string[];
+  /** messageCids that failed permanently (400/401/403) — will never succeed, do NOT retry. */
+  permanentlyFailed: string[];
 };
 
 /**


### PR DESCRIPTION
## Problem

After the sync redesign, the push-on-write path re-queues ALL failed CIDs for retry every 1 second, including permanent failures like `ProtocolAuthorizationRecordLimitExceeded` (400). This causes an infinite console spam loop for singleton protocol records (profile, avatar, hero, wallet) that already exist on the remote.

## Root cause

`pushMessages` returned all non-success replies in `PushResult.failed`, and `flushPendingPushes` re-queued everything in `failed` for retry. There was no distinction between transient errors (5xx, network) and permanent errors (400 protocol violations).

## Fix

`PushResult` now has three categories:
- `succeeded`: 202/204/409 (idempotent success)  
- `failed`: 5xx, network errors (transient — re-queued for retry)
- `permanentlyFailed`: 400/401/403 (permanent — logged as warning, NOT re-queued)

`isPermanentPushFailure()` classifies the response. `flushPendingPushes` only re-queues `failed`, not `permanentlyFailed`.

Permanent failures are rediscovered by the next SMT integrity check if local/remote state changes, but they don't spin in a hot retry loop.