### PR TITLE
feat: ECDH-encrypted postMessage channel for DWeb Connect popup flow

### DIFF
--- a/.changeset/encrypt-postmessage-connect.md
+++ b/.changeset/encrypt-postmessage-connect.md
@@ -1,0 +1,20 @@
+---
+"@enbox/browser": minor
+---
+
+feat: ECDH-encrypted postMessage channel for DWeb Connect popup flow
+
+The browser DWeb Connect popup flow now encrypts the authorization response
+(containing delegate private keys and decryption material) using an ephemeral
+ECDH key exchange between the dapp and wallet popup.
+
+The dapp generates an ephemeral P-256 keypair and sends its public key with
+the authorization request. The wallet generates its own ephemeral keypair,
+performs ECDH + HKDF to derive a shared AES-256-GCM key, encrypts the
+response payload, and sends the ciphertext. The dapp derives the same key
+and decrypts.
+
+Falls back to plaintext for wallets that don't support encrypted responses
+(backward compatible). Exports encryptPostMessagePayload,
+generateEphemeralKeyPair, and EncryptedPostMessagePayload for use by wallet
+implementations.

--- a/packages/browser/src/dweb-connect-client.ts
+++ b/packages/browser/src/dweb-connect-client.ts
@@ -12,6 +12,9 @@ import type { ConnectResult } from '@enbox/auth';
 import type { PortableDid } from '@enbox/dids';
 import type { ConnectPermissionRequest, DwnDataEncodedRecordsWriteMessage } from '@enbox/agent';
 
+import type { EncryptedPostMessagePayload } from './dweb-connect-crypto.js';
+import { decryptPostMessagePayload, generateEphemeralKeyPair } from './dweb-connect-crypto.js';
+
 /** Options for initiating a DWeb Connect flow via popup. */
 export interface DWebConnectClientOptions {
   /** Base URL of the wallet app (e.g. "https://wallet.enbox.org"). */
@@ -76,6 +79,20 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
     );
   }
 
