### PR TITLE
feat(agent,auth): add SecretStore for vault-encrypted secret persistence

### DIFF
--- a/packages/agent/src/enbox-user-agent.ts
+++ b/packages/agent/src/enbox-user-agent.ts
@@ -3,6 +3,7 @@ import type { BearerDid } from '@enbox/dids';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { EnboxRpc } from '@enbox/dwn-clients';
 import type { LocalDwnStrategy } from './local-dwn.js';
+import type { SecretStore } from './secret-store.js';
 import type { SyncEngine } from './types/sync.js';
 import type { DidInterface, DidRequest, DidResponse } from './did-api.js';
 import type { DwnInterface, DwnResponse, ProcessDwnRequest, SendDwnRequest } from './types/dwn.js';
@@ -23,6 +24,7 @@ import { LevelStore } from '@enbox/common';
 import { LocalKeyManager } from './local-key-manager.js';
 import { SyncEngineLevel } from './sync-engine-level.js';
 import { DidDht, DidJwk } from '@enbox/dids';
+import { InMemorySecretStore, VaultBackedSecretStore } from './secret-store.js';
 
 /**
  * Initialization parameters for {@link EnboxUserAgent}, including an optional recovery phrase that
@@ -84,6 +86,8 @@ export type AgentParams<TKeyManager extends AgentKeyManager = LocalKeyManager> =
   permissionsApi: AgentPermissionsApi;
   /** Remote procedure call (RPC) client used to communicate with other Enbox services. */
   rpcClient: EnboxRpc;
+  /** Vault-backed secret store for classified credentials. */
+  secretsApi?: SecretStore;
   /** Facilitates data synchronization of DWN records between nodes. */
   syncApi: SyncEngine;
 };
@@ -110,6 +114,7 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
   public keyManager: TKeyManager;
   public permissions: AgentPermissionsApi;
   public rpc: EnboxRpc;
+  public secrets: SecretStore;
   public sync: SyncEngine;
   public vault: HdIdentityVault;
 
@@ -124,6 +129,7 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
     this.keyManager = params.keyManager;
     this.permissions = params.permissionsApi;
     this.rpc = params.rpcClient;
+    this.secrets = params.secretsApi ?? new InMemorySecretStore();
     this.sync = params.syncApi;
     this.vault = params.agentVault;
 
@@ -164,6 +170,11 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
     agentVault ??= new HdIdentityVault({
       keyDerivationWorkFactor : 210_000,
       store                   : new LevelStore<string, string>({ location: `${dataPath}/VAULT_STORE` })
+    });
+
+    const secretsApi = new VaultBackedSecretStore({
+      vault : agentVault,
+      store : new LevelStore<string, string>({ location: `${dataPath}/SECRET_STORE` }),
     });
 
     cryptoApi ??= new AgentCryptoApi();
@@ -211,11 +222,12 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
       cryptoApi,
       didApi,
       dwnApi,
+      identityApi,
       keyManager,
       permissionsApi,
-      identityApi,
       rpcClient,
-      syncApi
+      secretsApi,
+      syncApi,
     });
   }
 

--- a/packages/agent/src/enbox-user-agent.ts
+++ b/packages/agent/src/enbox-user-agent.ts
@@ -163,7 +163,7 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
     dataPath = 'DATA/AGENT',
     localDwnStrategy,
     localDwnEndpoint,
-    agentDid, agentVault, cryptoApi, didApi, dwnApi, identityApi, keyManager, permissionsApi, rpcClient, syncApi
+    agentDid, agentVault, cryptoApi, didApi, dwnApi, identityApi, keyManager, permissionsApi, rpcClient, secretsApi, syncApi
   }: CreateUserAgentParams = {}
   ): Promise<EnboxUserAgent> {
 
@@ -172,7 +172,7 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
       store                   : new LevelStore<string, string>({ location: `${dataPath}/VAULT_STORE` })
     });
 
