### PR TITLE
docs: expand CLAUDE.md and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# Agent guide — Enbox monorepo
+
+This file orients automated agents and new contributors: **what the repo is**, **how packages relate**, and **where to look first**. For exhaustive commands (tests, Docker services, migrations, AWS, docs), use **`CLAUDE.md`** at the repo root as the single source of truth.
+
+## What this repository is
+
+Enbox is a **Bun** monorepo for **Decentralized Web Nodes (DWN)**, **DIDs** (`did:dht`, `did:jwk`), and **application SDKs**. It contains:
+
+- A spec-aligned **DWN engine** (`@enbox/dwn-sdk-js`) and **SQL-backed stores** (`@enbox/dwn-sql-store`).
+- A production-style **DWN server** (`@enbox/dwn-server`) with HTTP/WebSocket APIs, registration, and admin features.
+- **Client libraries**: low-level DWN clients (`@enbox/dwn-clients`), an **agent** with encrypted vault and DWN-backed stores (`@enbox/agent`), **headless auth** (`@enbox/auth`), a **high-level SDK** (`@enbox/api`), and **browser helpers** (`@enbox/browser`).
+- **Shared protocol definitions** (`@enbox/protocols`) and optional **codegen** (`@enbox/protocol-codegen`).
+- **`apps/docs`**: the public documentation site (Fumadocs + Next.js); it uses its own linter (Biome), not the ESLint graph used by packages.
+
+## Non-negotiable rule (tests vs production)
+
+**Never weaken production code only to satisfy tests.** If a test fails because mocks are wrong, fix the test or the stub — see the “Inviolable Rules” section in `CLAUDE.md`.
+
+## Workspace layout
+
+Published / primary packages live under `packages/`. Root `package.json` lists all **workspace members**; `examples/` holds Vite sample apps that are **not** workspace packages.
+
+| Package | One-line role |
+|---|---|
+| `@enbox/common` | Shared utilities, caches, LevelDB helpers |
+| `@enbox/crypto` | Cryptographic primitives and JWE |
+| `@enbox/dids` | DID creation, resolution, `did:dht` (Pkarr gateway required for tests) |
+| `@enbox/dwn-sdk-js` | DWN protocol implementation (style reference for TS/ESLint) |
+| `@enbox/dwn-sql-store` | SQL MessageStore/DataStore/StateIndex + **DWN** Kysely migrations |
+| `@enbox/dwn-clients` | DWN JSON-RPC / client transport |
+| `@enbox/dwn-server` | Runnable DWN server; **server** Kysely migrations separate from DWN store migrations |
+| `@enbox/agent` | `EnboxUserAgent`, vault, DWN data stores, sync |
+| `@enbox/auth` | `AuthManager`, sessions, password/connect flows, storage adapters |
+| `@enbox/api` | App-facing SDK; composes agent + auth |
+| `@enbox/browser` | Browser connect handlers and DWeb wiring (builds on agent, api, auth) |
+| `@enbox/protocols` | Reusable protocol definitions for the ecosystem |
+| `@enbox/protocol-codegen` | CLI to generate TS from schemas / protocols |
+| `@enbox/dwn-server-admin-ui` | Admin UI bundle consumed by the server |
+| `@enbox/electrobun-dwn` | **Private** desktop wrapper embedding the server |
+
+**Dependency direction (high level):** `common` → `crypto` → `dids` → `dwn-sdk-js` → (`dwn-sql-store`, `dwn-clients`) → `agent` → `auth` → `api`; `protocols` builds on `api` + `dwn-sdk-js`; `browser` sits above `agent`/`api`/`auth`; `dwn-server` combines `dwn-sdk-js`, `dwn-sql-store`, and `dwn-clients`. Exact edges are in each package’s `package.json` (`workspace:*`).
+
+## How apps use Enbox in practice
+
+Downstream repos typically consume **npm releases** of scoped `@enbox/*` packages (not the monorepo path directly).
+
+- **web-wallet** (package `@enbox/dweb-wallet`): Full stack — `agent`, `api`, `auth`, `browser`, `dwn-clients`, `protocols`, plus crypto/dids/common. Typical pattern: Vite + React, PWA, node stdlib browser shims, Vitest/Playwright.
+- **nutsd** (package `@enbox/nutsd`): Narrower surface — e.g. **`@enbox/browser`** (and Cashu) for wallet/DID UX without pulling the full DWN server stack into the app bundle.
+
+When changing public APIs, assume **multiple external apps** pin different semver ranges; follow the changeset workflow in `CLAUDE.md` for releases.
+
+## What to run before proposing a PR
+
+Minimum bar (from `CLAUDE.md`): **`bun run lint`**, **`bun run --filter @enbox/agent build`** (rebuild `dwn-sdk-js` first if you touched it), and **agent tests** with **`DID_DHT_GATEWAY_URI`** set. Full verification uses Docker test services and often a local DWN on port 3000 — details are in `CLAUDE.md` (“Local Test Infrastructure”).
+
+Turbo runs `test:node` only after upstream packages in the graph **`build`**, which matches how CI discovers type errors.
+
+## Where to make common kinds of changes
+
+| Goal | Likely packages / paths |
+|---|---|
+| DWN protocol, message handlers, in-memory stores | `packages/dwn-sdk-js/` |
+| Postgres/MySQL/SQLite persistence, DWN schema migrations | `packages/dwn-sql-store/src/migrations/` |
+| HTTP API, tenant registration, server-only tables | `packages/dwn-server/` (+ server migrations) |
+| Agent vault, DWN-backed stores, sync | `packages/agent/src/` |
+| Login/session/connect, `AuthManager` | `packages/auth/src/` |
+| High-level APIs for apps | `packages/api/src/` |
+| `dwn://` discovery, browser connect | `packages/browser/src/`, `packages/auth/src/discovery.ts` |
+| Shared protocol definitions | `packages/protocols/` |
+| Docs site content | `apps/docs/content/docs/` |
+
+## Cryptography and protocols (mental model)
+
+- **Vault (Layer 1):** BIP-39 + password-encrypted agent material (`HdIdentityVault` in agent).
+- **DWN records (Layer 2):** JWE with X25519 key agreement when `encryptionRequired` is set on protocol types; `$encryption` injected at protocol install.
+
+See `CLAUDE.md` → “Architecture Notes” for store inheritance and tenant vs agent DID.
+
+## Releases
+
+Packages publish via **Changesets**; do **not** hand-edit `version` fields for releases. Never run `changeset version` locally to consume changesets — CI owns that. See `CLAUDE.md` → “Releasing & Publishing Packages”.
+
+## Related infrastructure
+
+- **Pkarr / DHT gateway** for `did:dht` tests: `docker-compose.test.yaml` (documented in `CLAUDE.md`).
+- **Hosted DWN** (AWS): `infra/` and the deployment section in `CLAUDE.md`.
+- **dwn-relay** is a **separate** repository (`enboxorg/dwn-relay`), not this monorepo.
+
+---
+
+For command snippets, coverage expectations, ESLint/import rules, test harness patterns, and SQL migration conventions, read **`CLAUDE.md`**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ When changing public APIs, assume **multiple external apps** pin different semve
 
 Minimum bar (from `CLAUDE.md`): **`bun run lint`**, **`bun run --filter @enbox/agent build`** (rebuild `dwn-sdk-js` first if you touched it), and **agent tests** with **`DID_DHT_GATEWAY_URI`** set. Full verification uses Docker test services and often a local DWN on port 3000 — details are in `CLAUDE.md` (“Local Test Infrastructure”).
 
