### PR TITLE
changeset: patch bump for empty messageCid fix

### DIFF
--- a/.changeset/fix-empty-messagecid.md
+++ b/.changeset/fix-empty-messagecid.md
@@ -1,0 +1,7 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/dwn-server": patch
+"@enbox/agent": patch
+---
+
+fix: prevent empty messageCid in ProgressToken across EventLog and sync engine


### PR DESCRIPTION
## Summary

- Adds changeset for PR #791 (fix: prevent empty messageCid in ProgressToken)
- Bumps `@enbox/dwn-sdk-js`, `@enbox/dwn-server`, `@enbox/agent` as patch
- Transitive patch bumps for all dependents