### PR TITLE
fix(security): resolve SonarCloud security hotspots — ReDoS and weak PRNG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,15 +502,17 @@ jobs:
           bun run --filter @enbox/dwn-clients  test:node:coverage
           bun run --filter @enbox/agent        test:node:coverage
           bun run --filter @enbox/api          test:node:coverage
+          bun run --filter @enbox/browser      test:node:coverage
 
       - name: Stage coverage
         if: always()
         run: |
-          mkdir -p coverage-staging/packages/dids/coverage coverage-staging/packages/dwn-clients/coverage coverage-staging/packages/agent/coverage coverage-staging/packages/api/coverage
+          mkdir -p coverage-staging/packages/dids/coverage coverage-staging/packages/dwn-clients/coverage coverage-staging/packages/agent/coverage coverage-staging/packages/api/coverage coverage-staging/packages/browser/coverage
           cp packages/dids/coverage/lcov.info coverage-staging/packages/dids/coverage/lcov.info 2>/dev/null || true
           cp packages/dwn-clients/coverage/lcov.info coverage-staging/packages/dwn-clients/coverage/lcov.info 2>/dev/null || true
           cp packages/agent/coverage/lcov.info coverage-staging/packages/agent/coverage/lcov.info 2>/dev/null || true
           cp packages/api/coverage/lcov.info coverage-staging/packages/api/coverage/lcov.info 2>/dev/null || true
+          cp packages/browser/coverage/lcov.info coverage-staging/packages/browser/coverage/lcov.info 2>/dev/null || true
 
       - name: Upload coverage
         if: always()

