### PR TITLE
fix(browser): remove plaintext postMessage fallback in DWeb Connect client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -798,20 +798,20 @@ jobs:
           if-no-files-found: warn
 
   # ---------------------------------------------------------------------------
-  # Coverage (Node): merge node LCOV files, run diff-coverage gate, post PR
-  # comment.  Does NOT wait for browser tests — removes them from critical path.
+  # Coverage (Node): merge all LCOV files (node + browser), run diff-coverage
+  # gate, post PR comment.
   # ---------------------------------------------------------------------------
   coverage-node:
     name: 'Coverage: Node'
     runs-on: ubuntu-latest
     timeout-minutes: 6
-    needs: [changes, test-lightweight, test-dwn-sdk, test-agent-api, test-e2e, test-sql-store, test-dwn-server]
-    # Run only when at least one node test job actually ran (not all skipped)
+    needs: [changes, test-lightweight, test-dwn-sdk, test-agent-api, test-e2e, test-sql-store, test-dwn-server, test-browser]
+    # Run when at least one test job actually ran (node or browser)
     if: >-
       always() && !cancelled() && needs.changes.outputs.src == 'true' &&
       (needs.test-lightweight.result == 'success' || needs.test-dwn-sdk.result == 'success' ||
        needs.test-agent-api.result == 'success' || needs.test-sql-store.result == 'success' ||
-       needs.test-dwn-server.result == 'success')
+       needs.test-dwn-server.result == 'success' || needs.test-browser.result == 'success')
 
     steps:
       - name: Checkout repository
@@ -841,9 +841,6 @@ jobs:
           pattern: coverage-*
           path: .
           merge-multiple: true
-
-      - name: Remove browser coverage before merge
-        run: find . -path '*/coverage-browser-*' -type d -exec rm -rf {} + 2>/dev/null || true
 
       - name: Merge LCOV coverage
         run: bun run coverage:merge:reports

--- a/packages/browser/src/dweb-connect-client.ts
+++ b/packages/browser/src/dweb-connect-client.ts
@@ -107,15 +107,21 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
   // Generate an ephemeral ECDH keypair for this connect session.
   // The public key is sent to the wallet so it can encrypt the response
   // containing delegate private keys and decryption material.