-Turbo runs `test:node` only after upstream packages in the graph **`build`**, which matches how CI discovers type errors.
+In `turbo.json`, **`test:node`** declares `dependsOn: ["^build"]`, so it runs only after upstream workspace packages **`build`**. **`lint`** / **`lint:fix`** do not use that dependency — they are scheduled without an automatic `^build` first. Root **`turbo run test:node`** skips **`@enbox/dwn-sql-store`** because that package only defines **`test`**; run `bun run --filter @enbox/dwn-sql-store test` when you need its suite.
 
 ## Where to make common kinds of changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,18 @@ Enbox is a **Bun** monorepo for **Decentralized Web Nodes (DWN)**, **DIDs** (`di
 - **Shared protocol definitions** (`@enbox/protocols`) and optional **codegen** (`@enbox/protocol-codegen`).
 - **`apps/docs`**: the public documentation site (Fumadocs + Next.js); it uses its own linter (Biome), not the ESLint graph used by packages.
 
-## Non-negotiable rule (tests vs production)
+## Non-negotiable rules
 
-**Never weaken production code only to satisfy tests.** If a test fails because mocks are wrong, fix the test or the stub — see the “Inviolable Rules” section in `CLAUDE.md`.
+1. **Never weaken production code only to satisfy tests.** If a test fails because mocks are wrong, fix the test or the stub — see the “Inviolable Rules” section in `CLAUDE.md`.
+2. **Always work in a fresh worktree off the latest base branch** (default `main`, or whichever branch the user names). Never do long-running work on the primary clone, and never force-push shared branches.
+   ```bash
+   git fetch origin
+   git worktree add ../enbox-<task> -b <type>/<short-desc> origin/main
+   ```
+3. **Ship through a PR.** `main` is protected — every change (including doc-only ones) goes through `gh pr create` against the requested base. Use conventional commit titles (`fix(...)`, `feat(...)`, `docs: ...`, `chore(deps): ...`) matching the existing log.
+4. **Watch CI until it is green.** `gh pr checks <N> --watch`, `gh run view <id> --log-failed`. If CI fails, reproduce locally, fix forward in the same PR, and never merge with known failures or disable checks to unblock. Treat Quality Gate / coverage regressions as failures.
+5. **Style is non-negotiable.** Run `bun run lint` (and `bun run lint:fix`) before pushing. Match the conventions in `CLAUDE.md` → “Coding Style” and “Test Style”: type-import grouping, colon alignment in multi-key object literals, explicit return types and visibility, `.js` extensions on relative imports, kebab-case filenames, `.spec.ts` tests.
+6. **`@enbox/dwn-sdk-js` is the gold-standard package.** When a convention is ambiguous (errors, JSDoc, module layout, test shape, JSON Schema placement), follow `dwn-sdk-js` rather than any other package.
 
 ## Workspace layout
 
@@ -38,7 +47,15 @@ Published / primary packages live under `packages/`. Root `package.json` lists a
 | `@enbox/dwn-server-admin-ui` | Admin UI bundle consumed by the server |
 | `@enbox/electrobun-dwn` | **Private** desktop wrapper embedding the server |
 
