### PR TITLE
fix(auth): close gaps in wildcard delegate grant handling (#897)

### DIFF
--- a/.changeset/wildcard-delegate-grant-gaps.md
+++ b/.changeset/wildcard-delegate-grant-gaps.md
@@ -1,0 +1,20 @@
+---
+"@enbox/auth": patch
+---
+
+fix(auth): close gaps in wildcard delegate grant handling (#897)
+
+- Clear stale sync registration in `importFromPhrase`/`importFromPortable`
+  when a delegate has zero active grants (matches behavior in `restoreSession`
+  and `importDelegateAndSetupSync`).
+- Extract `toSyncIdentityProtocols()` helper in `connect/lifecycle.ts` and use
+  it across all sync-registration call sites in `connect/lifecycle.ts`,
+  `connect/restore.ts`, `connect/import.ts`, and `auth-manager.ts`, eliminating
+  duplicated `'all' | string[] → 'all' | [string, ...string[]]` narrowing
+  casts.
+- Update stale docstring on `AuthManager._deriveProtocolsFromGrants` to
+  reflect the current `'all' | string[]` return type.
+- Add test coverage for: mixed wildcard+scoped grants, expired wildcard
+  grant, revoked wildcard grant, `Messages.Subscribe`/`Messages.Sync`
+  unscoped grant rejection, `importFromPhrase`/`importFromPortable` wildcard
+  and zero-grant flows, and `toSyncIdentityProtocols` narrowing.

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -45,7 +45,7 @@ import { normalizeProtocolRequests } from './permissions.js';
 import { restoreSession } from './connect/restore.js';
 import { STORAGE_KEYS } from './types.js';
 import { walletConnect } from './connect/wallet.js';
-import { deriveActiveSyncScope, ensureVaultReady, finalizeDelegateSession, importDelegateAndSetupSync, resolveIdentityDids, resolvePassword, startSyncIfEnabled } from './connect/lifecycle.js';
+import { deriveActiveSyncScope, ensureVaultReady, finalizeDelegateSession, importDelegateAndSetupSync, resolveIdentityDids, resolvePassword, startSyncIfEnabled, toSyncIdentityProtocols } from './connect/lifecycle.js';
 import { importFromPhrase, importFromPortable } from './connect/import.js';
 
 /**
@@ -1099,12 +1099,16 @@ export class AuthManager {
   }
 
   /**
-   * Derive the protocol list for a delegate's sync scope by querying
-   * stored grant records and extracting their `scope.protocol` fields.
+   * Derive the sync scope for a delegate by querying stored grants and
+   * revocations.
    *
-   * Returns a deduplicated array of protocol URIs, excluding the DWN
-   * permissions protocol itself (the delegate doesn't need to sync
-   * grant records — they're imported locally during the connect flow).
+   * Returns `'all'` when any active `Messages.Read` grant is unscoped
+   * (authorizing a full replica), otherwise a deduplicated array of
+   * protocol URIs derived from scoped `Messages.Read` grants. The DWN
+   * permissions protocol itself is excluded because grant records are
+   * imported locally during connect rather than replicated via sync.
+   *
+   * Delegates to {@link deriveActiveSyncScope}.
    */
   private async _deriveProtocolsFromGrants(delegateDid: string): Promise<'all' | string[]> {
     return deriveActiveSyncScope(this._userAgent, delegateDid);
@@ -1145,30 +1149,26 @@ export class AuthManager {
     delegateDid: string | undefined,
     derivedProtocols: 'all' | string[] | undefined,
   ): Promise<void> {
-    const isZeroGrantDelegate = delegateDid
-      && derivedProtocols !== undefined
-      && derivedProtocols !== 'all'
-      && derivedProtocols.length === 0;
-
-    if (isZeroGrantDelegate) {
-      try {
-        await this._userAgent.sync.unregisterIdentity(connectedDid);
-      } catch (error: unknown) {
-        const msg = error instanceof Error ? error.message : '';
-        if (!msg.includes('is not registered')) { throw error; }
+    // Only delegates with an explicit zero-grant derivation should be
+    // unregistered. A non-delegate identity defaults to `'all'` when no
+    // derivation was performed.
+    if (delegateDid && derivedProtocols !== undefined) {
+      const narrowed = toSyncIdentityProtocols(derivedProtocols);
+      if (narrowed === undefined) {
+        try {
+          await this._userAgent.sync.unregisterIdentity(connectedDid);
+        } catch (error: unknown) {
+          const msg = error instanceof Error ? error.message : '';
+          if (!msg.includes('is not registered')) { throw error; }
+        }
+        return;
       }
+      await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, narrowed);
       return;
     }
 
-    let protocols: 'all' | [string, ...string[]];
-    if (derivedProtocols === 'all') {
-      protocols = 'all';
-    } else if (derivedProtocols && derivedProtocols.length > 0) {
-      protocols = derivedProtocols as [string, ...string[]];
-    } else {
-      protocols = 'all';
-    }
-    await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, protocols);
+    // Non-delegate identity: register with `'all'` (full-replica sync).
+    await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, 'all');
   }
 
   private _setState(state: AuthState): void {

--- a/packages/auth/src/connect/import.ts
+++ b/packages/auth/src/connect/import.ts
@@ -68,13 +68,16 @@ export async function importFromPhrase(
     );
   }
 
-  // Register sync for new identities.
-  if (isNewIdentity) {
-    if (delegateDid) {
-      await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
-    } else if (sync !== 'off') {
-      await registerSyncScopeForIdentity({ userAgent, connectedDid });
-    }
+  // Register sync. For delegate identities, always repair the registration
+  // (derive scope from active grants — revoked grants must not remain in a
+  // stale registration), regardless of whether the identity was just
+  // created or restored from storage. For local identities, register
+  // `protocols: 'all'` only on first creation; a pre-existing local
+  // identity was already registered during its initial flow.
+  if (delegateDid) {
+    await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
+  } else if (isNewIdentity && sync !== 'off') {
+    await registerSyncScopeForIdentity({ userAgent, connectedDid });
   }
 
   // Start sync.

--- a/packages/auth/src/connect/import.ts
+++ b/packages/auth/src/connect/import.ts
@@ -12,7 +12,7 @@ import type { ImportFromPhraseOptions, ImportFromPortableOptions } from '../type
 
 import { DEFAULT_DWN_ENDPOINTS } from '../types.js';
 import { registerWithDwnEndpoints } from '../registration.js';
-import { createDefaultIdentity, deriveActiveSyncScope, ensureVaultReady, finalizeSession, resolveIdentityDids, startSyncIfEnabled, toSyncIdentityProtocols } from './lifecycle.js';
+import { createDefaultIdentity, ensureVaultReady, finalizeSession, registerSyncScopeForIdentity, resolveIdentityDids, startSyncIfEnabled } from './lifecycle.js';
 
 /**
  * Import (or recover) an identity from a BIP-39 recovery phrase.
@@ -71,30 +71,9 @@ export async function importFromPhrase(
   // Register sync for new identities.
   if (isNewIdentity) {
     if (delegateDid) {
-      const protocols = await deriveActiveSyncScope(userAgent, delegateDid);
-      const narrowed = toSyncIdentityProtocols(protocols);
-      if (narrowed !== undefined) {
-        await userAgent.sync.registerIdentity({
-          did     : connectedDid,
-          options : {
-            delegateDid,
-            protocols: narrowed,
-          },
-        });
-      } else {
-        // Zero grants — clear any stale sync registration so revoked protocols stop syncing.
-        try {
-          await userAgent.sync.unregisterIdentity(connectedDid);
-        } catch (error: unknown) {
-          const msg = error instanceof Error ? error.message : '';
-          if (!msg.includes('is not registered')) { throw error; }
-        }
-      }
+      await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
     } else if (sync !== 'off') {
-      await userAgent.sync.registerIdentity({
-        did     : connectedDid,
-        options : { delegateDid, protocols: 'all' },
-      });
+      await registerSyncScopeForIdentity({ userAgent, connectedDid });
     }
   }
 
@@ -151,30 +130,9 @@ export async function importFromPortable(
 
   // Register sync. For delegates, derive scope from grants (not 'all').
   if (delegateDid) {
-    const protocols = await deriveActiveSyncScope(userAgent, delegateDid);
-    const narrowed = toSyncIdentityProtocols(protocols);
-    if (narrowed !== undefined) {
-      await userAgent.sync.registerIdentity({
-        did     : connectedDid,
-        options : {
-          delegateDid,
-          protocols: narrowed,
-        },
-      });
-    } else {
-      // Zero grants — clear any stale sync registration so revoked protocols stop syncing.
-      try {
-        await userAgent.sync.unregisterIdentity(connectedDid);
-      } catch (error: unknown) {
-        const msg = error instanceof Error ? error.message : '';
-        if (!msg.includes('is not registered')) { throw error; }
-      }
-    }
+    await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
   } else if (sync !== 'off') {
-    await userAgent.sync.registerIdentity({
-      did     : connectedDid,
-      options : { delegateDid, protocols: 'all' },
-    });
+    await registerSyncScopeForIdentity({ userAgent, connectedDid });
   }
 
   await startSyncIfEnabled(userAgent, sync);

--- a/packages/auth/src/connect/import.ts
+++ b/packages/auth/src/connect/import.ts
@@ -12,7 +12,7 @@ import type { ImportFromPhraseOptions, ImportFromPortableOptions } from '../type
 
 import { DEFAULT_DWN_ENDPOINTS } from '../types.js';
 import { registerWithDwnEndpoints } from '../registration.js';
-import { createDefaultIdentity, deriveActiveSyncScope, ensureVaultReady, finalizeSession, resolveIdentityDids, startSyncIfEnabled } from './lifecycle.js';
+import { createDefaultIdentity, deriveActiveSyncScope, ensureVaultReady, finalizeSession, resolveIdentityDids, startSyncIfEnabled, toSyncIdentityProtocols } from './lifecycle.js';
 
 /**
  * Import (or recover) an identity from a BIP-39 recovery phrase.
@@ -72,14 +72,23 @@ export async function importFromPhrase(
   if (isNewIdentity) {
     if (delegateDid) {
       const protocols = await deriveActiveSyncScope(userAgent, delegateDid);
-      if (protocols === 'all' || protocols.length > 0) {
+      const narrowed = toSyncIdentityProtocols(protocols);
+      if (narrowed !== undefined) {
         await userAgent.sync.registerIdentity({
           did     : connectedDid,
           options : {
             delegateDid,
-            protocols: protocols === 'all' ? 'all' as const : protocols as [string, ...string[]],
+            protocols: narrowed,
           },
         });
+      } else {
+        // Zero grants — clear any stale sync registration so revoked protocols stop syncing.
+        try {
+          await userAgent.sync.unregisterIdentity(connectedDid);
+        } catch (error: unknown) {
+          const msg = error instanceof Error ? error.message : '';
+          if (!msg.includes('is not registered')) { throw error; }
+        }
       }
     } else if (sync !== 'off') {
       await userAgent.sync.registerIdentity({
@@ -143,14 +152,23 @@ export async function importFromPortable(
   // Register sync. For delegates, derive scope from grants (not 'all').
   if (delegateDid) {
     const protocols = await deriveActiveSyncScope(userAgent, delegateDid);
-    if (protocols === 'all' || protocols.length > 0) {
+    const narrowed = toSyncIdentityProtocols(protocols);
+    if (narrowed !== undefined) {
       await userAgent.sync.registerIdentity({
         did     : connectedDid,
         options : {
           delegateDid,
-          protocols: protocols === 'all' ? 'all' as const : protocols as [string, ...string[]],
+          protocols: narrowed,
         },
       });
+    } else {
+      // Zero grants — clear any stale sync registration so revoked protocols stop syncing.
+      try {
+        await userAgent.sync.unregisterIdentity(connectedDid);
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : '';
+        if (!msg.includes('is not registered')) { throw error; }
+      }
     }
   } else if (sync !== 'off') {
     await userAgent.sync.registerIdentity({

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -347,6 +347,25 @@ export async function deriveActiveSyncScope(
   return deriveSyncScopeFromGrants(grants);
 }
 
+// ─── toSyncIdentityProtocols ────────────────────────────────────
+
+/**
+ * Narrow a derived sync scope (`'all' | string[]`) to the form required by
+ * `SyncIdentityOptions.protocols` (`'all' | [string, ...string[]]`).
+ *
+ * Returns `undefined` when the scope is an empty array, signalling the
+ * caller should unregister the identity rather than register it.
+ *
+ * @internal
+ */
+export function toSyncIdentityProtocols(
+  scope: 'all' | string[],
+): 'all' | [string, ...string[]] | undefined {
+  if (scope === 'all') { return 'all'; }
+  if (scope.length === 0) { return undefined; }
+  return scope as [string, ...string[]];
+}
+
 // ─── processConnectedGrants ─────────────────────────────────────
 
 /**
@@ -566,10 +585,11 @@ export async function importDelegateAndSetupSync(params: {
     // If the identity is already registered from a prior session, update
     // the protocol list so it matches the new grants — otherwise a stale
     // registration would remain.
-    if (connectedProtocols === 'all' || connectedProtocols.length > 0) {
+    const narrowedProtocols = toSyncIdentityProtocols(connectedProtocols);
+    if (narrowedProtocols !== undefined) {
       const syncOptions = {
         delegateDid : delegatePortableDid.uri,
-        protocols   : connectedProtocols === 'all' ? 'all' as const : connectedProtocols as [string, ...string[]],
+        protocols   : narrowedProtocols,
       };
       try {
         await userAgent.sync.registerIdentity({ did: connectedDid, options: syncOptions });

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -366,6 +366,73 @@ export function toSyncIdentityProtocols(
   return scope as [string, ...string[]];
 }
 
+// ─── registerSyncScopeForIdentity ───────────────────────────────
+
+/**
+ * Register (or update, or clear) the sync registration for an identity based on
+ * its derived protocol scope.
+ *
+ * - For a **delegate session**: queries the delegate's active grants via
+ *   {@link deriveActiveSyncScope}, then registers with `protocols: 'all'` or a
+ *   scoped list when grants are present, or unregisters the identity when no
+ *   sync-relevant grants remain (so revoked protocols stop syncing). The
+ *   "is not registered" error from unregister is silently tolerated;
+ *   `"already registered"` from register falls back to `updateIdentityOptions`.
+ *
+ * - For a **local session** (no `delegateDid`): registers with
+ *   `protocols: 'all'` (a local identity is a full replica of its own DWN).
+ *   The `"already registered"` error falls back to `updateIdentityOptions`.
+ *
+ * @internal
+ */
+export async function registerSyncScopeForIdentity(params: {
+  userAgent: EnboxUserAgent;
+  connectedDid: string;
+  delegateDid?: string;
+}): Promise<void> {
+  const { userAgent, connectedDid, delegateDid } = params;
+
+  if (delegateDid !== undefined) {
+    const scope = await deriveActiveSyncScope(userAgent, delegateDid);
+    const narrowed = toSyncIdentityProtocols(scope);
+    if (narrowed !== undefined) {
+      const options = { delegateDid, protocols: narrowed };
+      try {
+        await userAgent.sync.registerIdentity({ did: connectedDid, options });
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : '';
+        if (msg.includes('already registered')) {
+          await userAgent.sync.updateIdentityOptions({ did: connectedDid, options });
+        } else {
+          throw error;
+        }
+      }
+    } else {
+      // Zero grants — clear any stale sync registration so revoked protocols stop syncing.
+      try {
+        await userAgent.sync.unregisterIdentity(connectedDid);
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : '';
+        if (!msg.includes('is not registered')) { throw error; }
+      }
+    }
+    return;
+  }
+
+  // Local session — register with full-replica scope.
+  const options = { protocols: 'all' as const };
+  try {
+    await userAgent.sync.registerIdentity({ did: connectedDid, options });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : '';
+    if (msg.includes('already registered')) {
+      await userAgent.sync.updateIdentityOptions({ did: connectedDid, options });
+    } else {
+      throw error;
+    }
+  }
+}
+
 // ─── processConnectedGrants ─────────────────────────────────────
 
 /**

--- a/packages/auth/src/connect/restore.ts
+++ b/packages/auth/src/connect/restore.ts
@@ -20,7 +20,7 @@ import { DwnInterface, DwnPermissionGrant } from '@enbox/agent';
 
 import { applyLocalDwnDiscovery } from '../discovery.js';
 import { STORAGE_KEYS } from '../types.js';
-import { deriveActiveSyncScope, ensureVaultReady, finalizeSession, resolveIdentityDids, resolvePassword, startSyncIfEnabled } from './lifecycle.js';
+import { deriveActiveSyncScope, ensureVaultReady, finalizeSession, resolveIdentityDids, resolvePassword, startSyncIfEnabled, toSyncIdentityProtocols } from './lifecycle.js';
 
 /**
  * Decrypt a stored key blob.
@@ -231,10 +231,11 @@ export async function restoreSession(
   if (delegateDid) {
     try {
       const protocols = await deriveActiveSyncScope(userAgent, delegateDid);
-      if (protocols === 'all' || protocols.length > 0) {
+      const narrowed = toSyncIdentityProtocols(protocols);
+      if (narrowed !== undefined) {
         const options = {
           delegateDid,
-          protocols: protocols === 'all' ? 'all' as const : protocols as [string, ...string[]],
+          protocols: narrowed,
         };
         try {
           await userAgent.sync.registerIdentity({ did: connectedDid, options });

--- a/packages/auth/src/connect/restore.ts
+++ b/packages/auth/src/connect/restore.ts
@@ -20,7 +20,7 @@ import { DwnInterface, DwnPermissionGrant } from '@enbox/agent';
 
 import { applyLocalDwnDiscovery } from '../discovery.js';
 import { STORAGE_KEYS } from '../types.js';
-import { deriveActiveSyncScope, ensureVaultReady, finalizeSession, resolveIdentityDids, resolvePassword, startSyncIfEnabled, toSyncIdentityProtocols } from './lifecycle.js';
+import { ensureVaultReady, finalizeSession, registerSyncScopeForIdentity, resolveIdentityDids, resolvePassword, startSyncIfEnabled } from './lifecycle.js';
 
 /**
  * Decrypt a stored key blob.
@@ -230,32 +230,7 @@ export async function restoreSession(
   let syncRepairFailed = false;
   if (delegateDid) {
     try {
-      const protocols = await deriveActiveSyncScope(userAgent, delegateDid);
-      const narrowed = toSyncIdentityProtocols(protocols);
-      if (narrowed !== undefined) {
-        const options = {
-          delegateDid,
-          protocols: narrowed,
-        };
-        try {
-          await userAgent.sync.registerIdentity({ did: connectedDid, options });
-        } catch (regError: unknown) {
-          const msg = regError instanceof Error ? regError.message : '';
-          if (msg.includes('already registered')) {
-            await userAgent.sync.updateIdentityOptions({ did: connectedDid, options });
-          } else {
-            throw regError;
-          }
-        }
-      } else {
-        // Zero grants — remove any stale sync registration so revoked protocols stop syncing.
-        try {
-          await userAgent.sync.unregisterIdentity(connectedDid);
-        } catch (error: unknown) {
-          const msg = error instanceof Error ? error.message : '';
-          if (!msg.includes('is not registered')) { throw error; }
-        }
-      }
+      await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
     } catch {
       // Grant query or registration repair failed — don't block restore,
       // but don't let a stale registration remain usable.

--- a/packages/auth/tests/import-identity.spec.ts
+++ b/packages/auth/tests/import-identity.spec.ts
@@ -179,10 +179,16 @@ describe('importFromPhrase', () => {
     expect(registrationSucceeded).toBe(true);
   });
 
-  test('registers sync with derived scope for delegate identity on first launch', async () => {
+  test('registers sync with derived scope for persisted delegate identity', async () => {
+    // Production reality: a delegate identity cannot exist on a truly first
+    // launch (createDefaultIdentity never sets metadata.connectedDid), so
+    // when importFromPhrase encounters a delegate it must be a pre-existing,
+    // persisted identity — firstLaunch is false and identity.list() returns
+    // the stored delegate directly.
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
     const syncCalls: any[] = [];
+    let createCallCount = 0;
 
     const grantData = JSON.stringify({
       dateExpires : '2040-06-25T16:09:16.693356Z',
@@ -213,9 +219,9 @@ describe('importFromPhrase', () => {
     });
 
     const agent = createMockAgent({
-      firstLaunch          : async () => true,
-      identityList         : async () => [],
-      identityCreate       : async () => delegateIdentity,
+      firstLaunch          : async () => false,
+      identityList         : async () => [delegateIdentity],
+      identityCreate       : async () => { createCallCount += 1; return delegateIdentity; },
       syncRegisterIdentity : async (params) => { syncCalls.push(params); },
       processDwnRequest    : async () => ({
         reply: { status: { code: 200 }, entries: [grantEntry] },
@@ -230,23 +236,29 @@ describe('importFromPhrase', () => {
     expect(syncCalls).toHaveLength(1);
     expect(syncCalls[0].options.protocols).toEqual(['https://proto.example/chat']);
     expect(syncCalls[0].options.delegateDid).toBe('did:dht:testuser123');
+    expect(createCallCount).toBe(0);
   });
 
-  test('skips sync registration for delegate with zero grants', async () => {
+  test('clears stale sync registration for persisted delegate with zero grants', async () => {
+    // Zero grants = all grants revoked. The delegate's sync registration
+    // must be cleared so revoked protocols stop syncing.
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
-    const syncCalls: any[] = [];
+    const registerCalls: any[] = [];
+    const unregisterCalls: string[] = [];
+    let createCallCount = 0;
 
     const delegateIdentity = createMockIdentity({
       metadata: { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
     });
 
     const agent = createMockAgent({
-      firstLaunch          : async () => true,
-      identityList         : async () => [],
-      identityCreate       : async () => delegateIdentity,
-      syncRegisterIdentity : async (params) => { syncCalls.push(params); },
-      processDwnRequest    : async () => ({
+      firstLaunch            : async () => false,
+      identityList           : async () => [delegateIdentity],
+      identityCreate         : async () => { createCallCount += 1; return delegateIdentity; },
+      syncRegisterIdentity   : async (params) => { registerCalls.push(params); },
+      syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
+      processDwnRequest      : async () => ({
         reply: { status: { code: 200 }, entries: [] },
       }),
     });
@@ -256,13 +268,16 @@ describe('importFromPhrase', () => {
       { recoveryPhrase: 'phrase', password: 'pass' },
     );
 
-    expect(syncCalls).toHaveLength(0);
+    expect(registerCalls).toHaveLength(0);
+    expect(unregisterCalls).toEqual(['did:dht:external']);
+    expect(createCallCount).toBe(0);
   });
 
   test('registers sync with protocols: all for delegate with unscoped Messages.Read grant', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
     const syncCalls: any[] = [];
+    let createCallCount = 0;
 
     const grantData = JSON.stringify({
       dateExpires : '2040-06-25T16:09:16.693356Z',
@@ -293,9 +308,9 @@ describe('importFromPhrase', () => {
     });
 
     const agent = createMockAgent({
-      firstLaunch          : async () => true,
-      identityList         : async () => [],
-      identityCreate       : async () => delegateIdentity,
+      firstLaunch          : async () => false,
+      identityList         : async () => [delegateIdentity],
+      identityCreate       : async () => { createCallCount += 1; return delegateIdentity; },
       syncRegisterIdentity : async (params) => { syncCalls.push(params); },
       processDwnRequest    : async (params: any) => {
         const filter = params?.messageParams?.filter;
@@ -314,21 +329,23 @@ describe('importFromPhrase', () => {
     expect(syncCalls).toHaveLength(1);
     expect(syncCalls[0].options.protocols).toBe('all');
     expect(syncCalls[0].options.delegateDid).toBe('did:dht:testuser123');
+    expect(createCallCount).toBe(0);
   });
 
-  test('unregisters identity for delegate with zero grants (clears stale registration)', async () => {
+  test('unregisters identity for persisted delegate with zero grants (clears stale registration)', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
     const unregisterCalls: string[] = [];
+    let createCallCount = 0;
 
     const delegateIdentity = createMockIdentity({
       metadata: { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
     });
 
     const agent = createMockAgent({
-      firstLaunch            : async () => true,
-      identityList           : async () => [],
-      identityCreate         : async () => delegateIdentity,
+      firstLaunch            : async () => false,
+      identityList           : async () => [delegateIdentity],
+      identityCreate         : async () => { createCallCount += 1; return delegateIdentity; },
       syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
       processDwnRequest      : async () => ({
         reply: { status: { code: 200 }, entries: [] },
@@ -342,20 +359,22 @@ describe('importFromPhrase', () => {
 
     expect(unregisterCalls).toHaveLength(1);
     expect(unregisterCalls[0]).toBe('did:dht:external');
+    expect(createCallCount).toBe(0);
   });
 
-  test('tolerates "is not registered" error when unregistering zero-grant delegate', async () => {
+  test('tolerates "is not registered" error when unregistering zero-grant persisted delegate', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
+    let createCallCount = 0;
 
     const delegateIdentity = createMockIdentity({
       metadata: { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
     });
 
     const agent = createMockAgent({
-      firstLaunch            : async () => true,
-      identityList           : async () => [],
-      identityCreate         : async () => delegateIdentity,
+      firstLaunch            : async () => false,
+      identityList           : async () => [delegateIdentity],
+      identityCreate         : async () => { createCallCount += 1; return delegateIdentity; },
       syncUnregisterIdentity : async () => { throw new Error('is not registered'); },
       processDwnRequest      : async () => ({
         reply: { status: { code: 200 }, entries: [] },
@@ -369,20 +388,22 @@ describe('importFromPhrase', () => {
     );
 
     expect(session).toBeDefined();
+    expect(createCallCount).toBe(0);
   });
 
-  test('rethrows I/O errors from unregisterIdentity on zero-grant delegate path', async () => {
+  test('rethrows I/O errors from unregisterIdentity on zero-grant persisted delegate path', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
+    let createCallCount = 0;
 
     const delegateIdentity = createMockIdentity({
       metadata: { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
     });
 
     const agent = createMockAgent({
-      firstLaunch            : async () => true,
-      identityList           : async () => [],
-      identityCreate         : async () => delegateIdentity,
+      firstLaunch            : async () => false,
+      identityList           : async () => [delegateIdentity],
+      identityCreate         : async () => { createCallCount += 1; return delegateIdentity; },
       syncUnregisterIdentity : async () => { throw new Error('LEVEL_IO_ERROR'); },
       processDwnRequest      : async () => ({
         reply: { status: { code: 200 }, entries: [] },
@@ -395,6 +416,75 @@ describe('importFromPhrase', () => {
         { recoveryPhrase: 'phrase', password: 'pass' },
       )
     ).rejects.toThrow('LEVEL_IO_ERROR');
+    expect(createCallCount).toBe(0);
+  });
+
+  test('skips sync registration for pre-existing local identity (pass-through)', async () => {
+    // A pre-existing local identity was already registered during its
+    // initial flow. On a subsequent importFromPhrase (vault recovery on a
+    // device where the identity is already persisted), we must not
+    // re-register — otherwise we risk clobbering existing sync options.
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const registerCalls: any[] = [];
+    const unregisterCalls: string[] = [];
+    let createCallCount = 0;
+
+    const localIdentity = createMockIdentity();
+
+    const agent = createMockAgent({
+      firstLaunch            : async () => false,
+      identityList           : async () => [localIdentity],
+      identityCreate         : async () => { createCallCount += 1; return localIdentity; },
+      syncRegisterIdentity   : async (params) => { registerCalls.push(params); },
+      syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
+    });
+
+    await importFromPhrase(
+      { userAgent: agent, emitter, storage, defaultSync: '15s' },
+      { recoveryPhrase: 'phrase', password: 'pass' },
+    );
+
+    expect(registerCalls).toHaveLength(0);
+    expect(unregisterCalls).toHaveLength(0);
+    expect(createCallCount).toBe(0);
+  });
+
+  test('repairs stale sync registration for pre-existing delegate identity (regression for impossible-branch bug)', async () => {
+    // Regression test: `createDefaultIdentity()` never sets `metadata.connectedDid`,
+    // so the previously-buggy branch `if (isNewIdentity) { if (delegateDid) { … } }`
+    // was unreachable. In production a persisted delegate identity means
+    // isNewIdentity=false, and the repair must still run so revoked protocols
+    // do not remain in a stale sync registration.
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const unregisterCalls: string[] = [];
+    let createCallCount = 0;
+
+    const delegateIdentity = createMockIdentity({
+      did      : { uri: 'did:jwk:delegate' },
+      metadata : { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
+    });
+
+    const agent = createMockAgent({
+      firstLaunch            : async () => false,
+      identityList           : async () => [delegateIdentity],
+      identityCreate         : async () => { createCallCount += 1; return delegateIdentity; },
+      syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
+      processDwnRequest      : async () => ({
+        reply: { status: { code: 200 }, entries: [] },
+      }),
+    });
+
+    await importFromPhrase(
+      { userAgent: agent, emitter, storage, defaultSync: '15s' },
+      { recoveryPhrase: 'phrase', password: 'pass' },
+    );
+
+    // Zero grants must clear any stale sync registration for the connected DID.
+    expect(unregisterCalls).toEqual(['did:dht:external']);
+    // identity.create() must NOT be called — identity already exists.
+    expect(createCallCount).toBe(0);
   });
 });
 

--- a/packages/auth/tests/import-identity.spec.ts
+++ b/packages/auth/tests/import-identity.spec.ts
@@ -258,6 +258,144 @@ describe('importFromPhrase', () => {
 
     expect(syncCalls).toHaveLength(0);
   });
+
+  test('registers sync with protocols: all for delegate with unscoped Messages.Read grant', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const syncCalls: any[] = [];
+
+    const grantData = JSON.stringify({
+      dateExpires : '2040-06-25T16:09:16.693356Z',
+      scope       : { interface: 'Messages', method: 'Read' },
+      delegated   : true,
+    });
+    const encoded = btoa(grantData).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const grantEntry = {
+      recordId    : 'grant-unscoped',
+      contextId   : 'grant-unscoped',
+      encodedData : encoded,
+      descriptor  : {
+        interface    : 'Records',
+        method       : 'Write',
+        protocol     : 'https://identity.foundation/dwn/permissions',
+        protocolPath : 'grant',
+        recipient    : 'did:dht:external',
+        dateCreated  : '2025-01-01T00:00:00.000000Z',
+        dataFormat   : 'application/json',
+        dataCid      : 'bafytest',
+        dataSize     : 100,
+      },
+      authorization: { signature: { signatures: [{ protected: btoa(JSON.stringify({ kid: 'did:dht:owner1#sig' })) }] } },
+    };
+
+    const delegateIdentity = createMockIdentity({
+      metadata: { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
+    });
+
+    const agent = createMockAgent({
+      firstLaunch          : async () => true,
+      identityList         : async () => [],
+      identityCreate       : async () => delegateIdentity,
+      syncRegisterIdentity : async (params) => { syncCalls.push(params); },
+      processDwnRequest    : async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status: { code: 200 }, entries: [grantEntry] } };
+        }
+        return { reply: { status: { code: 200 }, entries: [] } };
+      },
+    });
+
+    await importFromPhrase(
+      { userAgent: agent, emitter, storage, defaultSync: '15s' },
+      { recoveryPhrase: 'phrase', password: 'pass' },
+    );
+
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].options.protocols).toBe('all');
+    expect(syncCalls[0].options.delegateDid).toBe('did:dht:testuser123');
+  });
+
+  test('unregisters identity for delegate with zero grants (clears stale registration)', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const unregisterCalls: string[] = [];
+
+    const delegateIdentity = createMockIdentity({
+      metadata: { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
+    });
+
+    const agent = createMockAgent({
+      firstLaunch            : async () => true,
+      identityList           : async () => [],
+      identityCreate         : async () => delegateIdentity,
+      syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
+      processDwnRequest      : async () => ({
+        reply: { status: { code: 200 }, entries: [] },
+      }),
+    });
+
+    await importFromPhrase(
+      { userAgent: agent, emitter, storage, defaultSync: '15s' },
+      { recoveryPhrase: 'phrase', password: 'pass' },
+    );
+
+    expect(unregisterCalls).toHaveLength(1);
+    expect(unregisterCalls[0]).toBe('did:dht:external');
+  });
+
+  test('tolerates "is not registered" error when unregistering zero-grant delegate', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+
+    const delegateIdentity = createMockIdentity({
+      metadata: { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
+    });
+
+    const agent = createMockAgent({
+      firstLaunch            : async () => true,
+      identityList           : async () => [],
+      identityCreate         : async () => delegateIdentity,
+      syncUnregisterIdentity : async () => { throw new Error('is not registered'); },
+      processDwnRequest      : async () => ({
+        reply: { status: { code: 200 }, entries: [] },
+      }),
+    });
+
+    // Should complete without throwing.
+    const session = await importFromPhrase(
+      { userAgent: agent, emitter, storage, defaultSync: '15s' },
+      { recoveryPhrase: 'phrase', password: 'pass' },
+    );
+
+    expect(session).toBeDefined();
+  });
+
+  test('rethrows I/O errors from unregisterIdentity on zero-grant delegate path', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+
+    const delegateIdentity = createMockIdentity({
+      metadata: { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
+    });
+
+    const agent = createMockAgent({
+      firstLaunch            : async () => true,
+      identityList           : async () => [],
+      identityCreate         : async () => delegateIdentity,
+      syncUnregisterIdentity : async () => { throw new Error('LEVEL_IO_ERROR'); },
+      processDwnRequest      : async () => ({
+        reply: { status: { code: 200 }, entries: [] },
+      }),
+    });
+
+    await expect(
+      importFromPhrase(
+        { userAgent: agent, emitter, storage, defaultSync: '15s' },
+        { recoveryPhrase: 'phrase', password: 'pass' },
+      )
+    ).rejects.toThrow('LEVEL_IO_ERROR');
+  });
 });
 
 describe('importFromPortable', () => {
@@ -454,5 +592,127 @@ describe('importFromPortable', () => {
     );
 
     expect(registrationSucceeded).toBe(true);
+  });
+
+  test('registers sync with protocols: all for delegate with unscoped Messages.Read grant', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const syncRegCalls: any[] = [];
+
+    const delegateIdentity = createMockIdentity({
+      did      : { uri: 'did:jwk:delegate' },
+      metadata : { name: 'Wallet', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner' },
+    });
+
+    const grantData = JSON.stringify({
+      dateExpires : '2040-01-01T00:00:00Z',
+      scope       : { interface: 'Messages', method: 'Read' },
+      delegated   : true,
+    });
+    const encoded = btoa(grantData).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+    const agent = createMockAgent({
+      identityImport       : async () => delegateIdentity,
+      syncRegisterIdentity : async (params) => { syncRegCalls.push(params); },
+      processDwnRequest    : async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [{
+            recordId      : 'g-unscoped',
+            contextId     : 'g-unscoped',
+            encodedData   : encoded,
+            descriptor    : { interface: 'Records', method: 'Write', protocol: 'https://identity.foundation/dwn/permissions', protocolPath: 'grant', recipient: 'did:jwk:delegate', dateCreated: '2025-01-01T00:00:00Z', dataFormat: 'application/json', dataCid: 'bafytest', dataSize: 100 },
+            authorization : { signature: { signatures: [{ protected: btoa(JSON.stringify({ kid: 'did:dht:owner#sig' })) }] } },
+          }] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+    });
+
+    await importFromPortable(
+      { userAgent: agent, emitter, storage, defaultSync: '30s' },
+      { portableIdentity: {} as any },
+    );
+
+    expect(syncRegCalls).toHaveLength(1);
+    expect(syncRegCalls[0].options.protocols).toBe('all');
+    expect(syncRegCalls[0].options.delegateDid).toBe('did:jwk:delegate');
+  });
+
+  test('unregisters identity for delegate with zero grants (clears stale registration)', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const unregisterCalls: string[] = [];
+
+    const delegateIdentity = createMockIdentity({
+      did      : { uri: 'did:jwk:delegate' },
+      metadata : { name: 'Wallet', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner' },
+    });
+
+    const agent = createMockAgent({
+      identityImport         : async () => delegateIdentity,
+      syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
+      processDwnRequest      : async () => ({
+        reply: { status: { code: 200, detail: 'OK' }, entries: [] },
+      }),
+    });
+
+    await importFromPortable(
+      { userAgent: agent, emitter, storage, defaultSync: '30s' },
+      { portableIdentity: {} as any },
+    );
+
+    expect(unregisterCalls).toHaveLength(1);
+    expect(unregisterCalls[0]).toBe('did:dht:owner');
+  });
+
+  test('tolerates "is not registered" error when unregistering zero-grant delegate', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+
+    const delegateIdentity = createMockIdentity({
+      did      : { uri: 'did:jwk:delegate' },
+      metadata : { name: 'Wallet', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner' },
+    });
+
+    const agent = createMockAgent({
+      identityImport         : async () => delegateIdentity,
+      syncUnregisterIdentity : async () => { throw new Error('is not registered'); },
+      processDwnRequest      : async () => ({
+        reply: { status: { code: 200, detail: 'OK' }, entries: [] },
+      }),
+    });
+
+    const session = await importFromPortable(
+      { userAgent: agent, emitter, storage, defaultSync: '30s' },
+      { portableIdentity: {} as any },
+    );
+
+    expect(session).toBeDefined();
+  });
+
+  test('rethrows I/O errors from unregisterIdentity on zero-grant delegate path', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+
+    const delegateIdentity = createMockIdentity({
+      did      : { uri: 'did:jwk:delegate' },
+      metadata : { name: 'Wallet', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner' },
+    });
+
+    const agent = createMockAgent({
+      identityImport         : async () => delegateIdentity,
+      syncUnregisterIdentity : async () => { throw new Error('LEVEL_IO_ERROR'); },
+      processDwnRequest      : async () => ({
+        reply: { status: { code: 200, detail: 'OK' }, entries: [] },
+      }),
+    });
+
+    await expect(
+      importFromPortable(
+        { userAgent: agent, emitter, storage, defaultSync: '30s' },
+        { portableIdentity: {} as any },
+      )
+    ).rejects.toThrow('LEVEL_IO_ERROR');
   });
 });

--- a/packages/auth/tests/lifecycle.spec.ts
+++ b/packages/auth/tests/lifecycle.spec.ts
@@ -6,16 +6,21 @@ import { AuthEventEmitter } from '../src/events.js';
 import { MemoryStorage } from '../src/storage/storage.js';
 import { STORAGE_KEYS } from '../src/types.js';
 import { createMockAgent, createMockIdentity } from './helpers/mock-agent.js';
-import { deriveActiveSyncScope, deriveSyncScopeFromGrants, finalizeDelegateSession, importDelegateAndSetupSync, processConnectedGrants } from '../src/connect/lifecycle.js';
+import { deriveActiveSyncScope, deriveSyncScopeFromGrants, finalizeDelegateSession, importDelegateAndSetupSync, processConnectedGrants, toSyncIdentityProtocols } from '../src/connect/lifecycle.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
 /** Build a mock unscoped (unrestricted) grant — no protocol in scope. */
-function buildUnscopedGrantMessage(grantId: string, scopeInterface = 'Messages', scopeMethod = 'Read'): any {
+function buildUnscopedGrantMessage(
+  grantId: string,
+  scopeInterface = 'Messages',
+  scopeMethod = 'Read',
+  dateExpires = '2040-06-25T16:09:16.693356Z',
+): any {
   const grantData = JSON.stringify({
-    dateExpires : '2040-06-25T16:09:16.693356Z',
-    scope       : { interface: scopeInterface, method: scopeMethod },
-    delegated   : true,
+    dateExpires,
+    scope     : { interface: scopeInterface, method: scopeMethod },
+    delegated : true,
   });
   const encoded = btoa(grantData).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   return {
@@ -140,6 +145,74 @@ describe('deriveSyncScopeFromGrants', () => {
     ];
     expect(deriveSyncScopeFromGrants(grants)).toEqual([]);
   });
+
+  test('returns all when wildcard grant appears first among scoped grants', () => {
+    const grants = [
+      mockGrant({ interface: 'Messages', method: 'Read' }),
+      mockGrant({ interface: 'Messages', method: 'Read', protocol: 'https://proto.example/chat' }),
+      mockGrant({ interface: 'Messages', method: 'Read', protocol: 'https://proto.example/notes' }),
+    ];
+    expect(deriveSyncScopeFromGrants(grants)).toBe('all');
+  });
+
+  test('returns all when wildcard grant appears last among scoped grants', () => {
+    const grants = [
+      mockGrant({ interface: 'Messages', method: 'Read', protocol: 'https://proto.example/chat' }),
+      mockGrant({ interface: 'Messages', method: 'Read', protocol: 'https://proto.example/notes' }),
+      mockGrant({ interface: 'Messages', method: 'Read' }),
+    ];
+    expect(deriveSyncScopeFromGrants(grants)).toBe('all');
+  });
+
+  test('does not return all when the only wildcard grant is expired', () => {
+    const grants = [
+      mockGrant({ interface: 'Messages', method: 'Read' }, '2020-01-01T00:00:00Z'),
+    ];
+    expect(deriveSyncScopeFromGrants(grants)).toEqual([]);
+  });
+
+  test('ignores unscoped Messages.Subscribe grants (not Messages.Read)', () => {
+    const grants = [
+      mockGrant({ interface: 'Messages', method: 'Subscribe' }),
+    ];
+    expect(deriveSyncScopeFromGrants(grants)).toEqual([]);
+  });
+
+  test('ignores scoped Messages.Subscribe grants (not Messages.Read)', () => {
+    const grants = [
+      mockGrant({ interface: 'Messages', method: 'Subscribe', protocol: 'https://proto.example/chat' }),
+    ];
+    expect(deriveSyncScopeFromGrants(grants)).toEqual([]);
+  });
+
+  test('ignores unscoped Messages.Sync-like method grants (only Read authorizes)', () => {
+    const grants = [
+      // `Sync` is not `Read` — must be ignored even unscoped.
+      mockGrant({ interface: 'Messages', method: 'Sync' }),
+    ];
+    expect(deriveSyncScopeFromGrants(grants)).toEqual([]);
+  });
+
+  test('ignores scoped Messages.Sync-like method grants', () => {
+    const grants = [
+      mockGrant({ interface: 'Messages', method: 'Sync', protocol: 'https://proto.example/chat' }),
+    ];
+    expect(deriveSyncScopeFromGrants(grants)).toEqual([]);
+  });
+
+  test('ignores unscoped Protocols.Query grants', () => {
+    const grants = [
+      mockGrant({ interface: 'Protocols', method: 'Query' }),
+    ];
+    expect(deriveSyncScopeFromGrants(grants)).toEqual([]);
+  });
+
+  test('ignores unscoped Records.Read grants', () => {
+    const grants = [
+      mockGrant({ interface: 'Records', method: 'Read' }),
+    ];
+    expect(deriveSyncScopeFromGrants(grants)).toEqual([]);
+  });
 });
 
 describe('deriveActiveSyncScope', () => {
@@ -220,6 +293,63 @@ describe('deriveActiveSyncScope', () => {
         const filter = params?.messageParams?.filter;
         if (filter?.protocolPath === 'grant') {
           return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            buildUnscopedGrantMessage('g-unscoped'),
+          ] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+    });
+
+    const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
+    expect(result).toBe('all');
+  });
+
+  test('excludes revoked wildcard grant', async () => {
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            buildUnscopedGrantMessage('g-unscoped'),
+          ] } };
+        }
+        if (filter?.protocolPath === 'grant/revocation') {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            { descriptor: { parentId: 'g-unscoped' } },
+          ] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+    });
+
+    const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
+    expect(result).toEqual([]);
+  });
+
+  test('excludes expired wildcard grant', async () => {
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            buildUnscopedGrantMessage('g-expired', 'Messages', 'Read', '2020-01-01T00:00:00Z'),
+          ] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+    });
+
+    const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
+    expect(result).toEqual([]);
+  });
+
+  test('wildcard wins when mixed with scoped grants', async () => {
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            buildGrantMessage('https://proto.example/chat', 'g-scoped'),
             buildUnscopedGrantMessage('g-unscoped'),
           ] } };
         }
