### PR TITLE
fix: remove unnecessary casts, flip negated conditions, apply optional chaining (S4325, S7735, S6582)

### DIFF
--- a/apps/docs/src/components/ai/page-actions.tsx
+++ b/apps/docs/src/components/ai/page-actions.tsx
@@ -72,7 +72,7 @@ export function ViewOptions({
   githubUrl: string;
 }) {
   const items = useMemo(() => {
-    const pageUrl = typeof window !== 'undefined' ? window.location.href : 'loading';
+    const pageUrl = typeof window === 'undefined' ? 'loading' : window.location.href;
     const q = `Read ${pageUrl}, I want to ask questions about it.`;
 
     return [

--- a/apps/docs/src/components/search.tsx
+++ b/apps/docs/src/components/search.tsx
@@ -39,7 +39,7 @@ export default function DefaultSearchDialog(props: SharedProps) {
           <SearchDialogInput />
           <SearchDialogClose />
         </SearchDialogHeader>
-        <SearchDialogList items={query.data !== 'empty' ? query.data : null} />
+        <SearchDialogList items={query.data === 'empty' ? null : query.data} />
       </SearchDialogContent>
     </SearchDialog>
   );

--- a/packages/agent/src/agent-did-resolver-cache.ts
+++ b/packages/agent/src/agent-did-resolver-cache.ts
@@ -55,7 +55,10 @@ export class AgentDidResolverCache extends DidResolverCacheLevel implements DidR
         // if a DID is stored in the DID Store, then we don't want to evict it from the cache until we have a successful resolution
         // upon a successful resolution, we will update both the storage and the cache with the newly resolved Document.
         const storedDid = await this.agent.did.get({ didUri: did, tenant: this.agent.agentDid.uri });
-        if ('undefined' !== typeof storedDid) {
+        if ('undefined' === typeof storedDid) {
+          this._resolving.delete(did);
+          this.cache.nextTick(() => this.cache.del(did));
+        } else {
           try {
             const result = await this.agent.did.resolve(did);
 
@@ -82,9 +85,6 @@ export class AgentDidResolverCache extends DidResolverCacheLevel implements DidR
           } finally {
             this._resolving.delete(did);
           }
-        } else {
-          this._resolving.delete(did);
-          this.cache.nextTick(() => this.cache.del(did));
         }
       }
       return cachedResult.value;

--- a/packages/agent/src/did-api.ts
+++ b/packages/agent/src/did-api.ts
@@ -303,7 +303,7 @@ export class AgentDidApi<TKeyManager extends AgentKeyManager = AgentKeyManager> 
       const parsedDid = Did.parse(uri);
       // currently only supporting DHT as a publishable method.
       // TODO: abstract this into the didMethod class so that other publishable methods can be supported.
-      if (parsedDid && parsedDid.method === 'dht') {
+      if (parsedDid?.method === 'dht') {
         await DidDht.publish({ did: bearerDid });
       }
     }

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -629,9 +629,9 @@ export class AgentDwnApi {
     let resubscribeFactory: ResubscribeFactory | undefined;
     if (subscriptionHandler !== undefined && !('messageCid' in request)) {
       resubscribeFactory = async (cursor?: ProgressToken): Promise<GenericMessage> => {
-        const resumeParams = cursor !== undefined
-          ? { ...request.messageParams, cursor } as DwnMessageParams[T]
-          : request.messageParams;
+        const resumeParams = cursor === undefined
+          ? request.messageParams
+          : { ...request.messageParams, cursor } as DwnMessageParams[T];
 
         const resumeRequest: ProcessDwnRequest<T> = { ...request, messageParams: resumeParams };
         const { message: resumeMessage } = await this.constructDwnMessage({ request: resumeRequest });
@@ -1211,8 +1211,22 @@ export class AgentDwnApi {
     let dwnMessage: DwnMessageInstance[T];
     const dwnMessageConstructor = dwnMessageConstructors[request.messageType];
 
-    // if there is no raw message provided, we need to create the dwn message
-    if (!rawMessage) {
+    // if a raw message is provided, parse it; otherwise create a new dwn message
+    if (rawMessage) {
+      dwnMessage = await dwnMessageConstructor.parse(rawMessage);
+      if (isRecordsWrite(dwnMessage) && request.signAsOwner) {
+        // if we are signing as owner, we use the author's signer
+        const signer = await this.getSigner(request.author);
+        await dwnMessage.signAsOwner(signer);
+      } else if (request.granteeDid && isRecordsWrite(dwnMessage) && request.signAsOwnerDelegate) {
+        // if we are signing as owner delegate, we use the grantee's signer and the provided delegated grant
+        const signer = await this.getSigner(request.granteeDid);
+
+        //if we have reached here, the presence of the grant params has already been checked
+        const messageParams = request.messageParams as DwnMessageParams[DwnInterface.RecordsWrite];
+        await dwnMessage.signAsOwnerDelegate(signer, messageParams.delegatedGrant!);
+      }
+    } else {
       if (request.messageParams === undefined) {
         throw new Error('AgentDwnApi: messageParams must be provided when rawMessage is not given.');
       }
@@ -1274,21 +1288,6 @@ export class AgentDwnApi {
 
         // Cache context key info for subsequent writes in this context
         this._contextKeyCache.set(contextId, { keyId, keyUri, contextDerivationPath });
-      }
-
-    } else {
-      dwnMessage = await dwnMessageConstructor.parse(rawMessage);
-      if (isRecordsWrite(dwnMessage) && request.signAsOwner) {
-        // if we are signing as owner, we use the author's signer
-        const signer = await this.getSigner(request.author);
-        await dwnMessage.signAsOwner(signer);
-      } else if (request.granteeDid && isRecordsWrite(dwnMessage) && request.signAsOwnerDelegate) {
-        // if we are signing as owner delegate, we use the grantee's signer and the provided delegated grant
-        const signer = await this.getSigner(request.granteeDid);
-
-        //if we have reached here, the presence of the grant params has already been checked
-        const messageParams = request.messageParams as DwnMessageParams[DwnInterface.RecordsWrite];
-        await dwnMessage.signAsOwnerDelegate(signer, messageParams.delegatedGrant!);
       }
     }
 

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -1297,7 +1297,7 @@ async function submitConnectResponse(
 
   logger.log('Encrypting connect response...');
   const encryptedResponse = await EnboxConnectProtocol.encryptResponse({
-    jwt              : responseObjectJwt!,
+    jwt              : responseObjectJwt,
     encryptionKey    : sharedKey,
     delegateDidKeyId : delegateBearerDid.document.verificationMethod![0].id,
     pin,

--- a/packages/agent/src/identity-api.ts
+++ b/packages/agent/src/identity-api.ts
@@ -256,11 +256,12 @@ export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyMana
       };
 
       // if no other services exist, create a new array with the DWN service
-      if (!portableDid.document.service) {
-        portableDid.document.service = [newDwnService];
-      } else {
-        // otherwise, push the new DWN service to the existing services
+      if (portableDid.document.service) {
+        // push the new DWN service to the existing services
         portableDid.document.service.push(newDwnService);
+      } else {
+        // no other services exist, create a new array with the DWN service
+        portableDid.document.service = [newDwnService];
       }
     }
 

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -1,6 +1,6 @@
 import type { EnboxAgent } from './types/agent.js';
 import type { CreateGrantParams, CreateRequestParams, CreateRevocationParams, FetchPermissionRequestParams, FetchPermissionsParams, GetPermissionParams, IsGrantRevokedParams, PermissionGrantEntry, PermissionRequestEntry, PermissionRevocationEntry, PermissionsApi } from './types/permissions.js';
-import type { DwnDataEncodedRecordsWriteMessage, DwnMessageParams, DwnMessagesPermissionScope, DwnPermissionScope, DwnProtocolPermissionScope, DwnRecordsPermissionScope, ProcessDwnRequest } from './types/dwn.js';
+import type { DwnDataEncodedRecordsWriteMessage, DwnMessageParams, DwnPermissionScope, DwnRecordsPermissionScope, ProcessDwnRequest } from './types/dwn.js';
 import type { PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData } from '@enbox/dwn-sdk-js';
 
 import { isRecordsType } from './dwn-api.js';
@@ -474,7 +474,7 @@ export class AgentPermissionsApi implements PermissionsApi {
           return true;
         }
       } else {
-        const messagesScope = scope as DwnMessagesPermissionScope | DwnProtocolPermissionScope;
+        const messagesScope = scope;
         // Checks for unrestricted protocol scope, if no protocol is defined in the scope it is unrestricted
         if (messagesScope.protocol === undefined) {
           return true;

--- a/packages/agent/src/prototyping/crypto/jose/jwe-flattened.ts
+++ b/packages/agent/src/prototyping/crypto/jose/jwe-flattened.ts
@@ -301,24 +301,24 @@ export class FlattenedJwe {
     const tag = decodeHeaderParam('tag', jwe.tag);
 
     // Decode the JWE Ciphertext to a byte array, and if present, append the Authentication Tag.
-    const ciphertext = tag !== undefined
-      ? new Uint8Array([
+    const ciphertext = tag === undefined
+      ? Convert.base64Url(jwe.ciphertext).toUint8Array()
+      : new Uint8Array([
         ...Convert.base64Url(jwe.ciphertext).toUint8Array(),
         ...(tag ?? [])
-      ])
-      : Convert.base64Url(jwe.ciphertext).toUint8Array();
+      ]);
 
     // If the JWE Additional Authenticated Data (AAD) is present, the Additional Authenticated Data
     // input to the Content Encryption Algorithm is
     // ASCII(Encoded Protected Header || '.' || BASE64URL(JWE AAD)). If the JWE AAD is absent, the
     // Additional Authenticated Data is ASCII(BASE64URL(UTF8(JWE Protected Header))).
-    const additionalData = jwe.aad !== undefined
-      ? new Uint8Array([
+    const additionalData = jwe.aad === undefined
+      ? Convert.string(jwe.protected ?? '').toUint8Array()
+      : new Uint8Array([
         ...Convert.string(jwe.protected ?? '').toUint8Array(),
         ...Convert.string('.').toUint8Array(),
         ...Convert.string(jwe.aad).toUint8Array()
-      ])
-      : Convert.string(jwe.protected ?? '').toUint8Array();
+      ]);
 
     // Decrypt the JWE using the Content Encryption Key (CEK) with:
     // - Key Manager: If the CEK is a Key Identifier.

--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -366,7 +366,7 @@ function extractProtocolAwareDeps(
           Buffer.from(payload, 'base64url').toString('utf-8')
         );
         const protocolRole = decoded.protocolRole as string | undefined;
-        if (protocolRole && protocolRole.includes(':')) {
+        if (protocolRole?.includes(':')) {
           // Cross-protocol role: "alias:protocolPath"
           const roleColonIdx = protocolRole.indexOf(':');
           const roleAlias = protocolRole.substring(0, roleColonIdx);

--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -518,7 +518,7 @@ export async function evaluateClosure(
       const currentProtocol = currentDesc.protocol as string | undefined;
       if (currentProtocol) {
         const cachedProtocolMsg = context.protocolCache.get(currentProtocol);
-        const protocolDef = (cachedProtocolMsg?.descriptor as any)?.definition;
+        const protocolDef = cachedProtocolMsg?.descriptor?.definition;
         if (protocolDef) {
           const protoAwareEdges = extractProtocolAwareDeps(current, protocolDef, context.isDelegateSession);
           const protoResult = await resolveEdges(

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -781,7 +781,7 @@ export class SyncEngineLevel implements SyncEngine {
     let drained = 0;
     while (true) {
       const entry = rt.inflight.get(rt.nextCommitOrdinal);
-      if (!entry || !entry.committed) { break; }
+      if (!entry?.committed) { break; }
 
       // This ordinal is committed — advance the durable checkpoint.
       ReplicationLedger.commitContiguousToken(link.pull, entry.token);
@@ -894,7 +894,7 @@ export class SyncEngineLevel implements SyncEngine {
 
       // Verify link still exists and is still repairing.
       const currentLink = this._activeLinks.get(linkKey);
-      if (!currentLink || currentLink.status !== 'repairing') { return; }
+      if (currentLink?.status !== 'repairing') { return; }
 
       try {
         await this.repairLink(linkKey);
@@ -1511,7 +1511,7 @@ export class SyncEngineLevel implements SyncEngine {
           // For protocol-scoped links, verify that all hard dependencies for
           // this operation are locally present before considering it committed.
           // Full-tenant scope bypasses this entirely (returns complete with 0 queries).
-          if (link && link.scope.kind === 'protocol') {
+          if (link?.scope.kind === 'protocol') {
             const messageStore = this.agent.dwn.node.storage.messageStore;
             let closureCtx = this._closureContexts.get(did);
             if (!closureCtx) {
@@ -2257,9 +2257,9 @@ export class SyncEngineLevel implements SyncEngine {
   private async getLocalRoot(did: string, delegateDid?: string, protocol?: string): Promise<string> {
     const si = this.stateIndex;
     if (si) {
-      const rootHash = protocol !== undefined
-        ? await si.getProtocolRoot(did, protocol)
-        : await si.getRoot(did);
+      const rootHash = protocol === undefined
+        ? await si.getRoot(did)
+        : await si.getProtocolRoot(did, protocol);
       return hashToHex(rootHash);
     }
 
@@ -2402,9 +2402,9 @@ export class SyncEngineLevel implements SyncEngine {
       if (si) {
         // Fast path: direct StateIndex access (local mode).
         const bitPath = SyncEngineLevel.parseBitPrefix(prefix);
-        const hash = protocol !== undefined
-          ? await si.getProtocolSubtreeHash(did, protocol, bitPath)
-          : await si.getSubtreeHash(did, bitPath);
+        const hash = protocol === undefined
+          ? await si.getSubtreeHash(did, bitPath)
+          : await si.getProtocolSubtreeHash(did, protocol, bitPath);
         hexHash = hashToHex(hash);
       } else {
         // Remote mode fallback.
@@ -2444,9 +2444,9 @@ export class SyncEngineLevel implements SyncEngine {
     const si = this.stateIndex;
     if (si) {
       const bitPath = SyncEngineLevel.parseBitPrefix(prefix);
-      const hash = protocol !== undefined
-        ? await si.getProtocolSubtreeHash(did, protocol, bitPath)
-        : await si.getSubtreeHash(did, bitPath);
+      const hash = protocol === undefined
+        ? await si.getSubtreeHash(did, bitPath)
+        : await si.getProtocolSubtreeHash(did, protocol, bitPath);
       return hashToHex(hash);
     }
 
@@ -2479,9 +2479,9 @@ export class SyncEngineLevel implements SyncEngine {
     const si = this.stateIndex;
     if (si) {
       const bitPath = SyncEngineLevel.parseBitPrefix(prefix);
-      return protocol !== undefined
-        ? await si.getProtocolLeaves(did, protocol, bitPath)
-        : await si.getLeaves(did, bitPath);
+      return protocol === undefined
+        ? await si.getLeaves(did, bitPath)
+        : await si.getProtocolLeaves(did, protocol, bitPath);
     }
 
     // Remote mode fallback.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -703,11 +703,11 @@ export class SyncEngineLevel implements SyncEngine {
         }
 
         this.emitEvent({ type: 'link:status-change', tenantDid: target.did, remoteEndpoint: target.dwnUrl, protocol: target.protocol, from: 'initializing', to: 'live' });
-        await this.ledger.setStatus(link!, 'live');
+        await this.ledger.setStatus(link, 'live');
 
         // If the link was marked dirty in a previous session, schedule
         // immediate reconciliation now that subscriptions are open.
-        if (link!.needsReconcile) {
+        if (link.needsReconcile) {
           this.scheduleReconcile(linkKey, 1000);
         }
       } catch (error: any) {
@@ -716,10 +716,10 @@ export class SyncEngineLevel implements SyncEngine {
           : buildLegacyCursorKey(target.did, target.dwnUrl, target.protocol);
 
         // Detect ProgressGap (410) — the cursor is stale, link needs SMT repair.
-        if ((error as any).isProgressGap && link) {
+        if (error.isProgressGap && link) {
           console.warn(`SyncEngineLevel: ProgressGap detected for ${target.did} -> ${target.dwnUrl}, initiating repair`);
           this.emitEvent({ type: 'gap:detected', tenantDid: target.did, remoteEndpoint: target.dwnUrl, protocol: target.protocol, reason: 'ProgressGap' });
-          const gapInfo = (error as any).gapInfo;
+          const gapInfo = error.gapInfo;
           await this.transitionToRepairing(linkKey, link, {
             resumeToken: gapInfo?.latestAvailable,
           });

--- a/packages/agent/src/utils.ts
+++ b/packages/agent/src/utils.ts
@@ -19,7 +19,7 @@ export async function getDwnServiceEndpointUrls(didUri: string, dereferencer: Di
       ? [serviceEndpoint]
       : Array.isArray(serviceEndpoint) && serviceEndpoint.every(endpoint => typeof endpoint === 'string')
       // If the service endpoint is an array of strings, use it as is.
-        ? serviceEndpoint as string[]
+        ? serviceEndpoint
         // If the service endpoint is neither a string nor an array of strings, return an empty array.
         : [];
 

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -783,7 +783,7 @@ export class DwnApi {
             author       : getRecordAuthor(message as DwnMessage[DwnInterface.RecordsWrite]),
             connectedDid : this.connectedDid,
             remoteOrigin,
-            initialWrite : initialWrite as DwnMessage[DwnInterface.RecordsWrite] | undefined,
+            initialWrite : initialWrite,
             protocolRole,
             delegateDid  : this.delegateDid,
           }, this.permissionsApi);

--- a/packages/api/src/live-query.ts
+++ b/packages/api/src/live-query.ts
@@ -220,15 +220,15 @@ export class LiveQuery extends EventTarget {
     } else {
       const knownTimestamp = this._knownRecords.get(record.id);
 
-      if (knownTimestamp !== undefined) {
+      if (knownTimestamp === undefined) {
+        changeType = 'create';
+      } else {
         // We've seen this recordId before (either from snapshot or a prior event).
         if (record.timestamp <= knownTimestamp) {
           // Duplicate or stale event from the overlap window — skip.
           return;
         }
         changeType = 'update';
-      } else {
-        changeType = 'create';
       }
 
       // Update the known state.

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -605,7 +605,7 @@ export class Record implements RecordModel {
       remoteOrigin : this._remoteOrigin,
       protocolRole : protocolRole ?? this._protocolRole,
       initialWrite,
-      encodedData  : data !== undefined ? dataBlob : this._encodedData,
+      encodedData  : data === undefined ? this._encodedData : dataBlob,
       ...responseMessage as DwnMessage[DwnInterface.RecordsWrite],
     }, this._permissionsApi);
 
@@ -622,7 +622,7 @@ export class Record implements RecordModel {
     this._contextId = msg.contextId;
     this._initialWrite = initialWrite;
     this._protocolRole = protocolRole ?? this._protocolRole;
-    this._encodedData = data !== undefined ? dataBlob : this._encodedData;
+    this._encodedData = data === undefined ? this._encodedData : dataBlob;
     this._readableStream = undefined; // Invalidate any consumed stream.
     this._rawMessageDirty = true; // Force rawMessage cache rebuild.
 

--- a/packages/api/src/repository.ts
+++ b/packages/api/src/repository.ts
@@ -147,7 +147,7 @@ function buildRootSingletonMethods(
         if (records.length > 0) {
           const { status, record } = await records[0].update({
             data: options.data,
-            ...(options.tags !== undefined ? { tags: options.tags } : {}),
+            ...(options.tags === undefined ? {} : { tags: options.tags }),
           } as never);
           return { status, record };
         }
@@ -245,7 +245,7 @@ function buildNestedSingletonMethods(
         if (records.length > 0) {
           const { status, record } = await records[0].update({
             data: options.data,
-            ...(options.tags !== undefined ? { tags: options.tags } : {}),
+            ...(options.tags === undefined ? {} : { tags: options.tags }),
           } as never);
           return { status, record };
         }

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -980,7 +980,7 @@ export class TypedEnbox<
           tags            : request.tags,
           protocol        : this._definition.protocol,
           protocolPath    : normalizedPath,
-          ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
+          ...(typeEntry?.schema === undefined ? {} : { schema: typeEntry.schema }),
           dataFormat      : request.dataFormat ?? typeEntry?.dataFormats?.[0],
         });
 
@@ -1048,7 +1048,7 @@ export class TypedEnbox<
             ...queryFilter,
             protocol     : this._definition.protocol,
             protocolPath : normalizedPath,
-            ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
+            ...(typeEntry?.schema === undefined ? {} : { schema: typeEntry.schema }),
           },
           dateSort     : request?.dateSort,
           pagination   : request?.pagination,
@@ -1107,7 +1107,7 @@ export class TypedEnbox<
             ...readFilter,
             protocol     : this._definition.protocol,
             protocolPath : normalizedPath,
-            ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
+            ...(typeEntry?.schema === undefined ? {} : { schema: typeEntry.schema }),
           },
         });
 
@@ -1205,7 +1205,7 @@ export class TypedEnbox<
             ...subFilter,
             protocol     : this._definition.protocol,
             protocolPath : normalizedPath,
-            ...(typeEntry?.schema !== undefined ? { schema: typeEntry.schema } : {}),
+            ...(typeEntry?.schema === undefined ? {} : { schema: typeEntry.schema }),
           },
           protocolRole: request?.protocolRole,
         });

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -959,7 +959,7 @@ export class TypedEnbox<
         const normalizedPath = normalizePath(path);
         await this._ensureReady(normalizedPath);
         const typeName = lastSegment(normalizedPath);
-        const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
+        const typeEntry = this._definition.types[typeName];
 
         // Auto-enable encryption when the type requires it.
         // Delegates CAN encrypt because the $encryption public keys in the
@@ -1032,7 +1032,7 @@ export class TypedEnbox<
         const normalizedPath = normalizePath(path);
         await this._ensureReady(normalizedPath);
         const typeName = lastSegment(normalizedPath);
-        const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
+        const typeEntry = this._definition.types[typeName];
 
         const queryFilter = mapParentContextId(request?.filter);
         // Auto-enable decryption when the type requires it. Delegates use
@@ -1091,7 +1091,7 @@ export class TypedEnbox<
         const normalizedPath = normalizePath(path);
         await this._ensureReady(normalizedPath);
         const typeName = lastSegment(normalizedPath);
-        const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
+        const typeEntry = this._definition.types[typeName];
 
         const readFilter = mapParentContextId(request.filter);
         // Auto-enable decryption when the type requires it. See query()
@@ -1195,7 +1195,7 @@ export class TypedEnbox<
         const normalizedPath = normalizePath(path);
         await this._ensureReady(normalizedPath);
         const typeName = lastSegment(normalizedPath);
-        const typeEntry = this._definition.types[typeName] as ProtocolType | undefined;
+        const typeEntry = this._definition.types[typeName];
 
         const subFilter = mapParentContextId(request?.filter);
 

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -563,7 +563,7 @@ export class AuthManager {
                     const sendReply = await this._userAgent.rpc.sendDwnRequest({
                       dwnUrl,
                       targetDid : connectedDid,
-                      message   : rawMessage as any,
+                      message   : rawMessage,
                       data,
                     });
                     if (sendReply?.status?.code === 202 || sendReply?.status?.code === 409) {

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -15,7 +15,7 @@
  */
 
 import type { PortableDid } from '@enbox/dids';
-import type { BearerIdentity, DelegateContextKey, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, DwnMessagesPermissionScope, DwnRecordsPermissionScope, EnboxUserAgent } from '@enbox/agent';
+import type { BearerIdentity, DelegateContextKey, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, EnboxUserAgent } from '@enbox/agent';
 
 import type { AuthEventEmitter } from '../events.js';
 import type { PasswordProvider } from '../password-provider.js';
@@ -373,7 +373,7 @@ export async function processConnectedGrants(params: {
   // ── Collect protocols ─────────────────────────────────────────────
 
   for (const { grant } of parsed) {
-    const protocol = (grant.scope as DwnMessagesPermissionScope | DwnRecordsPermissionScope).protocol;
+    const protocol = grant.scope.protocol;
     if (protocol && protocol !== PermissionsProtocol.uri) {
       connectedProtocols.add(protocol);
     }

--- a/packages/auth/src/connect/restore.ts
+++ b/packages/auth/src/connect/restore.ts
@@ -14,7 +14,7 @@ import type { StorageAdapter } from '../types.js';
 
 import type { EnboxUserAgent } from '@enbox/agent';
 
-import type { DwnDataEncodedRecordsWriteMessage, DwnMessagesPermissionScope, DwnRecordsPermissionScope } from '@enbox/agent';
+import type { DwnDataEncodedRecordsWriteMessage } from '@enbox/agent';
 
 import { Convert } from '@enbox/common';
 import { DataStream, PermissionsProtocol } from '@enbox/dwn-sdk-js';
@@ -444,7 +444,7 @@ async function sendRevocationToEndpoints(
       const reply = await userAgent.rpc.sendDwnRequest({
         dwnUrl,
         targetDid : connectedDid,
-        message   : rawMessage as any,
+        message   : rawMessage,
         data,
       });
       if (reply?.status?.code === 202 || reply?.status?.code === 409) {
@@ -550,7 +550,7 @@ async function deriveProtocolsFromGrants(
   if (response.reply.status.code === 200 && response.reply.entries) {
     for (const entry of response.reply.entries as DwnDataEncodedRecordsWriteMessage[]) {
       const grant = DwnPermissionGrant.parse(entry);
-      const scopeProtocol = (grant.scope as DwnMessagesPermissionScope | DwnRecordsPermissionScope).protocol;
+      const scopeProtocol = grant.scope.protocol;
       if (scopeProtocol && scopeProtocol !== PermissionsProtocol.uri) {
         protocols.push(scopeProtocol);
       }

--- a/packages/auth/src/discovery.ts
+++ b/packages/auth/src/discovery.ts
@@ -58,7 +58,7 @@ export function checkUrlForDwnDiscoveryPayload(): string | undefined {
 
   // Clear the fragment to prevent re-reading on subsequent calls or
   // if the user refreshes the page after the redirect.
-  if (typeof globalThis.history !== 'undefined' && globalThis.history.replaceState) {
+  if (globalThis.history?.replaceState) {
     const cleanUrl = globalThis.location.href.split('#')[0];
     globalThis.history.replaceState(null, '', cleanUrl);
   }

--- a/packages/auth/src/registration.ts
+++ b/packages/auth/src/registration.ts
@@ -103,8 +103,8 @@ export async function registerWithDwnEndpoints(
             tokenData = {
               registrationToken : refreshed.registrationToken,
               refreshToken      : refreshed.refreshToken,
-              expiresAt         : refreshed.expiresIn !== undefined
-                ? Date.now() + (refreshed.expiresIn * 1000) : undefined,
+              expiresAt         : refreshed.expiresIn === undefined
+                ? undefined : Date.now() + (refreshed.expiresIn * 1000),
               tokenUrl   : tokenData.tokenUrl,
               refreshUrl : tokenData.refreshUrl,
             };
@@ -140,8 +140,8 @@ export async function registerWithDwnEndpoints(
           tokenData = {
             registrationToken : tokenResponse.registrationToken,
             refreshToken      : tokenResponse.refreshToken,
-            expiresAt         : tokenResponse.expiresIn !== undefined
-              ? Date.now() + (tokenResponse.expiresIn * 1000) : undefined,
+            expiresAt         : tokenResponse.expiresIn === undefined
+              ? undefined : Date.now() + (tokenResponse.expiresIn * 1000),
             tokenUrl   : providerAuth.tokenUrl,
             refreshUrl : providerAuth.refreshUrl,
           };

--- a/packages/browser/src/web-features.ts
+++ b/packages/browser/src/web-features.ts
@@ -109,7 +109,9 @@ export async function handleEvent(
     }
   }
   try {
-    if (!path) {
+    if (path) {
+      return await fetchResource(event, did, drl, path, responseCache, options);
+    } else {
       const response = await didResolver.resolve(did);
       return new Response(JSON.stringify(response), {
         status  : 200,
@@ -117,8 +119,7 @@ export async function handleEvent(
           'Content-Type': 'application/json',
         },
       });
-    } else
-    {return await fetchResource(event, did, drl, path, responseCache, options);}
+    }
   } catch (error) {
     if (error instanceof Response) {
       return error;
@@ -576,12 +577,11 @@ export function activatePolyfills(options: ActivatePolyfillsOptions = {}): void 
   }
   if (typeof window !== 'undefined' && typeof window.document !== 'undefined') {
     if (options.injectStyles !== false) {
-      if (document.readyState !== 'loading') {injectElements();}
-      else {
+      if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', injectElements, {
           once: true,
         });
-      }
+      } else {injectElements();}
     }
     if (options.links !== false) {addLinkFeatures();}
   }

--- a/packages/crypto/src/cose/cose-key.ts
+++ b/packages/crypto/src/cose/cose-key.ts
@@ -172,10 +172,10 @@ export class CoseKey {
       coseKey.set(CoseKeyParamLabel.Crv, jwkCrvToCose[crv]);
 
       if (jwk.x !== undefined) {
-        coseKey.set(CoseKeyParamLabel.X, Convert.base64Url(jwk.x as string).toUint8Array());
+        coseKey.set(CoseKeyParamLabel.X, Convert.base64Url(jwk.x).toUint8Array());
       }
       if (jwk.d !== undefined) {
-        coseKey.set(CoseKeyParamLabel.D, Convert.base64Url(jwk.d as string).toUint8Array());
+        coseKey.set(CoseKeyParamLabel.D, Convert.base64Url(jwk.d).toUint8Array());
       }
     } else if (jwk.kty === 'EC') {
       coseKey.set(CoseKeyLabel.Kty, CoseKeyType.EC2);
@@ -187,13 +187,13 @@ export class CoseKey {
       coseKey.set(CoseKeyParamLabel.Crv, jwkCrvToCose[crv]);
 
       if (jwk.x !== undefined) {
-        coseKey.set(CoseKeyParamLabel.X, Convert.base64Url(jwk.x as string).toUint8Array());
+        coseKey.set(CoseKeyParamLabel.X, Convert.base64Url(jwk.x).toUint8Array());
       }
       if (jwk.y !== undefined) {
-        coseKey.set(CoseKeyParamLabel.Y, Convert.base64Url(jwk.y as string).toUint8Array());
+        coseKey.set(CoseKeyParamLabel.Y, Convert.base64Url(jwk.y).toUint8Array());
       }
       if (jwk.d !== undefined) {
-        coseKey.set(CoseKeyParamLabel.D, Convert.base64Url(jwk.d as string).toUint8Array());
+        coseKey.set(CoseKeyParamLabel.D, Convert.base64Url(jwk.d).toUint8Array());
       }
     } else {
       throw new CryptoError(CryptoErrorCode.AlgorithmNotSupported, `CoseKey: unsupported key type '${jwk.kty}'`);

--- a/packages/crypto/src/cose/cose-sign1.ts
+++ b/packages/crypto/src/cose/cose-sign1.ts
@@ -190,9 +190,9 @@ export class CoseSign1 {
     const protectedHeaderBytes = Cbor.encode(protectedHeaderMap);
 
     // Build the unprotected header.
-    const unprotectedHeaderMap = params.unprotectedHeader !== undefined
-      ? CoseSign1.buildUnprotectedHeaderMap(params.unprotectedHeader)
-      : new Map<number, unknown>();
+    const unprotectedHeaderMap = params.unprotectedHeader === undefined
+      ? new Map<number, unknown>()
+      : CoseSign1.buildUnprotectedHeaderMap(params.unprotectedHeader);
 
     // Construct the Sig_structure1 (to-be-signed bytes).
     const sigStructure = CoseSign1.buildSigStructure1(

--- a/packages/dids/src/bearer-did.ts
+++ b/packages/dids/src/bearer-did.ts
@@ -179,7 +179,7 @@ export class BearerDid {
       vm => extractDidFragment(vm.id) === (extractDidFragment(params?.methodId) ?? extractDidFragment(this.document.assertionMethod?.[0]))
     );
 
-    if (!(verificationMethod && verificationMethod.publicKeyJwk)) {
+    if (!verificationMethod?.publicKeyJwk) {
       throw new DidError(DidErrorCode.InternalError, 'A verification method intended for signing could not be determined from the DID Document');
     }
 

--- a/packages/dids/src/did.ts
+++ b/packages/dids/src/did.ts
@@ -152,7 +152,7 @@ export class Did {
     const match = Did.DID_URI_PATTERN.exec(didUri);
 
     // If the pattern does not match, or if the required groups are not found, return null.
-    if (!match || !match.groups) {return null;}
+    if (!match?.groups) {return null;}
 
     // Extract the method, id, params, path, query, and fragment from the regex match groups.
     const { method, id, path, query, fragment } = match.groups;

--- a/packages/dids/src/methods/did-dht-dns.ts
+++ b/packages/dids/src/methods/did-dht-dns.ts
@@ -208,7 +208,7 @@ export async function fromDnsPacket({ didUri, dnsPacket }: {
 
         // Determine the Verification Method ID: '0' for the identity key,
         // the id from the TXT Data Object, or the JWK thumbprint if an explicity Verification Method ID not defined.
-        const vmId = dnsRecordId === 'k0' ? '0' : id !== undefined ? id : await computeJwkThumbprint({ jwk: publicKey });
+        const vmId = dnsRecordId === 'k0' ? '0' : id === undefined ? await computeJwkThumbprint({ jwk: publicKey }) : id;
 
         // Initialize the `verificationMethod` array if it does not already exist.
         didDocument.verificationMethod ??= [];

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -237,7 +237,7 @@ export class DidDht extends DidMethod {
     for (const verificationMethod of verificationMethodsToAdd) {
       // Generate a random key for the verification method, or if its the Identity Key's
       // verification method (`id` is 0) use the key previously generated.
-      const keyUri = (verificationMethod.id && verificationMethod.id.split('#').pop() === '0')
+      const keyUri = (verificationMethod.id?.split('#').pop() === '0')
         ? identityKeyUri
         : await keyManager.generateKey({ algorithm: verificationMethod.algorithm });
 
@@ -368,7 +368,7 @@ export class DidDht extends DidMethod {
       vm => extractDidFragment(vm.id) === (extractDidFragment(methodId) ?? extractDidFragment(didDocument.assertionMethod?.[0]))
     );
 
-    if (!(verificationMethod && verificationMethod.publicKeyJwk)) {
+    if (!verificationMethod?.publicKeyJwk) {
       throw new DidError(DidErrorCode.InternalError, 'A verification method intended for signing could not be determined from the DID Document');
     }
 

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -263,7 +263,7 @@ export class DidDht extends DidMethod {
         // Initialize the purpose property if it does not already exist.
         document[purpose] ??= [];
         // Add the verification method to the purpose property.
-        document[purpose]!.push(methodId);
+        document[purpose].push(methodId);
       }
     }
 

--- a/packages/dids/src/methods/did-ion.ts
+++ b/packages/dids/src/methods/did-ion.ts
@@ -485,7 +485,7 @@ export class DidIon extends DidMethod {
       vm => vm.id === (methodId ?? didDocument.assertionMethod?.[0])
     );
 
-    if (!(verificationMethod && verificationMethod.publicKeyJwk)) {
+    if (!verificationMethod?.publicKeyJwk) {
       throw new DidError(DidErrorCode.InternalError, 'A verification method intended for signing could not be determined from the DID Document');
     }
 

--- a/packages/dids/src/methods/did-jwk.ts
+++ b/packages/dids/src/methods/did-jwk.ts
@@ -270,7 +270,7 @@ export class DidJwk extends DidMethod {
     // Attempt to find the verification method in the DID Document.
     const [ verificationMethod ] = didDocument.verificationMethod ?? [];
 
-    if (!(verificationMethod && verificationMethod.publicKeyJwk)) {
+    if (!verificationMethod?.publicKeyJwk) {
       throw new DidError(DidErrorCode.InternalError, 'A verification method intended for signing could not be determined from the DID Document');
     }
 

--- a/packages/dids/src/methods/did-key.ts
+++ b/packages/dids/src/methods/did-key.ts
@@ -351,7 +351,7 @@ export class DidKey extends DidMethod {
     const [ methodId ] = didDocument.assertionMethod || [];
     const verificationMethod = didDocument.verificationMethod?.find(vm => vm.id === methodId);
 
-    if (!(verificationMethod && verificationMethod.publicKeyJwk)) {
+    if (!verificationMethod?.publicKeyJwk) {
       throw new DidError(DidErrorCode.InternalError, 'A verification method intended for signing could not be determined from the DID Document');
     }
 

--- a/packages/dids/src/methods/did-web.ts
+++ b/packages/dids/src/methods/did-web.ts
@@ -281,7 +281,7 @@ export class DidWeb extends DidMethod {
       // Add the verification method to the specified purpose properties.
       for (const purpose of vmOptions.purposes ?? []) {
         document[purpose] ??= [];
-        document[purpose]!.push(methodId);
+        document[purpose].push(methodId);
       }
     }
 

--- a/packages/dids/src/methods/did-web.ts
+++ b/packages/dids/src/methods/did-web.ts
@@ -334,7 +334,7 @@ export class DidWeb extends DidMethod {
       ? didDocument.verificationMethod?.find(vm => extractDidFragment(vm.id) === targetFragment)
       : didDocument.verificationMethod?.[0];
 
-    if (!(verificationMethod && verificationMethod.publicKeyJwk)) {
+    if (!verificationMethod?.publicKeyJwk) {
       throw new DidError(
         DidErrorCode.InternalError,
         'A verification method intended for signing could not be determined from the DID Document'

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -309,7 +309,7 @@ export class HttpDwnRpcClient implements DwnRpc {
       // Compute the delay, preferring Retry-After when available.
       const retryAfterMs = lastResponse ? parseRetryAfterMs(lastResponse) : undefined;
       const backoffMs = computeBackoffDelay(attempt, baseDelayMs, maxDelayMs);
-      const delayMs = retryAfterMs !== undefined ? Math.max(retryAfterMs, backoffMs) : backoffMs;
+      const delayMs = retryAfterMs === undefined ? backoffMs : Math.max(retryAfterMs, backoffMs);
 
       await new Promise<void>((resolve): void => { setTimeout(resolve, delayMs); });
     }

--- a/packages/dwn-sdk-js/src/core/abstract-message.ts
+++ b/packages/dwn-sdk-js/src/core/abstract-message.ts
@@ -43,10 +43,10 @@ export abstract class AbstractMessage<M extends GenericMessage> implements Messa
 
       // if the message authorization contains author delegated grant, the author would be the grantor of the grant
       // else the author would be the signer of the message
-      if (message.authorization.authorDelegatedGrant !== undefined) {
-        this._author = Message.getSigner(message.authorization.authorDelegatedGrant);
-      } else {
+      if (message.authorization.authorDelegatedGrant === undefined) {
         this._author = this._signer;
+      } else {
+        this._author = Message.getSigner(message.authorization.authorDelegatedGrant);
       }
 
       this._signaturePayload = Jws.decodePlainObjectPayload(message.authorization.signature);

--- a/packages/dwn-sdk-js/src/core/abstract-message.ts
+++ b/packages/dwn-sdk-js/src/core/abstract-message.ts
@@ -10,7 +10,7 @@ import { Message } from './message.js';
 export abstract class AbstractMessage<M extends GenericMessage> implements MessageInterface<M> {
   private _message: M;
   public get message(): M {
-    return this._message as M;
+    return this._message;
   }
 
   private _signer: string | undefined;

--- a/packages/dwn-sdk-js/src/core/message.ts
+++ b/packages/dwn-sdk-js/src/core/message.ts
@@ -26,10 +26,10 @@ export class Message {
     }
 
     let author;
-    if (message.authorization.authorDelegatedGrant !== undefined) {
-      author = Message.getSigner(message.authorization.authorDelegatedGrant);
-    } else {
+    if (message.authorization.authorDelegatedGrant === undefined) {
       author = Message.getSigner(message);
+    } else {
+      author = Message.getSigner(message.authorization.authorDelegatedGrant);
     }
 
     return author;

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-action.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-action.ts
@@ -53,7 +53,7 @@ export async function verifyInvokedRole(
       );
     }
 
-    if (protocolDefinition.uses === undefined || protocolDefinition.uses[parsed.alias] === undefined) {
+    if (protocolDefinition.uses?.[parsed.alias] === undefined) {
       throw new DwnError(
         DwnErrorCode.ProtocolAuthorizationNotARole,
         `Cross-protocol role alias '${parsed.alias}' in '${protocolRole}' does not exist in the protocol's 'uses' map.`
@@ -68,7 +68,7 @@ export async function verifyInvokedRole(
       tenant, roleProtocolUri, messageStore, governingTimestamp
     );
     const roleRuleSet = getRuleSetAtPath(roleProtocolPath, refDefinition.structure);
-    if (roleRuleSet === undefined || !roleRuleSet.$role) {
+    if (!roleRuleSet?.$role) {
       throw new DwnError(
         DwnErrorCode.ProtocolAuthorizationNotARole,
         `Cross-protocol role path ${protocolRole} does not match role record type.`
@@ -77,7 +77,7 @@ export async function verifyInvokedRole(
   } else {
     // Local role: validate in the composing protocol's definition
     const roleRuleSet = getRuleSetAtPath(protocolRole, protocolDefinition.structure);
-    if (roleRuleSet === undefined || !roleRuleSet.$role) {
+    if (!roleRuleSet?.$role) {
       throw new DwnError(
         DwnErrorCode.ProtocolAuthorizationNotARole,
         `Protocol path ${protocolRole} does not match role record type.`

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -28,7 +28,7 @@ export async function verifyProtocolPathAndContextId(
   fetchProtocolDefinition: FetchProtocolDefinitionFn,
   governingTimestamp?: string,
 ): Promise<void> {
-  const declaredProtocolPath = inboundMessage.message.descriptor.protocolPath!;
+  const declaredProtocolPath = inboundMessage.message.descriptor.protocolPath;
   const declaredTypeName = getTypeName(declaredProtocolPath);
 
   const parentId = inboundMessage.message.descriptor.parentId;
@@ -47,7 +47,7 @@ export async function verifyProtocolPathAndContextId(
 
   // Determine the protocol URI for the parent query.
   // If the parent path segment has a `$ref` in the composing protocol, the parent lives in a different protocol.
-  const childProtocol = inboundMessage.message.descriptor.protocol!;
+  const childProtocol = inboundMessage.message.descriptor.protocol;
   const parentProtocolUri = await resolveParentProtocolUri(
     tenant, childProtocol, declaredProtocolPath, messageStore, fetchProtocolDefinition, governingTimestamp
   );
@@ -174,7 +174,7 @@ export async function verifyTypeWithComposition(
   fetchProtocolDefinition: FetchProtocolDefinitionFn,
   governingTimestamp?: string,
 ): Promise<void> {
-  const declaredProtocolPath = inboundMessage.descriptor.protocolPath!;
+  const declaredProtocolPath = inboundMessage.descriptor.protocolPath;
   const declaredTypeName = getTypeName(declaredProtocolPath);
 
   // Resolve which protocol types map to use.
@@ -231,7 +231,7 @@ export function verifyType(
   protocolTypes: ProtocolTypes,
   typeName?: string,
 ): void {
-  const declaredTypeName = typeName ?? getTypeName(inboundMessage.descriptor.protocolPath!);
+  const declaredTypeName = typeName ?? getTypeName(inboundMessage.descriptor.protocolPath);
   const typeNames = Object.keys(protocolTypes);
 
   if (!typeNames.includes(declaredTypeName)) {
@@ -361,12 +361,12 @@ export async function verifyAsRoleRecordIfNeeded(
     );
   }
 
-  const protocolPath = incomingRecordsWrite.message.descriptor.protocolPath!;
+  const protocolPath = incomingRecordsWrite.message.descriptor.protocolPath;
   const filter: Filter = {
     interface         : DwnInterfaceName.Records,
     method            : DwnMethodName.Write,
     isLatestBaseState : true,
-    protocol          : incomingRecordsWrite.message.descriptor.protocol!,
+    protocol          : incomingRecordsWrite.message.descriptor.protocol,
     protocolPath,
     recipient,
   };
@@ -422,12 +422,12 @@ export async function verifyRecordLimit(
   const { max, strategy } = ruleSet.$recordLimit;
 
   // Build a filter to count existing records at the same protocol path and parent context.
-  const protocolPath = incomingMessage.message.descriptor.protocolPath!;
+  const protocolPath = incomingMessage.message.descriptor.protocolPath;
   const filter: Filter = {
     interface         : DwnInterfaceName.Records,
     method            : DwnMethodName.Write,
     isLatestBaseState : true,
-    protocol          : incomingMessage.message.descriptor.protocol!,
+    protocol          : incomingMessage.message.descriptor.protocol,
     protocolPath,
   };
 

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -445,7 +445,7 @@ export async function verifyRecordLimit(
       throw new DwnError(
         DwnErrorCode.ProtocolAuthorizationRecordLimitExceeded,
         `record limit of ${max} reached at protocol path '${protocolPath}'` +
-        `${parentContextId !== '' ? ` under parent context '${parentContextId}'` : ''}` +
+        `${parentContextId === '' ? '' : ` under parent context '${parentContextId}'`}` +
         `: new records are rejected until existing records are deleted.`
       );
     }

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -61,7 +61,7 @@ export class ProtocolAuthorization {
     // fetch the protocol definition that was active at the governing timestamp
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
       tenant,
-      incomingMessage.message.descriptor.protocol!,
+      incomingMessage.message.descriptor.protocol,
       messageStore,
       governingTimestamp,
       coreProtocols,
@@ -85,7 +85,7 @@ export class ProtocolAuthorization {
 
     // get the rule set for the inbound message
     const ruleSet = ProtocolAuthorization.getRuleSet(
-      incomingMessage.message.descriptor.protocolPath!,
+      incomingMessage.message.descriptor.protocolPath,
       protocolDefinition,
     );
 
@@ -143,7 +143,7 @@ export class ProtocolAuthorization {
     // fetch the protocol definition that was active at the governing timestamp
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
       tenant,
-      incomingMessage.message.descriptor.protocol!,
+      incomingMessage.message.descriptor.protocol,
       messageStore,
       governingTimestamp,
       coreProtocols,
@@ -151,7 +151,7 @@ export class ProtocolAuthorization {
 
     // get the rule set for the inbound message
     const ruleSet = ProtocolAuthorization.getRuleSet(
-      incomingMessage.message.descriptor.protocolPath!,
+      incomingMessage.message.descriptor.protocolPath,
       protocolDefinition,
     );
 
@@ -161,8 +161,8 @@ export class ProtocolAuthorization {
     await verifyInvokedRole(
       tenant,
       incomingMessage,
-      incomingMessage.message.descriptor.protocol!,
-      incomingMessage.message.contextId!,
+      incomingMessage.message.descriptor.protocol,
+      incomingMessage.message.contextId,
       protocolDefinition,
       messageStore,
       boundFetchDefinition,
@@ -208,7 +208,7 @@ export class ProtocolAuthorization {
     // fetch the protocol definition that was active when the record was created
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
       tenant,
-      newestRecordsWrite.message.descriptor.protocol!,
+      newestRecordsWrite.message.descriptor.protocol,
       messageStore,
       governingTimestamp,
       coreProtocols,
@@ -216,7 +216,7 @@ export class ProtocolAuthorization {
 
     // get the rule set for the inbound message
     const ruleSet = ProtocolAuthorization.getRuleSet(
-      newestRecordsWrite.message.descriptor.protocolPath!,
+      newestRecordsWrite.message.descriptor.protocolPath,
       protocolDefinition,
     );
 
@@ -226,8 +226,8 @@ export class ProtocolAuthorization {
     await verifyInvokedRole(
       tenant,
       incomingMessage,
-      newestRecordsWrite.message.descriptor.protocol!,
-      newestRecordsWrite.message.contextId!,
+      newestRecordsWrite.message.descriptor.protocol,
+      newestRecordsWrite.message.contextId,
       protocolDefinition,
       messageStore,
       boundFetchDefinition,
@@ -319,7 +319,7 @@ export class ProtocolAuthorization {
     // fetch the protocol definition that was active when the record was created
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
       tenant,
-      recordsWrite.message.descriptor.protocol!,
+      recordsWrite.message.descriptor.protocol,
       messageStore,
       governingTimestamp,
       coreProtocols,
@@ -327,7 +327,7 @@ export class ProtocolAuthorization {
 
     // get the rule set for the inbound message
     const ruleSet = ProtocolAuthorization.getRuleSet(
-      recordsWrite.message.descriptor.protocolPath!,
+      recordsWrite.message.descriptor.protocolPath,
       protocolDefinition,
     );
 
@@ -337,8 +337,8 @@ export class ProtocolAuthorization {
     await verifyInvokedRole(
       tenant,
       incomingMessage,
-      recordsWrite.message.descriptor.protocol!,
-      recordsWrite.message.contextId!,
+      recordsWrite.message.descriptor.protocol,
+      recordsWrite.message.contextId,
       protocolDefinition,
       messageStore,
       boundFetchDefinition,

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -201,9 +201,9 @@ export class ProtocolAuthorization {
     const initialWrite = await fetchInitialWrite(
       tenant, newestRecordsWrite.message.recordId, messageStore
     );
-    const governingTimestamp = initialWrite !== undefined
-      ? initialWrite.descriptor.messageTimestamp
-      : newestRecordsWrite.message.descriptor.messageTimestamp;
+    const governingTimestamp = initialWrite === undefined
+      ? newestRecordsWrite.message.descriptor.messageTimestamp
+      : initialWrite.descriptor.messageTimestamp;
 
     // fetch the protocol definition that was active when the record was created
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
@@ -312,9 +312,9 @@ export class ProtocolAuthorization {
     const initialWrite = await fetchInitialWrite(
       tenant, incomingMessage.message.descriptor.recordId, messageStore
     );
-    const governingTimestamp = initialWrite !== undefined
-      ? initialWrite.descriptor.messageTimestamp
-      : recordsWrite.message.descriptor.messageTimestamp;
+    const governingTimestamp = initialWrite === undefined
+      ? recordsWrite.message.descriptor.messageTimestamp
+      : initialWrite.descriptor.messageTimestamp;
 
     // fetch the protocol definition that was active when the record was created
     const protocolDefinition = await ProtocolAuthorization.fetchProtocolDefinition(
@@ -389,12 +389,12 @@ export class ProtocolAuthorization {
       protocol  : protocolUri,
     };
 
-    if (messageTimestamp !== undefined) {
-      // temporal lookup: find the protocol definition active at the given timestamp
-      query.messageTimestamp = { lte: messageTimestamp };
-    } else {
+    if (messageTimestamp === undefined) {
       // default: return only the latest protocol definition
       query.isLatestBaseState = true;
+    } else {
+      // temporal lookup: find the protocol definition active at the given timestamp
+      query.messageTimestamp = { lte: messageTimestamp };
     }
 
     const { messages: protocols } = await messageStore.query(

--- a/packages/dwn-sdk-js/src/core/records-grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/records-grant-authorization.ts
@@ -153,7 +153,7 @@ export class RecordsGrantAuthorization {
 
     // If grant specifies a contextId, check that record falls under that contextId
     if (grantScope.contextId !== undefined) {
-      if (recordsWriteMessage.contextId === undefined || !recordsWriteMessage.contextId.startsWith(grantScope.contextId)) {
+      if (!recordsWriteMessage.contextId?.startsWith(grantScope.contextId)) {
         throw new DwnError(
           DwnErrorCode.RecordsGrantAuthorizationScopeContextIdMismatch,
           `Grant scope specifies different contextId than what appears in the record`

--- a/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
@@ -131,9 +131,7 @@ export class EventEmitterEventLog implements EventLog {
     let reason: ProgressGapReason;
     if (cursor.streamId !== expectedStreamId) {
       reason = 'stream_mismatch';
-    } else if (cursor.epoch !== this.epoch) {
-      reason = 'epoch_mismatch';
-    } else {
+    } else if (cursor.epoch === this.epoch) {
       // Check if position is still within replay bounds.
       const log = this.tenantLogs.get(tenant);
       if (log !== undefined && log.size > 0) {
@@ -148,6 +146,8 @@ export class EventEmitterEventLog implements EventLog {
       } else {
         return; // No events for tenant — cursor is vacuously valid (will get empty catch-up + EOSE).
       }
+    } else {
+      reason = 'epoch_mismatch';
     }
 
     // Build gap metadata.
@@ -226,7 +226,7 @@ export class EventEmitterEventLog implements EventLog {
       await this.validateCursor(tenant, cursor);
     }
 
-    const cursorSeq = cursor !== undefined ? EventEmitterEventLog.parsePosition(cursor.position) : undefined;
+    const cursorSeq = cursor === undefined ? undefined : EventEmitterEventLog.parsePosition(cursor.position);
     const log = this.tenantLogs.get(tenant);
 
     if (log === undefined || log.size === 0) {
@@ -319,12 +319,12 @@ export class EventEmitterEventLog implements EventLog {
         if (filters !== undefined && filters.length > 0) {
           if (!FilterUtility.matchAnyFilter(payload.indexes, filters)) { return; }
         }
-        if (!catchUpComplete) {
-          pendingLiveEvents.push({ event: payload.event, seq: payload.seq, messageCid: payload.messageCid });
-        } else {
+        if (catchUpComplete) {
           void tokenFromPayload(payload).then((token) => {
             listener({ type: 'event', cursor: token, event: payload.event });
           });
+        } else {
+          pendingLiveEvents.push({ event: payload.event, seq: payload.seq, messageCid: payload.messageCid });
         }
       };
 
@@ -334,9 +334,9 @@ export class EventEmitterEventLog implements EventLog {
       const readResult = await this.read(tenant, { cursor, filters });
       // The read cursor is the token of the last read event, or the input cursor if nothing new.
       const eoseCursor = readResult.cursor ?? cursor;
-      const lastCatchUpSeq = readResult.cursor !== undefined
-        ? EventEmitterEventLog.parsePosition(readResult.cursor.position)
-        : cursorSeq;
+      const lastCatchUpSeq = readResult.cursor === undefined
+        ? cursorSeq
+        : EventEmitterEventLog.parsePosition(readResult.cursor.position);
 
       // Use the messageCid captured by read() during its synchronous iteration.
       // This eliminates re-lookup races: read() populates entry.messageCid before

--- a/packages/dwn-sdk-js/src/handlers/messages-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-read.ts
@@ -52,16 +52,16 @@ export class MessagesReadHandler implements MethodHandler {
       const recordsWrite = entry.message as RecordsQueryReplyEntry;
       // RecordsWrite specific handling, if MessageStore has embedded `encodedData` return it with the entry.
       // we store `encodedData` along with the message if the data is below a certain threshold.
-      if (recordsWrite.encodedData !== undefined) {
-        const dataBytes = Encoder.base64UrlToBytes(recordsWrite.encodedData);
-        entry.data = DataStream.fromBytes(dataBytes);
-        delete recordsWrite.encodedData;
-      } else {
-        // otherwise check the data store for the associated data
+      if (recordsWrite.encodedData === undefined) {
+        // check the data store for the associated data
         const result = await this.deps.dataStore!.get(tenant, recordsWrite.recordId, recordsWrite.descriptor.dataCid);
         if (result?.dataStream !== undefined) {
           entry.data = result.dataStream;
         }
+      } else {
+        const dataBytes = Encoder.base64UrlToBytes(recordsWrite.encodedData);
+        entry.data = DataStream.fromBytes(dataBytes);
+        delete recordsWrite.encodedData;
       }
     }
 

--- a/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
@@ -65,7 +65,7 @@ export class MessagesSubscribeHandler implements MethodHandler {
         const gapInfo = (error as any).gapInfo as ProgressGapInfo | undefined;
         return {
           status : { code: 410, detail: 'Progress token gap' },
-          error  : gapInfo !== undefined ? { code: 'ProgressGap' as const, ...gapInfo } : undefined,
+          error  : gapInfo === undefined ? undefined : { code: 'ProgressGap' as const, ...gapInfo },
         };
       }
       return messageReplyFromError(error, 500);

--- a/packages/dwn-sdk-js/src/handlers/messages-sync.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-sync.ts
@@ -51,9 +51,9 @@ export class MessagesSyncHandler implements MethodHandler {
     try {
       switch (action) {
       case 'root': {
-        const rootHash = protocol !== undefined
-          ? await this.deps.stateIndex!.getProtocolRoot(tenant, protocol)
-          : await this.deps.stateIndex!.getRoot(tenant);
+        const rootHash = protocol === undefined
+          ? await this.deps.stateIndex!.getRoot(tenant)
+          : await this.deps.stateIndex!.getProtocolRoot(tenant, protocol);
         return {
           status : { code: 200, detail: 'OK' },
           root   : hashToHex(rootHash),
@@ -62,9 +62,9 @@ export class MessagesSyncHandler implements MethodHandler {
 
       case 'subtree': {
         const bitPath = MessagesSyncHandler.parseBitPrefix(prefix!);
-        const hash = protocol !== undefined
-          ? await this.deps.stateIndex!.getProtocolSubtreeHash(tenant, protocol, bitPath)
-          : await this.deps.stateIndex!.getSubtreeHash(tenant, bitPath);
+        const hash = protocol === undefined
+          ? await this.deps.stateIndex!.getSubtreeHash(tenant, bitPath)
+          : await this.deps.stateIndex!.getProtocolSubtreeHash(tenant, protocol, bitPath);
         return {
           status : { code: 200, detail: 'OK' },
           hash   : hashToHex(hash),
@@ -73,9 +73,9 @@ export class MessagesSyncHandler implements MethodHandler {
 
       case 'leaves': {
         const bitPath = MessagesSyncHandler.parseBitPrefix(prefix!);
-        const leaves = protocol !== undefined
-          ? await this.deps.stateIndex!.getProtocolLeaves(tenant, protocol, bitPath)
-          : await this.deps.stateIndex!.getLeaves(tenant, bitPath);
+        const leaves = protocol === undefined
+          ? await this.deps.stateIndex!.getLeaves(tenant, bitPath)
+          : await this.deps.stateIndex!.getProtocolLeaves(tenant, protocol, bitPath);
         return {
           status  : { code: 200, detail: 'OK' },
           entries : leaves,
@@ -165,18 +165,18 @@ export class MessagesSyncHandler implements MethodHandler {
       if (clientHash === undefined) {
         // Server has entries the client doesn't — enumerate server leaves.
         const bitPath = MessagesSyncHandler.parseBitPrefix(pfx);
-        const leaves = protocol !== undefined
-          ? await stateIndex.getProtocolLeaves(tenant, protocol, bitPath)
-          : await stateIndex.getLeaves(tenant, bitPath);
+        const leaves = protocol === undefined
+          ? await stateIndex.getLeaves(tenant, bitPath)
+          : await stateIndex.getProtocolLeaves(tenant, protocol, bitPath);
         onlyRemoteCids.push(...leaves);
         continue;
       }
 
       // Both sides have entries but they differ — enumerate both and set-diff.
       const bitPath = MessagesSyncHandler.parseBitPrefix(pfx);
-      const serverLeaves = protocol !== undefined
-        ? await stateIndex.getProtocolLeaves(tenant, protocol, bitPath)
-        : await stateIndex.getLeaves(tenant, bitPath);
+      const serverLeaves = protocol === undefined
+        ? await stateIndex.getLeaves(tenant, bitPath)
+        : await stateIndex.getProtocolLeaves(tenant, protocol, bitPath);
 
       // We don't have the client's leaves, so we report all server leaves
       // as onlyRemote (the client will de-duplicate locally). We also
@@ -210,9 +210,9 @@ export class MessagesSyncHandler implements MethodHandler {
 
     const walk = async (prefix: string, currentDepth: number): Promise<void> => {
       const bitPath = MessagesSyncHandler.parseBitPrefix(prefix);
-      const hash = protocol !== undefined
-        ? await stateIndex.getProtocolSubtreeHash(tenant, protocol, bitPath)
-        : await stateIndex.getSubtreeHash(tenant, bitPath);
+      const hash = protocol === undefined
+        ? await stateIndex.getSubtreeHash(tenant, bitPath)
+        : await stateIndex.getProtocolSubtreeHash(tenant, protocol, bitPath);
       const hexHash = hashToHex(hash);
 
       if (hexHash === defaultHashHex) {

--- a/packages/dwn-sdk-js/src/handlers/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/handlers/protocols-configure.ts
@@ -298,7 +298,7 @@ export class ProtocolsConfigureHandler implements MethodHandler {
 
             // Check that the role path exists and is marked $role: true in the referenced protocol
             const roleRuleSet = getRuleSetAtPath(parsed.protocolPath, refDefinition.structure);
-            if (roleRuleSet === undefined || !roleRuleSet.$role) {
+            if (!roleRuleSet?.$role) {
               throw new DwnError(
                 DwnErrorCode.ProtocolsConfigureInvalidCrossProtocolRole,
                 `cross-protocol role '${actionRule.role}' at protocol path '${childProtocolPath}' ` +

--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -115,11 +115,7 @@ export class RecordsReadHandler implements MethodHandler {
     }
 
     let data;
-    if (matchedRecordsWrite.encodedData !== undefined) {
-      const dataBytes = Encoder.base64UrlToBytes(matchedRecordsWrite.encodedData);
-      data = DataStream.fromBytes(dataBytes);
-      delete matchedRecordsWrite.encodedData;
-    } else {
+    if (matchedRecordsWrite.encodedData === undefined) {
       const result = await this.deps.dataStore!.get(tenant, matchedRecordsWrite.recordId, matchedRecordsWrite.descriptor.dataCid);
       if (result?.dataStream === undefined) {
         // The message envelope exists but the record data is unavailable (e.g., evicted
@@ -131,6 +127,10 @@ export class RecordsReadHandler implements MethodHandler {
         };
       }
       data = result.dataStream;
+    } else {
+      const dataBytes = Encoder.base64UrlToBytes(matchedRecordsWrite.encodedData);
+      data = DataStream.fromBytes(dataBytes);
+      delete matchedRecordsWrite.encodedData;
     }
 
     const recordsReadReply: RecordsReadReply = {

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -97,7 +97,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
           const gapInfo = (error as any).gapInfo as ProgressGapInfo | undefined;
           return {
             status : { code: 410, detail: 'Progress token gap' },
-            error  : gapInfo !== undefined ? { code: 'ProgressGap' as const, ...gapInfo } : undefined,
+            error  : gapInfo === undefined ? undefined : { code: 'ProgressGap' as const, ...gapInfo },
           };
         }
         return messageReplyFromError(error, 500);

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -121,9 +121,9 @@ export class RecordsWriteHandler implements MethodHandler {
 
     // Look up the core protocol (if any) for the incoming message so that lifecycle hooks
     // can be dispatched generically rather than checking for specific protocol URIs.
-    const coreProtocol = message.descriptor.protocol !== undefined
-      ? this.deps.coreProtocols?.get(message.descriptor.protocol)
-      : undefined;
+    const coreProtocol = message.descriptor.protocol === undefined
+      ? undefined
+      : this.deps.coreProtocols?.get(message.descriptor.protocol);
 
     try {
       if (newestExistingMessage?.descriptor.method === DwnMethodName.Delete) {
@@ -148,11 +148,8 @@ export class RecordsWriteHandler implements MethodHandler {
       let isLatestBaseState = false;
       let messageWithOptionalEncodedData = message as RecordsQueryReplyEntry;
 
-      if (dataStream !== undefined) {
-        messageWithOptionalEncodedData = await this.processMessageWithDataStream(tenant, message, dataStream);
-        isLatestBaseState = true;
-      } else {
-        // else data stream is NOT provided
+      if (dataStream === undefined) {
+        // data stream is NOT provided
 
         // if the incoming message is not an initial write, and no dataStream is provided, we would allow it provided it passes validation
         // processMessageWithoutDataStream() abstracts that logic
@@ -161,6 +158,9 @@ export class RecordsWriteHandler implements MethodHandler {
           messageWithOptionalEncodedData = await this.processMessageWithoutDataStream(tenant, message, newestExistingWrite );
           isLatestBaseState = true;
         }
+      } else {
+        messageWithOptionalEncodedData = await this.processMessageWithDataStream(tenant, message, dataStream);
+        isLatestBaseState = true;
       }
 
       const indexes = await recordsWrite.constructIndexes(isLatestBaseState);
@@ -257,9 +257,9 @@ export class RecordsWriteHandler implements MethodHandler {
       RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, dataCid, dataBytes.length);
 
       // Dispatch schema validation to the core protocol, if applicable.
-      const coreProtocol = message.descriptor.protocol !== undefined
-        ? this.deps.coreProtocols?.get(message.descriptor.protocol)
-        : undefined;
+      const coreProtocol = message.descriptor.protocol === undefined
+        ? undefined
+        : this.deps.coreProtocols?.get(message.descriptor.protocol);
       if (coreProtocol?.validateRecord !== undefined) {
         coreProtocol.validateRecord(message, dataBytes);
       }
@@ -304,13 +304,13 @@ export class RecordsWriteHandler implements MethodHandler {
 
     if (dataSize <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
       // we encode the data from the original write if it is smaller than the data-store threshold
-      if (newestExistingWrite.encodedData !== undefined) {
-        messageWithOptionalEncodedData.encodedData = newestExistingWrite.encodedData;
-      } else {
+      if (newestExistingWrite.encodedData === undefined) {
         throw new DwnError(
           DwnErrorCode.RecordsWriteMissingEncodedDataInPrevious,
           `No dataStream was provided and unable to get data from previous message`
         );
+      } else {
+        messageWithOptionalEncodedData.encodedData = newestExistingWrite.encodedData;
       }
     } else {
       // else just make sure the data is in the data store
@@ -396,7 +396,7 @@ export class RecordsWriteHandler implements MethodHandler {
       ruleSet = ruleSet[pathSegments[i]] as typeof ruleSet;
     }
 
-    if (ruleSet === undefined || ruleSet.$squash !== true) {
+    if (ruleSet?.$squash !== true) {
       return;
     }
 

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -106,7 +106,7 @@ export class RecordsWriteHandler implements MethodHandler {
         if (isInitial) {
           const hasInlineData = !!(newestExistingMessage as any).encodedData;
           const hasStoredData = this.deps.dataStore
-            ? !!(await this.deps.dataStore.get(tenant, recordsWrite.message.recordId, message.descriptor.dataCid!))
+            ? !!(await this.deps.dataStore.get(tenant, recordsWrite.message.recordId, message.descriptor.dataCid))
             : false;
           existingLacksData = !hasInlineData && !hasStoredData;
         }
@@ -252,7 +252,7 @@ export class RecordsWriteHandler implements MethodHandler {
     // if data is below the threshold, we store it within MessageStore
     if (message.descriptor.dataSize <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
       // validate data integrity before setting.
-      const dataBytes = await DataStream.toBytes(dataStream!);
+      const dataBytes = await DataStream.toBytes(dataStream);
       const dataCid = await Cid.computeDagPbCidFromBytes(dataBytes);
       RecordsWriteHandler.validateDataIntegrity(message.descriptor.dataCid, message.descriptor.dataSize, dataCid, dataBytes.length);
 

--- a/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
@@ -377,21 +377,21 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
       for (let j = i + 1; j < actionRules.length; j++) {
         const otherActionRule = actionRules[j];
 
-        if (actionRule.who !== undefined) {
-          if (actionRule.who === otherActionRule.who && actionRule.of === otherActionRule.of) {
-            throw new DwnError(
-              DwnErrorCode.ProtocolsConfigureDuplicateActorInRuleSet,
-              `More than one action rule per actor ${actionRule.who} of ${actionRule.of} ` +
-              `not allowed within a rule set: ${JSON.stringify(actionRule)}`
-            );
-          }
-        } else {
-          // else implicitly a role-based action rule
+        if (actionRule.who === undefined) {
+          // implicitly a role-based action rule
 
           if (actionRule.role === otherActionRule.role) {
             throw new DwnError(
               DwnErrorCode.ProtocolsConfigureDuplicateRoleInRuleSet,
               `More than one action rule per role ${actionRule.role} not allowed within a rule set: ${JSON.stringify(actionRule)}`
+            );
+          }
+        } else {
+          if (actionRule.who === otherActionRule.who && actionRule.of === otherActionRule.of) {
+            throw new DwnError(
+              DwnErrorCode.ProtocolsConfigureDuplicateActorInRuleSet,
+              `More than one action rule per actor ${actionRule.who} of ${actionRule.of} ` +
+              `not allowed within a rule set: ${JSON.stringify(actionRule)}`
             );
           }
         }
@@ -497,7 +497,7 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
     }
 
     // validate alias exists in `uses`
-    if (uses === undefined || uses[parsed.alias] === undefined) {
+    if (uses?.[parsed.alias] === undefined) {
       throw new DwnError(
         DwnErrorCode.ProtocolsConfigureInvalidRefAlias,
         `'$ref' alias '${parsed.alias}' at protocol path '${ruleSetProtocolPath}' does not exist in the 'uses' map.`
@@ -543,7 +543,7 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
       );
     }
 
-    if (uses === undefined || uses[parsed.alias] === undefined) {
+    if (uses?.[parsed.alias] === undefined) {
       const errorCode = fieldName === 'role'
         ? DwnErrorCode.ProtocolsConfigureInvalidCrossProtocolRole
         : DwnErrorCode.ProtocolsConfigureInvalidCrossProtocolOf;

--- a/packages/dwn-sdk-js/src/interfaces/records-delete.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-delete.ts
@@ -110,7 +110,7 @@ export class RecordsDelete extends AbstractMessage<RecordsDeleteMessage> {
    * @param messageStore Used to check if the grant has been revoked.
    */
   public async authorizeDelegate(recordsWriteToDelete: RecordsWriteMessage, messageStore: MessageStore): Promise<void> {
-    const delegatedGrant = PermissionGrant.parse(this.message.authorization!.authorDelegatedGrant!);
+    const delegatedGrant = PermissionGrant.parse(this.message.authorization.authorDelegatedGrant!);
     await RecordsGrantAuthorization.authorizeDelete({
       recordsDeleteMessage : this.message,
       recordsWriteToDelete,

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -549,7 +549,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     // `signature` generation
     const signature = await createSignerSignature({
       recordId    : this._message.recordId,
-      contextId   : this._message.contextId!, // contextId is computed just above, always defined here
+      contextId   : this._message.contextId, // contextId is computed just above, always defined here
       descriptorCid,
       attestation : this._message.attestation,
       encryption  : this._message.encryption,
@@ -872,7 +872,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
   public static async fetchInitialRecordsWrite(
     messageStore: MessageStore, tenant: string, recordId: string
   ): Promise<RecordsWrite | undefined> {
-    return fetchInitialRecordsWrite(messageStore, tenant, recordId) as Promise<RecordsWrite | undefined>;
+    return fetchInitialRecordsWrite(messageStore, tenant, recordId);
   }
 
   /** Delegate to `fetchInitialRecordsWriteMessage` in `records-write-query.ts`. */

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -232,10 +232,10 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       if (message.authorization.ownerSignature !== undefined) {
         // if the message authorization contains owner delegated grant, the owner would be the grantor of the grant
         // else the owner would be the signer of the owner signature
-        if (message.authorization.ownerDelegatedGrant !== undefined) {
-          this._owner = Message.getSigner(message.authorization.ownerDelegatedGrant);
-        } else {
+        if (message.authorization.ownerDelegatedGrant === undefined) {
           this._owner = Jws.getSignerDid(message.authorization.ownerSignature.signatures[0]);
+        } else {
+          this._owner = Message.getSigner(message.authorization.ownerDelegatedGrant);
         }
 
         this._ownerSignaturePayload = Jws.decodePlainObjectPayload(message.authorization.ownerSignature);
@@ -321,7 +321,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       protocol          : normalizeProtocolUrl(options.protocol),
       protocolPath      : options.protocolPath,
       recipient         : options.recipient,
-      schema            : options.schema !== undefined ? normalizeSchemaUrl(options.schema) : undefined,
+      schema            : options.schema === undefined ? undefined : normalizeSchemaUrl(options.schema),
       tags              : options.tags,
       parentId          : RecordsWrite.getRecordIdFromContextId(options.parentContextId),
       dataCid,
@@ -524,11 +524,11 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     // compute delegated grant ID and author if delegated grant is given
     let delegatedGrantId;
     let authorDid;
-    if (delegatedGrant !== undefined) {
+    if (delegatedGrant === undefined) {
+      authorDid = Jws.extractDid(signer.keyId);
+    } else {
       delegatedGrantId = await Message.getCid(delegatedGrant);
       authorDid = Jws.getSignerDid(delegatedGrant.authorization.signature.signatures[0]);
-    } else {
-      authorDid = Jws.extractDid(signer.keyId);
     }
 
     const descriptor = this._message.descriptor;

--- a/packages/dwn-sdk-js/src/protocols/permissions.ts
+++ b/packages/dwn-sdk-js/src/protocols/permissions.ts
@@ -605,7 +605,7 @@ export class PermissionsProtocol implements CoreProtocol {
    */
   private static validateTags(requestOrGrant: RecordsWriteMessage, scopedProtocol: string): void {
     // the protocol tag must be included with the record.
-    if (requestOrGrant.descriptor.tags === undefined || requestOrGrant.descriptor.tags.protocol === undefined) {
+    if (requestOrGrant.descriptor.tags?.protocol === undefined) {
       throw new DwnError(
         DwnErrorCode.PermissionsProtocolValidateScopeMissingProtocolTag,
         'Permission grants must have a `tags` property that contains a protocol tag'

--- a/packages/dwn-sdk-js/src/smt/sparse-merkle-tree.ts
+++ b/packages/dwn-sdk-js/src/smt/sparse-merkle-tree.ts
@@ -148,7 +148,7 @@ export class SparseMerkleTree {
         return this.defaultHashes[prefix.length];
       }
 
-      const internalNode = node as SMTInternalNode;
+      const internalNode = node;
       if (prefix[i]) {
         currentHash = internalNode.rightHash;
       } else {
@@ -186,7 +186,7 @@ export class SparseMerkleTree {
         return [];
       }
 
-      const internalNode = node as SMTInternalNode;
+      const internalNode = node;
       if (prefix[i]) {
         currentHash = internalNode.rightHash;
       } else {
@@ -266,7 +266,7 @@ export class SparseMerkleTree {
     }
 
     // Internal node — recurse into the appropriate child
-    const internalNode = node as SMTInternalNode;
+    const internalNode = node;
     const goRight = getBit(keyHash, depth);
 
     let newLeftHash: Hash;
@@ -405,7 +405,7 @@ export class SparseMerkleTree {
     }
 
     // Internal node — recurse into the appropriate child
-    const internalNode = node as SMTInternalNode;
+    const internalNode = node;
     const goRight = getBit(keyHash, depth);
 
     let newLeftHash: Hash;
@@ -477,7 +477,7 @@ export class SparseMerkleTree {
       return hashEquals(node.keyHash, keyHash);
     }
 
-    const internalNode = node as SMTInternalNode;
+    const internalNode = node;
     const goRight = getBit(keyHash, depth);
 
     if (goRight) {
@@ -508,7 +508,7 @@ export class SparseMerkleTree {
       return { siblings: [], leafNode: node, depth };
     }
 
-    const internalNode = node as SMTInternalNode;
+    const internalNode = node;
     const goRight = getBit(keyHash, depth);
 
     let childHash: Hash;
@@ -578,7 +578,7 @@ export class SparseMerkleTree {
       return [node.valueCid];
     }
 
-    const internalNode = node as SMTInternalNode;
+    const internalNode = node;
     const leftLeaves = await this.collectLeaves(internalNode.leftHash, depth + 1);
     const rightLeaves = await this.collectLeaves(internalNode.rightHash, depth + 1);
 

--- a/packages/dwn-sdk-js/src/smt/sparse-merkle-tree.ts
+++ b/packages/dwn-sdk-js/src/smt/sparse-merkle-tree.ts
@@ -142,7 +142,7 @@ export class SparseMerkleTree {
         // subtree hash would be if this leaf were pushed down to the prefix depth.
         // For simplicity, if we've hit a leaf, the subtree at this prefix
         // either contains this leaf or is empty.
-        if (node !== undefined && node.type === 'leaf') {
+        if (node?.type === 'leaf') {
           return this.computeSubtreeHashForLeaf(node, i, prefix);
         }
         return this.defaultHashes[prefix.length];
@@ -433,7 +433,7 @@ export class SparseMerkleTree {
     if (leftIsDefault || rightIsDefault) {
       const survivingHash = leftIsDefault ? newRightHash : newLeftHash;
       const survivingNode = await this.store.getNode(survivingHash);
-      if (survivingNode !== undefined && survivingNode.type === 'leaf') {
+      if (survivingNode?.type === 'leaf') {
         // Collapse: remove the internal node, return the leaf hash directly
         await this.store.deleteNode(currentHash);
         return survivingHash;

--- a/packages/dwn-sdk-js/src/store/index-level-compound.ts
+++ b/packages/dwn-sdk-js/src/store/index-level-compound.ts
@@ -203,7 +203,17 @@ export async function queryWithCompoundIndex(
   // determine the iterator bounds from the prefix
   const iteratorOptions: LevelWrapperIteratorOptions<string> = {};
 
-  if (cursor !== undefined) {
+  if (cursor === undefined) {
+    if (sortDirection === SortDirection.Ascending) {
+      iteratorOptions.gt = prefix;
+      iteratorOptions.lt = prefix + '\xff';
+    } else {
+      // for descending without cursor, start from the end of the prefix range
+      iteratorOptions.gt = prefix;
+      iteratorOptions.lt = prefix + '\xff';
+      iteratorOptions.reverse = true;
+    }
+  } else {
     // build the full compound key for the cursor position
     const cursorSortEncoded = encodeValue(cursor.value);
     const cursorKey = prefix + cursorSortEncoded + delimiter + cursor.messageCid;
@@ -215,16 +225,6 @@ export async function queryWithCompoundIndex(
     } else {
       iteratorOptions.lt = cursorKey;
       iteratorOptions.gt = prefix;
-      iteratorOptions.reverse = true;
-    }
-  } else {
-    if (sortDirection === SortDirection.Ascending) {
-      iteratorOptions.gt = prefix;
-      iteratorOptions.lt = prefix + '\xff';
-    } else {
-      // for descending without cursor, start from the end of the prefix range
-      iteratorOptions.gt = prefix;
-      iteratorOptions.lt = prefix + '\xff';
       iteratorOptions.reverse = true;
     }
   }

--- a/packages/dwn-sdk-js/src/store/index-level.ts
+++ b/packages/dwn-sdk-js/src/store/index-level.ts
@@ -498,13 +498,13 @@ export class IndexLevel {
 
     const sortedValues = [...matches.values()].sort((a,b) => this.sortItems(a,b, sortProperty, sortDirection));
 
-    const start = cursorStartingKey !== undefined ? this.findCursorStartingIndex(sortedValues, sortDirection, sortProperty, cursorStartingKey) : 0;
+    const start = cursorStartingKey === undefined ? 0 : this.findCursorStartingIndex(sortedValues, sortDirection, sortProperty, cursorStartingKey);
     if (start < 0) {
       // if the provided cursor does not come before any of the results, we return no results
       return [];
     }
 
-    const end = limit !== undefined ? start + limit: undefined;
+    const end = limit === undefined ? undefined : start + limit;
     return sortedValues.slice(start, end);
   }
 

--- a/packages/dwn-sdk-js/src/store/storage-controller.ts
+++ b/packages/dwn-sdk-js/src/store/storage-controller.ts
@@ -131,10 +131,10 @@ export class StorageController {
       }
 
       const existing = recordIdToMessages.get(recordId);
-      if (existing !== undefined) {
-        existing.push(msg);
-      } else {
+      if (existing === undefined) {
         recordIdToMessages.set(recordId, [msg]);
+      } else {
+        existing.push(msg);
       }
     }
 

--- a/packages/dwn-sdk-js/src/utils/messages.ts
+++ b/packages/dwn-sdk-js/src/utils/messages.ts
@@ -21,7 +21,7 @@ export class Messages {
     // normalize each filter, and only add non-empty filters to the returned array
     for (const filter of filters) {
       // normalize the protocol URL if it exists
-      const protocol = filter.protocol !== undefined ? normalizeProtocolUrl(filter.protocol) : undefined;
+      const protocol = filter.protocol === undefined ? undefined : normalizeProtocolUrl(filter.protocol);
 
       const messagesFilter = {
         ...filter,

--- a/packages/dwn-sdk-js/src/utils/messages.ts
+++ b/packages/dwn-sdk-js/src/utils/messages.ts
@@ -130,6 +130,6 @@ export class Messages {
       };
     }
 
-    return filterCopy as Filter;
+    return filterCopy;
   }
 }

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -375,7 +375,7 @@ export class Records {
       delete filterCopy.recipient;
     }
 
-    return filterCopy as Filter;
+    return filterCopy;
   }
 
   /**

--- a/packages/dwn-server-admin-ui/src/views/AuditLog.tsx
+++ b/packages/dwn-server-admin-ui/src/views/AuditLog.tsx
@@ -190,7 +190,7 @@ export function AuditLog({ path }: { path?: string }) {
           {cursor !== undefined && (
             <div class="pagination">
               <span class="info">
-                Showing {entries.length} entries{total !== undefined ? ` of ${total}` : ''}
+                Showing {entries.length} entries{total === undefined ? '' : ` of ${total}`}
               </span>
               <button class="btn" onClick={() => fetchAudit(true)} disabled={loadingMore}>
                 {loadingMore ? 'Loading...' : 'Load More'}

--- a/packages/dwn-server-admin-ui/src/views/Events.tsx
+++ b/packages/dwn-server-admin-ui/src/views/Events.tsx
@@ -123,7 +123,7 @@ export function Events({ path }: { path?: string }) {
                     <td>{evt.method}</td>
                     <td><span class={statusBadgeClass(evt.status)}>{evt.status}</span></td>
                     <td><span class={transportBadgeClass(evt.transport)}>{evt.transport.toUpperCase()}</span></td>
-                    <td>{evt.dataSize !== undefined ? formatBytes(evt.dataSize) : '\u2014'}</td>
+                    <td>{evt.dataSize === undefined ? '\u2014' : formatBytes(evt.dataSize)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/packages/dwn-server-admin-ui/src/views/Overview.tsx
+++ b/packages/dwn-server-admin-ui/src/views/Overview.tsx
@@ -96,7 +96,7 @@ export function Overview() {
                         <span class={`status-dot ${check.status === 'healthy' ? 'healthy' : check.status === 'unhealthy' ? 'unhealthy' : 'unknown'}`} />
                         {check.status}
                       </td>
-                      <td>{check.latencyMs !== undefined ? `${check.latencyMs}ms` : '—'}</td>
+                      <td>{check.latencyMs === undefined ? '—' : `${check.latencyMs}ms`}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/packages/dwn-server-admin-ui/src/views/Tenants.tsx
+++ b/packages/dwn-server-admin-ui/src/views/Tenants.tsx
@@ -297,7 +297,7 @@ function TenantList() {
 
             <div class="pagination">
               <div class="info">
-                Showing {items.length}{totalCount !== undefined ? ` of ${formatNumber(totalCount)}` : ''} tenant{items.length !== 1 ? 's' : ''}
+                Showing {items.length}{totalCount === undefined ? '' : ` of ${formatNumber(totalCount)}`} tenant{items.length === 1 ? '' : 's'}
               </div>
               <div style="display:flex;gap:8px">
                 <button
@@ -482,7 +482,7 @@ function MessageBrowser({ did }: { did: string }) {
 
           <div class="pagination">
             <div class="info">
-              Showing {messageItems.length} message{messageItems.length !== 1 ? 's' : ''}
+               Showing {messageItems.length} message{messageItems.length === 1 ? '' : 's'}
             </div>
             <div style="display:flex;gap:8px">
               <button
@@ -599,8 +599,8 @@ function TenantDetail({ did }: { did: string }) {
         <h2 style="margin-top:8px;word-break:break-all;font-family:var(--font-mono);font-size:14px">{did}</h2>
         {tenant && (
           <div style="display:flex;gap:8px;margin-top:8px">
-            <span class={`badge ${tenant.isActive !== false ? 'badge-success' : 'badge-muted'}`}>
-              {tenant.isActive !== false ? 'Active' : 'Inactive'}
+            <span class={`badge ${tenant.isActive === false ? 'badge-muted' : 'badge-success'}`}>
+              {tenant.isActive === false ? 'Inactive' : 'Active'}
             </span>
             <span class={`badge ${tenant.suspended ? 'badge-danger' : 'badge-success'}`}>
               {tenant.suspended ? 'Suspended' : 'Not Suspended'}

--- a/packages/dwn-server/src/admin/admin-api.ts
+++ b/packages/dwn-server/src/admin/admin-api.ts
@@ -913,7 +913,7 @@ export class AdminApi {
     const target = url.searchParams.get('target') ?? undefined;
     const limit = Math.min(parseIntOrDefault(url.searchParams.get('limit'), 50), 1000);
     const cursorParam = url.searchParams.get('cursor');
-    const cursor = cursorParam !== null ? parseIntOrDefault(cursorParam, 0) : undefined;
+    const cursor = cursorParam === null ? undefined : parseIntOrDefault(cursorParam, 0);
 
     const result = await this.#auditLog.query({ since, action, target, limit, cursor });
     return Response.json(result);
@@ -1060,7 +1060,7 @@ export class AdminApi {
     const protocol = url.searchParams.get('protocol') ?? undefined;
     const limit = Math.min(parseIntOrDefault(url.searchParams.get('limit'), 20), 100);
     const cursorParam = url.searchParams.get('cursor');
-    const cursor = cursorParam !== null ? parseIntOrDefault(cursorParam, 0) : undefined;
+    const cursor = cursorParam === null ? undefined : parseIntOrDefault(cursorParam, 0);
 
     const result = await this.#adminStore.getTenantMessages(did, {
       interface: iface,

--- a/packages/dwn-server/src/admin/admin-auth.ts
+++ b/packages/dwn-server/src/admin/admin-auth.ts
@@ -58,7 +58,7 @@ export function validateAdminAuth(
   }
 
   // Try session token if a session manager is available.
-  if (sessionManager && sessionManager.validate(suppliedToken)) {
+  if (sessionManager?.validate(suppliedToken)) {
     return { error: null, authMethod: 'session' };
   }
 

--- a/packages/dwn-server/src/admin/admin-store.ts
+++ b/packages/dwn-server/src/admin/admin-store.ts
@@ -365,7 +365,7 @@ export class AdminStore {
       protocolPath     : row.protocolPath,
       schema           : row.schema,
       dataFormat       : row.dataFormat,
-      dataSize         : row.dataSize !== null ? Number(row.dataSize) : null,
+      dataSize         : row.dataSize === null ? null : Number(row.dataSize),
       dateCreated      : row.dateCreated,
       messageTimestamp : row.messageTimestamp,
     }));

--- a/packages/dwn-server/src/delivery-service.ts
+++ b/packages/dwn-server/src/delivery-service.ts
@@ -224,7 +224,7 @@ export class DeliveryService implements MessageProcessedHook {
     }
 
     const ruleSet = getRuleSetAtPath(descriptor.protocolPath, protocolDefinition.structure);
-    if (!ruleSet || !ruleSet.$delivery) {
+    if (!ruleSet?.$delivery) {
       return;
     }
 

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -800,11 +800,11 @@ export class HttpApi {
         return Response.json({ success: true }, { status: 200 });
       } catch (error) {
         const dwnServerError = error as DwnServerError;
-        if (dwnServerError.code !== undefined) {
-          return Response.json(dwnServerError, { status: 400 });
-        } else {
+        if (dwnServerError.code === undefined) {
           log.info('Error handling registration request:', error);
           return Response.json({ success: false }, { status: 500 });
+        } else {
+          return Response.json(dwnServerError, { status: 400 });
         }
       }
     }
@@ -850,18 +850,18 @@ export class HttpApi {
         log.info(`Retrieving Connect Request object of ID: ${requestId}...`);
 
         const requestObjectJwt = await this.connectServer.getConnectRequest(requestId);
-        if (!requestObjectJwt) {
-          return Response.json({
-            ok     : false,
-            status : { code: 404, message: 'Not Found' },
-          }, { status: 404 });
-        } else {
+        if (requestObjectJwt) {
           const body = typeof requestObjectJwt === 'string'
             ? requestObjectJwt
             : JSON.stringify(requestObjectJwt);
           return new Response(body, {
             headers: { 'content-type': 'application/jwt' },
           });
+        } else {
+          return Response.json({
+            ok     : false,
+            status : { code: 404, message: 'Not Found' },
+          }, { status: 404 });
         }
       }
     }
@@ -910,16 +910,16 @@ export class HttpApi {
         log.info(`Retrieving ID token for state: ${state}...`);
 
         const idToken = await this.connectServer.getConnectResponse(state);
-        if (!idToken) {
-          return Response.json({
-            ok     : false,
-            status : { code: 404, message: 'Not Found' },
-          }, { status: 404 });
-        } else {
+        if (idToken) {
           const body = typeof idToken === 'string' ? idToken : JSON.stringify(idToken);
           return new Response(body, {
             headers: { 'content-type': 'application/jwt' },
           });
+        } else {
+          return Response.json({
+            ok     : false,
+            status : { code: 404, message: 'Not Found' },
+          }, { status: 404 });
         }
       }
     }

--- a/packages/dwn-server/src/plugins/event-log-nats.ts
+++ b/packages/dwn-server/src/plugins/event-log-nats.ts
@@ -252,13 +252,13 @@ export default class NatsEventLog implements EventLog {
     let reason: ProgressGapReason;
     if (cursor.streamId !== expectedStreamId) {
       reason = 'stream_mismatch';
-    } else if (cursor.epoch !== this.#epoch) {
-      reason = 'epoch_mismatch';
-    } else {
+    } else if (cursor.epoch === this.#epoch) {
       // Check if position is within replay bounds using BigInt
       // for safe handling of NATS sequences beyond Number.MAX_SAFE_INTEGER.
       const bounds = await this.getReplayBounds(tenant);
-      if (bounds !== undefined) {
+      if (bounds === undefined) {
+        return; // No events — vacuously valid.
+      } else {
         const cursorSeq = BigInt(cursor.position);
         const oldestSeq = BigInt(bounds.oldest.position);
         if (cursorSeq < oldestSeq - 1n) {
@@ -266,9 +266,9 @@ export default class NatsEventLog implements EventLog {
         } else {
           return; // Valid.
         }
-      } else {
-        return; // No events — vacuously valid.
       }
+    } else {
+      reason = 'epoch_mismatch';
     }
 
     const bounds = await this.getReplayBounds(tenant);
@@ -315,11 +315,11 @@ export default class NatsEventLog implements EventLog {
       ack_policy     : AckPolicy.None, // ordered consumers use AckNone
     };
 
-    if (cursor !== undefined) {
+    if (cursor === undefined) {
+      consumerOpts.deliver_policy = DeliverPolicy.All;
+    } else {
       consumerOpts.deliver_policy = DeliverPolicy.StartSequence;
       consumerOpts.opt_start_seq = Number(cursor.position) + 1;
-    } else {
-      consumerOpts.deliver_policy = DeliverPolicy.All;
     }
 
     const consumer = await this.#jsm!.consumers.add(this.#config.streamName, consumerOpts);
@@ -405,11 +405,11 @@ export default class NatsEventLog implements EventLog {
       inactive_threshold : 60_000_000_000, // 60 seconds in nanos
     };
 
-    if (cursor !== undefined) {
+    if (cursor === undefined) {
+      consumerOpts.deliver_policy = DeliverPolicy.New;
+    } else {
       consumerOpts.deliver_policy = DeliverPolicy.StartSequence;
       consumerOpts.opt_start_seq = Number(cursor.position) + 1;
-    } else {
-      consumerOpts.deliver_policy = DeliverPolicy.New;
     }
 
     await this.#jsm!.consumers.add(this.#config.streamName, consumerOpts);

--- a/packages/dwn-server/src/registration/proof-of-work-manager.ts
+++ b/packages/dwn-server/src/registration/proof-of-work-manager.ts
@@ -210,7 +210,12 @@ export class ProofOfWorkManager {
 
   private refreshChallengeNonce(): void {
     // If challenge seed is supplied, use it to deterministically generate the challenge nonces.
-    if (this.challengeSeed !== undefined) {
+    if (this.challengeSeed === undefined) {
+      const newChallengeNonce = ProofOfWork.generateNonce();
+
+      this.challengeNonces.previousChallengeNonce = this.challengeNonces.currentChallengeNonce;
+      this.challengeNonces.currentChallengeNonce = newChallengeNonce;
+    } else {
       const currentRefreshIntervalId = Math.floor(Date.now() / (this.challengeRefreshFrequencyInSeconds * 1000));
       const previousRefreshIntervalId = currentRefreshIntervalId - 1;
       const nextRefreshIntervalId = currentRefreshIntervalId + 1;
@@ -220,11 +225,6 @@ export class ProofOfWorkManager {
       const nextChallengeNonce = ProofOfWork.hashAsHexString([this.challengeSeed, nextRefreshIntervalId.toString(), this.challengeSeed]);
 
       this.challengeNonces = { previousChallengeNonce, currentChallengeNonce, nextChallengeNonce };
-    } else {
-      const newChallengeNonce = ProofOfWork.generateNonce();
-
-      this.challengeNonces.previousChallengeNonce = this.challengeNonces.currentChallengeNonce;
-      this.challengeNonces.currentChallengeNonce = newChallengeNonce;
     }
   }
 

--- a/packages/dwn-server/src/registration/registration-manager.ts
+++ b/packages/dwn-server/src/registration/registration-manager.ts
@@ -108,13 +108,13 @@ export class RegistrationManager implements TenantGate {
   public async handleRegistrationRequest(registrationRequest: RegistrationRequest): Promise<void> {
     if (registrationRequest.providerAuth?.registrationToken !== undefined) {
       await this.handleProviderAuthRegistration(registrationRequest);
-    } else if (registrationRequest.proofOfWork !== undefined) {
-      await this.handleProofOfWorkRegistration(registrationRequest);
-    } else {
+    } else if (registrationRequest.proofOfWork === undefined) {
       throw new DwnServerError(
         DwnServerErrorCode.RegistrationRequestMissingCredentials,
         'Registration request must include either providerAuth or proofOfWork credentials.',
       );
+    } else {
+      await this.handleProofOfWorkRegistration(registrationRequest);
     }
   }
 
@@ -154,9 +154,9 @@ export class RegistrationManager implements TenantGate {
       termsOfServiceHash : registrationRequest.registrationData.termsOfServiceHash,
       accountId          : validationResult.accountId,
       registrationType   : 'provider-auth',
-      metadata           : validationResult.metadata !== undefined
-        ? JSON.stringify(validationResult.metadata)
-        : undefined,
+      metadata           : validationResult.metadata === undefined
+        ? undefined
+        : JSON.stringify(validationResult.metadata),
     });
   }
 

--- a/packages/dwn-sql-store/src/message-store-sql.ts
+++ b/packages/dwn-sql-store/src/message-store-sql.ts
@@ -390,10 +390,10 @@ export class MessageStoreSql implements MessageStore {
       return { property: 'dateCreated', direction: messageSort.dateCreated };
     } else if (messageSort?.datePublished !== undefined) {
       return { property: 'datePublished', direction: messageSort.datePublished };
-    } else if (messageSort?.messageTimestamp !== undefined) {
-      return { property: 'messageTimestamp', direction: messageSort.messageTimestamp };
-    } else {
+    } else if (messageSort?.messageTimestamp === undefined) {
       return { property: 'messageTimestamp', direction: SortDirection.Ascending };
+    } else {
+      return { property: 'messageTimestamp', direction: messageSort.messageTimestamp };
     }
   }
 }

--- a/packages/electrobun-dwn/src/mainview/identity-runtime.ts
+++ b/packages/electrobun-dwn/src/mainview/identity-runtime.ts
@@ -214,15 +214,15 @@ class IdentityRuntimeController implements IdentityRuntime {
     const auth = await this._getAuth();
     if (!this._restoreAttempted) {
       this._restoreAttempted = true;
-      if (!auth.isLocked) {
+      if (auth.isLocked) {
+        // Locked vault is an expected state reflected in UI controls; avoid noisy warnings.
+        this._lastError = undefined;
+      } else {
         try {
           await auth.restoreSession();
         } catch (error) {
           this._lastError = errorMessage(error);
         }
-      } else {
-        // Locked vault is an expected state reflected in UI controls; avoid noisy warnings.
-        this._lastError = undefined;
       }
     }
 
@@ -759,7 +759,7 @@ class IdentityRuntimeController implements IdentityRuntime {
         title,
         url,
         ...(icon ? { icon } : {}),
-        ...(sortOrder !== undefined ? { sortOrder } : {}),
+        ...(sortOrder === undefined ? {} : { sortOrder }),
       };
 
       const existingRecord = rawLink.id ? existingLinksById.get(rawLink.id) : undefined;

--- a/packages/electrobun-dwn/src/mainview/identity-runtime.ts
+++ b/packages/electrobun-dwn/src/mainview/identity-runtime.ts
@@ -1325,6 +1325,6 @@ export function ensureIdentityRuntime(runtimeWindow: IdentityRuntimeHostWindow):
     runtimeWindow[identityRuntimeWindowKey] = new IdentityRuntimeController();
   }
 
-  return runtimeWindow[identityRuntimeWindowKey]!;
+  return runtimeWindow[identityRuntimeWindowKey];
 }
 

--- a/packages/electrobun-dwn/src/mainview/services/server-status.ts
+++ b/packages/electrobun-dwn/src/mainview/services/server-status.ts
@@ -76,7 +76,7 @@ function getEndpointFromQueryParam(): string | null {
   try {
     const params = new URLSearchParams(window.location.search);
     const endpoint = params.get('endpoint');
-    if (endpoint && endpoint.startsWith('http')) {
+    if (endpoint?.startsWith('http')) {
       return endpoint;
     }
   } catch {

--- a/packages/protocol-codegen/src/cli.ts
+++ b/packages/protocol-codegen/src/cli.ts
@@ -90,12 +90,12 @@ const cli = yargs(hideBin(process.argv))
       }
 
       // Write or print
-      if (args.output !== undefined) {
+      if (args.output === undefined) {
+        process.stdout.write(code);
+      } else {
         const outputPath = resolve(args.output);
         await writeFile(outputPath, code, 'utf-8');
         process.stderr.write(`\nWrote ${outputPath}\n`);
-      } else {
-        process.stdout.write(code);
       }
     },
   )


### PR DESCRIPTION
## Summary

Resolves ~165 mechanical SonarCloud code smells across 3 rules. Companion to #877 (S2933 readonly).

## Changes

### S4325 — Unnecessary type assertions (62 removed)
Removed redundant `as Type` casts and `!` non-null assertions where TypeScript already infers the correct type. ~28 assertions were intentionally kept where they genuinely narrow types.
- 23 files changed across `dwn-sdk-js`, `agent`, `api`, `auth`, `crypto`, `dids`, `dwn-server`, `dwn-sql-store`, `electrobun-dwn`

### S7735 — Unexpected negated condition (75 flipped)
Replaced `!x ? a : b` with `x ? b : a` and flipped `if (!x) { ... } else { ... }` blocks to put the positive case first.
- 35 files changed across 14 packages

### S6582 — Use optional chaining (28 applied)
Replaced `foo && foo.bar` patterns with `foo?.bar` optional chaining.
- 14 files changed across `dwn-sdk-js`, `agent`, `auth`, `dids`, `dwn-server`, `electrobun-dwn`

## Verification

| Package | Tests | Result |
|---|---|---|
| `dwn-sdk-js` | 1368 | 0 fail |
| `agent` | 1361 | 0 fail |
| `dwn-server` | 591 | 0 fail |
| Lint (all packages) | 27 tasks | all pass |

## Impact

Combined with #877, this eliminates **~405 code smells** (~36% of the total 1,116).