### PR TITLE
chore: changeset for permanent push failure fix

### DIFF
--- a/.changeset/fix-permanent-push-retry.md
+++ b/.changeset/fix-permanent-push-retry.md
@@ -1,0 +1,9 @@
+---
+"@enbox/agent": patch
+---
+
+fix: don't retry permanent push failures (400/401/403)
+
+Prevents infinite retry loop for protocol-scoped singleton records
+(profile, avatar, hero, wallet) that get 400 RecordLimitExceeded from
+the remote. PushResult now distinguishes transient vs permanent failures.


### PR DESCRIPTION
Changeset for the fix in #788. Bumps @enbox/agent to patch for the permanent push failure fix (don't retry 400/401/403).