### PR TITLE
ci: optimize pipeline with granular change detection and parallel stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
               - 'packages/dwn-sdk-js/src/**'
               - 'packages/dwn-sdk-js/tests/**'
               - 'packages/dwn-sdk-js/json-schemas/**'
+              - 'packages/dwn-sdk-js/build/**'
               - 'packages/dwn-sdk-js/package.json'
               - 'packages/dwn-sdk-js/tsconfig.json'
               - 'packages/dwn-sdk-js/vitest*.config.*'
@@ -136,6 +137,12 @@ jobs:
               - 'packages/api/tsconfig.json'
               - 'packages/api/vitest*.config.*'
 
+            protocols:
+              - 'packages/protocols/src/**'
+              - 'packages/protocols/tests/**'
+              - 'packages/protocols/package.json'
+              - 'packages/protocols/tsconfig.json'
+
             browser-pkg:
               - 'packages/browser/src/**'
               - 'packages/browser/tests/**'
@@ -157,6 +164,7 @@ jobs:
           agent="${{ steps.filter.outputs.agent }}"
           auth="${{ steps.filter.outputs.auth }}"
           api="${{ steps.filter.outputs.api }}"
+          protocols="${{ steps.filter.outputs.protocols }}"
           browser_pkg="${{ steps.filter.outputs.browser-pkg }}"
 
           # Propagate down the dependency graph
