### PR TITLE
fix(dwn-sdk-js): surface DID and resolution metadata in GeneralJwsVerifierGetPublicKeyNotFound

### DIFF
--- a/.changeset/diagnose-verifier-public-key-not-found.md
+++ b/.changeset/diagnose-verifier-public-key-not-found.md
@@ -1,0 +1,9 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+fix(dwn-sdk-js): surface DID and resolution metadata in `GeneralJwsVerifierGetPublicKeyNotFound`
+
+The previous error message — `"public key needed to verify signature not found in DID Document"` — could not distinguish a failed DID resolution (e.g. `did:dht` not yet propagated to the Pkarr relay, network error, unsupported DID method) from a genuine `kid` mismatch against a successfully resolved document. This made wallet-connect failures (e.g. `[@enbox/auth] Failed to store grant in delegate partition: GeneralJwsVerifierGetPublicKeyNotFound: ...`) effectively undebuggable.
+
+The verifier now includes the offending `kid`, the DID being resolved, and either the `didResolutionMetadata.error` / `errorMessage` or the list of available verification method IDs. Behaviour and error code (`GeneralJwsVerifierGetPublicKeyNotFound`) are unchanged.

--- a/packages/dwn-sdk-js/src/jose/jws/general/verifier.ts
+++ b/packages/dwn-sdk-js/src/jose/jws/general/verifier.ts
@@ -1,7 +1,7 @@
 import type { Cache } from '../../../types/cache.js';
 import type { GeneralJws } from '../../../types/jws-types.js';
 import type { PublicKeyJwk } from '../../../types/jose-types.js';
-import type { DidResolver, DidVerificationMethod } from '@enbox/dids';
+import type { DidResolutionResult, DidResolver, DidVerificationMethod } from '@enbox/dids';
 
 import { Encoder } from '../../../utils/encoder.js';
 import { Jws } from '../../../utils/jws.js';
