### PR TITLE
fix(dwn-sql-store): handle duplicate message put as no-op instead of 500

### DIFF
--- a/.changeset/idempotent-message-put.md
+++ b/.changeset/idempotent-message-put.md
@@ -1,0 +1,19 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/dwn-sql-store": patch
+---
+
+fix: handle duplicate message put as idempotent no-op
+
+MessageStore.put() now treats duplicate writes as no-ops across all
+store implementations. This prevents 500 errors when sync or
+protocol.send() re-delivers a message the DWN already has (race
+between the handler's CID check and the actual insert).
+
+dwn-sdk-js: added shared "idempotent put" test to testMessageStore()
+suite — runs against LevelDB and all SQL dialects automatically.
+
+dwn-sql-store: added isDuplicateKeyError() to detect unique constraint
+violations from PostgreSQL (23505), MySQL (ER_DUP_ENTRY/1062), SQLite
+(SQLITE_CONSTRAINT + UNIQUE), with a message-based fallback for
+unknown drivers. 10 unit tests cover all dialect error shapes.

--- a/packages/dwn-sdk-js/tests/store/message-store.spec.ts
+++ b/packages/dwn-sdk-js/tests/store/message-store.spec.ts
@@ -32,6 +32,25 @@ export function testMessageStore(): void {
         await messageStore.close();
       });
 
