### PR TITLE
test: sync recovery e2e + delegated connect e2e tests

### DIFF
--- a/packages/agent/tests/e2e/reconnection.e2e.spec.ts
+++ b/packages/agent/tests/e2e/reconnection.e2e.spec.ts
@@ -138,14 +138,12 @@ describe('E2E: pull subscription recovery after WebSocket drop', () => {
     expect(found).toBe(true);
 
     // Phase 2: Kill the WebSocket — the pull subscription is now dead.
+    // Write the post-drop record IMMEDIATELY (no pause) so it lands on
+    // the remote while the subscription is definitively unavailable.
+    // The reconnect backoff floor is ~500ms, so writing immediately
+    // guarantees the record exists on the remote before any reconnect.
     killAllWebSockets();
 
-    // Brief pause to let the close propagate.
-    await new Promise(r => setTimeout(r, 500));
-
-    // Write a new record directly to the remote AFTER the socket drop.
-    // This record can only reach the local DWN if the pull subscription
-    // recovers (reconnect + re-subscribe) or the SMT integrity check runs.
     const data2 = Convert.string('after drop').toUint8Array();
     const remoteWrite2 = await harness.agent.dwn.sendRequest({
       author        : did,
@@ -162,19 +160,24 @@ describe('E2E: pull subscription recovery after WebSocket drop', () => {
     expect(remoteWrite2.reply.status.code).toBe(202);
     const postDropRecordId = remoteWrite2.message!.recordId;
 
-    // Verify it does NOT exist locally yet (pull subscription is dead).
-    const immediate = await harness.agent.dwn.processRequest({
-      author        : did,
-      target        : did,
-      messageType   : DwnInterface.RecordsQuery,
-      messageParams : { filter: { protocol: todoProtocol.protocol, recordId: postDropRecordId } },
-    });
-    expect(immediate.reply.entries?.length ?? 0).toBe(0);
+    // Verify the record does NOT exist locally — the subscription was
+    // dead when the record was written to the remote. Poll for 300ms
+    // to confirm it stays absent (not just a point-in-time check).
+    for (let i = 0; i < 3; i++) {
+      const local = await harness.agent.dwn.processRequest({
+        author        : did,
+        target        : did,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { protocol: todoProtocol.protocol, recordId: postDropRecordId } },
+      });
+      expect(local.reply.entries?.length ?? 0).toBe(0);
+      await new Promise(r => setTimeout(r, 100));
+    }
 
     // Phase 3: Wait for auto-reconnect to re-establish the pull
     // subscription and deliver the post-drop record locally.
-    // JsonRpcSocket reconnect fires after ~1s, then re-subscription
-    // delivers the record (or the integrity check reconciles it).
+    // JsonRpcSocket reconnect fires after ~500-1000ms (backoff + jitter),
+    // then re-subscription replays from the cursor and delivers the record.
     deadline = Date.now() + 20_000;
     found = false;
     while (Date.now() < deadline) {


### PR DESCRIPTION
## Summary

Adds the reconnection e2e test from #811. This test exercises the real pull subscription recovery path — the only sync path that uses WebSocket and is affected by connection drops.

### reconnection.e2e.spec.ts (2 tests)

Proves that the pull subscription recovers after a WebSocket drop and delivers records that were written to the remote during the outage:

| Phase | Action | What it proves |
|---|---|---|
| 1 | Write record to **remote** via HTTP, verify it arrives **locally** | Pull subscription is working |
| 2 | `killAllWebSockets()` — force-close underlying WebSocket via `WebSocketDwnRpcClient.connections` static pool (without `closedByUser`) | Pull subscription is dead |
| 3 | **Immediately** write a new record to the **remote** (no pause — record lands before reconnect backoff floor of ~500ms) | Record exists on remote while subscription is definitively unavailable |
| 4 | Poll local DWN 3× over 300ms, assert record is **absent** each time | Sustained absence confirms subscription was actually dead |
| 5 | Wait up to 20s for record to appear **locally** | Auto-reconnect re-established pull subscription and delivered the record |
| 6 | `getSyncHealth()` reports zero failures | Engine recovered cleanly |

**Key design choices:**
- All writes go to the **remote** via `sendRequest` (HTTP). All assertions check the **local** DWN. The only way the record can reach local is through the pull subscription.
- The push path uses HTTP and is unaffected by WebSocket drops — this test deliberately avoids the push path to isolate reconnection.
- Writing immediately after killing the socket (no pause) eliminates the race between the reconnect backoff floor and the record write.
- Sustained absence polling (not just a point-in-time check) confirms the subscription was dead when the record was written.

### E2E suite totals

| File | Tests |
|---|---|
| `heartbeat.e2e.spec.ts` | 2 |
| `live-sync-convergence.e2e.spec.ts` | 3 |
| `reconnection.e2e.spec.ts` | 2 (new) |
| **Total** | **7** |

All 7 pass locally against real DWN server + Pkarr relay in ~50s.

## Addresses

- #811 — "drop WebSocket connection, verify reconnect + re-subscription + SMT reconciliation"
