### PR TITLE
chore: ignore Sonar duplication in package tests

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,4 @@ sonar.pullrequest.github.repository=enboxorg/enbox
 
 sonar.exclusions=**/node_modules/**,**/dist/**,**/out/**,**/.next/**,**/.turbo/**,**/coverage/**,**/coverage-browser/**,**/coverage-browser-*/**,**/generated/**,apps/docs/content/**
 sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx,**/*.config.ts,**/*.config.js,**/*.config.cjs,**/*.config.mjs,**/*.d.ts,**/dist/**,**/out/**
-sonar.cpd.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx
+sonar.cpd.exclusions=packages/**/tests/**


### PR DESCRIPTION
## Summary
- scope Sonar copy-paste detection exclusions to `packages/**/tests/**`
- keep duplicate-code reporting active for production files while ignoring duplicated test setup and fixtures
- make the intended test-only Sonar behavior explicit in repo config

## Validation
- `git diff --check`

## Note
This change affects repo-based Sonar config. If PR #829 still shows the old SonarCloud result immediately after this lands, re-run analysis on that branch or merge/rebase it onto `main` so the updated config is present in the PR branch snapshot.