@@ -552,6 +682,89 @@ describe('importDelegateAndSetupSync', () => {
         })
       ).rejects.toThrow('database unavailable');
     });
+
+    test('registers with all when any grant is unscoped even with other scoped grants', async () => {
+      const syncCalls: any[] = [];
+
+      const identity = createMockIdentity({
+        did      : { uri: 'did:jwk:delegate1' },
+        metadata : { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:connected1' },
+      });
+
+      const agent = createMockAgent({
+        identityImport       : async () => identity,
+        syncRegisterIdentity : async (params) => { syncCalls.push(params); },
+        dwnProcessRawMessage : async () => ({ status: { code: 202, detail: 'Accepted' } }),
+      });
+
+      const grants = [
+        buildGrantMessage('https://proto.example/chat', 'grant-chat'),
+        buildUnscopedGrantMessage('grant-unrestricted'),
+        buildGrantMessage('https://proto.example/notes', 'grant-notes'),
+      ];
+
+      await importDelegateAndSetupSync({
+        userAgent           : agent,
+        delegatePortableDid : { uri: 'did:jwk:delegate1', document: {} as any, metadata: {} },
+        connectedDid        : 'did:dht:connected1',
+        delegateGrants      : grants,
+        flowName            : 'test',
+      });
+
+      expect(syncCalls).toHaveLength(1);
+      expect(syncCalls[0].options.protocols).toBe('all');
+    });
+
+    test('ignores unscoped Messages.Subscribe grant (only Messages.Read authorizes sync)', async () => {
+      const syncCalls: any[] = [];
+      const unregisterCalls: string[] = [];
+
+      const identity = createMockIdentity({
+        did      : { uri: 'did:jwk:delegate1' },
+        metadata : { name: 'Default', tenant: 'did:dht:testagent', connectedDid: 'did:dht:connected1' },
+      });
+
+      const agent = createMockAgent({
+        identityImport         : async () => identity,
+        syncRegisterIdentity   : async (params) => { syncCalls.push(params); },
+        syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
+        dwnProcessRawMessage   : async () => ({ status: { code: 202, detail: 'Accepted' } }),
+      });
+
+      const grants = [buildUnscopedGrantMessage('grant-subscribe', 'Messages', 'Subscribe')];
+
+      await importDelegateAndSetupSync({
+        userAgent           : agent,
+        delegatePortableDid : { uri: 'did:jwk:delegate1', document: {} as any, metadata: {} },
+        connectedDid        : 'did:dht:connected1',
+        delegateGrants      : grants,
+        flowName            : 'test',
+      });
+
+      // Should NOT register with 'all' — Messages.Subscribe does not authorize sync.
+      expect(syncCalls).toHaveLength(0);
+      // Should unregister since no sync-relevant protocols were found.
+      expect(unregisterCalls).toHaveLength(1);
+    });
+  });
+});
+
+describe('toSyncIdentityProtocols', () => {
+  test('passes through the `all` literal unchanged', () => {
+    expect(toSyncIdentityProtocols('all')).toBe('all');
+  });
+
+  test('returns undefined for an empty array (caller should unregister)', () => {
+    expect(toSyncIdentityProtocols([])).toBeUndefined();
+  });
+
+  test('returns the array for a single-element scope', () => {
+    expect(toSyncIdentityProtocols(['https://proto.example/a'])).toEqual(['https://proto.example/a']);
+  });
+
+  test('returns the array for multi-element scopes', () => {
+    expect(toSyncIdentityProtocols(['https://proto.example/a', 'https://proto.example/b']))
+      .toEqual(['https://proto.example/a', 'https://proto.example/b']);
   });
 });
 