+      it('should accept the same message twice (idempotent put)', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const { message } = await TestDataGenerator.generateRecordsWrite();
+        const { messageTimestamp } = message.descriptor;
+
+        // First put — should succeed.
+        await messageStore.put(alice.did, message, { messageTimestamp });
+
+        // Second put of the exact same message — should be a no-op.
+        // This can happen when sync or protocol.send() re-delivers a
+        // message the DWN already has (race between CID check and insert).
+        await messageStore.put(alice.did, message, { messageTimestamp });
+
+        // Verify the message is stored exactly once.
+        const cid = await Message.getCid(message);
+        const stored = await messageStore.get(alice.did, cid);
+        expect(stored).toBeDefined();
+      });
+
       it('stores messages as cbor/sha256 encoded blocks with CID as key', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 

--- a/packages/dwn-sql-store/src/message-store-sql.ts
+++ b/packages/dwn-sql-store/src/message-store-sql.ts
@@ -112,7 +112,19 @@ export class MessageStoreSql implements MessageStore {
     // if any of these inserts would throw, the whole transaction would be rolled back.
     // otherwise it is committed.
     const putMessageOperation = this.constructPutMessageOperation({ tenant, messageCid, encodedMessageBytes, encodedData, indexes });
-    await executeWithTransaction(this.#db, putMessageOperation);
+    try {
+      await executeWithTransaction(this.#db, putMessageOperation);
+    } catch (error: unknown) {
+      if (isDuplicateKeyError(error)) {
+        // Idempotent write — the exact same message already exists.
+        // This is expected when sync or protocol.send() re-delivers a
+        // message the DWN already has.  A race between the handler's
+        // duplicate-CID check and the actual insert makes this
+        // unavoidable in concurrent environments.
+        return;
+      }
+      throw error;
+    }
   }
 
   /**
@@ -384,4 +396,59 @@ export class MessageStoreSql implements MessageStore {
       return { property: 'messageTimestamp', direction: SortDirection.Ascending };
     }
   }
+}
+
+/**
+ * Detect whether an error is a unique constraint violation from any
+ * supported database dialect.
+ *
+ * Each dialect surfaces the error differently:
+ *
+ * | Dialect    | Error code / errno             | Message pattern                                    |
+ * |------------|-------------------------------|----------------------------------------------------|
+ * | PostgreSQL | `code === '23505'`            | "duplicate key value violates unique constraint"   |
+ * | MySQL      | `errno === 1062`              | "Duplicate entry '...' for key '...'"              |
+ * | SQLite     | `code === 'SQLITE_CONSTRAINT'`| "UNIQUE constraint failed: ..."                    |
+ * | bun:sqlite | `code === 'SQLITE_CONSTRAINT_PRIMARYKEY'` or includes "UNIQUE" | same as above |
+ *
+ * @internal Exported for testing.
+ */
+export function isDuplicateKeyError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') {
+    return false;
+  }
+
+  const err = error as Record<string, unknown>;
+  const code = err.code;
+  const errno = err.errno;
+  const message = typeof err.message === 'string' ? err.message : '';
+
+  // PostgreSQL: error code 23505 = unique_violation
+  if (code === '23505') {
+    return true;
+  }
+
+  // MySQL: errno 1062 = ER_DUP_ENTRY
+  if (errno === 1062) {
+    return true;
+  }
+
+  // SQLite (better-sqlite3 / bun:sqlite): SQLITE_CONSTRAINT with UNIQUE
+  if (
+    typeof code === 'string' &&
+    code.startsWith('SQLITE_CONSTRAINT') &&
+    message.includes('UNIQUE')
+  ) {
+    return true;
+  }
+
+  // Fallback: message-based detection for unknown drivers
+  if (
+    (message.includes('duplicate key') || message.includes('Duplicate entry')) &&
+    (message.includes('messageCid') || message.includes('unique constraint'))
+  ) {
+    return true;
+  }
+
+  return false;
 }

--- a/packages/dwn-sql-store/tests/message-store-duplicate.spec.ts
+++ b/packages/dwn-sql-store/tests/message-store-duplicate.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+
+import { isDuplicateKeyError } from '../src/message-store-sql.js';
+
+// ---------------------------------------------------------------------------
+// isDuplicateKeyError — unit tests for all dialect error shapes
+// ---------------------------------------------------------------------------
+
+describe('isDuplicateKeyError', () => {
+  it('detects PostgreSQL unique_violation (code 23505)', () => {
+    const err = new Error('duplicate key value violates unique constraint "index_tenant_messageCid"');
+    (err as any).code = '23505';
+    expect(isDuplicateKeyError(err)).toBe(true);
+  });
+
+  it('detects MySQL ER_DUP_ENTRY (errno 1062)', () => {
+    const err = new Error('Duplicate entry \'did:dht:abc-bafyrei123\' for key \'index_tenant_messageCid\'');
+    (err as any).errno = 1062;
+    (err as any).code = 'ER_DUP_ENTRY';
+    expect(isDuplicateKeyError(err)).toBe(true);
+  });
+
+  it('detects SQLite SQLITE_CONSTRAINT with UNIQUE', () => {
+    const err = new Error('UNIQUE constraint failed: messageStoreMessages.tenant, messageStoreMessages.messageCid');
+    (err as any).code = 'SQLITE_CONSTRAINT';
+    expect(isDuplicateKeyError(err)).toBe(true);
+  });
+
+  it('detects bun:sqlite SQLITE_CONSTRAINT_PRIMARYKEY with UNIQUE message', () => {
+    const err = new Error('UNIQUE constraint failed: messageStoreMessages.tenant, messageStoreMessages.messageCid');
+    (err as any).code = 'SQLITE_CONSTRAINT_PRIMARYKEY';
+    expect(isDuplicateKeyError(err)).toBe(true);
+  });
+
+  it('detects via fallback message matching (duplicate key + messageCid)', () => {
+    const err = new Error('duplicate key value violates unique constraint on messageCid column');
+    expect(isDuplicateKeyError(err)).toBe(true);
+  });
+
+  it('detects via fallback message matching (Duplicate entry + unique constraint)', () => {
+    const err = new Error('Duplicate entry for key \'unique constraint\'');
+    expect(isDuplicateKeyError(err)).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isDuplicateKeyError(new Error('connection refused'))).toBe(false);
+    expect(isDuplicateKeyError(new Error('syntax error'))).toBe(false);
+    expect(isDuplicateKeyError(new Error('timeout'))).toBe(false);
+  });
+
+  it('does not match null/undefined', () => {
+    expect(isDuplicateKeyError(null)).toBe(false);
+    expect(isDuplicateKeyError(undefined)).toBe(false);
+  });
+
+  it('does not match non-error objects', () => {
+    expect(isDuplicateKeyError({ message: 'not an error' })).toBe(false);
+    expect(isDuplicateKeyError(42)).toBe(false);
+    expect(isDuplicateKeyError('string')).toBe(false);
+  });
+
+  it('does not match SQLITE_CONSTRAINT without UNIQUE in message', () => {
+    const err = new Error('NOT NULL constraint failed: table.column');
+    (err as any).code = 'SQLITE_CONSTRAINT';
+    expect(isDuplicateKeyError(err)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration test for idempotent put() is in the shared testMessageStore()
+// suite in @enbox/dwn-sdk-js, which runs against all SQL dialects
+// (PostgreSQL, MySQL, SQLite) via dwn-sql-store/tests/test-suite.spec.ts.
+// ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When sync or \`protocol.send()\` re-delivers a message the DWN already has, a race condition between the handler's duplicate-CID check and the actual database insert causes a Postgres \`unique_violation\` (error 23505) on \`index_tenant_messageCid\`. This surfaces as a 500 Internal Server Error to clients.

**From server logs:**
\`\`\`
ERROR: handleDwnProcessMessage error
duplicate key value violates unique constraint "index_tenant_messageCid"
Key (tenant, "messageCid")=(did:dht:..., bafyrei...) already exists.
\`\`\`

**Root cause:** The \`ProtocolsConfigureHandler\` checks for duplicate CIDs at line 62, but two concurrent requests (e.g., sync push + explicit \`protocol.send()\`) can both pass the check before either inserts.

**Fix:** \`MessageStoreSql.put()\` now catches unique constraint violations and treats them as successful no-ops:
- PostgreSQL: error code \`23505\` (unique_violation)
- SQLite: \`SQLITE_CONSTRAINT\` with "UNIQUE" in message
- Generic fallback: error message contains "duplicate key" + "messageCid"

This also needs deployment to \`dev.aws.dwn.enbox.id\` and \`enbox-dwn.fly.dev\` to eliminate the 500 errors nutsd users are seeing.