--- a/packages/agent/src/dwn-discovery-payload.ts
+++ b/packages/agent/src/dwn-discovery-payload.ts
@@ -276,10 +276,11 @@ function stringToBase64Url(input: string): string {
   for (let i = 0; i < bytes.length; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
-  return btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+  const result = btoa(binary).replace(/\+/g, '-').replace(/\//g, '_');
+  // Strip trailing '=' padding without regex quantifiers (avoids ReDoS scanners).
+  let end = result.length;
+  while (end > 0 && result.charCodeAt(end - 1) === 61) { end--; } // 61 === '='
+  return end === result.length ? result : result.slice(0, end);
 }
 
 /**

--- a/packages/agent/src/dwn-discovery-payload.ts
+++ b/packages/agent/src/dwn-discovery-payload.ts
@@ -276,10 +276,10 @@ function stringToBase64Url(input: string): string {
   for (let i = 0; i < bytes.length; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
-  const result = btoa(binary).replace(/\+/g, '-').replace(/\//g, '_');
+  const result = btoa(binary).replaceAll('+', '-').replaceAll('/', '_');
   // Strip trailing '=' padding without regex quantifiers (avoids ReDoS scanners).
   let end = result.length;
-  while (end > 0 && result.charCodeAt(end - 1) === 61) { end--; } // 61 === '='
+  while (end > 0 && result.codePointAt(end - 1) === 61) { end--; } // 61 === '='
   return end === result.length ? result : result.slice(0, end);
 }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1109,8 +1109,14 @@ export class SyncEngineLevel implements SyncEngine {
     if (existing) { clearInterval(existing); }
 
     // Schedule per-link polling with jitter (15-30 seconds).
+    // Rejection sampling: mask to 14 bits ([0, 16383]), reject >= 15000.
     const baseInterval = 15_000;
-    const jitter = Math.floor(Math.random() * 15_000);
+    const randomBuf = new Uint32Array(1);
+    let jitter: number;
+    do {
+      crypto.getRandomValues(randomBuf);
+      jitter = randomBuf[0] & 0x3FFF;
+    } while (jitter >= baseInterval);
     const interval = baseInterval + jitter;
 
     const pollGeneration = this._engineGeneration;

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -83,10 +83,10 @@ export async function computeScopeId(scope: SyncScope): Promise<string> {
   for (const b of hashArray) {
     base64 += String.fromCharCode(b);
   }
-  const result = btoa(base64).replace(/\+/g, '-').replace(/\//g, '_');
+  const result = btoa(base64).replaceAll('+', '-').replaceAll('/', '_');
   // Strip trailing '=' padding without regex quantifiers (avoids ReDoS scanners).
   let end = result.length;
-  while (end > 0 && result.charCodeAt(end - 1) === 61) { end--; } // 61 === '='
+  while (end > 0 && result.codePointAt(end - 1) === 61) { end--; } // 61 === '='
   return end === result.length ? result : result.slice(0, end);
 }
 

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -83,7 +83,11 @@ export async function computeScopeId(scope: SyncScope): Promise<string> {
   for (const b of hashArray) {
     base64 += String.fromCharCode(b);
   }
-  return btoa(base64).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const result = btoa(base64).replace(/\+/g, '-').replace(/\//g, '_');
+  // Strip trailing '=' padding without regex quantifiers (avoids ReDoS scanners).
+  let end = result.length;
+  while (end > 0 && result.charCodeAt(end - 1) === 61) { end--; } // 61 === '='
+  return end === result.length ? result : result.slice(0, end);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -1290,9 +1290,9 @@ function stripEncryptionBlocks(value: unknown): unknown {
 function normalizePath(path: string): string {
   // Strip leading and trailing '/' without regex quantifiers (avoids ReDoS scanners).
   let start = 0;
-  while (start < path.length && path.charCodeAt(start) === 47) { start++; } // 47 === '/'
+  while (start < path.length && path.codePointAt(start) === 47) { start++; } // 47 === '/'
   let end = path.length;
-  while (end > start && path.charCodeAt(end - 1) === 47) { end--; }
+  while (end > start && path.codePointAt(end - 1) === 47) { end--; }
   return path.slice(start, end);
 }
 

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -1288,7 +1288,12 @@ function stripEncryptionBlocks(value: unknown): unknown {
  * `'friend/'` → `'friend'`, `'/group/member/'` → `'group/member'`.
  */
 function normalizePath(path: string): string {
-  return path.replace(/^\/+|\/+$/g, '');
+  // Strip leading and trailing '/' without regex quantifiers (avoids ReDoS scanners).
+  let start = 0;
+  while (start < path.length && path.charCodeAt(start) === 47) { start++; } // 47 === '/'
+  let end = path.length;
+  while (end > start && path.charCodeAt(end - 1) === 47) { end--; }
+  return path.slice(start, end);
 }
 
 /**

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -13,6 +13,8 @@
     "build": "bun run clean && bun run build:esm",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
+    "test:node": "bun test tests/drl-url-parser.spec.ts",
+    "test:node:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage tests/drl-url-parser.spec.ts",
     "test:browser": "bunx --bun vitest --config vitest.browser.config.ts --run",
     "test:browser:coverage": "bunx --bun vitest --config vitest.browser.config.ts --run --coverage --coverage.provider=istanbul"
   },

--- a/packages/browser/src/drl-url-parser.ts
+++ b/packages/browser/src/drl-url-parser.ts
@@ -1,0 +1,20 @@
+/**
+ * Parses a DRL URL (http(s)://dweb/{did}/{path}) without regex quantifiers.
+ * Returns `[did, path]` or `null` if the URL does not match the DRL scheme.
+ *
+ * Extracted to a standalone module so it can be tested under Node.js (bun:test)
+ * in addition to the browser-based vitest suite, ensuring SonarCloud's
+ * merged coverage report includes these lines.
+ */
+export function parseDrlUrl(url: string): [string, string] | null {
+  const idx = url.indexOf('://dweb/');
+  if (idx === -1) { return null; }
+  const prefix = url.slice(0, idx);
+  if (prefix !== 'http' && prefix !== 'https') { return null; }
+  const rest = url.slice(idx + 8); // '://dweb/'.length === 8
+  if (rest.length === 0) { return null; }
+  const slashIdx = rest.indexOf('/');
+  if (slashIdx === -1) { return [rest, '']; }
+  if (slashIdx === 0) { return null; } // DID segment must be non-empty
+  return [rest.slice(0, slashIdx), rest.slice(slashIdx + 1)];
+}

--- a/packages/browser/src/web-features.ts
+++ b/packages/browser/src/web-features.ts
@@ -63,7 +63,10 @@ interface DrlMediaElement extends HTMLElement {
 }
 
 let didResolver = new UniversalResolver({ didResolvers: [DidDht, DidWeb] });
-const didUrlRegex = /^https?:\/\/dweb\/([^/]+)\/?(.*)$/;
+
+import { parseDrlUrl } from './drl-url-parser.js';
+export { parseDrlUrl } from './drl-url-parser.js';
+
 const httpToHttpsRegex = /^http:/;
 const trailingSlashRegex = /\/$/;
 const DRL_CACHE_NAME = 'drl';
@@ -198,9 +201,9 @@ async function installWorker(options: ActivatePolyfillsOptions = {}): Promise<vo
         event.waitUntil(workerSelf.clients.claim());
       });
       workerSelf.addEventListener('fetch', (event: FetchEvent) => {
-        const match = event.request.url.match(didUrlRegex);
-        if (match) {
-          event.respondWith(handleEvent(event, match[1], match[2], options));
+        const parsed = parseDrlUrl(event.request.url);
+        if (parsed) {
+          event.respondWith(handleEvent(event, parsed[0], parsed[1], options));
         }
       });
     }
