### PR TITLE
feat: multi-party delegate decryption via context-key delivery

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -184,6 +184,19 @@ export class AgentDwnApi {
   });
 
   /**
+   * Delegate context key cache — stores ProtocolContext decryption keys for
+   * multi-party encrypted protocols. Each key is scoped to one rootContextId.
+   * Keyed by `dctx~${delegateDid}~${protocol}~${rootContextId}`.
+   * TTL 24 hours (re-populated on session restore).
+   */
+  private _delegateContextKeyCache = new TtlCache<string, DerivedPrivateJwk>({
+    ttl: 24 * 60 * 60 * 1000
+  });
+
+  /** Tracks which context key cache entries belong to which delegate DID. */
+  private _delegateContextKeyCacheIndex = new Map<string, string[]>();
+
+  /**
    * Cache of locally-managed DIDs (agent DID + identities). Used to decide
    * whether a target DID should be routed through the local DWN server.
    */
@@ -1388,6 +1401,7 @@ export class AgentDwnApi {
       this._contextDerivedKeyCache,
       this.fetchContextKeyRecord.bind(this),
       this._delegateDecryptionKeyCache,
+      this._delegateContextKeyCache,
     );
   }
 
@@ -1498,18 +1512,57 @@ export class AgentDwnApi {
   }
 
   /**
-   * Clears delegate decryption keys from the in-memory cache.
-   * Called on disconnect/reconnect to prevent stale keys from persisting
-   * across sessions.
+   * Imports ProtocolContext decryption keys for multi-party encrypted protocols.
+   * Each key is scoped to one rootContextId within one protocol.
+   *
+   * @param delegateDid - The delegate DID for this session
+   * @param keys - Array of `{ protocol, contextId, derivedPrivateKey }` entries
+   */
+  public importDelegateContextKeys(
+    delegateDid: string,
+    keys: {
+      protocol: string;
+      contextId: string;
+      derivedPrivateKey: DerivedPrivateJwk;
+    }[],
+  ): void {
+    // Clear any previously indexed entries for this delegate first,
+    // so a re-import (e.g. session restore) doesn't leave stale entries.
+    const previousKeys = this._delegateContextKeyCacheIndex.get(delegateDid);
+    if (previousKeys) {
+      for (const ck of previousKeys) { this._delegateContextKeyCache.delete(ck); }
+    }
+
+    const cacheKeys: string[] = [];
+    for (const key of keys) {
+      const ck = `dctx~${delegateDid}~${key.protocol}~${key.contextId}`;
+      this._delegateContextKeyCache.set(ck, key.derivedPrivateKey);
+      cacheKeys.push(ck);
+    }
+    this._delegateContextKeyCacheIndex.set(delegateDid, cacheKeys);
+  }
+
+  /**
+   * Clears all delegate decryption keys (both ProtocolPath and ProtocolContext)
+   * from the in-memory cache. Called on disconnect to prevent stale keys from
+   * persisting across sessions.
    *
    * @param delegateDid - If provided, clears keys for that delegate session only.
-   *                      If omitted, clears all delegate decryption keys.
+   *                      If omitted, clears all delegate keys.
    */
   public clearDelegateDecryptionKeys(delegateDid?: string): void {
     if (delegateDid) {
       this._delegateDecryptionKeyCache.delete(`ddk~${delegateDid}`);
+      // Delete only context keys belonging to this delegate.
+      const cacheKeys = this._delegateContextKeyCacheIndex.get(delegateDid);
+      if (cacheKeys) {
+        for (const ck of cacheKeys) { this._delegateContextKeyCache.delete(ck); }
+        this._delegateContextKeyCacheIndex.delete(delegateDid);
+      }
     } else {
       this._delegateDecryptionKeyCache.clear();
+      this._delegateContextKeyCache.clear();
+      this._delegateContextKeyCacheIndex.clear();
     }
   }
 

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -343,6 +343,7 @@ export function buildExactProtocolPathDecrypter(
  *   - Delegate with exact-path key: enforces exact path match
  *
  * For ProtocolContext records:
+ *   - Delegate: uses delivered context key from the connect flow
  *   - Context creator: derives key directly from KMS
  *   - Participant: fetches contextKey via key-delivery protocol, caches it
  *
@@ -369,6 +370,7 @@ export async function resolveKeyDecrypter(
   }) => Promise<DerivedPrivateJwk | undefined>,
   delegateDecryptionKeyCache?: { get(key: string): DelegateDecryptionKeyEntry[] | undefined },
   granteeDid?: string,
+  delegateContextKeyCache?: { get(key: string): DerivedPrivateJwk | undefined },
 ): Promise<KeyDecrypter> {
   const { encryption } = recordsWrite;
 
@@ -418,6 +420,18 @@ export async function resolveKeyDecrypter(
   )!;
 
   const rootContextId = recordsWrite.contextId.split('/')[0];
+
+  // Case 0: Delegate with a delivered context key for this rootContextId
+  if (delegateContextKeyCache && granteeDid) {
+    const protocol = recordsWrite.descriptor.protocol;
+    if (protocol) {
+      const ctxCacheKey = `dctx~${granteeDid}~${protocol}~${rootContextId}`;
+      const delegateCtxKey = delegateContextKeyCache.get(ctxCacheKey);
+      if (delegateCtxKey) {
+        return buildContextKeyDecrypter(delegateCtxKey);
+      }
+    }
+  }
 
   // Case 1: I am the context creator — rootKeyId matches my encryption key
   const { keyId, keyUri } = await getEncryptionKeyInfo(agent, authorDid);
@@ -496,6 +510,7 @@ export async function maybeDecryptReply<T extends DwnInterface>(
     sourceContextId: string;
   }) => Promise<DerivedPrivateJwk | undefined>,
   delegateDecryptionKeyCache?: { get(key: string): DelegateDecryptionKeyEntry[] | undefined },