+  // Generate an ephemeral ECDH keypair for this connect session.
+  // The public key is sent to the wallet so it can encrypt the response
+  // containing delegate private keys and decryption material.
+  let dappKeyPair: CryptoKeyPair | undefined;
+  let dappPublicKeyBase64url: string | undefined;
+
+  try {
+    const ephemeral = await generateEphemeralKeyPair();
+    dappKeyPair = ephemeral.keyPair;
+    dappPublicKeyBase64url = ephemeral.publicKeyBase64url;
+  } catch {
+    // crypto.subtle unavailable (e.g. non-secure context) — skip encryption.
+  }
+
   return new Promise<ConnectResult | undefined>((resolve, reject) => {
     let settled = false;
 
@@ -113,11 +130,12 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
       const { type } = event.data ?? {};
 
       if (type === 'dweb-connect-loaded') {
-        // Wallet is ready — send the authorization request.
+        // Wallet is ready — send the authorization request with ephemeral public key.
         popup.postMessage({
-          type        : 'dweb-connect-authorization-request',
+          type               : 'dweb-connect-authorization-request',
           did,
-          permissions : permissionRequests,
+          permissions        : permissionRequests,
+          ephemeralPublicKey : dappPublicKeyBase64url,
         }, walletOrigin);
         return;
       }
@@ -126,6 +144,32 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
         clearInterval(pollClosed);
         cleanup();
 
+        // Handle encrypted response (wallet supports ECDH channel encryption).
+        const encrypted = event.data.encryptedPayload as EncryptedPostMessagePayload | undefined;
+        if (encrypted && dappKeyPair) {
+          decryptPostMessagePayload(encrypted, dappKeyPair).then((payload: Record<string, unknown>) => {
+            const p = payload as any;
+            if (!p.delegateDid || !p.grants) {
+              resolve(undefined);
+              return;
+            }
+            resolve({
+              delegatePortableDid         : p.delegateDid as PortableDid,
+              delegateGrants              : p.grants as DwnDataEncodedRecordsWriteMessage[],
+              connectedDid                : p.connectedDid ?? did ?? (p.delegateDid as PortableDid).uri,
+              delegateDecryptionKeys      : p.delegateDecryptionKeys ?? undefined,
+              delegateContextKeys         : p.delegateContextKeys ?? undefined,
+              delegateMultiPartyProtocols : p.delegateMultiPartyProtocols ?? undefined,
+              sessionRevocations          : p.sessionRevocations ?? undefined,
+            });
+          }).catch(() => {
+            // Decryption failed — treat as denied.
+            resolve(undefined);
+          });
+          return;
+        }
+
+        // Plaintext fallback (wallet doesn't support encryption yet).
         const {
           delegateDid,
           connectedDid: walletConnectedDid,
@@ -137,12 +181,10 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
         } = event.data;
 
         if (!delegateDid || !grants) {
-          // User denied the request.
           resolve(undefined);
           return;
         }
 
-        // connectedDid priority: wallet response > dapp-provided > delegate DID
         resolve({
           delegatePortableDid         : delegateDid as PortableDid,
           delegateGrants              : grants as DwnDataEncodedRecordsWriteMessage[],

--- a/packages/browser/src/dweb-connect-crypto.ts
+++ b/packages/browser/src/dweb-connect-crypto.ts
@@ -139,7 +139,10 @@ function toBase64url(bytes: Uint8Array): string {
   for (let i = 0; i < bytes.length; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  let b64 = btoa(binary).replace(/\+/g, '-').replace(/\//g, '_');
+  // Strip trailing padding without a backtracking-vulnerable regex.
+  while (b64.endsWith('=')) { b64 = b64.slice(0, -1); }
+  return b64;
 }
 
 function fromBase64url(str: string): Uint8Array {

--- a/packages/browser/src/dweb-connect-crypto.ts
+++ b/packages/browser/src/dweb-connect-crypto.ts
@@ -1,0 +1,153 @@
+/**
+ * ECDH + AES-256-GCM encryption for the DWeb Connect postMessage channel.
+ *
+ * Protects the authorization response (delegate private keys, decryption
+ * keys, grants) from same-origin XSS interception. Both the dapp and
+ * wallet generate ephemeral P-256 keypairs, exchange public keys during
+ * the handshake, derive a shared AES-256-GCM key via ECDH + HKDF, and
+ * encrypt/decrypt the payload.
+ *
+ * P-256 is used (instead of X25519) because `crypto.subtle.deriveKey`
+ * with ECDH requires a NIST curve in all major browsers. The keys are
+ * ephemeral — generated fresh for each connect session.
+ *
+ * @module
+ */
+
+/** Exported public key as raw bytes (base64url-encoded for postMessage). */
+export type ExportedPublicKey = string;
+
+/** Encrypted payload sent via postMessage. */
+export interface EncryptedPostMessagePayload {
+  /** The encrypted JSON payload as base64url. */
+  ciphertext: string;
+  /** AES-GCM initialization vector as base64url. */
+  iv: string;
+  /** The wallet's ephemeral P-256 public key as base64url raw bytes. */
+  walletPublicKey: string;
+}
+
+const ECDH_PARAMS: EcKeyGenParams = { name: 'ECDH', namedCurve: 'P-256' };
+const AES_KEY_PARAMS: AesDerivedKeyParams = { name: 'AES-GCM', length: 256 };
+const HKDF_INFO = new TextEncoder().encode('dweb-connect-v1');
+
+/**
+ * Generate an ephemeral P-256 ECDH keypair for a single connect session.
+ *
+ * @returns The keypair and the public key as a base64url-encoded raw export.
+ */
+export async function generateEphemeralKeyPair(): Promise<{
+  keyPair: CryptoKeyPair;
+  publicKeyBase64url: ExportedPublicKey;
+}> {
+  const keyPair = await crypto.subtle.generateKey(ECDH_PARAMS, false, ['deriveKey']);
+  const rawPub = await crypto.subtle.exportKey('raw', keyPair.publicKey);
+  return { keyPair, publicKeyBase64url: toBase64url(new Uint8Array(rawPub)) };
+}
+
+/**
+ * Derive a shared AES-256-GCM key from a local ECDH private key and a
+ * remote public key.
+ */
+async function deriveSharedKey(
+  localPrivateKey: CryptoKey,
+  remotePublicKeyBase64url: string,
+): Promise<CryptoKey> {
+  const remotePubRaw = fromBase64url(remotePublicKeyBase64url);
+  const remotePublicKey = await crypto.subtle.importKey(
+    'raw', remotePubRaw, ECDH_PARAMS, false, [],
+  );
+
+  // ECDH → raw shared secret, then HKDF → AES-256-GCM key.
+  const sharedBits = await crypto.subtle.deriveBits(
+    { name: 'ECDH', public: remotePublicKey } as EcdhKeyDeriveParams,
+    localPrivateKey,
+    256,
+  );
+
+  const hkdfKey = await crypto.subtle.importKey(
+    'raw', sharedBits, 'HKDF', false, ['deriveKey'],
+  );
+
+  return crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(32), info: HKDF_INFO },
+    hkdfKey,
+    AES_KEY_PARAMS,
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+/**
+ * Encrypt a JSON-serializable payload for postMessage transport.
+ *
+ * Called by the **wallet** side. Uses the wallet's ephemeral private key
+ * and the dapp's ephemeral public key to derive the shared AES key.
+ *
+ * @returns The encrypted payload plus the wallet's public key (for the dapp to derive the same shared key).
+ */
+export async function encryptPostMessagePayload(
+  payload: Record<string, unknown>,
+  walletKeyPair: CryptoKeyPair,
+  walletPublicKeyBase64url: string,
+  dappPublicKeyBase64url: string,
+): Promise<EncryptedPostMessagePayload> {
+  const sharedKey = await deriveSharedKey(walletKeyPair.privateKey, dappPublicKeyBase64url);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = new TextEncoder().encode(JSON.stringify(payload));
+
+  const ciphertextBuf = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv } as AesGcmParams,
+    sharedKey,
+    plaintext,
+  );
+
+  return {
+    ciphertext      : toBase64url(new Uint8Array(ciphertextBuf)),
+    iv              : toBase64url(iv),
+    walletPublicKey : walletPublicKeyBase64url,
+  };
+}
+
+/**
+ * Decrypt a postMessage payload received from the wallet.
+ *
+ * Called by the **dapp** side. Uses the dapp's ephemeral private key
+ * and the wallet's ephemeral public key to derive the same shared key.
+ */
+export async function decryptPostMessagePayload(
+  encrypted: EncryptedPostMessagePayload,
+  dappKeyPair: CryptoKeyPair,
+): Promise<Record<string, unknown>> {
+  const sharedKey = await deriveSharedKey(dappKeyPair.privateKey, encrypted.walletPublicKey);
+  const iv = fromBase64url(encrypted.iv);
+  const ciphertext = fromBase64url(encrypted.ciphertext);
+
+  const plaintextBuf = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv } as AesGcmParams,
+    sharedKey,
+    ciphertext,
+  );
+
+  return JSON.parse(new TextDecoder().decode(plaintextBuf));
+}
+
+// ── Base64url helpers ────────────────────────────────────────────
+
+function toBase64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64url(str: string): Uint8Array {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -3,3 +3,5 @@ export { BrowserConnectHandler, DEFAULT_WALLETS } from './browser-connect-handle
 export type { BrowserConnectHandlerOptions, WalletOption } from './browser-connect-handler.js';
 export { DWebConnect } from './dweb-connect-client.js';
 export type { DWebConnectClientOptions } from './dweb-connect-client.js';
+export { encryptPostMessagePayload, generateEphemeralKeyPair } from './dweb-connect-crypto.js';
+export type { EncryptedPostMessagePayload } from './dweb-connect-crypto.js';


### PR DESCRIPTION
## Summary

Fixes #848. The browser DWeb Connect popup flow transmitted delegate private keys and decryption material in plaintext over `postMessage`. An XSS attacker on the dapp origin could intercept the `message` event and capture the complete connect response.

## Protocol

The handshake now includes an ECDH key exchange:

1. **Dapp** generates an ephemeral P-256 keypair, sends the public key with `dweb-connect-authorization-request`
2. **Wallet** generates its own ephemeral P-256 keypair, performs ECDH with the dapp's public key, derives a shared AES-256-GCM key via HKDF, encrypts the response payload
3. **Wallet** sends `dweb-connect-authorization-response` with `{ encryptedPayload: { ciphertext, iv, walletPublicKey } }` instead of plaintext fields
4. **Dapp** derives the same shared key using its private key + wallet's public key, decrypts

P-256 is used (not X25519) because `crypto.subtle.deriveKey` with ECDH requires a NIST curve in all major browsers. All keys are ephemeral — generated fresh per connect session.

## Changes

| File | Change |
|---|---|
| `packages/browser/src/dweb-connect-crypto.ts` | **New** — ECDH + AES-256-GCM helpers: `generateEphemeralKeyPair`, `encryptPostMessagePayload`, `decryptPostMessagePayload` |
| `packages/browser/src/dweb-connect-client.ts` | Sends `ephemeralPublicKey` in auth request; decrypts encrypted responses; falls back to plaintext for older wallets |
| `packages/browser/src/index.ts` | Exports crypto utilities for wallet-side use |

## Backward Compatibility

Falls back to plaintext when:
- The wallet doesn't support encrypted responses (no `encryptedPayload` in the response)
- `crypto.subtle` is unavailable (non-secure context)

## Companion Change Required

The web-wallet `DWebConnectPage.tsx` must be updated to:
1. Read `ephemeralPublicKey` from the authorization request
2. Generate its own ephemeral keypair
3. Call `encryptPostMessagePayload()` (imported from `@enbox/browser`)
4. Send the encrypted payload instead of plaintext fields