-**Dependency direction (high level):** `common` → `crypto` → `dids` → `dwn-sdk-js` → (`dwn-sql-store`, `dwn-clients`) → `agent` → `auth` → `api`; `protocols` builds on `api` + `dwn-sdk-js`; `browser` sits above `agent`/`api`/`auth`; `dwn-server` combines `dwn-sdk-js`, `dwn-sql-store`, and `dwn-clients`. Exact edges are in each package’s `package.json` (`workspace:*`).
+**Dependency direction (high level):**
+
+- Core chain: `common` → `crypto` → `dids` → `dwn-sdk-js` → `dwn-clients` → `agent` → `auth` → `api`.
+- Server chain: `dwn-sdk-js` → `dwn-sql-store` → `dwn-server` (which also consumes `dwn-clients`).
+- `protocols` builds on `api` + `dwn-sdk-js`.
+- `browser` sits above `agent` + `api` + `auth` + `dids`; it does **not** pull in `dwn-server` or `dwn-sql-store`.
+- `agent` does **not** depend on `dwn-sql-store` — only `dwn-server` does. Agents talk to a DWN over `dwn-clients`.
+
+Exact edges live in each package’s `package.json` (`workspace:*`).
 
 ## How apps use Enbox in practice
 
@@ -47,7 +64,7 @@ Downstream repos typically consume **npm releases** of scoped `@enbox/*` package
 - **web-wallet** (package `@enbox/dweb-wallet`): Full stack — `agent`, `api`, `auth`, `browser`, `dwn-clients`, `protocols`, plus crypto/dids/common. Typical pattern: Vite + React, PWA, node stdlib browser shims, Vitest/Playwright.
 - **nutsd** (package `@enbox/nutsd`): Narrower surface — e.g. **`@enbox/browser`** (and Cashu) for wallet/DID UX without pulling the full DWN server stack into the app bundle.
 
-When changing public APIs, assume **multiple external apps** pin different semver ranges; follow the changeset workflow in `CLAUDE.md` for releases.
+When changing public APIs, assume **multiple external apps** pin different semver ranges; follow the changeset workflow in `CLAUDE.md` for releases. `.changeset/config.json` sets `updateInternalDependencies: "patch"`, so bumping one package (e.g. `dwn-sdk-js` as `minor`) auto-patches every direct consumer in the graph — keep that in mind when drafting changeset files.
 
 ## What to run before proposing a PR
 

--- a/BRANCH_PROTECTION_SETUP.md
+++ b/BRANCH_PROTECTION_SETUP.md
@@ -22,8 +22,28 @@ To ensure that all tests pass and coverage doesn't decrease before merging to ma
 - **Require branches to be up to date before merging**
 
 #### Required Status Checks
-Add these checks (they must run at least once before appearing in the list):
-1. `CI / CI Passed`
+Add **exactly one** check (it must have run at least once on the branch before appearing in the list):
+
+1. `CI Passed`
+
+> **Do not add `Lint`, `Build`, `SonarCloud Code Analysis`, or any individual CI job as a required check.**
+>
+> The CI workflow is designed so that `CI Passed` is the single umbrella gate (see `ci.yml` → `ci-passed` job). It aggregates every sub-job and correctly handles both real runs and skipped runs:
+>
+> - On doc-only PRs, `Detect Changes` returns `src=false`. `lint`, `build`, `coverage-*`, and `sonarcloud` are legitimately **skipped**, and `CI Passed` still reports success.
+> - On code PRs, `ci-passed` explicitly fails if any required sub-job (lint, build, tests, coverage, SonarCloud quality gate) reports failure.
+>
+> If you require `Lint` or `Build` directly, GitHub treats `SKIPPED` as "not passing" and blocks every doc-only PR forever. Worse, `SonarCloud Code Analysis` is a status posted by the **SonarCloud GitHub App** — it is never posted at all when the scan job is skipped, so any PR that skips the scan (docs-only, or when `SONAR_PROJECT_KEY`/`SONAR_ORG` are unset) will be stuck in a permanent pending state.
+>
+> The canonical required-checks list for this repo is therefore:
+>
+> ```
+> [
+>   { "context": "CI Passed", "integration_id": 15368 }
+> ]
+> ```
+>
+> (`integration_id: 15368` pins the check to the GitHub Actions app, preventing a third party from spoofing the status context.)
 
 ### Additional Settings
 - **Require conversation resolution before merging**
@@ -80,3 +100,25 @@ threshold=90
 ### Low coverage numbers locally
 - Verify test infrastructure is running (Docker containers for Pkarr, Postgres, MySQL)
 - See `CLAUDE.md` "Local Test Infrastructure" section for setup instructions