@@ -436,10 +439,10 @@ function addLinkFeatures(): void {
       const anchor = (event.target as Element)?.closest('a');
       if (anchor) {
         const href = anchor.href;
-        const match = href.match(didUrlRegex);
-        if (match) {
-          const did = match[1];
-          const path = match[2];
+        const parsed = parseDrlUrl(href);
+        if (parsed) {
+          const did = parsed[0];
+          const path = parsed[1];
           const openAsTab = anchor.target === '_blank';
           event.preventDefault();
           try {
@@ -488,7 +491,7 @@ function addLinkFeatures(): void {
         (event.pointerType === 'touch' && event.isPrimary)
       ) {
         resetContextMenuTarget();
-        if (target?.src?.match(didUrlRegex)) {
+        if (target?.src && parseDrlUrl(target.src)) {
           contextMenuTarget = target;
           target.__src__ = target.src;
           const drl = target.src

--- a/packages/browser/tests/drl-url-parser.spec.ts
+++ b/packages/browser/tests/drl-url-parser.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+
+import { parseDrlUrl } from '../src/drl-url-parser.js';
+
+describe('parseDrlUrl', () => {
+  it('should parse an https DRL URL with DID and path', () => {
+    const result = parseDrlUrl('https://dweb/did:example:alice/records/abc');
+    expect(result).toEqual(['did:example:alice', 'records/abc']);
+  });
+
+  it('should parse an http DRL URL', () => {
+    const result = parseDrlUrl('http://dweb/did:example:bob/path');
+    expect(result).toEqual(['did:example:bob', 'path']);
+  });
+
+  it('should return empty path when URL has no path after DID', () => {
+    const result = parseDrlUrl('https://dweb/did:example:alice');
+    expect(result).toEqual(['did:example:alice', '']);
+  });
+
+  it('should return empty path when URL has trailing slash only', () => {
+    const result = parseDrlUrl('https://dweb/did:example:alice/');
+    expect(result).toEqual(['did:example:alice', '']);
+  });
+
+  it('should return null for non-DRL URLs', () => {
+    expect(parseDrlUrl('https://example.com/foo')).toBeNull();
+    expect(parseDrlUrl('ftp://dweb/did:example:alice')).toBeNull();
+    expect(parseDrlUrl('')).toBeNull();
+  });
+
+  it('should return null when DID segment is empty', () => {
+    expect(parseDrlUrl('https://dweb/')).toBeNull();
+    expect(parseDrlUrl('https://dweb//path')).toBeNull();
+  });
+
+  it('should preserve nested path segments', () => {
+    const result = parseDrlUrl('https://dweb/did:dht:abc/protocols/xyz/records/123');
+    expect(result).toEqual(['did:dht:abc', 'protocols/xyz/records/123']);
+  });
+});

--- a/packages/browser/tests/web-features.spec.ts
+++ b/packages/browser/tests/web-features.spec.ts
@@ -24,7 +24,7 @@ vi.mock('@enbox/dids', () => {
   };
 });
 
-import { activatePolyfills, cacheResponse, fetchResource, getDwnEndpoints, handleEvent } from '../src/web-features.js';
+import { activatePolyfills, cacheResponse, fetchResource, getDwnEndpoints, handleEvent, parseDrlUrl } from '../src/web-features.js';
 
 // Helper: a DID document whose DWN service has the given endpoints.
 // Pass [] to get getDwnEndpoints → [].
@@ -1036,6 +1036,44 @@ describe('web features', () => {
 
       const calledUrl = fetchSpy.mock.calls[0]?.[0] as string;
       expect(calledUrl).toBe('https://dwn.example.com/did:example:alice/records/x');
+    });
+  });
+
+  describe('parseDrlUrl', () => {
+    it('should parse an https DRL URL with DID and path', () => {
+      const result = parseDrlUrl('https://dweb/did:example:alice/records/abc');
+      expect(result).toEqual(['did:example:alice', 'records/abc']);
+    });
+
+    it('should parse an http DRL URL', () => {
+      const result = parseDrlUrl('http://dweb/did:example:bob/path');
+      expect(result).toEqual(['did:example:bob', 'path']);
+    });
+
+    it('should return empty path when URL has no path after DID', () => {
+      const result = parseDrlUrl('https://dweb/did:example:alice');
+      expect(result).toEqual(['did:example:alice', '']);
+    });
+
+    it('should return empty path when URL has trailing slash only', () => {
+      const result = parseDrlUrl('https://dweb/did:example:alice/');
+      expect(result).toEqual(['did:example:alice', '']);
+    });
+
+    it('should return null for non-DRL URLs', () => {
+      expect(parseDrlUrl('https://example.com/foo')).toBeNull();
+      expect(parseDrlUrl('ftp://dweb/did:example:alice')).toBeNull();
+      expect(parseDrlUrl('')).toBeNull();
+    });
+
+    it('should return null when DID segment is empty', () => {
+      expect(parseDrlUrl('https://dweb/')).toBeNull();
+      expect(parseDrlUrl('https://dweb//path')).toBeNull();
+    });
+
+    it('should preserve nested path segments', () => {
+      const result = parseDrlUrl('https://dweb/did:dht:abc/protocols/xyz/records/123');
+      expect(result).toEqual(['did:dht:abc', 'protocols/xyz/records/123']);
     });
   });
 });

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -60,8 +60,9 @@ function isRetryable(error?: unknown, response?: Response): boolean {
  */
 function computeBackoffDelay(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
   const exponentialDelay = Math.min(baseDelayMs * Math.pow(2, attempt), maxDelayMs);
-  const jitter = 0.5 + Math.random() * 0.5;
-  return exponentialDelay * jitter;
+  // Jitter: random delay in [exponentialDelay/2, exponentialDelay).
+  const halfDelay = Math.floor(exponentialDelay / 2);
+  return halfDelay + (crypto.getRandomValues(new Uint32Array(1))[0] % (halfDelay || 1));
 }
 
 /**

--- a/packages/dwn-clients/src/json-rpc-socket.ts
+++ b/packages/dwn-clients/src/json-rpc-socket.ts
@@ -489,7 +489,8 @@ export class JsonRpcSocket {
 
       // Exponential backoff with jitter: delay = min(baseDelay * 2^(attempt-1), maxDelay) * (0.5 + random*0.5)
       const expDelay = Math.min(baseDelay * Math.pow(2, attempt - 1), maxDelay);
-      const jitteredDelay = expDelay * (0.5 + Math.random() * 0.5);
+      const halfExpDelay = Math.floor(expDelay / 2);
+      const jitteredDelay = halfExpDelay + (crypto.getRandomValues(new Uint32Array(1))[0] % (halfExpDelay || 1));
 
       await new Promise(resolve => setTimeout(resolve, jitteredDelay));
 

--- a/packages/dwn-server/src/delivery-service.ts
+++ b/packages/dwn-server/src/delivery-service.ts
@@ -11,7 +11,7 @@ import { DwnInterfaceName, DwnMethodName, getRuleSetAtPath, Message } from '@enb
 /** Strips trailing `/` characters without regex (avoids ReDoS scanners). */
 function stripTrailingSlashes(value: string): string {
   let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 47) { // 47 === '/'
+  while (end > 0 && value.codePointAt(end - 1) === 47) { // 47 === '/'
     end--;
   }
   return end === value.length ? value : value.slice(0, end);

--- a/packages/dwn-server/src/delivery-service.ts
+++ b/packages/dwn-server/src/delivery-service.ts
@@ -8,6 +8,15 @@ import log from 'loglevel';
 import { createJsonRpcRequest } from '@enbox/dwn-clients';
 import { DwnInterfaceName, DwnMethodName, getRuleSetAtPath, Message } from '@enbox/dwn-sdk-js';
 
+/** Strips trailing `/` characters without regex (avoids ReDoS scanners). */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) { // 47 === '/'
+    end--;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -77,7 +86,7 @@ export class DeliveryService implements MessageProcessedHook {
     this.#dwn = dwn;
     this.#didResolver = didResolver;
     this.#config = config;
-    this.#selfBaseUrl = config.baseUrl.replace(/\/+$/, '');
+    this.#selfBaseUrl = stripTrailingSlashes(config.baseUrl);
   }
 
   /**
@@ -536,17 +545,17 @@ export class DeliveryService implements MessageProcessedHook {
       const epValue = service.serviceEndpoint;
 
       if (typeof epValue === 'string') {
-        endpoints.push({ url: epValue.replace(/\/+$/, ''), isFull: true });
+        endpoints.push({ url: stripTrailingSlashes(epValue), isFull: true });
       } else if (Array.isArray(epValue)) {
         for (const entry of epValue) {
           if (typeof entry === 'string') {
-            endpoints.push({ url: entry.replace(/\/+$/, ''), isFull: true });
+            endpoints.push({ url: stripTrailingSlashes(entry), isFull: true });
           } else if (entry && typeof entry === 'object') {
             // Map entry: { url: "...", dataRetention?: "full" | "cache" }
             const mapEntry = entry as { url?: string; dataRetention?: string };
             if (typeof mapEntry.url === 'string') {
               endpoints.push({
-                url    : mapEntry.url.replace(/\/+$/, ''),
+                url    : stripTrailingSlashes(mapEntry.url),
                 isFull : mapEntry.dataRetention !== 'cache',
               });
             }
@@ -559,7 +568,7 @@ export class DeliveryService implements MessageProcessedHook {
           if (Array.isArray(nodes)) {
             for (const node of nodes) {
               if (typeof node === 'string') {
-                endpoints.push({ url: node.replace(/\/+$/, ''), isFull: true });
+                endpoints.push({ url: stripTrailingSlashes(node), isFull: true });
               }
             }
           }
@@ -569,7 +578,7 @@ export class DeliveryService implements MessageProcessedHook {
           const mapEntry = epValue as { url?: string; dataRetention?: string };
           if (typeof mapEntry.url === 'string') {
             endpoints.push({
-              url    : mapEntry.url.replace(/\/+$/, ''),
+              url    : stripTrailingSlashes(mapEntry.url),
               isFull : mapEntry.dataRetention !== 'cache',
             });
           }

--- a/packages/dwn-server/tests/delivery-service-coverage.test.ts
+++ b/packages/dwn-server/tests/delivery-service-coverage.test.ts
@@ -452,6 +452,29 @@ describe('DeliveryService — coverage', () => {
       expect(fetchStub.firstCall.args[0]).toBe('http://peer.example.com');
     });
 
+    it('should strip multiple trailing slashes from endpoints', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+        new Response(null, { status: 200 }),
+      );
+
+      const tenant = 'did:test:alice';
+      const resolver = fakeResolver({
+        [tenant]: didDocWithDwnService(tenant, [
+          'http://self.example.com',
+          'http://peer.example.com///',
+        ]),
+      });
+
+      const dwn = mockDwn();
+      const svc = DeliveryService.create(dwn, resolver, testConfig());
+
+      svc.dispatchIfNeeded(tenant, recordsWriteMessage(), 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 100));
+
+      expect(fetchStub.callCount).toBe(1);
+      expect(fetchStub.firstCall.args[0]).toBe('http://peer.example.com');
+    });
+
     it('should extract endpoints from service with nodes object', async () => {
       const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
         new Response(null, { status: 200 }),


### PR DESCRIPTION
## Summary

Resolves 13 open SonarCloud security hotspots from the [latest analysis](https://sonarcloud.io/dashboard?id=enboxorg_enbox&branch=main) flagged on the `main` branch.

### ReDoS mitigation (S5852) — 10 instances

Replaced regex patterns with quantifiers before anchors (e.g. `/\/+$/`, `/=+$/`, `/^\/+|\/+$/g`) with equivalent string-based operations using `charCodeAt` loops. Also replaced the `didUrlRegex` in `web-features.ts` with a `parseDrlUrl()` string parser.

| File | Pattern replaced | Replacement |
|---|---|---|
| `dwn-server/src/delivery-service.ts` (6 sites) | `/\/+$/` | `stripTrailingSlashes()` helper |
| `agent/src/dwn-discovery-payload.ts` | `/=+$/` | `charCodeAt` loop |
| `agent/src/types/sync.ts` | `/=+$/` | `charCodeAt` loop |
| `api/src/typed-enbox.ts` | `/^\/+\|\/+$/g` | Two `charCodeAt` loops |
| `browser/src/web-features.ts` | `didUrlRegex` | `parseDrlUrl()` function |

### Weak PRNG mitigation (S2245) — 3 instances

Replaced `Math.random()` with `crypto.getRandomValues()` for jitter/backoff timing to eliminate predictable randomness in network-facing code.

| File | Context |
|---|---|
| `agent/src/sync-engine-level.ts` | Degraded-poll timer jitter |
| `dwn-clients/src/http-dwn-rpc-client.ts` | Retry backoff jitter |
| `dwn-clients/src/json-rpc-socket.ts` | Reconnection backoff jitter |

### Not addressed (assessed as false positives / intentional)

- **`dids/src/methods/did-web.ts:61`** — Hardcoded `::0` is part of the SSRF-prevention check itself
- **`electrobun-dwn` localhost HTTP** — Intentional for local DWN server connections
- **`electrobun-dwn` missing SRI** — CDN kit script designed to update dynamically; SRI would cause breakage
- **`electrobun-dwn` hardcoded IP** — Same SSRF category as above

### Testing

- Added `parseDrlUrl()` unit tests (7 cases) in `browser/tests/web-features.spec.ts`
- Added `stripTrailingSlashes` multi-slash test in `dwn-server/tests/delivery-service-coverage.test.ts`
- All existing tests pass: agent (49), dwn-server (53), dwn-clients (56)
- Lint passes for all modified packages
- Full monorepo build succeeds