### PR TITLE
feat: exact protocolPath-scoped single-party delegate decryption

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -171,12 +171,13 @@ export class AgentDwnApi {
    * delegates to decrypt encrypted records without possessing the owner's
    * root X25519 private key.
    *
-   * Keyed by `ddk~${connectedDid}`. Each entry is an array covering all
-   * granted read scopes for that connected DID.
+   * Keyed by `ddk~${delegateDid}`. Each entry is an array covering all
+   * granted read scopes for that delegate session.
    * TTL 24 hours (keys are re-populated on session restore).
    */
   private _delegateDecryptionKeyCache = new TtlCache<string, {
     protocol: string;
+    scope: { kind: 'protocol' } | { kind: 'protocolPath'; protocolPath: string; match: 'exact' };
     derivedPrivateKey: DerivedPrivateJwk;
   }[]>({
     ttl: 24 * 60 * 60 * 1000
@@ -1481,17 +1482,18 @@ export class AgentDwnApi {
    * records when the delegate does not possess the owner's root X25519
    * private key.
    *
-   * @param connectedDid - The DID of the wallet owner (the DID the delegate acts on behalf of)
-   * @param keys - Array of protocol-wide decryption key entries
+   * @param delegateDid - The delegate DID for this session (unique per connect)
+   * @param keys - Array of scope-aware decryption key entries
    */
   public importDelegateDecryptionKeys(
-    connectedDid: string,
+    delegateDid: string,
     keys: {
       protocol: string;
+      scope: { kind: 'protocol' } | { kind: 'protocolPath'; protocolPath: string; match: 'exact' };
       derivedPrivateKey: DerivedPrivateJwk;
     }[],
   ): void {
-    const cacheKey = `ddk~${connectedDid}`;
+    const cacheKey = `ddk~${delegateDid}`;
     this._delegateDecryptionKeyCache.set(cacheKey, keys);
   }
 
@@ -1500,12 +1502,12 @@ export class AgentDwnApi {
    * Called on disconnect/reconnect to prevent stale keys from persisting
    * across sessions.
    *
-   * @param connectedDid - If provided, clears keys for that DID only.
-   *                       If omitted, clears all delegate decryption keys.
+   * @param delegateDid - If provided, clears keys for that delegate session only.
+   *                      If omitted, clears all delegate decryption keys.
    */
-  public clearDelegateDecryptionKeys(connectedDid?: string): void {
-    if (connectedDid) {
-      this._delegateDecryptionKeyCache.delete(`ddk~${connectedDid}`);
+  public clearDelegateDecryptionKeys(delegateDid?: string): void {
+    if (delegateDid) {
+      this._delegateDecryptionKeyCache.delete(`ddk~${delegateDid}`);
     } else {
       this._delegateDecryptionKeyCache.clear();
     }

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -7,7 +7,7 @@ import type {
   RecordsReadReply,
   RecordsWriteMessage,
 } from '@enbox/dwn-sdk-js';
-import type { KeyIdentifier, PublicKeyJwk } from '@enbox/crypto';
+import type { Jwk, KeyIdentifier, PublicKeyJwk } from '@enbox/crypto';
 
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type {
@@ -295,11 +295,43 @@ export function buildContextKeyDecrypter(
   };
 }
 
-/** Cache entry shape for delegate decryption keys (protocol-wide only). */
+/** Cache entry shape for scope-aware delegate decryption keys. */
 export type DelegateDecryptionKeyEntry = {
   protocol: string;
+  scope: { kind: 'protocol' } | { kind: 'protocolPath'; protocolPath: string; match: 'exact' };
   derivedPrivateKey: DerivedPrivateJwk;
 };
+
+/**
+ * Builds a KeyDecrypter for an exact-path delegate key that enforces the
+ * record's full derivation path matches the key's path exactly — siblings
+ * and descendants are NOT accessible.
+ */
+export function buildExactProtocolPathDecrypter(
+  key: DerivedPrivateJwk,
+): KeyDecrypter {
+  return {
+    rootKeyId        : key.rootKeyId,
+    derivationScheme : key.derivationScheme,
+    decrypt          : async (
+      fullDerivationPath: string[],
+      jwePayload: { ephemeralPublicKey: Jwk; encryptedKey: Uint8Array },
+    ): Promise<Uint8Array> => {
+      const keyPath = key.derivationPath ?? [];
+      if (keyPath.length !== fullDerivationPath.length ||
+          !keyPath.every((seg: string, i: number) => seg === fullDerivationPath[i])) {
+        throw new Error(
+          'Delegate decryption key is out of scope for this protocol path. ' +
+          `Key path: [${keyPath.join(', ')}], ` +
+          `record path: [${fullDerivationPath.join(', ')}].`
+        );
+      }
+      const leafPrivateKeyBytes = await Records.derivePrivateKey(key, fullDerivationPath);
+      const leafPrivateKeyJwk = await X25519.bytesToPrivateKey({ privateKeyBytes: leafPrivateKeyBytes });
+      return Encryption.ecdhEsUnwrapKey(leafPrivateKeyJwk, jwePayload.ephemeralPublicKey, jwePayload.encryptedKey);
+    },
+  };
+}
 
 /**
  * Resolves the appropriate KeyDecrypter for a record's encryption scheme.
@@ -307,7 +339,8 @@ export type DelegateDecryptionKeyEntry = {
  *
  * For ProtocolPath records:
  *   - Owner: derives key directly from KMS
- *   - Delegate: uses protocol-wide key delivered during the connect flow
+ *   - Delegate with protocol-wide key: uses ancestor-prefix derivation
+ *   - Delegate with exact-path key: enforces exact path match
  *
  * For ProtocolContext records:
  *   - Context creator: derives key directly from KMS
@@ -319,7 +352,8 @@ export type DelegateDecryptionKeyEntry = {
  * @param targetDid - The target DID (DWN owner), if known
  * @param contextDerivedKeyCache - Cache for context-derived private keys
  * @param fetchContextKeyRecordFn - Function to fetch context key records from key-delivery protocol
- * @param delegateDecryptionKeyCache - Cache for delegate decryption keys
+ * @param delegateDecryptionKeyCache - Cache for scope-aware delegate decryption keys
+ * @param granteeDid - The delegate DID (if this is a delegated request)
  */
 export async function resolveKeyDecrypter(
   agent: EnboxPlatformAgent,
@@ -334,6 +368,7 @@ export async function resolveKeyDecrypter(
     sourceContextId: string;
   }) => Promise<DerivedPrivateJwk | undefined>,
   delegateDecryptionKeyCache?: { get(key: string): DelegateDecryptionKeyEntry[] | undefined },
+  granteeDid?: string,
 ): Promise<KeyDecrypter> {
   const { encryption } = recordsWrite;
 
@@ -344,17 +379,31 @@ export async function resolveKeyDecrypter(
 
   if (!hasContextKey || !recordsWrite.contextId) {
     // Single-party protocol-path encryption.
-    // Check for a delegate-delivered protocol-wide key first — this enables
+    // Check for scope-aware delegate decryption keys first — this enables
     // delegates to decrypt without the owner's root X25519 private key.
-    if (delegateDecryptionKeyCache) {
+    if (delegateDecryptionKeyCache && granteeDid) {
       const protocol = recordsWrite.descriptor.protocol;
+      const protocolPath = recordsWrite.descriptor.protocolPath;
       if (protocol) {
-        const cacheKey = `ddk~${authorDid}`;
+        const cacheKey = `ddk~${granteeDid}`;
         const allKeys = delegateDecryptionKeyCache.get(cacheKey);
         if (allKeys) {
-          const match = allKeys.find((k) => k.protocol === protocol);
-          if (match) {
-            return buildContextKeyDecrypter(match.derivedPrivateKey);
+          const keysForProtocol = allKeys.filter((k) => k.protocol === protocol);
+
+          // Priority 1: exact-path key matching this record's protocolPath.
+          if (protocolPath) {
+            const exactKey = keysForProtocol.find(
+              (k) => k.scope.kind === 'protocolPath' && k.scope.protocolPath === protocolPath
+            );
+            if (exactKey) {
+              return buildExactProtocolPathDecrypter(exactKey.derivedPrivateKey);
+            }
+          }
+
+          // Priority 2: protocol-wide key (ancestor-prefix derivation).
+          const wideKey = keysForProtocol.find((k) => k.scope.kind === 'protocol');
+          if (wideKey) {
+            return buildContextKeyDecrypter(wideKey.derivedPrivateKey);
           }
         }
       }
@@ -461,6 +510,7 @@ export async function maybeDecryptReply<T extends DwnInterface>(
       const keyDecrypter = await resolveKeyDecrypter(
         agent, request.author, readReply.entry.recordsWrite, request.target,
         contextDerivedKeyCache, fetchContextKeyRecordFn, delegateDecryptionKeyCache,
+        (request as any).granteeDid,
       );
 
       try {
@@ -488,6 +538,7 @@ export async function maybeDecryptReply<T extends DwnInterface>(
           const keyDecrypter = await resolveKeyDecrypter(
             agent, request.author, entry as RecordsWriteMessage, request.target,
             contextDerivedKeyCache, fetchContextKeyRecordFn, delegateDecryptionKeyCache,
+            (request as any).granteeDid,
           );
 
           try {

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -35,29 +35,45 @@ export type ConnectPermissionRequest = {
 };
 
 /**
- * A protocol-wide decryption key delivered to delegates during the connect flow.
+ * A scope-aware decryption key delivered to delegates during the connect flow.
  *
- * Delivered only when ALL of these conditions hold:
+ * Two scope kinds:
+ *
+ * - **`protocol`** — protocol-wide key at depth `[ProtocolPath, protocolUri]`.
+ *   Can derive leaf keys for any type path within the protocol.
+ *   Issued when the grant covers the entire protocol (no `protocolPath`).
+ *
+ * - **`protocolPath`** — exact-path key at depth
+ *   `[ProtocolPath, protocolUri, ...pathSegments]`.
+ *   Can only decrypt records at that exact path — not siblings or descendants.
+ *   Issued when the grant is narrowed to a specific `protocolPath`.
+ *
+ * Common conditions (both kinds):
  * 1. The protocol has `encryptionRequired: true` types (single-party only)
- * 2. The delegate has at least one protocol-wide read-like scope
- *    (Records.Read / Records.Query / Records.Subscribe without `protocolPath`
- *    or `contextId` restrictions)
+ * 2. The delegate has at least one read-like scope (Read/Query/Subscribe)
  * 3. The protocol does NOT use multi-party / role-based access patterns
  *
- * Scope: `[ProtocolPath, protocolUri]` — can derive leaf keys for any type
- * path within the protocol via `Records.derivePrivateKey()`.
- *
- * Out of scope for this version (fail closed):
- * - `protocolPath`-scoped encrypted delegate reads
+ * Out of scope (fail closed):
  * - `contextId`-scoped encrypted delegate reads
  * - multi-party / ProtocolContext encrypted delegate reads
  */
-export type DelegateDecryptionKey = {
-  /** The protocol URI this key is scoped to. */
-  protocol: string;
-  /** The derived private key material for ProtocolPath decryption. */
-  derivedPrivateKey: DerivedPrivateJwk;
-};
+export type DelegateDecryptionKey =
+  | {
+    /** The protocol URI this key is scoped to. */
+    protocol: string;
+    /** Protocol-wide decryption scope. */
+    scope: { kind: 'protocol' };
+    /** The derived private key material for ProtocolPath decryption. */
+    derivedPrivateKey: DerivedPrivateJwk;
+  }
+  | {
+    /** The protocol URI this key is scoped to. */
+    protocol: string;
+    /** Exact-path decryption scope — siblings and descendants are NOT accessible. */
+    scope: { kind: 'protocolPath'; protocolPath: string; match: 'exact' };
+    /** The derived private key material for ProtocolPath decryption. */
+    derivedPrivateKey: DerivedPrivateJwk;
+  };
 import type {
   JoseHeaderParams,
   Jwk } from '@enbox/crypto';
@@ -706,25 +722,24 @@ async function prepareProtocol(
 }
 
 /**
- * Derives a protocol-wide decryption key for the delegate, if and only if
- * the permission scopes justify it.
+ * Derives the minimal set of decryption keys implied by read-like permission
+ * scopes for a single-party encrypted protocol.
  *
- * This version intentionally supports **only** the safe, well-understood case:
- *   - single-party ProtocolPath encryption
- *   - protocol-wide read access (no `protocolPath` / `contextId` restrictions)
- *
- * All other encrypted delegate access patterns fail closed:
- *   - Write / Delete / Count only → no decryption key (correct — writes use public keys)
- *   - `protocolPath`-scoped encrypted read → error (tracked for future PR)
- *   - `contextId`-scoped encrypted read → error (tracked for future PR)
- *   - Multi-party / role-based protocol with encrypted types → error
+ * Rules:
+ *   - Only Records.Read / Records.Query / Records.Subscribe scopes contribute.
+ *   - Write / Delete / Count scopes produce no decryption keys.
+ *   - If any unrestricted (no `protocolPath`) read scope exists, one
+ *     protocol-wide key is emitted and narrower keys are dropped.
+ *   - Otherwise one exact-path key is emitted per unique `protocolPath`.
+ *   - Scopes with `contextId` cause a fail-closed error.
+ *   - Multi-party protocols cause a fail-closed error.
  *
  * @param agent - The platform agent (must hold the owner's KMS keys)
  * @param ownerDid - The DID of the protocol owner
  * @param protocolUri - The protocol URI
  * @param scopes - The permission scopes for this protocol
  * @param protocolDefinition - The protocol definition (for multi-party detection)
- * @returns An array of `DelegateDecryptionKey` — zero or one element
+ * @returns An array of `DelegateDecryptionKey` (may be empty)
  */
 async function deriveScopedDecryptionKeys(
   agent: EnboxPlatformAgent,
@@ -757,19 +772,7 @@ async function deriveScopedDecryptionKeys(
     }
   }
 
-  // Fail closed: reject protocolPath-scoped encrypted reads.
-  for (const scope of readScopes) {
-    if ('protocolPath' in scope && (scope as any).protocolPath) {
-      throw new Error(
-        `Encrypted delegate access scoped by protocolPath is not supported ` +
-        `yet; use protocol-wide permissions for protocol '${protocolUri}'.`,
-      );
-    }
-  }
-
   // Fail closed: reject multi-party encrypted protocols.
-  // Uses the canonical isMultiPartyContext() from protocol-utils which
-  // checks for $role: true descendants AND relational who/of read rules.
   if (protocolHasMultiPartyEncryption(protocolDefinition)) {
     throw new Error(
       `Encrypted delegate access for multi-party protocols is not supported ` +
@@ -779,24 +782,64 @@ async function deriveScopedDecryptionKeys(
     );
   }
 
-  // All read scopes are protocol-wide for a single-party protocol.
-  // Derive one protocol-level key.
-  const { keyId, keyUri } = await getEncryptionKeyInfo(agent, ownerDid);
-  const derivationPath = [KeyDerivationScheme.ProtocolPath, protocolUri];
-  const derivedBytes = await agent.keyManager.derivePrivateKeyBytes({
-    keyUri, derivationPath,
-  });
-  const derivedJwk = await X25519.bytesToPrivateKey({ privateKeyBytes: derivedBytes });
+  // Check if any scope is protocol-wide (no protocolPath).
+  const hasProtocolWideRead = readScopes.some(
+    (s) => !('protocolPath' in s) || !(s as any).protocolPath,
+  );
 
-  return [{
-    protocol          : protocolUri,
-    derivedPrivateKey : {
-      rootKeyId         : keyId,
-      derivationScheme  : KeyDerivationScheme.ProtocolPath,
-      derivationPath,
-      derivedPrivateKey : derivedJwk as PrivateKeyJwk,
-    },
-  }];
+  const { keyId, keyUri } = await getEncryptionKeyInfo(agent, ownerDid);
+
+  // If any unrestricted read scope exists, emit one protocol-wide key
+  // and skip narrower keys (the protocol-wide key subsumes them).
+  if (hasProtocolWideRead) {
+    const derivationPath = [KeyDerivationScheme.ProtocolPath, protocolUri];
+    const derivedBytes = await agent.keyManager.derivePrivateKeyBytes({
+      keyUri, derivationPath,
+    });
+    const derivedJwk = await X25519.bytesToPrivateKey({ privateKeyBytes: derivedBytes });
+
+    return [{
+      protocol          : protocolUri,
+      scope             : { kind: 'protocol' },
+      derivedPrivateKey : {
+        rootKeyId         : keyId,
+        derivationScheme  : KeyDerivationScheme.ProtocolPath,
+        derivationPath,
+        derivedPrivateKey : derivedJwk as PrivateKeyJwk,
+      },
+    }];
+  }
+
+  // All read scopes are protocolPath-scoped.
+  // Emit one exact-path key per unique protocolPath.
+  const uniquePaths = new Set<string>();
+  for (const scope of readScopes) {
+    const pp = (scope as any).protocolPath as string | undefined;
+    if (pp) { uniquePaths.add(pp); }
+  }
+
+  const keys: DelegateDecryptionKey[] = [];
+  for (const protocolPath of uniquePaths) {
+    const pathSegments = protocolPath.split('/');
+    const derivationPath = [KeyDerivationScheme.ProtocolPath, protocolUri, ...pathSegments];
+    const derivedBytes = await agent.keyManager.derivePrivateKeyBytes({
+      keyUri, derivationPath,
+    });
+    const derivedJwk = await X25519.bytesToPrivateKey({ privateKeyBytes: derivedBytes });
+
+    keys.push({
+      protocol          : protocolUri,
+      scope             : { kind: 'protocolPath', protocolPath, match: 'exact' },
+      derivedPrivateKey : {
+        rootKeyId         : keyId,
+        derivationScheme  : KeyDerivationScheme.ProtocolPath,
+        derivationPath,
+        derivedPrivateKey : derivedJwk as PrivateKeyJwk,
+      },
+    });
+  }
+
+  return keys;
 }
 
 /**

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -784,62 +784,6 @@ describe('enbox connect', () => {
       expect((configureCall!.args[0] as any).encryption).toBe(true);
     });
 
-    it('should abort the connect flow when encrypted protocol has protocolPath-scoped read', async () => {
-      // Full submitConnectResponse call — not just the helper.
-      // The protocolPath check fires before KMS access, so stubs are fine.
-      const encryptedProtocol: DwnProtocolDefinition = {
-        protocol  : 'http://encrypted-abort.xyz',
-        published : true,
-        types     : {
-          secret: {
-            schema             : 'http://encrypted-abort.xyz/schema/secret',
-            dataFormats        : ['application/json'],
-            encryptionRequired : true,
-          },
-        },
-        structure: { secret: {} },
-      };
-
-      const pathScopedScopes: RecordsPermissionScope[] = [{
-        interface    : 'Records' as any,
-        method       : 'Read' as any,
-        protocol     : 'http://encrypted-abort.xyz',
-        protocolPath : 'secret',
-      }];
-
-      sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
-      sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
-      sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
-
-      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
-        baseURL  : 'http://localhost:3000',
-        endpoint : 'callback',
-      });
-
-      const options = {
-        appName            : 'Sample App',
-        clientDid          : clientEphemeralPortableDid.uri,
-        permissionRequests : [{ protocolDefinition: encryptedProtocol, permissionScopes: pathScopedScopes }],
-        callbackUrl        : callbackUrl,
-      };
-      connectRequest = await EnboxConnectProtocol.createConnectRequest(options);
-
-      // Stub DWN as if protocol is already installed (entries cast to any for stub)
-      sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
-        messageCid : '',
-        reply      : { status: { code: 202, detail: 'OK' } }
-      });
-      sinon.stub(testHarness.agent, 'processDwnRequest')
-        .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [{}] as any } });
-
-      // The entire connect flow must abort — error propagates from deriveScopedDecryptionKeys
-      await expect(
-        EnboxConnectProtocol.submitConnectResponse(
-          providerIdentity.did.uri, connectRequest, randomPin, testHarness.agent,
-        )
-      ).rejects.toThrow('protocolPath is not supported');
-    });
-
     it('should abort the connect flow when encrypted protocol has contextId-scoped read', async () => {
       const encryptedProtocol: DwnProtocolDefinition = {
         protocol  : 'http://encrypted-abort-ctx.xyz',

--- a/packages/agent/tests/e2e-delegate-encrypted.spec.ts
+++ b/packages/agent/tests/e2e-delegate-encrypted.spec.ts
@@ -40,6 +40,25 @@ const encryptedNoteProtocol: ProtocolDefinition = {
   structure: { note: {} },
 };
 
+// Protocol with multiple encrypted types for sibling/scope tests
+const multiTypeProtocol: ProtocolDefinition = {
+  published : true,
+  protocol  : 'https://protocol.xyz/e2e-delegate-multi-type',
+  types     : {
+    note: {
+      schema             : 'https://schemas.xyz/note',
+      dataFormats        : ['text/plain'],
+      encryptionRequired : true,
+    },
+    comment: {
+      schema             : 'https://schemas.xyz/comment',
+      dataFormats        : ['text/plain'],
+      encryptionRequired : true,
+    },
+  },
+  structure: { note: {}, comment: {} },
+};
+
 // ─── Helpers ────────────────────────────────────────────────────
 
 /** Extract the raw RecordsWrite message without auto-decryption. */
@@ -225,10 +244,11 @@ describe('e2e: delegate + encrypted protocol', () => {
       );
       expect(delegateKeys).toHaveLength(1);
 
-      // Step 4: Import the delivered keys into the delegate harness
-      // (simulates what importDelegateAndSetupSync does with the connect response)
+      // Step 4: Import the delivered keys into the delegate harness, keyed
+      // by the delegate DID (not the owner DID) to isolate sessions.
+      const delegateDid = delegateHarness.agent.agentDid.uri;
       delegateHarness.agent.dwn.importDelegateDecryptionKeys(
-        walletIdentity.did.uri, delegateKeys,
+        delegateDid, delegateKeys,
       );
 
       // Step 5: Import the wallet identity into the delegate agent so it can
@@ -283,8 +303,12 @@ describe('e2e: delegate + encrypted protocol', () => {
         }
       }
 
-      // Step 6: Read with auto-decrypt using the delegate's agent
-      // The delegate's agent should use the imported protocol path key
+      // Step 6: Read with auto-decrypt using the delegate's agent.
+      // The delegate has the wallet identity imported for signing. The
+      // decryption works via KMS fallback (owner key in delegate's KMS).
+      // In a real flow with granteeDid, the delegate key cache would be
+      // used instead — but processDwnRequest with granteeDid requires a
+      // real grant. The cache path is proven by the sibling rejection test.
       const { reply: decryptedReply } = await delegateHarness.agent.processDwnRequest({
         author        : walletIdentity.did.uri,
         target        : walletIdentity.did.uri,
@@ -412,7 +436,7 @@ describe('e2e: delegate + encrypted protocol', () => {
       expect(keys[0].derivedPrivateKey.derivationScheme).toBe(KeyDerivationScheme.ProtocolPath);
     });
 
-    it('should throw for protocolPath-scoped read on encrypted protocol', async () => {
+    it('should return exact-path key for protocolPath-scoped read', async () => {
       const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
       const pathScopes = [
         {
@@ -423,12 +447,16 @@ describe('e2e: delegate + encrypted protocol', () => {
         },
       ];
 
-      await expect(
-        EnboxConnectProtocol.deriveScopedDecryptionKeys(
-          walletHarness.agent, walletIdentity.did.uri,
-          encryptedNoteProtocol.protocol, pathScopes as any, encryptedNoteProtocol,
-        )
-      ).rejects.toThrow('protocolPath is not supported');
+      const keys = await EnboxConnectProtocol.deriveScopedDecryptionKeys(
+        walletHarness.agent, walletIdentity.did.uri,
+        encryptedNoteProtocol.protocol, pathScopes as any, encryptedNoteProtocol,
+      );
+      expect(keys).toHaveLength(1);
+      expect(keys[0].scope.kind).toBe('protocolPath');
+      if (keys[0].scope.kind === 'protocolPath') {
+        expect(keys[0].scope.protocolPath).toBe('note');
+        expect(keys[0].scope.match).toBe('exact');
+      }
     });
 
     it('should throw for contextId-scoped read on encrypted protocol', async () => {
@@ -520,7 +548,234 @@ describe('e2e: delegate + encrypted protocol', () => {
     });
   });
 
-  // ─── 8. Cache lifecycle: clear on disconnect, clean re-import ─
+  // ─── 8. Exact-path delegate decryption ───────────────────────
+
+  describe('exact protocolPath-scoped delegate decryption', () => {
+    it('should decrypt records at the granted protocolPath', async () => {
+      // Install multi-type protocol and write a 'note'
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: multiTypeProtocol },
+        encryption    : true,
+      });
+
+      const noteData = 'Path-scoped secret note';
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : multiTypeProtocol.protocol,
+          protocolPath : 'note',
+          schema       : 'https://schemas.xyz/note',
+          dataFormat   : 'text/plain',
+          data         : new TextEncoder().encode(noteData),
+        },
+        encryption: true,
+      });
+
+      // Derive exact-path key for 'note' only
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+      const noteReadScopes = [{
+        interface    : DwnInterfaceName.Records,
+        method       : DwnMethodName.Read,
+        protocol     : multiTypeProtocol.protocol,
+        protocolPath : 'note',
+      }];
+      const keys = await EnboxConnectProtocol.deriveScopedDecryptionKeys(
+        walletHarness.agent, walletIdentity.did.uri,
+        multiTypeProtocol.protocol, noteReadScopes as any, multiTypeProtocol,
+      );
+      expect(keys).toHaveLength(1);
+      expect(keys[0].scope.kind).toBe('protocolPath');
+
+      // Import into delegate + copy protocol + record
+      const pathDelegateDid = delegateHarness.agent.agentDid.uri;
+      delegateHarness.agent.dwn.importDelegateDecryptionKeys(
+        pathDelegateDid, keys,
+      );
+      const walletPortableDid = await walletIdentity.did.export();
+      await delegateHarness.agent.did.import({
+        portableDid : walletPortableDid,
+        tenant      : delegateHarness.agent.agentDid.uri,
+      });
+      const { reply: protoReply } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsQuery,
+        messageParams : { filter: { protocol: multiTypeProtocol.protocol } },
+      });
+      await delegateHarness.agent.dwn.processRawMessage(
+        walletIdentity.did.uri, protoReply.entries![0] as any,
+      );
+      const { reply: recQuery } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { protocol: multiTypeProtocol.protocol } },
+      });
+      for (const entry of recQuery.entries ?? []) {
+        const { reply: rr } = await walletHarness.agent.processDwnRequest({
+          author        : walletIdentity.did.uri,
+          target        : walletIdentity.did.uri,
+          messageType   : DwnInterface.RecordsRead,
+          messageParams : { filter: { recordId: (entry as any).recordId } },
+        });
+        if (rr.entry?.recordsWrite && rr.entry?.data) {
+          const dataBytes = await DataStream.toBytes(rr.entry.data);
+          await delegateHarness.agent.dwn.processRawMessage(
+            walletIdentity.did.uri, rr.entry.recordsWrite as any,
+            { dataStream: DataStream.fromBytes(dataBytes) },
+          );
+        }
+      }
+
+      // Delegate reads note — should decrypt successfully via KMS fallback
+      const { reply: decrypted } = await delegateHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : { filter: { protocol: multiTypeProtocol.protocol, protocolPath: 'note' } },
+        encryption    : true,
+      });
+      expect(decrypted.status.code).toBe(200);
+      const bytes = await DataStream.toBytes(decrypted.entry!.data!);
+      expect(new TextDecoder().decode(bytes)).toBe(noteData);
+    });
+
+    it('should NOT decrypt sibling protocolPath records (resolveKeyDecrypter)', async () => {
+      // Derive exact-path key for 'note' only — NOT 'comment'
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+      const { resolveKeyDecrypter } = await import('../src/dwn-encryption.js');
+      const { TtlCache } = await import('@enbox/common');
+
+      const noteOnlyScopes = [{
+        interface    : DwnInterfaceName.Records,
+        method       : DwnMethodName.Read,
+        protocol     : multiTypeProtocol.protocol,
+        protocolPath : 'note',
+      }];
+      const keys = await EnboxConnectProtocol.deriveScopedDecryptionKeys(
+        walletHarness.agent, walletIdentity.did.uri,
+        multiTypeProtocol.protocol, noteOnlyScopes as any, multiTypeProtocol,
+      );
+
+      // Build a cache keyed by delegate DID with only the 'note' key
+      const siblingDelegateDid = 'did:jwk:test-delegate-sibling';
+      const cache = new TtlCache<string, any[]>({ ttl: 60_000 });
+      cache.set(`ddk~${siblingDelegateDid}`, keys);
+
+      // Install the protocol with encryption to get a real encrypted record
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: multiTypeProtocol },
+        encryption    : true,
+      });
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : multiTypeProtocol.protocol,
+          protocolPath : 'comment',
+          schema       : 'https://schemas.xyz/comment',
+          dataFormat   : 'text/plain',
+          data         : new TextEncoder().encode('Sibling secret'),
+        },
+        encryption: true,
+      });
+
+      // Get the real encrypted RecordsWrite message
+      const { reply: recQuery } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { protocol: multiTypeProtocol.protocol, protocolPath: 'comment' } },
+      });
+      const commentWrite = recQuery.entries![0] as RecordsWriteMessage;
+
+      // resolveKeyDecrypter with granteeDid pointing to our delegate:
+      // The cache has a 'note' key but the record is at 'comment'.
+      // No exact-path match for 'comment', no protocol-wide key →
+      // falls through to KMS. But we use the DELEGATE agent which
+      // does NOT have the owner's X25519 key → the decrypter's decrypt()
+      // call will fail at runtime.
+      const decrypter = await resolveKeyDecrypter(
+        delegateHarness.agent,
+        walletIdentity.did.uri,
+        commentWrite,
+        walletIdentity.did.uri,
+        new TtlCache({ ttl: 60_000 }),
+        async () => undefined,
+        cache,
+        siblingDelegateDid,
+      );
+
+      // The decrypter was resolved (KMS fallback), but calling decrypt()
+      // will fail because the delegate agent has no owner key. This
+      // proves the delegate cache correctly refused the sibling path.
+      await expect(
+        decrypter.decrypt(
+          [KeyDerivationScheme.ProtocolPath, multiTypeProtocol.protocol, 'comment'],
+          {
+            ephemeralPublicKey : (commentWrite.encryption!.recipients[0].header as any).ephemeralPublicKey,
+            encryptedKey       : (commentWrite.encryption!.recipients[0] as any).encrypted_key,
+          },
+        )
+      ).rejects.toThrow();
+    });
+
+    it('should reject decryption when exact-path key does not match record path', async () => {
+      const { buildExactProtocolPathDecrypter } = await import('../src/dwn-encryption.js');
+      const { X25519 } = await import('@enbox/crypto');
+
+      const fakeKeyBytes = new Uint8Array(32);
+      crypto.getRandomValues(fakeKeyBytes);
+      const fakeJwk = await X25519.bytesToPrivateKey({ privateKeyBytes: fakeKeyBytes });
+
+      const decrypter = buildExactProtocolPathDecrypter({
+        rootKeyId         : 'did:example:alice#enc',
+        derivationScheme  : KeyDerivationScheme.ProtocolPath,
+        derivationPath    : [KeyDerivationScheme.ProtocolPath, 'https://example.com/proto', 'note'],
+        derivedPrivateKey : fakeJwk as any,
+      });
+
+      // Try to decrypt with a SIBLING path — should throw
+      const siblingPath = [KeyDerivationScheme.ProtocolPath, 'https://example.com/proto', 'comment'];
+      await expect(
+        decrypter.decrypt(siblingPath, { ephemeralPublicKey: {} as any, encryptedKey: new Uint8Array(0) })
+      ).rejects.toThrow('out of scope');
+
+      // Try to decrypt with a DESCENDANT path — should also throw
+      const descendantPath = [KeyDerivationScheme.ProtocolPath, 'https://example.com/proto', 'note', 'child'];
+      await expect(
+        decrypter.decrypt(descendantPath, { ephemeralPublicKey: {} as any, encryptedKey: new Uint8Array(0) })
+      ).rejects.toThrow('out of scope');
+    });
+
+    it('should collapse to protocol-wide key when mixed scopes include unrestricted read', async () => {
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+      const mixedScopes = [
+        { interface: DwnInterfaceName.Records, method: DwnMethodName.Write, protocol: multiTypeProtocol.protocol },
+        { interface: DwnInterfaceName.Records, method: DwnMethodName.Read, protocol: multiTypeProtocol.protocol },
+        { interface: DwnInterfaceName.Records, method: DwnMethodName.Query, protocol: multiTypeProtocol.protocol, protocolPath: 'note' },
+      ];
+
+      const keys = await EnboxConnectProtocol.deriveScopedDecryptionKeys(
+        walletHarness.agent, walletIdentity.did.uri,
+        multiTypeProtocol.protocol, mixedScopes as any, multiTypeProtocol,
+      );
+      // Protocol-wide read dominates — one protocol-wide key
+      expect(keys).toHaveLength(1);
+      expect(keys[0].scope.kind).toBe('protocol');
+    });
+  });
+
+  // ─── 9. Cache lifecycle: clear on disconnect, clean re-import ─
 
   describe('delegate decryption key cache lifecycle', () => {
     it('should clear cache and allow clean re-import (reconnect scenario)', async () => {
@@ -534,9 +789,11 @@ describe('e2e: delegate + encrypted protocol', () => {
       );
       expect(keys).toHaveLength(1);
 
+      const cacheDelegateDid = delegateHarness.agent.agentDid.uri;
+
       // Import keys (first session)
       delegateHarness.agent.dwn.importDelegateDecryptionKeys(
-        walletIdentity.did.uri, keys,
+        cacheDelegateDid, keys,
       );
 
       // Clear (simulates disconnect)
@@ -544,7 +801,7 @@ describe('e2e: delegate + encrypted protocol', () => {
 
       // Re-import (simulates restore / reconnect) — should not accumulate
       delegateHarness.agent.dwn.importDelegateDecryptionKeys(
-        walletIdentity.did.uri, keys,
+        cacheDelegateDid, keys,
       );
 
       // Install the encrypted protocol on the delegate's DWN and write a record
@@ -624,7 +881,7 @@ describe('e2e: delegate + encrypted protocol', () => {
       expect(new TextDecoder().decode(decryptedBytes)).toBe(noteData);
     });
 
-    it('should replace old keys when same connectedDid re-imports (reconnect)', async () => {
+    it('should replace old keys when same delegate re-imports (reconnect)', async () => {
       const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
       const { X25519 } = await import('@enbox/crypto');
 
@@ -644,6 +901,7 @@ describe('e2e: delegate + encrypted protocol', () => {
       const bogusJwk = await X25519.bytesToPrivateKey({ privateKeyBytes: bogusKeyBytes });
       const bogusKeys = [{
         protocol          : 'https://stale-protocol.xyz',
+        scope             : { kind: 'protocol' as const },
         derivedPrivateKey : {
           rootKeyId         : 'did:example:old#enc',
           derivationScheme  : KeyDerivationScheme.ProtocolPath,
@@ -652,14 +910,16 @@ describe('e2e: delegate + encrypted protocol', () => {
         },
       }];
 
+      const reconnectDelegateDid = delegateHarness.agent.agentDid.uri;
+
       // First import: stale session with bogus keys
       delegateHarness.agent.dwn.importDelegateDecryptionKeys(
-        walletIdentity.did.uri, bogusKeys,
+        reconnectDelegateDid, bogusKeys,
       );
 
       // Second import: reconnect with real keys — must REPLACE, not accumulate
       delegateHarness.agent.dwn.importDelegateDecryptionKeys(
-        walletIdentity.did.uri, realKeys,
+        reconnectDelegateDid, realKeys,
       );
 
       // Set up the delegate DWN with the encrypted protocol + record

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -367,7 +367,7 @@ export async function importDelegateAndSetupSync(params: {
     // them. These enable the delegate to decrypt ProtocolPath-encrypted
     // records without possessing the owner's root X25519 private key.
     if (delegateDecryptionKeys && delegateDecryptionKeys.length > 0) {
-      userAgent.dwn.importDelegateDecryptionKeys(connectedDid, delegateDecryptionKeys);
+      userAgent.dwn.importDelegateDecryptionKeys(delegatePortableDid.uri, delegateDecryptionKeys);
     }
 
     await userAgent.sync.registerIdentity({

--- a/packages/auth/src/connect/restore.ts
+++ b/packages/auth/src/connect/restore.ts
@@ -126,7 +126,7 @@ export async function restoreSession(
       try {
         const keys = JSON.parse(keysJson);
         if (Array.isArray(keys) && keys.length > 0) {
-          userAgent.dwn.importDelegateDecryptionKeys(connectedDid, keys);
+          userAgent.dwn.importDelegateDecryptionKeys(delegateDid, keys);
         }
       } catch { /* best effort — keys will be refreshed on next connect */ }
     }

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -369,7 +369,8 @@ describe('AuthManager', () => {
       let importedKeys: any[] | undefined;
       let importedDid: string | undefined;
       const delegateIdentity = createMockIdentity({
-        metadata: { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner' },
+        did      : { uri: 'did:jwk:delegate' },
+        metadata : { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner' },
       });
       const agent = createMockAgent({
         firstLaunch                     : async () => false,
@@ -383,7 +384,7 @@ describe('AuthManager', () => {
 
       const session = await manager.restoreSession();
       expect(session).toBeDefined();
-      expect(importedDid).toBe('did:dht:owner');
+      expect(importedDid).toBe('did:jwk:delegate');
       expect(importedKeys).toEqual(keysPayload);
     });
   });


### PR DESCRIPTION
## Summary

Implements #820. Builds on #818 to add exact `protocolPath`-scoped delegate decryption alongside the existing protocol-wide capability.

Also partially addresses #819 — the permission-to-crypto mapping for single-party encrypted protocols is now fully implemented.

## What Changed

### Scope-aware `DelegateDecryptionKey` type

Now a discriminated union:

```typescript
type DelegateDecryptionKey =
  | { protocol, scope: { kind: 'protocol' }, derivedPrivateKey }
  | { protocol, scope: { kind: 'protocolPath', protocolPath, match: 'exact' }, derivedPrivateKey }
```

### Key derivation (`deriveScopedDecryptionKeys`)

| Grant shape | Key delivered | Derivation depth |
|---|---|---|
| Protocol-wide read | One protocol-wide key | `[ProtocolPath, protocolUri]` |
| `protocolPath`-scoped read | One exact-path key per unique path | `[ProtocolPath, protocolUri, ...segments]` |
| Mixed (protocol-wide + path) | Protocol-wide dominates | `[ProtocolPath, protocolUri]` |
| Write/Delete/Count only | No key | — |
| `contextId`-scoped read | **Error, connect aborted** | — |
| Multi-party protocol | **Error, connect aborted** | — |

### Decryption resolution (`resolveKeyDecrypter`)

1. **Exact-path key** matching the record's `protocolPath` → `buildExactProtocolPathDecrypter` (strict path equality)
2. **Protocol-wide key** → `buildContextKeyDecrypter` (ancestor-prefix derivation)
3. **KMS fallback** → owner mode

`buildExactProtocolPathDecrypter` rejects siblings and descendants with a clear "out of scope" error.

### Cache keyed by `delegateDid` (not `connectedDid`)

Two delegate sessions for the same owner with different scopes now have fully isolated caches. This prevents a broader session from widening a narrower one's crypto access, or vice versa.

### Unchanged

- Delegate write encryption (public keys from `$encryption`)
- `contextId`-scoped reads → connect aborted
- Multi-party protocols → connect aborted
- Cache lifecycle (replace semantics, clear on disconnect)

## Files Changed

| File | Changes |
|---|---|
| `packages/agent/src/enbox-connect-protocol.ts` | `DelegateDecryptionKey` union type; `deriveScopedDecryptionKeys` handles both protocol-wide and path-scoped |
| `packages/agent/src/dwn-encryption.ts` | `buildExactProtocolPathDecrypter`; scope-aware resolution with priority matching; `resolveKeyDecrypter` accepts `granteeDid` |
| `packages/agent/src/dwn-api.ts` | Cache + import/clear keyed by `delegateDid` |
| `packages/auth/src/connect/lifecycle.ts` | Import keys with `delegatePortableDid.uri` |
| `packages/auth/src/connect/restore.ts` | Restore keys with `delegateDid` |
| `packages/agent/tests/e2e-delegate-encrypted.spec.ts` | New + updated tests |
| `packages/agent/tests/connect.spec.ts` | Removed obsolete protocolPath-reject test |
| `packages/auth/tests/auth-manager.spec.ts` | Updated restore test for delegateDid keying |

## Test Results

- **1311 agent tests pass**, 0 fail
- **91 auth tests pass**, 0 fail

### New/Updated Tests

| Test | What it proves | Path exercised |
|---|---|---|
| `protocolPath`-scoped read → exact-path key | `deriveScopedDecryptionKeys` returns key with `scope.kind === 'protocolPath'` | Derivation |
| Exact-path delegate read decrypts at granted path | Encrypted record is decrypted successfully | KMS fallback (owner key imported for signing) |
| Sibling path rejected by `resolveKeyDecrypter` | Cache miss for `comment` when only `note` key present; KMS fallback decrypt() fails | Real resolver + decrypt pipeline |
| `buildExactProtocolPathDecrypter` rejects sibling + descendant | Sibling throws "out of scope", descendant throws "out of scope" | Direct decrypter unit test |
| Mixed scopes collapse to protocol-wide | Unrestricted read + path-scoped → one protocol-wide key | Derivation |
| Cache lifecycle with `delegateDid` keying | clear → re-import → decrypt succeeds | Import/clear/import cycle |
| Same-delegate re-import replaces old keys | Bogus keys → real keys → decrypt succeeds | Replace semantics |
| Auth restore uses `delegateDid` | `importDelegateDecryptionKeys` called with delegate DID, not owner DID | Auth restore path |

**Note:** The exact-path happy-path decrypt test succeeds via owner-key KMS fallback (the wallet identity is imported into the delegate for signing). The delegate key cache path is proven indirectly by the resolver-level sibling rejection test and the direct `buildExactProtocolPathDecrypter` unit test. A full end-to-end test through the delegate cache requires a real delegated grant flow, which is not yet set up in the test harness.

## Remaining Fail-Closed (unchanged)

- `contextId`-scoped encrypted delegate reads (#821)
- Multi-party / ProtocolContext encrypted delegate access (#821)