+
+### A doc-only PR is stuck on `Expected — Waiting for status to be reported`
+This means the branch-protection rule lists a check that the CI workflow skipped (most commonly `Lint`, `Build`, or `SonarCloud Code Analysis`). Remove those from the required-checks list and keep only `CI Passed`. Inspect and repair the active ruleset with:
+
+```bash
+# List active rulesets and their IDs
+gh api repos/enboxorg/enbox/rulesets --jq '.[] | {id, name, enforcement}'
+
+# Inspect the current required checks for a ruleset
+gh api repos/enboxorg/enbox/rulesets/<ID> \
+  --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks'
+
+# Update the ruleset so only `CI Passed` is required
+gh api repos/enboxorg/enbox/rulesets/<ID> > /tmp/ruleset.json
+jq '{
+  name, target, enforcement, bypass_actors, conditions,
+  rules: [.rules[] | if .type=="required_status_checks" then
+    .parameters.required_status_checks = [{context:"CI Passed", integration_id:15368}]
+  else . end]
+}' /tmp/ruleset.json > /tmp/ruleset-updated.json
+gh api --method PUT repos/enboxorg/enbox/rulesets/<ID> --input /tmp/ruleset-updated.json
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,13 +79,17 @@ Code style in this repo is **strictly enforced** and routinely corrects drift. A
 
 Bun workspace monorepo for decentralized web infrastructure. Runtime is **Bun** (>=1.0.0). The repo root pins a **`packageManager`** field (see root `package.json`) so local Bun matches CI and lockfile expectations.
 
-**Task orchestration:** `bun run build`, `bun run lint`, and `bun run test:node` at the repo root invoke **Turbo** (`turbo.json`, pinned to `turbo@2.8.13` in root `devDependencies`). `build`, `lint`, `lint:fix`, and `test:node` all declare `dependsOn: ["^build"]`, so dependents build before their tasks run. `test:node` sets `cache: false` (runs are never cached); `build` declares `outputs: ["dist/**"]`.
+**Task orchestration:** `bun run build`, `bun run lint`, and `bun run test:node` at the repo root invoke **Turbo** (`turbo.json`, pinned to `turbo@2.8.13` in root `devDependencies`):
+
+- **`build`:** `dependsOn: ["^build"]`, `outputs: ["dist/**"]` — each package builds after its workspace dependencies.
+- **`test:node`:** `dependsOn: ["^build"]`, `cache: false` — tests run after upstream packages in the graph have built (matches CI type-check expectations).
+- **`lint` / `lint:fix`:** no `dependsOn` in `turbo.json` — they do **not** automatically run `^build` first. If a package’s ESLint setup assumes fresh `dist/` (rare), run `bun run build` before `bun run lint`.
 
 Root filter semantics:
 
 - `bun run build` excludes `@enbox/docs` (uses Biome/Next.js) **and** `@enbox/electrobun-dwn` (private desktop shell). Build `electrobun-dwn` explicitly with `bun run --filter @enbox/electrobun-dwn build` when working on it.
 - `bun run lint` / `lint:fix` exclude only `@enbox/docs`.
-- `bun run test:node` excludes only `@enbox/docs`. Note that `@enbox/dwn-sql-store` and `@enbox/dwn-server` name their suite `test` (not `test:node`), so they are skipped by the root `test:node` task. Run them directly: `bun run --filter @enbox/dwn-sql-store test`, `bun run --filter @enbox/dwn-server test`.
+- `bun run test:node` excludes only `@enbox/docs`. Turbo schedules `test:node` only in packages that **define** that script. **`@enbox/dwn-sql-store`** exposes **`test`** but not **`test:node`**, so it is omitted from root `turbo run test:node` — run `bun run --filter @enbox/dwn-sql-store test`. **`@enbox/dwn-server`** **does** define **`test:node`** and is included. **`@enbox/dwn-server-admin-ui`** defines a no-op **`test:node`** stub; **`@enbox/electrobun-dwn`** has no **`test:node`** script.
 
 ### Package Dependency Graph (build order)
 
@@ -183,7 +187,7 @@ gh api repos/enboxorg/enbox/pulls/<PR_NUMBER> -X PATCH -F body=@pr-body.md
 
 ### Running Tests
 
-All packages use **`bun test`** (Bun's native test runner).
+Most packages use **`bun test`** (Bun’s native test runner). **`@enbox/browser`** uses **Vitest** with the browser runner instead (see table below).
 
 #### Test framework by package
 
@@ -192,8 +196,8 @@ All packages use **`bun test`** (Bun's native test runner).
 | `@enbox/agent` | `bun test` | `bun run test:node` |
 | `@enbox/api` | `bun test` | `bun run test:node` |
 | `@enbox/dwn-sdk-js` | `bun test` | `bun run test:node` |
-| `@enbox/dwn-server` | `bun test` | `bun run test` |
-| `@enbox/dwn-sql-store` | `bun test` | `bun run test` |
+| `@enbox/dwn-server` | `bun test` | `bun run test:node` |
+| `@enbox/dwn-sql-store` | `bun test` | `bun run test` (no `test:node` script — not in root `turbo run test:node`) |
 | `@enbox/common` | `bun test` | `bun run test:node` |
 | `@enbox/crypto` | `bun test` | `bun run test:node` |
 | `@enbox/dids` | `bun test` | `bun run test:node` |
@@ -295,8 +299,11 @@ export DID_DHT_GATEWAY_URI=http://localhost:7527
 # Now run tests — these will all pass:
 bun run --filter @enbox/agent test:node       # 748 pass, 0 fail
 bun run --filter @enbox/api test:node         # all pass
+bun run --filter @enbox/auth test:node        # all pass (same Pkarr env)
 bun run --filter @enbox/dids test:node        # all pass
 bun run --filter @enbox/dwn-sdk-js test:node  # 978 pass, 0 fail
+bun run --filter @enbox/dwn-server test:node  # set NATS_URL for NatsEventLog tests
+bun run --filter @enbox/dwn-sql-store test    # script is named `test`, not `test:node`
 ```
 
 Alternatively, `./scripts/test-with-server.sh` automates the full cycle (start containers, build, run tests, tear down). If `did:dht` tests fail with `Failed to put Pkarr record`, the relay is not running.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,21 +10,36 @@ If a test fails because new production code interacts badly with a stubbed envir
 
 ## Monorepo Overview
 