@@ -170,7 +178,7 @@ jobs:
           needs_auth=$( [ "$needs_agent" = "true" ] || [ "$auth" = "true" ] && echo true || echo false )
           needs_api=$( [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$api" = "true" ] && echo true || echo false )
           needs_lightweight=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_auth" = "true" ] && echo true || echo false )
-          needs_agent_api_group=$( [ "$needs_dids" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$needs_api" = "true" ] || [ "$dwn_clients" = "true" ] && echo true || echo false )
+          needs_agent_api_group=$( [ "$needs_dids" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$needs_api" = "true" ] || [ "$dwn_clients" = "true" ] || [ "$protocols" = "true" ] && echo true || echo false )
           needs_browser_tests=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_dids" = "true" ] || [ "$needs_dwn_sdk" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_api" = "true" ] || [ "$browser_pkg" = "true" ] && echo true || echo false )
           needs_e2e=$( [ "$needs_agent" = "true" ] && echo true || echo false )
 
@@ -960,7 +968,10 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('coverage-report.md', 'utf8');
+            const nodeSection = fs.readFileSync('coverage-report.md', 'utf8');
+            const NODE_START = '<!-- coverage-node-start -->';
+            const NODE_END = '<!-- coverage-node-end -->';
+            const markedNode = `${NODE_START}\n${nodeSection}\n${NODE_END}`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -973,6 +984,16 @@ jobs:
             );
 
             if (existing) {
+              // Replace only the node section, preserving any browser section
+              let body = existing.body;
+              const startIdx = body.indexOf(NODE_START);
+              const endIdx = body.indexOf(NODE_END);
+              if (startIdx !== -1 && endIdx !== -1) {
+                body = body.slice(0, startIdx) + markedNode + body.slice(endIdx + NODE_END.length);
+              } else {
+                // First time node runs on this comment — prepend node section
+                body = markedNode + '\n\n' + body;
+              }
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -984,7 +1005,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body,
+                body: markedNode,
               });
             }
 
@@ -1131,7 +1152,10 @@ jobs:
           script: |
             const fs = require('fs');
             if (!fs.existsSync('browser-coverage-report.md')) return;
-            const browserSection = fs.readFileSync('browser-coverage-report.md', 'utf8');
+            const browserContent = fs.readFileSync('browser-coverage-report.md', 'utf8');
+            const BROWSER_START = '<!-- coverage-browser-start -->';
+            const BROWSER_END = '<!-- coverage-browser-end -->';
+            const markedBrowser = `${BROWSER_START}\n${browserContent}\n${BROWSER_END}`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -1144,9 +1168,14 @@ jobs:
             );
 
             if (existing) {
-              const body = existing.body.includes('Browser Coverage')
-                ? existing.body
-                : existing.body + '\n\n' + browserSection;
+              let body = existing.body;
+              const startIdx = body.indexOf(BROWSER_START);
+              const endIdx = body.indexOf(BROWSER_END);
+              if (startIdx !== -1 && endIdx !== -1) {
+                body = body.slice(0, startIdx) + markedBrowser + body.slice(endIdx + BROWSER_END.length);
+              } else {
+                body = body + '\n\n' + markedBrowser;
+              }
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -1154,7 +1183,7 @@ jobs:
                 body,
               });
             } else {
-              const body = '## Coverage Report\n\n_Node coverage not available for this run._\n\n' + browserSection;
+              const body = '## Coverage Report\n\n_Node coverage not available for this run._\n\n' + markedBrowser;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -1349,8 +1378,12 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [changes, coverage-node]
-    if: needs.changes.outputs.src == 'true' && vars.SONAR_PROJECT_KEY != '' && vars.SONAR_ORG != ''
+    needs: [changes, coverage-node, coverage-browser]
+    # Run after coverage jobs finish (whichever ran); OK if both are skipped
+    if: >-
+      always() && !cancelled() &&
+      needs.changes.outputs.src == 'true' &&
+      vars.SONAR_PROJECT_KEY != '' && vars.SONAR_ORG != ''
 
     steps:
       - name: Checkout repository
@@ -1368,6 +1401,7 @@ jobs:
 
       - name: Download merged coverage
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: coverage-merged
           path: coverage/merged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
     timeout-minutes: 2
     outputs:
       src: ${{ steps.filter.outputs.src }}
+      needs_common_crypto: ${{ steps.propagate.outputs.needs_common_crypto }}
+      needs_dids: ${{ steps.propagate.outputs.needs_dids }}
+      needs_dwn_sdk: ${{ steps.propagate.outputs.needs_dwn_sdk }}
+      needs_dwn_clients: ${{ steps.propagate.outputs.needs_dwn_clients }}
+      needs_dwn_sql_store: ${{ steps.propagate.outputs.needs_dwn_sql_store }}
+      needs_dwn_server: ${{ steps.propagate.outputs.needs_dwn_server }}
+      needs_agent: ${{ steps.propagate.outputs.needs_agent }}
+      needs_auth: ${{ steps.propagate.outputs.needs_auth }}
+      needs_api: ${{ steps.propagate.outputs.needs_api }}
+      needs_agent_api_group: ${{ steps.propagate.outputs.needs_agent_api_group }}
+      needs_browser_tests: ${{ steps.propagate.outputs.needs_browser_tests }}
+      needs_e2e: ${{ steps.propagate.outputs.needs_e2e }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,33 +46,129 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
-          # With the default predicate-quantifier ('some'), a file only needs
-          # to match ONE pattern to be considered changed.  Since '**' matches
-          # everything, the negation patterns were silently ignored and the
-          # filter always returned true.
-          #
-          # With 'every', a file must match ALL patterns.  A .md file matches
-          # '**' but fails '!**/*.md', so it's excluded — which is the
-          # intended behavior.
           predicate-quantifier: 'every'
           filters: |
             src:
-              - '**'
+              - added|modified: '**'
               - '!**/*.md'
               - '!**/LICENSE'
               - '!**/CODE_OF_CONDUCT*'
               - '!docs/**'
               - '!.changeset/**'
-              - '!scripts/**'
+
+            infra:
+              - 'package.json'
+              - 'bun.lock'
+              - 'tsconfig.json'
+              - 'turbo.json'
+              - 'eslint.config.cjs'
+              - '.github/workflows/ci.yml'
+              - 'scripts/**'
+              - 'build/**'
+
+            common-crypto:
+              - 'packages/common/src/**'
+              - 'packages/common/tests/**'
+              - 'packages/crypto/src/**'
+              - 'packages/crypto/tests/**'
+
+            dids:
+              - 'packages/dids/src/**'
+              - 'packages/dids/tests/**'
+
+            dwn-sdk:
+              - 'packages/dwn-sdk-js/src/**'
+              - 'packages/dwn-sdk-js/tests/**'
+              - 'packages/dwn-sdk-js/json-schemas/**'
+
+            dwn-clients:
+              - 'packages/dwn-clients/src/**'
+              - 'packages/dwn-clients/tests/**'
+
+            dwn-sql-store:
+              - 'packages/dwn-sql-store/src/**'
+              - 'packages/dwn-sql-store/tests/**'
+
+            dwn-server:
+              - 'packages/dwn-server/src/**'
+              - 'packages/dwn-server/tests/**'
+
+            agent:
+              - 'packages/agent/src/**'
+              - 'packages/agent/tests/**'
+
+            auth:
+              - 'packages/auth/src/**'
+              - 'packages/auth/tests/**'
+
+            api:
+              - 'packages/api/src/**'
+              - 'packages/api/tests/**'
+
+            browser-pkg:
+              - 'packages/browser/src/**'
+              - 'packages/browser/tests/**'
+
+      - name: Propagate changes through dependency graph
+        id: propagate
+        run: |
+          # Convert filter outputs to shell booleans
+          infra="${{ steps.filter.outputs.infra }}"
+          common_crypto="${{ steps.filter.outputs.common-crypto }}"
+          dids="${{ steps.filter.outputs.dids }}"
+          dwn_sdk="${{ steps.filter.outputs.dwn-sdk }}"
+          dwn_clients="${{ steps.filter.outputs.dwn-clients }}"
+          dwn_sql_store="${{ steps.filter.outputs.dwn-sql-store }}"
+          dwn_server="${{ steps.filter.outputs.dwn-server }}"
+          agent="${{ steps.filter.outputs.agent }}"
+          auth="${{ steps.filter.outputs.auth }}"
+          api="${{ steps.filter.outputs.api }}"
+          browser_pkg="${{ steps.filter.outputs.browser-pkg }}"
+
+          # Propagate down the dependency graph
+          needs_common_crypto=$( [ "$infra" = "true" ] || [ "$common_crypto" = "true" ] && echo true || echo false )
+          needs_dids=$( [ "$needs_common_crypto" = "true" ] || [ "$dids" = "true" ] && echo true || echo false )
+          needs_dwn_sdk=$( [ "$needs_dids" = "true" ] || [ "$dwn_sdk" = "true" ] && echo true || echo false )
+          needs_dwn_clients=$( [ "$needs_dwn_sdk" = "true" ] || [ "$dwn_clients" = "true" ] && echo true || echo false )
+          needs_dwn_sql_store=$( [ "$needs_dwn_sdk" = "true" ] || [ "$dwn_sql_store" = "true" ] && echo true || echo false )
+          needs_dwn_server=$( [ "$needs_dwn_sdk" = "true" ] || [ "$needs_dwn_clients" = "true" ] || [ "$needs_dwn_sql_store" = "true" ] || [ "$dwn_server" = "true" ] && echo true || echo false )
+          needs_agent=$( [ "$needs_dids" = "true" ] || [ "$needs_dwn_sdk" = "true" ] || [ "$needs_dwn_clients" = "true" ] || [ "$agent" = "true" ] && echo true || echo false )
+          needs_auth=$( [ "$needs_agent" = "true" ] || [ "$auth" = "true" ] && echo true || echo false )
+          needs_api=$( [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$api" = "true" ] && echo true || echo false )
+          needs_agent_api_group=$( [ "$needs_dids" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$needs_api" = "true" ] || [ "$dwn_clients" = "true" ] && echo true || echo false )
+          needs_browser_tests=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_dids" = "true" ] || [ "$needs_dwn_sdk" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_api" = "true" ] || [ "$browser_pkg" = "true" ] && echo true || echo false )
+          needs_e2e=$( [ "$needs_agent" = "true" ] && echo true || echo false )
+
+          # Write outputs
+          {
+            echo "needs_common_crypto=$needs_common_crypto"
+            echo "needs_dids=$needs_dids"
+            echo "needs_dwn_sdk=$needs_dwn_sdk"
+            echo "needs_dwn_clients=$needs_dwn_clients"
+            echo "needs_dwn_sql_store=$needs_dwn_sql_store"
+            echo "needs_dwn_server=$needs_dwn_server"
+            echo "needs_agent=$needs_agent"
+            echo "needs_auth=$needs_auth"
+            echo "needs_api=$needs_api"
+            echo "needs_agent_api_group=$needs_agent_api_group"
+            echo "needs_browser_tests=$needs_browser_tests"
+            echo "needs_e2e=$needs_e2e"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Change detection results:"
+          echo "  common_crypto=$needs_common_crypto dids=$needs_dids dwn_sdk=$needs_dwn_sdk"
+          echo "  dwn_clients=$needs_dwn_clients dwn_sql_store=$needs_dwn_sql_store dwn_server=$needs_dwn_server"
+          echo "  agent=$needs_agent auth=$needs_auth api=$needs_api"
+          echo "  agent_api_group=$needs_agent_api_group browser=$needs_browser_tests e2e=$needs_e2e"
 
   # ---------------------------------------------------------------------------
-  # Shared setup: install, lint, build, then upload the workspace as an artifact
-  # so downstream test jobs don't each have to rebuild.
+  # Lint: runs in parallel with build for fast feedback (no build needed —
+  # ESLint uses project: true which resolves .ts source files via tsconfig).
   # ---------------------------------------------------------------------------
-  setup:
-    name: Lint & Build
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 3
     needs: changes
     if: needs.changes.outputs.src == 'true'
 
@@ -87,6 +195,37 @@ jobs:
       - name: Lint
         run: bun run lint
 
+  # ---------------------------------------------------------------------------
+  # Build: runs in parallel with lint, produces workspace-build artifact for
+  # downstream test jobs.
+  # ---------------------------------------------------------------------------
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Restore bun cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-store-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-store-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Build
         run: bun run build
 
@@ -104,7 +243,8 @@ jobs:
     name: 'Test: common / crypto / auth'
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    needs: setup
+    needs: [build, changes]
+    if: needs.changes.outputs.needs_common_crypto == 'true'
 
     steps:
       - name: Checkout repository
@@ -162,7 +302,8 @@ jobs:
     name: 'Test: dwn-sdk-js'
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    needs: setup
+    needs: [build, changes]
+    if: needs.changes.outputs.needs_dwn_sdk == 'true'
 
     steps:
       - name: Checkout repository
@@ -215,7 +356,8 @@ jobs:
     name: 'Test: dids / agent / api'
     runs-on: ubuntu-latest
     timeout-minutes: 8
-    needs: setup
+    needs: [build, changes]
+    if: needs.changes.outputs.needs_agent_api_group == 'true'
 
     services:
       postgres-dwn-server:
@@ -342,8 +484,8 @@ jobs:
     name: 'Test: e2e (long-running)'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: setup
-    if: needs.changes.outputs.src == 'true'
+    needs: [build, changes]
+    if: needs.changes.outputs.needs_e2e == 'true'
 
     services:
       postgres-e2e:
@@ -443,7 +585,8 @@ jobs:
     name: 'Test: dwn-sql-store'
     runs-on: ubuntu-latest
     timeout-minutes: 8
-    needs: setup
+    needs: [build, changes]
+    if: needs.changes.outputs.needs_dwn_sql_store == 'true'
 
     services:
       postgres:
@@ -541,7 +684,8 @@ jobs:
     name: 'Test: dwn-server'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: setup
+    needs: [build, changes]
+    if: needs.changes.outputs.needs_dwn_server == 'true'
 
     steps:
       - name: Checkout repository
@@ -601,19 +745,21 @@ jobs:
           if-no-files-found: warn
 
   # ---------------------------------------------------------------------------
-  # Coverage: download package lcov files, merge them for SonarCloud, build an
-  # informational report, then comment the PR.
+  # Coverage (Node): merge node LCOV files, run diff-coverage gate, post PR
+  # comment.  Does NOT wait for browser tests — removes them from critical path.
   # ---------------------------------------------------------------------------
-  coverage:
-    name: Coverage Check & Merge
+  coverage-node:
+    name: 'Coverage: Node'
     runs-on: ubuntu-latest
     timeout-minutes: 6
-    needs: [changes, test-lightweight, test-dwn-sdk, test-agent-api, test-e2e, test-sql-store, test-dwn-server, test-browser]
+    needs: [changes, test-lightweight, test-dwn-sdk, test-agent-api, test-e2e, test-sql-store, test-dwn-server]
     if: always() && !cancelled() && needs.changes.outputs.src == 'true'
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -631,10 +777,10 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Download coverage artifacts
+      - name: Download node coverage artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: coverage-*
+          pattern: coverage-!(browser-*)
           path: .
           merge-multiple: true
 
@@ -648,6 +794,12 @@ jobs:
           path: coverage/merged/
           retention-days: 1
           if-no-files-found: error
+
+      - name: Diff-coverage gate
+        if: github.event_name == 'pull_request'
+        run: bun run scripts/diff-coverage.mjs
+        env:
+          DIFF_COVERAGE_THRESHOLD: '80'
 
       - name: Build coverage report
         id: coverage-check
@@ -705,7 +857,6 @@ jobs:
           mkdir -p coverage-badges
 
           node_file=$(mktemp)
-          browser_tsv=$(mktemp)
 
           for lcov_file in packages/*/coverage/lcov.info; do
             found_any=true
@@ -723,19 +874,6 @@ jobs:
             else
               echo "| $pkg | ${coverage}% | :white_check_mark: |" >> "$node_file"
             fi
-          done
-
-          for lcov_file in packages/*/coverage-browser-*/lcov.info; do
-            found_any=true
-            pkg=$(basename "$(dirname "$(dirname "$lcov_file")")")
-            coverage_dir=$(basename "$(dirname "$lcov_file")")
-            browser="${coverage_dir#coverage-browser-}"
-            coverage=$(parse_lcov "$lcov_file")
-            badge_color=$(badge_color_for "$coverage")
-
-            printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}\n' \
-              "$coverage" "$badge_color" > "coverage-badges/${pkg}-${browser}.json"
-            printf '%s\t%s\t%s\n' "$pkg" "$browser" "$coverage" >> "$browser_tsv"
           done
 
           {
@@ -761,41 +899,9 @@ jobs:
             else
               echo ":white_check_mark: **All packages meet the ${target}% coverage target.**"
             fi
-
-            echo ""
-
-            if [ -s "$browser_tsv" ]; then
-              echo "<details>"
-              echo "<summary>Browser Coverage (informational)</summary>"
-              echo ""
-              cr_icon='![Chromium](https://img.shields.io/badge/-Chromium-4285F4?logo=googlechrome&logoColor=white&style=flat-square)'
-              ff_icon='![Firefox](https://img.shields.io/badge/-Firefox-FF7139?logo=firefox&logoColor=white&style=flat-square)'
-              wk_icon='![WebKit](https://img.shields.io/badge/-WebKit-006CFF?logo=safari&logoColor=white&style=flat-square)'
-              echo "| Package | $cr_icon | $ff_icon | $wk_icon |"
-              echo "|---------|----------|---------|--------|"
-
-              sort -t$'\t' -k1,1 "$browser_tsv" -o "$browser_tsv"
-              pkg_list=$(cut -f1 "$browser_tsv" | sort -u)
-
-              for pkg in $pkg_list; do
-                chromium_cov=$(awk -F'\t' -v p="$pkg" '$1==p && $2=="chromium" {print $3}' "$browser_tsv")
-                firefox_cov=$(awk -F'\t' -v p="$pkg" '$1==p && $2=="firefox" {print $3}' "$browser_tsv")
-                webkit_cov=$(awk -F'\t' -v p="$pkg" '$1==p && $2=="webkit" {print $3}' "$browser_tsv")
-                cr_cell="${chromium_cov:+${chromium_cov}%}" ; cr_cell="${cr_cell:-—}"
-                ff_cell="${firefox_cov:+${firefox_cov}%}" ; ff_cell="${ff_cell:-—}"
-                wk_cell="${webkit_cov:+${webkit_cov}%}" ; wk_cell="${wk_cell:-—}"
-                echo "| $pkg | $cr_cell | $ff_cell | $wk_cell |"
-              done
-
-              echo ""
-              echo "_Browser coverage is informational only (subset of tests)._"
-              echo "_Node coverage target is informational only and does not gate CI._"
-              echo ""
-              echo "</details>"
-            fi
           } > coverage-report.md
 
-          rm -f "$node_file" "$browser_tsv"
+          rm -f "$node_file"
 
           cat coverage-report.md >> "$GITHUB_STEP_SUMMARY"
 
@@ -838,8 +944,6 @@ jobs:
               });
             }
 
-      # Update coverage badge data in a public Gist (main branch only).
-      # TODO: When the repo is made public, migrate to Codecov or GitHub Pages.
       - name: Update coverage badges
         if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
         env:
@@ -852,7 +956,6 @@ jobs:
 
           GIST_ID="02d15f39a46173a612a8862ec6d7cfcf"
 
-          # Build a single JSON payload with all badge files
           payload='{"files":{'
           first=true
           for badge_file in coverage-badges/*.json; do
@@ -864,7 +967,6 @@ jobs:
             else
               payload+=','
             fi
-            # Escape the content for JSON string value
             escaped=$(printf '%s' "$content" | jq -Rs .)
             payload+="\"$filename\":{\"content\":$escaped}"
             echo "  Badge: $filename -> $content"
@@ -887,6 +989,129 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
+  # Coverage (Browser): merges browser LCOV files and updates PR comment.
+  # Informational only — does not block ci-passed for node-only changes.
+  # ---------------------------------------------------------------------------
+  coverage-browser:
+    name: 'Coverage: Browser'
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    needs: [changes, test-browser]
+    if: always() && !cancelled() && needs.changes.outputs.needs_browser_tests == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download browser coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-browser-*
+          path: .
+          merge-multiple: true
+
+      - name: Build browser coverage report
+        shell: bash
+        run: |
+          shopt -s nullglob
+
+          parse_lcov() {
+            local lcov_file="$1"
+            local total_lf=0 total_lh=0 in_src=false
+            while IFS= read -r line; do
+              case "$line" in
+                SF:src/*|SF:*/src/*) in_src=true ;;
+                SF:*) in_src=false ;;
+                LF:*) if [ "$in_src" = true ]; then total_lf=$((total_lf + ${line#LF:})); fi ;;
+                LH:*) if [ "$in_src" = true ]; then total_lh=$((total_lh + ${line#LH:})); fi ;;
+              esac
+            done < "$lcov_file"
+            if [ "$total_lf" -gt 0 ]; then
+              awk "BEGIN { printf \"%.1f\", ($total_lh / $total_lf) * 100 }"
+            else
+              echo "0.0"
+            fi
+          }
+
+          browser_tsv=$(mktemp)
+          found_any=false
+
+          for lcov_file in packages/*/coverage-browser-*/lcov.info; do
+            found_any=true
+            pkg=$(basename "$(dirname "$(dirname "$lcov_file")")")
+            coverage_dir=$(basename "$(dirname "$lcov_file")")
+            browser="${coverage_dir#coverage-browser-}"
+            coverage=$(parse_lcov "$lcov_file")
+            printf '%s\t%s\t%s\n' "$pkg" "$browser" "$coverage" >> "$browser_tsv"
+          done
+
+          if [ "$found_any" = true ] && [ -s "$browser_tsv" ]; then
+            {
+              echo "<details>"
+              echo "<summary>Browser Coverage (informational)</summary>"
+              echo ""
+              cr_icon='![Chromium](https://img.shields.io/badge/-Chromium-4285F4?logo=googlechrome&logoColor=white&style=flat-square)'
+              ff_icon='![Firefox](https://img.shields.io/badge/-Firefox-FF7139?logo=firefox&logoColor=white&style=flat-square)'
+              wk_icon='![WebKit](https://img.shields.io/badge/-WebKit-006CFF?logo=safari&logoColor=white&style=flat-square)'
+              echo "| Package | $cr_icon | $ff_icon | $wk_icon |"
+              echo "|---------|----------|---------|--------|"
+
+              sort -t$'\t' -k1,1 "$browser_tsv" -o "$browser_tsv"
+              pkg_list=$(cut -f1 "$browser_tsv" | sort -u)
+
+              for pkg in $pkg_list; do
+                chromium_cov=$(awk -F'\t' -v p="$pkg" '$1==p && $2=="chromium" {print $3}' "$browser_tsv")
+                firefox_cov=$(awk -F'\t' -v p="$pkg" '$1==p && $2=="firefox" {print $3}' "$browser_tsv")
+                webkit_cov=$(awk -F'\t' -v p="$pkg" '$1==p && $2=="webkit" {print $3}' "$browser_tsv")
+                cr_cell="${chromium_cov:+${chromium_cov}%}" ; cr_cell="${cr_cell:-—}"
+                ff_cell="${firefox_cov:+${firefox_cov}%}" ; ff_cell="${ff_cell:-—}"
+                wk_cell="${webkit_cov:+${webkit_cov}%}" ; wk_cell="${wk_cell:-—}"
+                echo "| $pkg | $cr_cell | $ff_cell | $wk_cell |"
+              done
+
+              echo ""
+              echo "_Browser coverage is informational only (subset of tests)._"
+              echo ""
+              echo "</details>"
+            } > browser-coverage-report.md
+
+            cat browser-coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          rm -f "$browser_tsv"
+
+      - name: Append browser coverage to PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('browser-coverage-report.md')) return;
+            const browserSection = fs.readFileSync('browser-coverage-report.md', 'utf8');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Coverage Report')
+            );
+
+            if (existing) {
+              const body = existing.body.includes('Browser Coverage')
+                ? existing.body
+                : existing.body + '\n\n' + browserSection;
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            }
+
+  # ---------------------------------------------------------------------------
   # Browser tests: run Vitest browser mode with Playwright.
   #
   # Two-dimensional matrix: shard (package group) × browser.  Each cell runs
