### PR TITLE
fix(agent): remove cleartext kid from connect response JWE protected header

### DIFF
--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -435,18 +435,21 @@ async function decryptRequest({
 // Encryption: response (ECDH shared key + optional PIN)
 // ---------------------------------------------------------------------------
 
-/** Derives a shared ECDH key for encrypting/decrypting the connect response. */
-async function deriveSharedKey(
+/**
+ * Core ECDH key derivation from a raw public key JWK.
+ *
+ * Converts both keys to X25519, performs ECDH, and derives the final
+ * symmetric key via HKDF-SHA-256.
+ */
+async function deriveSharedKeyFromJwk(
   privateKeyDid: BearerDid,
-  publicKeyDid: DidDocument
+  publicKeyJwk: Jwk
 ): Promise<Uint8Array> {
   const privatePortableDid = await privateKeyDid.export();
-
-  const publicJwk = publicKeyDid.verificationMethod?.[0].publicKeyJwk!;
   const privateJwk = privatePortableDid.privateKeys?.[0]!;
-  publicJwk.alg = 'EdDSA';
+  const pubJwk = { ...publicKeyJwk, alg: 'EdDSA' };
 
-  const publicX25519 = await Ed25519.convertPublicKeyToX25519({ publicKey: publicJwk });
+  const publicX25519 = await Ed25519.convertPublicKeyToX25519({ publicKey: pubJwk });
   const privateX25519 = await Ed25519.convertPrivateKeyToX25519({ privateKey: privateJwk });
 
   const sharedKey = await X25519.sharedSecret({
@@ -463,6 +466,15 @@ async function deriveSharedKey(
   });
 }
 
+/** Derives a shared ECDH key for encrypting/decrypting the connect response. */
+async function deriveSharedKey(
+  privateKeyDid: BearerDid,
+  publicKeyDid: DidDocument
+): Promise<Uint8Array> {
+  const publicJwk = publicKeyDid.verificationMethod?.[0].publicKeyJwk!;
+  return deriveSharedKeyFromJwk(privateKeyDid, publicJwk);
+}
+
 /**
  * Encrypts the connect response JWT.
  *
@@ -475,20 +487,29 @@ async function deriveSharedKey(
 async function encryptResponse({
   jwt,
   encryptionKey,
-  delegateDidKeyId,
+  delegatePublicKeyJwk,
   pin,
 }: {
   jwt: string;
   encryptionKey: Uint8Array;
-  delegateDidKeyId: string;
+  delegatePublicKeyJwk: Jwk;
   pin?: string;
 }): Promise<string> {
+  // Include only the minimum key material (kty, crv, x) in the ephemeral
+  // public key header.  This avoids leaking DID-level identifiers (kid,
+  // alg, etc.) that would let the relay correlate sessions or resolve
+  // the delegate DID.  See https://github.com/enboxorg/enbox/issues/890
+  const epk: Jwk = {
+    kty : delegatePublicKeyJwk.kty,
+    crv : delegatePublicKeyJwk.crv,
+    x   : delegatePublicKeyJwk.x,
+  };
   const protectedHeader = {
     alg : 'dir',
     cty : 'JWT',
     enc : 'XC20P',
     typ : 'JWT',
-    kid : delegateDidKeyId,
+    epk,
   };
   const nonce = CryptoUtils.randomBytes(24);
 
@@ -533,16 +554,12 @@ async function decryptResponse(
     authenticationTagB64U,
   ] = jwe.split('.');
 
-  const header = Convert.base64Url(protectedHeaderB64U).toObject() as Jwk;
-  if (!header.kid) {
-    throw new Error('Connect: JWE protected header is missing required "kid" property.');
+  const header = Convert.base64Url(protectedHeaderB64U).toObject() as Record<string, unknown>;
+  if (!header.epk || typeof header.epk !== 'object') {
+    throw new Error('Connect: JWE protected header is missing required "epk" property.');
   }
-  const delegateResolvedDid = await DidJwk.resolve(header.kid.split('#')[0]);
 
-  const sharedKey = await EnboxConnectProtocol.deriveSharedKey(
-    clientDid,
-    delegateResolvedDid.didDocument!
-  );
+  const sharedKey = await deriveSharedKeyFromJwk(clientDid, header.epk as Jwk);
 
   // Build AAD — include PIN if provided (must match what was used during encryption).
   const aadObject = pin
@@ -1297,9 +1314,9 @@ async function submitConnectResponse(
 
   logger.log('Encrypting connect response...');
   const encryptedResponse = await EnboxConnectProtocol.encryptResponse({
-    jwt              : responseObjectJwt,
-    encryptionKey    : sharedKey,
-    delegateDidKeyId : delegateBearerDid.document.verificationMethod![0].id,
+    jwt                  : responseObjectJwt,
+    encryptionKey        : sharedKey,
+    delegatePublicKeyJwk : delegateBearerDid.document.verificationMethod![0].publicKeyJwk!,
     pin,
   });
 

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -524,7 +524,6 @@ describe('enbox connect', () => {
     });
 
     it('should throw when epk is missing from the protected header', async () => {
-      // Manually construct a JWE with no epk to verify the guard clause.
       const badHeader = { alg: 'dir', cty: 'JWT', enc: 'XC20P', typ: 'JWT' };
       const badJwe = [
         Convert.object(badHeader).toBase64Url(),
@@ -537,6 +536,173 @@ describe('enbox connect', () => {
       await expect(
         EnboxConnectProtocol.decryptResponse(clientEphemeralBearerDid, badJwe, randomPin)
       ).rejects.toThrow('missing required "epk"');
+    });
+
+    it('should throw when epk is null', async () => {
+      const badHeader = { alg: 'dir', cty: 'JWT', enc: 'XC20P', typ: 'JWT', epk: null };
+      const badJwe = [
+        Convert.object(badHeader).toBase64Url(),
+        '',
+        Convert.uint8Array(new Uint8Array(24)).toBase64Url(),
+        Convert.uint8Array(new Uint8Array(16)).toBase64Url(),
+        Convert.uint8Array(new Uint8Array(16)).toBase64Url(),
+      ].join('.');
+
+      await expect(
+        EnboxConnectProtocol.decryptResponse(clientEphemeralBearerDid, badJwe, randomPin)
+      ).rejects.toThrow('missing required "epk"');
+    });
+
+    it('should throw when epk is a string instead of an object', async () => {
+      const badHeader = { alg: 'dir', cty: 'JWT', enc: 'XC20P', typ: 'JWT', epk: 'did:jwk:abc' };
+      const badJwe = [
+        Convert.object(badHeader).toBase64Url(),
+        '',
+        Convert.uint8Array(new Uint8Array(24)).toBase64Url(),
+        Convert.uint8Array(new Uint8Array(16)).toBase64Url(),
+        Convert.uint8Array(new Uint8Array(16)).toBase64Url(),
+      ].join('.');
+
+      await expect(
+        EnboxConnectProtocol.decryptResponse(clientEphemeralBearerDid, badJwe, randomPin)
+      ).rejects.toThrow('missing required "epk"');
+    });
+
+    it('should throw when epk is a number', async () => {
+      const badHeader = { alg: 'dir', cty: 'JWT', enc: 'XC20P', typ: 'JWT', epk: 42 };
+      const badJwe = [
+        Convert.object(badHeader).toBase64Url(),
+        '',
+        Convert.uint8Array(new Uint8Array(24)).toBase64Url(),
+        Convert.uint8Array(new Uint8Array(16)).toBase64Url(),
+        Convert.uint8Array(new Uint8Array(16)).toBase64Url(),
+      ].join('.');
+
+      await expect(
+        EnboxConnectProtocol.decryptResponse(clientEphemeralBearerDid, badJwe, randomPin)
+      ).rejects.toThrow('missing required "epk"');
+    });
+
+    it('should fail decryption when the epk is tampered with', async () => {
+      // Swap the epk with a completely different key — ECDH will derive
+      // a different shared secret and AEAD decryption will fail.
+      const differentDid = await DidJwk.create();
+      const wrongEpk = differentDid.document.verificationMethod![0].publicKeyJwk!;
+
+      const [, ...rest] = connectResponseJwe.split('.');
+      const tamperedHeader = {
+        alg : 'dir',
+        cty : 'JWT',
+        enc : 'XC20P',
+        typ : 'JWT',
+        epk : { kty: wrongEpk.kty, crv: wrongEpk.crv, x: wrongEpk.x },
+      };
+      const tamperedJwe = [Convert.object(tamperedHeader).toBase64Url(), ...rest].join('.');
+
+      await expect(
+        EnboxConnectProtocol.decryptResponse(clientEphemeralBearerDid, tamperedJwe, randomPin)
+      ).rejects.toThrow();
+    });
+
+    it('should fail decryption when a different client DID is used', async () => {
+      const wrongClientDid = await DidJwk.create();
+
+      await expect(
+        EnboxConnectProtocol.decryptResponse(wrongClientDid, connectResponseJwe, randomPin)
+      ).rejects.toThrow();
+    });
+
+    it('should fail decryption when ciphertext is tampered with', async () => {
+      const parts = connectResponseJwe.split('.');
+      // Flip a byte in the ciphertext segment.
+      const ciphertextBytes = Convert.base64Url(parts[3]).toUint8Array();
+      ciphertextBytes[0] ^= 0xff;
+      parts[3] = Convert.uint8Array(ciphertextBytes).toBase64Url();
+      const tamperedJwe = parts.join('.');
+
+      await expect(
+        EnboxConnectProtocol.decryptResponse(clientEphemeralBearerDid, tamperedJwe, randomPin)
+      ).rejects.toThrow();
+    });
+
+    it('should fail when PIN was used during encryption but omitted during decryption', async () => {
+      // connectResponseJwe was encrypted WITH randomPin — decrypt without it.
+      await expect(
+        EnboxConnectProtocol.decryptResponse(clientEphemeralBearerDid, connectResponseJwe)
+      ).rejects.toThrow();
+    });
+
+    it('should fail when PIN was not used during encryption but provided during decryption', async () => {
+      const jweNoPin = await EnboxConnectProtocol.encryptResponse({
+        jwt                  : connectResponseJwt,
+        encryptionKey        : sharedECDHPrivateKey,
+        delegatePublicKeyJwk : delegateBearerDid.document.verificationMethod![0].publicKeyJwk!,
+      });
+
+      await expect(
+        EnboxConnectProtocol.decryptResponse(clientEphemeralBearerDid, jweNoPin, '1234')
+      ).rejects.toThrow();
+    });
+
+    it('should strip extra JWK fields (kid, alg, d) from the epk in the header', async () => {
+      // Pass a JWK that has extra identifying/private fields.
+      const fullJwk = {
+        ...delegateBearerDid.document.verificationMethod![0].publicKeyJwk!,
+        kid : 'some-identifying-kid',
+        alg : 'EdDSA',
+        d   : 'private-key-material-that-must-not-leak',
+      };
+
+      const jwe = await EnboxConnectProtocol.encryptResponse({
+        jwt                  : connectResponseJwt,
+        encryptionKey        : sharedECDHPrivateKey,
+        delegatePublicKeyJwk : fullJwk,
+        pin                  : randomPin,
+      });
+
+      const [headerB64U] = jwe.split('.');
+      const header = Convert.base64Url(headerB64U).toObject() as Record<string, unknown>;
+      const epk = header.epk as Record<string, unknown>;
+
+      expect(Object.keys(epk).sort()).toEqual(['crv', 'kty', 'x']);
+      expect(epk.kid).toBeUndefined();
+      expect(epk.alg).toBeUndefined();
+      expect(epk.d).toBeUndefined();
+
+      // Should still decrypt correctly since the key material is the same.
+      const decrypted = await EnboxConnectProtocol.decryptResponse(
+        clientEphemeralBearerDid, jwe, randomPin
+      );
+      expect(decrypted).toBe(connectResponseJwt);
+    });
+
+    it('should produce non-correlatable epk values for different delegate DIDs', async () => {
+      const delegate1 = await DidJwk.create();
+      const delegate2 = await DidJwk.create();
+
+      const sharedKey1 = await EnboxConnectProtocol.deriveSharedKey(
+        delegate1, clientEphemeralBearerDid.document
+      );
+      const sharedKey2 = await EnboxConnectProtocol.deriveSharedKey(
+        delegate2, clientEphemeralBearerDid.document
+      );
+
+      const jwe1 = await EnboxConnectProtocol.encryptResponse({
+        jwt                  : connectResponseJwt,
+        encryptionKey        : sharedKey1,
+        delegatePublicKeyJwk : delegate1.document.verificationMethod![0].publicKeyJwk!,
+      });
+      const jwe2 = await EnboxConnectProtocol.encryptResponse({
+        jwt                  : connectResponseJwt,
+        encryptionKey        : sharedKey2,
+        delegatePublicKeyJwk : delegate2.document.verificationMethod![0].publicKeyJwk!,
+      });
+
+      const header1 = Convert.base64Url(jwe1.split('.')[0]).toObject() as Record<string, any>;
+      const header2 = Convert.base64Url(jwe2.split('.')[0]).toObject() as Record<string, any>;
+
+      // The x coordinates must differ — each delegate has a unique key pair.
+      expect(header1.epk.x).not.toBe(header2.epk.x);
     });
   });
 

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -352,10 +352,10 @@ describe('enbox connect', () => {
         .stub(CryptoUtils, 'randomBytes')
         .returns(encryptionNonce);
       connectResponseJwe = await EnboxConnectProtocol.encryptResponse({
-        jwt              : connectResponseJwt,
-        encryptionKey    : sharedECDHPrivateKey,
-        pin              : randomPin,
-        delegateDidKeyId : delegateBearerDid.document.verificationMethod![0].id,
+        jwt                  : connectResponseJwt,
+        encryptionKey        : sharedECDHPrivateKey,
+        pin                  : randomPin,
+        delegatePublicKeyJwk : delegateBearerDid.document.verificationMethod![0].publicKeyJwk!,
       });
       expect(typeof connectResponseJwe).toBe('string');
       expect(randomBytesStub.calledOnce).toBe(true);
@@ -456,6 +456,89 @@ describe('enbox connect', () => {
   // NOTE: `end to end client test` and `initClient — error paths` were moved
   // to @enbox/auth (wallet-connect-client.spec.ts) since WalletConnect.initClient
   // now lives in that package.
+
+  describe('JWE privacy — no kid leak (issue #890)', () => {
+    it('should not include kid in the JWE protected header', async () => {
+      const [protectedHeaderB64U] = connectResponseJwe.split('.');
+      const header = Convert.base64Url(protectedHeaderB64U).toObject() as Record<string, unknown>;
+
+      expect(header.kid).toBeUndefined();
+    });
+
+    it('should include an epk (ephemeral public key) in the JWE protected header', async () => {
+      const [protectedHeaderB64U] = connectResponseJwe.split('.');
+      const header = Convert.base64Url(protectedHeaderB64U).toObject() as Record<string, unknown>;
+
+      expect(header.epk).toBeDefined();
+      expect(typeof header.epk).toBe('object');
+    });
+
+    it('should only include minimal key material (kty, crv, x) in epk — no kid or alg', async () => {
+      const [protectedHeaderB64U] = connectResponseJwe.split('.');
+      const header = Convert.base64Url(protectedHeaderB64U).toObject() as Record<string, unknown>;
+      const epk = header.epk as Record<string, unknown>;
+
+      expect(Object.keys(epk).sort()).toEqual(['crv', 'kty', 'x']);
+      expect(epk.kid).toBeUndefined();
+      expect(epk.alg).toBeUndefined();
+    });
+
+    it('should not contain a did: URI anywhere in the relay-visible protected header', async () => {
+      const [protectedHeaderB64U] = connectResponseJwe.split('.');
+      const headerJson = Convert.base64Url(protectedHeaderB64U).toString();
+
+      expect(headerJson).not.toContain('did:');
+    });
+
+    it('should decrypt correctly with epk-based key agreement (round-trip)', async () => {
+      // Encrypt a fresh response with epk, then decrypt — verifies the full round-trip.
+      const freshJwe = await EnboxConnectProtocol.encryptResponse({
+        jwt                  : connectResponseJwt,
+        encryptionKey        : sharedECDHPrivateKey,
+        pin                  : randomPin,
+        delegatePublicKeyJwk : delegateBearerDid.document.verificationMethod![0].publicKeyJwk!,
+      });
+
+      const decrypted = await EnboxConnectProtocol.decryptResponse(
+        clientEphemeralBearerDid,
+        freshJwe,
+        randomPin
+      );
+
+      expect(decrypted).toBe(connectResponseJwt);
+    });
+
+    it('should decrypt correctly without a PIN (local flow)', async () => {
+      const jweNoPin = await EnboxConnectProtocol.encryptResponse({
+        jwt                  : connectResponseJwt,
+        encryptionKey        : sharedECDHPrivateKey,
+        delegatePublicKeyJwk : delegateBearerDid.document.verificationMethod![0].publicKeyJwk!,
+      });
+
+      const decrypted = await EnboxConnectProtocol.decryptResponse(
+        clientEphemeralBearerDid,
+        jweNoPin,
+      );
+
+      expect(decrypted).toBe(connectResponseJwt);
+    });
+
+    it('should throw when epk is missing from the protected header', async () => {
+      // Manually construct a JWE with no epk to verify the guard clause.
+      const badHeader = { alg: 'dir', cty: 'JWT', enc: 'XC20P', typ: 'JWT' };
+      const badJwe = [
+        Convert.object(badHeader).toBase64Url(),
+        '',
+        Convert.uint8Array(new Uint8Array(24)).toBase64Url(),
+        Convert.uint8Array(new Uint8Array(16)).toBase64Url(),
+        Convert.uint8Array(new Uint8Array(16)).toBase64Url(),
+      ].join('.');
+
+      await expect(
+        EnboxConnectProtocol.decryptResponse(clientEphemeralBearerDid, badJwe, randomPin)
+      ).rejects.toThrow('missing required "epk"');
+    });
+  });
 
   describe('submitConnectResponse', () => {
     it('should not attempt to configure the protocol if it already exists', async () => {


### PR DESCRIPTION
## Summary

Fixes #890 — the wallet-connect relay flow was leaking the delegate DID's full `did:jwk:...#0` URI in the cleartext JWE protected header `kid` field, allowing the relay to resolve the delegate DID, correlate sessions, and fingerprint key types.

## Changes

- **`encryptResponse()`**: replaced `delegateDidKeyId` param with `delegatePublicKeyJwk`; the JWE protected header now carries a minimal `epk` (ephemeral public key) with only `kty`, `crv`, `x` — no `kid`, `alg`, or DID URI
- **`decryptResponse()`**: derives the ECDH shared key directly from the `epk` JWK instead of resolving a DID from `kid`
- Extracted `deriveSharedKeyFromJwk()` private helper to avoid duplicating ECDH logic between `deriveSharedKey()` and `decryptResponse()`
- Updated `submitConnectResponse()` call site to pass `publicKeyJwk` instead of verification method `id`
- No changes to `wallet-connect-client.ts` (same `decryptResponse` signature)

## Tests

Added 7 new tests in `JWE privacy — no kid leak (issue #890)`:

1. No `kid` in protected header
2. `epk` present in protected header
3. `epk` contains only minimal key material (`kty`, `crv`, `x`) — no `kid` or `alg`
4. No `did:` URI anywhere in relay-visible header
5. Round-trip encrypt/decrypt with `epk`-based key agreement
6. Round-trip without PIN (local flow)
7. Error when `epk` is missing from header

All 29 agent connect tests pass. All 6 auth wallet-connect tests pass. Lint clean.