### PR TITLE
feat(agent): reconciliation coverage tests + retire legacy syncCursors from live path

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -643,17 +643,19 @@ export class SyncEngineLevel implements SyncEngine {
         });
 
         // Cache the link for fast access by subscription handlers.
-        const linkKey = this.buildCursorKey(target.did, target.dwnUrl, target.protocol);
+        // Use scopeId from the link for consistent runtime identity.
+        const linkKey = this.buildLinkKey(target.did, target.dwnUrl, link.scopeId);
 
         // One-time migration: if the link has no pull checkpoint, check for
-        // a legacy cursor in the old syncCursors sublevel. Migrate it into
-        // the link's pull checkpoint, save, and delete the old entry.
+        // a legacy cursor in the old syncCursors sublevel. The legacy key
+        // used protocol, not scopeId, so we must build it the old way.
         if (!link.pull.contiguousAppliedToken) {
-          const legacyCursor = await this.getCursor(linkKey);
+          const legacyKey = this.buildLinkKey(target.did, target.dwnUrl, target.protocol);
+          const legacyCursor = await this.getCursor(legacyKey);
           if (legacyCursor) {
             ReplicationLedger.resetCheckpoint(link.pull, legacyCursor);
             await this.ledger.saveLink(link);
-            await this.deleteLegacyCursor(linkKey);
+            await this.deleteLegacyCursor(legacyKey);
           }
         }
 
