### PR TITLE
chore(deps): combined dependency updates — kysely, playwright, sonarqube-scan-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1104,7 +1104,7 @@ jobs:
           fi
 
       - name: Run SonarCloud scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_HOST_URL: https://sonarcloud.io
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "eslint-plugin-mocha": "10.4.3",
         "eventemitter3": "5.0.4",
         "globals": "15.6.0",
-        "playwright": "1.45.3",
+        "playwright": "1.55.1",
         "turbo": "2.8.13",
         "typescript": "5.9.3",
       },
@@ -307,7 +307,7 @@
         "@simplewebauthn/server": "13.2.3",
         "bytes": "3.1.2",
         "jose": "6.1.3",
-        "kysely": "0.26.3",
+        "kysely": "0.28.14",
         "loglevel": "1.8.1",
         "loglevel-plugin-prefix": "0.8.4",
         "mysql2": "3.9.8",
@@ -360,7 +360,7 @@
         "interface-store": "5.1.2",
         "ipfs-unixfs-exporter": "13.1.5",
         "ipfs-unixfs-importer": "15.1.5",
-        "kysely": "0.26.3",
+        "kysely": "0.28.14",
         "multiformats": "11.0.2",
       },
       "devDependencies": {
@@ -2040,7 +2040,7 @@
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
-    "kysely": ["kysely@0.26.3", "", {}, "sha512-yWSgGi9bY13b/W06DD2OCDDHQmq1kwTGYlQ4wpZkMOJqMGCstVCFIvxCCVG4KfY1/3G0MhDAcZsip/Lw8/vJWw=="],
+    "kysely": ["kysely@0.28.14", "", {}, "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA=="],
 
     "layerr": ["layerr@2.1.0", "", {}, "sha512-xDD9suWxfBYeXgqffRVH/Wqh+mqZrQcqPRn0I0ijl7iJQ7vu8gMGPt1Qop59pEW/jaIDNUN7+PX1Qk40+vuflg=="],
 
@@ -2416,9 +2416,9 @@
 
     "pixelmatch": ["pixelmatch@7.1.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng=="],
 
-    "playwright": ["playwright@1.45.3", "", { "dependencies": { "playwright-core": "1.45.3" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww=="],
+    "playwright": ["playwright@1.55.1", "", { "dependencies": { "playwright-core": "1.55.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A=="],
 
-    "playwright-core": ["playwright-core@1.45.3", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA=="],
+    "playwright-core": ["playwright-core@1.55.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w=="],
 
     "png-to-ico": ["png-to-ico@2.1.8", "", { "dependencies": { "@types/node": "^17.0.36", "minimist": "^1.2.6", "pngjs": "^6.0.0" }, "bin": { "png-to-ico": "bin/cli.js" } }, "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-mocha": "10.4.3",
     "eventemitter3": "5.0.4",
     "globals": "15.6.0",
-    "playwright": "1.45.3",
+    "playwright": "1.55.1",
     "turbo": "2.8.13",
     "typescript": "5.9.3"
   },

--- a/packages/dwn-server/package.json
+++ b/packages/dwn-server/package.json
@@ -41,7 +41,7 @@
     "@simplewebauthn/server": "13.2.3",
     "bytes": "3.1.2",
     "jose": "6.1.3",
-    "kysely": "0.26.3",
+    "kysely": "0.28.14",
     "loglevel": "1.8.1",
     "loglevel-plugin-prefix": "0.8.4",
     "mysql2": "3.9.8",

--- a/packages/dwn-sql-store/package.json
+++ b/packages/dwn-sql-store/package.json
@@ -31,7 +31,7 @@
     "interface-store": "5.1.2",
     "ipfs-unixfs-exporter": "13.1.5",
     "ipfs-unixfs-importer": "15.1.5",
-    "kysely": "0.26.3",
+    "kysely": "0.28.14",
     "multiformats": "11.0.2"
   },
   "devDependencies": {

--- a/packages/dwn-sql-store/src/dialect/bun-sqlite-adapter.ts
+++ b/packages/dwn-sql-store/src/dialect/bun-sqlite-adapter.ts
@@ -15,6 +15,7 @@ interface KyselySqliteStatement {
     changes: number | bigint;
     lastInsertRowid: number | bigint;
   };
+  iterate(parameters: ReadonlyArray<unknown>): IterableIterator<unknown>;
 }
 
 /**
@@ -75,6 +76,10 @@ export function createBunSqliteDatabase(
             changes: number | bigint;
             lastInsertRowid: number | bigint;
           };
+        },
+
+        iterate(parameters: ReadonlyArray<unknown>): IterableIterator<unknown> {
+          return stmt.iterate(...(parameters as any[])) as IterableIterator<unknown>;
         },
       };
     },


### PR DESCRIPTION
## Summary

Consolidates 4 dependabot PRs into a single update, verified with lint + build + full test suites.

- **kysely** 0.26.3 → 0.28.14 (`dwn-sql-store`, `dwn-server`)
- **playwright** 1.45.3 → 1.55.1 (root devDep)
- **SonarSource/sonarqube-scan-action** v5 → v6 (CI workflow)

## Adapter Fix

Kysely 0.28 added `iterate()` to the `SqliteStatement` interface. Updated `bun-sqlite-adapter.ts` to delegate to Bun's native `stmt.iterate()`.

## Verification

| Package | Tests | Result |
|---|---|---|
| `dwn-sql-store` | 2116 | 0 fail |
| `agent` | 1361 | 0 fail |
| `dwn-server` | 591 | 0 fail |
| Lint (all packages) | 27 tasks | all pass |

## Closes

Closes #831, closes #832, closes #833, closes #834