### PR TITLE
fix(dwn-sdk-js): regression tests for cross-protocol prune cascade (#298)

### DIFF
--- a/packages/dwn-sdk-js/src/store/storage-controller.ts
+++ b/packages/dwn-sdk-js/src/store/storage-controller.ts
@@ -79,8 +79,13 @@ export class StorageController {
     }
 
     if (message.descriptor.prune) {
-      // purge/hard-delete all descendent records
-      await StorageController.purgeRecordDescendants(tenant, message.descriptor.recordId, this.messageStore, this.dataStore, this.stateIndex);
+      // purge/hard-delete all descendant records. Cascade is intentionally protocol-agnostic:
+      // `parentContextId` is a structural link, and a prune removes the whole subtree regardless
+      // of which protocol a descendant lives in. Cross-protocol composing children (linked via
+      // `$ref`/`uses`) participate in the cascade. See issue #298 for the design discussion.
+      await StorageController.purgeRecordDescendants(
+        tenant, message.descriptor.recordId, this.messageStore, this.dataStore, this.stateIndex
+      );
     }
 
     // delete all existing messages that are not newest, except for the initial write
@@ -191,7 +196,21 @@ export class StorageController {
   }
 
   /**
-   * Purges (permanent hard-delete) all descendant's data of the given `recordId`.
+   * Purges (permanent hard-delete) all descendants of the given `recordId`, recursively.
+   *
+   * The cascade is intentionally protocol-agnostic: `parentContextId` is a structural link,
+   * so pruning a parent removes every record hanging off it regardless of which protocol a
+   * descendant lives in. Cross-protocol composing children (records in a different protocol
+   * that reference the parent via `$ref` / `uses`) are included in the cascade.
+   *
+   * Rationale (closes #298 as working-as-intended):
+   * - A DWN is tenant-owned storage. The tenant's prune authority extends across the whole
+   *   subtree they rooted, regardless of which protocol a descendant declares itself under.
+   * - Preserving cross-protocol orphans creates a half-alive state (readable but not
+   *   updatable, since `validateReferentialIntegrity` requires the pruned parent) that is
+   *   worse for callers than simply cascading.
+   * - Same-protocol cascade is already protocol-agnostic at every hop via `parentId`,
+   *   so treating cross-protocol boundaries differently was inconsistent.
    */
   public static async purgeRecordDescendants(
     tenant: string,
@@ -200,16 +219,15 @@ export class StorageController {
     dataStore: DataStore,
     stateIndex: StateIndex
   ): Promise<void> {
-    const filter = {
+    const filter: Filter = {
       interface : DwnInterfaceName.Records,
-      parentId  : recordId
+      parentId  : recordId,
     };
     const { messages: childMessages } = await messageStore.query(tenant, [filter]);
 
     // group the child messages by `recordId`
     const recordIdToMessagesMap = new Map<string, GenericMessage[]>();
     for (const message of childMessages) {
-      // get the recordId
       let recordId;
       if (Records.isRecordsWrite(message)) {
         recordId = message.recordId;
@@ -225,13 +243,10 @@ export class StorageController {
       }
     }
 
-    // purge all child's descendants first
     for (const childRecordId of recordIdToMessagesMap.keys()) {
-      // purge the child's descendent messages first
       await StorageController.purgeRecordDescendants(tenant, childRecordId, messageStore, dataStore, stateIndex);
     }
 
-    // then purge the child messages themselves
     for (const childRecordId of recordIdToMessagesMap.keys()) {
       await StorageController.purgeRecordMessages(tenant, recordIdToMessagesMap.get(childRecordId)!, messageStore, dataStore, stateIndex);
     }

--- a/packages/dwn-sdk-js/tests/features/records-prune-cross-protocol.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-prune-cross-protocol.spec.ts
@@ -1,0 +1,563 @@
+import type { DidResolver } from '@enbox/dids';
+import type { EventLog } from '../../src/types/subscriptions.js';
+import type { ProtocolDefinition } from '../../src/types/protocols-types.js';
+import type {
+  DataStore,
+  MessageStore,
+  ResumableTaskStore,
+  StateIndex,
+} from '../../src/index.js';
+
+import sinon from 'sinon';
+
+import { DwnInterfaceName } from '../../src/enums/dwn-interface-method.js';
+import { Message } from '../../src/core/message.js';
+import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestEventLog } from '../test-event-stream.js';
+import { TestStores } from '../test-stores.js';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import {
+  DataStream,
+  Dwn,
+  DwnConstant,
+  Jws,
+  ProtocolsConfigure,
+  RecordsDelete,
+  RecordsQuery,
+  RecordsRead,
+} from '../../src/index.js';
+import { DidKey, UniversalResolver } from '@enbox/dids';
+
+/**
+ * Regression tests for cross-protocol prune cascade — closes #298.
+ *
+ * Semantics (decision under #298):
+ * A `RecordsDelete` with `prune: true` cascades to every descendant of the
+ * pruned record, regardless of which protocol a descendant declares itself
+ * under. `parentContextId` is a structural link — pruning a parent removes
+ * the entire subtree it rooted. Cross-protocol composing children (records
+ * in a different protocol that reference the parent via `$ref` / `uses`)
+ * participate in the cascade on equal footing with same-protocol children.
+ *
+ * Rationale:
+ * - A DWN is tenant-owned storage. The tenant's prune authority extends
+ *   across the whole subtree they rooted, so walking the `parentId` chain
+ *   unconditionally is the correct semantic.
+ * - Preserving cross-protocol orphans creates a half-alive state — readable
+ *   but not updatable, since `validateReferentialIntegrity` in the
+ *   `RecordsWrite` handler rejects any write whose parent is missing —
+ *   which is worse for callers than cascading.
+ * - Same-protocol descendants at arbitrary depth already cascade via
+ *   `parentId` with no protocol filter; treating a cross-protocol hop
+ *   specially was inconsistent.
+ *
+ * These tests install multiple protocols linked via `uses` + `$ref`, write
+ * records across protocol boundaries, and assert that the entire subtree —
+ * same protocol or cross protocol, at any depth — is fully purged on prune.
+ */
+export function testRecordsPruneCrossProtocol(): void {
+  describe('records pruning — cross-protocol cascade (#298)', () => {
+    let didResolver: DidResolver;
+    let messageStore: MessageStore;
+    let dataStore: DataStore;
+    let resumableTaskStore: ResumableTaskStore;
+    let stateIndex: StateIndex;
+    let eventLog: EventLog;
+    let dwn: Dwn;
+
+    // Protocol A — `threads`: root `thread` type with a nested `participant` role.
+    const threadsProtocol: ProtocolDefinition = {
+      protocol  : 'https://threads.example.com',
+      published : true,
+      types     : {
+        thread      : { schema: 'https://threads.example.com/schemas/thread', dataFormats: ['application/json'] },
+        participant : { schema: 'https://threads.example.com/schemas/participant', dataFormats: ['application/json'] },
+      },
+      structure: {
+        thread: {
+          $actions: [
+            { who: 'anyone', can: ['create', 'read', 'prune'] },
+          ],
+          participant: {
+            $role    : true,
+            $actions : [
+              { who: 'anyone', can: ['read'] },
+              { who: 'author', of: 'thread', can: ['create'] },
+            ],
+          },
+        },
+      },
+    };
+
+    // Protocol B — `comments` composes `threads:thread` via `$ref`.
+    const commentsProtocol: ProtocolDefinition = {
+      protocol  : 'https://comments.example.com',
+      published : true,
+      uses      : {
+        threads: 'https://threads.example.com',
+      },
+      types: {
+        comment: { schema: 'https://comments.example.com/schemas/comment', dataFormats: ['application/json'] },
+      },
+      structure: {
+        thread: {
+          $ref    : 'threads:thread',
+          comment : {
+            $actions: [
+              { who: 'anyone', can: ['create', 'read'] },
+            ],
+          },
+        },
+      },
+    };
+
+    // Protocol C — `reactions` composes `threads:thread` via `$ref`, nesting
+    // `comment` → `reaction`. Used to exercise multi-level cascade through
+    // a cross-protocol hop.
+    const reactionsProtocol: ProtocolDefinition = {
+      protocol  : 'https://reactions.example.com',
+      published : true,
+      uses      : {
+        threads: 'https://threads.example.com',
+      },
+      types: {
+        comment  : { schema: 'https://reactions.example.com/schemas/comment', dataFormats: ['application/json'] },
+        reaction : { schema: 'https://reactions.example.com/schemas/reaction', dataFormats: ['application/json'] },
+      },
+      structure: {
+        thread: {
+          $ref    : 'threads:thread',
+          comment : {
+            $actions: [
+              { who: 'anyone', can: ['create', 'read'] },
+            ],
+            reaction: {
+              $actions: [
+                { who: 'anyone', can: ['create', 'read'] },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      didResolver = new UniversalResolver({ didResolvers: [DidKey] });
+
+      const stores = TestStores.get();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      resumableTaskStore = stores.resumableTaskStore;
+      stateIndex = stores.stateIndex;
+      eventLog = TestEventLog.get();
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, stateIndex, eventLog, resumableTaskStore });
+    });
+
+    beforeEach(async () => {
+      sinon.restore();
+
+      await messageStore.clear();
+      await dataStore.clear();
+      await resumableTaskStore.clear();
+      await stateIndex.clear();
+    });
+
+    afterAll(async () => {
+      await dwn.close();
+    });
+
+    it('should cascade-purge a cross-protocol composing child when the parent is pruned', async () => {
+      // Shape:
+      //   thread    (threads) ← pruned
+      //     comment (comments, cross-protocol child via $ref)
+      //
+      // Expected: both records fully purged. A cross-protocol child participates
+      // in the cascade on equal footing with a same-protocol child.
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: threadsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: commentsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+
+      const threadWrite = await TestDataGenerator.generateRecordsWrite({
+        author       : alice,
+        protocol     : threadsProtocol.protocol,
+        protocolPath : 'thread',
+        schema       : 'https://threads.example.com/schemas/thread',
+        dataFormat   : 'application/json',
+      });
+      expect(
+        (await dwn.processMessage(alice.did, threadWrite.message, { dataStream: threadWrite.dataStream })).status.code,
+      ).toBe(202);
+
+      const commentWrite = await TestDataGenerator.generateRecordsWrite({
+        author          : alice,
+        protocol        : commentsProtocol.protocol,
+        protocolPath    : 'thread/comment',
+        schema          : 'https://comments.example.com/schemas/comment',
+        dataFormat      : 'application/json',
+        parentContextId : threadWrite.message.contextId,
+      });
+      expect(
+        (await dwn.processMessage(alice.did, commentWrite.message, { dataStream: commentWrite.dataStream })).status.code,
+      ).toBe(202);
+
+      // Sanity: the comment is readable pre-prune.
+      expect(
+        (await dwn.processMessage(alice.did, (await RecordsRead.create({
+          signer : Jws.createSigner(alice),
+          filter : { recordId: commentWrite.message.recordId },
+        })).message)).status.code,
+      ).toBe(200);
+
+      const threadPrune = await RecordsDelete.create({
+        recordId : threadWrite.message.recordId,
+        prune    : true,
+        signer   : Jws.createSigner(alice),
+      });
+      expect((await dwn.processMessage(alice.did, threadPrune.message)).status.code).toBe(202);
+
+      // The cross-protocol comment is purged.
+      expect(
+        (await dwn.processMessage(alice.did, (await RecordsRead.create({
+          signer : Jws.createSigner(alice),
+          filter : { recordId: commentWrite.message.recordId },
+        })).message)).status.code,
+      ).toBe(404);
+
+      // Query confirms no records remain under the comments protocol.
+      const commentsQueryReply = await dwn.processMessage(
+        alice.did,
+        (await RecordsQuery.create({
+          signer : Jws.createSigner(alice),
+          filter : { protocol: commentsProtocol.protocol },
+        })).message,
+      );
+      expect(commentsQueryReply.status.code).toBe(200);
+      expect(commentsQueryReply.entries?.length).toBe(0);
+
+      // Message store has no residual messages for the comment's protocol.
+      const commentsStoreMessages = await messageStore.query(alice.did, [{
+        interface : DwnInterfaceName.Records,
+        protocol  : commentsProtocol.protocol,
+      }]);
+      expect(commentsStoreMessages.messages.length).toBe(0);
+    });
+
+    it('should cascade recursively through mixed same-protocol + cross-protocol subtrees', async () => {
+      // Shape (3 levels, 2 protocols, mixed siblings):
+      //   thread          (threads) ← pruned
+      //     participant   (threads, same-protocol sibling)
+      //     comment       (reactions, cross-protocol sibling via $ref)
+      //       reaction    (reactions, cross-protocol grandchild)
+      //
+      // Expected: every descendant purged regardless of protocol or depth.
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: threadsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: reactionsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+
+      const threadWrite = await TestDataGenerator.generateRecordsWrite({
+        author       : alice,
+        protocol     : threadsProtocol.protocol,
+        protocolPath : 'thread',
+        schema       : 'https://threads.example.com/schemas/thread',
+        dataFormat   : 'application/json',
+      });
+      await dwn.processMessage(alice.did, threadWrite.message, { dataStream: threadWrite.dataStream });
+
+      const participantWrite = await TestDataGenerator.generateRecordsWrite({
+        author          : alice,
+        recipient       : alice.did,
+        protocol        : threadsProtocol.protocol,
+        protocolPath    : 'thread/participant',
+        schema          : 'https://threads.example.com/schemas/participant',
+        dataFormat      : 'application/json',
+        parentContextId : threadWrite.message.contextId,
+      });
+      await dwn.processMessage(alice.did, participantWrite.message, { dataStream: participantWrite.dataStream });
+
+      const commentWrite = await TestDataGenerator.generateRecordsWrite({
+        author          : alice,
+        protocol        : reactionsProtocol.protocol,
+        protocolPath    : 'thread/comment',
+        schema          : 'https://reactions.example.com/schemas/comment',
+        dataFormat      : 'application/json',
+        parentContextId : threadWrite.message.contextId,
+      });
+      await dwn.processMessage(alice.did, commentWrite.message, { dataStream: commentWrite.dataStream });
+
+      const reactionWrite = await TestDataGenerator.generateRecordsWrite({
+        author          : alice,
+        protocol        : reactionsProtocol.protocol,
+        protocolPath    : 'thread/comment/reaction',
+        schema          : 'https://reactions.example.com/schemas/reaction',
+        dataFormat      : 'application/json',
+        parentContextId : commentWrite.message.contextId,
+      });
+      await dwn.processMessage(alice.did, reactionWrite.message, { dataStream: reactionWrite.dataStream });
+
+      const threadPrune = await RecordsDelete.create({
+        recordId : threadWrite.message.recordId,
+        prune    : true,
+        signer   : Jws.createSigner(alice),
+      });
+      expect((await dwn.processMessage(alice.did, threadPrune.message)).status.code).toBe(202);
+
+      // Every descendant is purged — same-protocol participant, cross-protocol
+      // comment, and the grandchild reaction that lives two levels below a
+      // cross-protocol hop.
+      for (const record of [participantWrite, commentWrite, reactionWrite]) {
+        const reply = await dwn.processMessage(
+          alice.did,
+          (await RecordsRead.create({
+            signer : Jws.createSigner(alice),
+            filter : { recordId: record.message.recordId },
+          })).message,
+        );
+        expect(reply.status.code).toBe(404);
+      }
+
+      const reactionsQueryReply = await dwn.processMessage(
+        alice.did,
+        (await RecordsQuery.create({
+          signer : Jws.createSigner(alice),
+          filter : { protocol: reactionsProtocol.protocol },
+        })).message,
+      );
+      expect(reactionsQueryReply.status.code).toBe(200);
+      expect(reactionsQueryReply.entries?.length).toBe(0);
+    });
+
+    it('should cascade across multiple sibling protocols rooted at the same parent', async () => {
+      // Shape:
+      //   thread            (threads) ← pruned
+      //     commentsChild   (comments, cross-protocol sibling A)
+      //     reactionsChild  (reactions, cross-protocol sibling B)
+      //       reaction      (reactions, grandchild)
+      //
+      // Two distinct cross-protocol children of the same parent, each in its own
+      // protocol, plus a grandchild under one of them. All must be purged.
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: threadsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: commentsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: reactionsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+
+      const threadWrite = await TestDataGenerator.generateRecordsWrite({
+        author       : alice,
+        protocol     : threadsProtocol.protocol,
+        protocolPath : 'thread',
+        schema       : 'https://threads.example.com/schemas/thread',
+        dataFormat   : 'application/json',
+      });
+      await dwn.processMessage(alice.did, threadWrite.message, { dataStream: threadWrite.dataStream });
+
+      const commentsChild = await TestDataGenerator.generateRecordsWrite({
+        author          : alice,
+        protocol        : commentsProtocol.protocol,
+        protocolPath    : 'thread/comment',
+        schema          : 'https://comments.example.com/schemas/comment',
+        dataFormat      : 'application/json',
+        parentContextId : threadWrite.message.contextId,
+      });
+      await dwn.processMessage(alice.did, commentsChild.message, { dataStream: commentsChild.dataStream });
+
+      const reactionsChild = await TestDataGenerator.generateRecordsWrite({
+        author          : alice,
+        protocol        : reactionsProtocol.protocol,
+        protocolPath    : 'thread/comment',
+        schema          : 'https://reactions.example.com/schemas/comment',
+        dataFormat      : 'application/json',
+        parentContextId : threadWrite.message.contextId,
+      });
+      await dwn.processMessage(alice.did, reactionsChild.message, { dataStream: reactionsChild.dataStream });
+
+      const reaction = await TestDataGenerator.generateRecordsWrite({
+        author          : alice,
+        protocol        : reactionsProtocol.protocol,
+        protocolPath    : 'thread/comment/reaction',
+        schema          : 'https://reactions.example.com/schemas/reaction',
+        dataFormat      : 'application/json',
+        parentContextId : reactionsChild.message.contextId,
+      });
+      await dwn.processMessage(alice.did, reaction.message, { dataStream: reaction.dataStream });
+
+      await dwn.processMessage(
+        alice.did,
+        (await RecordsDelete.create({
+          recordId : threadWrite.message.recordId,
+          prune    : true,
+          signer   : Jws.createSigner(alice),
+        })).message,
+      );
+
+      for (const record of [commentsChild, reactionsChild, reaction]) {
+        const reply = await dwn.processMessage(
+          alice.did,
+          (await RecordsRead.create({
+            signer : Jws.createSigner(alice),
+            filter : { recordId: record.message.recordId },
+          })).message,
+        );
+        expect(reply.status.code).toBe(404);
+      }
+
+      // Both sibling protocols are fully empty of records.
+      for (const protocol of [commentsProtocol.protocol, reactionsProtocol.protocol]) {
+        const queryReply = await dwn.processMessage(
+          alice.did,
+          (await RecordsQuery.create({
+            signer : Jws.createSigner(alice),
+            filter : { protocol },
+          })).message,
+        );
+        expect(queryReply.status.code).toBe(200);
+        expect(queryReply.entries?.length).toBe(0);
+      }
+    });
+
+    it('should fully clean up message store, state index, and data store for cross-protocol descendants', async () => {
+      // Hardening guard: after a cross-protocol prune cascade no trace of any
+      // descendant remains in any of the three underlying storage layers.
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: threadsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: commentsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+
+      const threadWrite = await TestDataGenerator.generateRecordsWrite({
+        author       : alice,
+        protocol     : threadsProtocol.protocol,
+        protocolPath : 'thread',
+        schema       : 'https://threads.example.com/schemas/thread',
+        dataFormat   : 'application/json',
+      });
+      await dwn.processMessage(alice.did, threadWrite.message, { dataStream: threadWrite.dataStream });
+
+      // Cross-protocol child whose payload is large enough to land in the data
+      // store (above the encode-with-message threshold). Forces the dataStore
+      // cleanup path to be exercised.
+      const largeCommentData = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1);
+      const commentWrite = await TestDataGenerator.generateRecordsWrite({
+        author          : alice,
+        protocol        : commentsProtocol.protocol,
+        protocolPath    : 'thread/comment',
+        schema          : 'https://comments.example.com/schemas/comment',
+        dataFormat      : 'application/json',
+        parentContextId : threadWrite.message.contextId,
+        data            : largeCommentData,
+      });
+      await dwn.processMessage(alice.did, commentWrite.message, { dataStream: DataStream.fromBytes(largeCommentData) });
+
+      // Sanity: the comment's data landed in the data store.
+      expect(
+        await dataStore.get(alice.did, commentWrite.message.recordId, commentWrite.message.descriptor.dataCid),
+      ).toBeDefined();
+
+      await dwn.processMessage(
+        alice.did,
+        (await RecordsDelete.create({
+          recordId : threadWrite.message.recordId,
+          prune    : true,
+          signer   : Jws.createSigner(alice),
+        })).message,
+      );
+
+      // Message store: no residual records for the comment's protocol.
+      const commentsStoreMessages = await messageStore.query(alice.did, [{
+        interface : DwnInterfaceName.Records,
+        protocol  : commentsProtocol.protocol,
+      }]);
+      expect(commentsStoreMessages.messages.length).toBe(0);
+
+      // Data store: comment's data is gone.
+      expect(
+        await dataStore.get(alice.did, commentWrite.message.recordId, commentWrite.message.descriptor.dataCid),
+      ).toBeUndefined();
+
+      // State index: no messageCid for the comment's RecordsWrite remains.
+      const commentRecordsWriteCid = await Message.getCid(commentWrite.message);
+      const allStateIndexCids = await stateIndex.getLeaves(alice.did, []);
+      expect(allStateIndexCids).not.toContain(commentRecordsWriteCid);
+    });
+
+    it('should leave cross-protocol composing children untouched on soft delete (prune omitted)', async () => {
+      // Negative control: soft-delete does not cascade. A RecordsDelete without
+      // `prune: true` only tombstones the parent and leaves descendants intact,
+      // cross-protocol or otherwise. This test guards against a regression
+      // where cascade-always inadvertently broadens soft-delete semantics.
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: threadsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+      await dwn.processMessage(
+        alice.did,
+        (await ProtocolsConfigure.create({ definition: commentsProtocol, signer: Jws.createSigner(alice) })).message,
+      );
+
+      const threadWrite = await TestDataGenerator.generateRecordsWrite({
+        author       : alice,
+        protocol     : threadsProtocol.protocol,
+        protocolPath : 'thread',
+        schema       : 'https://threads.example.com/schemas/thread',
+        dataFormat   : 'application/json',
+      });
+      await dwn.processMessage(alice.did, threadWrite.message, { dataStream: threadWrite.dataStream });
+
+      const commentWrite = await TestDataGenerator.generateRecordsWrite({
+        author          : alice,
+        protocol        : commentsProtocol.protocol,
+        protocolPath    : 'thread/comment',
+        schema          : 'https://comments.example.com/schemas/comment',
+        dataFormat      : 'application/json',
+        parentContextId : threadWrite.message.contextId,
+      });
+      await dwn.processMessage(alice.did, commentWrite.message, { dataStream: commentWrite.dataStream });
+
+      // Soft delete the thread (prune omitted).
+      expect(
+        (await dwn.processMessage(alice.did, (await RecordsDelete.create({
+          recordId : threadWrite.message.recordId,
+          signer   : Jws.createSigner(alice),
+        })).message)).status.code,
+      ).toBe(202);
+
+      // The cross-protocol comment is still readable.
+      expect(
+        (await dwn.processMessage(alice.did, (await RecordsRead.create({
+          signer : Jws.createSigner(alice),
+          filter : { recordId: commentWrite.message.recordId },
+        })).message)).status.code,
+      ).toBe(200);
+    });
+  });
+}

--- a/packages/dwn-sdk-js/tests/test-suite.ts
+++ b/packages/dwn-sdk-js/tests/test-suite.ts
@@ -26,6 +26,7 @@ import { testRecordsDeleteHandler } from './handlers/records-delete.spec.js';
 import { testRecordsDelivery } from './features/records-delivery.spec.js';
 import { testRecordsImmutable } from './features/records-immutable.spec.js';
 import { testRecordsPrune } from './features/records-prune.spec.js';
+import { testRecordsPruneCrossProtocol } from './features/records-prune-cross-protocol.spec.js';
 import { testRecordsQueryHandler } from './handlers/records-query.spec.js';
 import { testRecordsReadHandler } from './handlers/records-read.spec.js';
 import { testRecordsRecordLimit } from './features/records-record-limit.spec.js';
@@ -87,6 +88,7 @@ export class TestSuite {
     testRecordsDelivery();
     testRecordsImmutable();
     testRecordsPrune();
+    testRecordsPruneCrossProtocol();
     testRecordsRecordLimit();
     testRecordsSquash();
     testRecordsTags();


### PR DESCRIPTION
## Summary

Regression test suite for cross-protocol prune cascade. Closes #298 as working-as-intended.

## Background

`RecordsDelete` with `prune: true` cascades hard-deletes to every descendant of the pruned record, regardless of which protocol each descendant lives in. Issue #298 asked whether cross-protocol composing children (records referencing the pruned parent via `$ref` / `uses` from a different protocol) should be preserved.

The decision is to keep the current cascade-always semantic and guard it with regression tests:

- A DWN is tenant-owned storage. The tenant's prune authority extends across the whole subtree they rooted — `parentContextId` is a structural link, not a protocol-scoped one.
- Preserving cross-protocol orphans creates a half-alive state — readable but not updatable, since `validateReferentialIntegrity` in the `RecordsWrite` handler rejects any write whose parent is missing.
- Same-protocol descendants at arbitrary depth already cascade via `parentId` with no protocol filter; treating a cross-protocol hop specially would be inconsistent.

## Changes

- `packages/dwn-sdk-js/tests/features/records-prune-cross-protocol.spec.ts` (new) — 5 regression tests that install protocols linked via `uses` + `$ref`, write records across protocol boundaries, and assert the full cascade:
  - single-level cross-protocol child is purged
  - multi-level cascade through mixed same-protocol + cross-protocol subtrees
  - multiple sibling protocols rooted at the same parent all cascade
  - full cleanup in message store, data store, and state index (including the large-payload data-store path)
  - soft delete (prune omitted) does NOT cascade (negative control)
- `packages/dwn-sdk-js/tests/test-suite.ts` — registers the new suite.
- `packages/dwn-sdk-js/src/store/storage-controller.ts` — tightens the `Filter` type annotation on `purgeRecordDescendants` and expands the JSDoc to document the cascade-always contract. No functional change.

## Test plan

- [x] `bun run --filter @enbox/dwn-sdk-js test:node` — 1371 pass, 1 todo, 0 fail
- [x] `bun run lint` — clean
- [x] New regression suite visible: `records pruning — cross-protocol cascade (#298)` — 5/5 pass
- [x] CI green
