### PR TITLE
fix(agent): handle stale epoch in repair subscription reopening

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -668,9 +668,16 @@ export class SyncEngineLevel implements SyncEngine {
           console.warn(`SyncEngineLevel: ProgressGap detected for ${target.did} -> ${target.dwnUrl}, initiating repair`);
           this.emitEvent({ type: 'gap:detected', tenantDid: target.did, remoteEndpoint: target.dwnUrl, protocol: target.protocol, reason: 'ProgressGap' });
           const gapInfo = (error as any).gapInfo;
-          await this.transitionToRepairing(linkKey, link, {
-            resumeToken: gapInfo?.latestAvailable,
-          });
+          // Only use latestAvailable as resume token if it has a DIFFERENT
+          // epoch/stream than the failed cursor — otherwise the server had no
+          // events and fell back to echoing the failed cursor, which would
+          // cause the same ProgressGap on the reopened subscription.
+          const failedCursor = link.pull.contiguousAppliedToken;
+          const latest = gapInfo?.latestAvailable;
+          const resumeToken = (latest && failedCursor &&
+            (latest.epoch !== failedCursor.epoch || latest.streamId !== failedCursor.streamId))
+            ? latest : undefined;
+          await this.transitionToRepairing(linkKey, link, { resumeToken });
           continue;
         }
 
@@ -955,23 +962,61 @@ export class SyncEngineLevel implements SyncEngine {
       if (this._syncGeneration !== generation) { return; }
 
       // Step 5: Reopen subscriptions with the repaired checkpoints.
+      // If the resume token is stale (e.g., server/local DWN restarted with a
+      // new epoch), the subscription will get a ProgressGap (410). In that case,
+      // discard the checkpoint entirely and start fresh with no cursor.
       const target = { did, dwnUrl, delegateDid, protocol };
-      await this.openLivePullSubscription(target);
+      try {
+        await this.openLivePullSubscription(target);
+      } catch (pullErr: any) {
+        if (pullErr.isProgressGap) {
+          console.warn(`SyncEngineLevel: Stale pull resume token for ${did} -> ${dwnUrl}, resetting to start fresh`);
+          ReplicationLedger.resetCheckpoint(link.pull);
+          await this.ledger.saveLink(link);
+          if (this._syncGeneration !== generation) { return; }
+          await this.openLivePullSubscription(target);
+        } else {
+          throw pullErr;
+        }
+      }
       if (this._syncGeneration !== generation) { return; }
       try {
         await this.openLocalPushSubscription({
           ...target,
           pushCursor: link.push.contiguousAppliedToken,
         });
-      } catch (pushError) {
-        const pullSub = this._liveSubscriptions.find(
-          s => s.did === did && s.dwnUrl === dwnUrl && s.protocol === protocol
-        );
-        if (pullSub) {
-          try { await pullSub.close(); } catch { /* best effort */ }
-          this._liveSubscriptions = this._liveSubscriptions.filter(s => s !== pullSub);
+      } catch (pushError: any) {
+        // Handle stale push checkpoint (local DWN restarted with new epoch).
+        const is410 = pushError.isProgressGap ||
+          (pushError.message && pushError.message.includes('410'));
+        if (is410) {
+          console.warn(`SyncEngineLevel: Stale push checkpoint for ${did}, resetting to start fresh`);
+          ReplicationLedger.resetCheckpoint(link.push);
+          await this.ledger.saveLink(link);
+          if (this._syncGeneration !== generation) { return; }
+          try {
+            await this.openLocalPushSubscription(target);
+          } catch (retryPushError) {
+            // Clean up pull subscription on final failure.
+            const pullSub = this._liveSubscriptions.find(
+              s => s.did === did && s.dwnUrl === dwnUrl && s.protocol === protocol
+            );
+            if (pullSub) {
+              try { await pullSub.close(); } catch { /* best effort */ }
+              this._liveSubscriptions = this._liveSubscriptions.filter(s => s !== pullSub);
+            }
+            throw retryPushError;
+          }
+        } else {
+          const pullSub = this._liveSubscriptions.find(
+            s => s.did === did && s.dwnUrl === dwnUrl && s.protocol === protocol
+          );
+          if (pullSub) {
+            try { await pullSub.close(); } catch { /* best effort */ }
+            this._liveSubscriptions = this._liveSubscriptions.filter(s => s !== pullSub);
+          }
+          throw pushError;
         }
-        throw pushError;
       }
       if (this._syncGeneration !== generation) { return; }
 


### PR DESCRIPTION
## Summary

Fixes the repair loop where the sync engine repeatedly fails with `ProgressGap` after a server or local DWN restart.

## Problem

`EventEmitterEventLog` generates a new `epoch` on every restart. After deploying a new server version:

1. Wallet has stored checkpoints from the old epoch
2. Pull subscription → 410 (epoch_mismatch) → triggers repair
3. `gapInfo.latestAvailable` echoes back the same stale cursor (server has no events post-restart)
4. Repair resets checkpoint to the stale token → reopens subscription → 410 again
5. Loop until max attempts → `degraded_poll`

Same issue for push: browser reload gives the local DWN a new epoch, so the stored push checkpoint is also stale → `"Local MessagesSubscribe failed: 410 Progress token gap"`.

## Fix

**`doRepairLink`** — wrap subscription reopening in try/catch:
- Pull: if `openLivePullSubscription` gets ProgressGap, reset checkpoint to `undefined` (no cursor) and retry → subscription starts from "now"
- Push: if `openLocalPushSubscription` gets 410, reset push checkpoint and retry without cursor

**`startSync` ProgressGap handler** — only use `gapInfo.latestAvailable` as resume token if its epoch/stream actually differs from the failed cursor. When the server has no events, `latestAvailable` is the same stale cursor (server fell back to echoing the request), which would cause the same 410.

## Testing

- 130/130 sync-engine-private tests pass
- Build clean, lint clean