@@ -902,7 +1127,8 @@ jobs:
     name: 'Test: Browser (${{ matrix.shard.name }} / ${{ matrix.browser }})'
     runs-on: ubuntu-latest
     timeout-minutes: 21
-    needs: setup
+    needs: [build, changes]
+    if: needs.changes.outputs.needs_browser_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -1065,13 +1291,13 @@ jobs:
   # ---------------------------------------------------------------------------
   # SonarCloud: consume the merged LCOV artifact and publish analysis results.
   # The job activates once SONAR_PROJECT_KEY / SONAR_ORG repo vars are set.
-  # Quality gate waiting stays off until coverage improvement work lands.
+  # Quality gate is enforced (blocks PRs that fail the SonarCloud QG).
   # ---------------------------------------------------------------------------
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [changes, coverage]
+    needs: [changes, coverage-node]
     if: needs.changes.outputs.src == 'true' && vars.SONAR_PROJECT_KEY != '' && vars.SONAR_ORG != ''
 
     steps:
@@ -1113,6 +1339,8 @@ jobs:
             -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
             -Dsonar.organization=${{ vars.SONAR_ORG }}
             -Dsonar.pullrequest.github.repository=${{ github.repository }}
+            -Dsonar.qualitygate.wait=true
+            -Dsonar.qualitygate.timeout=300
 
   # ---------------------------------------------------------------------------
   # Gate job for branch protection — always runs so required checks pass even
