### PR TITLE
ci(release): read RELEASE_APP_CLIENT_ID from secrets (fix #907 follow-up)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          # Stored as a secret (not a variable) for setup convenience — the
+          # value isn't actually sensitive (Client IDs are visible on the App's
+          # public settings page) but treating it as a secret is harmless.
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Follow-up to #907. The Client ID was configured as a **secret** in this repo rather than a **variable**, so `vars.RELEASE_APP_CLIENT_ID` resolved to an empty string and the new `create-github-app-token` step failed:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

Reads it from `secrets.RELEASE_APP_CLIENT_ID` to match the existing configuration. Client IDs are not actually sensitive — they're visible on every GitHub App's public settings page — but storing the value as a secret is harmless and avoids forcing a re-do of the manual setup.

## Test plan

- [ ] After merge, the next push to `main` triggers Release; the `Generate GitHub App token` step succeeds and the workflow completes.
- [ ] The eventual update to PR #872 produces a `CI Passed` check (run by `ci.yml`) and the PR becomes mergeable.
