### PR TITLE
fix(ci): only enforce SonarCloud quality gate on PRs, not main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1421,11 +1421,14 @@ jobs:
           SONAR_HOST_URL: https://sonarcloud.io
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
+          # Quality gate enforcement only on PRs (new code period).
+          # Main branch pushes run the scan for analysis but don't block
+          # on pre-existing quality gate failures.
           args: >
             -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
             -Dsonar.organization=${{ vars.SONAR_ORG }}
             -Dsonar.pullrequest.github.repository=${{ github.repository }}
-            -Dsonar.qualitygate.wait=true
+            -Dsonar.qualitygate.wait=${{ github.event_name == 'pull_request' }}
             -Dsonar.qualitygate.timeout=300
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The CI pipeline optimization PR enabled `-Dsonar.qualitygate.wait=true` unconditionally. On the first `main` push after merge, SonarCloud's quality gate failed on pre-existing issues that were never gated before, breaking CI on main.

## Fix

Make the quality gate wait conditional: `${{ github.event_name == 'pull_request' }}`. This enforces the gate on PRs (where SonarCloud evaluates the "new code" period) but allows main pushes to run the scan for analysis without blocking on pre-existing failures.