@@ -1122,7 +1350,7 @@ jobs:
     name: CI Passed
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: [changes, test-lightweight, test-dwn-sdk, test-agent-api, test-e2e, test-sql-store, test-dwn-server, test-browser, coverage, sonarcloud]
+    needs: [changes, lint, build, test-lightweight, test-dwn-sdk, test-agent-api, test-e2e, test-sql-store, test-dwn-server, test-browser, coverage-node, coverage-browser, sonarcloud]
     if: always()
     steps:
       - name: Check results
@@ -1133,16 +1361,26 @@ jobs:
             exit 0
           fi
 
-          # All test jobs must succeed
-          if [ "${{ needs.test-lightweight.result }}" != "success" ]; then
+          # Lint and build must always succeed when src changed
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "::error::lint failed"
+            exit 1
+          fi
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "::error::build failed"
+            exit 1
+          fi
+
+          # Test jobs: required when they run, OK to skip (no relevant changes)
+          if [ "${{ needs.test-lightweight.result }}" != "success" ] && [ "${{ needs.test-lightweight.result }}" != "skipped" ]; then
             echo "::error::test-lightweight failed"
             exit 1
           fi
-          if [ "${{ needs.test-dwn-sdk.result }}" != "success" ]; then
+          if [ "${{ needs.test-dwn-sdk.result }}" != "success" ] && [ "${{ needs.test-dwn-sdk.result }}" != "skipped" ]; then
             echo "::error::test-dwn-sdk failed"
             exit 1
           fi
