### PR TITLE
fix(ci): split path filters to fix predicate-quantifier breaking all package detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      src: ${{ steps.filter.outputs.src }}
+      src: ${{ steps.src-filter.outputs.src }}
       needs_common_crypto: ${{ steps.propagate.outputs.needs_common_crypto }}
       needs_lightweight: ${{ steps.propagate.outputs.needs_lightweight }}
       needs_dids: ${{ steps.propagate.outputs.needs_dids }}
@@ -43,9 +43,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Two filter steps: 'src' needs predicate-quantifier 'every' so that
+      # negation patterns (e.g. !**/*.md) work correctly.  Per-package filters
+      # need the default 'some' (match ANY pattern) since each filter lists
+      # multiple inclusion globs for the same package.
       - name: Check for source changes
         uses: dorny/paths-filter@v3
-        id: filter
+        id: src-filter
         with:
           predicate-quantifier: 'every'
           filters: |
@@ -57,6 +61,11 @@ jobs:
               - '!docs/**'
               - '!.changeset/**'
 
+      - name: Detect per-package changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
             infra:
               - 'package.json'
               - 'bun.lock'


### PR DESCRIPTION
## Summary

Critical fix: `predicate-quantifier: 'every'` was applied globally to all path filters, which silently broke every per-package filter. With `every`, a changed file must match **all** patterns in a filter group — impossible for multi-pattern inclusion filters like `infra` (a file can't simultaneously be `package.json` AND `bun.lock` AND `tsconfig.json`).

**Impact**: All per-package filters (`infra`, `common-crypto`, `dids`, `agent`, etc.) always evaluated to `false`, causing all test jobs to be silently skipped on every push to main since the CI optimization landed. Only `src` worked because its negation patterns (`!**/*.md`, etc.) happen to all pass for non-docs files.

## Fix

Split into two `dorny/paths-filter` invocations:

1. **`src-filter`** (`predicate-quantifier: 'every'`): The `src` exclusion filter where negation patterns need AND semantics — a file must match `**` AND must not match `!**/*.md`, etc.

2. **`filter`** (default `some`): All per-package inclusion filters where matching ANY pattern should trigger the filter — a file matching `packages/agent/src/**` OR `packages/agent/package.json` should set `agent=true`.

## Verification

After this lands, any push that changes package source/config files should show the corresponding package filter as `true` in the "Detect Changes" job logs, and the relevant test jobs should run instead of being skipped.