-Bun workspace monorepo for decentralized web infrastructure. Runtime is **Bun** (>=1.0.0).
+Bun workspace monorepo for decentralized web infrastructure. Runtime is **Bun** (>=1.0.0). The repo root pins a **`packageManager`** field (see root `package.json`) so local Bun matches CI and lockfile expectations.
+
+**Task orchestration:** `bun run build`, `bun run lint`, and `bun run test:node` at the repo root invoke **Turbo** (`turbo.json`). Package `test:node` tasks declare `dependsOn: ["^build"]`, so dependents build before tests. Root scripts exclude `@enbox/docs` (Biome/Next.js) and `@enbox/electrobun-dwn` from the default `build` graph; build `electrobun-dwn` explicitly when working on that package.
 
 ### Package Dependency Graph (build order)
 
+Core stack (simplified — follow `workspace:*` in each `package.json` for exact edges):
+
 ```
-@enbox/common          (shared utilities, TtlCache, LevelStore)
-  @enbox/crypto        (Ed25519, X25519, secp256k1, AES, JWE)
-    @enbox/dids        (did:dht, did:jwk, resolution)
-      @enbox/dwn-sdk-js  (DWN protocol engine, message handlers, stores)
-        @enbox/agent     (agent framework: identity, key management, DWN stores, sync)
-          @enbox/api     (high-level SDK for apps)
-      @enbox/dwn-sql-store (SQL-backed DWN storage)
-        @enbox/dwn-server  (HTTP/WS DWN server)
-    @enbox/browser     (browser-specific DID tools)
+@enbox/common (TtlCache, LevelStore, shared utilities)
+  @enbox/crypto (Ed25519, X25519, secp256k1, AES, JWE)
+    @enbox/dids (did:dht, did:jwk, resolution)
+      @enbox/dwn-sdk-js (DWN protocol engine, handlers, in-memory stores, JSON Schemas)
+        @enbox/dwn-sql-store (Postgres/MySQL/SQLite DWN stores, Kysely migrations)
+          @enbox/dwn-server (HTTP/WebSocket DWN server, registration, admin API)
+        @enbox/dwn-clients (DWN JSON-RPC / transport clients — depends on dwn-sdk-js)
+        @enbox/agent (identity vault, DWN-backed stores, sync — uses dwn-clients)
+        @enbox/auth (AuthManager, sessions, connect flows — uses agent + dwn-clients)
+        @enbox/api (high-level app SDK — uses agent + auth + dwn-clients)
+        @enbox/protocols (published protocol definitions — uses api + dwn-sdk-js)
+      @enbox/browser (BrowserConnectHandler, DWeb connect UI helpers — uses agent, api, auth, dids)
 ```
+
+**Tooling / UI packages (not in the core server graph above):**
+
+| Package | Role |
+|---|---|
+| `@enbox/protocol-codegen` | CLI (`protocol-codegen`) — TypeScript types from protocol definitions / JSON Schema |
+| `@enbox/dwn-server-admin-ui` | Bundled Preact admin UI assets for the server |
+| `@enbox/electrobun-dwn` | **Private** — Electrobun desktop shell that embeds `@enbox/dwn-server` for a local DWN |
 
 Build from the bottom up. If you change `dwn-sdk-js`, rebuild it before building `agent`:
 
@@ -32,6 +47,8 @@ Build from the bottom up. If you change `dwn-sdk-js`, rebuild it before building
 bun run --filter @enbox/dwn-sdk-js build
 bun run --filter @enbox/agent build
 ```
+
+`@enbox/agent` and `@enbox/api` also run a **`build:browser`** step (bundled `browser.mjs` entry) for browser bundlers; run full `build` in those packages when changing browser-facing exports.
 
 ### Key Directories
 
@@ -47,6 +64,13 @@ bun run --filter @enbox/agent build
 | `packages/agent/src/test-harness.ts` | `PlatformAgentTestHarness` — test infrastructure (exported as public API) |
 | `packages/dwn-sdk-js/src/` | DWN SDK source (gold-standard for style) |
 | `packages/dwn-sdk-js/json-schemas/` | JSON Schema definitions for DWN messages |
+| `packages/dwn-clients/src/` | DWN client transport / JSON-RPC |
+| `packages/auth/src/` | `AuthManager`, storage adapters, connect and discovery helpers |
+| `packages/protocols/src/` | Shared protocol definitions consumed by apps |
+| `packages/protocol-codegen/src/` | Codegen CLI implementation |
+| `packages/dwn-server-admin-ui/` | Admin UI bundle source and build scripts |
+| `packages/electrobun-dwn/` | Electrobun-embedded local DWN (private package) |
+| `examples/dapp-demo/`, `examples/web-wallet/` | Sample Vite apps (not workspace members; link or copy local packages as needed) |
 | `apps/docs/` | Documentation site (Fumadocs + Next.js, deployed to Cloudflare Pages) |
 | `apps/docs/content/docs/` | MDX content (guides + API reference) |
 | `apps/docs/src/` | Next.js app source (layouts, components, styles) |
@@ -87,10 +111,15 @@ All packages use **`bun test`** (Bun's native test runner).
 | `@enbox/common` | `bun test` | `bun run test:node` |
 | `@enbox/crypto` | `bun test` | `bun run test:node` |
 | `@enbox/dids` | `bun test` | `bun run test:node` |
+| `@enbox/auth` | `bun test` | `bun run test:node` |
+| `@enbox/dwn-clients` | `bun test` | `bun run test:node` |
+| `@enbox/protocols` | `bun test` | `bun run test:node` |
+| `@enbox/protocol-codegen` | `bun test` | `bun run test:node` |
+| `@enbox/browser` | `bun test` / Vitest | `bun run test:node` (subset); `bun run test:browser` for browser tests |
 
-#### Agent / API tests (bun:test)
+#### Agent / API / Auth tests (bun:test)
 
-**Important:** Always set `DID_DHT_GATEWAY_URI` before running agent or API tests. Without it, ~115 agent tests and ~23 API tests will fail with Pkarr errors.
+**Important:** Always set `DID_DHT_GATEWAY_URI` before running **agent**, **api**, or **auth** tests. Without it, a large subset of tests will fail with Pkarr / `did:dht` publishing errors.
 
 ```bash
 export DID_DHT_GATEWAY_URI=http://localhost:7527