-          if [ "${{ needs.test-agent-api.result }}" != "success" ]; then
+          if [ "${{ needs.test-agent-api.result }}" != "success" ] && [ "${{ needs.test-agent-api.result }}" != "skipped" ]; then
             echo "::error::test-agent-api failed"
             exit 1
           fi
@@ -1150,27 +1388,38 @@ jobs:
             echo "::error::test-e2e failed"
             exit 1
           fi
-          if [ "${{ needs.test-sql-store.result }}" != "success" ]; then
+          if [ "${{ needs.test-sql-store.result }}" != "success" ] && [ "${{ needs.test-sql-store.result }}" != "skipped" ]; then
             echo "::error::test-sql-store failed"
             exit 1
           fi
-          if [ "${{ needs.test-dwn-server.result }}" != "success" ]; then
+          if [ "${{ needs.test-dwn-server.result }}" != "success" ] && [ "${{ needs.test-dwn-server.result }}" != "skipped" ]; then
             echo "::error::test-dwn-server failed"
             exit 1
           fi
-          if [ "${{ needs.test-browser.result }}" != "success" ]; then
+
+          # Browser tests: required when they run, OK to skip
+          if [ "${{ needs.test-browser.result }}" != "success" ] && [ "${{ needs.test-browser.result }}" != "skipped" ]; then
             echo "::error::test-browser failed"
             exit 1
           fi
 
-          if [ "${{ needs.coverage.result }}" != "success" ]; then
-            echo "::error::Coverage check failed"
+          # Coverage (node): required when it ran
+          if [ "${{ needs.coverage-node.result }}" != "success" ] && [ "${{ needs.coverage-node.result }}" != "skipped" ]; then
+            echo "::error::coverage-node failed"
             exit 1
           fi
 
-          if [ -n "${{ vars.SONAR_PROJECT_KEY }}" ] && [ -n "${{ vars.SONAR_ORG }}" ] && [ "${{ needs.sonarcloud.result }}" != "success" ]; then
-            echo "::error::SonarCloud scan failed"
-            exit 1
+          # Coverage (browser): informational — OK to skip or fail
+          if [ "${{ needs.coverage-browser.result }}" = "failure" ]; then
+            echo "::warning::coverage-browser failed (informational, not blocking)"
+          fi
+
+          # SonarCloud: required when configured and ran
+          if [ -n "${{ vars.SONAR_PROJECT_KEY }}" ] && [ -n "${{ vars.SONAR_ORG }}" ]; then
+            if [ "${{ needs.sonarcloud.result }}" != "success" ] && [ "${{ needs.sonarcloud.result }}" != "skipped" ]; then
+              echo "::error::SonarCloud scan failed"
+              exit 1
+            fi
           fi
 
           echo "All checks passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
       needs_common_crypto: ${{ steps.propagate.outputs.needs_common_crypto }}
+      needs_lightweight: ${{ steps.propagate.outputs.needs_lightweight }}
       needs_dids: ${{ steps.propagate.outputs.needs_dids }}
       needs_dwn_sdk: ${{ steps.propagate.outputs.needs_dwn_sdk }}
       needs_dwn_clients: ${{ steps.propagate.outputs.needs_dwn_clients }}
@@ -49,7 +50,7 @@ jobs:
           predicate-quantifier: 'every'
           filters: |
             src:
-              - added|modified: '**'
+              - '**'
               - '!**/*.md'
               - '!**/LICENSE'
               - '!**/CODE_OF_CONDUCT*'