@@ -662,9 +664,10 @@ export class SyncEngineLevel implements SyncEngine {
         // Open subscriptions — only transition to live if both succeed.
         // If pull succeeds but push fails, close the pull subscription to
         // avoid a resource leak with inconsistent state.
-        await this.openLivePullSubscription(target);
+        const targetWithKey = { ...target, linkKey };
+        await this.openLivePullSubscription(targetWithKey);
         try {
-          await this.openLocalPushSubscription(target);
+          await this.openLocalPushSubscription(targetWithKey);
         } catch (pushError) {
           // Close the already-opened pull subscription.
           const pullSub = this._liveSubscriptions.find(
@@ -683,11 +686,12 @@ export class SyncEngineLevel implements SyncEngine {
         // If the link was marked dirty in a previous session, schedule
         // immediate reconciliation now that subscriptions are open.
         if (link!.needsReconcile) {
-          const startupLinkKey = this.buildCursorKey(target.did, target.dwnUrl, target.protocol);
-          this.scheduleReconcile(startupLinkKey, 1000);
+          this.scheduleReconcile(linkKey, 1000);
         }
       } catch (error: any) {
-        const linkKey = this.buildCursorKey(target.did, target.dwnUrl, target.protocol);
+        const linkKey = link
+          ? this.buildLinkKey(target.did, target.dwnUrl, link.scopeId)
+          : this.buildLinkKey(target.did, target.dwnUrl, target.protocol);
 
         // Detect ProgressGap (410) — the cursor is stale, link needs SMT repair.
         if ((error as any).isProgressGap && link) {
@@ -996,7 +1000,7 @@ export class SyncEngineLevel implements SyncEngine {
       await this.ledger.saveLink(link);
       if (this._engineGeneration !== generation) { return; }
 
-      const target = { did, dwnUrl, delegateDid, protocol };
+      const target = { did, dwnUrl, delegateDid, protocol, linkKey };
       try {
         await this.openLivePullSubscription(target);
       } catch (pullErr: any) {
@@ -1230,12 +1234,13 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private async openLivePullSubscription(target: {
     did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
+    linkKey?: string;
   }): Promise<void> {
     const { did, delegateDid, dwnUrl, protocol } = target;
 
     // Resolve the cursor from the link's durable pull checkpoint.
     // Legacy syncCursors migration happens at link load time in startLiveSync().
-    const cursorKey = this.buildCursorKey(did, dwnUrl, protocol);
+    const cursorKey = target.linkKey ?? this.buildLinkKey(did, dwnUrl, protocol);
     const link = this._activeLinks.get(cursorKey);
     let cursor = link?.pull.contiguousAppliedToken;
 
@@ -1551,7 +1556,7 @@ export class SyncEngineLevel implements SyncEngine {
     });
 
     // Set per-link connectivity to online after successful subscription setup.
-    const pullLink = this._activeLinks.get(this.buildCursorKey(did, dwnUrl, protocol));
+    const pullLink = this._activeLinks.get(cursorKey);
     if (pullLink) {
       const prevPullConnectivity = pullLink.connectivity;
       pullLink.connectivity = 'online';
@@ -1571,6 +1576,7 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private async openLocalPushSubscription(target: {
     did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
+    linkKey?: string;
   }): Promise<void> {
     const { did, delegateDid, dwnUrl, protocol } = target;
 
@@ -1598,13 +1604,14 @@ export class SyncEngineLevel implements SyncEngine {
 
       // Subset scope filtering: only push events that match the link's
       // scope prefixes. Events outside the scope are not our responsibility.
-      const pushLink = this._activeLinks.get(this.buildCursorKey(did, dwnUrl, protocol));
+      const pushLinkKey = target.linkKey ?? this.buildLinkKey(did, dwnUrl, protocol);
+      const pushLink = this._activeLinks.get(pushLinkKey);
       if (pushLink && !isEventInScope(subMessage.event.message, pushLink.scope)) {
         return;
       }
 
       // Accumulate the message CID for a debounced push.
-      const targetKey = this.buildCursorKey(did, dwnUrl, protocol);
+      const targetKey = pushLinkKey;
       const cid = await Message.getCid(subMessage.event.message);
       if (cid === undefined) {
         return;
@@ -1873,9 +1880,16 @@ export class SyncEngineLevel implements SyncEngine {
   // Cursor persistence
   // ---------------------------------------------------------------------------
 
-  private buildCursorKey(did: string, dwnUrl: string, protocol?: string): string {
+  /**
+   * Build the runtime key for a replication link. Prefer `scopeId` (the
+   * deterministic hash from {@link computeScopeId}) over `protocol` — the
+   * `protocol` parameter is a legacy fallback used by poll-mode and cursor
+   * migration. Once all callers are migrated to pass `scopeId`, the
+   * `protocol` fallback can be removed.
+   */
+  private buildLinkKey(did: string, dwnUrl: string, scopeIdOrProtocol?: string): string {
     const base = `${did}${CURSOR_SEPARATOR}${dwnUrl}`;
-    return protocol ? `${base}${CURSOR_SEPARATOR}${protocol}` : base;
+    return scopeIdOrProtocol ? `${base}${CURSOR_SEPARATOR}${scopeIdOrProtocol}` : base;
   }
 
   /**

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -33,20 +33,20 @@ describe('SyncEngineLevel — private methods', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // buildCursorKey
+  // buildLinkKey
   // ---------------------------------------------------------------------------
 
-  describe('buildCursorKey', () => {
-    it('should build key without protocol', () => {
-      const key = (syncEngine as any).buildCursorKey('did:example:alice', 'https://dwn.example.com');
+  describe('buildLinkKey', () => {
+    it('should build key without scopeId/protocol', () => {
+      const key = (syncEngine as any).buildLinkKey('did:example:alice', 'https://dwn.example.com');
       expect(key).toBe('did:example:alice^https://dwn.example.com');
     });
 
-    it('should build key with protocol', () => {
-      const key = (syncEngine as any).buildCursorKey(
-        'did:example:alice', 'https://dwn.example.com', 'https://proto.example.com',
+    it('should build key with scopeId or protocol', () => {
+      const key = (syncEngine as any).buildLinkKey(
+        'did:example:alice', 'https://dwn.example.com', 'scope-hash-123',
       );
-      expect(key).toBe('did:example:alice^https://dwn.example.com^https://proto.example.com');
+      expect(key).toBe('did:example:alice^https://dwn.example.com^scope-hash-123');
     });
   });
 
@@ -755,7 +755,7 @@ describe('SyncEngineLevel — private methods', () => {
       sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       // Set up a link with protocolPathPrefixes in the scope.
-      const linkKey = (engine as any).buildCursorKey('did:example:alice', 'https://dwn.example.com', 'https://proto.example.com');
+      const linkKey = (engine as any).buildLinkKey('did:example:alice', 'https://dwn.example.com', 'https://proto.example.com');
       (engine as any)._activeLinks.set(linkKey, {
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
@@ -1347,7 +1347,7 @@ describe('SyncEngineLevel — private methods', () => {
       await engine.startSync({ mode: 'live', interval: '10s' });
 
       // _activeLinks should not contain the failed link.
-      const linkKey = (engine as any).buildCursorKey('did:example:alice', 'https://dwn.example.com', undefined);
+      const linkKey = (engine as any).buildLinkKey('did:example:alice', 'https://dwn.example.com', undefined);
       expect((engine as any)._activeLinks.has(linkKey)).toBe(false);
       expect((engine as any)._linkRuntimes.has(linkKey)).toBe(false);
 
@@ -1388,7 +1388,7 @@ describe('SyncEngineLevel — private methods', () => {
       expect((engine as any)._connectivityState).toBe('unknown');
       expect((engine as any)._liveSubscriptions.length).toBe(0);
 
-      const linkKey = (engine as any).buildCursorKey('did:example:alice', 'https://dwn.example.com', undefined);
+      const linkKey = (engine as any).buildLinkKey('did:example:alice', 'https://dwn.example.com', undefined);
       expect((engine as any)._activeLinks.has(linkKey)).toBe(false);
 
       await engine.stopSync();


### PR DESCRIPTION
## Summary

Three goals: restore coverage for the new reconciliation code from PR #795, retire the legacy `syncCursors` sublevel from the live sync path (Phase 1f), and normalize runtime link identity to use `scopeId` (Phase 1h).

## Coverage tests (+12 tests, 143 total in sync-engine-private)

All new reconciliation methods now have dedicated unit tests:

| Method | Tests | What's covered |
|---|---|---|
| `doReconcileLink` | 7 | Convergence verification (roots match → clear flag), divergence (roots differ → retry), lifecycle guards (skip non-live, skip during repair), short-circuit (roots match → no diff), generation bail, error → retry, full diff+pull+push flow |
| `reconcileLink` | 1 | Dedup — concurrent calls return same promise, only one execution |
| `scheduleReconcile` | 3 | Timer dedup, `_activeRepairs` guard, `_reconcileInFlight` guard |

Tests also updated for removed legacy paths:
- "should use existing cursor" → now uses `link.pull.contiguousAppliedToken` instead of `getCursor` stub
- EOSE/event handler tests → now use proper link objects instead of `setCursor` stubs

## Legacy cursor retirement (Phase 1f)

**One-time migration**: In `startLiveSync()`, when a link loads with no `pull.contiguousAppliedToken`, checks the old `syncCursors` sublevel. If a valid cursor exists, migrates it into `link.pull`, saves the link, and deletes the old entry. Subsequent loads find the cursor in the link — no repeated migration.

**Removed from live path**:
- `getCursor()` fallback in `openLivePullSubscription` — live path only uses `link.pull.contiguousAppliedToken`
- `setCursor()` calls in EOSE handler and event handler — legacy `!link` paths removed

**Kept for poll-mode**: `getCursor()`/`setCursor()` marked `@deprecated` but retained — poll-mode `sync()` still uses them.

## Runtime key normalization (Phase 1h)

**Rename**: `buildCursorKey()` → `buildLinkKey()` — signals this is the general runtime link identity, not just a cursor key.

**Key format change**: Live-mode runtime maps (`_activeLinks`, `_linkRuntimes`, etc.) now use `did^dwnUrl^scopeId` instead of `did^dwnUrl^protocol`. This eliminates the identity mismatch between runtime maps and the durable ledger (which already used `tenantDid^remoteEndpoint^scopeId`).

- `startLiveSync()` keys `_activeLinks` by `link.scopeId`
- Legacy cursor migration builds the old `did^dwnUrl^protocol` key separately for the one-time `syncCursors` lookup
- `openLivePullSubscription`/`openLocalPushSubscription` accept optional `linkKey` parameter
- `doRepairLink` passes `linkKey` through to subscription methods

## Files changed

| File | Change |
|---|---|
| `sync-engine-level.ts` | Legacy cursor retirement, `buildLinkKey` rename, scopeId normalization, `deleteLegacyCursor` helper |
| `sync-engine-private.spec.ts` | 12 new reconciliation tests, test updates for legacy path removal, `buildCursorKey` → `buildLinkKey` rename |

## Testing
- 143/143 sync-engine-private tests pass
- 275/275 all sync tests pass across 7 files
- Build clean, lint clean
