### PR TITLE
fix: add readonly to ~240 never-reassigned class members (S2933)

### DIFF
--- a/packages/agent/src/agent-did-resolver-cache.ts
+++ b/packages/agent/src/agent-did-resolver-cache.ts
@@ -21,7 +21,7 @@ export class AgentDidResolverCache extends DidResolverCacheLevel implements DidR
   private _agent?: EnboxPlatformAgent;
 
   /** A map of DIDs that are currently in-flight. This helps avoid going into an infinite loop */
-  private _resolving: Map<string, boolean> = new Map();
+  private readonly _resolving: Map<string, boolean> = new Map();
 
   constructor({ agent, db, location, ttl }: DidResolverCacheLevelParams & { agent?: EnboxPlatformAgent }) {
     super ({ db, location, ttl });

--- a/packages/agent/src/anonymous-dwn-api.ts
+++ b/packages/agent/src/anonymous-dwn-api.ts
@@ -98,8 +98,8 @@ export type AnonymousProtocolsQueryParams = {
  * ```
  */
 export class AnonymousDwnApi {
-  private _didResolver: DidUrlDereferencer;
-  private _rpcClient: EnboxRpc;
+  private readonly _didResolver: DidUrlDereferencer;
+  private readonly _rpcClient: EnboxRpc;
 
   constructor({ didResolver, rpcClient }: AnonymousDwnApiParams) {
     this._didResolver = didResolver;

--- a/packages/agent/src/crypto-api.ts
+++ b/packages/agent/src/crypto-api.ts
@@ -256,7 +256,7 @@ export class AgentCryptoApi implements CryptoApi<
    * that implements a specific cryptographic algorithm. This map is used to cache and reuse
    * instances for performance optimization, ensuring that each algorithm is instantiated only once.
    */
-  private _algorithmInstances: Map<AlgorithmConstructor, InstanceType<typeof CryptoAlgorithm>> = new Map();
+  private readonly _algorithmInstances: Map<AlgorithmConstructor, InstanceType<typeof CryptoAlgorithm>> = new Map();
 
   public async bytesToPrivateKey({ algorithm: algorithmIdentifier, privateKeyBytes }:
     CryptoApiBytesToPrivateKeyParams

--- a/packages/agent/src/did-api.ts
+++ b/packages/agent/src/did-api.ts
@@ -121,9 +121,9 @@ export class AgentDidApi<TKeyManager extends AgentKeyManager = AgentKeyManager> 
    */
   private _agent?: EnboxPlatformAgent;
 
-  private _didMethods: Map<string, DidMethodApi> = new Map();
+  private readonly _didMethods: Map<string, DidMethodApi> = new Map();
 
-  private _store: AgentDataStore<PortableDid>;
+  private readonly _store: AgentDataStore<PortableDid>;
 
   constructor({ agent, didMethods, resolverCache, store }: DidApiParams) {
     if (!didMethods) {

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -130,20 +130,20 @@ export class AgentDwnApi {
    * `undefined` in remote mode — all operations route through RPC to
    * the local DWN server endpoint.
    */
-  private _dwn?: Dwn;
+  private readonly _dwn?: Dwn;
 
   /**
    * The local DWN server endpoint for remote mode.
    * When set, `_dwn` is `undefined` and `processRequest()` routes
    * through `sendDwnRpcRequest()`.
    */
-  private _localDwnEndpoint?: string;
+  private readonly _localDwnEndpoint?: string;
 
   /**
    * Protocol definition cache — TTL 30 minutes. Protocols rarely change.
    * Keyed by `${tenantDid}~${protocolUri}`.
    */
-  private _protocolDefinitionCache = new TtlCache<string, ProtocolDefinition>({
+  private readonly _protocolDefinitionCache = new TtlCache<string, ProtocolDefinition>({
     ttl: 30 * 60 * 1000
   });
 
@@ -151,7 +151,7 @@ export class AgentDwnApi {
    * Context key cache — stores resolved context encryption key info for
    * multi-party protocols. Keyed by rootContextId. TTL 30 minutes.
    */
-  private _contextKeyCache = new TtlCache<string, {
+  private readonly _contextKeyCache = new TtlCache<string, {
     keyId: string;
     keyUri: KeyIdentifier;
     contextDerivationPath: string[];
@@ -162,7 +162,7 @@ export class AgentDwnApi {
    * where the current user is a participant (not the creator).
    * Keyed by `ctx~${authorDid}~${rootContextId}`. TTL 30 minutes.
    */
-  private _contextDerivedKeyCache = new TtlCache<string, DerivedPrivateJwk>({
+  private readonly _contextDerivedKeyCache = new TtlCache<string, DerivedPrivateJwk>({
     ttl: 30 * 60 * 1000
   });
 
@@ -176,7 +176,7 @@ export class AgentDwnApi {
    * granted read scopes for that delegate session.
    * TTL 24 hours (keys are re-populated on session restore).
    */
-  private _delegateDecryptionKeyCache = new TtlCache<string, {
+  private readonly _delegateDecryptionKeyCache = new TtlCache<string, {
     protocol: string;
     scope: { kind: 'protocol' } | { kind: 'protocolPath'; protocolPath: string; match: 'exact' };
     derivedPrivateKey: DerivedPrivateJwk;
@@ -190,12 +190,12 @@ export class AgentDwnApi {
    * Keyed by `dctx~${delegateDid}~${protocol}~${rootContextId}`.
    * TTL 24 hours (re-populated on session restore).
    */
-  private _delegateContextKeyCache = new TtlCache<string, DerivedPrivateJwk>({
+  private readonly _delegateContextKeyCache = new TtlCache<string, DerivedPrivateJwk>({
     ttl: 24 * 60 * 60 * 1000
   });
 
   /** Tracks which context key cache entries belong to which delegate DID. */
-  private _delegateContextKeyCacheIndex = new Map<string, string[]>();
+  private readonly _delegateContextKeyCacheIndex = new Map<string, string[]>();
 
   /**
    * Explicit registry of which multi-party protocols each delegate has
@@ -207,7 +207,7 @@ export class AgentDwnApi {
    * Unlike the context key cache, this registry is NOT time-limited —
    * it persists for the lifetime of the session.
    */
-  private _delegateMultiPartyProtocols = new Map<string, Set<string>>();
+  private readonly _delegateMultiPartyProtocols = new Map<string, Set<string>>();
 
   /**
    * Optional callback invoked when post-connect context keys are delivered
@@ -219,7 +219,7 @@ export class AgentDwnApi {
    * Cache of locally-managed DIDs (agent DID + identities). Used to decide
    * whether a target DID should be routed through the local DWN server.
    */
-  private _localManagedDidCache = new TtlCache<string, boolean>({
+  private readonly _localManagedDidCache = new TtlCache<string, boolean>({
     ttl: 30 * 60 * 1000
   });
 
@@ -1588,7 +1588,7 @@ export class AgentDwnApi {
    * Cache for key delivery protocol installation status per tenant.
    * Once confirmed installed, we skip re-checking for 21 days.
    */
-  private _keyDeliveryProtocolInstalledCache = new TtlCache<string, boolean>({
+  private readonly _keyDeliveryProtocolInstalledCache = new TtlCache<string, boolean>({
     ttl : 21 * 24 * 60 * 60 * 1000,
     max : 1000,
   });

--- a/packages/agent/src/hd-identity-vault.ts
+++ b/packages/agent/src/hd-identity-vault.ts
@@ -143,10 +143,10 @@ export class HdIdentityVault implements IdentityVault<{ InitializeResult: string
   public crypto = new AgentCryptoApi();
 
   /** Determines the computational intensity of the key derivation process. */
-  private _keyDerivationWorkFactor: number;
+  private readonly _keyDerivationWorkFactor: number;
 
   /** The underlying key-value store for the vault's encrypted content. */
-  private _store: KeyValueStore<string, string>;
+  private readonly _store: KeyValueStore<string, string>;
 
   /** The cryptographic key used to encrypt and decrypt the vault's content securely. */
   private _contentEncryptionKey: Jwk | undefined;

--- a/packages/agent/src/identity-api.ts
+++ b/packages/agent/src/identity-api.ts
@@ -54,7 +54,7 @@ export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyMana
    */
   private _agent?: EnboxPlatformAgent<TKeyManager>;
 
-  private _store: AgentDataStore<IdentityMetadata>;
+  private readonly _store: AgentDataStore<IdentityMetadata>;
 
   constructor({ agent, store }: IdentityApiParams<TKeyManager> = {}) {
     this._agent = agent;

--- a/packages/agent/src/local-dwn.ts
+++ b/packages/agent/src/local-dwn.ts
@@ -62,9 +62,9 @@ export class LocalDwnDiscovery {
   private _cacheExpiry = 0;
 
   constructor(
-    private _rpcClient: EnboxRpc,
-    private _cacheTtlMs = 10_000,
-    private _discoveryFile?: DwnDiscoveryFile,
+    private readonly _rpcClient: EnboxRpc,
+    private readonly _cacheTtlMs = 10_000,
+    private readonly _discoveryFile?: DwnDiscoveryFile,
   ) {}
 
   /**

--- a/packages/agent/src/local-key-manager.ts
+++ b/packages/agent/src/local-key-manager.ts
@@ -177,7 +177,7 @@ export class LocalKeyManager implements AgentKeyManager {
    * that implements a specific cryptographic algorithm. This map is used to cache and reuse
    * instances for performance optimization, ensuring that each algorithm is instantiated only once.
    */
-  private _algorithmInstances: Map<AlgorithmConstructor, InstanceType<typeof CryptoAlgorithm>> = new Map();
+  private readonly _algorithmInstances: Map<AlgorithmConstructor, InstanceType<typeof CryptoAlgorithm>> = new Map();
 
   /**
    * The `_keyStore` private variable in `LocalKeyManager` is a {@link AgentDataStore} instance used
@@ -187,7 +187,7 @@ export class LocalKeyManager implements AgentKeyManager {
    * persistent storage, providing flexibility in key management according to the application's
    * requirements.
    */
-  private _keyStore: AgentDataStore<Jwk>;
+  private readonly _keyStore: AgentDataStore<Jwk>;
 
   constructor({ agent, keyStore }: LocalKmsParams = {}) {
     this._agent = agent;

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -11,7 +11,7 @@ import { DwnInterface, DwnPermissionGrant, DwnPermissionRequest } from './types/
 export class AgentPermissionsApi implements PermissionsApi {
 
   /** cache for fetching a permission {@link PermissionGrant}, keyed by a specific MessageType and protocol */
-  private _cachedPermissions: TtlCache<string, PermissionGrantEntry> = new TtlCache({ ttl: 60 * 1000 });
+  private readonly _cachedPermissions: TtlCache<string, PermissionGrantEntry> = new TtlCache({ ttl: 60 * 1000 });
 
   private _agent?: EnboxAgent;
 

--- a/packages/agent/src/store-data.ts
+++ b/packages/agent/src/store-data.ts
@@ -93,7 +93,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
    * Uses the same 1-hour TTL as `_protocolInitializedCache` so both
    * caches expire and re-derive together. See comment above.
    */
-  private _tenantEncryptionActive: TtlCache<string, boolean> = new TtlCache({ ttl: ms('1 hour'), max: 1000 });
+  private readonly _tenantEncryptionActive: TtlCache<string, boolean> = new TtlCache({ ttl: ms('1 hour'), max: 1000 });
 
   /** Cached result of the `encryptionRequired` check on the protocol definition.
    *  Computed lazily on first access — the definition is immutable after assignment. */
@@ -429,7 +429,7 @@ export class InMemoryDataStore<TStoreObject extends Record<string, any> = Jwk> i
   /**
    * A private field that contains the Map used as the in-memory data store.
    */
-  private store: Map<string, TStoreObject> = new Map();
+  private readonly store: Map<string, TStoreObject> = new Map();
 
   public async delete({ id, agent, tenant }: DataStoreDeleteParams): Promise<boolean> {
     // Determine the tenant identifier (DID) for the delete operation.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -175,7 +175,7 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private _permissionsApi: PermissionsApi;
 
-  private _db: AbstractLevel<string | Buffer | Uint8Array>;
+  private readonly _db: AbstractLevel<string | Buffer | Uint8Array>;
   private _syncIntervalId?: ReturnType<typeof setInterval>;
   private _syncLock = false;
 
@@ -191,7 +191,7 @@ export class SyncEngineLevel implements SyncEngine {
    * Populated from the ledger on `startLiveSync`, used by subscription handlers
    * to avoid async ledger lookups on every event.
    */
-  private _activeLinks: Map<string, ReplicationLinkState> = new Map();
+  private readonly _activeLinks: Map<string, ReplicationLinkState> = new Map();
 
   /**
    * Per-link in-memory delivery-order tracking for the pull path. Keyed by
@@ -199,7 +199,7 @@ export class SyncEngineLevel implements SyncEngine {
    * restarts from `contiguousAppliedToken` and idempotent apply handles
    * re-delivered events.
    */
-  private _linkRuntimes: Map<string, LinkRuntimeState> = new Map();
+  private readonly _linkRuntimes: Map<string, LinkRuntimeState> = new Map();
 
   /**
    * Hex-encoded default hashes for empty subtrees at each depth, keyed by depth.
@@ -233,10 +233,10 @@ export class SyncEngineLevel implements SyncEngine {
   private _connectivityState: SyncConnectivityState = 'unknown';
 
   /** Registered event listeners for observability. */
-  private _eventListeners: Set<SyncEventListener> = new Set();
+  private readonly _eventListeners: Set<SyncEventListener> = new Set();
 
   /** Per-link push runtime: queue, debounce timer, retry state. */
-  private _pushRuntimes: Map<string, PushRuntimeState> = new Map();
+  private readonly _pushRuntimes: Map<string, PushRuntimeState> = new Map();
 
   /**
    * CIDs recently received via pull subscription, keyed by `cid|dwnUrl` to
@@ -244,7 +244,7 @@ export class SyncEngineLevel implements SyncEngine {
    * is only suppressed for push back to Provider A — it still fans out to
    * Provider B and C. TTL: 60 seconds. Cap: 10,000 entries.
    */
-  private _recentlyPulledCids: Map<string, number> = new Map();
+  private readonly _recentlyPulledCids: Map<string, number> = new Map();
 
   /** TTL for echo-loop suppression entries (60 seconds). */
   private static readonly ECHO_SUPPRESS_TTL_MS = 60_000;
@@ -254,7 +254,7 @@ export class SyncEngineLevel implements SyncEngine {
    * Caches ProtocolsConfigure and grant lookups across events for the same
    * tenant. Keyed by tenantDid to prevent cross-tenant cache pollution.
    */
-  private _closureContexts: Map<string, ClosureEvaluationContext> = new Map();
+  private readonly _closureContexts: Map<string, ClosureEvaluationContext> = new Map();
 
   /** Maximum entries in the echo-loop suppression cache. */
   private static readonly ECHO_SUPPRESS_MAX_ENTRIES = 10_000;
@@ -804,16 +804,16 @@ export class SyncEngineLevel implements SyncEngine {
   private static readonly MAX_REPAIR_ATTEMPTS = 3;
 
   /** Per-link degraded-poll interval timers. */
-  private _degradedPollTimers: Map<string, ReturnType<typeof setInterval>> = new Map();
+  private readonly _degradedPollTimers: Map<string, ReturnType<typeof setInterval>> = new Map();
 
   /** Per-link repair attempt counters. */
-  private _repairAttempts: Map<string, number> = new Map();
+  private readonly _repairAttempts: Map<string, number> = new Map();
 
   /** Per-link active repair promises — prevents concurrent repair for the same link. */
-  private _activeRepairs: Map<string, Promise<void>> = new Map();
+  private readonly _activeRepairs: Map<string, Promise<void>> = new Map();
 
   /** Per-link retry timers for failed repairs below max attempts. */
-  private _repairRetryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private readonly _repairRetryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 
   /** Backoff schedule for repair retries (milliseconds). */
   private static readonly REPAIR_BACKOFF_MS = [1_000, 3_000, 10_000];
@@ -824,7 +824,7 @@ export class SyncEngineLevel implements SyncEngine {
    * the post-repair checkpoint so the reopened subscription replays from
    * a valid boundary instead of starting live-only.
    */
-  private _repairContext: Map<string, { resumeToken?: ProgressToken }> = new Map();
+  private readonly _repairContext: Map<string, { resumeToken?: ProgressToken }> = new Map();
 
   /**
    * Central helper for transitioning a link to `repairing`. Encapsulates:
@@ -1983,10 +1983,10 @@ export class SyncEngineLevel implements SyncEngine {
   // ---------------------------------------------------------------------------
 
   /** Active reconcile timers, keyed by link key. */
-  private _reconcileTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private readonly _reconcileTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 
   /** Active reconcile operations, keyed by link key (dedup). */
-  private _reconcileInFlight: Map<string, Promise<void>> = new Map();
+  private readonly _reconcileInFlight: Map<string, Promise<void>> = new Map();
 
   /**
    * Schedule a per-link reconciliation after a short debounce. Coalesces

--- a/packages/agent/src/sync-replication-ledger.ts
+++ b/packages/agent/src/sync-replication-ledger.ts
@@ -21,7 +21,7 @@ const KEY_SEP = '^';
  */
 export class ReplicationLedger {
   private readonly db: AbstractLevel<string | Buffer | Uint8Array>;
-  private sublevel;
+  private readonly sublevel;
 
   constructor(db: AbstractLevel<string | Buffer | Uint8Array>) {
     this.db = db;

--- a/packages/api/src/did-api.ts
+++ b/packages/api/src/did-api.ts
@@ -40,10 +40,10 @@ export class DidApi {
    * Holds the instance of a {@link EnboxAgent} that represents the current execution context for
    * the `DidApi`. This agent is used to process DID requests.
    */
-  private agent: EnboxAgent;
+  private readonly agent: EnboxAgent;
 
   /** The DID of the tenant under which DID operations are being performed. */
-  private connectedDid: string;
+  private readonly connectedDid: string;
 
   constructor(options: { agent: EnboxAgent, connectedDid: string }) {
     this.agent = options.agent;

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -241,7 +241,7 @@ export class DwnApi {
    * Holds the instance of a {@link EnboxAgent} that represents the current execution context for
    * the `DwnApi`. This agent is used to process DWN requests.
    */
-  private agent: EnboxAgent;
+  private readonly agent: EnboxAgent;
 
   /**
    * The DID of the DWN tenant under which operations are being performed.
@@ -255,10 +255,10 @@ export class DwnApi {
   set connectedDid(did: string) { this._connectedDid = did; }
 
   /** (optional) The DID of the signer when signing with permissions */
-  private delegateDid?: string;
+  private readonly delegateDid?: string;
 
   /** Holds the instance of {@link AgentPermissionsApi} that helps when dealing with permissions protocol records */
-  private permissionsApi: AgentPermissionsApi;
+  private readonly permissionsApi: AgentPermissionsApi;
 
   constructor(options: { agent: EnboxAgent, connectedDid: string, delegateDid?: string }) {
     this.agent = options.agent;

--- a/packages/api/src/dwn-reader-api.ts
+++ b/packages/api/src/dwn-reader-api.ts
@@ -148,7 +148,7 @@ export type ReaderProtocolsQueryResponse = DwnResponseStatus & {
  * @beta
  */
 export class DwnReaderApi {
-  private _anonymousDwn: AnonymousDwnApi;
+  private readonly _anonymousDwn: AnonymousDwnApi;
 
   constructor(anonymousDwn: AnonymousDwnApi) {
     this._anonymousDwn = anonymousDwn;

--- a/packages/api/src/enbox.ts
+++ b/packages/api/src/enbox.ts
@@ -95,7 +95,7 @@ export class Enbox {
   public did: DidApi;
 
   /** Internal DWN API instance. Use {@link Enbox.using} for protocol-scoped access. */
-  private _dwn: DwnApi;
+  private readonly _dwn: DwnApi;
 
   /**
    * Cache of {@link TypedEnbox} instances keyed by protocol URI.
@@ -104,7 +104,7 @@ export class Enbox {
    * instance for a given protocol across multiple call sites, avoiding
    * redundant protocol installations and duplicated internal state.
    */
-  private _typedInstances = new Map<string, TypedEnbox<ProtocolDefinition, SchemaMap>>();
+  private readonly _typedInstances = new Map<string, TypedEnbox<ProtocolDefinition, SchemaMap>>();
 
   /** Exposed instance to the VC APIs, allow users to issue, present and verify VCs. */
   public vc: VcApi;

--- a/packages/api/src/grant-revocation.ts
+++ b/packages/api/src/grant-revocation.ts
@@ -31,9 +31,9 @@ export interface GrantRevocationOptions {
  */
 export class PermissionGrantRevocation implements GrantRevocationModel {
   /** The PermissionsAPI used to interact with the underlying revocation  */
-  private _permissions: AgentPermissionsApi;
+  private readonly _permissions: AgentPermissionsApi;
   /** The DID to use as the author and default target for the underlying revocation */
-  private _connectedDid: string;
+  private readonly _connectedDid: string;
   /** The DWN `RecordsWrite` message, along with encodedData that represents the revocation */
   private _message: DwnDataEncodedRecordsWriteMessage;
 

--- a/packages/api/src/live-query.ts
+++ b/packages/api/src/live-query.ts
@@ -150,10 +150,10 @@ export class LiveQuery extends EventTarget {
   readonly cursor?: PaginationCursor;
 
   /** The underlying DWN subscription handle. */
-  private _subscription: DwnMessageSubscription;
+  private readonly _subscription: DwnMessageSubscription;
 
   /** Tracks known record states for dedup and change-type classification. */
-  private _knownRecords: Map<string, string>;
+  private readonly _knownRecords: Map<string, string>;
 
   /** Whether the live query has been closed. */
   private _closed = false;

--- a/packages/api/src/permission-grant.ts
+++ b/packages/api/src/permission-grant.ts
@@ -93,13 +93,13 @@ export interface PermissionGrantOptions {
  */
 export class PermissionGrant implements PermissionGrantModel {
   /** The PermissionsAPI used to interact with the underlying permission grant */
-  private _permissions: AgentPermissionsApi;
+  private readonly _permissions: AgentPermissionsApi;
   /** The DID to use as the author and default target for the underlying permission grant */
-  private _connectedDid: string;
+  private readonly _connectedDid: string;
   /** The underlying DWN `RecordsWrite` message along with encoded data that represent the grant */
   private _message: DwnDataEncodedRecordsWriteMessage;
   /** The parsed grant object */
-  private _grant: DwnPermissionGrant;
+  private readonly _grant: DwnPermissionGrant;
 
   private constructor({ api, connectedDid, message, grant }:{
     api: AgentPermissionsApi;

--- a/packages/api/src/permission-request.ts
+++ b/packages/api/src/permission-request.ts
@@ -59,13 +59,13 @@ export interface PermissionRequestModel {
  */
 export class PermissionRequest implements PermissionRequestModel {
   /** The PermissionsAPI used to interact with the underlying permission request */
-  private _permissions: AgentPermissionsApi;
+  private readonly _permissions: AgentPermissionsApi;
   /** The DID to use as the author and default target for the underlying permission request */
-  private _connectedDid: string;
+  private readonly _connectedDid: string;
   /** The underlying DWN `RecordsWrite` message along with encoded data that represent the request */
   private _message: DwnDataEncodedRecordsWriteMessage;
   /** The parsed permission request object */
-  private _request: DwnPermissionRequest;
+  private readonly _request: DwnPermissionRequest;
 
   private constructor({ api, connectedDid, message, request }: {
     api: AgentPermissionsApi;

--- a/packages/api/src/protocol.ts
+++ b/packages/api/src/protocol.ts
@@ -31,13 +31,13 @@ export type ProtocolMetadata = {
  */
 export class Protocol {
   /** The {@link EnboxAgent} instance that handles DWNs requests. */
-  private _agent: EnboxAgent;
+  private readonly _agent: EnboxAgent;
 
   /** Metadata associated with the protocol, including the author and optional message CID. */
-  private _metadata: ProtocolMetadata;
+  private readonly _metadata: ProtocolMetadata;
 
   /** The ProtocolsConfigureMessage containing the detailed configuration for the protocol. */
-  private _protocolsConfigureMessage: DwnMessage[DwnInterface.ProtocolsConfigure];
+  private readonly _protocolsConfigureMessage: DwnMessage[DwnInterface.ProtocolsConfigure];
 
   /**
    * Constructs a new instance of the Protocol class.

--- a/packages/api/src/read-only-record.ts
+++ b/packages/api/src/read-only-record.ts
@@ -48,19 +48,19 @@ export type ReadOnlyRecordOptions = {
  */
 export class ReadOnlyRecord {
   // Private backing fields.
-  private _anonymousDwn: AnonymousDwnApi;
-  private _remoteOrigin: string;
-  private _author: string;
-  private _creator: string;
-  private _descriptor: RecordsWriteDescriptor;
-  private _recordId: string;
-  private _contextId?: string;
-  private _initialWrite?: RecordsWriteMessage;
-  private _encodedData?: Blob;
+  private readonly _anonymousDwn: AnonymousDwnApi;
+  private readonly _remoteOrigin: string;
+  private readonly _author: string;
+  private readonly _creator: string;
+  private readonly _descriptor: RecordsWriteDescriptor;
+  private readonly _recordId: string;
+  private readonly _contextId?: string;
+  private readonly _initialWrite?: RecordsWriteMessage;
+  private readonly _encodedData?: Blob;
   private _readableStream?: ReadableStream;
-  private _authorization: RecordsWriteMessage['authorization'];
-  private _attestation?: RecordsWriteMessage['attestation'];
-  private _encryption?: RecordsWriteMessage['encryption'];
+  private readonly _authorization: RecordsWriteMessage['authorization'];
+  private readonly _attestation?: RecordsWriteMessage['attestation'];
+  private readonly _encryption?: RecordsWriteMessage['encryption'];
 
   constructor(options: ReadOnlyRecordOptions) {
     const { rawMessage, initialWrite, encodedData, data, remoteOrigin, anonymousDwn } = options;

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -90,31 +90,31 @@ export class Record implements RecordModel {
    * Cache to minimize the amount of redundant two-phase commits we do in store() and send()
    * Retains awareness of the last 100 records stored/sent for up to 100 target DIDs each.
    */
-  private static _sendCache = SendCache;
+  private static readonly _sendCache = SendCache;
 
   // Record instance metadata.
 
   /** The {@link EnboxAgent} instance that handles DWNs requests. */
-  private _agent: EnboxAgent;
+  private readonly _agent: EnboxAgent;
   /** The DID of the DWN tenant under which operations are being performed. */
-  private _connectedDid: string;
+  private readonly _connectedDid: string;
   /** The optional DID that is delegated to act on behalf of the connectedDid */
-  private _delegateDid?: string;
+  private readonly _delegateDid?: string;
   /** cache for fetching a permission {@link PermissionGrant}, keyed by a specific MessageType and protocol */
-  private _permissionsApi: PermissionsApi;
+  private readonly _permissionsApi: PermissionsApi;
   /** Encoded data of the record, if available. */
   private _encodedData?: Blob;
   /** Stream of the record's data (Web ReadableStream for cross-platform compatibility). */
   private _readableStream?: ReadableStream;
   /** The origin DID if the record was fetched from a remote DWN. */
-  private _remoteOrigin?: string;
+  private readonly _remoteOrigin?: string;
 
   // Private variables for DWN `RecordsWrite` message properties.
 
   /** The DID of the entity that most recently authored or deleted the record. */
-  private _author: string;
+  private readonly _author: string;
   /** The DID of the entity that originally created the record. */
-  private _creator: string;
+  private readonly _creator: string;
   /** Attestation JWS signature. */
   private _attestation?: DwnMessage[DwnInterface.RecordsWrite]['attestation'];
   /** Authorization signature(s). */
@@ -132,7 +132,7 @@ export class Record implements RecordModel {
   /** Flag indicating if the initial write has been signed by the owner. */
   private _initialWriteSigned: boolean;
   /** Unique identifier of the record. */
-  private _recordId: string;
+  private readonly _recordId: string;
   /** Role under which the record is written. */
   private _protocolRole?: RecordOptions['protocolRole'];
 

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -552,19 +552,19 @@ export class TypedEnbox<
   M extends SchemaMap = SchemaMap,
 > {
   /** @internal */
-  private _dwn: DwnApi;
+  private readonly _dwn: DwnApi;
   /** @internal */
-  private _definition: D;
+  private readonly _definition: D;
   /** @internal */
   private _configured: boolean = false;
   /** @internal */
   private _ensureReadyPromise: Promise<void> | null = null;
   /** @internal */
-  private _validPaths: Set<string>;
+  private readonly _validPaths: Set<string>;
   /** @internal */
   private _records?: TypedEnbox<D, M>['records'];
   /** @internal — cached result of the `hasEncryptedTypes` scan (definition is immutable). */
-  private _hasEncryptedTypes: boolean;
+  private readonly _hasEncryptedTypes: boolean;
 
   /**
    * @internal Create a new `TypedEnbox` instance. Use `enbox.using(protocol)` instead.

--- a/packages/api/src/typed-live-query.ts
+++ b/packages/api/src/typed-live-query.ts
@@ -65,7 +65,7 @@ export type TypedRecordChange<T> = {
  */
 export class TypedLiveQuery<T> {
   /** The underlying untyped LiveQuery instance. */
-  private _liveQuery: LiveQuery;
+  private readonly _liveQuery: LiveQuery;
 
   /** Cached typed record array, built lazily from the underlying records. */
   private _typedRecords?: TypedRecord<T>[];

--- a/packages/api/src/typed-record.ts
+++ b/packages/api/src/typed-record.ts
@@ -189,7 +189,7 @@ export type TypedRecordDeleteResult<T> = DwnResponseStatus & {
  */
 export class TypedRecord<T> {
   /** @internal The underlying untyped Record instance. */
-  private _record: Record;
+  private readonly _record: Record;
 
   /**
    * @internal Wrap an untyped {@link Record} in a type-safe shell.

--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -116,14 +116,14 @@ export class SendCache {
    * A private static map that serves as the core storage mechanism for the cache. It maps record
    * IDs to a set of target DIDs, indicating which records have been sent to which targets.
   */
-  private static cache = new Map<string, Set<string>>();
+  private static readonly cache = new Map<string, Set<string>>();
 
   /**
    * The maximum number of entries allowed in the cache. Once this limit is exceeded, the oldest
    * entries are evicted to make room for new ones. This limit applies both to the number of records
    * and the number of targets per record.
    */
-  private static sendCacheLimit = 100;
+  private static readonly sendCacheLimit = 100;
 
   /**
    * Checks if a given record ID has been sent to a specified target DID. This method is used to

--- a/packages/api/src/vc-api.ts
+++ b/packages/api/src/vc-api.ts
@@ -10,10 +10,10 @@ export class VcApi {
    * Holds the instance of a {@link EnboxAgent} that represents the current execution context for
    * the `VcApi`. This agent is used to process VC requests.
    */
-  private agent: EnboxAgent;
+  private readonly agent: EnboxAgent;
 
   /** The DID of the tenant under which DID operations are being performed. */
-  private connectedDid: string;
+  private readonly connectedDid: string;
 
   constructor(options: { agent: EnboxAgent, connectedDid: string }) {
     this.agent = options.agent;

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -84,21 +84,21 @@ import { importFromPhrase, importFromPortable } from './connect/import.js';
  * ```
  */
 export class AuthManager {
-  private _userAgent: EnboxUserAgent;
-  private _emitter: AuthEventEmitter;
-  private _storage: StorageAdapter;
+  private readonly _userAgent: EnboxUserAgent;
+  private readonly _emitter: AuthEventEmitter;
+  private readonly _storage: StorageAdapter;
   private _session: AuthSession | undefined;
   private _state: AuthState = 'uninitialized';
   private _isConnecting = false;
   private _isShutDown = false;
 
   // Default options from create()
-  private _defaultPassword?: string;
-  private _passwordProvider?: PasswordProvider;
-  private _defaultSync?: SyncOption;
-  private _defaultDwnEndpoints?: string[];
-  private _registration?: RegistrationOptions;
-  private _connectHandler?: ConnectHandler;
+  private readonly _defaultPassword?: string;
+  private readonly _passwordProvider?: PasswordProvider;
+  private readonly _defaultSync?: SyncOption;
+  private readonly _defaultDwnEndpoints?: string[];
+  private readonly _registration?: RegistrationOptions;
+  private readonly _connectHandler?: ConnectHandler;
 
   /**
    * The local DWN server endpoint discovered during `create()`, if any.
@@ -106,7 +106,7 @@ export class AuthManager {
    * event listeners are attached, so consumers should check this property
    * after `create()` returns rather than relying solely on events.
    */
-  private _localDwnEndpoint?: string;
+  private readonly _localDwnEndpoint?: string;
 
   private constructor(params: {
     userAgent: EnboxUserAgent;

--- a/packages/auth/src/events.ts
+++ b/packages/auth/src/events.ts
@@ -19,7 +19,7 @@ import type { AuthEvent, AuthEventHandler, AuthEventMap } from './types.js';
  * ```
  */
 export class AuthEventEmitter {
-  private _listeners = new Map<AuthEvent, Set<AuthEventHandler<AuthEvent>>>();
+  private readonly _listeners = new Map<AuthEvent, Set<AuthEventHandler<AuthEvent>>>();
 
   /**
    * Subscribe to an event. Returns an unsubscribe function.

--- a/packages/common/src/stores.ts
+++ b/packages/common/src/stores.ts
@@ -5,7 +5,7 @@ import { Level } from 'level';
 import type { KeyValueStore } from './types.js';
 
 export class LevelStore<K = string, V = any> implements KeyValueStore<K, V> {
-  private store: AbstractLevel<string | Buffer | Uint8Array, K, V>;
+  private readonly store: AbstractLevel<string | Buffer | Uint8Array, K, V>;
 
   constructor({ db, location = 'DATASTORE' }: {
     db?: AbstractLevel<string | Buffer | Uint8Array, K, V>;
@@ -68,7 +68,7 @@ export class MemoryStore<K, V> implements KeyValueStore<K, V> {
   /**
    * A private field that contains the Map used as the key-value store.
    */
-  private store: Map<K, V> = new Map();
+  private readonly store: Map<K, V> = new Map();
 
   /**
    * Clears all entries in the key-value store.

--- a/packages/crypto/src/local-key-manager.ts
+++ b/packages/crypto/src/local-key-manager.ts
@@ -122,7 +122,7 @@ export class LocalKeyManager implements
    * that implements a specific cryptographic algorithm. This map is used to cache and reuse
    * instances for performance optimization, ensuring that each algorithm is instantiated only once.
    */
-  private _algorithmInstances: Map<AlgorithmConstructor, InstanceType<typeof CryptoAlgorithm>> = new Map();
+  private readonly _algorithmInstances: Map<AlgorithmConstructor, InstanceType<typeof CryptoAlgorithm>> = new Map();
 
   /**
    * The `_keyStore` private variable in `LocalKeyManager` is a `KeyValueStore` instance used for
@@ -132,7 +132,7 @@ export class LocalKeyManager implements
    * persistent storage, providing flexibility in key management according to the application's
    * requirements.
    */
-  private _keyStore: KeyValueStore<KeyIdentifier, Jwk>;
+  private readonly _keyStore: KeyValueStore<KeyIdentifier, Jwk>;
 
   constructor(params?: LocalKeyManagerParams) {
     this._keyStore = params?.keyStore ?? new MemoryStore<KeyIdentifier, Jwk>();

--- a/packages/dids/src/methods/did-key-utils.ts
+++ b/packages/dids/src/methods/did-key-utils.ts
@@ -42,7 +42,7 @@ export class DidKeyUtils {
    * // Returns 'ed25519-pub', the multicodec name for an Ed25519 public key
    * ```
    */
-  private static JWK_TO_MULTICODEC: { [key: string]: string } = {
+  private static readonly JWK_TO_MULTICODEC: { [key: string]: string } = {
     'Ed25519:public'    : 'ed25519-pub',
     'Ed25519:private'   : 'ed25519-priv',
     'secp256k1:public'  : 'secp256k1-pub',
@@ -76,7 +76,7 @@ export class DidKeyUtils {
    * // Returns a partial JWK for an Ed25519 public key
    * ```
    */
-  private static MULTICODEC_TO_JWK: { [key: string]: Jwk } = {
+  private static readonly MULTICODEC_TO_JWK: { [key: string]: Jwk } = {
     'ed25519-pub'    : { crv: 'Ed25519', kty: 'OKP', x: '' },
     'ed25519-priv'   : { crv: 'Ed25519', kty: 'OKP', x: '', d: '' },
     'secp256k1-pub'  : { crv: 'secp256k1', kty: 'EC', x: '', y: '' },

--- a/packages/dids/src/resolver/resolver-cache-memory.ts
+++ b/packages/dids/src/resolver/resolver-cache-memory.ts
@@ -20,7 +20,7 @@ export type DidResolverCacheMemoryParams = {
 };
 
 export class DidResolverCacheMemory implements DidResolverCache {
-  private cache: TtlCache<string, DidResolutionResult>;
+  private readonly cache: TtlCache<string, DidResolutionResult>;
 
   constructor({ ttl = '15m' }: DidResolverCacheMemoryParams = {}) {
     this.cache = new TtlCache({ ttl: ms(ttl) });

--- a/packages/dids/src/resolver/universal-resolver.ts
+++ b/packages/dids/src/resolver/universal-resolver.ts
@@ -71,7 +71,7 @@ export class UniversalResolver implements DidResolver, DidUrlDereferencer {
   /**
    * A map to store method resolvers against method names.
    */
-  private didResolvers: Map<string, DidMethodResolver> = new Map();
+  private readonly didResolvers: Map<string, DidMethodResolver> = new Map();
 
   /**
    * Constructs a new `DidResolver`.

--- a/packages/dwn-clients/src/dwn-server-info-cache-memory.ts
+++ b/packages/dwn-clients/src/dwn-server-info-cache-memory.ts
@@ -20,7 +20,7 @@ export type DwnServerInfoCacheMemoryParams = {
 };
 
 export class DwnServerInfoCacheMemory implements DwnServerInfoCache {
-  private cache: TtlCache<string, ServerInfo>;
+  private readonly cache: TtlCache<string, ServerInfo>;
 
   constructor({ ttl = '15m' }: DwnServerInfoCacheMemoryParams= {}) {
     this.cache = new TtlCache({ ttl: ms(ttl) });

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -99,8 +99,8 @@ function parseRetryAfterMs(response: Response): number | undefined {
  * Respects the `Retry-After` response header when present.
  */
 export class HttpDwnRpcClient implements DwnRpc {
-  private serverInfoCache: DwnServerInfoCache;
-  private _retryOptions: Required<HttpRetryOptions>;
+  private readonly serverInfoCache: DwnServerInfoCache;
+  private readonly _retryOptions: Required<HttpRetryOptions>;
 
   constructor(serverInfoCache?: DwnServerInfoCache, retryOptions?: HttpRetryOptions) {
     this.serverInfoCache = serverInfoCache ?? new DwnServerInfoCacheMemory();

--- a/packages/dwn-clients/src/json-rpc-socket.ts
+++ b/packages/dwn-clients/src/json-rpc-socket.ts
@@ -92,20 +92,20 @@ export class JsonRpcSocket {
    * handler is added before sending and removed on response or timeout.
    * For subscriptions, the handler lives until explicitly closed.
    */
-  private messageHandlers: Map<JsonRpcId, (event: { data: any }) => void> = new Map();
+  private readonly messageHandlers: Map<JsonRpcId, (event: { data: any }) => void> = new Map();
 
   /**
    * Set of JSON-RPC ids that belong to subscription handlers (as opposed to
    * one-shot request handlers). Subscription handlers survive reconnection;
    * one-shot handlers are rejected on unexpected close.
    */
-  private subscriptionHandlerIds: Set<JsonRpcId> = new Set();
+  private readonly subscriptionHandlerIds: Set<JsonRpcId> = new Set();
 
   /** The URL to connect/reconnect to. */
-  private url: string;
+  private readonly url: string;
 
   /** Stored options for reconnection. */
-  private options: JsonRpcSocketOptions;
+  private readonly options: JsonRpcSocketOptions;
 
   /** Whether `close()` was called intentionally by the user. */
   private closedByUser = false;
@@ -127,7 +127,7 @@ export class JsonRpcSocket {
 
   private constructor(
     private socket: WebSocket,
-    private responseTimeout: number,
+    private readonly responseTimeout: number,
     url: string,
     options: JsonRpcSocketOptions,
   ) {

--- a/packages/dwn-clients/src/rpc-client.ts
+++ b/packages/dwn-clients/src/rpc-client.ts
@@ -44,7 +44,7 @@ export interface EnboxRpc extends DwnRpc, DidRpc, DwnServerInfoRpc {}
  * Client used to communicate with Dwn Servers
  */
 export class EnboxRpcClient implements EnboxRpc {
-  private transportClients: Map<string, EnboxRpc>;
+  private readonly transportClients: Map<string, EnboxRpc>;
 
   constructor(clients: EnboxRpc[] = []) {
     this.transportClients = new Map();

--- a/packages/dwn-clients/src/web-socket-clients.ts
+++ b/packages/dwn-clients/src/web-socket-clients.ts
@@ -42,7 +42,7 @@ interface SocketConnection {
 export class WebSocketDwnRpcClient implements DwnRpc {
   public get transportProtocols(): string[] { return ['ws:', 'wss:']; }
   // a map of dwn host to WebSocket connection
-  private static connections = new Map<string, SocketConnection>();
+  private static readonly connections = new Map<string, SocketConnection>();
 
   async sendDwnRequest(request: DwnRpcRequest): Promise<DwnRpcResponse> {
 

--- a/packages/dwn-sdk-js/src/core/abstract-message.ts
+++ b/packages/dwn-sdk-js/src/core/abstract-message.ts
@@ -8,22 +8,22 @@ import { Message } from './message.js';
  * An abstract implementation of the `MessageInterface` interface.
  */
 export abstract class AbstractMessage<M extends GenericMessage> implements MessageInterface<M> {
-  private _message: M;
+  private readonly _message: M;
   public get message(): M {
     return this._message as M;
   }
 
-  private _signer: string | undefined;
+  private readonly _signer: string | undefined;
   public get signer(): string | undefined {
     return this._signer;
   }
 
-  private _author: string | undefined;
+  private readonly _author: string | undefined;
   public get author(): string | undefined {
     return this._author;
   }
 
-  private _signaturePayload: GenericSignaturePayload | undefined;
+  private readonly _signaturePayload: GenericSignaturePayload | undefined;
   public get signaturePayload(): GenericSignaturePayload | undefined {
     return this._signaturePayload;
   }

--- a/packages/dwn-sdk-js/src/core/resumable-task-manager.ts
+++ b/packages/dwn-sdk-js/src/core/resumable-task-manager.ts
@@ -20,9 +20,9 @@ export class ResumableTaskManager {
   public static readonly timeoutExtensionFrequencyInSeconds = 30;
 
   private resumableTaskBatchSize = 100;
-  private resumableTaskHandlers: { [key:string]: (taskData: any) => Promise<void> };
+  private readonly resumableTaskHandlers: { [key:string]: (taskData: any) => Promise<void> };
 
-  public constructor(private resumableTaskStore: ResumableTaskStore, storageController: StorageController) {
+  public constructor(private readonly resumableTaskStore: ResumableTaskStore, storageController: StorageController) {
     // assign resumable task handlers
     this.resumableTaskHandlers = {
       // NOTE: The arrow function is IMPORTANT here, else the `this` context will be lost within the invoked method.

--- a/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
@@ -65,21 +65,21 @@ export interface EventEmitterEventLogConfig {
  * For multi-node deployments, use a distributed implementation (NATS, Redis, etc.).
  */
 export class EventEmitterEventLog implements EventLog {
-  private emitter = mitt<EmitterEvents>();
+  private readonly emitter = mitt<EmitterEvents>();
   private isOpen: boolean = false;
-  private errorHandler: (error: any) => void = (error): void => { console.error('event log error', error); };
-  private maxEventsPerTenant: number;
+  private readonly errorHandler: (error: any) => void = (error): void => { console.error('event log error', error); };
+  private readonly maxEventsPerTenant: number;
 
   /**
    * Per-tenant ordered event storage.
    * Key: tenant DID → Map of seq → StoredEntry.
    */
-  private tenantLogs: Map<string, Map<number, StoredEntry>> = new Map();
+  private readonly tenantLogs: Map<string, Map<number, StoredEntry>> = new Map();
 
   /**
    * Per-tenant monotonic sequence counter.
    */
-  private tenantSeqs: Map<string, number> = new Map();
+  private readonly tenantSeqs: Map<string, number> = new Map();
 
   /**
    * Epoch for this EventLog instance. Generated once at construction as a

--- a/packages/dwn-sdk-js/src/handlers/messages-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-read.ts
@@ -18,7 +18,7 @@ type HandleArgs = { tenant: string, message: MessagesReadMessage };
 
 export class MessagesReadHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) {}
+  constructor(private readonly deps: HandlerDependencies) {}
 
   public async handle({ tenant, message }: HandleArgs): Promise<MessagesReadReply> {
     let messagesRead: MessagesRead;

--- a/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
@@ -14,7 +14,7 @@ import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
 export class MessagesSubscribeHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) {}
+  constructor(private readonly deps: HandlerDependencies) {}
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/handlers/messages-sync.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-sync.ts
@@ -25,7 +25,7 @@ const DEFAULT_MAX_INLINE_DATA_SIZE = DwnConstant.maxDataSizeAllowedToBeEncoded;
 
 export class MessagesSyncHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) { }
+  constructor(private readonly deps: HandlerDependencies) { }
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/handlers/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/handlers/protocols-configure.ts
@@ -15,7 +15,7 @@ import { getRuleSetAtPath, parseCrossProtocolRef } from '../utils/protocols.js';
 
 export class ProtocolsConfigureHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) { }
+  constructor(private readonly deps: HandlerDependencies) { }
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/handlers/protocols-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/protocols-query.ts
@@ -11,7 +11,7 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export class ProtocolsQueryHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) { }
+  constructor(private readonly deps: HandlerDependencies) { }
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/handlers/records-count.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-count.ts
@@ -14,7 +14,7 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export class RecordsCountHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) { }
+  constructor(private readonly deps: HandlerDependencies) { }
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/handlers/records-delete.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-delete.ts
@@ -18,7 +18,7 @@ import { ResumableTaskName } from '../core/resumable-task-manager.js';
 
 export class RecordsDeleteHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) { }
+  constructor(private readonly deps: HandlerDependencies) { }
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/handlers/records-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-query.ts
@@ -18,7 +18,7 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export class RecordsQueryHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) { }
+  constructor(private readonly deps: HandlerDependencies) { }
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -20,7 +20,7 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export class RecordsReadHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) { }
+  constructor(private readonly deps: HandlerDependencies) { }
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -20,7 +20,7 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 
 export class RecordsSubscribeHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) { }
+  constructor(private readonly deps: HandlerDependencies) { }
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -27,7 +27,7 @@ type HandlerArgs = { tenant: string, message: RecordsWriteMessage, dataStream?: 
 
 export class RecordsWriteHandler implements MethodHandler {
 
-  constructor(private deps: HandlerDependencies) { }
+  constructor(private readonly deps: HandlerDependencies) { }
 
   public async handle({
     tenant,

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -135,9 +135,9 @@ export type CreateFromOptions = {
  * NOTE: Unable to extend `AbstractMessage` directly because the incompatible `_message` type, which is not just a generic `<M>` type.
  */
 export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
-  private parentContextId: string | undefined;
+  private readonly parentContextId: string | undefined;
 
-  private _message: InternalRecordsWriteMessage;
+  private readonly _message: InternalRecordsWriteMessage;
   /**
    * Valid JSON message representing this RecordsWrite.
    * @throws `DwnErrorCode.RecordsWriteMissingSigner` if the message is not signed yet.

--- a/packages/dwn-sdk-js/src/jose/jws/general/builder.ts
+++ b/packages/dwn-sdk-js/src/jose/jws/general/builder.ts
@@ -4,7 +4,7 @@ import type { MessageSigner } from '../../../types/signer.js';
 import { Encoder } from '../../../utils/encoder.js';
 
 export class GeneralJwsBuilder {
-  private jws: GeneralJws;
+  private readonly jws: GeneralJws;
 
   private constructor(jws: GeneralJws) {
     this.jws = jws;

--- a/packages/dwn-sdk-js/src/smt/smt-store-level.ts
+++ b/packages/dwn-sdk-js/src/smt/smt-store-level.ts
@@ -31,7 +31,7 @@ type SerializedLeafNode = {
 type SerializedNode = SerializedInternalNode | SerializedLeafNode;
 
 export class SMTStoreLevel implements SMTNodeStore {
-  private db: LevelWrapper<string>;
+  private readonly db: LevelWrapper<string>;
   private nodesPartition!: LevelWrapper<string>;
   private metaPartition!: LevelWrapper<string>;
   private initialized = false;

--- a/packages/dwn-sdk-js/src/smt/smt-store-memory.ts
+++ b/packages/dwn-sdk-js/src/smt/smt-store-memory.ts
@@ -8,7 +8,7 @@ import type { Hash, SMTNode, SMTNodeStore } from '../types/smt-types.js';
 import { hashToHex } from './smt-utils.js';
 
 export class SMTStoreMemory implements SMTNodeStore {
-  private nodes: Map<string, SMTNode> = new Map();
+  private readonly nodes: Map<string, SMTNode> = new Map();
   private root: Hash | undefined;
 
   async open(): Promise<void> {

--- a/packages/dwn-sdk-js/src/smt/sparse-merkle-tree.ts
+++ b/packages/dwn-sdk-js/src/smt/sparse-merkle-tree.ts
@@ -19,7 +19,7 @@ import type { Hash, SMTDiffResult, SMTInternalNode, SMTLeafNode, SMTNodeStore, S
 import { getBit, hashChildren, hashEquals, hashKey, hashLeaf, initDefaultHashes, SMT_DEPTH } from './smt-utils.js';
 
 export class SparseMerkleTree {
-  private store: SMTNodeStore;
+  private readonly store: SMTNodeStore;
   private defaultHashes!: Hash[];
 
   constructor(store: SMTNodeStore) {

--- a/packages/dwn-sdk-js/src/state-index/state-index-level.ts
+++ b/packages/dwn-sdk-js/src/state-index/state-index-level.ts
@@ -28,7 +28,7 @@ export type StateIndexLevelConfig = {
 };
 
 export class StateIndexLevel implements StateIndex {
-  private config: StateIndexLevelConfig;
+  private readonly config: StateIndexLevelConfig;
   private db!: LevelWrapper<string>;
 
   /**
@@ -36,13 +36,13 @@ export class StateIndexLevel implements StateIndex {
    * Stores promises to avoid race conditions when multiple concurrent operations
    * trigger lazy initialization of the same tenant's SMT.
    */
-  private globalTrees: Map<string, Promise<SparseMerkleTree>> = new Map();
+  private readonly globalTrees: Map<string, Promise<SparseMerkleTree>> = new Map();
 
   /**
    * Cache of per-tenant, per-protocol SMTs. Key format: `{tenant}\x00{protocol}`
    * Stores promises to avoid race conditions (same reason as globalTrees).
    */
-  private protocolTrees: Map<string, Promise<SparseMerkleTree>> = new Map();
+  private readonly protocolTrees: Map<string, Promise<SparseMerkleTree>> = new Map();
 
   constructor(config?: StateIndexLevelConfig) {
     this.config = {

--- a/packages/dwn-sdk-js/src/store/index-level.ts
+++ b/packages/dwn-sdk-js/src/store/index-level.ts
@@ -53,7 +53,7 @@ export interface IndexLevelOptions {
 export class IndexLevel {
   db: LevelWrapper<string>;
   config: IndexLevelConfig;
-  private _compoundIndexes: CompoundIndexDefinition[];
+  private readonly _compoundIndexes: CompoundIndexDefinition[];
 
   constructor(config: IndexLevelConfig) {
     this.config = {
@@ -735,7 +735,7 @@ export class IndexLevel {
   /**
    * Joins the given values using the `\x00` (\u0000) character.
    */
-  private static delimiter = `\x00`;
+  private static readonly delimiter = `\x00`;
   private static keySegmentJoin(...values: string[]): string {
     return values.join(IndexLevel.delimiter);
   }

--- a/packages/dwn-sdk-js/src/store/storage-controller.ts
+++ b/packages/dwn-sdk-js/src/store/storage-controller.ts
@@ -30,10 +30,10 @@ export type ResumableRecordsSquashData = {
  */
 export class StorageController {
 
-  private messageStore: MessageStore;
-  private dataStore: DataStore;
-  private stateIndex: StateIndex;
-  private eventLog?: EventLog;
+  private readonly messageStore: MessageStore;
+  private readonly dataStore: DataStore;
+  private readonly stateIndex: StateIndex;
+  private readonly eventLog?: EventLog;
 
   public constructor({ messageStore, dataStore, stateIndex, eventLog }: {
     messageStore : MessageStore,

--- a/packages/dwn-sdk-js/src/utils/memory-cache.ts
+++ b/packages/dwn-sdk-js/src/utils/memory-cache.ts
@@ -5,12 +5,12 @@ import { LRUCache } from 'lru-cache';
  * A cache using local memory.
  */
 export class MemoryCache implements Cache {
-  private cache: LRUCache<string, any>;
+  private readonly cache: LRUCache<string, any>;
 
   /**
    * @param timeToLiveInSeconds time-to-live for every key-value pair set in the cache
    */
-  public constructor (private timeToLiveInSeconds: number) {
+  public constructor (private readonly timeToLiveInSeconds: number) {
     this.cache = new LRUCache({
       max : 100_000,
       ttl : timeToLiveInSeconds * 1000

--- a/packages/dwn-sdk-js/src/utils/private-key-signer.ts
+++ b/packages/dwn-sdk-js/src/utils/private-key-signer.ts
@@ -30,8 +30,8 @@ export type PrivateKeySignerOptions = {
 export class PrivateKeySigner implements MessageSigner {
   public keyId;
   public algorithm;
-  private privateJwk: PrivateKeyJwk;
-  private signatureAlgorithm;
+  private readonly privateJwk: PrivateKeyJwk;
+  private readonly signatureAlgorithm;
 
   public constructor(options: PrivateKeySignerOptions) {
     if (options.keyId === undefined && options.privateJwk.kid === undefined) {

--- a/packages/dwn-server/src/admin/admin-api.ts
+++ b/packages/dwn-server/src/admin/admin-api.ts
@@ -72,14 +72,14 @@ export class AdminApi {
   #passkeyStore: AdminPasskeyStore | undefined;
   #sessionManager: AdminSessionManager | undefined;
   /** In-memory challenge store: maps challenge → expiry timestamp. */
-  #challenges: Map<string, number> = new Map();
+  readonly #challenges: Map<string, number> = new Map();
   /** Challenge TTL: 60 seconds. */
   static readonly #CHALLENGE_TTL_MS = 60_000;
-  #startTime: number;
+  readonly #startTime: number;
   #packageInfo: { version?: string };
   #metricsInterval: ReturnType<typeof setInterval> | undefined;
   /** Tracks last failed-auth audit timestamp per IP to rate-limit logging. */
-  #failedAuthLog: Map<string, number> = new Map();
+  readonly #failedAuthLog: Map<string, number> = new Map();
   /** Minimum interval between audit log entries for the same IP (60 seconds). */
   static readonly #AUTH_AUDIT_INTERVAL_MS = 60_000;
 

--- a/packages/dwn-server/src/admin/admin-passkey-store.ts
+++ b/packages/dwn-server/src/admin/admin-passkey-store.ts
@@ -34,7 +34,7 @@ export type AdminPasskeyRecord = {
 export class AdminPasskeyStore {
   static readonly #tableName = 'adminPasskeys';
 
-  #db: Kysely<PasskeyDatabase>;
+  readonly #db: Kysely<PasskeyDatabase>;
 
   private constructor(dialect: Dialect) {
     this.#db = new Kysely<PasskeyDatabase>({ dialect });

--- a/packages/dwn-server/src/admin/admin-session.ts
+++ b/packages/dwn-server/src/admin/admin-session.ts
@@ -28,8 +28,8 @@ export class AdminSessionManager {
   /** Cleanup runs every 10 minutes. */
   static readonly #CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
 
-  #sessions: Map<string, SessionEntry> = new Map();
-  #ttlMs: number;
+  readonly #sessions: Map<string, SessionEntry> = new Map();
+  readonly #ttlMs: number;
   #cleanupInterval: ReturnType<typeof setInterval> | undefined;
 
   constructor(ttlSeconds?: number) {

--- a/packages/dwn-server/src/admin/admin-store.ts
+++ b/packages/dwn-server/src/admin/admin-store.ts
@@ -12,10 +12,10 @@ import { getDialectFromUrl } from '../storage.js';
  * runs direct SQL for operations like listing tenants and computing aggregates.
  */
 export class AdminStore {
-  private db: Kysely<AdminDatabase>;
+  private readonly db: Kysely<AdminDatabase>;
   private cachedGlobalStats: GlobalStats | undefined;
   private cachedGlobalStatsTimestamp = 0;
-  private cacheTtlMs: number;
+  private readonly cacheTtlMs: number;
 
   private constructor(dialect: Dialect, cacheTtlMs: number) {
     this.db = new Kysely<AdminDatabase>({ dialect });

--- a/packages/dwn-server/src/admin/audit-log.ts
+++ b/packages/dwn-server/src/admin/audit-log.ts
@@ -70,7 +70,7 @@ export class AuditLog {
   /** Cleanup runs every hour. */
   static readonly #CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 
-  #db: Kysely<AuditDatabase>;
+  readonly #db: Kysely<AuditDatabase>;
   #retentionConfig: AuditRetentionConfig | undefined;
   #cleanupInterval: ReturnType<typeof setInterval> | undefined;
 

--- a/packages/dwn-server/src/admin/webhook-manager.ts
+++ b/packages/dwn-server/src/admin/webhook-manager.ts
@@ -35,7 +35,7 @@ export class WebhookManager {
   static readonly #maxRetries = 3;
   static readonly #retryDelaysMs = [1000, 5000, 15000];
 
-  #db: Kysely<WebhookDatabase>;
+  readonly #db: Kysely<WebhookDatabase>;
 
   private constructor(dialect: Dialect) {
     this.#db = new Kysely<WebhookDatabase>({ dialect });

--- a/packages/dwn-server/src/connect/connect-server.ts
+++ b/packages/dwn-server/src/connect/connect-server.ts
@@ -35,7 +35,7 @@ export type SetConnectRequestResult = {
 export class ConnectServer {
   public static readonly ttlInSeconds = 600;
 
-  private baseUrl: string;
+  private readonly baseUrl: string;
   private cache: SqlTtlCache;
 
   /**

--- a/packages/dwn-server/src/connect/sql-ttl-cache.ts
+++ b/packages/dwn-server/src/connect/sql-ttl-cache.ts
@@ -8,7 +8,7 @@ export class SqlTtlCache {
   private static readonly cacheTableName = 'cacheEntries';
   private static readonly cleanupIntervalInSeconds = 60;
 
-  private db: Kysely<CacheDatabase>;
+  private readonly db: Kysely<CacheDatabase>;
   private cleanupTimer: NodeJS.Timeout;
 
   private constructor(sqlDialect: Dialect) {

--- a/packages/dwn-server/src/connection/connection-manager.ts
+++ b/packages/dwn-server/src/connection/connection-manager.ts
@@ -34,15 +34,15 @@ export interface ConnectionManager {
  */
 export class InMemoryConnectionManager implements ConnectionManager {
   constructor(
-    private dwn: Dwn,
-    private connections: Map<ServerWebSocket<WsData>, SocketConnection> = new Map(),
-    private maxInFlight?: number,
-    private activityLog?: ActivityLog,
-    private adminStore?: AdminStore,
-    private registrationStore?: RegistrationStore,
-    private serverConfig?: DwnServerConfig,
-    private tenantRateLimiter?: RateLimiter,
-    private messageProcessedHooks?: MessageProcessedHook[],
+    private readonly dwn: Dwn,
+    private readonly connections: Map<ServerWebSocket<WsData>, SocketConnection> = new Map(),
+    private readonly maxInFlight?: number,
+    private readonly activityLog?: ActivityLog,
+    private readonly adminStore?: AdminStore,
+    private readonly registrationStore?: RegistrationStore,
+    private readonly serverConfig?: DwnServerConfig,
+    private readonly tenantRateLimiter?: RateLimiter,
+    private readonly messageProcessedHooks?: MessageProcessedHook[],
   ) {}
 
   async connect(socket: ServerWebSocket<WsData>): Promise<void> {

--- a/packages/dwn-server/src/connection/socket-connection.ts
+++ b/packages/dwn-server/src/connection/socket-connection.ts
@@ -38,22 +38,22 @@ export class SocketConnection {
   /** Timestamp when the connection was established (for admin introspection). */
   public readonly connectedAt: number = Date.now();
 
-  private heartbeatInterval: ReturnType<typeof setInterval>;
-  private subscriptions: Map<JsonRpcId, JsonRpcSubscription> = new Map();
-  private flowControllers: Map<JsonRpcId, FlowController> = new Map();
+  private readonly heartbeatInterval: ReturnType<typeof setInterval>;
+  private readonly subscriptions: Map<JsonRpcId, JsonRpcSubscription> = new Map();
+  private readonly flowControllers: Map<JsonRpcId, FlowController> = new Map();
   private isAlive: boolean;
 
   constructor(
-    private socket: ServerWebSocket<WsData>,
-    private dwn: Dwn,
-    private onCloseCallback?: () => void,
-    private maxInFlight: number = DEFAULT_MAX_IN_FLIGHT,
-    private activityLog?: ActivityLog,
-    private adminStore?: AdminStore,
-    private registrationStore?: RegistrationStore,
-    private serverConfig?: DwnServerConfig,
-    private tenantRateLimiter?: RateLimiter,
-    private messageProcessedHooks?: MessageProcessedHook[],
+    private readonly socket: ServerWebSocket<WsData>,
+    private readonly dwn: Dwn,
+    private readonly onCloseCallback?: () => void,
+    private readonly maxInFlight: number = DEFAULT_MAX_IN_FLIGHT,
+    private readonly activityLog?: ActivityLog,
+    private readonly adminStore?: AdminStore,
+    private readonly registrationStore?: RegistrationStore,
+    private readonly serverConfig?: DwnServerConfig,
+    private readonly tenantRateLimiter?: RateLimiter,
+    private readonly messageProcessedHooks?: MessageProcessedHook[],
   ){
     // Bun handles ping/pong automatically at the protocol level, but we still
     // want an application-level heartbeat to detect dead connections.

--- a/packages/dwn-server/src/dwn-server.ts
+++ b/packages/dwn-server/src/dwn-server.ts
@@ -101,9 +101,9 @@ export class DwnServer {
   #auditLog: AuditLog | undefined;
   #passkeyStore: AdminPasskeyStore | undefined;
   #sessionManager: AdminSessionManager | undefined;
-  #externalHooks: MessageProcessedHook[];
-  #externalRegistrationManager: RegistrationManager | undefined;
-  #externalOpenAuthHandler: OpenAuthHandler | undefined;
+  readonly #externalHooks: MessageProcessedHook[];
+  readonly #externalRegistrationManager: RegistrationManager | undefined;
+  readonly #externalOpenAuthHandler: OpenAuthHandler | undefined;
 
   /**
    * @param options.dwn - Dwn instance to use as an override.

--- a/packages/dwn-server/src/plugins/event-log-nats.ts
+++ b/packages/dwn-server/src/plugins/event-log-nats.ts
@@ -161,13 +161,13 @@ function tenantToSubjectToken(tenant: string): string {
  * Must be a default export with a no-arg constructor.
  */
 export default class NatsEventLog implements EventLog {
-  #config: NatsEventLogConfig;
+  readonly #config: NatsEventLogConfig;
   #nc: NatsConnection | undefined;
   #js: JetStreamClient | undefined;
   #jsm: JetStreamManager | undefined;
 
   /** Active subscription consumers, keyed by consumer name. */
-  #activeConsumers: Map<string, { messages?: ConsumerMessages; stopped: boolean }> = new Map();
+  readonly #activeConsumers: Map<string, { messages?: ConsumerMessages; stopped: boolean }> = new Map();
 
   /**
    * Epoch for this EventLog instance. Stable as long as the JetStream stream exists.

--- a/packages/dwn-server/src/rate-limiter.ts
+++ b/packages/dwn-server/src/rate-limiter.ts
@@ -25,7 +25,7 @@ type Bucket = {
 export class RateLimiter {
   #refillRate: number;
   #maxTokens: number;
-  #buckets: Map<string, Bucket> = new Map();
+  readonly #buckets: Map<string, Bucket> = new Map();
   #cleanupInterval: ReturnType<typeof setInterval> | undefined;
 
   /** Stale buckets older than 5 minutes are purged. */

--- a/packages/dwn-server/src/registration/jwt-provider-auth-plugin.ts
+++ b/packages/dwn-server/src/registration/jwt-provider-auth-plugin.ts
@@ -36,9 +36,9 @@ export type JwtProviderAuthPluginOptions = {
  * {@link ProviderAuthPlugin} instead.
  */
 export class JwtProviderAuthPlugin implements ProviderAuthPlugin {
-  #getKey: Uint8Array | jose.JWTVerifyGetKey;
-  #issuer: string | undefined;
-  #audience: string | undefined;
+  readonly #getKey: Uint8Array | jose.JWTVerifyGetKey;
+  readonly #issuer: string | undefined;
+  readonly #audience: string | undefined;
 
   private constructor(
     getKey: Uint8Array | jose.JWTVerifyGetKey,

--- a/packages/dwn-server/src/registration/open-auth-handler.ts
+++ b/packages/dwn-server/src/registration/open-auth-handler.ts
@@ -28,14 +28,14 @@ const MAX_PENDING_CODES = 10_000;
 const CLEANUP_INTERVAL_MS = 60_000;
 
 export class OpenAuthHandler {
-  #secret: Uint8Array;
-  #issuer: string;
+  readonly #secret: Uint8Array;
+  readonly #issuer: string;
   /** Pending authorization codes. Maps code → { redirectUri, expiresAt }. */
-  #pendingCodes: Map<string, { redirectUri: string; expiresAt: number }>;
+  readonly #pendingCodes: Map<string, { redirectUri: string; expiresAt: number }>;
   /** Registration token TTL in seconds. Default: 1 year. */
-  #tokenTtlSeconds: number;
+  readonly #tokenTtlSeconds: number;
   /** Periodic cleanup timer for expired codes. */
-  #cleanupTimer: ReturnType<typeof setInterval>;
+  readonly #cleanupTimer: ReturnType<typeof setInterval>;
 
   private constructor(secret: Uint8Array, issuer: string, tokenTtlSeconds: number) {
     this.#secret = secret;

--- a/packages/dwn-server/src/registration/proof-of-work-manager.ts
+++ b/packages/dwn-server/src/registration/proof-of-work-manager.ts
@@ -20,14 +20,14 @@ export class ProofOfWorkManager {
 
   // There is opportunity to improve implementation here.
   // TODO: https://github.com/enboxorg/enbox/issues/101
-  private proofOfWorkOfLastMinute: Map<string, number> = new Map(); // proofOfWorkId -> timestamp of proof-of-work
+  private readonly proofOfWorkOfLastMinute: Map<string, number> = new Map(); // proofOfWorkId -> timestamp of proof-of-work
 
   // Seed to generate the challenge nonce from, this allows all DWN instances in a cluster to generate the same challenge.
-  private challengeSeed?: string;
-  private difficultyIncreaseMultiplier: number;
+  private readonly challengeSeed?: string;
+  private readonly difficultyIncreaseMultiplier: number;
   private currentMaximumAllowedHashValueAsBigInt: bigint;
-  private initialMaximumAllowedHashValueAsBigInt: bigint;
-  private desiredSolveCountPerMinute: number;
+  private readonly initialMaximumAllowedHashValueAsBigInt: bigint;
+  private readonly desiredSolveCountPerMinute: number;
 
   /**
    * How often the challenge nonce is refreshed.

--- a/packages/dwn-server/src/registration/registration-store.ts
+++ b/packages/dwn-server/src/registration/registration-store.ts
@@ -12,7 +12,7 @@ export class RegistrationStore {
   private static readonly registeredTenantTableName = 'registeredTenants';
   private static readonly tenantQuotasTableName = 'tenantQuotas';
 
-  private db: Kysely<RegistrationDatabase>;
+  private readonly db: Kysely<RegistrationDatabase>;
 
   private constructor (sqlDialect: Dialect) {
     this.db = new Kysely<RegistrationDatabase>({ dialect: sqlDialect });

--- a/packages/dwn-server/src/server-migration-runner.ts
+++ b/packages/dwn-server/src/server-migration-runner.ts
@@ -11,7 +11,7 @@ import { Migrator } from 'kysely';
  * dialect, producing the concrete Kysely {@link Migration} objects.
  */
 class ServerMigrationProvider implements MigrationProvider {
-  #dialect: Dialect;
+  readonly #dialect: Dialect;
   #factories: ReadonlyArray<readonly [name: string, factory: ServerMigrationFactory]>;
 
   constructor(

--- a/packages/dwn-server/src/ws-api.ts
+++ b/packages/dwn-server/src/ws-api.ts
@@ -14,7 +14,7 @@ import { InMemoryConnectionManager } from './connection/connection-manager.js';
 
 export class WsApi {
   dwn: Dwn;
-  #connectionManager: ConnectionManager;
+  readonly #connectionManager: ConnectionManager;
 
   constructor(
     httpApi: HttpApi, dwn: Dwn, connectionManager?: ConnectionManager,

--- a/packages/dwn-sql-store/src/blockstore-sql.ts
+++ b/packages/dwn-sql-store/src/blockstore-sql.ts
@@ -17,8 +17,8 @@ import { CID } from 'multiformats';
  * `DataStoreSql`. This class does not own the connection lifecycle.
  */
 export class BlockstoreSql implements Blockstore {
-  #db: Kysely<DwnDatabaseType>;
-  #rootDataCid: string;
+  readonly #db: Kysely<DwnDatabaseType>;
+  readonly #rootDataCid: string;
 
   constructor(db: Kysely<DwnDatabaseType>, rootDataCid: string) {
     this.#db = db;

--- a/packages/dwn-sql-store/src/data-store-s3.ts
+++ b/packages/dwn-sql-store/src/data-store-s3.ts
@@ -29,12 +29,12 @@ import { Kysely, sql } from 'kysely';
  * (`queueSize * partSize`).
  */
 export class DataStoreS3 implements DataStore {
-  #dialect: Dialect;
+  readonly #dialect: Dialect;
   #db: Kysely<DwnDatabaseType> | null = null;
-  #s3: S3Client;
-  #bucket: string;
-  #partSize: number;
-  #queueSize: number;
+  readonly #s3: S3Client;
+  readonly #bucket: string;
+  readonly #partSize: number;
+  readonly #queueSize: number;
 
   constructor(config: DataStoreS3Config) {
     this.#dialect = config.dialect;

--- a/packages/dwn-sql-store/src/data-store-sql.ts
+++ b/packages/dwn-sql-store/src/data-store-sql.ts
@@ -23,7 +23,7 @@ import { Kysely, sql } from 'kysely';
  * when the last ref to a `dataCid` is gone.
  */
 export class DataStoreSql implements DataStore {
-  #dialect: Dialect;
+  readonly #dialect: Dialect;
   #db: Kysely<DwnDatabaseType> | null = null;
 
   constructor(dialect: Dialect) {

--- a/packages/dwn-sql-store/src/message-store-sql.ts
+++ b/packages/dwn-sql-store/src/message-store-sql.ts
@@ -27,8 +27,8 @@ import { Kysely, sql } from 'kysely';
 
 
 export class MessageStoreSql implements MessageStore {
-  #dialect: Dialect;
-  #tags: TagTables;
+  readonly #dialect: Dialect;
+  readonly #tags: TagTables;
   #db: Kysely<DwnDatabaseType> | null = null;
 
   constructor(dialect: Dialect) {

--- a/packages/dwn-sql-store/src/migration-provider.ts
+++ b/packages/dwn-sql-store/src/migration-provider.ts
@@ -25,7 +25,7 @@ export type DwnMigrationFactory = (dialect: Dialect) => Migration;
  * ```
  */
 export class DwnMigrationProvider implements MigrationProvider {
-  #dialect: Dialect;
+  readonly #dialect: Dialect;
   #factories: ReadonlyArray<readonly [name: string, factory: DwnMigrationFactory]>;
 
   constructor(

--- a/packages/dwn-sql-store/src/resumable-task-store-sql.ts
+++ b/packages/dwn-sql-store/src/resumable-task-store-sql.ts
@@ -9,7 +9,7 @@ import { Kysely, sql } from 'kysely';
 export class ResumableTaskStoreSql implements ResumableTaskStore {
   private static readonly taskTimeoutInSeconds = 60;
 
-  #dialect: Dialect;
+  readonly #dialect: Dialect;
   #db: Kysely<DwnDatabaseType> | null = null;
 
   constructor(dialect: Dialect) {

--- a/packages/dwn-sql-store/src/smt-store-sql.ts
+++ b/packages/dwn-sql-store/src/smt-store-sql.ts
@@ -27,9 +27,9 @@ export type SMTStoreSqlParams = {
 };
 
 export class SMTStoreSql implements SMTNodeStore {
-  #db: Kysely<DwnDatabaseType>;
-  #tenant: string;
-  #scope: string;
+  readonly #db: Kysely<DwnDatabaseType>;
+  readonly #tenant: string;
+  readonly #scope: string;
 
   constructor({ db, tenant, scope }: SMTStoreSqlParams) {
     this.#db = db;

--- a/packages/dwn-sql-store/src/state-index-sql.ts
+++ b/packages/dwn-sql-store/src/state-index-sql.ts
@@ -21,7 +21,7 @@ import { SparseMerkleTree } from '@enbox/dwn-sdk-js';
 import { Kysely, sql } from 'kysely';
 
 export class StateIndexSql implements StateIndex {
-  #dialect: Dialect;
+  readonly #dialect: Dialect;
   #db: Kysely<DwnDatabaseType> | null = null;
 
   /**
@@ -29,13 +29,13 @@ export class StateIndexSql implements StateIndex {
    * Stores promises to avoid race conditions when multiple concurrent operations
    * trigger lazy initialization for the same tenant.
    */
-  #globalTrees: Map<string, Promise<SparseMerkleTree>> = new Map();
+  readonly #globalTrees: Map<string, Promise<SparseMerkleTree>> = new Map();
 
   /**
    * Cache of per-tenant, per-protocol SMTs. Key format: `{tenant}\x00{protocol}`.
    * Stores promises to avoid race conditions.
    */
-  #protocolTrees: Map<string, Promise<SparseMerkleTree>> = new Map();
+  readonly #protocolTrees: Map<string, Promise<SparseMerkleTree>> = new Map();
 
   constructor(dialect: Dialect) {
     this.#dialect = dialect;

--- a/packages/dwn-sql-store/src/utils/tags.ts
+++ b/packages/dwn-sql-store/src/utils/tags.ts
@@ -13,7 +13,7 @@ export class TagTables {
   /**
    * @param dialect the target dialect, necessary for returning the `insertId`
    */
-  constructor(private dialect: Dialect){}
+  constructor(private readonly dialect: Dialect){}
 
   /**
    * Inserts the given tags associated with the given foreign `insertId`.


### PR DESCRIPTION
## Summary

Adds the `readonly` modifier to ~240 class members across 93 source files that are assigned once (in the constructor or factory method) and never reassigned. This is the largest single SonarCloud rule (S2933) accounting for ~23% of all code smells.

## Scope

All packages with source code:

| Package | Members Fixed |
|---|---|
| `dwn-server` | ~47 |
| `api` | ~40 |
| `dwn-sdk-js` | ~26 (12 were fixed in #876) |
| `agent` | ~33 |
| `dwn-sql-store` | ~14 |
| `auth` | ~12 |
| `dwn-clients` | ~8 |
| `dids` | ~4 |
| `crypto` | ~2 |
| `common` | ~2 |

## What changed

- `private foo` → `private readonly foo` where the member is never reassigned
- `private #foo` → `readonly #foo` for ES private fields
- `constructor(private foo)` → `constructor(private readonly foo)` for parameter properties
- Fixed `readonly static` → `static readonly` ordering where the script got it backwards
- Reverted a few false positives where members ARE reassigned (e.g. `_isAlive`, `_session`, `_state`, `_readableStream`, `resumableTaskBatchSize`)

## Verification

- Lint: 27/27 tasks pass
- Build: all packages pass
- No behavioral changes — `readonly` is a compile-time-only constraint