### PR TITLE
fix(agent): stabilize flaky stopSync timeout test

### DIFF
--- a/packages/agent/tests/sync-engine-identity.spec.ts
+++ b/packages/agent/tests/sync-engine-identity.spec.ts
@@ -172,7 +172,9 @@ describe('SyncEngineLevel — identity management', () => {
       const engine = new SyncEngineLevel({ db });
       (engine as any)._syncLock = true;
 
-      await expect(engine.stopSync(200)).rejects.toThrow('did not complete within');
+      // Use timeout < 100 so stopSync only needs one short sleep before
+      // throwing, making the test fast and resilient to CI timer jitter.
+      await expect(engine.stopSync(10)).rejects.toThrow('did not complete within');
 
       (engine as any)._syncLock = false;
     });


### PR DESCRIPTION
## Summary

Fixes the intermittently failing `SyncEngineLevel > stopSync > should throw when sync lock does not clear within timeout` test that has been causing CI flakes.

## Root Cause

The test called `stopSync(200)` which required **two real `setTimeout(100)` calls** before the timeout check triggered. On loaded CI runners, `setTimeout(100)` can easily drift to 115-150ms+, pushing the total wall-clock time past the test framework's expectations or causing race conditions with promise rejection handling.

## Fix

Changed `stopSync(200)` to `stopSync(10)`. With `timeout < 100`, the production code uses `setTimeout(resolve, timeout)` = 10ms, and the elapsed counter exceeds the threshold after just one iteration. The test:

- Exercises the **exact same code path** (sync lock held → polling loop → timeout error)
- Completes in ~10ms instead of ~200ms
- Verified stable across 5 consecutive local runs (0 failures)

No production code changes.