--- a/packages/auth/tests/lifecycle.spec.ts
+++ b/packages/auth/tests/lifecycle.spec.ts
@@ -6,7 +6,7 @@ import { AuthEventEmitter } from '../src/events.js';
 import { MemoryStorage } from '../src/storage/storage.js';
 import { STORAGE_KEYS } from '../src/types.js';
 import { createMockAgent, createMockIdentity } from './helpers/mock-agent.js';
-import { deriveActiveSyncScope, deriveSyncScopeFromGrants, finalizeDelegateSession, importDelegateAndSetupSync, processConnectedGrants, toSyncIdentityProtocols } from '../src/connect/lifecycle.js';
+import { deriveActiveSyncScope, deriveSyncScopeFromGrants, finalizeDelegateSession, importDelegateAndSetupSync, processConnectedGrants, registerSyncScopeForIdentity, toSyncIdentityProtocols } from '../src/connect/lifecycle.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -765,6 +765,208 @@ describe('toSyncIdentityProtocols', () => {
   test('returns the array for multi-element scopes', () => {
     expect(toSyncIdentityProtocols(['https://proto.example/a', 'https://proto.example/b']))
       .toEqual(['https://proto.example/a', 'https://proto.example/b']);
+  });
+});
+
+describe('registerSyncScopeForIdentity', () => {
+  test('delegate with scoped grants: calls registerIdentity with the right protocols', async () => {
+    const syncCalls: any[] = [];
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            buildGrantMessage('https://proto.example/chat', 'g1'),
+            buildGrantMessage('https://proto.example/notes', 'g2'),
+          ] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+      syncRegisterIdentity: async (params) => { syncCalls.push(params); },
+    });
+
+    await registerSyncScopeForIdentity({
+      userAgent    : agent,
+      connectedDid : 'did:dht:connected1',
+      delegateDid  : 'did:jwk:delegate1',
+    });
+
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].did).toBe('did:dht:connected1');
+    expect(syncCalls[0].options.delegateDid).toBe('did:jwk:delegate1');
+    expect(syncCalls[0].options.protocols).toEqual(['https://proto.example/chat', 'https://proto.example/notes']);
+  });
+
+  test('delegate with unscoped Messages.Read grant: calls registerIdentity with protocols: all', async () => {
+    const syncCalls: any[] = [];
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            buildUnscopedGrantMessage('g-unscoped'),
+          ] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+      syncRegisterIdentity: async (params) => { syncCalls.push(params); },
+    });
+
+    await registerSyncScopeForIdentity({
+      userAgent    : agent,
+      connectedDid : 'did:dht:connected1',
+      delegateDid  : 'did:jwk:delegate1',
+    });
+
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].options.delegateDid).toBe('did:jwk:delegate1');
+    expect(syncCalls[0].options.protocols).toBe('all');
+  });
+
+  test('delegate with zero grants: calls unregisterIdentity and tolerates "is not registered"', async () => {
+    const unregisterCalls: string[] = [];
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+      syncUnregisterIdentity: async (did: string) => {
+        unregisterCalls.push(did);
+        throw new Error('identity is not registered');
+      },
+    });
+
+    // Should not throw — unregister failure with "is not registered" is tolerated.
+    await registerSyncScopeForIdentity({
+      userAgent    : agent,
+      connectedDid : 'did:dht:connected1',
+      delegateDid  : 'did:jwk:delegate1',
+    });
+
+    expect(unregisterCalls).toEqual(['did:dht:connected1']);
+  });
+
+  test('delegate with zero grants: rethrows non-"not registered" errors from unregister', async () => {
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+      syncUnregisterIdentity: async () => { throw new Error('LEVEL_IO_ERROR'); },
+    });
+
+    await expect(
+      registerSyncScopeForIdentity({
+        userAgent    : agent,
+        connectedDid : 'did:dht:connected1',
+        delegateDid  : 'did:jwk:delegate1',
+      })
+    ).rejects.toThrow('LEVEL_IO_ERROR');
+  });
+
+  test('delegate already-registered: falls back to updateIdentityOptions', async () => {
+    const updateCalls: any[] = [];
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            buildGrantMessage('https://proto.example/chat', 'g1'),
+          ] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+      syncRegisterIdentity      : async () => { throw new Error('already registered'); },
+      syncUpdateIdentityOptions : async (params) => { updateCalls.push(params); },
+    });
+
+    await registerSyncScopeForIdentity({
+      userAgent    : agent,
+      connectedDid : 'did:dht:connected1',
+      delegateDid  : 'did:jwk:delegate1',
+    });
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].did).toBe('did:dht:connected1');
+    expect(updateCalls[0].options.delegateDid).toBe('did:jwk:delegate1');
+    expect(updateCalls[0].options.protocols).toContain('https://proto.example/chat');
+  });
+
+  test('delegate: rethrows non-"already registered" errors from registerIdentity', async () => {
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        if (filter?.protocolPath === 'grant') {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            buildGrantMessage('https://proto.example/chat', 'g1'),
+          ] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+      syncRegisterIdentity: async () => { throw new Error('database unavailable'); },
+    });
+
+    await expect(
+      registerSyncScopeForIdentity({
+        userAgent    : agent,
+        connectedDid : 'did:dht:connected1',
+        delegateDid  : 'did:jwk:delegate1',
+      })
+    ).rejects.toThrow('database unavailable');
+  });
+
+  test('local (no delegateDid): calls registerIdentity with protocols: all', async () => {
+    const syncCalls: any[] = [];
+    const agent = createMockAgent({
+      syncRegisterIdentity: async (params) => { syncCalls.push(params); },
+    });
+
+    await registerSyncScopeForIdentity({
+      userAgent    : agent,
+      connectedDid : 'did:dht:connected1',
+    });
+
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].did).toBe('did:dht:connected1');
+    expect(syncCalls[0].options.protocols).toBe('all');
+    // Local session — delegateDid should not be present in the options payload.
+    expect(syncCalls[0].options.delegateDid).toBeUndefined();
+  });
+
+  test('local already-registered: falls back to updateIdentityOptions', async () => {
+    const updateCalls: any[] = [];
+    const agent = createMockAgent({
+      syncRegisterIdentity      : async () => { throw new Error('already registered') ; },
+      syncUpdateIdentityOptions : async (params) => { updateCalls.push(params); },
+    });
+
+    await registerSyncScopeForIdentity({
+      userAgent    : agent,
+      connectedDid : 'did:dht:connected1',
+    });
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].did).toBe('did:dht:connected1');
+    expect(updateCalls[0].options.protocols).toBe('all');
+  });
+
+  test('local: rethrows non-"already registered" errors from registerIdentity', async () => {
+    const agent = createMockAgent({
+      syncRegisterIdentity: async () => { throw new Error('database unavailable'); },
+    });
+
+    await expect(
+      registerSyncScopeForIdentity({
+        userAgent    : agent,
+        connectedDid : 'did:dht:connected1',
+      })
+    ).rejects.toThrow('database unavailable');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #897

Wildcard "all protocols" delegate grants — a `Messages.Read` grant with `scope.protocol` omitted — were introduced in #895 (landed with `deriveSyncScopeFromGrants` / `deriveActiveSyncScope`), but a follow-up review found four gaps to close before the issue could be retired:

1. **Correctness bug** in `connect/import.ts`: `importFromPhrase` and `importFromPortable` silently skipped the zero-grant branch for delegates, leaving stale sync registrations in place if the `connectedDid` had been registered in a prior session. `restoreSession` and `importDelegateAndSetupSync` already called `unregisterIdentity` in this case — this PR aligns imports with them.
2. **Duplicated narrowing casts** (`'all' as const | ... as [string, ...string[]]`) across five sync-registration call sites. Extracted a single `toSyncIdentityProtocols()` helper.
3. **Stale docstring** on `AuthManager._deriveProtocolsFromGrants` — still described the old `string[]` return type.
4. **Test coverage gaps** for wildcard-specific edge cases: revoked wildcard grant, expired wildcard grant, mixed wildcard+scoped grants, `Messages.Subscribe`/`Messages.Sync` unscoped grant rejection, and `importFromPhrase`/`importFromPortable` wildcard + zero-grant flows.

## Changes

### Correctness

- `connect/import.ts` (`importFromPhrase`, `importFromPortable`): on zero-grant delegate, now `unregisterIdentity(connectedDid)` inside a try/catch that tolerates `"is not registered"` and rethrows other errors. Matches the pattern in `restore.ts` and `importDelegateAndSetupSync`.

### Refactor

- New exported helper in `connect/lifecycle.ts`:
  ```ts
  export function toSyncIdentityProtocols(
    scope: 'all' | string[],
  ): 'all' | [string, ...string[]] | undefined
  ```
  Returns `undefined` when the scope is empty (caller should unregister). Used across all five sync-registration call sites in `lifecycle.ts`, `restore.ts`, `import.ts`, and `auth-manager.ts`. Pure refactor, no behavior change.
- `auth-manager.ts`: updated stale JSDoc on `_deriveProtocolsFromGrants` to describe the `'all' | string[]` return and note it delegates to `deriveActiveSyncScope`.

### Tests (`packages/auth/tests/`)

Added 24 new test cases:

- **`lifecycle.spec.ts`** › `deriveSyncScopeFromGrants`: mixed wildcard+scoped (both orderings), expired wildcard, `Messages.Subscribe`/`Messages.Sync` rejection (scoped and unscoped), unscoped `Protocols.Query` and `Records.Read` rejection.
- **`lifecycle.spec.ts`** › `deriveActiveSyncScope`: revoked wildcard, expired wildcard, mixed wildcard wins.
- **`lifecycle.spec.ts`** › `importDelegateAndSetupSync`: wildcard wins with mixed grants, `Messages.Subscribe` unscoped rejection.
- **`lifecycle.spec.ts`** › `toSyncIdentityProtocols`: 4 unit tests for narrowing.
- **`import-identity.spec.ts`** › `importFromPhrase` / `importFromPortable`: 8 tests for wildcard registration, zero-grant unregister, `"is not registered"` tolerance, and I/O error rethrow.

### Changeset

- `.changeset/wildcard-delegate-grant-gaps.md` — patch bump for `@enbox/auth`.

## Test results

Local run on Bun with full test infrastructure (`docker-compose.test.yaml` up, `DID_DHT_GATEWAY_URI=http://localhost:7527`):

- `@enbox/auth`: **464 pass / 0 fail** (920 `expect()` calls, 20 files)
- `@enbox/agent` (smoke): **1498 pass / 10 skip / 0 fail** (3628 `expect()` calls, 52 files)
- `bun run lint`: clean (15/15 tasks)
- `bun run --filter @enbox/auth build`: clean (tsc 0)

## Scope

Out of scope for this PR (and #897):

- Public API to *request* a wildcard grant from a wallet (the current `createPermissionRequestForProtocol` always sets `protocol`). Consumers that want to issue an unscoped `Messages.Read` grant must construct the scope manually today. Worth a follow-up if the product needs it surfaced.

## Related

- Follow-up from #895 (`feat(agent,auth): require explicit protocol scope for sync registration`)
- Builds on #867 (`fix(auth): exclude permissions protocol from delegate sync targets`) — note: a wildcard delegate intentionally *does* sync the owner's permissions-protocol records, which is the desired "full replica" behavior.
