### PR TITLE
docs: rewrite README for developer-facing positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,183 +1,289 @@
-# Enbox
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./assets/enbox-mark-dark.svg">
+  <img alt="Enbox" src="./assets/enbox-mark-light.svg" width="40">
+</picture>
 
-[![CI](https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/ci.yml?branch=main&label=ci&color=2ea043)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Apache--2.0-357ec7)](./LICENSE)
-[![Bun](https://img.shields.io/badge/runtime-Bun-%23e8d5b7?logo=bun&logoColor=f9f1e1)](https://bun.sh)
+# en**b**ox
 
-> **Research Preview** -- Enbox is under heavy development. Expect breaking changes. Not yet accepting external contributions. See [Status & Contributing](#status--contributing).
+### The decentralised backend for web apps.
 
-A toolkit for decentralized identity and encrypted personal data storage.
+[![CI](https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/ci.yml?branch=main&label=ci&style=flat-square&color=2ea043)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-545d69?style=flat-square)](./LICENSE)
+[![Bun](https://img.shields.io/badge/runtime-Bun-f9f1e1?style=flat-square&logo=bun&logoColor=f9f1e1)](https://bun.sh)
+[![npm](https://img.shields.io/npm/v/@enbox/api?style=flat-square&label=%40enbox%2Fapi&color=357ec7)](https://www.npmjs.com/package/@enbox/api)
 
-## Table of Contents
+---
 
-- [Why Enbox?](#why-enbox)
-- [Quick Start](#quick-start)
-- [How It Works](#how-it-works)
-- [Packages](#packages)
-- [Testing](#testing)
-- [Development](#development)
-- [Security](#security)
-- [Status & Contributing](#status--contributing)
+> [!CAUTION]
+> **Research Preview -- Not Production Ready**
+>
+> Enbox is under heavy, active development. You should expect:
+>
+> - **Breaking API changes** without prior deprecation
+> - **Data loss** -- preview DWN servers may be wiped at any time
+> - **Security gaps** -- the codebase has not been audited; do not store sensitive data
+> - **Missing documentation** -- some features are undocumented or partially documented
+>
+> We are not yet accepting external contributions. If you build on Enbox today, pin your
+> dependencies and be prepared to adapt. This notice will be removed when Enbox reaches
+> a stable release.
 
-## Why Enbox?
+---
 
-- **User-owned data** -- Data lives in Decentralized Web Nodes (DWNs) that users control, not in application databases.
-- **End-to-end encryption** -- Two-layer encryption (seed-phrase vault + DWN record-level JWE) with no plaintext fallback.
-- **Protocol-driven** -- Declarative schemas define record types, access rules, and encryption requirements. Interoperable across applications.
-- **Decentralized identity** -- Built on DIDs (`did:dht`, `did:jwk`) with deterministic key derivation and recovery from a 12-word seed phrase.
-- **Cross-platform** -- Runs in Node.js (Bun) and modern browsers (Chrome 101+, Firefox 108+, Safari 16+).
+## What is Enbox?
+
+Think **Supabase or Firebase, but decentralised and user-owned**. Instead of storing your users' data in your database, Enbox gives every user their own encrypted personal datastore -- a [Decentralized Web Node](https://identity.foundation/decentralized-web-node/spec/) (DWN) -- that syncs across devices and apps.
+
+You get the same developer experience you're used to: typed schemas, real-time subscriptions, queries, and a high-level SDK. But your app never touches a centralised database. Users own their data, control who can access it, and can take it with them.
+
+**No vendor lock-in. No server to maintain (unless you want to). No user table.**
+
+### How it compares
+
+| | Supabase / Firebase | Enbox |
+|---|---|---|
+| Data ownership | You host it, you own it | Users own their data |
+| Auth | Email/password, OAuth | Decentralized Identifiers (DIDs) + seed phrases |
+| Schema | SQL tables / Firestore collections | Protocol definitions (declarative, portable) |
+| Real-time | Postgres changes / Firestore snapshots | DWN subscriptions (LiveQuery) |
+| Encryption | At-rest (server-side) | End-to-end (two-layer: vault + record-level JWE) |
+| Hosting | Managed cloud | Self-host, use preview servers, or both |
+| Vendor lock-in | Yes | No -- data follows the user |
+
+---
 
 ## Quick Start
-
-Most applications only need the `@enbox/api` package:
 
 ```bash
 bun add @enbox/api
 ```
 
-```ts
-import { defineProtocol, Web5 } from '@enbox/api';
+### 1. Connect
 
-// Connect -- creates a local agent, identity vault, and DID
+Create an agent with a DID. Data syncs to the DWN endpoints you specify -- use a [preview server](#preview-dwn-servers) or [your own](#deploy-your-own).
+
+```ts
+import { Web5 } from '@enbox/api';
+
 const { web5, did: myDid } = await Web5.connect({
   password: 'user-chosen-password',
+  didCreateOptions: {
+    dwnEndpoints: ['https://enbox-dwn.fly.dev'],  // ← your DWN server(s)
+  },
 });
+```
 
-// Define a protocol with typed data shapes
-const NotesProtocol = defineProtocol({
-  protocol  : 'https://example.com/notes',
-  published : true,
+### 2. Define a protocol
+
+Protocols are like schemas -- they describe record types, access rules, and encryption. Any app that speaks the same protocol can interoperate.
+
+```ts
+import { defineProtocol } from '@enbox/api';
+
+const TaskProtocol = defineProtocol({
+  protocol  : 'https://example.com/tasks',
+  published : false,
   types     : {
-    note: {
-      schema      : 'https://example.com/schemas/note',
+    project: {
+      schema      : 'https://example.com/schemas/project',
       dataFormats : ['application/json'],
+    },
+    task: {
+      schema              : 'https://example.com/schemas/task',
+      dataFormats         : ['application/json'],
+      encryptionRequired  : true,   // ← encrypted at the DWN layer
     },
   },
   structure: {
-    note: {},
+    project: {
+      $tags: { name: { type: 'string' } },    // queryable metadata
+      task: {},                                 // tasks nest under projects
+    },
   },
 } as const, {} as {
-  note: { title: string; body: string };
+  project: { name: string; description?: string };
+  task:    { title: string; done: boolean; assignee?: string };
+});
+```
+
+### 3. Write and query data
+
+```ts
+const tasks = web5.using(TaskProtocol);
+await tasks.configure();   // install the protocol on the local DWN
+
+// Create a project
+const { record: project } = await tasks.records.create('project', {
+  data: { name: 'Launch', description: 'Ship the MVP' },
+  tags: { name: 'Launch' },
 });
 
-// Scope all operations to the protocol
-const notes = web5.using(NotesProtocol);
-await notes.configure();
-
-// Create a record (path, data, and schema are type-checked)
-const { record } = await notes.records.create('note', {
-  data: { title: 'Hello', body: 'World' },
+// Create a task nested under the project (encrypted automatically)
+await tasks.records.create('task', {
+  parentContextId : project.contextId,
+  data            : { title: 'Write README', done: false },
 });
 
-// Query records back -- data is typed automatically
-const { records } = await notes.records.query('note');
-for (const r of records) {
-  const note = await r.data.json(); // { title: string; body: string }
-  console.log(r.id, note.title);
+// Query all projects
+const { records: projects } = await tasks.records.query('project');
+for (const p of projects) {
+  const data = await p.data.json();   // { name: string; description?: string }
+  console.log(data.name);
 }
 ```
 
-See the [`@enbox/api` README](./packages/api/README.md) for the repository pattern, pre-built protocols, subscriptions, and full API reference.
+### 4. Subscribe to changes
 
-## How It Works
-
-```
-┌──────────────────────────────────────────────────────────┐
-│  Your Application                                        │
-│  ┌────────────────────────────────────────────────────┐  │
-│  │  @enbox/api   (Web5.connect, typed protocols)      │  │
-│  └────────────────────────┬───────────────────────────┘  │
-│  ┌────────────────────────▼───────────────────────────┐  │
-│  │  @enbox/agent  (identity vault, keys, sync)        │  │
-│  └────────────────────────┬───────────────────────────┘  │
-│  ┌────────────────────────▼───────────────────────────┐  │
-│  │  @enbox/dwn-sdk-js  (protocol engine, handlers)    │  │
-│  └────────────────────────┬───────────────────────────┘  │
-└───────────────────────────┼──────────────────────────────┘
-                            │ sync
-              ┌─────────────▼─────────────┐
-              │  @enbox/dwn-server        │
-              │  Remote DWN (HTTP/WS)     │
-              │  + SQL storage            │
-              └───────────────────────────┘
+```ts
+const { subscription } = await tasks.subscribe();
+subscription.on('change', () => {
+  // Re-query or refresh your UI -- changes sync across devices
+  console.log('Data changed');
+});
 ```
 
-**Agent**: Manages DIDs, cryptographic keys, and an encrypted identity vault (BIP-39 seed phrase). Syncs data between local and remote DWNs.
+See the [`@enbox/api` README](./packages/api/README.md) for the full API: repository pattern, singletons, pagination, permissions, and more.
 
-**DWN**: A personal datastore governed by [protocols](https://identity.foundation/decentralized-web-node/spec/) -- declarative schemas that define record types, access control, and encryption rules. Each user controls their own node.
+---
 
-**Two-Layer Encryption**: (1) A user password encrypts the agent's portable DID as AES-256-GCM JWE via PBKDF2. (2) Protocol types with `encryptionRequired: true` are encrypted using ECDH-ES+A256KW key agreement with the tenant's X25519 key. Recovery requires only the 12-word seed phrase.
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Your Application                                            │
+│                                                              │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │  @enbox/api                                            │  │
+│  │  Web5.connect() · defineProtocol() · typed queries     │  │
+│  └────────────────────────┬───────────────────────────────┘  │
+│  ┌────────────────────────▼───────────────────────────────┐  │
+│  │  @enbox/agent                                          │  │
+│  │  Identity vault · key management · DWN sync engine     │  │
+│  └────────────────────────┬───────────────────────────────┘  │
+│  ┌────────────────────────▼───────────────────────────────┐  │
+│  │  @enbox/dwn-sdk-js                                     │  │
+│  │  Protocol engine · message handlers · storage layer    │  │
+│  └────────────────────────┬───────────────────────────────┘  │
+└───────────────────────────┼──────────────────────────────────┘
+                            │  sync (HTTP + WebSocket)
+              ┌─────────────▼──────────────┐
+              │  @enbox/dwn-server         │
+              │  Multi-tenant remote DWN   │
+              │  PostgreSQL · SQLite · S3  │
+              └────────────────────────────┘
+```
+
+**Agent** -- manages DIDs, cryptographic keys, and an encrypted identity vault derived from a 12-word BIP-39 seed phrase. Syncs data between a local DWN (in-browser or on-device) and one or more remote DWN servers.
+
+**DWN** -- a personal datastore governed by [protocols](https://identity.foundation/decentralized-web-node/spec/): declarative schemas that define record types, access control, and encryption rules. Each user controls their own node. Apps that speak the same protocol can interoperate without coordination.
+
+**Two-layer encryption** -- (1) a user password encrypts the agent's identity as AES-256-GCM JWE via PBKDF2. (2) Protocol types with `encryptionRequired: true` are encrypted with ECDH-ES+A256KW key agreement using the tenant's X25519 key. Recovery requires only the seed phrase.
+
+---
+
+## Preview DWN Servers
+
+Two public preview DWN servers are available for development and testing. These are free to use but come with **no uptime guarantees, no data persistence guarantees, and no security guarantees**.
+
+| Server | URL | Infrastructure |
+|---|---|---|
+| **Fly.io** | `https://enbox-dwn.fly.dev` | Fly.io, SQLite |
+| **AWS** | `https://dev.aws.dwn.enbox.id` | ECS + Aurora PostgreSQL, us-east-1 |
+
+Pass one or both when connecting:
+
+```ts
+const { web5 } = await Web5.connect({
+  password: 'my-password',
+  didCreateOptions: {
+    dwnEndpoints: [
+      'https://enbox-dwn.fly.dev',
+      'https://dev.aws.dwn.enbox.id',
+    ],
+  },
+});
+```
+
+Or configure at the auth manager level (for apps using `@enbox/auth` directly):
+
+```ts
+import { AuthManager } from '@enbox/auth';
+
+const auth = await AuthManager.create({
+  dwnEndpoints: ['https://your-dwn.example.com'],  // ← all identities use this
+});
+
+// Or override per-identity at connect time:
+const session = await auth.connectLocal({
+  dwnEndpoints: ['https://eu.dwn.example.com'],    // ← this identity only
+});
+```
+
+Check server health:
+
+```bash
+curl https://enbox-dwn.fly.dev/health
+curl https://dev.aws.dwn.enbox.id/health
+```
+
+### Deploy Your Own
+
+You can self-host a DWN server anywhere Docker runs. The server supports PostgreSQL, SQLite, and MySQL for storage, with optional S3 for large blobs.
+
+```bash
+# Quick start with Docker Compose
+git clone https://github.com/enboxorg/enbox.git
+cd enbox
+docker compose up dwn-server
+```
+
+Then point your app at it:
+
+```ts
+const { web5 } = await Web5.connect({
+  password: 'my-password',
+  didCreateOptions: {
+    dwnEndpoints: ['https://dwn.your-domain.com'],
+  },
+});
+```
+
+See [docs/HOSTING.md](./docs/HOSTING.md) for the full deployment guide: Docker Compose configuration, environment variables, production checklist, Fly.io one-click deploy, and AWS ECS setup.
+
+---
 
 ## Packages
 
 ### Application Layer
 
-| Package | Version | Description |
+| Package | npm | What it does |
 |---|---|---|
-| [`@enbox/api`](./packages/api) | [![npm](https://img.shields.io/npm/v/@enbox/api?color=357ec7)](https://www.npmjs.com/package/@enbox/api) | High-level SDK -- `Web5.connect()`, typed protocols, repository pattern |
-| [`@enbox/protocols`](./packages/protocols) | [![npm](https://img.shields.io/npm/v/@enbox/protocols?color=357ec7)](https://www.npmjs.com/package/@enbox/protocols) | Pre-built protocol definitions with JSON Schemas |
-| [`@enbox/protocol-codegen`](./packages/protocol-codegen) | [![npm](https://img.shields.io/npm/v/@enbox/protocol-codegen?color=357ec7)](https://www.npmjs.com/package/@enbox/protocol-codegen) | CLI: generate TypeScript types from protocol definitions |
+| [`@enbox/api`](./packages/api) | [![npm](https://img.shields.io/npm/v/@enbox/api?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/api) | **Start here.** `Web5.connect()`, typed protocols, queries, subscriptions |
+| [`@enbox/auth`](./packages/auth) | [![npm](https://img.shields.io/npm/v/@enbox/auth?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/auth) | Auth manager: local connect, wallet-connect, session restore |
+| [`@enbox/browser`](./packages/browser) | [![npm](https://img.shields.io/npm/v/@enbox/browser?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/browser) | Browser SDK: `Enbox.connect()`, polyfills, `repository()` helper |
+| [`@enbox/protocols`](./packages/protocols) | [![npm](https://img.shields.io/npm/v/@enbox/protocols?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/protocols) | Pre-built protocol definitions with JSON Schemas |
+| [`@enbox/protocol-codegen`](./packages/protocol-codegen) | [![npm](https://img.shields.io/npm/v/@enbox/protocol-codegen?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/protocol-codegen) | CLI to generate TypeScript types from protocol definitions |
 
 ### Agent & Identity
 
-| Package | Version | Description |
+| Package | npm | What it does |
 |---|---|---|
-| [`@enbox/agent`](./packages/agent) | [![npm](https://img.shields.io/npm/v/@enbox/agent?color=357ec7)](https://www.npmjs.com/package/@enbox/agent) | Agent framework: identity vault, key management, sync engine |
-| [`@enbox/dids`](./packages/dids) | [![npm](https://img.shields.io/npm/v/@enbox/dids?color=357ec7)](https://www.npmjs.com/package/@enbox/dids) | DID methods (`did:dht`, `did:jwk`), resolution |
-| [`@enbox/crypto`](./packages/crypto) | [![npm](https://img.shields.io/npm/v/@enbox/crypto?color=357ec7)](https://www.npmjs.com/package/@enbox/crypto) | Ed25519, X25519, secp256k1, AES, PBKDF2, JWE |
-| [`@enbox/common`](./packages/common) | [![npm](https://img.shields.io/npm/v/@enbox/common?color=357ec7)](https://www.npmjs.com/package/@enbox/common) | Shared utilities: `TtlCache`, `LevelStore`, data conversion |
-| [`@enbox/browser`](./packages/browser) | [![npm](https://img.shields.io/npm/v/@enbox/browser?color=357ec7)](https://www.npmjs.com/package/@enbox/browser) | Browser polyfills and DRL resolution |
+| [`@enbox/agent`](./packages/agent) | [![npm](https://img.shields.io/npm/v/@enbox/agent?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/agent) | Identity vault, key management, DWN sync engine |
+| [`@enbox/dids`](./packages/dids) | [![npm](https://img.shields.io/npm/v/@enbox/dids?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dids) | DID methods (`did:dht`, `did:jwk`, `did:web`), resolution |
+| [`@enbox/crypto`](./packages/crypto) | [![npm](https://img.shields.io/npm/v/@enbox/crypto?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/crypto) | Ed25519, X25519, secp256k1, AES, PBKDF2, JWE |
+| [`@enbox/common`](./packages/common) | [![npm](https://img.shields.io/npm/v/@enbox/common?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/common) | Shared utilities: `TtlCache`, `LevelStore`, data conversion |
 
 ### DWN Infrastructure
 
-| Package | Version | Description |
+| Package | npm | What it does |
 |---|---|---|
-| [`@enbox/dwn-sdk-js`](./packages/dwn-sdk-js) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-sdk-js?color=357ec7)](https://www.npmjs.com/package/@enbox/dwn-sdk-js) | DWN protocol engine, message handlers, storage interfaces |
-| [`@enbox/dwn-clients`](./packages/dwn-clients) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-clients?color=357ec7)](https://www.npmjs.com/package/@enbox/dwn-clients) | DWN client libraries, JSON-RPC transport |
-| [`@enbox/dwn-server`](./packages/dwn-server) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-server?color=357ec7)](https://www.npmjs.com/package/@enbox/dwn-server) | Multi-tenant remote DWN server (HTTP/WS via Bun.serve) |
-| [`@enbox/dwn-relay`](https://github.com/enboxorg/dwn-relay) | -- | DWN relay/cache node (standalone repo) |
-| [`@enbox/dwn-sql-store`](./packages/dwn-sql-store) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-sql-store?color=357ec7)](https://www.npmjs.com/package/@enbox/dwn-sql-store) | SQL-backed DWN storage (PostgreSQL, SQLite, MySQL) |
-| [`@enbox/dwn-server-admin-ui`](./packages/dwn-server-admin-ui) | -- | Admin dashboard for DWN server |
+| [`@enbox/dwn-sdk-js`](./packages/dwn-sdk-js) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-sdk-js?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dwn-sdk-js) | DWN protocol engine, message handlers, storage interfaces |
+| [`@enbox/dwn-clients`](./packages/dwn-clients) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-clients?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dwn-clients) | DWN client libraries, JSON-RPC transport |
+| [`@enbox/dwn-server`](./packages/dwn-server) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-server?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dwn-server) | Multi-tenant DWN server (HTTP/WS via Bun.serve) |
+| [`@enbox/dwn-sql-store`](./packages/dwn-sql-store) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-sql-store?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dwn-sql-store) | SQL-backed storage (PostgreSQL, SQLite, MySQL) |
+| [`@enbox/dwn-relay`](https://github.com/enboxorg/dwn-relay) | -- | DWN relay/cache node ([standalone repo](https://github.com/enboxorg/dwn-relay)) |
 
-### Build Order
-
-```
-@enbox/common → @enbox/crypto → @enbox/dids → @enbox/dwn-sdk-js → @enbox/dwn-clients → @enbox/agent → @enbox/api → @enbox/protocols
-```
-
-## Testing
-
-### Coverage
-
-| Package | Coverage |
-|---|---|
-| `@enbox/api` | [![api](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/api.json&color=2ea043)](packages/api) |
-| `@enbox/agent` | [![agent](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/agent.json&color=2ea043)](packages/agent) |
-| `@enbox/common` | [![common](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/common.json&color=2ea043)](packages/common) |
-| `@enbox/crypto` | [![crypto](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/crypto.json&color=2ea043)](packages/crypto) |
-| `@enbox/dids` | [![dids](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dids.json&color=2ea043)](packages/dids) |
-| `@enbox/dwn-clients` | [![dwn-clients](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-clients.json&color=2ea043)](packages/dwn-clients) |
-| `@enbox/dwn-sdk-js` | [![dwn-sdk-js](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sdk-js.json&color=2ea043)](packages/dwn-sdk-js) |
-| `@enbox/dwn-server` | [![dwn-server](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-server.json&color=2ea043)](packages/dwn-server) |
-| `@enbox/dwn-sql-store` | [![dwn-sql-store](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sql-store.json&color=2ea043)](packages/dwn-sql-store) |
-
-### Browser Support
-
-Seven packages run browser tests via Vitest + Playwright across Chromium, Firefox, and WebKit:
-
-| Package | Chromium | Firefox | WebKit |
-|---|:---:|:---:|:---:|
-| `@enbox/common` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `@enbox/crypto` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `@enbox/dids` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `@enbox/browser` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `@enbox/dwn-sdk-js` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `@enbox/agent` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `@enbox/api` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-
-Browser build targets: Chrome 101+, Firefox 108+, Safari 16+.
-
-For the full testing guide (Docker services, DWN server setup, CI matrix, coverage commands), see [docs/TESTING.md](./docs/TESTING.md).
+---
 
 ## Development
 
@@ -194,50 +300,69 @@ bun install
 bun run build
 ```
 
-See [GETTING_STARTED.md](./GETTING_STARTED.md) for a more detailed walkthrough.
-
-### Common Commands
+### Commands
 
 ```bash
-bun run test:node                          # Run all Node tests
+bun run build                              # Build all packages
+bun run test:node                          # Run all tests
 bun run lint                               # Lint all packages
-bun run lint:fix                           # Auto-fix lint issues
-bun run --filter @enbox/agent build        # Build a specific package
-bun run clean                              # Clean build artifacts
-BROWSER=chromium bun run --filter @enbox/dwn-sdk-js test:browser  # Browser tests
+bun run --filter @enbox/agent build        # Build a single package
 ```
 
-### Hosting a DWN Server
+### Test Infrastructure
 
-See [docs/HOSTING.md](./docs/HOSTING.md) for Docker Compose setup, configuration, production checklist, and Fly.io deployment.
+Several packages require Docker services (Pkarr relay, PostgreSQL, NATS) and a local DWN server for their full test suites.
+
+```bash
+docker compose -f docker-compose.test.yaml up -d --wait
+export DID_DHT_GATEWAY_URI=http://localhost:7527
+bun run test:node
+```
+
+See [docs/TESTING.md](./docs/TESTING.md) for the complete testing guide. See [GETTING_STARTED.md](./GETTING_STARTED.md) for a detailed development walkthrough.
+
+### Test Coverage
+
+| Package | Coverage |
+|---|---|
+| `@enbox/api` | [![api](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/api.json&color=2ea043)](packages/api) |
+| `@enbox/agent` | [![agent](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/agent.json&color=2ea043)](packages/agent) |
+| `@enbox/common` | [![common](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/common.json&color=2ea043)](packages/common) |
+| `@enbox/crypto` | [![crypto](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/crypto.json&color=2ea043)](packages/crypto) |
+| `@enbox/dids` | [![dids](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dids.json&color=2ea043)](packages/dids) |
+| `@enbox/dwn-sdk-js` | [![dwn-sdk-js](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sdk-js.json&color=2ea043)](packages/dwn-sdk-js) |
+| `@enbox/dwn-server` | [![dwn-server](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-server.json&color=2ea043)](packages/dwn-server) |
+| `@enbox/dwn-sql-store` | [![dwn-sql-store](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sql-store.json&color=2ea043)](packages/dwn-sql-store) |
+
+### Browser Support
+
+Chromium, Firefox, and WebKit are tested via Playwright. Build targets: Chrome 101+, Firefox 108+, Safari 16+.
 
 ### Releasing
 
-Packages are published to npm via [Changesets](https://github.com/changesets/changesets). Never bump versions manually -- run `bun changeset` to create a changeset, then CI handles version bumps and publishing.
-
-## Security
-
-If you discover a security vulnerability, please report it responsibly. **Do not open a public issue.** Instead, email [security@enbox.org](mailto:security@enbox.org) with details. We will acknowledge receipt within 48 hours.
-
-## Status & Contributing
-
-Enbox is a **research preview under heavy development**. APIs will change without notice. We are not yet accepting external contributions -- if you're interested in contributing, watch the repo for updates.
-
-See contribution guides in individual packages for context: [dwn-server](./packages/dwn-server/CONTRIBUTING.md), [dwn-sdk-js](./packages/dwn-sdk-js/CONTRIBUTING.md).
-
-## AI / LLM Agent Context
-
-For architecture notes, coding style, test patterns, and build instructions, see [`CLAUDE.md`](./CLAUDE.md).
-
-## License
-
-Apache-2.0
-
-## Related Resources
-
-- [Decentralized Web Node Specification](https://identity.foundation/decentralized-web-node/spec/)
-- [DID Specification](https://www.w3.org/TR/did-core/)
+Packages are published to npm via [Changesets](https://github.com/changesets/changesets). Never bump versions manually -- run `bun changeset`, then CI handles the rest.
 
 ---
 
-*This monorepo consolidates packages from the [decentralized-identity](https://github.com/decentralized-identity) organization, including [dwn-sdk-js](https://github.com/decentralized-identity/dwn-sdk-js), [dwn-server](https://github.com/decentralized-identity/dwn-server), [dwn-sql-store](https://github.com/decentralized-identity/dwn-sql-store), and the web5-js monorepo.*
+## Security
+
+If you discover a security vulnerability, please report it responsibly. **Do not open a public issue.** Email [security@enbox.org](mailto:security@enbox.org) with details. We will acknowledge receipt within 48 hours.
+
+## Status & Contributing
+
+Enbox is a **research preview under heavy development**. APIs will change without notice. We are not yet accepting external contributions -- watch the repo for updates.
+
+## License
+
+[Apache-2.0](./LICENSE)
+
+## Resources
+
+- [Decentralized Web Node Specification](https://identity.foundation/decentralized-web-node/spec/)
+- [DID Core Specification](https://www.w3.org/TR/did-core/)
+- [Enbox Documentation](https://enbox-docs.pages.dev) *(work in progress)*
+- [Hosting Guide](./docs/HOSTING.md)
+
+---
+
+<sub>This monorepo consolidates packages from the [decentralized-identity](https://github.com/decentralized-identity) organisation, including [dwn-sdk-js](https://github.com/decentralized-identity/dwn-sdk-js), [dwn-server](https://github.com/decentralized-identity/dwn-server), [dwn-sql-store](https://github.com/decentralized-identity/dwn-sql-store), and the web5-js monorepo.</sub>

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ Your app talks to a **local DWN** running in the browser or on the device. The a
 
 **Two-layer encryption** -- (1) a user password encrypts the agent's identity as AES-256-GCM JWE via PBKDF2. (2) Protocol types with `encryptionRequired: true` are encrypted with ECDH-ES+A256KW key agreement using the tenant's X25519 key. Recovery requires only the seed phrase.
 
+### Sending data to another user
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./assets/dwn-alice-bob-dark.svg">
+  <img alt="Alice-to-Bob flow: Alice writes a record, her agent resolves Bob's DID to discover his DWN endpoint, sends an encrypted message, and Bob's app syncs it" src="./assets/dwn-alice-bob-light.svg">
+</picture>
+
+When Alice wants to send data to Bob, her agent resolves Bob's DID to discover the DWN service endpoint listed in his DID document. The message is encrypted to Bob's public key and delivered directly to Bob's DWN server. Bob's app picks it up on the next sync. No intermediary, no shared database, no account on Alice's service -- just two DIDs and a protocol they both understand.
+
 ---
 
 ## DWN Servers

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Your app talks to a **local DWN** running in the browser or on the device. The a
   <img alt="Alice-to-Bob flow: Alice writes a record, her agent resolves Bob's DID to discover his DWN endpoint, sends an encrypted message, and Bob's app syncs it" src="./assets/dwn-alice-bob-light.svg">
 </picture>
 
-When Alice wants to send data to Bob, her agent resolves Bob's DID to discover the DWN service endpoint listed in his DID document. The message is encrypted to Bob's public key and delivered directly to Bob's DWN server. Bob's app picks it up on the next sync. No intermediary, no shared database, no account on Alice's service -- just two DIDs and a protocol they both understand.
+Alice's app resolves Bob's DID to discover the DWN service endpoint in his DID document, then sends an encrypted record directly to Bob's DWN. Bob's app picks it up on the next sync. No relay, no shared database, no account on Alice's service -- just two DIDs and a protocol they both understand.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,23 +32,19 @@
 
 ## What is Enbox?
 
-Think **Supabase or Firebase, but decentralised and user-owned**. Instead of storing your users' data in your database, Enbox gives every user their own encrypted personal datastore -- a [Decentralized Web Node](https://identity.foundation/decentralized-web-node/spec/) (DWN) -- that syncs across devices and apps.
+An open-source TypeScript SDK for building apps on [Decentralized Web Nodes](https://identity.foundation/decentralized-web-node/spec/) (DWNs). You get typed schemas, real-time subscriptions, queries, and end-to-end encryption -- but instead of a centralised database, every user gets their own encrypted personal datastore that syncs across devices and apps.
 
-You get the same developer experience you're used to: typed schemas, real-time subscriptions, queries, and a high-level SDK. But your app never touches a centralised database. Users own their data, control who can access it, and can take it with them.
+DWN is an **open standard** -- not an Enbox product. Anyone can run a DWN server, and any app that speaks the same protocol can interoperate. Enbox is a toolkit for building on that standard: an SDK, an agent framework, a server implementation, and the cryptographic primitives underneath.
 
-**No vendor lock-in. No server to maintain (unless you want to). No user table.**
-
-### How it compares
-
-| | Supabase / Firebase | Enbox |
+| | Centralised backend | DWN-based (Enbox) |
 |---|---|---|
-| Data ownership | You host it, you own it | Users own their data |
-| Auth | Email/password, OAuth | Decentralized Identifiers (DIDs) + seed phrases |
-| Schema | SQL tables / Firestore collections | Protocol definitions (declarative, portable) |
-| Real-time | Postgres changes / Firestore snapshots | DWN subscriptions (LiveQuery) |
-| Encryption | At-rest (server-side) | End-to-end (two-layer: vault + record-level JWE) |
-| Hosting | Managed cloud | Self-host, use preview servers, or both |
-| Vendor lock-in | Yes | No -- data follows the user |
+| Data ownership | Provider holds all user data | Each user controls their own node |
+| Auth | Email/password, OAuth providers | Decentralized Identifiers (DIDs) + seed phrase recovery |
+| Schema | SQL tables, document collections | Protocol definitions (declarative, portable across apps) |
+| Real-time | Server-pushed change feeds | DWN subscriptions (LiveQuery) |
+| Encryption | At-rest, server-side | End-to-end (two-layer: vault + record-level JWE) |
+| Hosting | Managed cloud, single vendor | Run your own server, use a community node, or both |
+| Lock-in | Data lives in the provider's infra | Data follows the user -- switch apps without losing anything |
 
 ---
 
@@ -173,24 +169,26 @@ See the [`@enbox/api` README](./packages/api/README.md) for the full API: reposi
               └────────────────────────────┘
 ```
 
-**Agent** -- manages DIDs, cryptographic keys, and an encrypted identity vault derived from a 12-word BIP-39 seed phrase. Syncs data between a local DWN (in-browser or on-device) and one or more remote DWN servers.
+**Agent** -- manages DIDs, cryptographic keys, and an encrypted identity vault derived from a 12-word BIP-39 seed phrase. Syncs data between a local DWN (in-browser or on-device) and any remote DWN server the user has configured.
 
-**DWN** -- a personal datastore governed by [protocols](https://identity.foundation/decentralized-web-node/spec/): declarative schemas that define record types, access control, and encryption rules. Each user controls their own node. Apps that speak the same protocol can interoperate without coordination.
+**DWN** -- an [open-standard](https://identity.foundation/decentralized-web-node/spec/) personal datastore governed by protocols: declarative schemas that define record types, access control, and encryption rules. Each user controls their own node. The server is interchangeable -- run by you, the user, a community operator, or all three.
 
 **Two-layer encryption** -- (1) a user password encrypts the agent's identity as AES-256-GCM JWE via PBKDF2. (2) Protocol types with `encryptionRequired: true` are encrypted with ECDH-ES+A256KW key agreement using the tenant's X25519 key. Recovery requires only the seed phrase.
 
 ---
 
-## Preview DWN Servers
+## DWN Servers
 
-Two public preview DWN servers are available for development and testing. These are free to use but come with **no uptime guarantees, no data persistence guarantees, and no security guarantees**.
+A DWN server is a multi-tenant node that stores and relays messages on behalf of users. **Anyone can run one** -- it's just an HTTP/WebSocket server backed by a database. There is no central authority; users can point their DID at any server (or several).
 
-| Server | URL | Infrastructure |
+We run two preview nodes for development and testing. They are free to use but come with **no uptime, data persistence, or security guarantees**:
+
+| Node | URL | Notes |
 |---|---|---|
-| **Fly.io** | `https://enbox-dwn.fly.dev` | Fly.io, SQLite |
-| **AWS** | `https://dev.aws.dwn.enbox.id` | ECS + Aurora PostgreSQL, us-east-1 |
+| Fly.io | `https://enbox-dwn.fly.dev` | SQLite-backed, single region |
+| AWS | `https://dev.aws.dwn.enbox.id` | Aurora PostgreSQL, us-east-1 |
 
-Pass one or both when connecting:
+Pass any DWN endpoint(s) when connecting:
 
 ```ts
 const { web5 } = await Web5.connect({
@@ -226,9 +224,9 @@ curl https://enbox-dwn.fly.dev/health
 curl https://dev.aws.dwn.enbox.id/health
 ```
 
-### Deploy Your Own
+### Run Your Own Node
 
-You can self-host a DWN server anywhere Docker runs. The server supports PostgreSQL, SQLite, and MySQL for storage, with optional S3 for large blobs.
+The `@enbox/dwn-server` package is a production-ready DWN server that runs anywhere Docker does. It supports PostgreSQL, SQLite, and MySQL for storage, with optional S3 for large blobs.
 
 ```bash
 # Quick start with Docker Compose

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 An open-source TypeScript SDK for building apps on [Decentralized Web Nodes](https://identity.foundation/decentralized-web-node/spec/) (DWNs). You get typed schemas, real-time subscriptions, queries, and end-to-end encryption -- but instead of a centralised database, every user gets their own encrypted personal datastore that syncs across devices and apps.
 
-DWN is an **open standard** -- not an Enbox product. Anyone can run a DWN server, and any app that speaks the same protocol can interoperate. Enbox is a toolkit for building on that standard: an SDK, an agent framework, a server implementation, and the cryptographic primitives underneath.
+DWN is an [open standard](https://identity.foundation/decentralized-web-node/spec/) maintained by the Decentralized Identity Foundation. Anyone can run a DWN server, and any app that speaks the same protocol can interoperate. Enbox provides the tooling to build on that standard: an SDK, an agent framework, a server implementation, and the cryptographic primitives underneath.
 
 | | Centralised backend | DWN-based (Enbox) |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -51,79 +51,78 @@ DWN is an **open standard** -- not an Enbox product. Anyone can run a DWN server
 ## Quick Start
 
 ```bash
-bun add @enbox/api
+bun add @enbox/api @enbox/auth
 ```
 
 ### 1. Connect
 
-Create an agent with a DID. Data syncs to the DWN endpoints you specify -- use a [preview server](#preview-dwn-servers) or [your own](#deploy-your-own).
+Create an auth session and an Enbox instance. Data syncs to whatever DWN endpoint(s) you configure -- a [community node](#dwn-servers), [your own](#run-your-own-node), or both.
 
 ```ts
-import { Web5 } from '@enbox/api';
+import { AuthManager } from '@enbox/auth';
+import { Enbox, defineProtocol } from '@enbox/api';
 
-const { web5, did: myDid } = await Web5.connect({
-  password: 'user-chosen-password',
-  didCreateOptions: {
-    dwnEndpoints: ['https://enbox-dwn.fly.dev'],  // ← your DWN server(s)
-  },
+const auth = await AuthManager.create({
+  dwnEndpoints : ['https://enbox-dwn.fly.dev'],   // ← any DWN server
 });
+
+const session = await auth.connectLocal({ createIdentity: true });
+const enbox   = Enbox.connect({ session });
 ```
 
 ### 2. Define a protocol
 
-Protocols are like schemas -- they describe record types, access rules, and encryption. Any app that speaks the same protocol can interoperate.
+Protocols are declarative schemas -- they describe record types, nesting, access rules, and encryption. Any app that installs the same protocol can read and write the same record shapes.
 
 ```ts
-import { defineProtocol } from '@enbox/api';
-
-const TaskProtocol = defineProtocol({
-  protocol  : 'https://example.com/tasks',
+const BookmarkProtocol = defineProtocol({
+  protocol  : 'https://example.com/bookmarks',
   published : false,
   types     : {
-    project: {
-      schema      : 'https://example.com/schemas/project',
+    folder: {
+      schema      : 'https://example.com/schemas/folder',
       dataFormats : ['application/json'],
     },
-    task: {
-      schema              : 'https://example.com/schemas/task',
+    bookmark: {
+      schema              : 'https://example.com/schemas/bookmark',
       dataFormats         : ['application/json'],
-      encryptionRequired  : true,   // ← encrypted at the DWN layer
+      encryptionRequired  : true,    // ← end-to-end encrypted at the DWN layer
     },
   },
   structure: {
-    project: {
-      $tags: { name: { type: 'string' } },    // queryable metadata
-      task: {},                                 // tasks nest under projects
+    folder: {
+      $tags    : { name: { type: 'string' } },   // queryable server-side
+      bookmark : {},                               // bookmarks nest under folders
     },
   },
 } as const, {} as {
-  project: { name: string; description?: string };
-  task:    { title: string; done: boolean; assignee?: string };
+  folder:   { name: string };
+  bookmark: { url: string; title: string; note?: string };
 });
 ```
 
 ### 3. Write and query data
 
 ```ts
-const tasks = web5.using(TaskProtocol);
-await tasks.configure();   // install the protocol on the local DWN
+const bookmarks = enbox.using(BookmarkProtocol);
+await bookmarks.configure();   // install the protocol on the user's DWN
 
-// Create a project
-const { record: project } = await tasks.records.create('project', {
-  data: { name: 'Launch', description: 'Ship the MVP' },
-  tags: { name: 'Launch' },
+// Create a folder
+const { record: folder } = await bookmarks.records.create('folder', {
+  data : { name: 'Reading List' },
+  tags : { name: 'Reading List' },
 });
 
-// Create a task nested under the project (encrypted automatically)
-await tasks.records.create('task', {
-  parentContextId : project.contextId,
-  data            : { title: 'Write README', done: false },
+// Add a bookmark (nested under the folder, encrypted automatically)
+await bookmarks.records.create('bookmark', {
+  parentContextId : folder.contextId,
+  data            : { url: 'https://example.com', title: 'Example', note: 'Check later' },
 });
 
-// Query all projects
-const { records: projects } = await tasks.records.query('project');
-for (const p of projects) {
-  const data = await p.data.json();   // { name: string; description?: string }
+// Query all folders
+const { records: folders } = await bookmarks.records.query('folder');
+for (const f of folders) {
+  const data = await f.data.json();   // { name: string }
   console.log(data.name);
 }
 ```
@@ -131,14 +130,15 @@ for (const p of projects) {
 ### 4. Subscribe to changes
 
 ```ts
-const { subscription } = await tasks.subscribe();
+const { subscription } = await bookmarks.subscribe();
 subscription.on('change', () => {
-  // Re-query or refresh your UI -- changes sync across devices
-  console.log('Data changed');
+  // Re-query or refresh your UI -- changes sync across devices in real time
 });
 ```
 
-See the [`@enbox/api` README](./packages/api/README.md) for the full API: repository pattern, singletons, pagination, permissions, and more.
+For browser apps, `@enbox/browser` re-exports everything from `@enbox/api` and `@enbox/auth` in a single import plus browser-specific helpers (`BrowserConnectHandler`, wallet-connect, DRL polyfills).
+
+See the [`@enbox/api` README](./packages/api/README.md) for the full API: `repository()` helper, singletons, pagination, permissions, and more.
 
 ---
 
@@ -188,32 +188,23 @@ We run two preview nodes for development and testing. They are free to use but c
 | Fly.io | `https://enbox-dwn.fly.dev` | SQLite-backed, single region |
 | AWS | `https://dev.aws.dwn.enbox.id` | Aurora PostgreSQL, us-east-1 |
 
-Pass any DWN endpoint(s) when connecting:
-
-```ts
-const { web5 } = await Web5.connect({
-  password: 'my-password',
-  didCreateOptions: {
-    dwnEndpoints: [
-      'https://enbox-dwn.fly.dev',
-      'https://dev.aws.dwn.enbox.id',
-    ],
-  },
-});
-```
-
-Or configure at the auth manager level (for apps using `@enbox/auth` directly):
+Set DWN endpoints when creating the auth manager, or override per-identity:
 
 ```ts
 import { AuthManager } from '@enbox/auth';
 
+// Default for all identities created through this manager
 const auth = await AuthManager.create({
-  dwnEndpoints: ['https://your-dwn.example.com'],  // ← all identities use this
+  dwnEndpoints: [
+    'https://enbox-dwn.fly.dev',
+    'https://dev.aws.dwn.enbox.id',
+  ],
 });
 
-// Or override per-identity at connect time:
+// Or override for a specific identity
 const session = await auth.connectLocal({
-  dwnEndpoints: ['https://eu.dwn.example.com'],    // ← this identity only
+  dwnEndpoints  : ['https://eu.dwn.example.com'],
+  createIdentity: true,
 });
 ```
 
@@ -238,11 +229,8 @@ docker compose up dwn-server
 Then point your app at it:
 
 ```ts
-const { web5 } = await Web5.connect({
-  password: 'my-password',
-  didCreateOptions: {
-    dwnEndpoints: ['https://dwn.your-domain.com'],
-  },
+const auth = await AuthManager.create({
+  dwnEndpoints: ['https://dwn.your-domain.com'],
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="./assets/enbox-mark-dark.svg">
-  <img alt="Enbox" src="./assets/enbox-mark-light.svg" width="40">
-</picture>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./assets/enbox-mark-dark.svg">
+    <img alt="Enbox" src="./assets/enbox-mark-light.svg" width="40">
+  </picture>
+</p>
 
-# en**b**ox
+<h1 align="center">en<strong>b</strong>ox</h1>
 
-### The decentralised backend for web apps.
+<p align="center">
+  <strong>The decentralised backend for web apps.</strong>
+</p>
 
-[![CI](https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/ci.yml?branch=main&label=ci&style=flat-square&color=2ea043)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Apache--2.0-545d69?style=flat-square)](./LICENSE)
-[![Bun](https://img.shields.io/badge/runtime-Bun-f9f1e1?style=flat-square&logo=bun&logoColor=f9f1e1)](https://bun.sh)
-[![npm](https://img.shields.io/npm/v/@enbox/api?style=flat-square&label=%40enbox%2Fapi&color=357ec7)](https://www.npmjs.com/package/@enbox/api)
+<p align="center">
+  <a href="https://github.com/enboxorg/enbox/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/enboxorg/enbox/ci.yml?branch=main&label=ci&style=flat-square&color=2ea043" alt="CI"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-545d69?style=flat-square" alt="License"></a>
+  <a href="https://bun.sh"><img src="https://img.shields.io/badge/runtime-Bun-f9f1e1?style=flat-square&logo=bun&logoColor=f9f1e1" alt="Bun"></a>
+  <a href="https://www.npmjs.com/package/@enbox/api"><img src="https://img.shields.io/npm/v/@enbox/api?style=flat-square&label=%40enbox%2Fapi&color=357ec7" alt="npm"></a>
+</p>
 
 ---
 
@@ -142,34 +148,16 @@ See the [`@enbox/api` README](./packages/api/README.md) for the full API: `repos
 
 ---
 
-## Architecture
+## How it works
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│  Your Application                                            │
-│                                                              │
-│  ┌────────────────────────────────────────────────────────┐  │
-│  │  @enbox/api                                            │  │
-│  │  Web5.connect() · defineProtocol() · typed queries     │  │
-│  └────────────────────────┬───────────────────────────────┘  │
-│  ┌────────────────────────▼───────────────────────────────┐  │
-│  │  @enbox/agent                                          │  │
-│  │  Identity vault · key management · DWN sync engine     │  │
-│  └────────────────────────┬───────────────────────────────┘  │
-│  ┌────────────────────────▼───────────────────────────────┐  │
-│  │  @enbox/dwn-sdk-js                                     │  │
-│  │  Protocol engine · message handlers · storage layer    │  │
-│  └────────────────────────┬───────────────────────────────┘  │
-└───────────────────────────┼──────────────────────────────────┘
-                            │  sync (HTTP + WebSocket)
-              ┌─────────────▼──────────────┐
-              │  @enbox/dwn-server         │
-              │  Multi-tenant remote DWN   │
-              │  PostgreSQL · SQLite · S3  │
-              └────────────────────────────┘
-```
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./assets/dwn-flow-dark.svg">
+  <img alt="DWN sync flow: Your App → Local DWN → encrypted sync → Remote DWN → other devices" src="./assets/dwn-flow-light.svg">
+</picture>
 
-**Agent** -- manages DIDs, cryptographic keys, and an encrypted identity vault derived from a 12-word BIP-39 seed phrase. Syncs data between a local DWN (in-browser or on-device) and any remote DWN server the user has configured.
+Your app talks to a **local DWN** running in the browser or on the device. The agent syncs encrypted messages to one or more **remote DWN servers** over HTTP/WebSocket. The remote server stores ciphertext -- it cannot read the data. Other devices and apps sync from the same remote node, staying in sync automatically.
+
+**Agent** -- manages DIDs, cryptographic keys, and an encrypted identity vault derived from a 12-word BIP-39 seed phrase. Syncs data between the local DWN and any remote DWN server the user has configured.
 
 **DWN** -- an [open-standard](https://identity.foundation/decentralized-web-node/spec/) personal datastore governed by protocols: declarative schemas that define record types, access control, and encryption rules. Each user controls their own node. The server is interchangeable -- run by you, the user, a community operator, or all three.
 
@@ -332,7 +320,7 @@ Packages are published to npm via [Changesets](https://github.com/changesets/cha
 
 ## Security
 
-If you discover a security vulnerability, please report it responsibly. **Do not open a public issue.** Email [security@enbox.org](mailto:security@enbox.org) with details. We will acknowledge receipt within 48 hours.
+If you discover a security vulnerability, please report it responsibly. **Do not open a public issue.** Email [security@enboxorg.com](mailto:security@enboxorg.com) with details. We will acknowledge receipt within 48 hours.
 
 ## Status & Contributing
 

--- a/assets/dwn-alice-bob-dark.svg
+++ b/assets/dwn-alice-bob-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 280" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 310" fill="none">
   <style>
     text { font-family: ui-monospace, 'JetBrains Mono', 'Cascadia Code', monospace; }
     .label { fill: #ffffff; font-size: 13px; font-weight: 600; }
@@ -25,79 +25,79 @@
   </style>
 
   <!-- Background -->
-  <rect width="800" height="280" fill="#0e1011" rx="12"/>
+  <rect width="820" height="310" fill="#0e1011" rx="12"/>
 
   <!-- ═══ ALICE (left) ═══ -->
 
-  <text x="50" y="30" class="persona" fill="#5ef2c8">ALICE</text>
+  <text x="40" y="30" class="persona" fill="#5ef2c8">ALICE</text>
 
-  <rect x="50" y="40" width="140" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
-  <text x="120" y="74" text-anchor="middle" class="label">Alice's App</text>
-  <text x="120" y="92" text-anchor="middle" class="sublabel">@enbox/api</text>
+  <rect x="40" y="42" width="150" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
+  <text x="115" y="76" text-anchor="middle" class="label">Alice's App</text>
+  <text x="115" y="94" text-anchor="middle" class="sublabel">@enbox/api</text>
 
   <!-- ═══ DID RESOLUTION (center) ═══ -->
 
-  <rect x="290" y="40" width="180" height="80" class="box" fill="#131618" stroke="#21252a"/>
-  <text x="380" y="72" text-anchor="middle" class="label" fill="#66c2ff">DID Resolution</text>
-  <text x="380" y="92" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
+  <rect x="300" y="42" width="200" height="80" class="box" fill="#131618" stroke="#21252a"/>
+  <text x="400" y="76" text-anchor="middle" class="label" fill="#66c2ff">DID Resolution</text>
+  <text x="400" y="94" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
 
   <!-- Arrow: Alice -> Resolver (step 1) -->
-  <line x1="190" y1="65" x2="288" y2="65" class="arrow-resolve"/>
-  <polygon points="288,60 298,65 288,70" fill="#66c2ff"/>
-  <text x="239" y="57" text-anchor="middle" class="step" fill="#66c2ff">1</text>
+  <line x1="190" y1="68" x2="298" y2="68" class="arrow-resolve"/>
+  <polygon points="298,63 308,68 298,73" fill="#66c2ff"/>
+  <text x="244" y="58" text-anchor="middle" class="step" fill="#66c2ff">1</text>
 
   <!-- Animated resolve dots -->
-  <circle cx="222" cy="65" r="2.5" class="dot-blue d1"/>
-  <circle cx="244" cy="65" r="2.5" class="dot-blue d2"/>
-  <circle cx="266" cy="65" r="2.5" class="dot-blue d3"/>
+  <circle cx="225" cy="68" r="2.5" class="dot-blue d1"/>
+  <circle cx="250" cy="68" r="2.5" class="dot-blue d2"/>
+  <circle cx="275" cy="68" r="2.5" class="dot-blue d3"/>
 
-  <!-- Arrow: Resolver returns endpoint (step 1 return) -->
-  <line x1="288" y1="95" x2="190" y2="95" class="arrow-resolve"/>
-  <polygon points="190,90 180,95 190,100" fill="#66c2ff"/>
-  <text x="239" y="109" text-anchor="middle" class="did-text">Bob's DWN endpoint</text>
+  <!-- Arrow: Resolver returns endpoint -->
+  <line x1="298" y1="96" x2="190" y2="96" class="arrow-resolve"/>
+  <polygon points="190,91 180,96 190,101" fill="#66c2ff"/>
+  <text x="244" y="114" text-anchor="middle" class="did-text">Bob's DWN endpoint</text>
 
   <!-- ═══ BOB (right) ═══ -->
 
-  <text x="570" y="30" class="persona" fill="#ff9f6a">BOB</text>
+  <text x="620" y="30" class="persona" fill="#ff9f6a">BOB</text>
 
   <!-- Bob's DWN -->
-  <rect x="570" y="40" width="140" height="80" class="box" fill="#1a1d20" stroke="#3d444d"/>
-  <text x="640" y="74" text-anchor="middle" class="label">Bob's DWN</text>
-  <text x="640" y="92" text-anchor="middle" class="did-text">did:dht:bob...</text>
+  <rect x="620" y="42" width="150" height="80" class="box" fill="#1a1d20" stroke="#3d444d"/>
+  <text x="695" y="76" text-anchor="middle" class="label">Bob's DWN</text>
+  <text x="695" y="94" text-anchor="middle" class="did-text">did:dht:bob...</text>
 
   <!-- Bob's App -->
-  <rect x="570" y="160" width="140" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
-  <text x="640" y="194" text-anchor="middle" class="label">Bob's App</text>
-  <text x="640" y="212" text-anchor="middle" class="sublabel">@enbox/api</text>
+  <rect x="620" y="180" width="150" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
+  <text x="695" y="214" text-anchor="middle" class="label">Bob's App</text>
+  <text x="695" y="232" text-anchor="middle" class="sublabel">@enbox/api</text>
 
   <!-- Arrow: Alice App -> Bob DWN (step 2 — send encrypted message) -->
-  <path d="M 120 120 L 120 148 L 568 148 L 568 122" class="arrow-accent" fill="none"/>
-  <polygon points="563,122 568,112 573,122" fill="#5ef2c8"/>
-  <text x="344" y="142" text-anchor="middle" class="step" fill="#5ef2c8">2</text>
+  <path d="M 115 122 L 115 155 L 618 155 L 618 124" class="arrow-accent" fill="none"/>
+  <polygon points="613,124 618,114 623,124" fill="#5ef2c8"/>
+  <text x="366" y="148" text-anchor="middle" class="step" fill="#5ef2c8">2</text>
 
   <!-- Animated send dots -->
-  <circle cx="250" cy="148" r="3" class="dot d4"/>
-  <circle cx="344" cy="148" r="3" class="dot d5"/>
-  <circle cx="438" cy="148" r="3" class="dot d6"/>
+  <circle cx="250" cy="155" r="3" class="dot d4"/>
+  <circle cx="380" cy="155" r="3" class="dot d5"/>
+  <circle cx="510" cy="155" r="3" class="dot d6"/>
 
   <!-- Arrow: Bob DWN -> Bob App (step 3 — sync) -->
-  <line x1="640" y1="120" x2="640" y2="158" class="arrow"/>
-  <polygon points="635,158 640,168 645,158" fill="#545d69"/>
-  <text x="655" y="145" class="step">3</text>
+  <line x1="695" y1="122" x2="695" y2="178" class="arrow"/>
+  <polygon points="690,178 695,188 700,178" fill="#545d69"/>
+  <text x="710" y="155" class="step">3</text>
 
-  <!-- ═══ STEP LABELS ═══ -->
+  <!-- ═══ STEP LEGEND ═══ -->
 
-  <rect x="50" y="230" width="660" height="36" rx="6" fill="#131618" stroke="#21252a" stroke-width="1"/>
+  <rect x="40" y="272" width="730" height="28" rx="6" fill="#131618" stroke="#21252a" stroke-width="1"/>
 
-  <circle cx="72" cy="248" r="8" fill="#1a1d20" stroke="#66c2ff" stroke-width="1"/>
-  <text x="72" y="252" text-anchor="middle" class="step" fill="#66c2ff">1</text>
-  <text x="88" y="252" class="sublabel">Resolve Bob's DID → discover DWN endpoint</text>
+  <circle cx="62" cy="286" r="8" fill="#1a1d20" stroke="#66c2ff" stroke-width="1"/>
+  <text x="62" y="290" text-anchor="middle" class="step" fill="#66c2ff">1</text>
+  <text x="78" y="290" class="sublabel">Resolve Bob's DID → discover endpoint</text>
 
-  <circle cx="340" cy="248" r="8" fill="#1a1d20" stroke="#5ef2c8" stroke-width="1"/>
-  <text x="340" y="252" text-anchor="middle" class="step" fill="#5ef2c8">2</text>
-  <text x="356" y="252" class="sublabel">Send encrypted record directly to Bob's DWN</text>
+  <circle cx="318" cy="286" r="8" fill="#1a1d20" stroke="#5ef2c8" stroke-width="1"/>
+  <text x="318" y="290" text-anchor="middle" class="step" fill="#5ef2c8">2</text>
+  <text x="334" y="290" class="sublabel">Send encrypted record to Bob's DWN</text>
 
-  <circle cx="580" cy="248" r="8" fill="#1a1d20" stroke="#545d69" stroke-width="1"/>
-  <text x="580" y="252" text-anchor="middle" class="step">3</text>
-  <text x="596" y="252" class="sublabel">Bob's app syncs and decrypts</text>
+  <circle cx="576" cy="286" r="8" fill="#1a1d20" stroke="#545d69" stroke-width="1"/>
+  <text x="576" y="290" text-anchor="middle" class="step">3</text>
+  <text x="592" y="290" class="sublabel">Bob's app syncs and decrypts</text>
 </svg>

--- a/assets/dwn-alice-bob-dark.svg
+++ b/assets/dwn-alice-bob-dark.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 320" fill="none">
+  <style>
+    text { font-family: ui-monospace, 'JetBrains Mono', 'Cascadia Code', monospace; }
+    .label { fill: #ffffff; font-size: 13px; font-weight: 600; }
+    .sublabel { fill: #78828f; font-size: 10px; }
+    .step { fill: #545d69; font-size: 10px; font-weight: 600; }
+    .box { stroke-width: 1.5; rx: 8; }
+    .arrow { stroke: #545d69; stroke-width: 1.5; stroke-linecap: round; }
+    .arrow-accent { stroke: #5ef2c8; stroke-width: 1.5; stroke-linecap: round; }
+    .arrow-resolve { stroke: #66c2ff; stroke-width: 1.5; stroke-linecap: round; stroke-dasharray: 6 4; }
+    .dot { fill: #5ef2c8; }
+    .dot-blue { fill: #66c2ff; }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.3; }
+      50% { opacity: 1; }
+    }
+    .d1 { animation: pulse 2.4s ease-in-out infinite; }
+    .d2 { animation: pulse 2.4s ease-in-out 0.3s infinite; }
+    .d3 { animation: pulse 2.4s ease-in-out 0.6s infinite; }
+    .d4 { animation: pulse 2.4s ease-in-out 0.15s infinite; }
+    .d5 { animation: pulse 2.4s ease-in-out 0.45s infinite; }
+    .d6 { animation: pulse 2.4s ease-in-out 0.75s infinite; }
+    .persona { font-size: 11px; font-weight: 600; letter-spacing: 0.5px; }
+    .did-text { fill: #78828f; font-size: 9px; }
+  </style>
+
+  <!-- Background -->
+  <rect width="800" height="320" fill="#0e1011" rx="12"/>
+
+  <!-- ═══ ALICE ROW (y=40) ═══ -->
+
+  <!-- Alice persona label -->
+  <text x="30" y="30" class="persona" fill="#5ef2c8">ALICE</text>
+
+  <!-- Alice's App -->
+  <rect x="30" y="40" width="130" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
+  <text x="95" y="74" text-anchor="middle" class="label">Alice's App</text>
+  <text x="95" y="92" text-anchor="middle" class="sublabel">@enbox/api</text>
+
+  <!-- Alice's DWN -->
+  <rect x="220" y="40" width="130" height="80" class="box" fill="#1a1d20" stroke="#3d444d"/>
+  <text x="285" y="74" text-anchor="middle" class="label">Alice's DWN</text>
+  <text x="285" y="92" text-anchor="middle" class="did-text">did:dht:alice...</text>
+
+  <!-- Arrow: Alice App -> Alice DWN -->
+  <line x1="160" y1="80" x2="218" y2="80" class="arrow"/>
+  <polygon points="218,75 228,80 218,85" fill="#545d69"/>
+  <text x="189" y="72" text-anchor="middle" class="step">1</text>
+
+  <!-- ═══ DID RESOLUTION (center) ═══ -->
+
+  <!-- DID Resolver cloud -->
+  <rect x="310" y="150" width="180" height="60" class="box" fill="#131618" stroke="#21252a"/>
+  <text x="400" y="176" text-anchor="middle" class="label" fill="#66c2ff">DID Resolution</text>
+  <text x="400" y="193" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
+
+  <!-- Arrow: Alice DWN -> Resolver (resolve Bob's DID) -->
+  <path d="M 285 120 L 285 155 L 308 155" class="arrow-resolve" fill="none"/>
+  <polygon points="308,150 318,155 308,160" fill="#66c2ff"/>
+  <text x="272" y="142" text-anchor="middle" class="step" fill="#66c2ff">2</text>
+  <text x="285" y="155" text-anchor="end" class="did-text" dx="-8">resolve did:dht:bob...</text>
+
+  <!-- Arrow: Resolver -> returns endpoint -->
+  <path d="M 490 170 L 530 170 L 530 80 L 538 80" class="arrow-resolve" fill="none"/>
+  <polygon points="538,75 548,80 538,85" fill="#66c2ff"/>
+  <text x="552" y="142" text-anchor="middle" class="did-text">DWN endpoint</text>
+
+  <!-- Animated resolve dots -->
+  <circle cx="340" cy="155" r="2.5" class="dot-blue d1"/>
+  <circle cx="360" cy="155" r="2.5" class="dot-blue d2"/>
+  <circle cx="380" cy="155" r="2.5" class="dot-blue d3"/>
+
+  <!-- ═══ BOB ROW (y=40) ═══ -->
+
+  <!-- Bob persona label -->
+  <text x="550" y="30" class="persona" fill="#ff9f6a">BOB</text>
+
+  <!-- Bob's Remote DWN -->
+  <rect x="550" y="40" width="130" height="80" class="box" fill="#1a1d20" stroke="#3d444d"/>
+  <text x="615" y="74" text-anchor="middle" class="label">Bob's DWN</text>
+  <text x="615" y="92" text-anchor="middle" class="did-text">did:dht:bob...</text>
+
+  <!-- Bob's App -->
+  <rect x="550" y="230" width="130" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
+  <text x="615" y="264" text-anchor="middle" class="label">Bob's App</text>
+  <text x="615" y="282" text-anchor="middle" class="sublabel">@enbox/api</text>
+
+  <!-- Arrow: Alice DWN -> Bob DWN (send message) -->
+  <line x1="350" y1="72" x2="548" y2="72" class="arrow-accent"/>
+  <polygon points="548,67 558,72 548,77" fill="#5ef2c8"/>
+  <text x="449" y="64" text-anchor="middle" class="step" fill="#5ef2c8">3</text>
+
+  <!-- Animated send dots -->
+  <circle cx="410" cy="72" r="3" class="dot d4"/>
+  <circle cx="440" cy="72" r="3" class="dot d5"/>
+  <circle cx="470" cy="72" r="3" class="dot d6"/>
+
+  <!-- Arrow: Bob DWN -> Bob App (sync) -->
+  <line x1="615" y1="120" x2="615" y2="228" class="arrow"/>
+  <polygon points="610,228 615,238 620,228" fill="#545d69"/>
+  <text x="628" y="178" class="step">4</text>
+
+  <!-- ═══ STEP LABELS ═══ -->
+
+  <rect x="30" y="260" width="420" height="50" rx="6" fill="#131618" stroke="#21252a" stroke-width="1"/>
+
+  <circle cx="50" cy="275" r="8" fill="#1a1d20" stroke="#545d69" stroke-width="1"/>
+  <text x="50" y="279" text-anchor="middle" class="step">1</text>
+  <text x="66" y="279" class="sublabel">Alice writes a record</text>
+
+  <circle cx="50" cy="296" r="8" fill="#1a1d20" stroke="#66c2ff" stroke-width="1"/>
+  <text x="50" y="300" text-anchor="middle" class="step" fill="#66c2ff">2</text>
+  <text x="66" y="300" class="sublabel">Agent resolves Bob's DID to find his DWN endpoint</text>
+
+  <circle cx="250" cy="275" r="8" fill="#1a1d20" stroke="#5ef2c8" stroke-width="1"/>
+  <text x="250" y="279" text-anchor="middle" class="step" fill="#5ef2c8">3</text>
+  <text x="266" y="279" class="sublabel">Encrypted message sent to Bob's DWN</text>
+
+  <circle cx="250" cy="296" r="8" fill="#1a1d20" stroke="#545d69" stroke-width="1"/>
+  <text x="250" y="300" text-anchor="middle" class="step">4</text>
+  <text x="266" y="300" class="sublabel">Bob's app syncs and decrypts</text>
+</svg>

--- a/assets/dwn-alice-bob-dark.svg
+++ b/assets/dwn-alice-bob-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 320" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 280" fill="none">
   <style>
     text { font-family: ui-monospace, 'JetBrains Mono', 'Cascadia Code', monospace; }
     .label { fill: #ffffff; font-size: 13px; font-weight: 600; }
@@ -25,98 +25,79 @@
   </style>
 
   <!-- Background -->
-  <rect width="800" height="320" fill="#0e1011" rx="12"/>
+  <rect width="800" height="280" fill="#0e1011" rx="12"/>
 
-  <!-- ═══ ALICE ROW (y=40) ═══ -->
+  <!-- ═══ ALICE (left) ═══ -->
 
-  <!-- Alice persona label -->
-  <text x="30" y="30" class="persona" fill="#5ef2c8">ALICE</text>
+  <text x="50" y="30" class="persona" fill="#5ef2c8">ALICE</text>
 
-  <!-- Alice's App -->
-  <rect x="30" y="40" width="130" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
-  <text x="95" y="74" text-anchor="middle" class="label">Alice's App</text>
-  <text x="95" y="92" text-anchor="middle" class="sublabel">@enbox/api</text>
-
-  <!-- Alice's DWN -->
-  <rect x="220" y="40" width="130" height="80" class="box" fill="#1a1d20" stroke="#3d444d"/>
-  <text x="285" y="74" text-anchor="middle" class="label">Alice's DWN</text>
-  <text x="285" y="92" text-anchor="middle" class="did-text">did:dht:alice...</text>
-
-  <!-- Arrow: Alice App -> Alice DWN -->
-  <line x1="160" y1="80" x2="218" y2="80" class="arrow"/>
-  <polygon points="218,75 228,80 218,85" fill="#545d69"/>
-  <text x="189" y="72" text-anchor="middle" class="step">1</text>
+  <rect x="50" y="40" width="140" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
+  <text x="120" y="74" text-anchor="middle" class="label">Alice's App</text>
+  <text x="120" y="92" text-anchor="middle" class="sublabel">@enbox/api</text>
 
   <!-- ═══ DID RESOLUTION (center) ═══ -->
 
-  <!-- DID Resolver cloud -->
-  <rect x="310" y="150" width="180" height="60" class="box" fill="#131618" stroke="#21252a"/>
-  <text x="400" y="176" text-anchor="middle" class="label" fill="#66c2ff">DID Resolution</text>
-  <text x="400" y="193" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
+  <rect x="290" y="40" width="180" height="80" class="box" fill="#131618" stroke="#21252a"/>
+  <text x="380" y="72" text-anchor="middle" class="label" fill="#66c2ff">DID Resolution</text>
+  <text x="380" y="92" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
 
-  <!-- Arrow: Alice DWN -> Resolver (resolve Bob's DID) -->
-  <path d="M 285 120 L 285 155 L 308 155" class="arrow-resolve" fill="none"/>
-  <polygon points="308,150 318,155 308,160" fill="#66c2ff"/>
-  <text x="272" y="142" text-anchor="middle" class="step" fill="#66c2ff">2</text>
-  <text x="285" y="155" text-anchor="end" class="did-text" dx="-8">resolve did:dht:bob...</text>
-
-  <!-- Arrow: Resolver -> returns endpoint -->
-  <path d="M 490 170 L 530 170 L 530 80 L 538 80" class="arrow-resolve" fill="none"/>
-  <polygon points="538,75 548,80 538,85" fill="#66c2ff"/>
-  <text x="552" y="142" text-anchor="middle" class="did-text">DWN endpoint</text>
+  <!-- Arrow: Alice -> Resolver (step 1) -->
+  <line x1="190" y1="65" x2="288" y2="65" class="arrow-resolve"/>
+  <polygon points="288,60 298,65 288,70" fill="#66c2ff"/>
+  <text x="239" y="57" text-anchor="middle" class="step" fill="#66c2ff">1</text>
 
   <!-- Animated resolve dots -->
-  <circle cx="340" cy="155" r="2.5" class="dot-blue d1"/>
-  <circle cx="360" cy="155" r="2.5" class="dot-blue d2"/>
-  <circle cx="380" cy="155" r="2.5" class="dot-blue d3"/>
+  <circle cx="222" cy="65" r="2.5" class="dot-blue d1"/>
+  <circle cx="244" cy="65" r="2.5" class="dot-blue d2"/>
+  <circle cx="266" cy="65" r="2.5" class="dot-blue d3"/>
 
-  <!-- ═══ BOB ROW (y=40) ═══ -->
+  <!-- Arrow: Resolver returns endpoint (step 1 return) -->
+  <line x1="288" y1="95" x2="190" y2="95" class="arrow-resolve"/>
+  <polygon points="190,90 180,95 190,100" fill="#66c2ff"/>
+  <text x="239" y="109" text-anchor="middle" class="did-text">Bob's DWN endpoint</text>
 
-  <!-- Bob persona label -->
-  <text x="550" y="30" class="persona" fill="#ff9f6a">BOB</text>
+  <!-- ═══ BOB (right) ═══ -->
 
-  <!-- Bob's Remote DWN -->
-  <rect x="550" y="40" width="130" height="80" class="box" fill="#1a1d20" stroke="#3d444d"/>
-  <text x="615" y="74" text-anchor="middle" class="label">Bob's DWN</text>
-  <text x="615" y="92" text-anchor="middle" class="did-text">did:dht:bob...</text>
+  <text x="570" y="30" class="persona" fill="#ff9f6a">BOB</text>
+
+  <!-- Bob's DWN -->
+  <rect x="570" y="40" width="140" height="80" class="box" fill="#1a1d20" stroke="#3d444d"/>
+  <text x="640" y="74" text-anchor="middle" class="label">Bob's DWN</text>
+  <text x="640" y="92" text-anchor="middle" class="did-text">did:dht:bob...</text>
 
   <!-- Bob's App -->
-  <rect x="550" y="230" width="130" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
-  <text x="615" y="264" text-anchor="middle" class="label">Bob's App</text>
-  <text x="615" y="282" text-anchor="middle" class="sublabel">@enbox/api</text>
+  <rect x="570" y="160" width="140" height="80" class="box" fill="#1a1d20" stroke="#2a2f35"/>
+  <text x="640" y="194" text-anchor="middle" class="label">Bob's App</text>
+  <text x="640" y="212" text-anchor="middle" class="sublabel">@enbox/api</text>
 
-  <!-- Arrow: Alice DWN -> Bob DWN (send message) -->
-  <line x1="350" y1="72" x2="548" y2="72" class="arrow-accent"/>
-  <polygon points="548,67 558,72 548,77" fill="#5ef2c8"/>
-  <text x="449" y="64" text-anchor="middle" class="step" fill="#5ef2c8">3</text>
+  <!-- Arrow: Alice App -> Bob DWN (step 2 — send encrypted message) -->
+  <path d="M 120 120 L 120 148 L 568 148 L 568 122" class="arrow-accent" fill="none"/>
+  <polygon points="563,122 568,112 573,122" fill="#5ef2c8"/>
+  <text x="344" y="142" text-anchor="middle" class="step" fill="#5ef2c8">2</text>
 
   <!-- Animated send dots -->
-  <circle cx="410" cy="72" r="3" class="dot d4"/>
-  <circle cx="440" cy="72" r="3" class="dot d5"/>
-  <circle cx="470" cy="72" r="3" class="dot d6"/>
+  <circle cx="250" cy="148" r="3" class="dot d4"/>
+  <circle cx="344" cy="148" r="3" class="dot d5"/>
+  <circle cx="438" cy="148" r="3" class="dot d6"/>
 
-  <!-- Arrow: Bob DWN -> Bob App (sync) -->
-  <line x1="615" y1="120" x2="615" y2="228" class="arrow"/>
-  <polygon points="610,228 615,238 620,228" fill="#545d69"/>
-  <text x="628" y="178" class="step">4</text>
+  <!-- Arrow: Bob DWN -> Bob App (step 3 — sync) -->
+  <line x1="640" y1="120" x2="640" y2="158" class="arrow"/>
+  <polygon points="635,158 640,168 645,158" fill="#545d69"/>
+  <text x="655" y="145" class="step">3</text>
 
   <!-- ═══ STEP LABELS ═══ -->
 
-  <rect x="30" y="260" width="420" height="50" rx="6" fill="#131618" stroke="#21252a" stroke-width="1"/>
+  <rect x="50" y="230" width="660" height="36" rx="6" fill="#131618" stroke="#21252a" stroke-width="1"/>
 
-  <circle cx="50" cy="275" r="8" fill="#1a1d20" stroke="#545d69" stroke-width="1"/>
-  <text x="50" y="279" text-anchor="middle" class="step">1</text>
-  <text x="66" y="279" class="sublabel">Alice writes a record</text>
+  <circle cx="72" cy="248" r="8" fill="#1a1d20" stroke="#66c2ff" stroke-width="1"/>
+  <text x="72" y="252" text-anchor="middle" class="step" fill="#66c2ff">1</text>
+  <text x="88" y="252" class="sublabel">Resolve Bob's DID → discover DWN endpoint</text>
 
-  <circle cx="50" cy="296" r="8" fill="#1a1d20" stroke="#66c2ff" stroke-width="1"/>
-  <text x="50" y="300" text-anchor="middle" class="step" fill="#66c2ff">2</text>
-  <text x="66" y="300" class="sublabel">Agent resolves Bob's DID to find his DWN endpoint</text>
+  <circle cx="340" cy="248" r="8" fill="#1a1d20" stroke="#5ef2c8" stroke-width="1"/>
+  <text x="340" y="252" text-anchor="middle" class="step" fill="#5ef2c8">2</text>
+  <text x="356" y="252" class="sublabel">Send encrypted record directly to Bob's DWN</text>
 
-  <circle cx="250" cy="275" r="8" fill="#1a1d20" stroke="#5ef2c8" stroke-width="1"/>
-  <text x="250" y="279" text-anchor="middle" class="step" fill="#5ef2c8">3</text>
-  <text x="266" y="279" class="sublabel">Encrypted message sent to Bob's DWN</text>
-
-  <circle cx="250" cy="296" r="8" fill="#1a1d20" stroke="#545d69" stroke-width="1"/>
-  <text x="250" y="300" text-anchor="middle" class="step">4</text>
-  <text x="266" y="300" class="sublabel">Bob's app syncs and decrypts</text>
+  <circle cx="580" cy="248" r="8" fill="#1a1d20" stroke="#545d69" stroke-width="1"/>
+  <text x="580" y="252" text-anchor="middle" class="step">3</text>
+  <text x="596" y="252" class="sublabel">Bob's app syncs and decrypts</text>
 </svg>

--- a/assets/dwn-alice-bob-light.svg
+++ b/assets/dwn-alice-bob-light.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 320" fill="none">
+  <style>
+    text { font-family: ui-monospace, 'JetBrains Mono', 'Cascadia Code', monospace; }
+    .label { fill: #1a1d20; font-size: 13px; font-weight: 600; }
+    .sublabel { fill: #545d69; font-size: 10px; }
+    .step { fill: #78828f; font-size: 10px; font-weight: 600; }
+    .box { stroke-width: 1.5; rx: 8; }
+    .arrow { stroke: #a0a9b4; stroke-width: 1.5; stroke-linecap: round; }
+    .arrow-accent { stroke: #0d9668; stroke-width: 1.5; stroke-linecap: round; }
+    .arrow-resolve { stroke: #2b7ab5; stroke-width: 1.5; stroke-linecap: round; stroke-dasharray: 6 4; }
+    .dot { fill: #0d9668; }
+    .dot-blue { fill: #2b7ab5; }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.3; }
+      50% { opacity: 1; }
+    }
+    .d1 { animation: pulse 2.4s ease-in-out infinite; }
+    .d2 { animation: pulse 2.4s ease-in-out 0.3s infinite; }
+    .d3 { animation: pulse 2.4s ease-in-out 0.6s infinite; }
+    .d4 { animation: pulse 2.4s ease-in-out 0.15s infinite; }
+    .d5 { animation: pulse 2.4s ease-in-out 0.45s infinite; }
+    .d6 { animation: pulse 2.4s ease-in-out 0.75s infinite; }
+    .persona { font-size: 11px; font-weight: 600; letter-spacing: 0.5px; }
+    .did-text { fill: #78828f; font-size: 9px; }
+  </style>
+
+  <!-- Background -->
+  <rect width="800" height="320" fill="#f3f4f6" rx="12"/>
+
+  <!-- ═══ ALICE ROW ═══ -->
+
+  <text x="30" y="30" class="persona" fill="#0d9668">ALICE</text>
+
+  <rect x="30" y="40" width="130" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
+  <text x="95" y="74" text-anchor="middle" class="label">Alice's App</text>
+  <text x="95" y="92" text-anchor="middle" class="sublabel">@enbox/api</text>
+
+  <rect x="220" y="40" width="130" height="80" class="box" fill="#ffffff" stroke="#a0a9b4"/>
+  <text x="285" y="74" text-anchor="middle" class="label">Alice's DWN</text>
+  <text x="285" y="92" text-anchor="middle" class="did-text">did:dht:alice...</text>
+
+  <line x1="160" y1="80" x2="218" y2="80" class="arrow"/>
+  <polygon points="218,75 228,80 218,85" fill="#a0a9b4"/>
+  <text x="189" y="72" text-anchor="middle" class="step">1</text>
+
+  <!-- ═══ DID RESOLUTION ═══ -->
+
+  <rect x="310" y="150" width="180" height="60" class="box" fill="#e2e5e9" stroke="#c4cad1"/>
+  <text x="400" y="176" text-anchor="middle" class="label" fill="#2b7ab5">DID Resolution</text>
+  <text x="400" y="193" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
+
+  <path d="M 285 120 L 285 155 L 308 155" class="arrow-resolve" fill="none"/>
+  <polygon points="308,150 318,155 308,160" fill="#2b7ab5"/>
+  <text x="272" y="142" text-anchor="middle" class="step" fill="#2b7ab5">2</text>
+  <text x="285" y="155" text-anchor="end" class="did-text" dx="-8">resolve did:dht:bob...</text>
+
+  <path d="M 490 170 L 530 170 L 530 80 L 538 80" class="arrow-resolve" fill="none"/>
+  <polygon points="538,75 548,80 538,85" fill="#2b7ab5"/>
+  <text x="552" y="142" text-anchor="middle" class="did-text">DWN endpoint</text>
+
+  <circle cx="340" cy="155" r="2.5" class="dot-blue d1"/>
+  <circle cx="360" cy="155" r="2.5" class="dot-blue d2"/>
+  <circle cx="380" cy="155" r="2.5" class="dot-blue d3"/>
+
+  <!-- ═══ BOB ROW ═══ -->
+
+  <text x="550" y="30" class="persona" fill="#d4713a">BOB</text>
+
+  <rect x="550" y="40" width="130" height="80" class="box" fill="#ffffff" stroke="#a0a9b4"/>
+  <text x="615" y="74" text-anchor="middle" class="label">Bob's DWN</text>
+  <text x="615" y="92" text-anchor="middle" class="did-text">did:dht:bob...</text>
+
+  <rect x="550" y="230" width="130" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
+  <text x="615" y="264" text-anchor="middle" class="label">Bob's App</text>
+  <text x="615" y="282" text-anchor="middle" class="sublabel">@enbox/api</text>
+
+  <line x1="350" y1="72" x2="548" y2="72" class="arrow-accent"/>
+  <polygon points="548,67 558,72 548,77" fill="#0d9668"/>
+  <text x="449" y="64" text-anchor="middle" class="step" fill="#0d9668">3</text>
+
+  <circle cx="410" cy="72" r="3" class="dot d4"/>
+  <circle cx="440" cy="72" r="3" class="dot d5"/>
+  <circle cx="470" cy="72" r="3" class="dot d6"/>
+
+  <line x1="615" y1="120" x2="615" y2="228" class="arrow"/>
+  <polygon points="610,228 615,238 620,228" fill="#a0a9b4"/>
+  <text x="628" y="178" class="step">4</text>
+
+  <!-- ═══ STEP LABELS ═══ -->
+
+  <rect x="30" y="260" width="420" height="50" rx="6" fill="#e2e5e9" stroke="#c4cad1" stroke-width="1"/>
+
+  <circle cx="50" cy="275" r="8" fill="#ffffff" stroke="#a0a9b4" stroke-width="1"/>
+  <text x="50" y="279" text-anchor="middle" class="step">1</text>
+  <text x="66" y="279" class="sublabel">Alice writes a record</text>
+
+  <circle cx="50" cy="296" r="8" fill="#ffffff" stroke="#2b7ab5" stroke-width="1"/>
+  <text x="50" y="300" text-anchor="middle" class="step" fill="#2b7ab5">2</text>
+  <text x="66" y="300" class="sublabel">Agent resolves Bob's DID to find his DWN endpoint</text>
+
+  <circle cx="250" cy="275" r="8" fill="#ffffff" stroke="#0d9668" stroke-width="1"/>
+  <text x="250" y="279" text-anchor="middle" class="step" fill="#0d9668">3</text>
+  <text x="266" y="279" class="sublabel">Encrypted message sent to Bob's DWN</text>
+
+  <circle cx="250" cy="296" r="8" fill="#ffffff" stroke="#a0a9b4" stroke-width="1"/>
+  <text x="250" y="300" text-anchor="middle" class="step">4</text>
+  <text x="266" y="300" class="sublabel">Bob's app syncs and decrypts</text>
+</svg>

--- a/assets/dwn-alice-bob-light.svg
+++ b/assets/dwn-alice-bob-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 320" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 280" fill="none">
   <style>
     text { font-family: ui-monospace, 'JetBrains Mono', 'Cascadia Code', monospace; }
     .label { fill: #1a1d20; font-size: 13px; font-weight: 600; }
@@ -25,84 +25,77 @@
   </style>
 
   <!-- Background -->
-  <rect width="800" height="320" fill="#f3f4f6" rx="12"/>
+  <rect width="800" height="280" fill="#f3f4f6" rx="12"/>
 
-  <!-- ═══ ALICE ROW ═══ -->
+  <!-- ═══ ALICE (left) ═══ -->
 
-  <text x="30" y="30" class="persona" fill="#0d9668">ALICE</text>
+  <text x="50" y="30" class="persona" fill="#0d9668">ALICE</text>
 
-  <rect x="30" y="40" width="130" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
-  <text x="95" y="74" text-anchor="middle" class="label">Alice's App</text>
-  <text x="95" y="92" text-anchor="middle" class="sublabel">@enbox/api</text>
+  <rect x="50" y="40" width="140" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
+  <text x="120" y="74" text-anchor="middle" class="label">Alice's App</text>
+  <text x="120" y="92" text-anchor="middle" class="sublabel">@enbox/api</text>
 
-  <rect x="220" y="40" width="130" height="80" class="box" fill="#ffffff" stroke="#a0a9b4"/>
-  <text x="285" y="74" text-anchor="middle" class="label">Alice's DWN</text>
-  <text x="285" y="92" text-anchor="middle" class="did-text">did:dht:alice...</text>
+  <!-- ═══ DID RESOLUTION (center) ═══ -->
 
-  <line x1="160" y1="80" x2="218" y2="80" class="arrow"/>
-  <polygon points="218,75 228,80 218,85" fill="#a0a9b4"/>
-  <text x="189" y="72" text-anchor="middle" class="step">1</text>
+  <rect x="290" y="40" width="180" height="80" class="box" fill="#e2e5e9" stroke="#c4cad1"/>
+  <text x="380" y="72" text-anchor="middle" class="label" fill="#2b7ab5">DID Resolution</text>
+  <text x="380" y="92" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
 
-  <!-- ═══ DID RESOLUTION ═══ -->
+  <!-- Arrow: Alice -> Resolver -->
+  <line x1="190" y1="65" x2="288" y2="65" class="arrow-resolve"/>
+  <polygon points="288,60 298,65 288,70" fill="#2b7ab5"/>
+  <text x="239" y="57" text-anchor="middle" class="step" fill="#2b7ab5">1</text>
 
-  <rect x="310" y="150" width="180" height="60" class="box" fill="#e2e5e9" stroke="#c4cad1"/>
-  <text x="400" y="176" text-anchor="middle" class="label" fill="#2b7ab5">DID Resolution</text>
-  <text x="400" y="193" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
+  <!-- Animated resolve dots -->
+  <circle cx="222" cy="65" r="2.5" class="dot-blue d1"/>
+  <circle cx="244" cy="65" r="2.5" class="dot-blue d2"/>
+  <circle cx="266" cy="65" r="2.5" class="dot-blue d3"/>
 
-  <path d="M 285 120 L 285 155 L 308 155" class="arrow-resolve" fill="none"/>
-  <polygon points="308,150 318,155 308,160" fill="#2b7ab5"/>
-  <text x="272" y="142" text-anchor="middle" class="step" fill="#2b7ab5">2</text>
-  <text x="285" y="155" text-anchor="end" class="did-text" dx="-8">resolve did:dht:bob...</text>
+  <!-- Arrow: Resolver returns endpoint -->
+  <line x1="288" y1="95" x2="190" y2="95" class="arrow-resolve"/>
+  <polygon points="190,90 180,95 190,100" fill="#2b7ab5"/>
+  <text x="239" y="109" text-anchor="middle" class="did-text">Bob's DWN endpoint</text>
 
-  <path d="M 490 170 L 530 170 L 530 80 L 538 80" class="arrow-resolve" fill="none"/>
-  <polygon points="538,75 548,80 538,85" fill="#2b7ab5"/>
-  <text x="552" y="142" text-anchor="middle" class="did-text">DWN endpoint</text>
+  <!-- ═══ BOB (right) ═══ -->
 
-  <circle cx="340" cy="155" r="2.5" class="dot-blue d1"/>
-  <circle cx="360" cy="155" r="2.5" class="dot-blue d2"/>
-  <circle cx="380" cy="155" r="2.5" class="dot-blue d3"/>
+  <text x="570" y="30" class="persona" fill="#d4713a">BOB</text>
 
-  <!-- ═══ BOB ROW ═══ -->
+  <rect x="570" y="40" width="140" height="80" class="box" fill="#ffffff" stroke="#a0a9b4"/>
+  <text x="640" y="74" text-anchor="middle" class="label">Bob's DWN</text>
+  <text x="640" y="92" text-anchor="middle" class="did-text">did:dht:bob...</text>
 
-  <text x="550" y="30" class="persona" fill="#d4713a">BOB</text>
+  <rect x="570" y="160" width="140" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
+  <text x="640" y="194" text-anchor="middle" class="label">Bob's App</text>
+  <text x="640" y="212" text-anchor="middle" class="sublabel">@enbox/api</text>
 
-  <rect x="550" y="40" width="130" height="80" class="box" fill="#ffffff" stroke="#a0a9b4"/>
-  <text x="615" y="74" text-anchor="middle" class="label">Bob's DWN</text>
-  <text x="615" y="92" text-anchor="middle" class="did-text">did:dht:bob...</text>
+  <!-- Arrow: Alice App -> Bob DWN -->
+  <path d="M 120 120 L 120 148 L 568 148 L 568 122" class="arrow-accent" fill="none"/>
+  <polygon points="563,122 568,112 573,122" fill="#0d9668"/>
+  <text x="344" y="142" text-anchor="middle" class="step" fill="#0d9668">2</text>
 
-  <rect x="550" y="230" width="130" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
-  <text x="615" y="264" text-anchor="middle" class="label">Bob's App</text>
-  <text x="615" y="282" text-anchor="middle" class="sublabel">@enbox/api</text>
+  <!-- Animated send dots -->
+  <circle cx="250" cy="148" r="3" class="dot d4"/>
+  <circle cx="344" cy="148" r="3" class="dot d5"/>
+  <circle cx="438" cy="148" r="3" class="dot d6"/>
 
-  <line x1="350" y1="72" x2="548" y2="72" class="arrow-accent"/>
-  <polygon points="548,67 558,72 548,77" fill="#0d9668"/>
-  <text x="449" y="64" text-anchor="middle" class="step" fill="#0d9668">3</text>
-
-  <circle cx="410" cy="72" r="3" class="dot d4"/>
-  <circle cx="440" cy="72" r="3" class="dot d5"/>
-  <circle cx="470" cy="72" r="3" class="dot d6"/>
-
-  <line x1="615" y1="120" x2="615" y2="228" class="arrow"/>
-  <polygon points="610,228 615,238 620,228" fill="#a0a9b4"/>
-  <text x="628" y="178" class="step">4</text>
+  <!-- Arrow: Bob DWN -> Bob App -->
+  <line x1="640" y1="120" x2="640" y2="158" class="arrow"/>
+  <polygon points="635,158 640,168 645,158" fill="#a0a9b4"/>
+  <text x="655" y="145" class="step">3</text>
 
   <!-- ═══ STEP LABELS ═══ -->
 
-  <rect x="30" y="260" width="420" height="50" rx="6" fill="#e2e5e9" stroke="#c4cad1" stroke-width="1"/>
+  <rect x="50" y="230" width="660" height="36" rx="6" fill="#e2e5e9" stroke="#c4cad1" stroke-width="1"/>
 
-  <circle cx="50" cy="275" r="8" fill="#ffffff" stroke="#a0a9b4" stroke-width="1"/>
-  <text x="50" y="279" text-anchor="middle" class="step">1</text>
-  <text x="66" y="279" class="sublabel">Alice writes a record</text>
+  <circle cx="72" cy="248" r="8" fill="#ffffff" stroke="#2b7ab5" stroke-width="1"/>
+  <text x="72" y="252" text-anchor="middle" class="step" fill="#2b7ab5">1</text>
+  <text x="88" y="252" class="sublabel">Resolve Bob's DID → discover DWN endpoint</text>
 
-  <circle cx="50" cy="296" r="8" fill="#ffffff" stroke="#2b7ab5" stroke-width="1"/>
-  <text x="50" y="300" text-anchor="middle" class="step" fill="#2b7ab5">2</text>
-  <text x="66" y="300" class="sublabel">Agent resolves Bob's DID to find his DWN endpoint</text>
+  <circle cx="340" cy="248" r="8" fill="#ffffff" stroke="#0d9668" stroke-width="1"/>
+  <text x="340" y="252" text-anchor="middle" class="step" fill="#0d9668">2</text>
+  <text x="356" y="252" class="sublabel">Send encrypted record directly to Bob's DWN</text>
 
-  <circle cx="250" cy="275" r="8" fill="#ffffff" stroke="#0d9668" stroke-width="1"/>
-  <text x="250" y="279" text-anchor="middle" class="step" fill="#0d9668">3</text>
-  <text x="266" y="279" class="sublabel">Encrypted message sent to Bob's DWN</text>
-
-  <circle cx="250" cy="296" r="8" fill="#ffffff" stroke="#a0a9b4" stroke-width="1"/>
-  <text x="250" y="300" text-anchor="middle" class="step">4</text>
-  <text x="266" y="300" class="sublabel">Bob's app syncs and decrypts</text>
+  <circle cx="580" cy="248" r="8" fill="#ffffff" stroke="#a0a9b4" stroke-width="1"/>
+  <text x="580" y="252" text-anchor="middle" class="step">3</text>
+  <text x="596" y="252" class="sublabel">Bob's app syncs and decrypts</text>
 </svg>

--- a/assets/dwn-alice-bob-light.svg
+++ b/assets/dwn-alice-bob-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 280" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 310" fill="none">
   <style>
     text { font-family: ui-monospace, 'JetBrains Mono', 'Cascadia Code', monospace; }
     .label { fill: #1a1d20; font-size: 13px; font-weight: 600; }
@@ -25,77 +25,77 @@
   </style>
 
   <!-- Background -->
-  <rect width="800" height="280" fill="#f3f4f6" rx="12"/>
+  <rect width="820" height="310" fill="#f3f4f6" rx="12"/>
 
   <!-- ═══ ALICE (left) ═══ -->
 
-  <text x="50" y="30" class="persona" fill="#0d9668">ALICE</text>
+  <text x="40" y="30" class="persona" fill="#0d9668">ALICE</text>
 
-  <rect x="50" y="40" width="140" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
-  <text x="120" y="74" text-anchor="middle" class="label">Alice's App</text>
-  <text x="120" y="92" text-anchor="middle" class="sublabel">@enbox/api</text>
+  <rect x="40" y="42" width="150" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
+  <text x="115" y="76" text-anchor="middle" class="label">Alice's App</text>
+  <text x="115" y="94" text-anchor="middle" class="sublabel">@enbox/api</text>
 
   <!-- ═══ DID RESOLUTION (center) ═══ -->
 
-  <rect x="290" y="40" width="180" height="80" class="box" fill="#e2e5e9" stroke="#c4cad1"/>
-  <text x="380" y="72" text-anchor="middle" class="label" fill="#2b7ab5">DID Resolution</text>
-  <text x="380" y="92" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
+  <rect x="300" y="42" width="200" height="80" class="box" fill="#e2e5e9" stroke="#c4cad1"/>
+  <text x="400" y="76" text-anchor="middle" class="label" fill="#2b7ab5">DID Resolution</text>
+  <text x="400" y="94" text-anchor="middle" class="sublabel">did:dht · did:web · did:jwk</text>
 
   <!-- Arrow: Alice -> Resolver -->
-  <line x1="190" y1="65" x2="288" y2="65" class="arrow-resolve"/>
-  <polygon points="288,60 298,65 288,70" fill="#2b7ab5"/>
-  <text x="239" y="57" text-anchor="middle" class="step" fill="#2b7ab5">1</text>
+  <line x1="190" y1="68" x2="298" y2="68" class="arrow-resolve"/>
+  <polygon points="298,63 308,68 298,73" fill="#2b7ab5"/>
+  <text x="244" y="58" text-anchor="middle" class="step" fill="#2b7ab5">1</text>
 
   <!-- Animated resolve dots -->
-  <circle cx="222" cy="65" r="2.5" class="dot-blue d1"/>
-  <circle cx="244" cy="65" r="2.5" class="dot-blue d2"/>
-  <circle cx="266" cy="65" r="2.5" class="dot-blue d3"/>
+  <circle cx="225" cy="68" r="2.5" class="dot-blue d1"/>
+  <circle cx="250" cy="68" r="2.5" class="dot-blue d2"/>
+  <circle cx="275" cy="68" r="2.5" class="dot-blue d3"/>
 
   <!-- Arrow: Resolver returns endpoint -->
-  <line x1="288" y1="95" x2="190" y2="95" class="arrow-resolve"/>
-  <polygon points="190,90 180,95 190,100" fill="#2b7ab5"/>
-  <text x="239" y="109" text-anchor="middle" class="did-text">Bob's DWN endpoint</text>
+  <line x1="298" y1="96" x2="190" y2="96" class="arrow-resolve"/>
+  <polygon points="190,91 180,96 190,101" fill="#2b7ab5"/>
+  <text x="244" y="114" text-anchor="middle" class="did-text">Bob's DWN endpoint</text>
 
   <!-- ═══ BOB (right) ═══ -->
 
-  <text x="570" y="30" class="persona" fill="#d4713a">BOB</text>
+  <text x="620" y="30" class="persona" fill="#d4713a">BOB</text>
 
-  <rect x="570" y="40" width="140" height="80" class="box" fill="#ffffff" stroke="#a0a9b4"/>
-  <text x="640" y="74" text-anchor="middle" class="label">Bob's DWN</text>
-  <text x="640" y="92" text-anchor="middle" class="did-text">did:dht:bob...</text>
+  <rect x="620" y="42" width="150" height="80" class="box" fill="#ffffff" stroke="#a0a9b4"/>
+  <text x="695" y="76" text-anchor="middle" class="label">Bob's DWN</text>
+  <text x="695" y="94" text-anchor="middle" class="did-text">did:dht:bob...</text>
 
-  <rect x="570" y="160" width="140" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
-  <text x="640" y="194" text-anchor="middle" class="label">Bob's App</text>
-  <text x="640" y="212" text-anchor="middle" class="sublabel">@enbox/api</text>
+  <rect x="620" y="180" width="150" height="80" class="box" fill="#ffffff" stroke="#c4cad1"/>
+  <text x="695" y="214" text-anchor="middle" class="label">Bob's App</text>
+  <text x="695" y="232" text-anchor="middle" class="sublabel">@enbox/api</text>
 
   <!-- Arrow: Alice App -> Bob DWN -->
-  <path d="M 120 120 L 120 148 L 568 148 L 568 122" class="arrow-accent" fill="none"/>
-  <polygon points="563,122 568,112 573,122" fill="#0d9668"/>
-  <text x="344" y="142" text-anchor="middle" class="step" fill="#0d9668">2</text>
+  <path d="M 115 122 L 115 155 L 618 155 L 618 124" class="arrow-accent" fill="none"/>
+  <polygon points="613,124 618,114 623,124" fill="#0d9668"/>
+  <text x="366" y="148" text-anchor="middle" class="step" fill="#0d9668">2</text>
 
   <!-- Animated send dots -->
-  <circle cx="250" cy="148" r="3" class="dot d4"/>
-  <circle cx="344" cy="148" r="3" class="dot d5"/>
-  <circle cx="438" cy="148" r="3" class="dot d6"/>
+  <circle cx="250" cy="155" r="3" class="dot d4"/>
+  <circle cx="380" cy="155" r="3" class="dot d5"/>
+  <circle cx="510" cy="155" r="3" class="dot d6"/>
 
   <!-- Arrow: Bob DWN -> Bob App -->
-  <line x1="640" y1="120" x2="640" y2="158" class="arrow"/>
-  <polygon points="635,158 640,168 645,158" fill="#a0a9b4"/>
-  <text x="655" y="145" class="step">3</text>
+  <line x1="695" y1="122" x2="695" y2="178" class="arrow"/>
+  <polygon points="690,178 695,188 700,178" fill="#a0a9b4"/>
+  <text x="710" y="155" class="step">3</text>
 
-  <!-- ═══ STEP LABELS ═══ -->
+  <!-- ═══ STEP LEGEND ═══ -->
 
-  <rect x="50" y="230" width="660" height="36" rx="6" fill="#e2e5e9" stroke="#c4cad1" stroke-width="1"/>
+  <rect x="40" y="272" width="730" height="28" rx="6" fill="#e2e5e9" stroke="#c4cad1" stroke-width="1"/>
 
-  <circle cx="72" cy="248" r="8" fill="#ffffff" stroke="#2b7ab5" stroke-width="1"/>
-  <text x="72" y="252" text-anchor="middle" class="step" fill="#2b7ab5">1</text>
-  <text x="88" y="252" class="sublabel">Resolve Bob's DID → discover DWN endpoint</text>
+  <circle cx="62" cy="286" r="8" fill="#ffffff" stroke="#2b7ab5" stroke-width="1"/>
+  <text x="62" y="290" text-anchor="middle" class="step" fill="#2b7ab5">1</text>
+  <text x="78" y="290" class="sublabel">Resolve Bob's DID → discover endpoint</text>
 
-  <circle cx="340" cy="248" r="8" fill="#ffffff" stroke="#0d9668" stroke-width="1"/>
-  <text x="340" y="252" text-anchor="middle" class="step" fill="#0d9668">2</text>
-  <text x="356" y="252" class="sublabel">Send encrypted record directly to Bob's DWN</text>
+  <circle cx="318" cy="286" r="8" fill="#ffffff" stroke="#0d9668" stroke-width="1"/>
+  <text x="318" y="290" text-anchor="middle" class="step" fill="#0d9668">2</text>
+  <text x="334" y="290" class="sublabel">Send encrypted record to Bob's DWN</text>
 
-  <circle cx="580" cy="248" r="8" fill="#ffffff" stroke="#a0a9b4" stroke-width="1"/>
-  <text x="580" y="252" text-anchor="middle" class="step">3</text>
-  <text x="596" y="252" class="sublabel">Bob's app syncs and decrypts</text>
+  <circle cx="576" cy="286" r="8" fill="#ffffff" stroke="#a0a9b4" stroke-width="1"/>
+  <text x="576" y="290" text-anchor="middle" class="step">3</text>
+  <text x="592" y="290" class="sublabel">Bob's app syncs and decrypts</text>
 </svg>

--- a/assets/dwn-flow-dark.svg
+++ b/assets/dwn-flow-dark.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" fill="none">
+  <style>
+    text { font-family: ui-monospace, 'JetBrains Mono', 'Cascadia Code', monospace; }
+    .label { fill: #ffffff; font-size: 13px; font-weight: 600; }
+    .sublabel { fill: #78828f; font-size: 10px; }
+    .box { stroke-width: 1.5; rx: 8; }
+    .arrow { stroke: #545d69; stroke-width: 1.5; stroke-linecap: round; }
+    .dot { fill: #5ef2c8; }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.3; }
+      50% { opacity: 1; }
+    }
+    .d1 { animation: pulse 2.4s ease-in-out infinite; }
+    .d2 { animation: pulse 2.4s ease-in-out 0.3s infinite; }
+    .d3 { animation: pulse 2.4s ease-in-out 0.6s infinite; }
+    .d4 { animation: pulse 2.4s ease-in-out 0.15s infinite; }
+    .d5 { animation: pulse 2.4s ease-in-out 0.45s infinite; }
+    .d6 { animation: pulse 2.4s ease-in-out 0.75s infinite; }
+    .lock { fill: #5ef2c8; font-size: 14px; }
+  </style>
+
+  <!-- Background -->
+  <rect width="800" height="200" fill="#0e1011" rx="12"/>
+
+  <!-- App box -->
+  <rect x="30" y="50" width="150" height="100" class="box" fill="#1a1d20" stroke="#2a2f35"/>
+  <text x="105" y="92" text-anchor="middle" class="label">Your App</text>
+  <text x="105" y="112" text-anchor="middle" class="sublabel">@enbox/api</text>
+
+  <!-- Local DWN box -->
+  <rect x="250" y="50" width="150" height="100" class="box" fill="#1a1d20" stroke="#2a2f35"/>
+  <text x="325" y="92" text-anchor="middle" class="label">Local DWN</text>
+  <text x="325" y="112" text-anchor="middle" class="sublabel">in-browser / on-device</text>
+
+  <!-- Remote DWN box -->
+  <rect x="540" y="50" width="150" height="100" class="box" fill="#1a1d20" stroke="#2a2f35"/>
+  <text x="615" y="92" text-anchor="middle" class="label">Remote DWN</text>
+  <text x="615" y="112" text-anchor="middle" class="sublabel">any server, anywhere</text>
+
+  <!-- Another device box -->
+  <rect x="540" y="3" width="150" height="38" class="box" fill="#131618" stroke="#21252a"/>
+  <text x="615" y="27" text-anchor="middle" class="sublabel">Another device / app</text>
+
+  <!-- Arrow: App -> Local DWN -->
+  <line x1="180" y1="100" x2="248" y2="100" class="arrow"/>
+  <polygon points="248,95 258,100 248,105" fill="#545d69"/>
+
+  <!-- Arrow: Local DWN -> Remote DWN (encrypted sync) -->
+  <line x1="400" y1="93" x2="538" y2="93" class="arrow" stroke-dasharray="0"/>
+  <polygon points="538,88 548,93 538,98" fill="#545d69"/>
+
+  <!-- Arrow: Remote DWN -> Local DWN (sync back) -->
+  <line x1="538" y1="107" x2="400" y2="107" class="arrow"/>
+  <polygon points="400,102 390,107 400,112" fill="#545d69"/>
+
+  <!-- Arrow: Remote DWN -> Other device -->
+  <line x1="615" y1="50" x2="615" y2="43" class="arrow"/>
+  <polygon points="610,43 615,33 620,43" fill="#545d69"/>
+
+  <!-- Animated sync dots (forward) -->
+  <circle cx="430" cy="93" r="3" class="dot d1"/>
+  <circle cx="460" cy="93" r="3" class="dot d2"/>
+  <circle cx="490" cy="93" r="3" class="dot d3"/>
+
+  <!-- Animated sync dots (return) -->
+  <circle cx="500" cy="107" r="3" class="dot d4"/>
+  <circle cx="470" cy="107" r="3" class="dot d5"/>
+  <circle cx="440" cy="107" r="3" class="dot d6"/>
+
+  <!-- Encryption lock icon between sync arrows -->
+  <text x="465" y="79" text-anchor="middle" class="lock">&#x1F512;</text>
+  <text x="465" y="130" text-anchor="middle" class="sublabel">encrypted sync</text>
+
+  <!-- User owns this label -->
+  <rect x="250" y="160" width="150" height="24" rx="4" fill="#21252a"/>
+  <text x="325" y="176" text-anchor="middle" class="sublabel" fill="#5ef2c8">user-controlled</text>
+
+  <rect x="540" y="160" width="150" height="24" rx="4" fill="#21252a"/>
+  <text x="615" y="176" text-anchor="middle" class="sublabel" fill="#78828f">operator-blind (E2EE)</text>
+</svg>

--- a/assets/dwn-flow-light.svg
+++ b/assets/dwn-flow-light.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" fill="none">
+  <style>
+    text { font-family: ui-monospace, 'JetBrains Mono', 'Cascadia Code', monospace; }
+    .label { fill: #1a1d20; font-size: 13px; font-weight: 600; }
+    .sublabel { fill: #545d69; font-size: 10px; }
+    .box { stroke-width: 1.5; rx: 8; }
+    .arrow { stroke: #a0a9b4; stroke-width: 1.5; stroke-linecap: round; }
+    .dot { fill: #0d9668; }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.3; }
+      50% { opacity: 1; }
+    }
+    .d1 { animation: pulse 2.4s ease-in-out infinite; }
+    .d2 { animation: pulse 2.4s ease-in-out 0.3s infinite; }
+    .d3 { animation: pulse 2.4s ease-in-out 0.6s infinite; }
+    .d4 { animation: pulse 2.4s ease-in-out 0.15s infinite; }
+    .d5 { animation: pulse 2.4s ease-in-out 0.45s infinite; }
+    .d6 { animation: pulse 2.4s ease-in-out 0.75s infinite; }
+    .lock { fill: #0d9668; font-size: 14px; }
+  </style>
+
+  <!-- Background -->
+  <rect width="800" height="200" fill="#f3f4f6" rx="12"/>
+
+  <!-- App box -->
+  <rect x="30" y="50" width="150" height="100" class="box" fill="#ffffff" stroke="#c4cad1"/>
+  <text x="105" y="92" text-anchor="middle" class="label">Your App</text>
+  <text x="105" y="112" text-anchor="middle" class="sublabel">@enbox/api</text>
+
+  <!-- Local DWN box -->
+  <rect x="250" y="50" width="150" height="100" class="box" fill="#ffffff" stroke="#c4cad1"/>
+  <text x="325" y="92" text-anchor="middle" class="label">Local DWN</text>
+  <text x="325" y="112" text-anchor="middle" class="sublabel">in-browser / on-device</text>
+
+  <!-- Remote DWN box -->
+  <rect x="540" y="50" width="150" height="100" class="box" fill="#ffffff" stroke="#c4cad1"/>
+  <text x="615" y="92" text-anchor="middle" class="label">Remote DWN</text>
+  <text x="615" y="112" text-anchor="middle" class="sublabel">any server, anywhere</text>
+
+  <!-- Another device box -->
+  <rect x="540" y="3" width="150" height="38" class="box" fill="#e2e5e9" stroke="#c4cad1"/>
+  <text x="615" y="27" text-anchor="middle" class="sublabel">Another device / app</text>
+
+  <!-- Arrow: App -> Local DWN -->
+  <line x1="180" y1="100" x2="248" y2="100" class="arrow"/>
+  <polygon points="248,95 258,100 248,105" fill="#a0a9b4"/>
+
+  <!-- Arrow: Local DWN -> Remote DWN -->
+  <line x1="400" y1="93" x2="538" y2="93" class="arrow"/>
+  <polygon points="538,88 548,93 538,98" fill="#a0a9b4"/>
+
+  <!-- Arrow: Remote DWN -> Local DWN -->
+  <line x1="538" y1="107" x2="400" y2="107" class="arrow"/>
+  <polygon points="400,102 390,107 400,112" fill="#a0a9b4"/>
+
+  <!-- Arrow: Remote DWN -> Other device -->
+  <line x1="615" y1="50" x2="615" y2="43" class="arrow"/>
+  <polygon points="610,43 615,33 620,43" fill="#a0a9b4"/>
+
+  <!-- Animated sync dots (forward) -->
+  <circle cx="430" cy="93" r="3" class="dot d1"/>
+  <circle cx="460" cy="93" r="3" class="dot d2"/>
+  <circle cx="490" cy="93" r="3" class="dot d3"/>
+
+  <!-- Animated sync dots (return) -->
+  <circle cx="500" cy="107" r="3" class="dot d4"/>
+  <circle cx="470" cy="107" r="3" class="dot d5"/>
+  <circle cx="440" cy="107" r="3" class="dot d6"/>
+
+  <!-- Encryption lock icon -->
+  <text x="465" y="79" text-anchor="middle" class="lock">&#x1F512;</text>
+  <text x="465" y="130" text-anchor="middle" class="sublabel">encrypted sync</text>
+
+  <!-- Labels -->
+  <rect x="250" y="160" width="150" height="24" rx="4" fill="#e2e5e9"/>
+  <text x="325" y="176" text-anchor="middle" class="sublabel" fill="#0d9668">user-controlled</text>
+
+  <rect x="540" y="160" width="150" height="24" rx="4" fill="#e2e5e9"/>
+  <text x="615" y="176" text-anchor="middle" class="sublabel" fill="#545d69">operator-blind (E2EE)</text>
+</svg>

--- a/assets/enbox-mark-dark.svg
+++ b/assets/enbox-mark-dark.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="20" height="20" rx="4" stroke="#545d69" stroke-width="1.5" fill="none"/>
+  <rect x="10" y="10" width="20" height="20" rx="4" stroke="#78828f" stroke-width="1.5" fill="none"/>
+  <rect x="16" y="16" width="20" height="20" rx="4" stroke="#ffffff" stroke-width="1.5" fill="none"/>
+  <circle cx="26" cy="26" r="2.5" fill="#ffffff"/>
+</svg>

--- a/assets/enbox-mark-light.svg
+++ b/assets/enbox-mark-light.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="20" height="20" rx="4" stroke="#78828f" stroke-width="1.5" fill="none"/>
+  <rect x="10" y="10" width="20" height="20" rx="4" stroke="#a0a9b4" stroke-width="1.5" fill="none"/>
+  <rect x="16" y="16" width="20" height="20" rx="4" stroke="#1a1816" stroke-width="1.5" fill="none"/>
+  <circle cx="26" cy="26" r="2.5" fill="#1a1816"/>
+</svg>


### PR DESCRIPTION
## Summary

- Rewrites the README targeting web developers evaluating Enbox as an open-source SDK for building on Decentralized Web Nodes
- Positions around the DWN open standard (not as a competing service) -- comparison table uses "Centralised backend" vs "DWN-based" rather than naming specific products
- All code examples use the real current API (`AuthManager`, `Enbox.connect({ session })`, `enbox.using()`) -- no `Web5` references
- Adds a prominent `[!CAUTION]` research preview banner covering breaking changes, data loss, security gaps
- Quick Start walks through connect -> define protocol -> write/query -> subscribe using a generic bookmarks example with `encryptionRequired`, nested records, and tags
- Documents DWN servers as an open concept anyone can run, with two community preview nodes (Fly.io + AWS) listed for convenience
- Shows `dwnEndpoints` configuration at the `AuthManager.create()` level (default) and per-identity override via `connectLocal()`
- Adds `@enbox/auth` and `@enbox/browser` to the packages table
- Commits enbox-mark SVG assets (dark/light) from the design system for the header
- Uses design-token-derived badge colors, flat-square style
