### PR TITLE
fix(agent,auth): downgrade singleton push warning + add delete to default permissions

### DIFF
--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -361,7 +361,14 @@ export async function pushMessages({ did, dwnUrl, delegateDid, protocol, message
         // Permanent failures (400/401/403) will never succeed — do NOT retry.
         // These include protocol violations (RecordLimitExceeded), auth errors,
         // and schema validation failures.
-        console.warn(`SyncEngineLevel: push permanently failed for ${cid}: ${reply.status.code} ${reply.status.detail}`);
+        if (reply.status.code === 400 && reply.status.detail?.includes('record limit')) {
+          // Expected for singleton convergence in multi-device scenarios:
+          // one device created a singleton record, this device has a
+          // different one, and the remote rejects the duplicate.
+          console.debug(`SyncEngineLevel: singleton already exists on remote, skipping push for ${cid}`);
+        } else {
+          console.warn(`SyncEngineLevel: push permanently failed for ${cid}: ${reply.status.code} ${reply.status.detail}`);
+        }
         permanentlyFailed.push(cid);
       } else {
         // Transient failures (5xx, etc.) — worth retrying.

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -423,7 +423,7 @@ export type ProtocolRequest =
 export type Permission = 'write' | 'read' | 'delete' | 'query' | 'subscribe' | 'configure';
 
 /** Default permissions granted when only a protocol definition is provided. */
-export const DEFAULT_PERMISSIONS: Permission[] = ['read', 'write', 'query', 'subscribe', 'configure'];
+export const DEFAULT_PERMISSIONS: Permission[] = ['read', 'write', 'delete', 'query', 'subscribe', 'configure'];
 
 /**
  * Options for a handler-based (delegated) connect flow.


### PR DESCRIPTION
## Summary

Two fixes for the multi-wallet + notesd demo (issue enboxorg/enbox-internal#17):

- **`sync-messages.ts`**: Downgrade `RecordLimitExceeded` push warnings to `console.debug`. These are expected in multi-device scenarios where both devices create singleton records (profile, avatar, hero) — one device's push is correctly rejected by the remote. The sync engine already handles this as a permanent failure with no retry; the `console.warn` was just noisy.

- **`auth/types.ts`**: Add `'delete'` to `DEFAULT_PERMISSIONS`. Apps passing a bare protocol definition to `auth.connect({ protocols: [MyProtocol] })` were getting `['read', 'write', 'query', 'subscribe', 'configure']` but no `Records.Delete` grant. Any app with delete functionality (like notesd) would fail with permission errors in the delegated connect flow. The `Permission` type already included `'delete'`; its absence from defaults was an oversight.

## Changes

| File | Change |
|---|---|
| `packages/agent/src/sync-messages.ts` | `console.warn` → `console.debug` for record-limit push failures |
| `packages/auth/src/types.ts` | Added `'delete'` to `DEFAULT_PERMISSIONS` |

## Verification

- Agent: lint clean, build clean, 34/34 sync-messages tests pass, 59/59 sync-engine tests pass
- Auth: lint clean, build clean, 330/330 tests pass