@@ -89,12 +89,19 @@ export class GeneralJwsVerifier {
 
   /**
    * Gets the public key given a fully qualified key ID (`kid`) by resolving the DID to its DID Document.
+   *
+   * Throws `GeneralJwsVerifierGetPublicKeyNotFound` when the public key cannot be located.
+   * The error message distinguishes between two failure modes so callers can tell them apart:
+   *   1. DID resolution failed (network error, DID not published, method not supported, etc.).
+   *      The resolution metadata error code and message are included.
+   *   2. DID resolved successfully but the requested `kid` does not match any verification
+   *      method in the DID Document. The list of available verification method IDs is included.
    */
   private static async getPublicKey(kid: string, didResolver: DidResolver): Promise<PublicKeyJwk> {
     // `resolve` throws exception if DID is invalid, DID method is not supported,
     // or resolving DID fails
     const did = Jws.extractDid(kid);
-    const { didDocument } = await didResolver.resolve(did);
+    const { didDocument, didResolutionMetadata } = await didResolver.resolve(did);
     const { verificationMethod: verificationMethods = [] } = didDocument || {};
 
     let verificationMethod: DidVerificationMethod | undefined;
@@ -110,7 +117,10 @@ export class GeneralJwsVerifier {
     }
 
     if (!verificationMethod) {
-      throw new DwnError(DwnErrorCode.GeneralJwsVerifierGetPublicKeyNotFound, 'public key needed to verify signature not found in DID Document');
+      throw new DwnError(
+        DwnErrorCode.GeneralJwsVerifierGetPublicKeyNotFound,
+        GeneralJwsVerifier.buildPublicKeyNotFoundMessage(kid, did, didDocument, didResolutionMetadata, verificationMethods),
+      );
     }
 
     validateJsonSchema('JwkVerificationMethod', verificationMethod);
@@ -118,5 +128,36 @@ export class GeneralJwsVerifier {
     const { publicKeyJwk: publicJwk } = verificationMethod;
 
     return publicJwk as PublicKeyJwk;
+  }
+
+  /**
+   * Builds a diagnostic error message for `GeneralJwsVerifierGetPublicKeyNotFound`.
+   * Surfaces resolution metadata or available verification methods so operators can
+   * distinguish between an unreachable DID and a `kid` mismatch.
+   */
+  private static buildPublicKeyNotFoundMessage(
+    kid: string,
+    did: string,
+    didDocument: DidResolutionResult['didDocument'],
+    didResolutionMetadata: DidResolutionResult['didResolutionMetadata'] | undefined,
+    verificationMethods: DidVerificationMethod[],
+  ): string {
+    const resolutionError = didResolutionMetadata?.error;
+    if (resolutionError !== undefined) {
+      const resolutionErrorMessage = didResolutionMetadata?.errorMessage;
+      const detail = resolutionErrorMessage ? `${resolutionError} — ${resolutionErrorMessage}` : resolutionError;
+      return `unable to resolve DID '${did}' to verify signature with kid '${kid}': ${detail}`;
+    }
+
+    if (didDocument === undefined || didDocument === null) {
+      return `DID Document not found for '${did}' when verifying signature with kid '${kid}'`;
+    }
+
+    if (verificationMethods.length === 0) {
+      return `DID Document for '${did}' has no verification methods to verify signature with kid '${kid}'`;
+    }
+
+    const availableIds = verificationMethods.map((method) => method.id).join(', ');
+    return `public key for kid '${kid}' not found in DID Document for '${did}' (available verification methods: [${availableIds}])`;
   }
 }

--- a/packages/dwn-sdk-js/tests/jose/jws/general.spec.ts
+++ b/packages/dwn-sdk-js/tests/jose/jws/general.spec.ts
@@ -275,4 +275,132 @@ describe('General JWS Sign/Verify', () => {
     sinon.assert.calledTwice(cacheSetSpy);
   });
 
+  describe('GeneralJwsVerifierGetPublicKeyNotFound diagnostics', () => {
+    const buildJwsForKid = async (kid: string): Promise<{ jws: any; }> => {
+      const { privateJwk } = await Ed25519.generateKeyPair();
+      const payloadBytes = new TextEncoder().encode('anyPayloadValue');
+      const jwsBuilder = await GeneralJwsBuilder.create(payloadBytes, [new PrivateKeySigner({ privateJwk, keyId: kid })]);
+      return { jws: jwsBuilder.getJws() };
+    };
+
+    it('should include the resolution error code and message when the DID cannot be resolved', async () => {
+      const kid = 'did:dht:absent#0';
+      const { jws } = await buildJwsForKid(kid);
+
+      const resolverStub = sinon.createStubInstance(UniversalResolver, {
+        // @ts-ignore
+        resolve: sinon.stub().resolves({
+          didResolutionMetadata : { error: 'notFound', errorMessage: 'BEP44 record not found' },
+          didDocument           : null,
+          didDocumentMetadata   : {},
+        }),
+      });
+
+      let caught: DwnError | undefined;
+      try {
+        await GeneralJwsVerifier.verifySignatures(jws, resolverStub);
+      } catch (error) {
+        caught = error as DwnError;
+      }
+
+      expect(caught).toBeInstanceOf(DwnError);
+      expect(caught!.code).toBe(DwnErrorCode.GeneralJwsVerifierGetPublicKeyNotFound);
+      expect(caught!.message).toContain('did:dht:absent');
+      expect(caught!.message).toContain(kid);
+      expect(caught!.message).toContain('notFound');
+      expect(caught!.message).toContain('BEP44 record not found');
+    });
+
+    it('should explain when the DID Document is missing without an explicit resolution error', async () => {
+      const kid = 'did:dht:silent#0';
+      const { jws } = await buildJwsForKid(kid);
+
+      const resolverStub = sinon.createStubInstance(UniversalResolver, {
+        // @ts-ignore
+        resolve: sinon.stub().resolves({
+          didResolutionMetadata : {},
+          didDocument           : undefined,
+          didDocumentMetadata   : {},
+        }),
+      });
+
+      let caught: DwnError | undefined;
+      try {
+        await GeneralJwsVerifier.verifySignatures(jws, resolverStub);
+      } catch (error) {
+        caught = error as DwnError;
+      }
+
+      expect(caught).toBeInstanceOf(DwnError);
+      expect(caught!.code).toBe(DwnErrorCode.GeneralJwsVerifierGetPublicKeyNotFound);
+      expect(caught!.message).toContain('DID Document not found');
+      expect(caught!.message).toContain('did:dht:silent');
+      expect(caught!.message).toContain(kid);
+    });
+
+    it('should list the available verification method ids when the kid does not match any', async () => {
+      const { privateJwk } = await Ed25519.generateKeyPair();
+      const { publicJwk: otherPublicJwk } = await Ed25519.generateKeyPair();
+      const payloadBytes = new TextEncoder().encode('anyPayloadValue');
+      const kid = 'did:jank:alice#missing-key';
+      const jwsBuilder = await GeneralJwsBuilder.create(payloadBytes, [new PrivateKeySigner({ privateJwk, keyId: kid })]);
+      const jws = jwsBuilder.getJws();
+
+      const resolverStub = sinon.createStubInstance(UniversalResolver, {
+        // @ts-ignore
+        resolve: sinon.stub().withArgs('did:jank:alice').resolves({
+          didResolutionMetadata : {},
+          didDocument           : {
+            verificationMethod: [
+              { id: 'did:jank:alice#sig', type: 'JsonWebKey2020', controller: 'did:jank:alice', publicKeyJwk: otherPublicJwk },
+              { id: 'did:jank:alice#enc', type: 'JsonWebKey2020', controller: 'did:jank:alice', publicKeyJwk: otherPublicJwk },
+            ],
+          },
+          didDocumentMetadata: {},
+        }),
+      });
+
+      let caught: DwnError | undefined;
+      try {
+        await GeneralJwsVerifier.verifySignatures(jws, resolverStub);
+      } catch (error) {
+        caught = error as DwnError;
+      }
+
+      expect(caught).toBeInstanceOf(DwnError);
+      expect(caught!.code).toBe(DwnErrorCode.GeneralJwsVerifierGetPublicKeyNotFound);
+      expect(caught!.message).toContain(kid);
+      expect(caught!.message).toContain('available verification methods');
+      expect(caught!.message).toContain('did:jank:alice#sig');
+      expect(caught!.message).toContain('did:jank:alice#enc');
+    });
+
+    it('should report when the DID Document has no verification methods', async () => {
+      const kid = 'did:jank:empty#0';
+      const { jws } = await buildJwsForKid(kid);
+
+      const resolverStub = sinon.createStubInstance(UniversalResolver, {
+        // @ts-ignore
+        resolve: sinon.stub().withArgs('did:jank:empty').resolves({
+          didResolutionMetadata : {},
+          didDocument           : { verificationMethod: [] },
+          didDocumentMetadata   : {},
+        }),
+      });
+
+      let caught: DwnError | undefined;
+      try {
+        await GeneralJwsVerifier.verifySignatures(jws, resolverStub);
+      } catch (error) {
+        caught = error as DwnError;
+      }
+
+      expect(caught).toBeInstanceOf(DwnError);
+      expect(caught!.code).toBe(DwnErrorCode.GeneralJwsVerifierGetPublicKeyNotFound);
+      expect(caught!.message).toContain('has no verification methods');
+      expect(caught!.message).toContain('did:jank:empty');
+      expect(caught!.message).toContain(kid);
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

The `GeneralJwsVerifierGetPublicKeyNotFound` error currently raises a single generic message — _"public key needed to verify signature not found in DID Document"_ — for two very different failure modes:

1. **DID resolution failed** — the resolver returned no `didDocument` (network error, `did:dht` not yet propagated to the Pkarr relay, `methodNotSupported`, etc.). The metadata contains the real cause but it was being silently dropped.
2. **`kid` mismatch** — the document resolved fine but no `verificationMethod.id` matches the `kid` in the JWS protected header.

When a user reports
> `[@enbox/auth] Wallet connect failed: [@enbox/auth] Failed to store grant in delegate partition: GeneralJwsVerifierGetPublicKeyNotFound: public key needed to verify signature not found in DID Document`
…there is no way to tell whether the wallet's `did:dht` failed to publish, the dapp can't reach the Pkarr gateway, or the delegate `did:jwk`'s `kid` is wrong.

After this change the error includes the `kid`, the resolved DID, and either the resolution metadata or the available verification method IDs:

- `unable to resolve DID 'did:dht:abc' to verify signature with kid 'did:dht:abc#0': notFound — BEP44 record not found`
- `DID Document not found for 'did:dht:abc' when verifying signature with kid 'did:dht:abc#0'`
- `DID Document for 'did:jwk:abc' has no verification methods to verify signature with kid 'did:jwk:abc#0'`
- `public key for kid 'did:jwk:abc#missing' not found in DID Document for 'did:jwk:abc' (available verification methods: [did:jwk:abc#0, did:jwk:abc#enc])`

The error code (`GeneralJwsVerifierGetPublicKeyNotFound`) and overall behavior are unchanged — only the diagnostic message is enriched, so this is a strict improvement with no behavior risk.

### Why this matters for wallet connect

`processConnectedGrants` (in `@enbox/auth`) writes each delegate grant into the agent's local DWN with `signAsOwner: true`. The DWN re-validates **both** signatures on the resulting `RecordsWrite`:

- `authorSignature` — signed by the wallet's primary DID (typically `did:dht`, resolved over the network via Pkarr)
- `ownerSignature` — signed by the delegate's `did:jwk` (resolved locally)

If either resolution path fails (Pkarr relay propagation lag, DID method mismatch, gateway unreachable), the verifier currently produces an opaque error with no breadcrumbs. With this change the failing `kid` and resolution error are surfaced through `reply.status.detail`, and bubble all the way up to the user-facing wallet-connect error.

## Changes

- `packages/dwn-sdk-js/src/jose/jws/general/verifier.ts`
  - Capture `didResolutionMetadata` alongside `didDocument`.
  - New private helper `buildPublicKeyNotFoundMessage` that picks one of four diagnostic forms based on what the resolver returned.
  - `DidResolutionResult` added as a type-only import.
- `packages/dwn-sdk-js/tests/jose/jws/general.spec.ts`
  - Four new tests under `GeneralJwsVerifierGetPublicKeyNotFound diagnostics` covering each branch.
- `.changeset/diagnose-verifier-public-key-not-found.md`
  - Patch bump for `@enbox/dwn-sdk-js`.

## Test plan

- [x] `bun run lint` (dwn-sdk-js)
- [x] `bun run build` (dwn-sdk-js, then agent + auth, both build clean against the change)
- [x] `bun run test:node` for `@enbox/dwn-sdk-js` — **1375 pass / 0 fail / 1 todo** (incl. 4 new diagnostics tests)
- [x] `bun test tests/dwn-api.spec.ts` for `@enbox/agent` — **137 pass / 0 fail**
- [x] `bun test tests/lifecycle.spec.ts tests/wallet-connect.spec.ts` for `@enbox/auth` — **79 pass / 0 fail**


Made with [Cursor](https://cursor.com)