@@ -136,7 +165,7 @@ export DID_DHT_GATEWAY_URI=http://localhost:7527
 export NATS_URL=nats://localhost:4222
 ```
 
-Without `DID_DHT_GATEWAY_URI`, tests in `agent` (~115 tests), `api` (~23 tests), and `dids` (~1 test) will fail with `DidError: internalError: Failed to put Pkarr record`. These are NOT real test failures — the tests are correct, they just need the gateway.
+Without `DID_DHT_GATEWAY_URI`, tests in `agent`, `api`, `auth`, and `dids` that publish `did:dht` will fail with `DidError: internalError: Failed to put Pkarr record`. These are NOT real test failures — the tests are correct, they just need the gateway.
 
 ### Services provided by `docker-compose.test.yaml`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,84 @@ Production code must NEVER be weakened, loosened, or given special-case handling
 
 If a test fails because new production code interacts badly with a stubbed environment, the fix belongs **entirely in the test**: update the stubs to properly simulate reality, or stub the new production method directly on the handler/class instance. The production code path must remain exactly as strict as the real-world scenario demands.
 
+## Contributor Workflow
+
+The workflow below is non-optional. Follow it for every change, no matter how small.
+
+### 1. Always work in a fresh worktree off the latest base branch
+
+Never run destructive operations (rebase, force-push, branch reset) on the repo's main clone — use a dedicated worktree per task so your in-flight work is always isolated. Default base branch is **`main`** unless the user explicitly requests another branch.
+
+```bash
+cd /path/to/enbox            # the main clone
+git fetch origin             # always refresh first
+git worktree add ../enbox-<short-task-name> -b <type>/<short-desc> origin/main
+cd ../enbox-<short-task-name>
+bun install                  # first-time per worktree
+```
+
+If the user nominates a different base (`release/x.y`, a feature integration branch, etc.), substitute it for `origin/main` above. When the task is done and merged, clean up:
+
+```bash
+git worktree remove ../enbox-<short-task-name>
+git branch -d <type>/<short-desc>   # only after the PR is merged
+```
+
+Branch naming follows the existing convention in `git log`: `fix/...`, `feat/...`, `chore/...`, `docs/...`, `perf/...`. Keep it concise.
+
+### 2. Open a PR — do not push to `main`
+
+`main` is protected (see `BRANCH_PROTECTION_SETUP.md`). Every change — including doc-only updates and one-line fixes — goes through a pull request:
+
+1. Commit with a conventional message (`<type>(<scope>): <summary>`) matching the log (e.g. `fix(agent): …`, `feat(auth): …`, `docs: …`, `chore(deps): …`).
+2. Push your branch to `origin` (never force-push shared branches).
+3. Open the PR against the requested base branch (default `main`) with `gh pr create`.
+4. Keep the PR description tight: **Summary**, **Test plan** (checklist), and any migration/rollout notes.
+
+See “GitHub CLI (`gh`) — use REST API for mutations” below for the known `gh pr edit --body` gotcha.
+
+### 3. Verify CI — never walk away from a red pipeline
+
+Opening a PR is not the end of the job. Watch CI through to green:
+
+```bash
+gh pr checks <PR_NUMBER> --watch        # live tail until all checks finish
+gh run view <run-id> --log-failed       # inspect a failed workflow
+gh pr view <PR_NUMBER> --json statusCheckRollup
+```
+
+If CI fails:
+
+- **Reproduce locally first.** Match the failing command (lint, build, `test:node`, coverage, docs build, deploy) exactly. CI log paths map 1:1 to the `scripts/` and root `package.json` entries.
+- **Fix forward in the same PR** — do not merge with known failures and do not disable checks.
+- **Transient failures:** re-run with `gh run rerun <run-id> --failed` only after you’ve confirmed the failure is genuinely environmental (e.g. registry flake). Document the rationale in a PR comment; never silently re-run to mask a real bug.
+- **Quality Gate (SonarCloud) / coverage regressions** count as CI failures — address them, don’t override.
+
+Merging the PR is the final step of the task, not opening it.
+
+### 4. Style matters — match the codebase, not your preference
+
+Code style in this repo is **strictly enforced** and routinely corrects drift. Always:
+
+- Run `bun run lint` locally before pushing; run `bun run lint:fix` to auto-fix the fixable subset. The shared flat config (`eslint.config.cjs`) is the source of truth for every package except `apps/docs` (Biome).
+- Follow the conventions in the [Coding Style](#coding-style) and [Test Style](#test-style) sections below: type-import grouping, colon alignment in multi-key object literals, explicit return types and visibility modifiers, `.js` extensions on relative imports, kebab-case files, `.spec.ts` tests, etc.
+- Read the diff you’re producing. Style drift in a PR (inconsistent quote style, stray `any`, unsorted imports, missing return types) is the single most common reason PRs get bounced. ESLint catches most of it; a careful human review catches the rest.
+
+### 5. When in doubt, read `dwn-sdk-js`
+
+`@enbox/dwn-sdk-js` is the **gold-standard package** in this monorepo — the oldest, the most reviewed, and the template every other package is measured against for both style and structure. When a convention is ambiguous (error types, JSDoc density, module layout, test shape, `DwnError` + `DwnErrorCode`, JSON Schema organization, `todo-plz` usage), **follow `dwn-sdk-js`** rather than whatever another package happens to do.
+
 ## Monorepo Overview
 
 Bun workspace monorepo for decentralized web infrastructure. Runtime is **Bun** (>=1.0.0). The repo root pins a **`packageManager`** field (see root `package.json`) so local Bun matches CI and lockfile expectations.
 
-**Task orchestration:** `bun run build`, `bun run lint`, and `bun run test:node` at the repo root invoke **Turbo** (`turbo.json`). Package `test:node` tasks declare `dependsOn: ["^build"]`, so dependents build before tests. Root scripts exclude `@enbox/docs` (Biome/Next.js) and `@enbox/electrobun-dwn` from the default `build` graph; build `electrobun-dwn` explicitly when working on that package.
+**Task orchestration:** `bun run build`, `bun run lint`, and `bun run test:node` at the repo root invoke **Turbo** (`turbo.json`, pinned to `turbo@2.8.13` in root `devDependencies`). `build`, `lint`, `lint:fix`, and `test:node` all declare `dependsOn: ["^build"]`, so dependents build before their tasks run. `test:node` sets `cache: false` (runs are never cached); `build` declares `outputs: ["dist/**"]`.
+
+Root filter semantics:
+
+- `bun run build` excludes `@enbox/docs` (uses Biome/Next.js) **and** `@enbox/electrobun-dwn` (private desktop shell). Build `electrobun-dwn` explicitly with `bun run --filter @enbox/electrobun-dwn build` when working on it.
+- `bun run lint` / `lint:fix` exclude only `@enbox/docs`.
+- `bun run test:node` excludes only `@enbox/docs`. Note that `@enbox/dwn-sql-store` and `@enbox/dwn-server` name their suite `test` (not `test:node`), so they are skipped by the root `test:node` task. Run them directly: `bun run --filter @enbox/dwn-sql-store test`, `bun run --filter @enbox/dwn-server test`.
 
 ### Package Dependency Graph (build order)
 
@@ -24,14 +97,20 @@ Core stack (simplified — follow `workspace:*` in each `package.json` for exact
     @enbox/dids (did:dht, did:jwk, resolution)
       @enbox/dwn-sdk-js (DWN protocol engine, handlers, in-memory stores, JSON Schemas)
         @enbox/dwn-sql-store (Postgres/MySQL/SQLite DWN stores, Kysely migrations)
-          @enbox/dwn-server (HTTP/WebSocket DWN server, registration, admin API)
-        @enbox/dwn-clients (DWN JSON-RPC / transport clients — depends on dwn-sdk-js)
-        @enbox/agent (identity vault, DWN-backed stores, sync — uses dwn-clients)
-        @enbox/auth (AuthManager, sessions, connect flows — uses agent + dwn-clients)
-        @enbox/api (high-level app SDK — uses agent + auth + dwn-clients)
-        @enbox/protocols (published protocol definitions — uses api + dwn-sdk-js)
-      @enbox/browser (BrowserConnectHandler, DWeb connect UI helpers — uses agent, api, auth, dids)
+        @enbox/dwn-clients (DWN JSON-RPC / transport clients)
+          @enbox/dwn-server (HTTP/WebSocket DWN server, registration, admin API — uses dwn-sdk-js + dwn-sql-store + dwn-clients)
+          @enbox/agent (identity vault, DWN-backed stores, sync — uses dwn-sdk-js + dwn-clients)
+            @enbox/auth (AuthManager, sessions, connect flows — uses agent + dwn-sdk-js + dwn-clients)
+              @enbox/api (high-level app SDK — uses agent + auth + dwn-clients)
+                @enbox/protocols (published protocol definitions — uses api + dwn-sdk-js)
+                @enbox/browser (BrowserConnectHandler, DWeb connect UI helpers — uses agent + api + auth + dids)
 ```
