### PR TITLE
ci(release): use GitHub App token so version PRs trigger CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,26 @@ jobs:
       id-token: write
 
     steps:
+      # Mint a short-lived installation token from the release GitHub App. We
+      # cannot use the default `GITHUB_TOKEN` because pushes/PRs made with it
+      # do not trigger downstream workflows (recursion prevention), which means
+      # the `CI Passed` required check is never produced on the version PR and
+      # it stays permanently `BLOCKED`. The App acts as a distinct identity, so
+      # its commits/PR updates do trigger `ci.yml` normally.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Persist App credentials so any `git push` performed by the
+          # `version` / `release` scripts uses the App identity, not
+          # `github-actions[bot]`.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -68,7 +86,9 @@ jobs:
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # App token (not GITHUB_TOKEN) so the version PR's commits trigger
+          # `ci.yml` and produce the required `CI Passed` status check.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # bun publish reads the npm token from bunfig or NPM_CONFIG_TOKEN


### PR DESCRIPTION
## Summary

Switches the `release.yml` workflow from the default `GITHUB_TOKEN` to a token minted from a dedicated **release GitHub App**, so that the changesets-bot's pushes to `changeset-release/main` trigger `ci.yml` and produce the required `CI Passed` status check.

### Why this is needed

The default `GITHUB_TOKEN` does **not** trigger downstream workflows on commits/PRs it creates ([GitHub's recursion-prevention behavior](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)).

Two recent changes turned that long-standing behavior into a hard block:
1. **#882** (Apr 11) renamed/added the aggregate gate job in `ci.yml` to `CI Passed`.
2. The `main` branch ruleset was updated on **Apr 23** to require `CI Passed`.

After that, the next changeset-bot push (Apr 24, on PR #872) didn't trigger `ci.yml`, so `CI Passed` is missing — and the PR is `MERGEABLE` but `BLOCKED` indefinitely. Previous version-packages PRs merged successfully because `CI Passed` wasn't a required check then.

### What changes

- Mint an installation token via [`actions/create-github-app-token@v3`](https://github.com/actions/create-github-app-token) before checkout.
- Pass that token to `actions/checkout@v4`'s `token` input so `git push` calls in `bun run version` / `bun run release` use the App identity.
- Pass it to `changesets/action`'s `GITHUB_TOKEN` env so the version PR is created/updated as the App.

## Required setup before merging

This PR will fail until the App is created and the secrets/variables are configured. Steps for an org admin:

1. **Create a GitHub App** (org-owned) at https://github.com/organizations/enboxorg/settings/apps/new. Suggested name: `enbox-release-bot`.
2. **Permissions** (Repository permissions only):
   - **Contents:** Read & write
   - **Pull requests:** Read & write
   - *(Optional — only if a future changeset ever needs to touch a workflow file)* **Workflows:** Read & write
3. **Subscribe to no events**, **Where can this GitHub App be installed?** → "Only on this account".
4. After creating, **generate a private key** (downloads a `.pem` file).
5. **Install the App** on the `enboxorg/enbox` repository (org settings → Installed GitHub Apps).
6. Add to the repository:
   - **Variable** (Settings → Secrets and variables → Actions → Variables): `RELEASE_APP_CLIENT_ID` = the App's **Client ID** (from the App's General settings, not the numeric App ID — `client-id` is the new recommended input as of v3.1).
   - **Secret** (Settings → Secrets and variables → Actions → Secrets): `RELEASE_APP_PRIVATE_KEY` = full contents of the downloaded `.pem` file (including the `-----BEGIN/END RSA PRIVATE KEY-----` lines).

## Recovery for the existing stuck PR (#872)

After this PR is merged:

- The next push to `main` that includes a changeset will run the new release workflow under the App identity, which will re-push to `changeset-release/main` and trigger `ci.yml` on PR #872, producing the missing `CI Passed` check.
- If you want to unblock #872 immediately without waiting for a new changeset, close+reopen it: `gh pr close 872 -R enboxorg/enbox && gh pr reopen 872 -R enboxorg/enbox`. The reopen fires `pull_request` under your identity, so CI runs.

## Test plan

- [ ] Org admin creates the `enbox-release-bot` GitHub App, generates private key, installs on the repo
- [ ] Add `RELEASE_APP_CLIENT_ID` repo variable and `RELEASE_APP_PRIVATE_KEY` repo secret
- [ ] Merge this PR; subsequent release workflow runs successfully (check Actions → Release)
- [ ] Future "chore: version packages" PRs show a `CI Passed` check and become mergeable without manual intervention