@@ -69,45 +70,78 @@ jobs:
             common-crypto:
               - 'packages/common/src/**'
               - 'packages/common/tests/**'
+              - 'packages/common/package.json'
+              - 'packages/common/tsconfig.json'
+              - 'packages/common/vitest*.config.*'
               - 'packages/crypto/src/**'
               - 'packages/crypto/tests/**'
+              - 'packages/crypto/package.json'
+              - 'packages/crypto/tsconfig.json'
+              - 'packages/crypto/vitest*.config.*'
 
             dids:
               - 'packages/dids/src/**'
               - 'packages/dids/tests/**'
+              - 'packages/dids/package.json'
+              - 'packages/dids/tsconfig.json'
+              - 'packages/dids/vitest*.config.*'
 
             dwn-sdk:
               - 'packages/dwn-sdk-js/src/**'
               - 'packages/dwn-sdk-js/tests/**'
               - 'packages/dwn-sdk-js/json-schemas/**'
+              - 'packages/dwn-sdk-js/package.json'
+              - 'packages/dwn-sdk-js/tsconfig.json'
+              - 'packages/dwn-sdk-js/vitest*.config.*'
 
             dwn-clients:
               - 'packages/dwn-clients/src/**'
               - 'packages/dwn-clients/tests/**'
+              - 'packages/dwn-clients/package.json'
+              - 'packages/dwn-clients/tsconfig.json'
+              - 'packages/dwn-clients/vitest*.config.*'
 
             dwn-sql-store:
               - 'packages/dwn-sql-store/src/**'
               - 'packages/dwn-sql-store/tests/**'
+              - 'packages/dwn-sql-store/package.json'
+              - 'packages/dwn-sql-store/tsconfig.json'
+              - 'packages/dwn-sql-store/vitest*.config.*'
 
             dwn-server:
               - 'packages/dwn-server/src/**'
               - 'packages/dwn-server/tests/**'
+              - 'packages/dwn-server/package.json'
+              - 'packages/dwn-server/tsconfig.json'
+              - 'packages/dwn-server/vitest*.config.*'
 
             agent:
               - 'packages/agent/src/**'
               - 'packages/agent/tests/**'
+              - 'packages/agent/package.json'
+              - 'packages/agent/tsconfig.json'
+              - 'packages/agent/vitest*.config.*'
 
             auth:
               - 'packages/auth/src/**'
               - 'packages/auth/tests/**'
+              - 'packages/auth/package.json'
+              - 'packages/auth/tsconfig.json'
+              - 'packages/auth/vitest*.config.*'
 
             api:
               - 'packages/api/src/**'
               - 'packages/api/tests/**'
+              - 'packages/api/package.json'
+              - 'packages/api/tsconfig.json'
+              - 'packages/api/vitest*.config.*'
 
             browser-pkg:
               - 'packages/browser/src/**'
               - 'packages/browser/tests/**'
+              - 'packages/browser/package.json'
+              - 'packages/browser/tsconfig.json'
+              - 'packages/browser/vitest*.config.*'
 
       - name: Propagate changes through dependency graph
         id: propagate
@@ -135,6 +169,7 @@ jobs:
           needs_agent=$( [ "$needs_dids" = "true" ] || [ "$needs_dwn_sdk" = "true" ] || [ "$needs_dwn_clients" = "true" ] || [ "$agent" = "true" ] && echo true || echo false )
           needs_auth=$( [ "$needs_agent" = "true" ] || [ "$auth" = "true" ] && echo true || echo false )
           needs_api=$( [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$api" = "true" ] && echo true || echo false )
+          needs_lightweight=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_auth" = "true" ] && echo true || echo false )
           needs_agent_api_group=$( [ "$needs_dids" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$needs_api" = "true" ] || [ "$dwn_clients" = "true" ] && echo true || echo false )
           needs_browser_tests=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_dids" = "true" ] || [ "$needs_dwn_sdk" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_api" = "true" ] || [ "$browser_pkg" = "true" ] && echo true || echo false )
           needs_e2e=$( [ "$needs_agent" = "true" ] && echo true || echo false )
@@ -142,6 +177,7 @@ jobs:
           # Write outputs
           {
             echo "needs_common_crypto=$needs_common_crypto"
+            echo "needs_lightweight=$needs_lightweight"
             echo "needs_dids=$needs_dids"
             echo "needs_dwn_sdk=$needs_dwn_sdk"
             echo "needs_dwn_clients=$needs_dwn_clients"
@@ -244,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     needs: [build, changes]
-    if: needs.changes.outputs.needs_common_crypto == 'true'
+    if: needs.changes.outputs.needs_lightweight == 'true'
 
     steps:
       - name: Checkout repository
@@ -1115,6 +1151,14 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
+                body,
+              });
+            } else {
+              const body = '## Coverage Report\n\n_Node coverage not available for this run._\n\n' + browserSection;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
                 body,
               });
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,7 +753,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 6
     needs: [changes, test-lightweight, test-dwn-sdk, test-agent-api, test-e2e, test-sql-store, test-dwn-server]
-    if: always() && !cancelled() && needs.changes.outputs.src == 'true'
+    # Run only when at least one node test job actually ran (not all skipped)
+    if: >-
+      always() && !cancelled() && needs.changes.outputs.src == 'true' &&
+      (needs.test-lightweight.result == 'success' || needs.test-dwn-sdk.result == 'success' ||
+       needs.test-agent-api.result == 'success' || needs.test-sql-store.result == 'success' ||
+       needs.test-dwn-server.result == 'success')
 
     steps:
       - name: Checkout repository
@@ -780,9 +785,12 @@ jobs:
       - name: Download node coverage artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: coverage-!(browser-*)
+          pattern: coverage-*
           path: .
           merge-multiple: true
+
+      - name: Remove browser coverage before merge
+        run: find . -path '*/coverage-browser-*' -type d -exec rm -rf {} + 2>/dev/null || true
 
       - name: Merge LCOV coverage
         run: bun run coverage:merge:reports
@@ -1403,7 +1411,7 @@ jobs:
             exit 1
           fi
 
-          # Coverage (node): required when it ran
+          # Coverage (node): required when it ran, OK to skip (no test jobs ran)
           if [ "${{ needs.coverage-node.result }}" != "success" ] && [ "${{ needs.coverage-node.result }}" != "skipped" ]; then
             echo "::error::coverage-node failed"
             exit 1