+
+Notes on the graph:
+
+- `@enbox/agent` does **not** depend on `@enbox/dwn-sql-store`; only `@enbox/dwn-server` does. The agent talks to a DWN over `@enbox/dwn-clients`.
+- `@enbox/auth` depends directly on `@enbox/agent`, `@enbox/dwn-sdk-js`, and `@enbox/dwn-clients` (plus `common`/`crypto`/`dids`).
+- `@enbox/browser` composes `agent` + `api` + `auth` + `dids`; it does not pull in `dwn-server` or `dwn-sql-store`.
 
 **Tooling / UI packages (not in the core server graph above):**
 
@@ -48,7 +127,11 @@ bun run --filter @enbox/dwn-sdk-js build
 bun run --filter @enbox/agent build
 ```
 
-`@enbox/agent` and `@enbox/api` also run a **`build:browser`** step (bundled `browser.mjs` entry) for browser bundlers; run full `build` in those packages when changing browser-facing exports.
+Most packages expose a `build:browser` script, but it means different things:
+
+- **`@enbox/agent`** and **`@enbox/api`** emit a bundled `dist/browser.mjs` via `build/browser-bundle.js` (esbuild) with node-stdlib shims (`--node-shims`). Run their full `build` after changing browser-facing exports.
+- **`@enbox/common`**, **`@enbox/crypto`**, **`@enbox/dids`**, **`@enbox/dwn-sdk-js`**, and **`@enbox/browser`** expose `build:browser` as a pass-through (often aliased to `build:esm`); there is no separate browser bundle artifact.
+- **`@enbox/auth`**, **`@enbox/dwn-clients`**, **`@enbox/dwn-server`**, **`@enbox/dwn-sql-store`**, **`@enbox/protocols`**, and **`@enbox/protocol-codegen`** do not define `build:browser`.
 
 ### Key Directories
 
@@ -75,6 +158,9 @@ bun run --filter @enbox/agent build
 | `apps/docs/content/docs/` | MDX content (guides + API reference) |
 | `apps/docs/src/` | Next.js app source (layouts, components, styles) |
 | `docs/` | Existing markdown docs (HOSTING.md, TESTING.md, architecture/) |
+| `scripts/` | CI / release helpers — `publish.sh`, `ci-setup.sh`, `run-node-coverage.sh`, `run-browser-coverage.sh`, `merge-lcov.mjs`, `test-with-server.sh` |
+| `build/` | Shared build helpers — `browser-bundle.js` (esbuild browser bundler for `@enbox/agent` / `@enbox/api`) |
+| `turbo.json`, `eslint.config.cjs` | Root Turbo task graph and shared ESLint flat config used by every package except `apps/docs` (which uses Biome) |
 
 ## Pre-Push Requirements
 
@@ -115,7 +201,7 @@ All packages use **`bun test`** (Bun's native test runner).
 | `@enbox/dwn-clients` | `bun test` | `bun run test:node` |
 | `@enbox/protocols` | `bun test` | `bun run test:node` |
 | `@enbox/protocol-codegen` | `bun test` | `bun run test:node` |
-| `@enbox/browser` | `bun test` / Vitest | `bun run test:node` (subset); `bun run test:browser` for browser tests |
+| `@enbox/browser` | Vitest (browser runner) | `bun run test:browser` — **no `test:node` suite**; browser-only via `@vitest/browser-playwright` |
 
 #### Agent / API / Auth tests (bun:test)
 
@@ -171,7 +257,7 @@ Without `DID_DHT_GATEWAY_URI`, tests in `agent`, `api`, `auth`, and `dids` that 
 
 | Service | Container | Port | Used by |
 |---|---|---|---|
-| Pkarr relay | `enbox-test-pkarr` | `localhost:7527` | `dids`, `agent`, `api` (did:dht publishing) |
+| Pkarr relay | `enbox-test-pkarr` | `localhost:7527` | `dids`, `agent`, `api`, `auth` (did:dht publishing) |
 | PostgreSQL 15 | `enbox-test-postgres` | `localhost:5433` | `dwn-server`, `dwn-sql-store` |
 | PostgreSQL 13 | `enbox-test-postgres-sdk` | `localhost:5432` | `dwn-sql-store` (SDK test suite) |
 | MySQL 8 | `enbox-test-mysql` | `localhost:3306` | `dwn-sql-store` |
@@ -308,6 +394,8 @@ feat: add provider-auth-v0 client methods and Web5.connect() integration
 ## Coding Style
 
 Style is derived from `dwn-sdk-js` (gold standard). ESLint enforces most rules.
+
+**Linter boundary:** every workspace package uses the shared ESLint flat config at the repo root (`eslint.config.cjs`); `apps/docs` is the only member that uses **Biome** instead and is explicitly filtered out of `bun run lint` / `lint:fix`. Do not run `eslint` against `apps/docs` and do not run Biome against `packages/*`.
 
 ### Imports
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md:** Document Turbo orchestration, pinned Bun, default build exclusions (`@enbox/docs`, `@enbox/electrobun-dwn`). Extend the package dependency graph with `dwn-clients`, `auth`, `protocols`, and tooling packages (`protocol-codegen`, `dwn-server-admin-ui`, `electrobun-dwn`). Add key paths for those packages and `examples/`. Expand the test matrix; clarify `DID_DHT_GATEWAY_URI` for auth tests. Note `build:browser` for agent and api.
- **AGENTS.md:** New orientation guide for agents and contributors (package map, dependency flow, where to change what, downstream app patterns).

## Test plan

- [x] Documentation only; no code or test changes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes with no runtime, build, or test code modifications.
> 
> **Overview**
> Adds a new `AGENTS.md` guide to orient automated agents and new contributors, including package roles, dependency direction, common change locations, and pre-PR checks.
> 
> Significantly expands `CLAUDE.md` with stricter contributor workflow guidance (worktrees/PR/CI), clearer Turbo task orchestration and filtering behavior, an updated dependency graph, and an expanded test matrix (including `@enbox/auth` and `@enbox/browser` runner differences) plus clarified required env vars like `DID_DHT_GATEWAY_URI`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968c347424bcd0da71fca5143fdc63249b35d5b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->