### PR TITLE
chore: add changeset for agent + auth demo fixes

### DIFF
--- a/.changeset/fix-demo-permissions.md
+++ b/.changeset/fix-demo-permissions.md
@@ -1,0 +1,12 @@
+---
+"@enbox/agent": patch
+"@enbox/auth": patch
+---
+
+fix: add delete to default connect permissions and quiet singleton push warnings
+
+Adds `'delete'` to `DEFAULT_PERMISSIONS` in `@enbox/auth` so apps using
+bare protocol definitions in `auth.connect()` get `Records.Delete` grants
+by default. Downgrades `RecordLimitExceeded` sync push warnings to debug
+level in `@enbox/agent` — these are expected in multi-device singleton
+convergence scenarios.


### PR DESCRIPTION
## Summary

Adds the changeset for the fixes merged in #803:

- **`@enbox/agent` patch**: Downgraded `RecordLimitExceeded` sync push warning to `console.debug`
- **`@enbox/auth` patch**: Added `'delete'` to `DEFAULT_PERMISSIONS`