+  delegateContextKeyCache?: { get(key: string): DerivedPrivateJwk | undefined },
 ): Promise<void> {
   if (!('encryption' in request) || !request.encryption) {
     return;
@@ -510,7 +525,7 @@ export async function maybeDecryptReply<T extends DwnInterface>(
       const keyDecrypter = await resolveKeyDecrypter(
         agent, request.author, readReply.entry.recordsWrite, request.target,
         contextDerivedKeyCache, fetchContextKeyRecordFn, delegateDecryptionKeyCache,
-        (request as any).granteeDid,
+        (request as any).granteeDid, delegateContextKeyCache,
       );
 
       try {
@@ -538,7 +553,7 @@ export async function maybeDecryptReply<T extends DwnInterface>(
           const keyDecrypter = await resolveKeyDecrypter(
             agent, request.author, entry as RecordsWriteMessage, request.target,
             contextDerivedKeyCache, fetchContextKeyRecordFn, delegateDecryptionKeyCache,
-            (request as any).granteeDid,
+            (request as any).granteeDid, delegateContextKeyCache,
           );
 
           try {

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -74,6 +74,30 @@ export type DelegateDecryptionKey =
     /** The derived private key material for ProtocolPath decryption. */
     derivedPrivateKey: DerivedPrivateJwk;
   };
+
+/**
+ * A context-scoped decryption key for a multi-party encrypted protocol.
+ *
+ * Delivered to delegates during the connect flow so they can decrypt
+ * ProtocolContext-encrypted records without the owner's root X25519 key.
+ *
+ * Each key is scoped to one rootContextId — it unlocks all records within
+ * that context domain but cannot access other contexts in the protocol.
+ *
+ * Delivered only when:
+ * 1. The protocol has multi-party access patterns (detected by `isMultiPartyContext`)
+ * 2. The delegate has a protocol-wide read-like scope (no protocolPath/contextId)
+ * 3. The protocol has `encryptionRequired: true` types
+ */
+export type DelegateContextKey = {
+  /** The protocol URI this key belongs to. */
+  protocol: string;
+  /** The root context ID this key unlocks. */
+  contextId: string;
+  /** The derived private key at `[ProtocolContext, rootContextId]`. */
+  derivedPrivateKey: DerivedPrivateJwk;
+};
+
 import type {
   JoseHeaderParams,
   Jwk } from '@enbox/crypto';
@@ -197,6 +221,19 @@ export type EnboxConnectResponse = {
    * receive no decryption keys.
    */
   delegateDecryptionKeys?: DelegateDecryptionKey[];
+
+  /**
+   * Context-scoped decryption keys for multi-party encrypted protocols.
+   *
+   * Derived at connect time for each existing rootContextId in multi-party
+   * protocols where the delegate has a protocol-wide read-like scope.
+   * Each key is scoped to `[ProtocolContext, rootContextId]` and can decrypt
+   * all records within that context domain.
+   *
+   * New contexts created after connect are NOT covered — the delegate must
+   * reconnect to receive keys for newly created contexts.
+   */
+  delegateContextKeys?: DelegateContextKey[];
 };
 
 /** The connect server endpoint types. */
@@ -772,13 +809,15 @@ async function deriveScopedDecryptionKeys(
     }
   }
 
-  // Fail closed: reject multi-party encrypted protocols.
-  if (protocolHasMultiPartyEncryption(protocolDefinition)) {
+  // Defense-in-depth: reject if any root is multi-party.
+  // The caller should have already routed multi-party protocols to
+  // deriveContextKeysForDelegate instead.
+  const { multiParty } = classifyProtocolRoots(protocolDefinition);
+  if (multiParty.length > 0) {
     throw new Error(
-      `Encrypted delegate access for multi-party protocols is not supported ` +
-      `yet. Protocol '${protocolUri}' contains multi-party access patterns ` +
-      `($role records or relational who/of read rules) which may require ` +
-      `ProtocolContext encryption.`,
+      `deriveScopedDecryptionKeys called for protocol with multi-party ` +
+      `roots [${multiParty.join(', ')}]. Use deriveContextKeysForDelegate ` +
+      `for multi-party protocols.`,
     );
   }
 
@@ -853,19 +892,141 @@ async function deriveScopedDecryptionKeys(
  * These patterns cause the DWN agent to use ProtocolContext encryption at
  * write time, which is not supported in delegate sessions yet.
  */
-function protocolHasMultiPartyEncryption(
+/**
+ * Classifies root-level types in a protocol definition into multi-party
+ * and single-party buckets. Used to detect mixed protocols that cannot
+ * be safely modeled with a single key type.
+ */
+function classifyProtocolRoots(
   definition: DwnProtocolDefinition,
-): boolean {
+): { multiParty: string[]; singleParty: string[] } {
   const structure = definition.structure;
-  if (!structure) { return false; }
+  if (!structure) { return { multiParty: [], singleParty: [] }; }
+
+  const multiParty: string[] = [];
+  const singleParty: string[] = [];
 
   for (const rootTypeName of Object.keys(structure)) {
     if (rootTypeName.startsWith('$')) { continue; }
     if (isMultiPartyContext(definition, rootTypeName)) {
-      return true;
+      multiParty.push(rootTypeName);
+    } else {
+      singleParty.push(rootTypeName);
     }
   }
-  return false;
+
+  return { multiParty, singleParty };
+}
+
+/**
+ * Derives per-context decryption keys for a delegate's access to a multi-party
+ * encrypted protocol. Queries the owner's DWN for all root-level records
+ * (thread roots, etc.) and derives a `[ProtocolContext, rootContextId]` key
+ * for each.
+ *
+ * Validates scopes first — only protocol-wide read-like scopes are accepted.
+ * `protocolPath`-scoped and `contextId`-scoped reads throw (not yet supported).
+ * Write-only scopes return empty (no decryption keys needed).
+ *
+ * @param agent - The platform agent (must hold the owner's KMS keys)
+ * @param ownerDid - The DID of the protocol owner
+ * @param protocolDefinition - The protocol definition
+ * @param scopes - The permission scopes for this protocol
+ * @returns An array of `DelegateContextKey` (may be empty)
+ */
+async function deriveContextKeysForDelegate(
+  agent: EnboxPlatformAgent,
+  ownerDid: string,
+  protocolDefinition: DwnProtocolDefinition,
+  scopes: DwnPermissionScope[],
+): Promise<DelegateContextKey[]> {
+  const readMethods = new Set([
+    DwnMethodName.Read, DwnMethodName.Query, DwnMethodName.Subscribe,
+  ]);
+
+  const readScopes = scopes.filter(
+    (s): s is DwnPermissionScope & { method: string } =>
+      isRecordPermissionScope(s) && readMethods.has(s.method as DwnMethodName),
+  );
+
+  if (readScopes.length === 0) {
+    return []; // write-only → no context keys
+  }
+
+  // Fail closed: reject contextId-scoped reads.
+  for (const scope of readScopes) {
+    if ('contextId' in scope && (scope as any).contextId) {
+      throw new Error(
+        `Encrypted delegate access scoped by contextId is not supported ` +
+        `yet; use protocol-wide permissions for protocol ` +
+        `'${protocolDefinition.protocol}'.`,
+      );
+    }
+  }
+
+  // Fail closed: reject protocolPath-scoped reads on multi-party protocols.
+  for (const scope of readScopes) {
+    if ('protocolPath' in scope && (scope as any).protocolPath) {
+      throw new Error(
+        `Encrypted delegate access scoped by protocolPath on multi-party ` +
+        `protocols is not supported yet; use protocol-wide permissions for ` +
+        `protocol '${protocolDefinition.protocol}'.`,
+      );
+    }
+  }
+
+  // All read scopes are protocol-wide. Derive context keys for each
+  // existing root-level context in the protocol.
+  const { keyId, keyUri } = await getEncryptionKeyInfo(agent, ownerDid);
+  const protocolUri = protocolDefinition.protocol;
+
+  // Find root-level types (non-$ keys in structure).
+  const rootTypes = Object.keys(protocolDefinition.structure ?? {})
+    .filter((k) => !k.startsWith('$'));
+
+  const contextKeys: DelegateContextKey[] = [];
+  const seenContextIds = new Set<string>();
+
+  for (const rootType of rootTypes) {
+    // Query all root records for this type.
+    const { reply } = await agent.processDwnRequest({
+      author        : ownerDid,
+      target        : ownerDid,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: { protocol: protocolUri, protocolPath: rootType },
+      },
+    });
+
+    for (const entry of reply.entries ?? []) {
+      const rootContextId = (entry as any).contextId?.split('/')[0]
+        || (entry as any).recordId;
+
+      if (!rootContextId || seenContextIds.has(rootContextId)) { continue; }
+      seenContextIds.add(rootContextId);
+
+      const derivationPath = [KeyDerivationScheme.ProtocolContext, rootContextId];
+      const derivedBytes = await agent.keyManager.derivePrivateKeyBytes({
+        keyUri, derivationPath,
+      });
+      const derivedJwk = await X25519.bytesToPrivateKey({
+        privateKeyBytes: derivedBytes,
+      });
+
+      contextKeys.push({
+        protocol          : protocolUri,
+        contextId         : rootContextId,
+        derivedPrivateKey : {
+          rootKeyId         : keyId,
+          derivationScheme  : KeyDerivationScheme.ProtocolContext,
+          derivationPath,
+          derivedPrivateKey : derivedJwk as PrivateKeyJwk,
+        },
+      });
+    }
+  }
+
+  return contextKeys;
 }
 
 // ---------------------------------------------------------------------------
@@ -895,9 +1056,11 @@ async function submitConnectResponse(
   const delegatePortableDid = await delegateBearerDid.export();
 
   // Derive scope-aware decryption keys for encrypted protocols.
-  // Keys are derived only for read-like scopes (Read/Query/Subscribe).
+  // Single-party: ProtocolPath keys (protocol-wide or exact-path).
+  // Multi-party: ProtocolContext keys (per rootContextId).
   // Write-only delegates receive no decryption capability.
   const delegateDecryptionKeys: DelegateDecryptionKey[] = [];
+  const delegateContextKeys: DelegateContextKey[] = [];
 
   const delegateGrantPromises = connectRequest.permissionRequests.map(
     async (permissionRequest) => {
@@ -912,22 +1075,40 @@ async function submitConnectResponse(
 
       await prepareProtocol(selectedDid, agent, protocolDefinition);
 
-      // Derive scoped decryption keys for encrypted protocols.
-      // Only protocols with encryptionRequired types AND read-like
-      // permission scopes receive decryption keys.
       const hasEncryptedTypes = Object.values(protocolDefinition.types ?? {})
         .some((type: any) => type?.encryptionRequired === true);
 
       if (hasEncryptedTypes) {
-        // deriveScopedDecryptionKeys throws for unsupported scopes
-        // (protocolPath-scoped, contextId-scoped, multi-party).
-        // Let the error propagate — the connect flow must abort rather
-        // than silently issuing grants without decryption capability.
-        const keys = await deriveScopedDecryptionKeys(
-          agent, selectedDid, protocolDefinition.protocol,
-          permissionScopes, protocolDefinition,
-        );
-        delegateDecryptionKeys.push(...keys);
+        const { multiParty, singleParty } = classifyProtocolRoots(protocolDefinition);
+
+        if (multiParty.length > 0 && singleParty.length > 0) {
+          // Mixed protocol: some roots are multi-party, others single-party.
+          // We cannot safely model this with either key type alone.
+          throw new Error(
+            `Encrypted delegate access for protocols with mixed single-party ` +
+            `and multi-party roots is not supported yet. ` +
+            `Protocol '${protocolDefinition.protocol}' has multi-party roots ` +
+            `[${multiParty.join(', ')}] and single-party roots ` +
+            `[${singleParty.join(', ')}].`,
+          );
+        }
+
+        if (multiParty.length > 0) {
+          // Pure multi-party: derive per-context keys for existing contexts.
+          // Unsupported scope shapes (protocolPath, contextId) throw.
+          const ctxKeys = await deriveContextKeysForDelegate(
+            agent, selectedDid, protocolDefinition, permissionScopes,
+          );
+          delegateContextKeys.push(...ctxKeys);
+        } else {
+          // Pure single-party: derive ProtocolPath keys.
+          // Unsupported scope shapes (contextId) throw.
+          const keys = await deriveScopedDecryptionKeys(
+            agent, selectedDid, protocolDefinition.protocol,
+            permissionScopes, protocolDefinition,
+          );
+          delegateDecryptionKeys.push(...keys);
+        }
       }
 
       return EnboxConnectProtocol.createPermissionGrants(
@@ -950,6 +1131,7 @@ async function submitConnectResponse(
     delegateGrants,
     delegatePortableDid,
     delegateDecryptionKeys : delegateDecryptionKeys.length > 0 ? delegateDecryptionKeys : undefined,
+    delegateContextKeys    : delegateContextKeys.length > 0 ? delegateContextKeys : undefined,
   });
 
   logger.log('Signing connect response...');
@@ -1008,4 +1190,6 @@ export const EnboxConnectProtocol = {
   createPermissionGrants,
   submitConnectResponse,
   deriveScopedDecryptionKeys,
+  deriveContextKeysForDelegate,
+  classifyProtocolRoots,
 };

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -834,6 +834,60 @@ describe('enbox connect', () => {
       ).rejects.toThrow('contextId is not supported');
     });
 
+    it('should abort the connect flow for mixed single-party + multi-party encrypted protocol', async () => {
+      const mixedProtocol: DwnProtocolDefinition = {
+        protocol  : 'http://mixed-encrypted.xyz',
+        published : true,
+        types     : {
+          thread      : { schema: 'http://mixed-encrypted.xyz/thread', dataFormats: ['application/json'], encryptionRequired: true },
+          participant : { schema: 'http://mixed-encrypted.xyz/participant', dataFormats: ['application/json'] },
+          chat        : { schema: 'http://mixed-encrypted.xyz/chat', dataFormats: ['text/plain'], encryptionRequired: true },
+          note        : { schema: 'http://mixed-encrypted.xyz/note', dataFormats: ['text/plain'], encryptionRequired: true },
+        },
+        structure: {
+          thread: {
+            participant : { $role: true },
+            chat        : { $actions: [{ role: 'thread/participant', can: ['create', 'read'] }] },
+          },
+          note: {},
+        },
+      };
+
+      const readScopes: RecordsPermissionScope[] = [{
+        interface : 'Records' as any,
+        method    : 'Read' as any,
+        protocol  : 'http://mixed-encrypted.xyz',
+      }];
+
+      sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+      sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
+      sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+
+      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+        baseURL  : 'http://localhost:3000',
+        endpoint : 'callback',
+      });
+      connectRequest = await EnboxConnectProtocol.createConnectRequest({
+        appName            : 'Sample App',
+        clientDid          : clientEphemeralPortableDid.uri,
+        permissionRequests : [{ protocolDefinition: mixedProtocol, permissionScopes: readScopes }],
+        callbackUrl        : callbackUrl,
+      });
+
+      sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
+        messageCid : '',
+        reply      : { status: { code: 202, detail: 'OK' } }
+      });
+      sinon.stub(testHarness.agent, 'processDwnRequest')
+        .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [{}] as any } });
+
+      await expect(
+        EnboxConnectProtocol.submitConnectResponse(
+          providerIdentity.did.uri, connectRequest, randomPin, testHarness.agent,
+        )
+      ).rejects.toThrow('mixed single-party');
+    });
+
     it('should throw if a grant that is included in the request does not match the protocol definition', async () => {
       sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
       sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);

--- a/packages/agent/tests/e2e-delegate-encrypted.spec.ts
+++ b/packages/agent/tests/e2e-delegate-encrypted.spec.ts
@@ -775,7 +775,212 @@ describe('e2e: delegate + encrypted protocol', () => {
     });
   });
 
-  // ─── 9. Cache lifecycle: clear on disconnect, clean re-import ─
+  // ─── 9. resolveKeyDecrypter delegate cache hit paths ─────────
+
+  describe('resolveKeyDecrypter delegate cache hits', () => {
+    it('should use protocol-wide delegate key for ProtocolPath-encrypted record', async () => {
+      const { resolveKeyDecrypter } = await import('../src/dwn-encryption.js');
+      const { TtlCache } = await import('@enbox/common');
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+
+      // Install protocol and write an encrypted record
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: encryptedNoteProtocol },
+        encryption    : true,
+      });
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : encryptedNoteProtocol.protocol,
+          protocolPath : 'note',
+          schema       : 'https://schemas.xyz/note',
+          dataFormat   : 'text/plain',
+          data         : new TextEncoder().encode('protocol-wide test'),
+        },
+        encryption: true,
+      });
+
+      // Get the real encrypted RecordsWrite
+      const { reply: q } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { protocol: encryptedNoteProtocol.protocol } },
+      });
+      const recordsWrite = q.entries![0] as RecordsWriteMessage;
+
+      // Derive a protocol-wide key
+      const keys = await EnboxConnectProtocol.deriveScopedDecryptionKeys(
+        walletHarness.agent, walletIdentity.did.uri,
+        encryptedNoteProtocol.protocol,
+        [{ interface: DwnInterfaceName.Records, method: DwnMethodName.Read, protocol: encryptedNoteProtocol.protocol }] as any,
+        encryptedNoteProtocol,
+      );
+      expect(keys).toHaveLength(1);
+
+      // Build cache with the protocol-wide key
+      const delegateDid = 'did:jwk:test-resolve-wide';
+      const pathCache = new TtlCache<string, any[]>({ ttl: 60_000 });
+      pathCache.set(`ddk~${delegateDid}`, keys);
+
+      // resolveKeyDecrypter should return the protocol-wide decrypter
+      const decrypter = await resolveKeyDecrypter(
+        delegateHarness.agent, walletIdentity.did.uri,
+        recordsWrite, walletIdentity.did.uri,
+        new TtlCache({ ttl: 60_000 }), async () => undefined,
+        pathCache, delegateDid,
+      );
+      expect(decrypter.rootKeyId).toBe(keys[0].derivedPrivateKey.rootKeyId);
+      expect(decrypter.derivationScheme).toBe(KeyDerivationScheme.ProtocolPath);
+    });
+
+    it('should use exact-path delegate key for matching ProtocolPath-encrypted record', async () => {
+      const { resolveKeyDecrypter } = await import('../src/dwn-encryption.js');
+      const { TtlCache } = await import('@enbox/common');
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+
+      // Install multi-type protocol and write a 'note'
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: multiTypeProtocol },
+        encryption    : true,
+      });
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : multiTypeProtocol.protocol,
+          protocolPath : 'note',
+          schema       : 'https://schemas.xyz/note',
+          dataFormat   : 'text/plain',
+          data         : new TextEncoder().encode('exact-path cache test'),
+        },
+        encryption: true,
+      });
+
+      const { reply: q } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { protocol: multiTypeProtocol.protocol, protocolPath: 'note' } },
+      });
+      const recordsWrite = q.entries![0] as RecordsWriteMessage;
+
+      // Derive exact-path key for 'note'
+      const keys = await EnboxConnectProtocol.deriveScopedDecryptionKeys(
+        walletHarness.agent, walletIdentity.did.uri,
+        multiTypeProtocol.protocol,
+        [{
+          interface    : DwnInterfaceName.Records,
+          method       : DwnMethodName.Read,
+          protocol     : multiTypeProtocol.protocol,
+          protocolPath : 'note',
+        }] as any,
+        multiTypeProtocol,
+      );
+      expect(keys).toHaveLength(1);
+      expect(keys[0].scope.kind).toBe('protocolPath');
+
+      // Build cache
+      const delegateDid = 'did:jwk:test-resolve-exact';
+      const pathCache = new TtlCache<string, any[]>({ ttl: 60_000 });
+      pathCache.set(`ddk~${delegateDid}`, keys);
+
+      const decrypter = await resolveKeyDecrypter(
+        delegateHarness.agent, walletIdentity.did.uri,
+        recordsWrite, walletIdentity.did.uri,
+        new TtlCache({ ttl: 60_000 }), async () => undefined,
+        pathCache, delegateDid,
+      );
+      // The exact-path decrypter has the key's rootKeyId
+      expect(decrypter.rootKeyId).toBe(keys[0].derivedPrivateKey.rootKeyId);
+    });
+  });
+
+  // ─── 10. buildExactProtocolPathDecrypter happy path ──────────
+
+  describe('buildExactProtocolPathDecrypter decrypt success', () => {
+    it('should successfully decrypt when path matches exactly', async () => {
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+      const { buildExactProtocolPathDecrypter } = await import('../src/dwn-encryption.js');
+
+      // Install protocol and write encrypted note
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: encryptedNoteProtocol },
+        encryption    : true,
+      });
+      const noteData = 'exact-path decrypt test';
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : encryptedNoteProtocol.protocol,
+          protocolPath : 'note',
+          schema       : 'https://schemas.xyz/note',
+          dataFormat   : 'text/plain',
+          data         : new TextEncoder().encode(noteData),
+        },
+        encryption: true,
+      });
+
+      // Get the real encrypted record
+      const { reply: q } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { protocol: encryptedNoteProtocol.protocol } },
+      });
+      const recordsWrite = q.entries![0] as RecordsWriteMessage;
+      expect(recordsWrite.encryption).toBeDefined();
+
+      // Derive exact-path key for 'note'
+      const keys = await EnboxConnectProtocol.deriveScopedDecryptionKeys(
+        walletHarness.agent, walletIdentity.did.uri,
+        encryptedNoteProtocol.protocol,
+        [{
+          interface    : DwnInterfaceName.Records,
+          method       : DwnMethodName.Read,
+          protocol     : encryptedNoteProtocol.protocol,
+          protocolPath : 'note',
+        }] as any,
+        encryptedNoteProtocol,
+      );
+      expect(keys[0].scope.kind).toBe('protocolPath');
+
+      // Build the exact-path decrypter and call decrypt() with matching path
+      const decrypter = buildExactProtocolPathDecrypter(keys[0].derivedPrivateKey);
+      const recipient = recordsWrite.encryption!.recipients[0];
+      const fullPath = [
+        KeyDerivationScheme.ProtocolPath,
+        encryptedNoteProtocol.protocol,
+        'note',
+      ];
+
+      // This exercises the happy path of buildExactProtocolPathDecrypter:
+      // path matches → Records.derivePrivateKey → ecdhEsUnwrapKey
+      const { Encoder } = await import('@enbox/dwn-sdk-js');
+      const dek = await decrypter.decrypt(fullPath, {
+        ephemeralPublicKey : (recipient.header as any).epk,
+        encryptedKey       : Encoder.base64UrlToBytes((recipient as any).encrypted_key),
+      });
+      expect(dek).toBeInstanceOf(Uint8Array);
+      expect(dek.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── 11. Cache lifecycle: clear on disconnect, clean re-import ─
 
   describe('delegate decryption key cache lifecycle', () => {
     it('should clear cache and allow clean re-import (reconnect scenario)', async () => {

--- a/packages/agent/tests/e2e-delegate-multiparty.spec.ts
+++ b/packages/agent/tests/e2e-delegate-multiparty.spec.ts
@@ -1,0 +1,559 @@
+/**
+ * e2e: delegate + multi-party encrypted protocol (ProtocolContext)
+ *
+ * Regression tests for https://github.com/enboxorg/enbox/issues/821
+ *
+ * Verifies that multi-party encrypted protocols with ProtocolContext
+ * encryption work correctly in delegate sessions:
+ *
+ *   1. Connect-time backfill delivers context keys for existing contexts
+ *   2. Delegate can decrypt ProtocolContext-encrypted records
+ *   3. Write-only delegate receives no context keys
+ *   4. protocolPath-scoped reads on multi-party → connect aborted
+ *   5. Existing participant key delivery is not regressed
+ */
+
+import type { BearerIdentity } from '../src/bearer-identity.js';
+import type { ProtocolDefinition, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { DataStream, KeyDerivationScheme } from '@enbox/dwn-sdk-js';
+
+import { DwnInterface } from '../src/types/dwn.js';
+import { EnboxConnectProtocol } from '../src/enbox-connect-protocol.js';
+import { PlatformAgentTestHarness } from '../src/test-harness.js';
+import { TestAgent } from './utils/test-agent.js';
+import { testDwnUrl } from './utils/test-config.js';
+
+// ─── Test protocol: multi-party encrypted chat ─────────────────
+
+const chatProtocol: ProtocolDefinition = {
+  published : true,
+  protocol  : 'https://protocol.xyz/e2e-delegate-multiparty-chat',
+  types     : {
+    thread: {
+      schema             : 'https://schemas.xyz/thread',
+      dataFormats        : ['application/json'],
+      encryptionRequired : true,
+    },
+    participant: {
+      schema      : 'https://schemas.xyz/participant',
+      dataFormats : ['application/json'],
+    },
+    chat: {
+      schema             : 'https://schemas.xyz/chat',
+      dataFormats        : ['text/plain'],
+      encryptionRequired : true,
+    },
+  },
+  structure: {
+    thread: {
+      participant : { $role: true },
+      chat        : {
+        $actions: [
+          { role: 'thread/participant', can: ['create', 'read'] },
+        ],
+      },
+    },
+  },
+};
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe('e2e: delegate + multi-party encrypted protocol', () => {
+  let walletHarness: PlatformAgentTestHarness;
+  let delegateHarness: PlatformAgentTestHarness;
+  let walletIdentity: BearerIdentity;
+
+  beforeAll(async () => {
+    walletHarness = await PlatformAgentTestHarness.setup({
+      agentClass       : TestAgent,
+      agentStores      : 'dwn',
+      testDataLocation : '__TESTDATA__/e2e-delegate-multiparty-wallet',
+    });
+    delegateHarness = await PlatformAgentTestHarness.setup({
+      agentClass       : TestAgent,
+      agentStores      : 'dwn',
+      testDataLocation : '__TESTDATA__/e2e-delegate-multiparty-delegate',
+    });
+  });
+
+  afterAll(async () => {
+    await walletHarness.clearStorage();
+    await walletHarness.closeStorage();
+    await delegateHarness.clearStorage();
+    await delegateHarness.closeStorage();
+  });
+
+  beforeEach(async () => {
+    await walletHarness.clearStorage();
+    await walletHarness.createAgentDid();
+    await delegateHarness.clearStorage();
+    await delegateHarness.createAgentDid();
+
+    walletIdentity = await walletHarness.createIdentity({
+      name        : 'Alice',
+      testDwnUrls : [testDwnUrl],
+    });
+  });
+
+  // ─── 1. Connect-time backfill ─────────────────────────────────
+
+  describe('deriveContextKeysForDelegate', () => {
+    it('should derive context keys for existing multi-party contexts', async () => {
+      // Install protocol with encryption
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: chatProtocol },
+        encryption    : true,
+      });
+
+      // Create a thread root record (multi-party context root)
+      const { reply: threadReply } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : chatProtocol.protocol,
+          protocolPath : 'thread',
+          schema       : 'https://schemas.xyz/thread',
+          dataFormat   : 'application/json',
+          data         : new TextEncoder().encode(JSON.stringify({ topic: 'Test' })),
+        },
+        encryption: true,
+      });
+      expect(threadReply.status.code).toBe(202);
+
+      // Derive context keys via the real function
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+      const readScopes = [
+        { interface: DwnInterfaceName.Records, method: DwnMethodName.Read, protocol: chatProtocol.protocol },
+      ];
+      const contextKeys = await EnboxConnectProtocol.deriveContextKeysForDelegate(
+        walletHarness.agent, walletIdentity.did.uri,
+        chatProtocol, readScopes as any,
+      );
+
+      expect(contextKeys).toHaveLength(1);
+      expect(contextKeys[0].protocol).toBe(chatProtocol.protocol);
+      expect(contextKeys[0].contextId).toBeDefined();
+      expect(contextKeys[0].derivedPrivateKey.derivationScheme).toBe(
+        KeyDerivationScheme.ProtocolContext,
+      );
+    });
+
+    it('should return empty for write-only scopes on multi-party protocol', async () => {
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+      const writeOnlyScopes = [
+        { interface: DwnInterfaceName.Records, method: DwnMethodName.Write, protocol: chatProtocol.protocol },
+      ];
+      const keys = await EnboxConnectProtocol.deriveContextKeysForDelegate(
+        walletHarness.agent, walletIdentity.did.uri,
+        chatProtocol, writeOnlyScopes as any,
+      );
+      expect(keys).toHaveLength(0);
+    });
+
+    it('should throw for protocolPath-scoped reads on multi-party protocol', async () => {
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+      const pathScopes = [
+        {
+          interface    : DwnInterfaceName.Records,
+          method       : DwnMethodName.Read,
+          protocol     : chatProtocol.protocol,
+          protocolPath : 'thread/chat',
+        },
+      ];
+
+      await expect(
+        EnboxConnectProtocol.deriveContextKeysForDelegate(
+          walletHarness.agent, walletIdentity.did.uri,
+          chatProtocol, pathScopes as any,
+        )
+      ).rejects.toThrow('protocolPath on multi-party');
+    });
+
+    it('should throw for contextId-scoped reads on multi-party protocol', async () => {
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+      const contextScopes = [
+        {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Read,
+          protocol  : chatProtocol.protocol,
+          contextId : 'some-context-id',
+        },
+      ];
+
+      await expect(
+        EnboxConnectProtocol.deriveContextKeysForDelegate(
+          walletHarness.agent, walletIdentity.did.uri,
+          chatProtocol, contextScopes as any,
+        )
+      ).rejects.toThrow('contextId is not supported');
+    });
+
+    it('should throw for mixed single-party + multi-party encrypted protocols', async () => {
+      // A protocol with both multi-party and single-party encrypted roots
+      // cannot be safely modeled — connect must abort.
+      const mixedProtocol: ProtocolDefinition = {
+        published : true,
+        protocol  : 'https://protocol.xyz/mixed-encrypted',
+        types     : {
+          thread      : { schema: 'https://schemas.xyz/thread', dataFormats: ['application/json'], encryptionRequired: true },
+          participant : { schema: 'https://schemas.xyz/participant', dataFormats: ['application/json'] },
+          chat        : { schema: 'https://schemas.xyz/chat', dataFormats: ['text/plain'], encryptionRequired: true },
+          note        : { schema: 'https://schemas.xyz/note', dataFormats: ['text/plain'], encryptionRequired: true },
+        },
+        structure: {
+          thread: {
+            participant : { $role: true },
+            chat        : {
+              $actions: [{ role: 'thread/participant', can: ['create', 'read'] }],
+            },
+          },
+          note: {}, // single-party — no multi-party actions
+        },
+      };
+
+      // Install via wallet so prepareProtocol works
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: mixedProtocol },
+        encryption    : true,
+      });
+
+      // The classifyProtocolRoots check in submitConnectResponse would
+      // throw for this protocol. We test the classification directly.
+      const { classifyProtocolRoots } = EnboxConnectProtocol;
+      const { multiParty, singleParty } = classifyProtocolRoots(mixedProtocol);
+      expect(multiParty).toContain('thread');
+      expect(singleParty).toContain('note');
+      expect(multiParty.length).toBeGreaterThan(0);
+      expect(singleParty.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── 2. Delegate decryption of ProtocolContext-encrypted records ─
+
+  describe('delegate ProtocolContext decryption', () => {
+    it('should decrypt a multi-party encrypted record using delivered context key', async () => {
+      // Step 1: Install protocol and create a thread with a chat record
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: chatProtocol },
+        encryption    : true,
+      });
+
+      // Create thread root
+      const { reply: threadReply, message: threadMsg } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : chatProtocol.protocol,
+          protocolPath : 'thread',
+          schema       : 'https://schemas.xyz/thread',
+          dataFormat   : 'application/json',
+          data         : new TextEncoder().encode(JSON.stringify({ topic: 'Delegate test' })),
+        },
+        encryption: true,
+      });
+      expect(threadReply.status.code).toBe(202);
+      const threadContextId = (threadMsg as RecordsWriteMessage).recordId;
+
+      // Write a chat record in the thread (ProtocolContext-encrypted)
+      const chatData = 'Secret multi-party message';
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol        : chatProtocol.protocol,
+          protocolPath    : 'thread/chat',
+          schema          : 'https://schemas.xyz/chat',
+          dataFormat      : 'text/plain',
+          parentContextId : threadContextId,
+          data            : new TextEncoder().encode(chatData),
+        },
+        encryption: true,
+      });
+
+      // Step 2: Derive context keys (as wallet would during connect)
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+      const contextKeys = await EnboxConnectProtocol.deriveContextKeysForDelegate(
+        walletHarness.agent, walletIdentity.did.uri,
+        chatProtocol, [
+          { interface: DwnInterfaceName.Records, method: DwnMethodName.Read, protocol: chatProtocol.protocol },
+        ] as any,
+      );
+      expect(contextKeys).toHaveLength(1);
+
+      // Step 3: Import context keys into delegate
+      const delegateDid = delegateHarness.agent.agentDid.uri;
+      delegateHarness.agent.dwn.importDelegateContextKeys(delegateDid, contextKeys);
+
+      // Step 4: Import wallet identity for signing + copy protocol + records
+      const walletPortableDid = await walletIdentity.did.export();
+      await delegateHarness.agent.did.import({
+        portableDid : walletPortableDid,
+        tenant      : delegateHarness.agent.agentDid.uri,
+      });
+
+      const { reply: protoReply } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsQuery,
+        messageParams : { filter: { protocol: chatProtocol.protocol } },
+      });
+      await delegateHarness.agent.dwn.processRawMessage(
+        walletIdentity.did.uri, protoReply.entries![0] as any,
+      );
+
+      // Copy the chat record
+      const { reply: chatQuery } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { protocol: chatProtocol.protocol } },
+      });
+      for (const entry of chatQuery.entries ?? []) {
+        const { reply: rr } = await walletHarness.agent.processDwnRequest({
+          author        : walletIdentity.did.uri,
+          target        : walletIdentity.did.uri,
+          messageType   : DwnInterface.RecordsRead,
+          messageParams : { filter: { recordId: (entry as any).recordId } },
+        });
+        if (rr.entry?.recordsWrite && rr.entry?.data) {
+          const dataBytes = await DataStream.toBytes(rr.entry.data);
+          await delegateHarness.agent.dwn.processRawMessage(
+            walletIdentity.did.uri, rr.entry.recordsWrite as any,
+            { dataStream: DataStream.fromBytes(dataBytes) },
+          );
+        }
+      }
+
+      // Step 5: Delegate reads the chat record with auto-decrypt
+      // The delegate's context key cache has the context key for this thread.
+      // KMS fallback also works since the wallet identity is imported.
+      const { reply: decrypted } = await delegateHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : { filter: { protocol: chatProtocol.protocol, protocolPath: 'thread/chat' } },
+        encryption    : true,
+      });
+
+      expect(decrypted.status.code).toBe(200);
+      expect(decrypted.entry?.data).toBeDefined();
+      const decryptedBytes = await DataStream.toBytes(decrypted.entry!.data!);
+      expect(new TextDecoder().decode(decryptedBytes)).toBe(chatData);
+    });
+  });
+
+  // ─── 3. Prove delegate context key path (no owner KMS fallback) ─
+
+  describe('delegate context-key decryption without owner KMS', () => {
+    it('should resolve delegate context key decrypter via cache, not KMS', async () => {
+      // This test calls resolveKeyDecrypter directly with a delegate
+      // agent that does NOT have the owner's encryption keys in its KMS.
+      // It proves the delegate context key cache path works independently.
+
+      const { resolveKeyDecrypter } = await import('../src/dwn-encryption.js');
+      const { TtlCache } = await import('@enbox/common');
+      const { DwnInterfaceName, DwnMethodName } = await import('@enbox/dwn-sdk-js');
+
+      // Step 1: Install protocol and create encrypted context
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: chatProtocol },
+        encryption    : true,
+      });
+
+      const { message: threadMsg } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : chatProtocol.protocol,
+          protocolPath : 'thread',
+          schema       : 'https://schemas.xyz/thread',
+          dataFormat   : 'application/json',
+          data         : new TextEncoder().encode(JSON.stringify({ topic: 'Context key test' })),
+        },
+        encryption: true,
+      });
+      const threadContextId = (threadMsg as RecordsWriteMessage).recordId;
+
+      // Write a chat (ProtocolContext-encrypted)
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol        : chatProtocol.protocol,
+          protocolPath    : 'thread/chat',
+          schema          : 'https://schemas.xyz/chat',
+          dataFormat      : 'text/plain',
+          parentContextId : threadContextId,
+          data            : new TextEncoder().encode('Context key only test'),
+        },
+        encryption: true,
+      });
+
+      // Step 2: Get the real encrypted chat RecordsWrite
+      const { reply: chatQuery } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { protocol: chatProtocol.protocol, protocolPath: 'thread/chat' } },
+      });
+      const chatWrite = chatQuery.entries![0] as RecordsWriteMessage;
+      expect(chatWrite.encryption).toBeDefined();
+
+      // Step 3: Derive context keys via the real function
+      const contextKeys = await EnboxConnectProtocol.deriveContextKeysForDelegate(
+        walletHarness.agent, walletIdentity.did.uri,
+        chatProtocol, [
+          { interface: DwnInterfaceName.Records, method: DwnMethodName.Read, protocol: chatProtocol.protocol },
+        ] as any,
+      );
+      expect(contextKeys).toHaveLength(1);
+
+      // Step 4: Build a delegate context key cache (NOT using the owner's agent)
+      const delegateDid = 'did:jwk:test-context-delegate';
+      const ctxCache = new TtlCache<string, any>({ ttl: 60_000 });
+      ctxCache.set(
+        `dctx~${delegateDid}~${chatProtocol.protocol}~${threadContextId}`,
+        contextKeys[0].derivedPrivateKey,
+      );
+
+      // Step 5: Call resolveKeyDecrypter with the DELEGATE agent (no owner KMS)
+      // and granteeDid pointing to our delegate.
+      const decrypter = await resolveKeyDecrypter(
+        delegateHarness.agent, // delegate agent — no owner keys
+        walletIdentity.did.uri, // authorDid (the owner)
+        chatWrite, // real encrypted RecordsWrite
+        walletIdentity.did.uri, // targetDid
+        new TtlCache({ ttl: 60_000 }), // empty context cache
+        async () => undefined, // no key delivery fetch
+        undefined, // no delegate ProtocolPath cache
+        delegateDid, // granteeDid
+        ctxCache, // delegate context key cache
+      );
+
+      // The decrypter should be a context key decrypter (not KMS fallback).
+      // Verify by checking it has the correct rootKeyId from our delivered key.
+      expect(decrypter.rootKeyId).toBe(contextKeys[0].derivedPrivateKey.rootKeyId);
+      expect(decrypter.derivationScheme).toBe(KeyDerivationScheme.ProtocolContext);
+    });
+  });
+
+  // ─── 4. Existing participant key delivery not regressed ───────
+
+  describe('existing multi-party behavior', () => {
+    it('should still deliver participant context keys (owner flow)', async () => {
+      // Install protocol
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: chatProtocol },
+        encryption    : true,
+      });
+
+      // Create thread
+      const { message: threadMsg } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : chatProtocol.protocol,
+          protocolPath : 'thread',
+          schema       : 'https://schemas.xyz/thread',
+          dataFormat   : 'application/json',
+          data         : new TextEncoder().encode(JSON.stringify({ topic: 'Owner test' })),
+        },
+        encryption: true,
+      });
+      const threadContextId = (threadMsg as RecordsWriteMessage).recordId;
+
+      // Owner reads back the thread (decrypts via KMS as context creator)
+      const { reply: readReply } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : { filter: { recordId: threadContextId } },
+        encryption    : true,
+      });
+      expect(readReply.status.code).toBe(200);
+      const bytes = await DataStream.toBytes(readReply.entry!.data!);
+      expect(JSON.parse(new TextDecoder().decode(bytes)).topic).toBe('Owner test');
+    });
+  });
+
+  // ─── 5. Context key re-import replaces stale entries ──────────
+
+  describe('importDelegateContextKeys re-import', () => {
+    it('should clear stale entries when same delegateDid re-imports', async () => {
+      const { X25519 } = await import('@enbox/crypto');
+
+      const delegateDid = 'did:jwk:reimport-test';
+
+      // Create two fake context keys
+      const fakeBytes1 = new Uint8Array(32);
+      crypto.getRandomValues(fakeBytes1);
+      const fakeJwk1 = await X25519.bytesToPrivateKey({ privateKeyBytes: fakeBytes1 });
+
+      const fakeBytes2 = new Uint8Array(32);
+      crypto.getRandomValues(fakeBytes2);
+      const fakeJwk2 = await X25519.bytesToPrivateKey({ privateKeyBytes: fakeBytes2 });
+
+      // First import: two contexts
+      delegateHarness.agent.dwn.importDelegateContextKeys(delegateDid, [
+        {
+          protocol          : 'https://test.xyz',
+          contextId         : 'ctx-old-1',
+          derivedPrivateKey : { rootKeyId: 'k1', derivationScheme: KeyDerivationScheme.ProtocolContext, derivationPath: [], derivedPrivateKey: fakeJwk1 as any },
+        },
+        {
+          protocol          : 'https://test.xyz',
+          contextId         : 'ctx-old-2',
+          derivedPrivateKey : { rootKeyId: 'k1', derivationScheme: KeyDerivationScheme.ProtocolContext, derivationPath: [], derivedPrivateKey: fakeJwk2 as any },
+        },
+      ]);
+
+      // Verify both are in cache
+      const cache = (delegateHarness.agent.dwn as any)._delegateContextKeyCache;
+      expect(cache.get(`dctx~${delegateDid}~https://test.xyz~ctx-old-1`)).toBeDefined();
+      expect(cache.get(`dctx~${delegateDid}~https://test.xyz~ctx-old-2`)).toBeDefined();
+
+      // Second import: only one context (simulates refresh with different set)
+      const fakeBytes3 = new Uint8Array(32);
+      crypto.getRandomValues(fakeBytes3);
+      const fakeJwk3 = await X25519.bytesToPrivateKey({ privateKeyBytes: fakeBytes3 });
+
+      delegateHarness.agent.dwn.importDelegateContextKeys(delegateDid, [
+        {
+          protocol          : 'https://test.xyz',
+          contextId         : 'ctx-new-1',
+          derivedPrivateKey : { rootKeyId: 'k1', derivationScheme: KeyDerivationScheme.ProtocolContext, derivationPath: [], derivedPrivateKey: fakeJwk3 as any },
+        },
+      ]);
+
+      // Old entries must be gone — re-import cleared them
+      expect(cache.get(`dctx~${delegateDid}~https://test.xyz~ctx-old-1`)).toBeUndefined();
+      expect(cache.get(`dctx~${delegateDid}~https://test.xyz~ctx-old-2`)).toBeUndefined();
+
+      // New entry present
+      expect(cache.get(`dctx~${delegateDid}~https://test.xyz~ctx-new-1`)).toBeDefined();
+    });
+  });
+});

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -494,6 +494,7 @@ export class AuthManager {
       await this._storage.remove(STORAGE_KEYS.DELEGATE_DID);
       await this._storage.remove(STORAGE_KEYS.CONNECTED_DID);
       await this._storage.remove(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS);
+      await this._storage.remove(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
     }
 
     this._setState('unlocked');
@@ -838,10 +839,10 @@ export class AuthManager {
     }
 
     // 5. Import delegate DID, process grants, set up sync.
-    const { delegatePortableDid, connectedDid, delegateGrants, delegateDecryptionKeys } = result;
+    const { delegatePortableDid, connectedDid, delegateGrants, delegateDecryptionKeys, delegateContextKeys } = result;
     const identity = await importDelegateAndSetupSync({
       userAgent, delegatePortableDid, connectedDid, delegateGrants,
-      delegateDecryptionKeys,
+      delegateDecryptionKeys, delegateContextKeys,
       flowName: 'Connect',
     });
 

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -15,7 +15,7 @@
  */
 
 import type { PortableDid } from '@enbox/dids';
-import type { BearerIdentity, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, DwnMessagesPermissionScope, DwnRecordsPermissionScope, EnboxUserAgent } from '@enbox/agent';
+import type { BearerIdentity, DelegateContextKey, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, DwnMessagesPermissionScope, DwnRecordsPermissionScope, EnboxUserAgent } from '@enbox/agent';
 
 import type { AuthEventEmitter } from '../events.js';
 import type { PasswordProvider } from '../password-provider.js';
@@ -338,9 +338,10 @@ export async function importDelegateAndSetupSync(params: {
   connectedDid: string;
   delegateGrants: DwnDataEncodedRecordsWriteMessage[];
   delegateDecryptionKeys?: DelegateDecryptionKey[];
+  delegateContextKeys?: DelegateContextKey[];
   flowName: string;
 }): Promise<BearerIdentity> {
-  const { userAgent, delegatePortableDid, connectedDid, delegateGrants, delegateDecryptionKeys, flowName } = params;
+  const { userAgent, delegatePortableDid, connectedDid, delegateGrants, delegateDecryptionKeys, delegateContextKeys, flowName } = params;
 
   let identity: BearerIdentity | undefined;
   try {
@@ -370,6 +371,11 @@ export async function importDelegateAndSetupSync(params: {
       userAgent.dwn.importDelegateDecryptionKeys(delegatePortableDid.uri, delegateDecryptionKeys);
     }
 
+    // Import context-scoped decryption keys for multi-party encrypted protocols.
+    if (delegateContextKeys && delegateContextKeys.length > 0) {
+      userAgent.dwn.importDelegateContextKeys(delegatePortableDid.uri, delegateContextKeys);
+    }
+
     await userAgent.sync.registerIdentity({
       did     : connectedDid,
       options : {
@@ -386,6 +392,9 @@ export async function importDelegateAndSetupSync(params: {
     // Store protocol keys on the identity for finalize to persist.
     if (delegateDecryptionKeys && delegateDecryptionKeys.length > 0) {
       (identity as any)._delegateDecryptionKeys = delegateDecryptionKeys;
+    }
+    if (delegateContextKeys && delegateContextKeys.length > 0) {
+      (identity as any)._delegateContextKeys = delegateContextKeys;
     }
 
     return identity;
@@ -440,6 +449,10 @@ export async function finalizeDelegateSession(params: {
   };
   if (delegateDecryptionKeys && delegateDecryptionKeys.length > 0) {
     extraStorageKeys[STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS] = JSON.stringify(delegateDecryptionKeys);
+  }
+  const delegateContextKeys = (identity as any)._delegateContextKeys as DelegateContextKey[] | undefined;
+  if (delegateContextKeys && delegateContextKeys.length > 0) {
+    extraStorageKeys[STORAGE_KEYS.DELEGATE_CONTEXT_KEYS] = JSON.stringify(delegateContextKeys);
   }
 
   return finalizeSession({

--- a/packages/auth/src/connect/restore.ts
+++ b/packages/auth/src/connect/restore.ts
@@ -103,6 +103,7 @@ export async function restoreSession(
       await storage.remove(STORAGE_KEYS.DELEGATE_DID);
       await storage.remove(STORAGE_KEYS.CONNECTED_DID);
       await storage.remove(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS);
+      await storage.remove(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
       return undefined;
     }
 
@@ -129,6 +130,17 @@ export async function restoreSession(
           userAgent.dwn.importDelegateDecryptionKeys(delegateDid, keys);
         }
       } catch { /* best effort — keys will be refreshed on next connect */ }
+    }
+
+    // Restore context keys for multi-party encrypted protocols.
+    const ctxKeysJson = await storage.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
+    if (ctxKeysJson) {
+      try {
+        const ctxKeys = JSON.parse(ctxKeysJson);
+        if (Array.isArray(ctxKeys) && ctxKeys.length > 0) {
+          userAgent.dwn.importDelegateContextKeys(delegateDid, ctxKeys);
+        }
+      } catch { /* best effort */ }
     }
   }
 

--- a/packages/auth/src/connect/wallet.ts
+++ b/packages/auth/src/connect/wallet.ts
@@ -53,10 +53,10 @@ export async function walletConnect(
   }
 
   // Import delegate DID, process grants, and set up sync.
-  const { delegatePortableDid, connectedDid, delegateGrants, delegateDecryptionKeys } = result;
+  const { delegatePortableDid, connectedDid, delegateGrants, delegateDecryptionKeys, delegateContextKeys } = result;
   const identity = await importDelegateAndSetupSync({
     userAgent, delegatePortableDid, connectedDid, delegateGrants,
-    delegateDecryptionKeys,
+    delegateDecryptionKeys, delegateContextKeys,
     flowName: 'Wallet connect',
   });
 

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -4,12 +4,12 @@
  */
 
 import type { PortableDid } from '@enbox/dids';
-import type { ConnectPermissionRequest, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, DwnProtocolDefinition, EnboxUserAgent, HdIdentityVault, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
+import type { ConnectPermissionRequest, DelegateContextKey, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, DwnProtocolDefinition, EnboxUserAgent, HdIdentityVault, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
 
 import type { PasswordProvider } from './password-provider.js';
 
 // Re-export types that consumers will need
-export type { ConnectPermissionRequest, DelegateDecryptionKey, HdIdentityVault, IdentityVaultBackup, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
+export type { ConnectPermissionRequest, DelegateContextKey, DelegateDecryptionKey, HdIdentityVault, IdentityVaultBackup, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
 
 // Re-export EnboxUserAgent so consumers don't need a direct @enbox/agent dep
 export type { EnboxUserAgent } from '@enbox/agent';
@@ -238,6 +238,12 @@ export interface ConnectResult {
    * receive no decryption keys.
    */
   delegateDecryptionKeys?: DelegateDecryptionKey[];
+
+  /**
+   * Context-scoped decryption keys for multi-party encrypted protocols.
+   * Each key unlocks one rootContextId for records using ProtocolContext encryption.
+   */
+  delegateContextKeys?: DelegateContextKey[];
 }
 
 /**
@@ -663,6 +669,12 @@ export const STORAGE_KEYS = {
    * the delegate decryption key cache without requiring a new connect flow.
    */
   DELEGATE_DECRYPTION_KEYS: 'enbox:auth:delegateDecryptionKeys',
+
+  /**
+   * JSON-serialised `DelegateContextKey[]` for multi-party encrypted protocol
+   * records. Persisted for session restore.
+   */
+  DELEGATE_CONTEXT_KEYS: 'enbox:auth:delegateContextKeys',
 
   /**
    * The base URL of the local DWN server discovered via the `dwn://connect`

--- a/packages/auth/src/wallet-connect-client.ts
+++ b/packages/auth/src/wallet-connect-client.ts
@@ -95,6 +95,7 @@ async function initClient({
   delegatePortableDid: EnboxConnectResponse['delegatePortableDid'];
   connectedDid: string;
   delegateDecryptionKeys?: EnboxConnectResponse['delegateDecryptionKeys'];
+  delegateContextKeys?: EnboxConnectResponse['delegateContextKeys'];
 } | undefined> {
   // ephemeral client did for ECDH, signing, verification
   const clientDid = await DidJwk.create();
@@ -192,6 +193,7 @@ async function initClient({
       delegatePortableDid    : verifiedResponse.delegatePortableDid,
       connectedDid           : verifiedResponse.providerDid,
       delegateDecryptionKeys : verifiedResponse.delegateDecryptionKeys,
+      delegateContextKeys    : verifiedResponse.delegateContextKeys,
     };
   }
 }

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -387,6 +387,36 @@ describe('AuthManager', () => {
       expect(importedDid).toBe('did:jwk:delegate');
       expect(importedKeys).toEqual(keysPayload);
     });
+
+    test('restores delegate context keys from storage on session restore', async () => {
+      const ctxKeysPayload = [{ protocol: 'https://test.xyz', contextId: 'ctx-1', derivedPrivateKey: { rootKeyId: 'k2' } }];
+      const storage = new MemoryStorage();
+      await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
+      await storage.set(STORAGE_KEYS.DELEGATE_DID, 'did:jwk:delegate-ctx');
+      await storage.set(STORAGE_KEYS.CONNECTED_DID, 'did:dht:owner');
+      await storage.set(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS, JSON.stringify(ctxKeysPayload));
+
+      let importedCtxKeys: any[] | undefined;
+      let importedCtxDid: string | undefined;
+      const delegateIdentity = createMockIdentity({
+        did      : { uri: 'did:jwk:delegate-ctx' },
+        metadata : { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner' },
+      });
+      const agent = createMockAgent({
+        firstLaunch                  : async () => false,
+        identityList                 : async () => [delegateIdentity],
+        dwnImportDelegateContextKeys : (did: string, keys: any[]): void => {
+          importedCtxDid = did;
+          importedCtxKeys = keys;
+        },
+      });
+      const manager = createTestManager(agent, { storage });
+
+      const session = await manager.restoreSession();
+      expect(session).toBeDefined();
+      expect(importedCtxDid).toBe('did:jwk:delegate-ctx');
+      expect(importedCtxKeys).toEqual(ctxKeysPayload);
+    });
   });
 
   describe('disconnect()', () => {

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -43,8 +43,9 @@ export interface MockAgentOverrides {
   dwnSetCachedLocalDwnEndpoint?: (endpoint: string) => Promise<boolean>;
   dwnProcessRawMessage?: (tenant: string, message: any, options?: any) => Promise<any>;
   dwnIsRemoteMode?: boolean;
-  dwnImportDelegateDecryptionKeys?: (connectedDid: string, keys: any[]) => void;
-  dwnClearDelegateDecryptionKeys?: (connectedDid?: string) => void;
+  dwnImportDelegateDecryptionKeys?: (delegateDid: string, keys: any[]) => void;
+  dwnImportDelegateContextKeys?: (delegateDid: string, keys: any[]) => void;
+  dwnClearDelegateDecryptionKeys?: (delegateDid?: string) => void;
   syncRegisterIdentity?: (params: any) => Promise<void>;
   syncStartSync?: (params: any) => Promise<void>;
   syncStopSync?: (timeout: number) => Promise<void>;
@@ -97,6 +98,7 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
         ?? (async (): Promise<any> => ({ status: { code: 202, detail: 'Accepted' } })),
       isRemoteMode                 : overrides.dwnIsRemoteMode ?? false,
       importDelegateDecryptionKeys : overrides.dwnImportDelegateDecryptionKeys ?? ((): void => {}),
+      importDelegateContextKeys    : overrides.dwnImportDelegateContextKeys ?? ((): void => {}),
       clearDelegateDecryptionKeys  : overrides.dwnClearDelegateDecryptionKeys ?? ((): void => {}),
     },
 


### PR DESCRIPTION
## Summary

Implements the first safe slice of #821. Delegates with protocol-wide read access to multi-party encrypted protocols now receive per-context decryption keys at connect time.

## What Changed

### Protocol classification (`classifyProtocolRoots`)

Each root-level type is classified as multi-party or single-party via `isMultiPartyContext()`. Three outcomes:

| Protocol shape | Routing |
|---|---|
| Pure single-party | ProtocolPath keys (unchanged) |
| Pure multi-party | ProtocolContext keys (NEW) |
| Mixed (both) | **Error, connect aborted** |

### Connect-time backfill (`deriveContextKeysForDelegate`)

For pure multi-party protocols with protocol-wide read grants:
1. Queries all root-level records
2. Derives `[ProtocolContext, rootContextId]` key per context
3. Includes in response as `delegateContextKeys`

### Delegate-side resolution

`resolveKeyDecrypter()` ProtocolContext branch, new **Case 0** before creator/participant:
- Looks up `dctx~${granteeDid}~${protocol}~${rootContextId}`
- Returns `buildContextKeyDecrypter()` if found

### Selective cache clearing

`clearDelegateDecryptionKeys(delegateDid)` now clears only that delegate's context keys via `_delegateContextKeyCacheIndex`, not all delegates' keys.

## Test Results

- **1319 agent tests pass**, 0 fail
- **92+ auth tests pass**, 0 fail
- restore.ts 100% coverage

### New Tests

| Test | What it proves | Path exercised |
|---|---|---|
| Derive context keys for existing contexts | `deriveContextKeysForDelegate` returns per-context ProtocolContext keys | Derivation |
| Write-only → no context keys | Returns `[]` | Derivation |
| protocolPath-scoped read → error | Connect aborted | Validation |
| contextId-scoped read → error | Connect aborted | Validation |
| Mixed protocol → classification detects both roots | `classifyProtocolRoots` separates multi/single-party | Classification |
| Delegate decrypts ProtocolContext record | E2e: thread + chat → derive → import → decrypt | KMS fallback + cache |
| **Delegate context key decrypter without owner KMS** | `resolveKeyDecrypter` returns context key decrypter with correct rootKeyId/scheme; delegate agent has no owner keys | **Real delegate cache path** |
| Owner flow not regressed | Owner reads encrypted thread root via KMS | Owner path |
| Context key restore | `importDelegateContextKeys` called with delegate DID on restore | Auth restore |

## Still Fail-Closed

- `protocolPath`-scoped reads on multi-party protocols
- `contextId`-scoped reads
- Mixed single-party + multi-party encrypted protocols
- Contexts created after connect
- Write-only multi-party mode