--- a/scripts/diff-coverage.mjs
+++ b/scripts/diff-coverage.mjs
@@ -17,7 +17,7 @@
 
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, relative } from 'node:path';
+import { resolve } from 'node:path';
 
 const THRESHOLD = Number(process.env.DIFF_COVERAGE_THRESHOLD ?? 80);
 const LCOV_PATH = resolve('coverage/merged/lcov.info');

--- a/scripts/diff-coverage.mjs
+++ b/scripts/diff-coverage.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env bun
+/**
+ * Diff-coverage gate: enforces minimum coverage on lines changed in a PR.
+ *
+ * Reads the merged LCOV report and cross-references it with `git diff` to
+ * compute coverage on only the lines that were added or modified. This is
+ * the industry-standard approach (similar to Codecov's "patch coverage" or
+ * SonarCloud's "new code" period).
+ *
+ * Environment:
+ *   DIFF_COVERAGE_THRESHOLD — minimum % coverage on changed lines (default: 80)
+ *
+ * Exit codes:
+ *   0 — coverage meets threshold (or no changed source lines found)
+ *   1 — coverage below threshold
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, relative } from 'node:path';
+
+const THRESHOLD = Number(process.env.DIFF_COVERAGE_THRESHOLD ?? 80);
+const LCOV_PATH = resolve('coverage/merged/lcov.info');
+
+// ---------------------------------------------------------------------------
+// 1. Parse merged LCOV into a map of file → Set<coveredLineNumbers>
+//    and file → Set<instrumentedLineNumbers>
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} lcovContent
+ * @returns {Map<string, { instrumented: Set<number>, covered: Set<number> }>}
+ */
+function parseLcov(lcovContent) {
+  /** @type {Map<string, { instrumented: Set<number>, covered: Set<number> }>} */
+  const files = new Map();
+  let currentFile = null;
+
+  for (const line of lcovContent.split('\n')) {
+    if (line.startsWith('SF:')) {
+      currentFile = line.slice(3).trim();
+      if (!files.has(currentFile)) {
+        files.set(currentFile, { instrumented: new Set(), covered: new Set() });
+      }
+    } else if (line.startsWith('DA:') && currentFile) {
+      const parts = line.slice(3).split(',');
+      const lineNum = Number(parts[0]);
+      const hitCount = Number(parts[1]);
+      const entry = files.get(currentFile);
+      entry.instrumented.add(lineNum);
+      if (hitCount > 0) {
+        entry.covered.add(lineNum);
+      }
+    } else if (line === 'end_of_record') {
+      currentFile = null;
+    }
+  }
+
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Get changed lines from git diff
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a map of file path → Set<line numbers> that were added/modified.
+ * @returns {Map<string, Set<number>>}
+ */
+function getChangedLines() {
+  /** @type {Map<string, Set<number>>} */
+  const changedLines = new Map();
+
+  // Get the unified diff against the merge base
+  let diff;
+  try {
+    diff = execSync(
+      'git diff origin/main...HEAD --unified=0 -- "packages/*/src/**/*.ts" ":!*.spec.ts" ":!*.test.ts" ":!*.d.ts"',
+      { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 }
+    );
+  } catch {
+    // If origin/main doesn't exist (e.g. shallow clone), try HEAD~1
+    try {
+      diff = execSync(
+        'git diff HEAD~1...HEAD --unified=0 -- "packages/*/src/**/*.ts" ":!*.spec.ts" ":!*.test.ts" ":!*.d.ts"',
+        { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 }
+      );
+    } catch {
+      console.log('Could not compute git diff — skipping diff-coverage check');
+      return changedLines;
+    }
+  }
+
+  let currentFile = null;
+
+  for (const line of diff.split('\n')) {
+    // +++ b/packages/common/src/foo.ts
+    if (line.startsWith('+++ b/')) {
+      currentFile = line.slice(6);
+      if (!changedLines.has(currentFile)) {
+        changedLines.set(currentFile, new Set());
+      }
+    }
+    // @@ -old,count +new,count @@
+    else if (line.startsWith('@@') && currentFile) {
+      const match = line.match(/\+(\d+)(?:,(\d+))?/);
+      if (match) {
+        const start = Number(match[1]);
+        const count = match[2] !== undefined ? Number(match[2]) : 1;
+        const lines = changedLines.get(currentFile);
+        for (let i = start; i < start + count; i++) {
+          lines.add(i);
+        }
+      }
+    }
+  }
+
+  return changedLines;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Cross-reference and compute diff-coverage
+// ---------------------------------------------------------------------------
+
+function main() {
+  if (!existsSync(LCOV_PATH)) {
+    console.log(`No LCOV file at ${LCOV_PATH} — skipping diff-coverage check`);
+    process.exit(0);
+  }
+
+  const lcovContent = readFileSync(LCOV_PATH, 'utf8');
+  const lcovData = parseLcov(lcovContent);
+  const changedLines = getChangedLines();
+
+  if (changedLines.size === 0) {
+    console.log('No changed source files found — diff-coverage check passes');
+    process.exit(0);
+  }
+
+  let totalChanged = 0;
+  let totalCovered = 0;
+  const fileResults = [];
+
+  for (const [filePath, lines] of changedLines) {
+    // LCOV paths may be relative to the package dir — try multiple resolutions
+    let lcovEntry = lcovData.get(filePath);
+
+    if (!lcovEntry) {
+      // Try matching by suffix: LCOV may use paths like "src/foo.ts" while
+      // git diff uses "packages/common/src/foo.ts"
+      for (const [lcovPath, entry] of lcovData) {
+        if (filePath.endsWith(lcovPath) || lcovPath.endsWith(filePath)) {
+          lcovEntry = entry;
+          break;
+        }
+        // Also try: packages/common/src/foo.ts matches src/foo.ts
+        const relFromPackage = filePath.replace(/^packages\/[^/]+\//, '');
+        if (lcovPath === relFromPackage || lcovPath.endsWith('/' + relFromPackage)) {
+          lcovEntry = entry;
+          break;
+        }
+      }
+    }
+
+    if (!lcovEntry) {
+      // File not in coverage data — might be a new file with no tests
+      const count = lines.size;
+      totalChanged += count;
+      fileResults.push({ file: filePath, changed: count, covered: 0, pct: 0 });
+      continue;
+    }
+
+    // Only count lines that are both changed AND instrumented
+    let fileChanged = 0;
+    let fileCovered = 0;
+    const uncoveredLines = [];
+
+    for (const lineNum of lines) {
+      if (lcovEntry.instrumented.has(lineNum)) {
+        fileChanged++;
+        if (lcovEntry.covered.has(lineNum)) {
+          fileCovered++;
+        } else {
+          uncoveredLines.push(lineNum);
+        }
+      }
+    }
+
+    if (fileChanged > 0) {
+      totalChanged += fileChanged;
+      totalCovered += fileCovered;
+      const pct = Math.round((fileCovered / fileChanged) * 1000) / 10;
+      fileResults.push({
+        file: filePath,
+        changed: fileChanged,
+        covered: fileCovered,
+        pct,
+        uncoveredLines: uncoveredLines.slice(0, 10), // Show first 10
+      });
+    }
+  }
+
+  // Print results
+  console.log('\n=== Diff-Coverage Report ===\n');
+
+  if (totalChanged === 0) {
+    console.log('No instrumented changed lines found — diff-coverage check passes');
+    process.exit(0);
+  }
+
+  const overallPct = Math.round((totalCovered / totalChanged) * 1000) / 10;
+
+  // Sort by coverage ascending (worst first)
+  fileResults.sort((a, b) => a.pct - b.pct);
+
+  console.log(`${'File'.padEnd(60)} ${'Changed'.padStart(8)} ${'Covered'.padStart(8)} ${'%'.padStart(7)}`);
+  console.log('-'.repeat(85));
+
+  for (const r of fileResults) {
+    const shortFile = r.file.length > 58 ? '...' + r.file.slice(-55) : r.file;
+    const marker = r.pct < THRESHOLD ? ' <--' : '';
+    console.log(`${shortFile.padEnd(60)} ${String(r.changed).padStart(8)} ${String(r.covered).padStart(8)} ${(r.pct + '%').padStart(7)}${marker}`);
+
+    if (r.uncoveredLines && r.uncoveredLines.length > 0) {
+      const lineStr = r.uncoveredLines.join(', ');
+      const suffix = r.uncoveredLines.length < (r.changed - r.covered) ? ', ...' : '';
+      console.log(`${''.padEnd(60)}   uncovered: L${lineStr}${suffix}`);
+    }
+  }
+
+  console.log('-'.repeat(85));
+  console.log(`${'TOTAL'.padEnd(60)} ${String(totalChanged).padStart(8)} ${String(totalCovered).padStart(8)} ${(overallPct + '%').padStart(7)}`);
+  console.log(`\nThreshold: ${THRESHOLD}%`);
+
+  if (overallPct < THRESHOLD) {
+    console.log(`\n::error::Diff-coverage ${overallPct}% is below the ${THRESHOLD}% threshold. Add tests for uncovered changed lines.`);
+    process.exit(1);
+  } else {
+    console.log(`\nDiff-coverage ${overallPct}% meets the ${THRESHOLD}% threshold.`);
+    process.exit(0);
+  }
+}
+
+main();

--- a/turbo.json
+++ b/turbo.json
@@ -5,12 +5,8 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
-    "lint": {
-      "dependsOn": ["^build"]
-    },
-    "lint:fix": {
-      "dependsOn": ["^build"]
-    },
+    "lint": {},
+    "lint:fix": {},
     "test:node": {
       "dependsOn": ["^build"],
       "cache": false


### PR DESCRIPTION
## Summary

Overhaul the CI pipeline to cut typical PR wall-clock time from ~40min to ~15-20min for targeted changes, improve quality gates, and eliminate wasted compute.

## Changes

### 1. Granular Change Detection
Replace the single `src` boolean with per-package path filters (`common-crypto`, `dids`, `dwn-sdk`, `agent`, etc.) and a dependency propagation step that computes `needs_*` outputs respecting the package dependency graph. Each test job now has an `if:` condition so only affected jobs run.

### 2. Parallel Lint & Build
Split the fused `setup` job into independent `lint` and `build` jobs that run in parallel. Lint failures give instant feedback (~2min) without waiting for the full build.

### 3. Lint Independence from Build (`turbo.json`)
Remove `^build` dependency from `lint` and `lint:fix` tasks — ESLint uses `project: true` which resolves TypeScript source files via tsconfig, not compiled `dist/` output.

### 4. Split Coverage Pipeline
- **`coverage-node`**: Merges only node LCOV files, runs diff-coverage gate, posts PR comment. Does NOT wait for browser tests.
- **`coverage-browser`**: Merges browser LCOV files independently, appends to PR comment. Informational only.

This removes the 21-min browser test matrix from the critical path for node coverage and SonarCloud.

### 5. Diff-Coverage Quality Gate
New `scripts/diff-coverage.mjs` enforces 80% coverage on changed lines only (industry-standard "patch coverage"). The absolute 96% target remains as an informational warning. This is the hard gate that actually prevents coverage regression.

### 6. Conditional Browser Tests
Browser tests (9 jobs) only run when `needs_browser_tests == 'true'`. Server-only changes skip them entirely.

### 7. SonarCloud Quality Gate
Enable `-Dsonar.qualitygate.wait=true` with 5-min timeout so SonarCloud's own quality gate actually blocks PRs. Depends on `coverage-node` instead of the old `coverage` job.

### 8. Updated `ci-passed` Gate
All test jobs use `success || skipped` checks so partial runs (where irrelevant jobs are skipped) still pass the gate correctly.

## Estimated Wall-Clock Times

| Change scope | Jobs triggered | Estimated time |
|---|---|---|
| Server-only (dwn-server) | lint, build, test-dwn-server, coverage-node, sonar | ~18 min |
| Common/crypto | lint, build, test-lightweight + dependents, coverage-node, sonar | ~24 min |
| Agent-only | lint, build, test-agent-api, test-e2e, coverage-node, sonar, test-browser | ~26 min |
| Full (infra change) | All jobs | ~26 min (vs ~42 today) |
| Docs-only | changes only | ~2 min |

## Files Changed

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Major restructure (all items above) |
| `turbo.json` | Remove `^build` from lint tasks |
| `scripts/diff-coverage.mjs` | New diff-coverage enforcement script |

## Verification Checklist

- [ ] Lint passes without building first (`bun run lint` with no prior `bun run build`)
- [ ] Change detection: create test branches with changes in different packages, verify only expected jobs trigger
- [ ] Diff-coverage script: test with uncovered new lines (should fail) and well-covered PR (should pass)
- [ ] SonarCloud QG: verify quality gate blocks when enabled
- [ ] `ci-passed` gate: verify all skip/success conditions work for partial runs
- [ ] Full pipeline: push and verify CI runs correctly end-to-end
- [ ] Docs-only PR: verify pipeline skips correctly