-  let dappKeyPair: CryptoKeyPair | undefined;
-  let dappPublicKeyBase64url: string | undefined;
+  // Encryption is mandatory — if key generation fails (e.g. non-secure
+  // context where crypto.subtle is unavailable), the connect flow aborts.
+  let dappKeyPair: CryptoKeyPair;
+  let dappPublicKeyBase64url: string;
 
   try {
     const ephemeral = await generateEphemeralKeyPair();
     dappKeyPair = ephemeral.keyPair;
     dappPublicKeyBase64url = ephemeral.publicKeyBase64url;
   } catch {
-    // crypto.subtle unavailable (e.g. non-secure context) — skip encryption.
+    popup.close();
+    throw new Error(
+      '[@enbox/browser] DWeb Connect requires a secure context (HTTPS) for encrypted key exchange. '
+      + 'crypto.subtle is not available in this environment.'
+    );
   }
 
   return new Promise<ConnectResult | undefined>((resolve, reject) => {
@@ -173,55 +179,39 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
         clearInterval(pollClosed);
         cleanup();
 
-        // Handle encrypted response (wallet supports ECDH channel encryption).
-        const encrypted = event.data.encryptedPayload as EncryptedPostMessagePayload | undefined;
-        if (encrypted && dappKeyPair) {
-          decryptPostMessagePayload(encrypted, dappKeyPair).then((payload: Record<string, unknown>) => {
-            const p = payload as any;
-            if (!p.delegateDid || !p.grants) {
-              resolve(undefined);
-              return;
-            }
-            resolve({
-              delegatePortableDid         : p.delegateDid as PortableDid,
-              delegateGrants              : p.grants as DwnDataEncodedRecordsWriteMessage[],
-              connectedDid                : p.connectedDid ?? did ?? (p.delegateDid as PortableDid).uri,
-              delegateDecryptionKeys      : p.delegateDecryptionKeys ?? undefined,
-              delegateContextKeys         : p.delegateContextKeys ?? undefined,
-              delegateMultiPartyProtocols : p.delegateMultiPartyProtocols ?? undefined,
-              sessionRevocations          : p.sessionRevocations ?? undefined,
-            });
-          }).catch(() => {
-            // Decryption failed — treat as denied.
-            resolve(undefined);
-          });
-          return;
-        }
-
-        // Plaintext fallback (wallet doesn't support encryption yet).
-        const {
-          delegateDid,
-          connectedDid: walletConnectedDid,
-          grants,
-          delegateDecryptionKeys,
-          delegateContextKeys,
-          delegateMultiPartyProtocols,
-          sessionRevocations,
-        } = event.data;
-
-        if (!delegateDid || !grants) {
+        // If the wallet sent an explicit error, treat as denied.
+        if (event.data.error) {
           resolve(undefined);
           return;
         }
 
-        resolve({
-          delegatePortableDid         : delegateDid as PortableDid,
-          delegateGrants              : grants as DwnDataEncodedRecordsWriteMessage[],
-          connectedDid                : walletConnectedDid ?? did ?? delegateDid.uri,
-          delegateDecryptionKeys      : delegateDecryptionKeys ?? undefined,
-          delegateContextKeys         : delegateContextKeys ?? undefined,
-          delegateMultiPartyProtocols : delegateMultiPartyProtocols ?? undefined,
-          sessionRevocations          : sessionRevocations ?? undefined,
+        // Require an encrypted response. The dapp always sends an
+        // ephemeralPublicKey, so a plaintext response means either the
+        // wallet is outdated or something intercepted the flow.
+        const encrypted = event.data.encryptedPayload as EncryptedPostMessagePayload | undefined;
+        if (!encrypted) {
+          resolve(undefined);
+          return;
+        }
+
+        decryptPostMessagePayload(encrypted, dappKeyPair).then((payload: Record<string, unknown>) => {
+          const p = payload as any;
+          if (!p.delegateDid || !p.grants) {
+            resolve(undefined);
+            return;
+          }
+          resolve({
+            delegatePortableDid         : p.delegateDid as PortableDid,
+            delegateGrants              : p.grants as DwnDataEncodedRecordsWriteMessage[],
+            connectedDid                : p.connectedDid ?? did ?? (p.delegateDid as PortableDid).uri,
+            delegateDecryptionKeys      : p.delegateDecryptionKeys ?? undefined,
+            delegateContextKeys         : p.delegateContextKeys ?? undefined,
+            delegateMultiPartyProtocols : p.delegateMultiPartyProtocols ?? undefined,
+            sessionRevocations          : p.sessionRevocations ?? undefined,
+          });
+        }).catch(() => {
+          // Decryption failed — treat as denied.
+          resolve(undefined);
         });
       }
     };

--- a/packages/browser/src/dweb-connect-crypto.ts
+++ b/packages/browser/src/dweb-connect-crypto.ts
@@ -40,7 +40,7 @@ export async function generateEphemeralKeyPair(): Promise<{
   keyPair: CryptoKeyPair;
   publicKeyBase64url: ExportedPublicKey;
 }> {
-  const keyPair = await crypto.subtle.generateKey(ECDH_PARAMS, false, ['deriveKey']);
+  const keyPair = await crypto.subtle.generateKey(ECDH_PARAMS, false, ['deriveBits']);
   const rawPub = await crypto.subtle.exportKey('raw', keyPair.publicKey);
   return { keyPair, publicKeyBase64url: toBase64url(new Uint8Array(rawPub)) };
 }

--- a/packages/browser/tests/dweb-connect-client.spec.ts
+++ b/packages/browser/tests/dweb-connect-client.spec.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+
+import { DWebConnect } from '../src/dweb-connect-client.js';
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const WALLET_URL = 'https://wallet.example.com';
+const WALLET_ORIGIN = 'https://wallet.example.com';
+const TEST_DID = 'did:jwk:test123';
+
+/** Minimal ConnectPermissionRequest for tests. */
+function stubPermissionRequest(): any {
+  return {
+    protocolDefinition : { protocol: 'https://proto.example.com', types: {}, structure: {} },
+    permissionScopes   : [{ protocol: 'https://proto.example.com', interface: 'Records', method: 'Write' }],
+  };
+}
+
+/** Creates a fake popup window returned by window.open(). */
+function createFakePopup(): { closed: boolean; close: ReturnType<typeof mock>; postMessage: ReturnType<typeof mock> } {
+  return {
+    closed      : false,
+    close       : mock(() => undefined),
+    postMessage : mock(() => undefined),
+  };
+}
+
+/**
+ * Dispatch a MessageEvent on `window` from the wallet origin.
+ * Uses the real window.dispatchEvent so the listener registered
+ * by initClient receives it.
+ */
+function dispatchWalletMessage(data: Record<string, unknown>): void {
+  window.dispatchEvent(new MessageEvent('message', { data, origin: WALLET_ORIGIN }));
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+describe('DWebConnect.initClient', () => {
+  let windowOpenSpy: ReturnType<typeof spyOn>;
+  let fakePopup: ReturnType<typeof createFakePopup>;
+
+  beforeEach(() => {
+    fakePopup = createFakePopup();
+    windowOpenSpy = spyOn(window, 'open').mockReturnValue(fakePopup as any);
+  });
+
+  afterEach(() => {
+    windowOpenSpy.mockRestore();
+  });
+
+  // ── Encryption required ─────────────────────────────────────
+
+  describe('encryption required', () => {
+    it('should throw and close popup when ephemeral key generation fails', async () => {
+      // Stub crypto.subtle.generateKey to simulate non-secure context.
+      const generateKeySpy = spyOn(crypto.subtle, 'generateKey')
+        .mockRejectedValue(new Error('not available'));
+
+      try {
+        await expect(
+          DWebConnect.initClient({
+            walletUrl          : WALLET_URL,
+            did                : TEST_DID,
+            permissionRequests : [stubPermissionRequest()],
+            timeout            : 1000,
+          }),
+        ).rejects.toThrow('requires a secure context');
+
+        expect(fakePopup.close).toHaveBeenCalled();
+      } finally {
+        generateKeySpy.mockRestore();
+      }
+    });
+
+    it('should throw when popup is blocked', async () => {
+      windowOpenSpy.mockReturnValue(null as any);
+
+      await expect(
+        DWebConnect.initClient({
+          walletUrl          : WALLET_URL,
+          did                : TEST_DID,
+          permissionRequests : [stubPermissionRequest()],
+        }),
+      ).rejects.toThrow('Popup blocked');
+    });
+  });
+
+  // ── Response handling ───────────────────────────────────────
+
+  describe('response handling', () => {
+    it('should reject plaintext responses (no encryptedPayload)', async () => {
+      const promise = DWebConnect.initClient({
+        walletUrl          : WALLET_URL,
+        did                : TEST_DID,
+        permissionRequests : [stubPermissionRequest()],
+        timeout            : 5000,
+      });
+
+      // Wait for the listener to be registered.
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Simulate wallet loaded.
+      dispatchWalletMessage({ type: 'dweb-connect-loaded' });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Simulate a plaintext response (the old vulnerable path).
+      dispatchWalletMessage({
+        type        : 'dweb-connect-authorization-response',
+        delegateDid : { uri: 'did:jwk:delegate', privateKeys: [{ kty: 'OKP' }] },
+        grants      : [{ fake: true }],
+      });
+
+      const result = await promise;
+      // Plaintext response must be rejected — resolved as undefined (denied).
+      expect(result).toBeUndefined();
+    });
+
+    it('should treat wallet error response as denied', async () => {
+      const promise = DWebConnect.initClient({
+        walletUrl          : WALLET_URL,
+        did                : TEST_DID,
+        permissionRequests : [stubPermissionRequest()],
+        timeout            : 5000,
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+      dispatchWalletMessage({ type: 'dweb-connect-loaded' });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Wallet sends an explicit error.
+      dispatchWalletMessage({
+        type   : 'dweb-connect-authorization-response',
+        error  : 'encryption_required',
+        reason : 'Wallet requires an encrypted channel.',
+      });
+
+      const result = await promise;
+      expect(result).toBeUndefined();
+    });
+
+    it('should treat decryption failure as denied', async () => {
+      const promise = DWebConnect.initClient({
+        walletUrl          : WALLET_URL,
+        did                : TEST_DID,
+        permissionRequests : [stubPermissionRequest()],
+        timeout            : 5000,
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+      dispatchWalletMessage({ type: 'dweb-connect-loaded' });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Send an encryptedPayload that cannot be decrypted (garbled data).
+      dispatchWalletMessage({
+        type             : 'dweb-connect-authorization-response',
+        encryptedPayload : {
+          ciphertext      : 'AAAA',
+          iv              : 'BBBB',
+          walletPublicKey : 'CCCC',
+        },
+      });
+
+      const result = await promise;
+      expect(result).toBeUndefined();
+    });
+
+    it('should decrypt a valid encrypted response', async () => {
+      // Import the encrypt helper to build a real encrypted payload.
+      const { encryptPostMessagePayload } = await import('../src/dweb-connect-crypto.js');
+
+      // Intercept the ephemeral public key the client sends to the wallet.
+      let dappPublicKey: string | undefined;
+      fakePopup.postMessage = mock((msg: any) => {
+        if (msg?.type === 'dweb-connect-authorization-request') {
+          dappPublicKey = msg.ephemeralPublicKey;
+        }
+      });
+
+      const promise = DWebConnect.initClient({
+        walletUrl          : WALLET_URL,
+        did                : TEST_DID,
+        permissionRequests : [stubPermissionRequest()],
+        timeout            : 10_000,
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Wallet loaded — triggers the auth request postMessage.
+      dispatchWalletMessage({ type: 'dweb-connect-loaded' });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(dappPublicKey).toBeDefined();
+
+      // Generate a wallet keypair with 'deriveBits' usage (needed by
+      // encryptPostMessagePayload → deriveSharedKey → deriveBits).
+      const walletKeyPair = await crypto.subtle.generateKey(
+        { name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveBits'],
+      );
+      const walletPubRaw = await crypto.subtle.exportKey('raw', walletKeyPair.publicKey);
+      const walletPubB64 = btoa(String.fromCharCode(...new Uint8Array(walletPubRaw)))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+      const responsePayload = {
+        delegateDid  : { uri: 'did:jwk:delegate', privateKeys: [{ kty: 'OKP' }] },
+        connectedDid : TEST_DID,
+        grants       : [{ recordId: 'grant1' }],
+      };
+
+      const encrypted = await encryptPostMessagePayload(
+        responsePayload,
+        walletKeyPair,
+        walletPubB64,
+        dappPublicKey!,
+      );
+
+      dispatchWalletMessage({
+        type             : 'dweb-connect-authorization-response',
+        encryptedPayload : encrypted,
+      });
+
+      const result = await promise;
+      expect(result).toBeDefined();
+      expect(result!.delegatePortableDid.uri).toBe('did:jwk:delegate');
+      expect(result!.connectedDid).toBe(TEST_DID);
+      expect(result!.delegateGrants).toHaveLength(1);
+    });
+
+    it('should resolve undefined for encrypted response missing delegateDid', async () => {
+      const { encryptPostMessagePayload } = await import('../src/dweb-connect-crypto.js');
+
+      let dappPublicKey: string | undefined;
+      fakePopup.postMessage = mock((msg: any) => {
+        if (msg?.type === 'dweb-connect-authorization-request') {
+          dappPublicKey = msg.ephemeralPublicKey;
+        }
+      });
+
+      const promise = DWebConnect.initClient({
+        walletUrl          : WALLET_URL,
+        did                : TEST_DID,
+        permissionRequests : [stubPermissionRequest()],
+        timeout            : 10_000,
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+      dispatchWalletMessage({ type: 'dweb-connect-loaded' });
+      await new Promise((r) => setTimeout(r, 100));
+
+      const walletKeyPair = await crypto.subtle.generateKey(
+        { name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveBits'],
+      );
+      const walletPubRaw = await crypto.subtle.exportKey('raw', walletKeyPair.publicKey);
+      const walletPubB64 = btoa(String.fromCharCode(...new Uint8Array(walletPubRaw)))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+      // Payload is missing delegateDid and grants (user denied in wallet).
+      const encrypted = await encryptPostMessagePayload(
+        { someOtherField: true },
+        walletKeyPair,
+        walletPubB64,
+        dappPublicKey!,
+      );
+
+      dispatchWalletMessage({
+        type             : 'dweb-connect-authorization-response',
+        encryptedPayload : encrypted,
+      });
+
+      const result = await promise;
+      expect(result).toBeUndefined();
+    });
+
+    it('should always include ephemeralPublicKey in the auth request', async () => {
+      let sentMessage: any;
+      fakePopup.postMessage = mock((msg: any) => {
+        if (msg?.type === 'dweb-connect-authorization-request') {
+          sentMessage = msg;
+        }
+      });
+
+      const promise = DWebConnect.initClient({
+        walletUrl          : WALLET_URL,
+        did                : TEST_DID,
+        permissionRequests : [stubPermissionRequest()],
+        timeout            : 5000,
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+      dispatchWalletMessage({ type: 'dweb-connect-loaded' });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(sentMessage).toBeDefined();
+      expect(sentMessage.ephemeralPublicKey).toBeDefined();
+      expect(typeof sentMessage.ephemeralPublicKey).toBe('string');
+      expect(sentMessage.ephemeralPublicKey.length).toBeGreaterThan(0);
+
+      // Clean up: send an error response so the promise resolves.
+      dispatchWalletMessage({
+        type  : 'dweb-connect-authorization-response',
+        error : 'test_cleanup',
+      });
+
+      await promise;
+    });
+
+    it('should ignore messages from non-wallet origins', async () => {
+      const promise = DWebConnect.initClient({
+        walletUrl          : WALLET_URL,
+        did                : TEST_DID,
+        permissionRequests : [stubPermissionRequest()],
+        timeout            : 5000,
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Message from wrong origin — should be ignored.
+      window.dispatchEvent(new MessageEvent('message', {
+        data   : { type: 'dweb-connect-authorization-response', error: 'should_be_ignored' },
+        origin : 'https://evil.example.com',
+      }));
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Correct origin — terminates the flow.
+      dispatchWalletMessage({
+        type  : 'dweb-connect-authorization-response',
+        error : 'encryption_required',
+      });
+
+      const result = await promise;
+      expect(result).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #886 (dapp side — wallet-side fix tracked separately in `enboxorg/web-wallet`).

Removes the plaintext `postMessage` fallback in the DWeb Connect client (`@enbox/browser`), which previously allowed delegate private keys, permission grants, and decryption keys to be sent unencrypted when ECDH key exchange failed or the wallet didn't support encryption.

## Changes

- **Ephemeral key generation failure is now fatal**: if `crypto.subtle` is unavailable (e.g. non-secure HTTP context), the connect flow throws a clear error instead of silently skipping encryption
- **Plaintext responses are rejected**: the dapp only accepts `encryptedPayload` responses — plaintext `delegateDid`/`grants` fields in `event.data` are no longer parsed
- **Wallet error responses handled**: explicit `error` fields (`encryption_required`, `encryption_failed`) from the wallet are treated as denied connections

## What was exposed (before this fix)

When either fallback fired, the following were sent as a plain JS object via `postMessage`, interceptable by any code on the dapp origin:

| Field | Sensitivity |
|---|---|
| `delegateDid.privateKeys` | Ed25519 + X25519 private keys |
| `delegateDecryptionKeys` | HD-derived X25519 private keys |
| `grants` | Signed permission grant messages |
| `connectedDid` | User's real DID URI |

## Companion PR

The wallet side (`DwebConnect.tsx`) needs a matching change to encrypt the response payload and refuse to send plaintext. That fix will be in a separate PR in `enboxorg/web-wallet`.