### PR TITLE
chore: exclude test duplication from Sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,4 +13,5 @@ sonar.javascript.lcov.reportPaths=./coverage/merged/lcov.info
 sonar.pullrequest.github.repository=enboxorg/enbox
 
 sonar.exclusions=**/node_modules/**,**/dist/**,**/out/**,**/.next/**,**/.turbo/**,**/coverage/**,**/coverage-browser/**,**/coverage-browser-*/**,**/generated/**,apps/docs/content/**
-sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/*.test.ts,**/*.config.ts,**/*.config.js,**/*.config.cjs,**/*.config.mjs,**/*.d.ts,**/dist/**,**/out/**
+sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx,**/*.config.ts,**/*.config.js,**/*.config.cjs,**/*.config.mjs,**/*.d.ts,**/dist/**,**/out/**
+sonar.cpd.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx


### PR DESCRIPTION
## Summary
- exclude `tests/`, `*.spec.*`, and `*.test.*` files from Sonar copy-paste detection
- keep test files analyzable by Sonar while preventing duplicated test setup from tripping the quality gate
- align coverage exclusions to also cover TSX test files

## Why
PR #829 is currently failing the SonarCloud quality gate on `new_duplicated_lines_density`, and the duplicated new code is coming from test files rather than production sources.

## Validation
- `git diff --check`