-    const secretsApi = new VaultBackedSecretStore({
+    secretsApi ??= new VaultBackedSecretStore({
       vault : agentVault,
       store : new LevelStore<string, string>({ location: `${dataPath}/SECRET_STORE` }),
     });

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -32,6 +32,7 @@ export * from './identity-api.js';
 export * from './local-dwn.js';
 export * from './local-key-manager.js';
 export * from './permissions-api.js';
+export * from './secret-store.js';
 export * from './store-data.js';
 export * from './store-did.js';
 export * from './store-identity.js';

--- a/packages/agent/src/secret-store.ts
+++ b/packages/agent/src/secret-store.ts
@@ -1,0 +1,173 @@
+import type { KeyValueStore } from '@enbox/common';
+
+import type { IdentityVault } from './types/identity-vault.js';
+
+/**
+ * Options for storing a secret.
+ */
+export type SecretStorePutOptions = {
+  /**
+   * ISO-8601 timestamp after which the secret is considered expired.
+   *
+   * Expired secrets are silently deleted on the next {@link SecretStore.get}
+   * call and `undefined` is returned.
+   */
+  expiresAt?: string;
+};
+
+/**
+ * Platform-agnostic interface for storing classified secrets encrypted at rest
+ * by the agent vault.
+ *
+ * Implementations must ensure that plaintext secret material is never persisted
+ * to browser-accessible storage such as `localStorage` or `sessionStorage`.
+ */
+export interface SecretStore {
+  /**
+   * Store a secret, encrypted at rest with the vault key.
+   *
+   * @param key - Unique identifier for the secret.
+   * @param value - The secret bytes to store.
+   * @param options - Optional metadata (e.g. TTL).
+   * @throws If the vault is locked.
+   */
+  put(key: string, value: Uint8Array, options?: SecretStorePutOptions): Promise<void>;
+
+  /**
+   * Retrieve and decrypt a secret.
+   *
+   * Returns `undefined` if the key does not exist or the secret has expired.
+   *
+   * @param key - The identifier used when the secret was stored.
+   * @throws If the vault is locked.
+   */
+  get(key: string): Promise<Uint8Array | undefined>;
+
+  /**
+   * Delete a secret.
+   *
+   * @param key - The identifier used when the secret was stored.
+   * @returns `true` if the key existed and was removed, `false` otherwise.
+   */
+  delete(key: string): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+//  Internal envelope persisted in the backing KeyValueStore.
+// ---------------------------------------------------------------------------
+
+/** @internal */
+type SecretEnvelope = {
+  /** Compact JWE encrypted by the vault's content encryption key. */
+  jwe: string;
+
+  /** Optional ISO-8601 expiry timestamp. */
+  expiresAt?: string;
+};
+
+// ---------------------------------------------------------------------------
+//  VaultBackedSecretStore
+// ---------------------------------------------------------------------------
+
+/**
+ * Vault-backed implementation of {@link SecretStore}.
+ *
+ * Secrets are encrypted with the vault's content encryption key (AES-256-GCM
+ * via `dir` algorithm) before being persisted to the backing
+ * {@link KeyValueStore}. The vault must be unlocked for {@link put} and
+ * {@link get} operations; {@link delete} does not require the vault to be
+ * unlocked since it only removes the encrypted envelope.
+ */
+export class VaultBackedSecretStore implements SecretStore {
+  private readonly _vault: IdentityVault;
+  private readonly _store: KeyValueStore<string, string>;
+
+  constructor({ vault, store }: {
+    vault : IdentityVault;
+    store : KeyValueStore<string, string>;
+  }) {
+    this._vault = vault;
+    this._store = store;
+  }
+
+  public async put(
+    key: string,
+    value: Uint8Array,
+    options?: SecretStorePutOptions,
+  ): Promise<void> {
+    // vault.encryptData() throws if the vault is locked.
+    const jwe = await this._vault.encryptData({ plaintext: value });
+
+    const envelope: SecretEnvelope = { jwe };
+    if (options?.expiresAt !== undefined) {
+      envelope.expiresAt = options.expiresAt;
+    }
+
+    await this._store.set(key, JSON.stringify(envelope));
+  }
+
+  public async get(key: string): Promise<Uint8Array | undefined> {
+    const raw = await this._store.get(key);
+    if (raw === undefined) { return undefined; }
+
+    const envelope = JSON.parse(raw) as SecretEnvelope;
+
+    // Purge expired secrets.
+    if (envelope.expiresAt !== undefined && new Date(envelope.expiresAt).getTime() <= Date.now()) {
+      await this._store.delete(key);
+      return undefined;
+    }
+
+    // vault.decryptData() throws if the vault is locked.
+    return this._vault.decryptData({ jwe: envelope.jwe });
+  }
+
+  public async delete(key: string): Promise<boolean> {
+    const existing = await this._store.get(key);
+    if (existing === undefined) { return false; }
+    await this._store.delete(key);
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+//  InMemorySecretStore
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory implementation of {@link SecretStore} for testing.
+ *
+ * Secrets are stored as plain `Uint8Array` values in a `Map` — no encryption,
+ * no persistence. This is suitable only for unit tests.
+ */
+export class InMemorySecretStore implements SecretStore {
+  private readonly _store = new Map<string, { value: Uint8Array; expiresAt?: string }>();
+
+  public async put(
+    key: string,
+    value: Uint8Array,
+    options?: SecretStorePutOptions,
+  ): Promise<void> {
+    this._store.set(key, {
+      value     : new Uint8Array(value),
+      expiresAt : options?.expiresAt,
+    });
+  }
+
+  public async get(key: string): Promise<Uint8Array | undefined> {
+    const entry = this._store.get(key);
+    if (entry === undefined) { return undefined; }
+
+    // Purge expired secrets.
+    if (entry.expiresAt !== undefined && new Date(entry.expiresAt).getTime() <= Date.now()) {
+      this._store.delete(key);
+      return undefined;
+    }
+
+    return new Uint8Array(entry.value);
+  }
+
+  public async delete(key: string): Promise<boolean> {
+    return this._store.delete(key);
+  }
+}

--- a/packages/agent/src/test-harness.ts
+++ b/packages/agent/src/test-harness.ts
@@ -33,6 +33,8 @@ type StoreSetupResult = {
   keyManager: LocalKeyManager;
   permissionsApi: AgentPermissionsApi;
   secretsApi: InMemorySecretStore | VaultBackedSecretStore;
+  /** Backing KeyValueStore for VaultBackedSecretStore (for clear/close lifecycle). */
+  secretStore?: KeyValueStore<string, string>;
   vaultStore: KeyValueStore<string, string>;
 };
 
@@ -46,6 +48,8 @@ type PlatformAgentTestHarnessParams = {
   dwnStateIndex: StateIndexLevel;
   dwnMessageStore: MessageStoreLevel;
   dwnResumableTaskStore: ResumableTaskStoreLevel;
+  /** Backing KeyValueStore for VaultBackedSecretStore (disk mode only). */
+  secretStore?: KeyValueStore<string, string>;
   syncStore: AbstractLevel<string | Buffer | Uint8Array>;
   vaultStore: KeyValueStore<string, string>;
   dwnStores: {
@@ -66,6 +70,7 @@ export class PlatformAgentTestHarness {
   public dwnStateIndex: StateIndexLevel;
   public dwnMessageStore: MessageStoreLevel;
   public dwnResumableTaskStore: ResumableTaskStoreLevel;
+  public secretStore?: KeyValueStore<string, string>;
   public syncStore: AbstractLevel<string | Buffer | Uint8Array>;
   public vaultStore: KeyValueStore<string, string>;
 
@@ -89,6 +94,7 @@ export class PlatformAgentTestHarness {
     this.dwnDataStore = params.dwnDataStore;
     this.dwnStateIndex = params.dwnStateIndex;
     this.dwnMessageStore = params.dwnMessageStore;
+    this.secretStore = params.secretStore;
     this.syncStore = params.syncStore;
     this.vaultStore = params.vaultStore;
     this.dwnResumableTaskStore = params.dwnResumableTaskStore;
@@ -108,6 +114,7 @@ export class PlatformAgentTestHarness {
     await this.dwnResumableTaskStore.clear();
     await this.syncStore.clear();
     await this.vaultStore.clear();
+    if (this.secretStore) { await this.secretStore.clear(); }
     (this.agent.vault as any)['_cachedInitialized'] = undefined;
     await this.agent.permissions.clear();
     this.dwnStores.clear();
@@ -156,6 +163,7 @@ export class PlatformAgentTestHarness {
     await this.dwnStateIndex.close();
     await this.dwnMessageStore.close();
     await this.dwnResumableTaskStore.close();
+    if (this.secretStore) { await this.secretStore.close(); }
     await this.syncStore.close();
     await this.vaultStore.close();
   }
@@ -253,6 +261,7 @@ export class PlatformAgentTestHarness {
       vaultStore,
       permissionsApi,
       secretsApi,
+      secretStore,
     } = (agentStores === 'memory')
       ? PlatformAgentTestHarness.useMemoryStores()
       : PlatformAgentTestHarness.useDiskStores({ testDataLocation, stores: dwnStores });
@@ -312,8 +321,9 @@ export class PlatformAgentTestHarness {
       dwnMessageStore,
       dwnResumableTaskStore,
       dwnStores,
+      secretStore,
       syncStore,
-      vaultStore
+      vaultStore,
     });
   }
 
@@ -351,12 +361,13 @@ export class PlatformAgentTestHarness {
 
     const permissionsApi = new AgentPermissionsApi({ agent });
 
+    const secretStore = new LevelStore<string, string>({ location: testDataPath('SECRET_STORE') });
     const secretsApi = new VaultBackedSecretStore({
       vault : agentVault,
-      store : new LevelStore<string, string>({ location: testDataPath('SECRET_STORE') }),
+      store : secretStore,
     });
 
-    return { agentVault, didApi, didResolverCache, identityApi, keyManager, permissionsApi, secretsApi, vaultStore };
+    return { agentVault, didApi, didResolverCache, identityApi, keyManager, permissionsApi, secretsApi, secretStore, vaultStore };
   }
 
   private static useMemoryStores({ agent }: { agent?: EnboxPlatformAgent<LocalKeyManager> } = {}): StoreSetupResult {

--- a/packages/agent/src/test-harness.ts
+++ b/packages/agent/src/test-harness.ts
@@ -23,6 +23,7 @@ import { SyncEngineLevel } from './sync-engine-level.js';
 import { DwnDidStore, InMemoryDidStore } from './store-did.js';
 import { DwnIdentityStore, InMemoryIdentityStore } from './store-identity.js';
 import { DwnKeyStore, InMemoryKeyStore } from './store-key.js';
+import { InMemorySecretStore, VaultBackedSecretStore } from './secret-store.js';
 
 type StoreSetupResult = {
   agentVault: HdIdentityVault;
@@ -31,6 +32,7 @@ type StoreSetupResult = {
   identityApi: AgentIdentityApi<LocalKeyManager>;
   keyManager: LocalKeyManager;
   permissionsApi: AgentPermissionsApi;
+  secretsApi: InMemorySecretStore | VaultBackedSecretStore;
   vaultStore: KeyValueStore<string, string>;
 };
 
@@ -120,11 +122,12 @@ export class PlatformAgentTestHarness {
 
     // Easiest way to start with fresh in-memory stores is to re-instantiate Agent components.
     if (this.agentStores === 'memory') {
-      const { didApi, identityApi, permissionsApi, keyManager } = PlatformAgentTestHarness.useMemoryStores({ agent: this.agent });
+      const { didApi, identityApi, permissionsApi, keyManager, secretsApi } = PlatformAgentTestHarness.useMemoryStores({ agent: this.agent });
       this.agent.did = didApi;
       this.agent.identity = identityApi;
       this.agent.keyManager = keyManager;
       this.agent.permissions = permissionsApi;
+      this.agent.secrets = secretsApi;
     }
   }
 
@@ -248,7 +251,8 @@ export class PlatformAgentTestHarness {
       keyManager,
       didResolverCache,
       vaultStore,
-      permissionsApi
+      permissionsApi,
+      secretsApi,
     } = (agentStores === 'memory')
       ? PlatformAgentTestHarness.useMemoryStores()
       : PlatformAgentTestHarness.useDiskStores({ testDataLocation, stores: dwnStores });
@@ -294,6 +298,7 @@ export class PlatformAgentTestHarness {
       keyManager,
       permissionsApi,
       rpcClient,
+      secretsApi,
       syncApi,
     });
 
@@ -346,7 +351,12 @@ export class PlatformAgentTestHarness {
 
     const permissionsApi = new AgentPermissionsApi({ agent });
 
-    return { agentVault, didApi, didResolverCache, identityApi, keyManager, permissionsApi, vaultStore };
+    const secretsApi = new VaultBackedSecretStore({
+      vault : agentVault,
+      store : new LevelStore<string, string>({ location: testDataPath('SECRET_STORE') }),
+    });
+
+    return { agentVault, didApi, didResolverCache, identityApi, keyManager, permissionsApi, secretsApi, vaultStore };
   }
 
   private static useMemoryStores({ agent }: { agent?: EnboxPlatformAgent<LocalKeyManager> } = {}): StoreSetupResult {
@@ -369,6 +379,8 @@ export class PlatformAgentTestHarness {
 
     const permissionsApi = new AgentPermissionsApi({ agent });
 
-    return { agentVault, didApi, didResolverCache, identityApi, keyManager, permissionsApi, vaultStore };
+    const secretsApi = new InMemorySecretStore();
+
+    return { agentVault, didApi, didResolverCache, identityApi, keyManager, permissionsApi, secretsApi, vaultStore };
   }
 }

--- a/packages/agent/src/types/agent.ts
+++ b/packages/agent/src/types/agent.ts
@@ -170,14 +170,8 @@ export interface EnboxPlatformAgent<TKeyManager extends AgentKeyManager = AgentK
    */
   sync: SyncEngine;
 
-  /**
-   * Vault-backed secret store for classified credentials such as registration
-   * tokens, refresh tokens, and delegate decryption keys. Secrets are
-   * encrypted at rest with the vault's content encryption key and never
-   * written to browser-accessible storage.
-   */
+  /** Vault-backed secret store for classified credentials, encrypted at rest with the vault key. */
   secrets: SecretStore;
-
   /**
    * An instance of {@link IdentityVault}, providing secure storage and management of an Enbox Agent's
    * DID and cryptographic keys.

--- a/packages/agent/src/types/agent.ts
+++ b/packages/agent/src/types/agent.ts
@@ -7,6 +7,7 @@ import type { AgentKeyManager } from './key-manager.js';
 import type { AgentPermissionsApi } from '../permissions-api.js';
 import type { EnboxRpc } from '@enbox/dwn-clients';
 import type { IdentityVault } from './identity-vault.js';
+import type { SecretStore } from '../secret-store.js';
 import type { SyncEngine } from './sync.js';
 import type { AgentDidApi, DidInterface, DidRequest, DidResponse } from '../did-api.js';
 import type { DwnInterface, DwnResponse, ProcessDwnRequest, SendDwnRequest } from './dwn.js';
@@ -168,6 +169,14 @@ export interface EnboxPlatformAgent<TKeyManager extends AgentKeyManager = AgentK
    * agent's data with the state of the distributed network.
    */
   sync: SyncEngine;
+
+  /**
+   * Vault-backed secret store for classified credentials such as registration
+   * tokens, refresh tokens, and delegate decryption keys. Secrets are
+   * encrypted at rest with the vault's content encryption key and never
+   * written to browser-accessible storage.
+   */
+  secrets: SecretStore;
 
   /**
    * An instance of {@link IdentityVault}, providing secure storage and management of an Enbox Agent's

--- a/packages/agent/tests/secret-store.spec.ts
+++ b/packages/agent/tests/secret-store.spec.ts
@@ -1,0 +1,430 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { Convert, MemoryStore } from '@enbox/common';
+
+import { HdIdentityVault } from '../src/hd-identity-vault.js';
+import { InMemorySecretStore, VaultBackedSecretStore } from '../src/secret-store.js';
+
+// ---------------------------------------------------------------------------
+//  Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_PASSWORD = 'test-password';
+
+/** Encode a string as Uint8Array for convenience. */
+function toBytes(s: string): Uint8Array {
+  return Convert.string(s).toUint8Array();
+}
+
+/** Decode Uint8Array back to a string. */
+function fromBytes(b: Uint8Array): string {
+  return Convert.uint8Array(b).toString();
+}
+
+/** Create an unlocked vault backed by an in-memory store. */
+async function createUnlockedVault(): Promise<{
+  vault: HdIdentityVault;
+  vaultStore: MemoryStore<string, string>;
+}> {
+  const vaultStore = new MemoryStore<string, string>();
+  const vault = new HdIdentityVault({ keyDerivationWorkFactor: 1, store: vaultStore });
+  await vault.initialize({ password: TEST_PASSWORD });
+  return { vault, vaultStore };
+}
+
+// ===========================================================================
+//  InMemorySecretStore
+// ===========================================================================
+
+describe('SecretStore', () => {
+  describe('InMemorySecretStore', () => {
+    let store: InMemorySecretStore;
+
+    beforeEach(() => {
+      store = new InMemorySecretStore();
+    });
+
+    // ─── put / get ───────────────────────────────────────────────
+
+    describe('put() and get()', () => {
+      it('should round-trip a secret', async () => {
+        const value = toBytes('my-secret-token');
+        await store.put('token:server-1', value);
+
+        const retrieved = await store.get('token:server-1');
+        expect(retrieved).toBeDefined();
+        expect(fromBytes(retrieved!)).toBe('my-secret-token');
+      });
+
+      it('should store binary data without corruption', async () => {
+        const binary = new Uint8Array([0, 1, 127, 128, 255]);
+        await store.put('binary-key', binary);
+
+        const retrieved = await store.get('binary-key');
+        expect(retrieved).toEqual(binary);
+      });
+
+      it('should overwrite an existing secret on re-put', async () => {
+        await store.put('key', toBytes('first'));
+        await store.put('key', toBytes('second'));
+
+        const retrieved = await store.get('key');
+        expect(fromBytes(retrieved!)).toBe('second');
+      });
+
+      it('should isolate stored values from the original buffer', async () => {
+        const original = toBytes('original');
+        await store.put('key', original);
+
+        // Mutate the input buffer after put.
+        original[0] = 0xFF;
+
+        const retrieved = await store.get('key');
+        expect(fromBytes(retrieved!)).toBe('original');
+      });
+
+      it('should isolate returned values from the internal store', async () => {
+        await store.put('key', toBytes('value'));
+        const first = await store.get('key');
+        first![0] = 0xFF; // mutate returned buffer
+
+        const second = await store.get('key');
+        expect(fromBytes(second!)).toBe('value');
+      });
+    });
+
+    // ─── get — missing key ───────────────────────────────────────
+
+    describe('get() — missing key', () => {
+      it('should return undefined for a non-existent key', async () => {
+        const result = await store.get('does-not-exist');
+        expect(result).toBeUndefined();
+      });
+    });
+
+    // ─── delete ──────────────────────────────────────────────────
+
+    describe('delete()', () => {
+      it('should delete an existing secret and return true', async () => {
+        await store.put('key', toBytes('value'));
+
+        const deleted = await store.delete('key');
+        expect(deleted).toBe(true);
+
+        const after = await store.get('key');
+        expect(after).toBeUndefined();
+      });
+
+      it('should return false for a non-existent key', async () => {
+        const deleted = await store.delete('does-not-exist');
+        expect(deleted).toBe(false);
+      });
+    });
+
+    // ─── TTL / expiry ────────────────────────────────────────────
+
+    describe('expiry (expiresAt)', () => {
+      it('should return undefined and auto-delete when the secret has expired', async () => {
+        const pastDate = new Date(Date.now() - 60_000).toISOString();
+        await store.put('expired', toBytes('old'), { expiresAt: pastDate });
+
+        const result = await store.get('expired');
+        expect(result).toBeUndefined();
+
+        // Verify it was actually deleted, not just skipped.
+        const again = await store.get('expired');
+        expect(again).toBeUndefined();
+      });
+
+      it('should return the secret when it has not yet expired', async () => {
+        const futureDate = new Date(Date.now() + 60_000).toISOString();
+        await store.put('valid', toBytes('still-good'), { expiresAt: futureDate });
+
+        const result = await store.get('valid');
+        expect(result).toBeDefined();
+        expect(fromBytes(result!)).toBe('still-good');
+      });
+
+      it('should treat exactly-now as expired (boundary)', async () => {
+        // Set expiresAt to a time that is definitely in the past by the time get() runs.
+        const justPast = new Date(Date.now() - 1).toISOString();
+        await store.put('boundary', toBytes('edge'), { expiresAt: justPast });
+
+        const result = await store.get('boundary');
+        expect(result).toBeUndefined();
+      });
+
+      it('should allow secrets without expiry to persist indefinitely', async () => {
+        await store.put('no-ttl', toBytes('forever'));
+
+        const result = await store.get('no-ttl');
+        expect(fromBytes(result!)).toBe('forever');
+      });
+    });
+  });
+
+  // =========================================================================
+  //  VaultBackedSecretStore
+  // =========================================================================
+
+  describe('VaultBackedSecretStore', () => {
+    let vault: HdIdentityVault;
+    let vaultStore: MemoryStore<string, string>;
+    let backingStore: MemoryStore<string, string>;
+    let store: VaultBackedSecretStore;
+
+    beforeAll(async () => {
+      ({ vault, vaultStore } = await createUnlockedVault());
+    });
+
+    beforeEach(async () => {
+      backingStore = new MemoryStore<string, string>();
+      store = new VaultBackedSecretStore({ vault, store: backingStore });
+
+      // Ensure vault is unlocked before each test.
+      if (vault.isLocked()) {
+        await vault.unlock({ password: TEST_PASSWORD });
+      }
+    });
+
+    afterAll(async () => {
+      await vaultStore.close();
+    });
+
+    // ─── put / get ───────────────────────────────────────────────
+
+    describe('put() and get()', () => {
+      it('should round-trip a secret through vault encryption', async () => {
+        const value = toBytes('registration-token-abc');
+        await store.put('reg:server-1', value);
+
+        const retrieved = await store.get('reg:server-1');
+        expect(retrieved).toBeDefined();
+        expect(fromBytes(retrieved!)).toBe('registration-token-abc');
+      });
+
+      it('should store binary data without corruption', async () => {
+        const binary = new Uint8Array([0, 1, 127, 128, 255]);
+        await store.put('binary-key', binary);
+
+        const retrieved = await store.get('binary-key');
+        expect(retrieved).toEqual(binary);
+      });
+
+      it('should overwrite an existing secret on re-put', async () => {
+        await store.put('key', toBytes('first'));
+        await store.put('key', toBytes('second'));
+
+        const retrieved = await store.get('key');
+        expect(fromBytes(retrieved!)).toBe('second');
+      });
+
+      it('should store different secrets under different keys', async () => {
+        await store.put('key-a', toBytes('alpha'));
+        await store.put('key-b', toBytes('bravo'));
+
+        expect(fromBytes((await store.get('key-a'))!)).toBe('alpha');
+        expect(fromBytes((await store.get('key-b'))!)).toBe('bravo');
+      });
+    });
+
+    // ─── encryption at rest ──────────────────────────────────────
+
+    describe('encryption at rest', () => {
+      it('should store data as encrypted JWE in the backing store', async () => {
+        await store.put('secret', toBytes('plaintext-value'));
+
+        // Read the raw backing store entry — it should be a JSON envelope
+        // containing a JWE, not the plaintext.
+        const raw = await backingStore.get('secret');
+        expect(raw).toBeDefined();
+        expect(raw).not.toContain('plaintext-value');
+
+        const envelope = JSON.parse(raw!);
+        expect(envelope.jwe).toBeDefined();
+        expect(typeof envelope.jwe).toBe('string');
+
+        // Compact JWE has 5 dot-separated parts.
+        const parts = envelope.jwe.split('.');
+        expect(parts.length).toBe(5);
+      });
+
+      it('should persist expiresAt metadata alongside the JWE', async () => {
+        const expiresAt = '2099-12-31T23:59:59.000Z';
+        await store.put('expiring', toBytes('temp'), { expiresAt });
+
+        const raw = await backingStore.get('expiring');
+        const envelope = JSON.parse(raw!);
+        expect(envelope.expiresAt).toBe(expiresAt);
+      });
+
+      it('should omit expiresAt when not provided', async () => {
+        await store.put('no-ttl', toBytes('permanent'));
+
+        const raw = await backingStore.get('no-ttl');
+        const envelope = JSON.parse(raw!);
+        expect(envelope.expiresAt).toBeUndefined();
+      });
+    });
+
+    // ─── get — missing key ───────────────────────────────────────
+
+    describe('get() — missing key', () => {
+      it('should return undefined for a non-existent key', async () => {
+        const result = await store.get('does-not-exist');
+        expect(result).toBeUndefined();
+      });
+    });
+
+    // ─── delete ──────────────────────────────────────────────────
+
+    describe('delete()', () => {
+      it('should delete an existing secret and return true', async () => {
+        await store.put('key', toBytes('value'));
+
+        const deleted = await store.delete('key');
+        expect(deleted).toBe(true);
+
+        const after = await store.get('key');
+        expect(after).toBeUndefined();
+      });
+
+      it('should return false for a non-existent key', async () => {
+        const deleted = await store.delete('does-not-exist');
+        expect(deleted).toBe(false);
+      });
+
+      it('should not require the vault to be unlocked', async () => {
+        await store.put('key', toBytes('value'));
+
+        // Lock the vault.
+        await vault.lock();
+
+        // Delete should still work — it only touches the backing store.
+        const deleted = await store.delete('key');
+        expect(deleted).toBe(true);
+
+        // Re-unlock for subsequent tests.
+        await vault.unlock({ password: TEST_PASSWORD });
+      });
+    });
+
+    // ─── TTL / expiry ────────────────────────────────────────────
+
+    describe('expiry (expiresAt)', () => {
+      it('should return undefined and auto-delete when the secret has expired', async () => {
+        const pastDate = new Date(Date.now() - 60_000).toISOString();
+        await store.put('expired', toBytes('old'), { expiresAt: pastDate });
+
+        const result = await store.get('expired');
+        expect(result).toBeUndefined();
+
+        // Verify it was actually purged from the backing store.
+        const raw = await backingStore.get('expired');
+        expect(raw).toBeUndefined();
+      });
+
+      it('should return the secret when it has not yet expired', async () => {
+        const futureDate = new Date(Date.now() + 60_000).toISOString();
+        await store.put('valid', toBytes('still-good'), { expiresAt: futureDate });
+
+        const result = await store.get('valid');
+        expect(result).toBeDefined();
+        expect(fromBytes(result!)).toBe('still-good');
+      });
+    });
+
+    // ─── vault locked behavior ───────────────────────────────────
+
+    describe('vault locked behavior', () => {
+      afterEach(async () => {
+        // Always re-unlock so other tests aren't affected.
+        if (vault.isLocked()) {
+          await vault.unlock({ password: TEST_PASSWORD });
+        }
+      });
+
+      it('should throw on put() when the vault is locked', async () => {
+        await vault.lock();
+
+        await expect(
+          store.put('key', toBytes('value'))
+        ).rejects.toThrow('vault is locked');
+      });
+
+      it('should throw on get() when the vault is locked and the key exists', async () => {
+        // Store a secret while unlocked.
+        await store.put('key', toBytes('value'));
+
+        await vault.lock();
+
+        // get() must fail because decryption requires the vault CEK.
+        await expect(
+          store.get('key')
+        ).rejects.toThrow('vault is locked');
+      });
+
+      it('should return undefined on get() when the vault is locked and key does not exist', async () => {
+        await vault.lock();
+
+        // No encrypted data to decrypt → undefined (not a throw).
+        const result = await store.get('no-such-key');
+        expect(result).toBeUndefined();
+      });
+
+      it('should allow delete() when the vault is locked', async () => {
+        await store.put('key', toBytes('to-delete'));
+        await vault.lock();
+
+        const deleted = await store.delete('key');
+        expect(deleted).toBe(true);
+      });
+    });
+
+    // ─── vault unlock / re-read ──────────────────────────────────
+
+    describe('vault unlock cycle', () => {
+      it('should decrypt secrets after vault lock/unlock cycle', async () => {
+        await store.put('persistent', toBytes('survives-lock'));
+
+        // Lock and re-unlock.
+        await vault.lock();
+        await vault.unlock({ password: TEST_PASSWORD });
+
+        const result = await store.get('persistent');
+        expect(result).toBeDefined();
+        expect(fromBytes(result!)).toBe('survives-lock');
+      });
+    });
+
+    // ─── empty value ─────────────────────────────────────────────
+
+    describe('edge cases', () => {
+      it('should handle an empty Uint8Array value', async () => {
+        await store.put('empty', new Uint8Array(0));
+
+        const result = await store.get('empty');
+        expect(result).toBeDefined();
+        expect(result!.length).toBe(0);
+      });
+
+      it('should handle keys with special characters', async () => {
+        const key = 'enbox:auth:registrationTokens:https://dwn.example.com/api';
+        await store.put(key, toBytes('token'));
+
+        const result = await store.get(key);
+        expect(fromBytes(result!)).toBe('token');
+      });
+
+      it('should handle large values', async () => {
+        const large = new Uint8Array(64 * 1024);
+        for (let i = 0; i < large.length; i++) {
+          large[i] = i % 256;
+        }
+        await store.put('large', large);
+
+        const result = await store.get('large');
+        expect(result).toEqual(large);
+      });
+    });
+  });
+});

--- a/packages/agent/tests/utils/test-agent.ts
+++ b/packages/agent/tests/utils/test-agent.ts
@@ -8,6 +8,7 @@ import type { AgentPermissionsApi } from '../../src/permissions-api.js';
 import type { EnboxPlatformAgent } from '../../src/types/agent.js';
 import type { EnboxRpc } from '@enbox/dwn-clients';
 import type { IdentityVault } from '../../src/types/identity-vault.js';
+import type { SecretStore } from '../../src/secret-store.js';
 import type { SyncEngine } from '../../src/types/sync.js';
 import type { AgentDidApi, DidInterface } from '../../src/did-api.js';
 import type { DidRequest, DidResponse } from '../../src/did-api.js';
@@ -19,6 +20,8 @@ import type {
 } from '../../src/types/dwn.js';
 import type { ProcessVcRequest, SendVcRequest, VcResponse } from '../../src/types/vc.js';
 
+import { InMemorySecretStore } from '../../src/secret-store.js';
+
 type TestAgentParams<TKeyManager extends AgentKeyManager> = {
   agentVault: IdentityVault;
   cryptoApi: AgentCryptoApi;
@@ -28,6 +31,7 @@ type TestAgentParams<TKeyManager extends AgentKeyManager> = {
   keyManager: TKeyManager;
   permissionsApi: AgentPermissionsApi;
   rpcClient: EnboxRpc;
+  secretsApi?: SecretStore;
   syncApi: SyncEngine;
 };
 
@@ -39,6 +43,7 @@ export class TestAgent<TKeyManager extends AgentKeyManager> implements EnboxPlat
   public keyManager: TKeyManager;
   public permissions: AgentPermissionsApi;
   public rpc: EnboxRpc;
+  public secrets: SecretStore;
   public sync: SyncEngine;
   public vault: IdentityVault;
 
@@ -52,6 +57,7 @@ export class TestAgent<TKeyManager extends AgentKeyManager> implements EnboxPlat
     this.keyManager = params.keyManager;
     this.permissions = params.permissionsApi;
     this.rpc = params.rpcClient;
+    this.secrets = params.secretsApi ?? new InMemorySecretStore();
     this.sync = params.syncApi;
     this.vault = params.agentVault;
 

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -623,6 +623,7 @@ export class AuthManager {
     } else {
       // Clean disconnect: ALWAYS clear all session markers regardless
       // of revocation outcome. Retry context is independent (step below).
+      // Delegate keys are removed from both SecretStore and legacy StorageAdapter.
       await Promise.all([
         this._storage.remove(STORAGE_KEYS.PREVIOUSLY_CONNECTED),
         this._storage.remove(STORAGE_KEYS.ACTIVE_IDENTITY),
@@ -632,6 +633,8 @@ export class AuthManager {
         this._storage.remove(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS),
         this._storage.remove(STORAGE_KEYS.DELEGATE_MULTI_PARTY_PROTOCOLS),
         this._storage.remove(STORAGE_KEYS.SESSION_REVOCATIONS),
+        this._userAgent.secrets.delete(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS).catch(() => {}),
+        this._userAgent.secrets.delete(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS).catch(() => {}),
       ]);
     }
 

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -604,6 +604,13 @@ export class AuthManager {
       // Nuclear wipe: clear all persisted auth data.
       await this._storage.clear();
 
+      // Wipe all secrets from the vault-backed SecretStore.
+      await Promise.all([
+        this._userAgent.secrets.delete(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS).catch(() => {}),
+        this._userAgent.secrets.delete(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS).catch(() => {}),
+        this._userAgent.secrets.delete(STORAGE_KEYS.REGISTRATION_TOKENS).catch(() => {}),
+      ]);
+
       // Also clear non-prefixed localStorage and IndexedDB (browser).
       if (typeof globalThis.localStorage !== 'undefined') {
         globalThis.localStorage.clear();

--- a/packages/auth/src/connect/import.ts
+++ b/packages/auth/src/connect/import.ts
@@ -57,11 +57,12 @@ export async function importFromPhrase(
   if (ctx.registration) {
     await registerWithDwnEndpoints(
       {
-        userAgent : userAgent,
+        userAgent   : userAgent,
         dwnEndpoints,
-        agentDid  : userAgent.agentDid.uri,
+        agentDid    : userAgent.agentDid.uri,
         connectedDid,
-        storage   : storage,
+        secretStore : userAgent.secrets,
+        storage     : storage,
       },
       ctx.registration,
     );
@@ -115,11 +116,12 @@ export async function importFromPortable(
     const dwnEndpoints = ctx.defaultDwnEndpoints ?? DEFAULT_DWN_ENDPOINTS;
     await registerWithDwnEndpoints(
       {
-        userAgent : userAgent,
+        userAgent   : userAgent,
         dwnEndpoints,
-        agentDid  : userAgent.agentDid.uri,
+        agentDid    : userAgent.agentDid.uri,
         connectedDid,
-        storage   : storage,
+        secretStore : userAgent.secrets,
+        storage     : storage,
       },
       ctx.registration,
     );

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -547,7 +547,9 @@ export async function finalizeDelegateSession(params: {
   await startSyncIfEnabled(userAgent, sync);
 
   // Persist protocol path keys alongside the delegate session markers
-  // so they survive agent restarts.
+  // so they survive agent restarts.  Delegate keys are stored in the
+  // vault-backed SecretStore (encrypted at rest), while non-secret
+  // session markers go into the plaintext StorageAdapter.
   const delegateDecryptionKeys = (identity as any)._delegateDecryptionKeys as DelegateDecryptionKey[] | undefined;
   const extraStorageKeys: Record<string, string> = {
     [STORAGE_KEYS.DELEGATE_DID]  : delegateDid,
@@ -555,20 +557,24 @@ export async function finalizeDelegateSession(params: {
   };
   const delegateContextKeys = (identity as any)._delegateContextKeys as DelegateContextKey[] | undefined;
 
-  // Encrypt decryption keys and context keys in parallel — both are independent.
-  const [decKeysJwe, ctxKeysJwe] = await Promise.all([
-    delegateDecryptionKeys?.length
-      ? userAgent.vault.encryptData({ plaintext: Convert.string(JSON.stringify(delegateDecryptionKeys)).toUint8Array() })
-      : undefined,
-    delegateContextKeys?.length
-      ? userAgent.vault.encryptData({ plaintext: Convert.string(JSON.stringify(delegateContextKeys)).toUint8Array() })
-      : undefined,
-  ]);
-  if (decKeysJwe) {
-    extraStorageKeys[STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS] = decKeysJwe;
+  // Store delegate keys in the SecretStore (encrypted at rest).
+  // Both writes are independent and can run in parallel.
+  const secretWrites: Promise<void>[] = [];
+  if (delegateDecryptionKeys?.length) {
+    secretWrites.push(
+      userAgent.secrets.put(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS, Convert.string(JSON.stringify(delegateDecryptionKeys)).toUint8Array()),
+    );
   }
-  if (ctxKeysJwe) {
-    extraStorageKeys[STORAGE_KEYS.DELEGATE_CONTEXT_KEYS] = ctxKeysJwe;
+  if (delegateContextKeys?.length) {
+    secretWrites.push(
+      userAgent.secrets.put(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS, Convert.string(JSON.stringify(delegateContextKeys)).toUint8Array()),
+    );
+  }
+  if (secretWrites.length > 0) {
+    await Promise.all(secretWrites);
+    // Best-effort cleanup of any legacy plaintext copies.
+    try { await storage.remove(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS); } catch { /* best-effort */ }
+    try { await storage.remove(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS); } catch { /* best-effort */ }
   }
   const delegateMultiPartyProtocols = (identity as any)._delegateMultiPartyProtocols as string[] | undefined;
   if (delegateMultiPartyProtocols && delegateMultiPartyProtocols.length > 0) {
@@ -586,9 +592,8 @@ export async function finalizeDelegateSession(params: {
     if (changedDelegateDid !== delegateDid) { return; }
     try {
       const keys = userAgent.dwn.exportDelegateContextKeys(delegateDid);
-      const pt = Convert.string(JSON.stringify(keys)).toUint8Array();
-      const encrypted = await userAgent.vault.encryptData({ plaintext: pt });
-      await storage.set(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS, encrypted);
+      const bytes = Convert.string(JSON.stringify(keys)).toUint8Array();
+      await userAgent.secrets.put(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS, bytes);
     } catch { /* best effort — keys will be re-derived on next connect */ }
   };
 

--- a/packages/auth/src/connect/local.ts
+++ b/packages/auth/src/connect/local.ts
@@ -81,11 +81,12 @@ export async function localConnect(
   if (ctx.registration) {
     await registerWithDwnEndpoints(
       {
-        userAgent : userAgent,
+        userAgent   : userAgent,
         dwnEndpoints,
-        agentDid  : userAgent.agentDid.uri,
+        agentDid    : userAgent.agentDid.uri,
         connectedDid,
-        storage   : storage,
+        secretStore : userAgent.secrets,
+        storage     : storage,
       },
       ctx.registration,
     );

--- a/packages/auth/src/connect/restore.ts
+++ b/packages/auth/src/connect/restore.ts
@@ -46,6 +46,45 @@ async function decryptStoredKeys(
 }
 
 /**
+ * Load delegate keys from SecretStore, falling back to legacy StorageAdapter.
+ *
+ * On a successful legacy read the keys are migrated into the SecretStore and
+ * the plaintext/JWE copy is removed (best-effort). Returns the JSON string
+ * representation of the keys, or `undefined` if nothing is stored.
+ */
+async function loadDelegateKeysWithFallback(
+  userAgent: EnboxUserAgent,
+  storage: StorageAdapter,
+  key: string,
+): Promise<string | undefined> {
+  // 1. Try SecretStore (preferred path).
+  try {
+    const bytes = await userAgent.secrets.get(key);
+    if (bytes) {
+      return Convert.uint8Array(bytes).toString();
+    }
+  } catch { /* vault may be locked — fall through to legacy path */ }
+
+  // 2. Fall back to legacy StorageAdapter (JWE or plaintext JSON).
+  const legacy = await storage.get(key);
+  if (!legacy) { return undefined; }
+
+  try {
+    const json = await decryptStoredKeys(userAgent, legacy);
+
+    // Migrate into SecretStore and remove legacy copy (best-effort).
+    try {
+      await userAgent.secrets.put(key, Convert.string(json).toUint8Array());
+      await storage.remove(key);
+    } catch { /* best-effort migration */ }
+
+    return json;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Attempt to restore a previous session.
  *
  * Returns `undefined` if no previous session exists.
@@ -153,6 +192,7 @@ export async function restoreSession(
 
     if (!isAgentOnlySession) {
       // Truly stale session data — clean up and bail.
+      // Remove delegate keys from both SecretStore and legacy StorageAdapter.
       await storage.remove(STORAGE_KEYS.PREVIOUSLY_CONNECTED);
       await storage.remove(STORAGE_KEYS.ACTIVE_IDENTITY);
       await storage.remove(STORAGE_KEYS.DELEGATE_DID);
@@ -161,6 +201,8 @@ export async function restoreSession(
       await storage.remove(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
       await storage.remove(STORAGE_KEYS.DELEGATE_MULTI_PARTY_PROTOCOLS);
       await storage.remove(STORAGE_KEYS.SESSION_REVOCATIONS);
+      try { await userAgent.secrets.delete(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS); } catch { /* best-effort */ }
+      try { await userAgent.secrets.delete(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS); } catch { /* best-effort */ }
       // Do NOT remove REVOCATION_RETRY_CONTEXT here — it has its own
       // lifecycle managed by the retry maintenance path. Stale session
       // cleanup must not silently drop pending revocations.
@@ -206,16 +248,19 @@ export async function restoreSession(
   // Start sync after the registration is correct.
   await startSyncIfEnabled(userAgent, ctx.defaultSync);
 
-  // Restore delegate decryption keys if persisted.
-  // Keys are stored as compact JWE (encrypted with the vault CEK).
-  // Falls back to plaintext JSON for backward compatibility with sessions
-  // created before the encryption-at-rest fix.
+  // Restore delegate decryption keys and context keys.
+  //
+  // Keys are loaded from the vault-backed SecretStore (preferred). When
+  // the SecretStore is empty, we fall back to the legacy StorageAdapter
+  // which may hold either a compact JWE (encrypted with the vault CEK)
+  // or raw JSON (from sessions created before the encryption-at-rest fix).
+  // On successful fallback, the legacy copy is removed (best-effort) so
+  // all future reads come from the SecretStore.
   if (delegateDid && connectedDid) {
-    const storedKeys = await storage.get(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS);
-    if (storedKeys) {
+    const decryptionKeysJson = await loadDelegateKeysWithFallback(userAgent, storage, STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS);
+    if (decryptionKeysJson) {
       try {
-        const keysJson = await decryptStoredKeys(userAgent, storedKeys);
-        const keys = JSON.parse(keysJson);
+        const keys = JSON.parse(decryptionKeysJson);
         if (Array.isArray(keys) && keys.length > 0) {
           userAgent.dwn.importDelegateDecryptionKeys(delegateDid, keys);
         }
@@ -223,7 +268,7 @@ export async function restoreSession(
     }
 
     // Restore context keys for multi-party encrypted protocols.
-    const storedCtxKeys = await storage.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
+    const contextKeysJson = await loadDelegateKeysWithFallback(userAgent, storage, STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
     // Restore multi-party protocol registrations (not encrypted — no key material).
     const mpProtocolsJson = await storage.get(STORAGE_KEYS.DELEGATE_MULTI_PARTY_PROTOCOLS);
     let multiPartyProtocols: string[] | undefined;
@@ -234,12 +279,9 @@ export async function restoreSession(
       } catch { /* best effort */ }
     }
 
-    if (storedCtxKeys || multiPartyProtocols) {
+    if (contextKeysJson || multiPartyProtocols) {
       try {
-        const ctxKeysJson = storedCtxKeys
-          ? await decryptStoredKeys(userAgent, storedCtxKeys)
-          : '[]';
-        const ctxKeys = JSON.parse(ctxKeysJson);
+        const ctxKeys = contextKeysJson ? JSON.parse(contextKeysJson) : [];
         userAgent.dwn.importDelegateContextKeys(
           delegateDid,
           Array.isArray(ctxKeys) ? ctxKeys : [],
@@ -255,9 +297,8 @@ export async function restoreSession(
       if (changedDelegateDid !== restoreDelegateDid) { return; }
       try {
         const keys = userAgent.dwn.exportDelegateContextKeys(restoreDelegateDid);
-        const pt = Convert.string(JSON.stringify(keys)).toUint8Array();
-        const encrypted = await userAgent.vault.encryptData({ plaintext: pt });
-        await storage.set(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS, encrypted);
+        const bytes = Convert.string(JSON.stringify(keys)).toUint8Array();
+        await userAgent.secrets.put(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS, bytes);
       } catch { /* best effort — keys will be re-derived on next connect */ }
     };
   }

--- a/packages/auth/src/connect/wallet.ts
+++ b/packages/auth/src/connect/wallet.ts
@@ -71,8 +71,9 @@ export async function walletConnect(
       {
         userAgent,
         dwnEndpoints,
-        agentDid: userAgent.agentDid.uri,
+        agentDid    : userAgent.agentDid.uri,
         connectedDid,
+        secretStore : userAgent.secrets,
         storage,
       },
       ctx.registration,

--- a/packages/auth/src/registration.ts
+++ b/packages/auth/src/registration.ts
@@ -11,8 +11,9 @@
  * @module
  */
 
-import type { EnboxUserAgent } from '@enbox/agent';
+import type { EnboxUserAgent, SecretStore } from '@enbox/agent';
 
+import { Convert } from '@enbox/common';
 import { DwnRegistrar } from '@enbox/dwn-clients';
 
 import { STORAGE_KEYS } from './types.js';
@@ -38,8 +39,20 @@ export interface RegistrationContext {
   connectedDid: string;
 
   /**
-   * Storage adapter for automatic token persistence.
-   * Only used when `registration.persistTokens` is `true`.
+   * Vault-backed secret store for encrypted token persistence.
+   *
+   * When provided **and** the vault is unlocked, registration tokens are
+   * stored here instead of in the plaintext `StorageAdapter`, keeping
+   * bearer credentials out of `localStorage`.
+   */
+  secretStore?: SecretStore;
+
+  /**
+   * Plaintext storage adapter for automatic token persistence.
+   *
+   * @deprecated Prefer {@link secretStore} when the vault is available.
+   *             This field is retained for backwards compatibility with
+   *             callers that have not yet migrated.
    */
   storage?: StorageAdapter;
 }
@@ -60,14 +73,19 @@ export async function registerWithDwnEndpoints(
   ctx: RegistrationContext,
   registration: RegistrationOptions,
 ): Promise<void> {
-  const { userAgent, dwnEndpoints, agentDid, connectedDid, storage } = ctx;
+  const { userAgent, dwnEndpoints, agentDid, connectedDid, secretStore, storage } = ctx;
 
-  // Load initial tokens: when persistTokens is enabled, load from storage
-  // (ignoring any explicit registrationTokens). Otherwise use the explicit map.
+  // Load initial tokens: when persistTokens is enabled, load from the
+  // vault-backed SecretStore (preferred) or plaintext StorageAdapter
+  // (fallback). Otherwise use the explicit map.
   let seedTokens: Record<string, RegistrationTokenData> = {};
 
-  if (registration.persistTokens && storage) {
-    seedTokens = await loadTokensFromStorage(storage);
+  if (registration.persistTokens) {
+    if (secretStore) {
+      seedTokens = await loadTokensFromSecretStore(secretStore);
+    } else if (storage) {
+      seedTokens = await loadTokensFromStorage(storage);
+    }
   } else {
     seedTokens = registration.registrationTokens ?? {};
   }
@@ -162,9 +180,13 @@ export async function registerWithDwnEndpoints(
       }
     }
 
-    // Persist tokens to storage when auto-persistence is enabled.
-    if (registration.persistTokens && storage) {
-      await saveTokensToStorage(storage, updatedTokens);
+    // Persist tokens: prefer vault-backed SecretStore over plaintext StorageAdapter.
+    if (registration.persistTokens) {
+      if (secretStore) {
+        await saveTokensToSecretStore(secretStore, updatedTokens);
+      } else if (storage) {
+        await saveTokensToStorage(storage, updatedTokens);
+      }
     }
 
     // Notify app of updated tokens (always, even when auto-persisting).
@@ -209,4 +231,39 @@ export async function saveTokensToStorage(
   tokens: Record<string, RegistrationTokenData>,
 ): Promise<void> {
   await storage.set(STORAGE_KEYS.REGISTRATION_TOKENS, JSON.stringify(tokens));
+}
+
+// ─── SecretStore helpers ─────────────────────────────────────────
+
+/**
+ * Load registration tokens from the vault-backed {@link SecretStore}.
+ *
+ * Returns an empty record if no tokens are stored, the stored value is
+ * corrupt, or the vault is locked (best-effort — never throws).
+ *
+ * @internal
+ */
+export async function loadTokensFromSecretStore(
+  secretStore: SecretStore,
+): Promise<Record<string, RegistrationTokenData>> {
+  try {
+    const bytes = await secretStore.get(STORAGE_KEYS.REGISTRATION_TOKENS);
+    if (!bytes) { return {}; }
+    const json = Convert.uint8Array(bytes).toString();
+    return JSON.parse(json) as Record<string, RegistrationTokenData>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Save registration tokens to the vault-backed {@link SecretStore}.
+ * @internal
+ */
+export async function saveTokensToSecretStore(
+  secretStore: SecretStore,
+  tokens: Record<string, RegistrationTokenData>,
+): Promise<void> {
+  const bytes = Convert.string(JSON.stringify(tokens)).toUint8Array();
+  await secretStore.put(STORAGE_KEYS.REGISTRATION_TOKENS, bytes);
 }

--- a/packages/auth/src/registration.ts
+++ b/packages/auth/src/registration.ts
@@ -75,15 +75,17 @@ export async function registerWithDwnEndpoints(
 ): Promise<void> {
   const { userAgent, dwnEndpoints, agentDid, connectedDid, secretStore, storage } = ctx;
 
-  // Load initial tokens: when persistTokens is enabled, load from the
-  // vault-backed SecretStore (preferred) or plaintext StorageAdapter
-  // (fallback). Otherwise use the explicit map.
+  // Load initial tokens: when persistTokens is enabled, try the
+  // vault-backed SecretStore first, then fall back to the legacy plaintext
+  // StorageAdapter.  This ensures upgraded clients that already have tokens
+  // in localStorage can still read them (and migrate them on the next save).
   let seedTokens: Record<string, RegistrationTokenData> = {};
 
   if (registration.persistTokens) {
     if (secretStore) {
       seedTokens = await loadTokensFromSecretStore(secretStore);
-    } else if (storage) {
+    }
+    if (Object.keys(seedTokens).length === 0 && storage) {
       seedTokens = await loadTokensFromStorage(storage);
     }
   } else {
@@ -181,9 +183,14 @@ export async function registerWithDwnEndpoints(
     }
 
     // Persist tokens: prefer vault-backed SecretStore over plaintext StorageAdapter.
+    // When migrating to SecretStore, also clear the legacy plaintext copy so
+    // bearer tokens no longer sit in localStorage.
     if (registration.persistTokens) {
       if (secretStore) {
         await saveTokensToSecretStore(secretStore, updatedTokens);
+        if (storage) {
+          await storage.remove(STORAGE_KEYS.REGISTRATION_TOKENS);
+        }
       } else if (storage) {
         await saveTokensToStorage(storage, updatedTokens);
       }

--- a/packages/auth/src/registration.ts
+++ b/packages/auth/src/registration.ts
@@ -188,8 +188,11 @@ export async function registerWithDwnEndpoints(
     if (registration.persistTokens) {
       if (secretStore) {
         await saveTokensToSecretStore(secretStore, updatedTokens);
+        // Best-effort cleanup: remove the legacy plaintext copy so bearer
+        // tokens no longer sit in localStorage.  A failure here must not
+        // turn a successful registration into an error.
         if (storage) {
-          await storage.remove(STORAGE_KEYS.REGISTRATION_TOKENS);
+          try { await storage.remove(STORAGE_KEYS.REGISTRATION_TOKENS); } catch { /* best-effort */ }
         }
       } else if (storage) {
         await saveTokensToStorage(storage, updatedTokens);

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -171,7 +171,8 @@ export interface RegistrationOptions {
    * endpoint, it is used directly without re-running the auth flow.
    *
    * When {@link persistTokens} is `true`, this field is ignored —
-   * tokens are loaded automatically from the `StorageAdapter`.
+   * tokens are loaded automatically from the agent's vault-backed
+   * `SecretStore` (preferred) or the legacy `StorageAdapter` (fallback).
    */
   registrationTokens?: Record<string, RegistrationTokenData>;
 
@@ -180,20 +181,28 @@ export interface RegistrationOptions {
    * The app should persist these for future sessions.
    *
    * When {@link persistTokens} is `true`, tokens are saved automatically
-   * to the `StorageAdapter`. This callback is still invoked (if provided)
-   * **after** the automatic save, so consumers can observe token changes
-   * without handling persistence themselves.
+   * to the agent's vault-backed `SecretStore` (or the legacy
+   * `StorageAdapter` when no `SecretStore` is available). This callback
+   * is still invoked (if provided) **after** the automatic save, so
+   * consumers can observe token changes without handling persistence
+   * themselves.
    */
   onRegistrationTokens?: (tokens: Record<string, RegistrationTokenData>) => void;
 
   /**
-   * Automatically persist and restore registration tokens using the
-   * auth manager's `StorageAdapter`.
+   * Automatically persist and restore registration tokens.
    *
-   * When `true`, tokens are loaded from storage before registration and
-   * saved back after new or refreshed tokens are obtained. This removes
-   * the need for consumers to implement their own token I/O via
+   * When `true`, tokens are loaded before registration and saved back
+   * after new or refreshed tokens are obtained, removing the need for
+   * consumers to implement their own token I/O via
    * {@link registrationTokens} and {@link onRegistrationTokens}.
+   *
+   * **Storage preference:** tokens are stored in the agent's vault-backed
+   * `SecretStore` (encrypted at rest) when available.  On the first run
+   * after an upgrade, any tokens left in the legacy plaintext
+   * `StorageAdapter` are migrated into the `SecretStore` and the
+   * plaintext copy is removed.  If no `SecretStore` is provided, the
+   * `StorageAdapter` is used as a fallback.
    *
    * Defaults to `false` for backward compatibility.
    *

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -769,13 +769,20 @@ describe('AuthManager', () => {
       expect(clearCalled).toBe(true);
     });
 
-    test('nuclear disconnect clears all storage', async () => {
+    test('nuclear disconnect clears all storage including SecretStore', async () => {
+      const { Convert } = await import('@enbox/common');
       const storage = new MemoryStorage();
 
       const agent = createMockAgent({
         firstLaunch  : async () => false,
         identityList : async () => [createMockIdentity()],
       });
+
+      // Pre-populate SecretStore with all secret types.
+      await agent.secrets.put(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS, Convert.string('[]').toUint8Array());
+      await agent.secrets.put(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS, Convert.string('[]').toUint8Array());
+      await agent.secrets.put(STORAGE_KEYS.REGISTRATION_TOKENS, Convert.string('{}').toUint8Array());
+
       const manager = createTestManager(agent, { storage });
       await manager.connect({ password: 'test' });
 
@@ -783,6 +790,11 @@ describe('AuthManager', () => {
 
       expect(manager.state).toBe('unlocked');
       expect(manager.session).toBeUndefined();
+
+      // All secrets must be wiped.
+      expect(await agent.secrets.get(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS)).toBeUndefined();
+      expect(await agent.secrets.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS)).toBeUndefined();
+      expect(await agent.secrets.get(STORAGE_KEYS.REGISTRATION_TOKENS)).toBeUndefined();
     });
 
     test('emits session-end event with DID', async () => {

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -465,6 +465,40 @@ describe('AuthManager', () => {
       expect(importedKeys).toEqual(keysPayload);
     });
 
+    test('migrates legacy delegate decryption keys from StorageAdapter to SecretStore on restore', async () => {
+      const { Convert } = await import('@enbox/common');
+      const keysPayload = [{ protocol: 'https://test.xyz', derivedPrivateKey: { rootKeyId: 'k-migrate' } }];
+      const storage = new MemoryStorage();
+      await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
+      await storage.set(STORAGE_KEYS.DELEGATE_DID, 'did:jwk:delegate');
+      await storage.set(STORAGE_KEYS.CONNECTED_DID, 'did:dht:owner');
+      // Place keys in legacy StorageAdapter (plaintext JSON — pre-encryption era).
+      await storage.set(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS, JSON.stringify(keysPayload));
+
+      let importedKeys: any[] | undefined;
+      const delegateIdentity = createMockIdentity({
+        did      : { uri: 'did:jwk:delegate' },
+        metadata : { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner' },
+      });
+      const agent = createMockAgent({
+        firstLaunch                     : async () => false,
+        identityList                    : async () => [delegateIdentity],
+        dwnImportDelegateDecryptionKeys : (_did: string, keys: any[]): void => { importedKeys = keys; },
+      });
+      const manager = createTestManager(agent, { storage });
+
+      await manager.restoreSession();
+      expect(importedKeys).toEqual(keysPayload);
+
+      // Legacy copy should have been removed.
+      expect(await storage.get(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS)).toBeNull();
+
+      // Keys should now be in SecretStore.
+      const migratedBytes = await agent.secrets.get(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS);
+      expect(migratedBytes).toBeDefined();
+      expect(JSON.parse(Convert.uint8Array(migratedBytes!).toString())).toEqual(keysPayload);
+    });
+
     test('restores delegate context keys from storage on session restore', async () => {
       const ctxKeysPayload = [{ protocol: 'https://test.xyz', contextId: 'ctx-1', derivedPrivateKey: { rootKeyId: 'k2' } }];
       const storage = new MemoryStorage();
@@ -612,15 +646,14 @@ describe('AuthManager', () => {
       expect(callback).toBeDefined();
       await callback('did:jwk:persist-restore');
 
-      // Verify the new key was persisted to storage (encrypted as JWE).
-      const persistedJwe = await storage.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
-      expect(persistedJwe).toBeDefined();
-      // The stored value is a compact JWE. Decrypt with the mock vault.
-      const decryptedBytes = await agent.vault.decryptData({ jwe: persistedJwe! });
-      const persisted = JSON.parse(new TextDecoder().decode(decryptedBytes));
+      // Verify the new key was persisted to the agent's SecretStore.
+      const persistedBytes = await agent.secrets.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
+      expect(persistedBytes).toBeDefined();
+      const persisted = JSON.parse(new TextDecoder().decode(persistedBytes!));
       expect(persisted).toEqual([newContextKey]);
 
-      // Verify a second restore would pick up the persisted keys
+      // Verify a second restore would pick up the persisted keys.
+      // Share the same SecretStore so keys survive across agent instances.
       let secondRestoreKeys: any[] | undefined;
       const agent2 = createMockAgent({
         firstLaunch                  : async () => false,
@@ -629,6 +662,7 @@ describe('AuthManager', () => {
           secondRestoreKeys = keys;
         },
       });
+      (agent2 as any).secrets = agent.secrets;
       const manager2 = createTestManager(agent2, { storage });
       await manager2.restoreSession();
 
@@ -696,6 +730,28 @@ describe('AuthManager', () => {
 
       expect(await storage.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS)).toBeNull();
       expect(await storage.get(STORAGE_KEYS.DELEGATE_MULTI_PARTY_PROTOCOLS)).toBeNull();
+    });
+
+    test('clean disconnect clears delegate keys from SecretStore', async () => {
+      const { Convert } = await import('@enbox/common');
+      const storage = new MemoryStorage();
+      await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
+
+      const agent = createMockAgent({
+        firstLaunch  : async () => false,
+        identityList : async () => [createMockIdentity()],
+      });
+
+      // Pre-populate SecretStore with delegate keys.
+      await agent.secrets.put(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS, Convert.string('[]').toUint8Array());
+      await agent.secrets.put(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS, Convert.string('[]').toUint8Array());
+
+      const manager = createTestManager(agent, { storage });
+      await manager.connect({ password: 'test' });
+      await manager.disconnect();
+
+      expect(await agent.secrets.get(STORAGE_KEYS.DELEGATE_DECRYPTION_KEYS)).toBeUndefined();
+      expect(await agent.secrets.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS)).toBeUndefined();
     });
 
     test('nuclear disconnect clears delegate decryption key cache', async () => {

--- a/packages/auth/tests/dwn-registration.spec.ts
+++ b/packages/auth/tests/dwn-registration.spec.ts
@@ -1116,4 +1116,52 @@ describe('SecretStore token helpers', () => {
     const leftover = await storage.get(STORAGE_KEYS.REGISTRATION_TOKENS);
     expect(leftover).toBeNull();
   });
+
+  test('succeeds even when legacy storage.remove() throws during migration', async () => {
+    mockRegisterTenant.mockClear();
+    mockRegisterTenant.mockImplementation(async () => {});
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['proof-of-work-sha256-v0'],
+        maxFileSize              : 10_000_000,
+      }),
+    });
+
+    const { InMemorySecretStore } = await import('@enbox/agent');
+    const secretStore = new InMemorySecretStore();
+    const storage = new MemoryStorage();
+
+    // Pre-populate legacy tokens.
+    await saveTokensToStorage(storage, {
+      'https://dwn1.example.com': { registrationToken: 'legacy' },
+    });
+
+    // Make remove() throw to simulate a storage failure.
+    storage.remove = async (): Promise<void> => { throw new Error('disk full'); };
+
+    let successCalled = false;
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        secretStore,
+        storage,
+      },
+      {
+        onSuccess     : () => { successCalled = true; },
+        onFailure     : () => {},
+        persistTokens : true,
+      },
+    );
+
+    // Registration should still succeed — remove() failure is best-effort.
+    expect(successCalled).toBe(true);
+
+    // Tokens should be in the SecretStore regardless.
+    const persisted = await loadTokensFromSecretStore(secretStore);
+    expect(persisted['https://dwn1.example.com'].registrationToken).toBe('legacy');
+  });
 });

--- a/packages/auth/tests/dwn-registration.spec.ts
+++ b/packages/auth/tests/dwn-registration.spec.ts
@@ -5,8 +5,10 @@ import { MemoryStorage } from '../src/storage/storage.js';
 import { STORAGE_KEYS } from '../src/types.js';
 
 import {
+  loadTokensFromSecretStore,
   loadTokensFromStorage,
   registerWithDwnEndpoints,
+  saveTokensToSecretStore,
   saveTokensToStorage,
 } from '../src/registration.js';
 
@@ -957,5 +959,108 @@ describe('registerWithDwnEndpoints with persistTokens', () => {
 
     // Should still succeed — loadTokensFromStorage returns {} on error
     expect(successCalled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+//  SecretStore helpers
+// ---------------------------------------------------------------------------
+
+describe('SecretStore token helpers', () => {
+  test('saveTokensToSecretStore and loadTokensFromSecretStore round-trip', async () => {
+    const { InMemorySecretStore } = await import('@enbox/agent');
+    const secretStore = new InMemorySecretStore();
+
+    const tokens: Record<string, RegistrationTokenData> = {
+      'https://dwn1.example.com': {
+        registrationToken : 'reg-abc',
+        refreshToken      : 'refresh-xyz',
+        expiresAt         : Date.now() + 60_000,
+        tokenUrl          : 'https://auth.example.com/token',
+        refreshUrl        : 'https://auth.example.com/refresh',
+      },
+    };
+
+    await saveTokensToSecretStore(secretStore, tokens);
+    const loaded = await loadTokensFromSecretStore(secretStore);
+
+    expect(loaded).toEqual(tokens);
+  });
+
+  test('loadTokensFromSecretStore returns empty object when no tokens stored', async () => {
+    const { InMemorySecretStore } = await import('@enbox/agent');
+    const secretStore = new InMemorySecretStore();
+
+    const loaded = await loadTokensFromSecretStore(secretStore);
+    expect(loaded).toEqual({});
+  });
+
+  test('loadTokensFromSecretStore returns empty object on corrupt data', async () => {
+    const { InMemorySecretStore } = await import('@enbox/agent');
+    const secretStore = new InMemorySecretStore();
+
+    // Store invalid JSON bytes.
+    await secretStore.put('enbox:auth:registrationTokens', new Uint8Array([0xFF, 0xFE]));
+
+    const loaded = await loadTokensFromSecretStore(secretStore);
+    expect(loaded).toEqual({});
+  });
+
+  test('loadTokensFromSecretStore returns empty object when secretStore.get throws', async () => {
+    const throwingStore = {
+      async put(): Promise<void> { /* no-op */ },
+      async get(): Promise<Uint8Array | undefined> { throw new Error('vault is locked'); },
+      async delete(): Promise<boolean> { return false; },
+    };
+
+    const loaded = await loadTokensFromSecretStore(throwingStore);
+    expect(loaded).toEqual({});
+  });
+
+  test('registerWithDwnEndpoints persists to secretStore when provided', async () => {
+    mockRegisterTenant.mockClear();
+    mockRegisterTenant.mockImplementation(async () => {});
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['proof-of-work-sha256-v0'],
+        maxFileSize              : 10_000_000,
+      }),
+    });
+
+    const { InMemorySecretStore } = await import('@enbox/agent');
+    const secretStore = new InMemorySecretStore();
+
+    // Pre-populate tokens in the secret store.
+    const seedTokens: Record<string, RegistrationTokenData> = {
+      'https://dwn1.example.com': {
+        registrationToken : 'pre-existing',
+        expiresAt         : Date.now() + 60_000,
+      },
+    };
+    await saveTokensToSecretStore(secretStore, seedTokens);
+
+    let successCalled = false;
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        secretStore,
+      },
+      {
+        onSuccess     : () => { successCalled = true; },
+        onFailure     : () => {},
+        persistTokens : true,
+      },
+    );
+
+    expect(successCalled).toBe(true);
+
+    // Tokens should have been persisted back to the secret store.
+    const persisted = await loadTokensFromSecretStore(secretStore);
+    expect(persisted['https://dwn1.example.com']).toBeDefined();
+    expect(persisted['https://dwn1.example.com'].registrationToken).toBe('pre-existing');
   });
 });

--- a/packages/auth/tests/dwn-registration.spec.ts
+++ b/packages/auth/tests/dwn-registration.spec.ts
@@ -1063,4 +1063,57 @@ describe('SecretStore token helpers', () => {
     expect(persisted['https://dwn1.example.com']).toBeDefined();
     expect(persisted['https://dwn1.example.com'].registrationToken).toBe('pre-existing');
   });
+
+  test('migrates legacy StorageAdapter tokens to SecretStore and clears plaintext copy', async () => {
+    mockRegisterTenant.mockClear();
+    mockRegisterTenant.mockImplementation(async () => {});
+
+    const agent = createMockAgent({
+      rpcGetServerInfo: async () => ({
+        registrationRequirements : ['proof-of-work-sha256-v0'],
+        maxFileSize              : 10_000_000,
+      }),
+    });
+
+    const { InMemorySecretStore } = await import('@enbox/agent');
+    const secretStore = new InMemorySecretStore();
+    const storage = new MemoryStorage();
+
+    // Pre-populate tokens in the LEGACY storage only (simulates upgrade).
+    const legacyTokens: Record<string, RegistrationTokenData> = {
+      'https://dwn1.example.com': {
+        registrationToken : 'legacy-token',
+        expiresAt         : Date.now() + 60_000,
+      },
+    };
+    await saveTokensToStorage(storage, legacyTokens);
+
+    let successCalled = false;
+    await registerWithDwnEndpoints(
+      {
+        userAgent    : agent,
+        dwnEndpoints : ['https://dwn1.example.com'],
+        agentDid     : 'did:dht:agent1',
+        connectedDid : 'did:dht:user1',
+        secretStore,
+        storage,
+      },
+      {
+        onSuccess     : () => { successCalled = true; },
+        onFailure     : () => {},
+        persistTokens : true,
+      },
+    );
+
+    expect(successCalled).toBe(true);
+
+    // Tokens should have migrated into the SecretStore.
+    const migrated = await loadTokensFromSecretStore(secretStore);
+    expect(migrated['https://dwn1.example.com']).toBeDefined();
+    expect(migrated['https://dwn1.example.com'].registrationToken).toBe('legacy-token');
+
+    // Legacy plaintext copy should have been removed.
+    const leftover = await storage.get(STORAGE_KEYS.REGISTRATION_TOKENS);
+    expect(leftover).toBeNull();
+  });
 });

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -5,6 +5,8 @@
 
 import type { EnboxUserAgent } from '@enbox/agent';
 
+import { InMemorySecretStore } from '@enbox/agent';
+
 /** Minimal BearerIdentity-like object for testing. */
 export interface MockIdentity {
   did: { uri: string };
@@ -102,7 +104,8 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
   const defaultIdentity = createMockIdentity();
 
   return {
-    agentDid: { uri: 'did:dht:testagent' },
+    agentDid : { uri: 'did:dht:testagent' },
+    secrets  : new InMemorySecretStore(),
 
     firstLaunch : overrides.firstLaunch ?? (async (): Promise<boolean> => false),
     initialize  : overrides.initialize ?? (async (): Promise<string> => 'word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12'),

--- a/packages/auth/tests/lifecycle.spec.ts
+++ b/packages/auth/tests/lifecycle.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
+import { Convert } from '@enbox/common';
+
 import { AuthEventEmitter } from '../src/events.js';
 import { MemoryStorage } from '../src/storage/storage.js';
 import { STORAGE_KEYS } from '../src/types.js';
@@ -168,10 +170,11 @@ describe('finalizeDelegateSession', () => {
       // Fire the callback with matching delegate DID.
       await callback('did:jwk:delegate1');
 
-      // Context keys should be encrypted and persisted.
-      const stored = await storage.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
+      // Context keys should be persisted in the agent's SecretStore.
+      const stored = await agent.secrets.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
       expect(stored).toBeDefined();
-      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(Convert.uint8Array(stored!).toString());
+      expect(parsed).toEqual(exportedKeys);
     });
 
     test('ignores callback when delegate DID does not match', async () => {
@@ -201,9 +204,9 @@ describe('finalizeDelegateSession', () => {
       // Fire with non-matching delegate — should be a no-op.
       await callback('did:jwk:different');
 
-      // No context keys should be stored.
-      const stored = await storage.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
-      expect(stored).toBeNull();
+      // No context keys should be stored in SecretStore.
+      const stored = await agent.secrets.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
+      expect(stored).toBeUndefined();
     });
   });
 });

--- a/packages/auth/tests/wallet-connect.spec.ts
+++ b/packages/auth/tests/wallet-connect.spec.ts
@@ -725,11 +725,10 @@ describe('walletConnect', () => {
     );
 
     // Both context keys and multi-party protocols should be persisted.
-    // Context keys are encrypted as JWE; multi-party protocols are plain JSON (no key material).
-    const ctxKeysJwe = await storage.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
-    expect(ctxKeysJwe).toBeDefined();
-    const ctxKeysBytes = await agent.vault.decryptData({ jwe: ctxKeysJwe! });
-    expect(JSON.parse(new TextDecoder().decode(ctxKeysBytes))).toEqual(ctxKeys);
+    // Context keys are stored in the vault-backed SecretStore; multi-party protocols are plain JSON.
+    const ctxKeysBytes = await agent.secrets.get(STORAGE_KEYS.DELEGATE_CONTEXT_KEYS);
+    expect(ctxKeysBytes).toBeDefined();
+    expect(JSON.parse(new TextDecoder().decode(ctxKeysBytes!))).toEqual(ctxKeys);
 
     const mpProtocolsJson = await storage.get(STORAGE_KEYS.DELEGATE_MULTI_PARTY_PROTOCOLS);
     expect(mpProtocolsJson).toBeDefined();

--- a/scripts/diff-coverage.mjs
+++ b/scripts/diff-coverage.mjs
@@ -75,14 +75,14 @@ function getChangedLines() {
   let diff;
   try {
     diff = execSync(
-      'git diff origin/main...HEAD --unified=0 -- "packages/*/src/**/*.ts" ":!*.spec.ts" ":!*.test.ts" ":!*.d.ts"',
+      'git diff origin/main...HEAD --unified=0 -- "packages/*/src/*.ts" "packages/*/src/**/*.ts" ":!*.spec.ts" ":!*.test.ts" ":!*.d.ts"',
       { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 }
     );
   } catch {
     // If origin/main doesn't exist (e.g. shallow clone), try HEAD~1
     try {
       diff = execSync(
-        'git diff HEAD~1...HEAD --unified=0 -- "packages/*/src/**/*.ts" ":!*.spec.ts" ":!*.test.ts" ":!*.d.ts"',
+        'git diff HEAD~1...HEAD --unified=0 -- "packages/*/src/*.ts" "packages/*/src/**/*.ts" ":!*.spec.ts" ":!*.test.ts" ":!*.d.ts"',
         { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 }
       );
     } catch {


### PR DESCRIPTION
## Summary

Adds a `SecretStore` abstraction to `@enbox/agent` that stores classified secrets (registration tokens, refresh tokens, delegate decryption keys) encrypted at rest using the vault's content encryption key (AES-256-GCM), keeping them out of browser-accessible `localStorage`/`sessionStorage`.

Closes #893

## Changes

### `@enbox/agent`

- **New `SecretStore` interface** (`put`/`get`/`delete`) with `Uint8Array` values and optional TTL (`expiresAt`)
- **`VaultBackedSecretStore`** — encrypts secrets via the vault's CEK into compact JWE before persisting to a `KeyValueStore` (LevelDB in production). Throws when vault is locked for `put()`/`get()`; `delete()` works regardless. Auto-purges expired secrets on read.
- **`InMemorySecretStore`** — plain `Map`-backed implementation for unit tests
- **`EnboxPlatformAgent.secrets`** — new interface member, wired into `EnboxUserAgent` (backed by `SECRET_STORE` LevelDB) and `TestAgent` (in-memory)
- **`PlatformAgentTestHarness`** — wires the appropriate `SecretStore` implementation for both `'memory'` and `'dwn'` store modes

### `@enbox/auth`

- **`RegistrationContext.secretStore`** — new optional field; when provided, registration tokens are persisted to the vault-backed `SecretStore` instead of the plaintext `StorageAdapter`
- **`loadTokensFromSecretStore()` / `saveTokensToSecretStore()`** — new helpers that serialize tokens as `Uint8Array` for the `SecretStore` API
- All connect flows (`local`, `wallet`, `import`) now pass `userAgent.secrets` in the registration context

### Tests

33 new tests in `secret-store.spec.ts` covering:
- CRUD round-trips for both implementations
- Encryption at rest verification (JWE structure in backing store)
- TTL/expiry (auto-purge, future-dated persistence, boundary)
- Vault locked behavior (throws on put/get, allows delete, undefined for missing keys)
- Vault lock/unlock cycle (secrets survive re-unlock)
- Edge cases (empty values, special characters, large payloads, buffer isolation)

## Verification

- `bun run lint` — 0 errors, 0 warnings
- `bun run build` — all packages build successfully
- `bun run test:node` (agent) — 1394 pass, 0 fail (includes 33 new tests)