### PR TITLE
fix: browser DWeb Connect parses full ConnectResult with delegate encryption artifacts

### DIFF
--- a/.changeset/fix-browser-connect-parity.md
+++ b/.changeset/fix-browser-connect-parity.md
@@ -1,0 +1,11 @@
+---
+"@enbox/browser": patch
+---
+
+fix: browser DWeb Connect client now parses full ConnectResult including delegate encryption artifacts
+
+The browser popup connect flow was only extracting delegateDid, connectedDid, and
+grants from the wallet's postMessage response — missing delegateDecryptionKeys,
+delegateContextKeys, delegateMultiPartyProtocols, and sessionRevocations. Without
+these, the delegate session had no decryption material, causing encrypted records
+to be unreadable after page refresh and key-delivery protocol closure failures.

--- a/packages/browser/src/dweb-connect-client.ts
+++ b/packages/browser/src/dweb-connect-client.ts
@@ -126,7 +126,15 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
         clearInterval(pollClosed);
         cleanup();
 
-        const { delegateDid, connectedDid: walletConnectedDid, grants } = event.data;
+        const {
+          delegateDid,
+          connectedDid: walletConnectedDid,
+          grants,
+          delegateDecryptionKeys,
+          delegateContextKeys,
+          delegateMultiPartyProtocols,
+          sessionRevocations,
+        } = event.data;
 
         if (!delegateDid || !grants) {
           // User denied the request.
@@ -136,9 +144,13 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
 
         // connectedDid priority: wallet response > dapp-provided > delegate DID
         resolve({
-          delegatePortableDid : delegateDid as PortableDid,
-          delegateGrants      : grants as DwnDataEncodedRecordsWriteMessage[],
-          connectedDid        : walletConnectedDid ?? did ?? delegateDid.uri,
+          delegatePortableDid         : delegateDid as PortableDid,
+          delegateGrants              : grants as DwnDataEncodedRecordsWriteMessage[],
+          connectedDid                : walletConnectedDid ?? did ?? delegateDid.uri,
+          delegateDecryptionKeys      : delegateDecryptionKeys ?? undefined,
+          delegateContextKeys         : delegateContextKeys ?? undefined,
+          delegateMultiPartyProtocols : delegateMultiPartyProtocols ?? undefined,
+          sessionRevocations          : sessionRevocations ?? undefined,
         });
       }
     };


### PR DESCRIPTION
## Summary

The browser popup DWeb Connect flow (`@enbox/browser`) was only extracting 3 of 7 `ConnectResult` fields from the wallet's `postMessage` response. The relay-mediated flow (`wallet-connect-client.ts`) already returned all 7 fields — this brings the browser popup path to parity.

## Root Cause

`dweb-connect-client.ts:129` destructured only `{ delegateDid, connectedDid, grants }` from `event.data`. The 4 encryption-critical fields were silently dropped:

| Field | Purpose | Was parsed? |
|---|---|---|
| `delegateDecryptionKeys` | ProtocolPath decryption keys for encrypted records | **NO** |
| `delegateContextKeys` | Multi-party context decryption keys | **NO** |
| `delegateMultiPartyProtocols` | Protocol URIs for post-connect key delivery | **NO** |
| `sessionRevocations` | Grant-scoped revocation mappings for disconnect | **NO** |

Without `delegateDecryptionKeys`, the delegate session has no decryption material. Encrypted records can be written (the write path uses only public keys from `$encryption`) but **cannot be read back after page refresh** — producing `Key not found: urn:jwk:...` errors.

## Fix

`dweb-connect-client.ts` now extracts and returns all 7 `ConnectResult` fields from the wallet's `postMessage` response.

## Companion Change (web-wallet)

The wallet-side `DWebConnectPage.tsx` must also be updated to **produce** these fields (derive decryption keys, add X25519 to delegate DID, etc.). That change is in the web-wallet repo.