### PR TITLE
perf(connect): single-flight DID resolver + skip redundant prepareProtocol + connect.perf instrumentation

### DIFF
--- a/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
+++ b/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
@@ -15,7 +15,7 @@ perf(connect): single-flight DID resolver + connect.perf timing instrumentation
   still resolve independently so method-specific options cannot be mixed.
 
 - `@enbox/agent`: `submitConnectResponse` now emits `[connect.perf]`
-  structured timing logs for each phase (delegate DID creation, permission
-  grant fan-out, revocation grant creation/fan-out, response signing/
-  encryption, callback POST, total) so operators can bisect remaining
+  timing logs around the wallet-side critical path (delegate DID creation,
+  permission grant fan-out, revocation grant creation/fan-out, response
+  signing/encryption, callback POST, total) so operators can bisect remaining
   wall-time directly from wallet debug logs.

--- a/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
+++ b/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
@@ -1,7 +1,7 @@
 ---
 "@enbox/dids": patch
 "@enbox/agent": patch
-"@enbox/common": minor
+"@enbox/common": patch
 ---
 
 perf(connect): single-flight DID resolver + connect.perf timing instrumentation

--- a/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
+++ b/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
@@ -1,0 +1,21 @@
+---
+"@enbox/dids": patch
+"@enbox/agent": patch
+---
+
+perf(connect): single-flight DID resolver + connect.perf timing instrumentation
+
+- `@enbox/dids`: `UniversalResolver.resolve` now coalesces concurrent
+  no-options resolutions of the same DID via an in-flight map. Without this, parallel
+  callers (e.g. the wallet's `Promise.all`-fanned `prepareProtocol` calls)
+  each issued an independent BEP44 lookup against the `did:dht` relay,
+  multiplying wall-time by N and saturating per-host browser connection
+  limits. A second concurrent resolution for the same DID now awaits the
+  first instead of starting its own. Calls that pass per-resolution options
+  still resolve independently so method-specific options cannot be mixed.
+
+- `@enbox/agent`: `submitConnectResponse` now emits `[connect.perf]`
+  structured timing logs for each phase (delegate DID creation, permission
+  grant fan-out, revocation grant creation/fan-out, response signing/
+  encryption, callback POST, total) so operators can bisect remaining
+  wall-time directly from wallet debug logs.

--- a/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
+++ b/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
@@ -1,6 +1,7 @@
 ---
 "@enbox/dids": patch
 "@enbox/agent": patch
+"@enbox/common": minor
 ---
 
 perf(connect): single-flight DID resolver + connect.perf timing instrumentation
@@ -19,3 +20,6 @@ perf(connect): single-flight DID resolver + connect.perf timing instrumentation
   permission grant fan-out, revocation grant creation/fan-out, response
   signing/encryption, callback POST, total) so operators can bisect remaining
   wall-time directly from wallet debug logs.
+
+- `@enbox/common`: add reusable `nowMs()` and `timed()` helpers for
+  monotonic elapsed-duration measurement and success/failure timing logs.

--- a/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
+++ b/.changeset/perf-connect-resolver-stampede-and-redundant-prepare.md
@@ -23,3 +23,5 @@ perf(connect): single-flight DID resolver + connect.perf timing instrumentation
 
 - `@enbox/common`: add reusable `nowMs()` and `timed()` helpers for
   monotonic elapsed-duration measurement and success/failure timing logs.
+  `sleep()` now explicitly clamps negative durations to `0`, matching its
+  documented behavior without relying on runtime timeout coercion.

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -1519,7 +1519,7 @@ async function submitConnectResponse(
       });
 
       const { encodedData: revEncoded, ...revRawMessage } = revGrant.message;
-      const revData = Convert.base64Url(revEncoded).toUint8Array();
+      const revData = Uint8Array.from(Convert.base64Url(revEncoded).toUint8Array());
 
       // Include the revocation grant in the delegate grants for distribution.
       delegateGrants.push(revGrant.message);
@@ -1538,7 +1538,7 @@ async function submitConnectResponse(
               dwnUrl,
               targetDid : selectedDid,
               message   : revRawMessage,
-              data      : new Blob([revData as BlobPart]),
+              data      : new Blob([revData]),
               signal    : AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS),
             }),
         ),

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -1644,14 +1644,22 @@ async function submitConnectResponse(
     logger.log(`Sending connect response to: ${connectRequest.callbackUrl}`);
     await timed(
       'response.callbackPost',
-      () => fetch(connectRequest.callbackUrl, {
-        body    : formEncodedRequest,
-        method  : 'POST',
-        headers : {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        signal: AbortSignal.timeout(30_000),
-      }),
+      async () => {
+        const response = await fetch(connectRequest.callbackUrl, {
+          body    : formEncodedRequest,
+          method  : 'POST',
+          headers : {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          signal: AbortSignal.timeout(30_000),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Connect: callback POST failed with HTTP ${response.status}.`);
+        }
+
+        return response;
+      },
     );
   } catch (err) {
     outcome = 'fail';

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -1545,7 +1545,6 @@ async function submitConnectResponse(
       );
     }
 
-    logger.log('Building connect response...');
     const responseObject = await timed(
       `${CONNECT_PERF_LOG_PREFIX} response.build`,
       () => EnboxConnectProtocol.createConnectResponse({
@@ -1562,7 +1561,6 @@ async function submitConnectResponse(
       }),
     );
 
-    logger.log('Signing connect response...');
     const responseObjectJwt = await timed(
       `${CONNECT_PERF_LOG_PREFIX} response.sign`,
       () => EnboxConnectProtocol.signJwt({
@@ -1599,7 +1597,6 @@ async function submitConnectResponse(
       state    : connectRequest.state,
     }).toString();
 
-    logger.log(`Sending connect response to: ${connectRequest.callbackUrl}`);
     await timed(
       `${CONNECT_PERF_LOG_PREFIX} response.callbackPost`,
       async () => {
@@ -1613,6 +1610,9 @@ async function submitConnectResponse(
         });
 
         if (!response.ok) {
+          // NOTE: delegate grants have already been written/fanned out by this
+          // point, so callers may observe partial owner-side state when the
+          // callback server rejects the final response delivery.
           throw new Error(`Connect: callback POST failed with HTTP ${response.status}.`);
         }
 

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -103,7 +103,7 @@ import type {
   Jwk } from '@enbox/crypto';
 
 import { type BearerDid, DidJwk } from '@enbox/dids';
-import { concatenateUrl, Convert, logger } from '@enbox/common';
+import { concatenateUrl, Convert, logger, nowMs, timed } from '@enbox/common';
 import {
   CryptoUtils,
   Ed25519,
@@ -151,50 +151,8 @@ const CONNECT_FANOUT_CONCURRENCY = 8;
  */
 const CONNECT_REQUEST_TIMEOUT_MS = 10_000;
 
-// ---------------------------------------------------------------------------
-// Perf instrumentation
-// ---------------------------------------------------------------------------
-
-/**
- * Returns a high-resolution monotonic timestamp in milliseconds.
- *
- * Uses `performance.now()` when available (browser, Node 16+, Bun) so that
- * timings are immune to wall-clock adjustments; falls back to `Date.now()`
- * in the unlikely case `performance` is missing. Used by the connect-flow
- * instrumentation below.
- */
-function nowMs(): number {
-  // `performance.now()` is widely available in Node 16+, browsers and Bun.
-  // Guard for environments (e.g. very old runtimes) where it may be absent.
-  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
-    return performance.now();
-  }
-  return Date.now();
-}
-
-/**
- * Times an async operation and emits a structured `connect.perf` log line.
- *
- * Used to instrument the wallet-side connect "Authorizing" critical path so
- * that operators can bisect remaining wall-time between phases (protocol
- * install, grant creation, fan-out, response signing, etc.) directly from
- * the wallet's debug logs without needing additional tooling.
- *
- * Failures are logged and re-thrown unchanged.
- */
-async function timed<T>(label: string, fn: () => Promise<T>): Promise<T> {
-  const start = nowMs();
-  try {
-    const result = await fn();
-    const elapsed = nowMs() - start;
-    logger.log(`[connect.perf] ${label} ok in ${elapsed.toFixed(1)}ms`);
-    return result;
-  } catch (err) {
-    const elapsed = nowMs() - start;
-    logger.log(`[connect.perf] ${label} fail in ${elapsed.toFixed(1)}ms`);
-    throw err;
-  }
-}
+/** Log namespace used for wallet-side connect critical-path timings. */
+const CONNECT_PERF_LOG_PREFIX = '[connect.perf]';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1365,12 +1323,12 @@ async function submitConnectResponse(
   let sessionGrantCount = 0;
   let outcome: 'ok' | 'fail' = 'ok';
   logger.log(
-    `[connect.perf] submitConnectResponse.start `
+    `${CONNECT_PERF_LOG_PREFIX} submitConnectResponse.start `
     + `(protocols=${numProtocols}, scopes=${numScopes})`,
   );
 
   try {
-    const delegateBearerDid = await timed('delegateDid.create', () => DidJwk.create());
+    const delegateBearerDid = await timed(`${CONNECT_PERF_LOG_PREFIX} delegateDid.create`, () => DidJwk.create());
     const delegatePortableDid = await delegateBearerDid.export();
 
     // Add X25519 key derived from the delegate's Ed25519 key.
@@ -1430,7 +1388,7 @@ async function submitConnectResponse(
     const delegateMultiPartyProtocols: string[] = [];
 
     const delegateGrants = await timed(
-      `permissionGrants.fanout (protocols=${numProtocols})`,
+      `${CONNECT_PERF_LOG_PREFIX} permissionGrants.fanout (protocols=${numProtocols})`,
       async () => {
         const delegateGrantPromises = connectRequest.permissionRequests.map(
           async (permissionRequest) => {
@@ -1529,7 +1487,7 @@ async function submitConnectResponse(
     // cap parallelism to avoid head-of-line blocking when sessionGrantCount is
     // large (e.g. dapp requesting many scopes at once).
     const revGrantResults = await timed(
-      `revocationGrants.create (n=${sessionGrantCount})`,
+      `${CONNECT_PERF_LOG_PREFIX} revocationGrants.create (n=${sessionGrantCount})`,
       () => mapConcurrent(
         delegateGrants.slice(0, sessionGrantCount),
         CONNECT_FANOUT_CONCURRENCY,
@@ -1571,7 +1529,7 @@ async function submitConnectResponse(
 
     if (revSendTasks.length > 0) {
       await timed(
-        `revocationGrants.fanout (sends=${revSendTasks.length}, endpoints=${revGrantEndpoints.length})`,
+        `${CONNECT_PERF_LOG_PREFIX} revocationGrants.fanout (sends=${revSendTasks.length}, endpoints=${revGrantEndpoints.length})`,
         () => mapConcurrentSettled(
           revSendTasks,
           CONNECT_FANOUT_CONCURRENCY,
@@ -1589,7 +1547,7 @@ async function submitConnectResponse(
 
     logger.log('Building connect response...');
     const responseObject = await timed(
-      'response.build',
+      `${CONNECT_PERF_LOG_PREFIX} response.build`,
       () => EnboxConnectProtocol.createConnectResponse({
         providerDid                 : selectedDid,
         delegateDid                 : delegateBearerDid.uri,
@@ -1606,7 +1564,7 @@ async function submitConnectResponse(
 
     logger.log('Signing connect response...');
     const responseObjectJwt = await timed(
-      'response.sign',
+      `${CONNECT_PERF_LOG_PREFIX} response.sign`,
       () => EnboxConnectProtocol.signJwt({
         did  : delegateBearerDid,
         data : responseObject,
@@ -1614,12 +1572,12 @@ async function submitConnectResponse(
     );
 
     const clientDid = await timed(
-      'clientDid.resolve',
+      `${CONNECT_PERF_LOG_PREFIX} clientDid.resolve`,
       () => DidJwk.resolve(connectRequest.clientDid),
     );
 
     const sharedKey = await timed(
-      'response.deriveSharedKey',
+      `${CONNECT_PERF_LOG_PREFIX} response.deriveSharedKey`,
       () => EnboxConnectProtocol.deriveSharedKey(
         delegateBearerDid,
         clientDid?.didDocument!,
@@ -1627,7 +1585,7 @@ async function submitConnectResponse(
     );
 
     const encryptedResponse = await timed(
-      'response.encrypt',
+      `${CONNECT_PERF_LOG_PREFIX} response.encrypt`,
       () => EnboxConnectProtocol.encryptResponse({
         jwt                  : responseObjectJwt,
         encryptionKey        : sharedKey,
@@ -1643,7 +1601,7 @@ async function submitConnectResponse(
 
     logger.log(`Sending connect response to: ${connectRequest.callbackUrl}`);
     await timed(
-      'response.callbackPost',
+      `${CONNECT_PERF_LOG_PREFIX} response.callbackPost`,
       async () => {
         const response = await fetch(connectRequest.callbackUrl, {
           body    : formEncodedRequest,
@@ -1667,7 +1625,7 @@ async function submitConnectResponse(
   } finally {
     const totalElapsed = nowMs() - submitStart;
     logger.log(
-      `[connect.perf] submitConnectResponse.total ${outcome} in ${totalElapsed.toFixed(1)}ms `
+      `${CONNECT_PERF_LOG_PREFIX} submitConnectResponse.total ${outcome} in ${totalElapsed.toFixed(1)}ms `
       + `(protocols=${numProtocols}, scopes=${numScopes}, sessionGrants=${sessionGrantCount})`,
     );
   }

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -152,6 +152,51 @@ const CONNECT_FANOUT_CONCURRENCY = 8;
 const CONNECT_REQUEST_TIMEOUT_MS = 10_000;
 
 // ---------------------------------------------------------------------------
+// Perf instrumentation
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a high-resolution monotonic timestamp in milliseconds.
+ *
+ * Uses `performance.now()` when available (browser, Node 16+, Bun) so that
+ * timings are immune to wall-clock adjustments; falls back to `Date.now()`
+ * in the unlikely case `performance` is missing. Used by the connect-flow
+ * instrumentation below.
+ */
+function nowMs(): number {
+  // `performance.now()` is widely available in Node 16+, browsers and Bun.
+  // Guard for environments (e.g. very old runtimes) where it may be absent.
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+/**
+ * Times an async operation and emits a structured `connect.perf` log line.
+ *
+ * Used to instrument the wallet-side connect "Authorizing" critical path so
+ * that operators can bisect remaining wall-time between phases (protocol
+ * install, grant creation, fan-out, response signing, etc.) directly from
+ * the wallet's debug logs without needing additional tooling.
+ *
+ * Failures are logged and re-thrown unchanged.
+ */
+async function timed<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const start = nowMs();
+  try {
+    const result = await fn();
+    const elapsed = nowMs() - start;
+    logger.log(`[connect.perf] ${label} ok in ${elapsed.toFixed(1)}ms`);
+    return result;
+  } catch (err) {
+    const elapsed = nowMs() - start;
+    logger.log(`[connect.perf] ${label} fail in ${elapsed.toFixed(1)}ms`);
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -1308,261 +1353,316 @@ async function submitConnectResponse(
   pin: string | undefined,
   agent: EnboxPlatformAgent
 ): Promise<void> {
-  const delegateBearerDid = await DidJwk.create();
-  const delegatePortableDid = await delegateBearerDid.export();
-
-  // Add X25519 key derived from the delegate's Ed25519 key.
-  // did:jwk only supports one verification method, but DWN encryption
-  // requires X25519 for key agreement. Including the derived X25519
-  // private key in the PortableDid ensures the delegate agent's KMS
-  // has both keys after import. The Ed25519→X25519 conversion is a
-  // standard cryptographic operation (RFC 8032 / libsodium).
-  const delegateEdPrivateKey = delegatePortableDid.privateKeys![0];
-  const delegateX25519PrivateKey = await Ed25519.convertPrivateKeyToX25519({
-    privateKey: delegateEdPrivateKey,
-  });
-  delegatePortableDid.privateKeys!.push(delegateX25519PrivateKey);
-
-  // Derive the delegate's key-delivery ProtocolPath leaf public key.
-  // This is the pre-derived key that the owner will use later when writing
-  // contextKey records addressed to this delegate. The owner cannot derive
-  // this from the delegate's root public key alone (HKDF needs the private
-  // key), so we compute it now while we have temporary access to the
-  // delegate's private key material.
-  const delegateX25519PrivateKeyBytes = await X25519.privateKeyToBytes({
-    privateKey: delegateX25519PrivateKey,
-  });
-  const keyDeliveryDerivationPath = [
-    KeyDerivationScheme.ProtocolPath,
-    KeyDeliveryProtocolDefinition.protocol,
-    'contextKey',
-  ];
-  const delegateLeafPrivateKeyBytes = await HdKey.derivePrivateKeyBytes(
-    delegateX25519PrivateKeyBytes, keyDeliveryDerivationPath,
+  const submitStart = nowMs();
+  const numProtocols = connectRequest.permissionRequests.length;
+  const numScopes = connectRequest.permissionRequests.reduce(
+    (sum, req) => sum + req.permissionScopes.length,
+    0,
   );
-  const delegateLeafPrivateKeyJwk = await X25519.bytesToPrivateKey({
-    privateKeyBytes: delegateLeafPrivateKeyBytes,
-  });
-  const delegateKeyDeliveryLeafPublicKey = await X25519.getPublicKey({
-    key: delegateLeafPrivateKeyJwk,
-  });
-
-  // The rootKeyId is the delegate's keyAgreement VM id (e.g. `did:jwk:...#0`).
-  // For did:jwk this is the Ed25519 VM, but getEncryptionKeyInfo() also returns
-  // this same id after Ed25519→X25519 conversion. The DWN SDK matches the JWE
-  // `kid` header against the KeyDecrypter's `rootKeyId`, so both sides must use
-  // the same id — which they do because both derive from verificationMethod.id
-  // of the keyAgreement relationship.
-  const delegateKeyAgreementVmId = delegateBearerDid.document.verificationMethod![0].id;
-  const delegateKeyDeliveryData = {
-    rootKeyId    : delegateKeyAgreementVmId,
-    publicKeyJwk : delegateKeyDeliveryLeafPublicKey,
-  };
-
-  // Derive scope-aware decryption keys for encrypted protocols.
-  // Single-party: ProtocolPath keys (protocol-wide or exact-path).
-  // Multi-party: ProtocolContext keys (per rootContextId).
-  // Write-only delegates receive no decryption capability.
-  const delegateDecryptionKeys: DelegateDecryptionKey[] = [];
-  const delegateContextKeys: DelegateContextKey[] = [];
-  const delegateMultiPartyProtocols: string[] = [];
-
-  const delegateGrantPromises = connectRequest.permissionRequests.map(
-    async (permissionRequest) => {
-      const { protocolDefinition, permissionScopes } = permissionRequest;
-
-      const grantsMatchProtocolUri = permissionScopes.every(
-        scope => 'protocol' in scope && scope.protocol === protocolDefinition.protocol
-      );
-      if (!grantsMatchProtocolUri) {
-        throw new Error('All permission scopes must match the protocol URI they are provided with.');
-      }
-
-      await prepareProtocol(selectedDid, agent, protocolDefinition);
-
-      const hasEncryptedTypes = Object.values(protocolDefinition.types ?? {})
-        .some((type: any) => type?.encryptionRequired === true);
-
-      if (hasEncryptedTypes) {
-        const { multiParty, singleParty } = classifyProtocolRoots(protocolDefinition);
-
-        if (multiParty.length > 0 && singleParty.length > 0) {
-          // Mixed protocol: some roots are multi-party, others single-party.
-          // We cannot safely model this with either key type alone.
-          throw new Error(
-            `Encrypted delegate access for protocols with mixed single-party ` +
-            `and multi-party roots is not supported yet. ` +
-            `Protocol '${protocolDefinition.protocol}' has multi-party roots ` +
-            `[${multiParty.join(', ')}] and single-party roots ` +
-            `[${singleParty.join(', ')}].`,
-          );
-        }
-
-        if (multiParty.length > 0) {
-          // Pure multi-party: derive per-context keys for existing contexts.
-          // Unsupported scope shapes (protocolPath, contextId) throw.
-          const ctxKeys = await deriveContextKeysForDelegate(
-            agent, selectedDid, protocolDefinition, permissionScopes,
-          );
-          delegateContextKeys.push(...ctxKeys);
-
-          // Only register the protocol for post-connect delivery if the
-          // delegate has at least one read-like scope. Write-only delegates
-          // must NOT receive context keys — they have no decryption need.
-          const readMethods = new Set([
-            DwnMethodName.Read, DwnMethodName.Query, DwnMethodName.Subscribe,
-          ]);
-          const hasReadLikeScope = permissionScopes.some(
-            (s): boolean => isRecordPermissionScope(s) && readMethods.has(s.method as DwnMethodName),
-          );
-          if (hasReadLikeScope) {
-            delegateMultiPartyProtocols.push(protocolDefinition.protocol);
-          }
-        } else {
-          // Pure single-party: derive ProtocolPath keys.
-          // Unsupported scope shapes (contextId) throw.
-          const keys = await deriveScopedDecryptionKeys(
-            agent, selectedDid, protocolDefinition.protocol,
-            permissionScopes, protocolDefinition,
-          );
-          delegateDecryptionKeys.push(...keys);
-        }
-      }
-
-      return EnboxConnectProtocol.createPermissionGrants(
-        selectedDid,
-        delegateBearerDid,
-        agent,
-        permissionScopes,
-        delegateKeyDeliveryData,
-      );
-    }
+  // Tracked across the try/finally so the aggregate `submitConnectResponse.total`
+  // log emits on both success and failure paths — operators bisecting wall-time
+  // from wallet debug logs need the total even when a phase throws.
+  let sessionGrantCount = 0;
+  let outcome: 'ok' | 'fail' = 'ok';
+  logger.log(
+    `[connect.perf] submitConnectResponse.start `
+    + `(protocols=${numProtocols}, scopes=${numScopes})`,
   );
 
-  const delegateGrants = (await Promise.all(delegateGrantPromises)).flat();
-
-  // Create per-grant contextId-scoped revocation grants.
-  // Each revocation grant authorizes the delegate to write a revocation
-  // ONLY for the specific session grant it corresponds to.
-  const permissionsApi = new AgentPermissionsApi({ agent });
-  const sessionRevocations: { grantId: string; revocationGrantId: string }[] = [];
-  let revGrantEndpoints: string[] = [];
   try {
-    revGrantEndpoints = await agent.dwn.getDwnEndpointUrlsForTarget(selectedDid);
-  } catch {
-    // Endpoint resolution failure — revocation grants will be local-only until sync.
-  }
+    const delegateBearerDid = await timed('delegateDid.create', () => DidJwk.create());
+    const delegatePortableDid = await delegateBearerDid.export();
 
-  // Snapshot the current length — revocation grants are appended to delegateGrants
-  // below, but we must NOT iterate over them (they are meta-grants, not session grants).
-  const sessionGrantCount = delegateGrants.length;
+    // Add X25519 key derived from the delegate's Ed25519 key.
+    // did:jwk only supports one verification method, but DWN encryption
+    // requires X25519 for key agreement. Including the derived X25519
+    // private key in the PortableDid ensures the delegate agent's KMS
+    // has both keys after import. The Ed25519→X25519 conversion is a
+    // standard cryptographic operation (RFC 8032 / libsodium).
+    const delegateEdPrivateKey = delegatePortableDid.privateKeys![0];
+    const delegateX25519PrivateKey = await Ed25519.convertPrivateKeyToX25519({
+      privateKey: delegateEdPrivateKey,
+    });
+    delegatePortableDid.privateKeys!.push(delegateX25519PrivateKey);
 
-  // Phase 1: create all revocation grants locally with bounded concurrency.
-  // createGrant is local-only (storage + signing) so it's cheap, but we still
-  // cap parallelism to avoid head-of-line blocking when sessionGrantCount is
-  // large (e.g. dapp requesting many scopes at once).
-  const revGrantResults = await mapConcurrent(
-    delegateGrants.slice(0, sessionGrantCount),
-    CONNECT_FANOUT_CONCURRENCY,
-    (grantMessage) =>
-      permissionsApi.createGrant({
-        delegated : true,
-        store     : true,
-        grantedTo : delegateBearerDid.uri,
-        scope     : {
-          interface : DwnInterfaceName.Records,
-          method    : DwnMethodName.Write,
-          protocol  : PermissionsProtocol.uri,
-          contextId : grantMessage.recordId,
-        },
-        dateExpires : '2040-06-25T16:09:16.693356Z',
-        author      : selectedDid,
-      }).then((revGrant) => ({ grantMessage, revGrant })),
-  );
-
-  // Phase 2: fan out every revocation grant to every owner DWN endpoint with
-  // a single global concurrency cap so that (grants × endpoints) cannot blow
-  // up. This is best-effort (sync delivers eventually) so individual failures
-  // are tolerated by `mapConcurrentSettled`.
-  const revSendTasks = revGrantResults.flatMap(({ grantMessage, revGrant }) => {
-    sessionRevocations.push({
-      grantId           : grantMessage.recordId,
-      revocationGrantId : revGrant.message.recordId,
+    // Derive the delegate's key-delivery ProtocolPath leaf public key.
+    // This is the pre-derived key that the owner will use later when writing
+    // contextKey records addressed to this delegate. The owner cannot derive
+    // this from the delegate's root public key alone (HKDF needs the private
+    // key), so we compute it now while we have temporary access to the
+    // delegate's private key material.
+    const delegateX25519PrivateKeyBytes = await X25519.privateKeyToBytes({
+      privateKey: delegateX25519PrivateKey,
+    });
+    const keyDeliveryDerivationPath = [
+      KeyDerivationScheme.ProtocolPath,
+      KeyDeliveryProtocolDefinition.protocol,
+      'contextKey',
+    ];
+    const delegateLeafPrivateKeyBytes = await HdKey.derivePrivateKeyBytes(
+      delegateX25519PrivateKeyBytes, keyDeliveryDerivationPath,
+    );
+    const delegateLeafPrivateKeyJwk = await X25519.bytesToPrivateKey({
+      privateKeyBytes: delegateLeafPrivateKeyBytes,
+    });
+    const delegateKeyDeliveryLeafPublicKey = await X25519.getPublicKey({
+      key: delegateLeafPrivateKeyJwk,
     });
 
-    const { encodedData: revEncoded, ...revRawMessage } = revGrant.message;
-    const revData = Convert.base64Url(revEncoded).toUint8Array();
+    // The rootKeyId is the delegate's keyAgreement VM id (e.g. `did:jwk:...#0`).
+    // For did:jwk this is the Ed25519 VM, but getEncryptionKeyInfo() also returns
+    // this same id after Ed25519→X25519 conversion. The DWN SDK matches the JWE
+    // `kid` header against the KeyDecrypter's `rootKeyId`, so both sides must use
+    // the same id — which they do because both derive from verificationMethod.id
+    // of the keyAgreement relationship.
+    const delegateKeyAgreementVmId = delegateBearerDid.document.verificationMethod![0].id;
+    const delegateKeyDeliveryData = {
+      rootKeyId    : delegateKeyAgreementVmId,
+      publicKeyJwk : delegateKeyDeliveryLeafPublicKey,
+    };
 
-    // Include the revocation grant in the delegate grants for distribution.
-    delegateGrants.push(revGrant.message);
+    // Derive scope-aware decryption keys for encrypted protocols.
+    // Single-party: ProtocolPath keys (protocol-wide or exact-path).
+    // Multi-party: ProtocolContext keys (per rootContextId).
+    // Write-only delegates receive no decryption capability.
+    const delegateDecryptionKeys: DelegateDecryptionKey[] = [];
+    const delegateContextKeys: DelegateContextKey[] = [];
+    const delegateMultiPartyProtocols: string[] = [];
 
-    return revGrantEndpoints.map((dwnUrl) => ({ revRawMessage, revData, dwnUrl }));
-  });
+    const delegateGrants = await timed(
+      `permissionGrants.fanout (protocols=${numProtocols})`,
+      async () => {
+        const delegateGrantPromises = connectRequest.permissionRequests.map(
+          async (permissionRequest) => {
+            const { protocolDefinition, permissionScopes } = permissionRequest;
 
-  if (revSendTasks.length > 0) {
-    await mapConcurrentSettled(
-      revSendTasks,
-      CONNECT_FANOUT_CONCURRENCY,
-      ({ revRawMessage, revData, dwnUrl }) =>
-        agent.rpc.sendDwnRequest({
-          dwnUrl,
-          targetDid : selectedDid,
-          message   : revRawMessage,
-          data      : new Blob([revData as BlobPart]),
-          signal    : AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS),
-        }),
+            const grantsMatchProtocolUri = permissionScopes.every(
+              scope => 'protocol' in scope && scope.protocol === protocolDefinition.protocol
+            );
+            if (!grantsMatchProtocolUri) {
+              throw new Error('All permission scopes must match the protocol URI they are provided with.');
+            }
+
+            await prepareProtocol(selectedDid, agent, protocolDefinition);
+
+            const hasEncryptedTypes = Object.values(protocolDefinition.types ?? {})
+              .some((type: any) => type?.encryptionRequired === true);
+
+            if (hasEncryptedTypes) {
+              const { multiParty, singleParty } = classifyProtocolRoots(protocolDefinition);
+
+              if (multiParty.length > 0 && singleParty.length > 0) {
+                // Mixed protocol: some roots are multi-party, others single-party.
+                // We cannot safely model this with either key type alone.
+                throw new Error(
+                  `Encrypted delegate access for protocols with mixed single-party ` +
+                  `and multi-party roots is not supported yet. ` +
+                  `Protocol '${protocolDefinition.protocol}' has multi-party roots ` +
+                  `[${multiParty.join(', ')}] and single-party roots ` +
+                  `[${singleParty.join(', ')}].`,
+                );
+              }
+
+              if (multiParty.length > 0) {
+                // Pure multi-party: derive per-context keys for existing contexts.
+                // Unsupported scope shapes (protocolPath, contextId) throw.
+                const ctxKeys = await deriveContextKeysForDelegate(
+                  agent, selectedDid, protocolDefinition, permissionScopes,
+                );
+                delegateContextKeys.push(...ctxKeys);
+
+                // Only register the protocol for post-connect delivery if the
+                // delegate has at least one read-like scope. Write-only delegates
+                // must NOT receive context keys — they have no decryption need.
+                const readMethods = new Set([
+                  DwnMethodName.Read, DwnMethodName.Query, DwnMethodName.Subscribe,
+                ]);
+                const hasReadLikeScope = permissionScopes.some(
+                  (s): boolean => isRecordPermissionScope(s) && readMethods.has(s.method as DwnMethodName),
+                );
+                if (hasReadLikeScope) {
+                  delegateMultiPartyProtocols.push(protocolDefinition.protocol);
+                }
+              } else {
+                // Pure single-party: derive ProtocolPath keys.
+                // Unsupported scope shapes (contextId) throw.
+                const keys = await deriveScopedDecryptionKeys(
+                  agent, selectedDid, protocolDefinition.protocol,
+                  permissionScopes, protocolDefinition,
+                );
+                delegateDecryptionKeys.push(...keys);
+              }
+            }
+
+            return EnboxConnectProtocol.createPermissionGrants(
+              selectedDid,
+              delegateBearerDid,
+              agent,
+              permissionScopes,
+              delegateKeyDeliveryData,
+            );
+          }
+        );
+
+        return (await Promise.all(delegateGrantPromises)).flat();
+      },
+    );
+
+    // Create per-grant contextId-scoped revocation grants.
+    // Each revocation grant authorizes the delegate to write a revocation
+    // ONLY for the specific session grant it corresponds to.
+    const permissionsApi = new AgentPermissionsApi({ agent });
+    const sessionRevocations: { grantId: string; revocationGrantId: string }[] = [];
+    let revGrantEndpoints: string[] = [];
+    try {
+      revGrantEndpoints = await agent.dwn.getDwnEndpointUrlsForTarget(selectedDid);
+    } catch {
+      // Endpoint resolution failure — revocation grants will be local-only until sync.
+    }
+
+    // Snapshot the current length — revocation grants are appended to delegateGrants
+    // below, but we must NOT iterate over them (they are meta-grants, not session grants).
+    sessionGrantCount = delegateGrants.length;
+
+    // Phase 1: create all revocation grants locally with bounded concurrency.
+    // createGrant is local-only (storage + signing) so it's cheap, but we still
+    // cap parallelism to avoid head-of-line blocking when sessionGrantCount is
+    // large (e.g. dapp requesting many scopes at once).
+    const revGrantResults = await timed(
+      `revocationGrants.create (n=${sessionGrantCount})`,
+      () => mapConcurrent(
+        delegateGrants.slice(0, sessionGrantCount),
+        CONNECT_FANOUT_CONCURRENCY,
+        (grantMessage) =>
+          permissionsApi.createGrant({
+            delegated : true,
+            store     : true,
+            grantedTo : delegateBearerDid.uri,
+            scope     : {
+              interface : DwnInterfaceName.Records,
+              method    : DwnMethodName.Write,
+              protocol  : PermissionsProtocol.uri,
+              contextId : grantMessage.recordId,
+            },
+            dateExpires : '2040-06-25T16:09:16.693356Z',
+            author      : selectedDid,
+          }).then((revGrant) => ({ grantMessage, revGrant })),
+      ),
+    );
+
+    // Phase 2: fan out every revocation grant to every owner DWN endpoint with
+    // a single global concurrency cap so that (grants × endpoints) cannot blow
+    // up. This is best-effort (sync delivers eventually) so individual failures
+    // are tolerated by `mapConcurrentSettled`.
+    const revSendTasks = revGrantResults.flatMap(({ grantMessage, revGrant }) => {
+      sessionRevocations.push({
+        grantId           : grantMessage.recordId,
+        revocationGrantId : revGrant.message.recordId,
+      });
+
+      const { encodedData: revEncoded, ...revRawMessage } = revGrant.message;
+      const revData = Convert.base64Url(revEncoded).toUint8Array();
+
+      // Include the revocation grant in the delegate grants for distribution.
+      delegateGrants.push(revGrant.message);
+
+      return revGrantEndpoints.map((dwnUrl) => ({ revRawMessage, revData, dwnUrl }));
+    });
+
+    if (revSendTasks.length > 0) {
+      await timed(
+        `revocationGrants.fanout (sends=${revSendTasks.length}, endpoints=${revGrantEndpoints.length})`,
+        () => mapConcurrentSettled(
+          revSendTasks,
+          CONNECT_FANOUT_CONCURRENCY,
+          ({ revRawMessage, revData, dwnUrl }) =>
+            agent.rpc.sendDwnRequest({
+              dwnUrl,
+              targetDid : selectedDid,
+              message   : revRawMessage,
+              data      : new Blob([revData as BlobPart]),
+              signal    : AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS),
+            }),
+        ),
+      );
+    }
+
+    logger.log('Building connect response...');
+    const responseObject = await timed(
+      'response.build',
+      () => EnboxConnectProtocol.createConnectResponse({
+        providerDid                 : selectedDid,
+        delegateDid                 : delegateBearerDid.uri,
+        aud                         : connectRequest.clientDid,
+        nonce                       : connectRequest.nonce,
+        delegateGrants,
+        delegatePortableDid,
+        delegateDecryptionKeys      : delegateDecryptionKeys.length > 0 ? delegateDecryptionKeys : undefined,
+        delegateContextKeys         : delegateContextKeys.length > 0 ? delegateContextKeys : undefined,
+        delegateMultiPartyProtocols : delegateMultiPartyProtocols.length > 0 ? delegateMultiPartyProtocols : undefined,
+        sessionRevocations          : sessionRevocations.length > 0 ? sessionRevocations : undefined,
+      }),
+    );
+
+    logger.log('Signing connect response...');
+    const responseObjectJwt = await timed(
+      'response.sign',
+      () => EnboxConnectProtocol.signJwt({
+        did  : delegateBearerDid,
+        data : responseObject,
+      }),
+    );
+
+    const clientDid = await timed(
+      'clientDid.resolve',
+      () => DidJwk.resolve(connectRequest.clientDid),
+    );
+
+    const sharedKey = await timed(
+      'response.deriveSharedKey',
+      () => EnboxConnectProtocol.deriveSharedKey(
+        delegateBearerDid,
+        clientDid?.didDocument!,
+      ),
+    );
+
+    const encryptedResponse = await timed(
+      'response.encrypt',
+      () => EnboxConnectProtocol.encryptResponse({
+        jwt                  : responseObjectJwt,
+        encryptionKey        : sharedKey,
+        delegatePublicKeyJwk : delegateBearerDid.document.verificationMethod![0].publicKeyJwk!,
+        pin,
+      }),
+    );
+
+    const formEncodedRequest = new URLSearchParams({
+      id_token : encryptedResponse,
+      state    : connectRequest.state,
+    }).toString();
+
+    logger.log(`Sending connect response to: ${connectRequest.callbackUrl}`);
+    await timed(
+      'response.callbackPost',
+      () => fetch(connectRequest.callbackUrl, {
+        body    : formEncodedRequest,
+        method  : 'POST',
+        headers : {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        signal: AbortSignal.timeout(30_000),
+      }),
+    );
+  } catch (err) {
+    outcome = 'fail';
+    throw err;
+  } finally {
+    const totalElapsed = nowMs() - submitStart;
+    logger.log(
+      `[connect.perf] submitConnectResponse.total ${outcome} in ${totalElapsed.toFixed(1)}ms `
+      + `(protocols=${numProtocols}, scopes=${numScopes}, sessionGrants=${sessionGrantCount})`,
     );
   }
-
-  logger.log('Building connect response...');
-  const responseObject = await EnboxConnectProtocol.createConnectResponse({
-    providerDid                 : selectedDid,
-    delegateDid                 : delegateBearerDid.uri,
-    aud                         : connectRequest.clientDid,
-    nonce                       : connectRequest.nonce,
-    delegateGrants,
-    delegatePortableDid,
-    delegateDecryptionKeys      : delegateDecryptionKeys.length > 0 ? delegateDecryptionKeys : undefined,
-    delegateContextKeys         : delegateContextKeys.length > 0 ? delegateContextKeys : undefined,
-    delegateMultiPartyProtocols : delegateMultiPartyProtocols.length > 0 ? delegateMultiPartyProtocols : undefined,
-    sessionRevocations          : sessionRevocations.length > 0 ? sessionRevocations : undefined,
-  });
-
-  logger.log('Signing connect response...');
-  const responseObjectJwt = await EnboxConnectProtocol.signJwt({
-    did  : delegateBearerDid,
-    data : responseObject,
-  });
-
-  const clientDid = await DidJwk.resolve(connectRequest.clientDid);
-
-  const sharedKey = await EnboxConnectProtocol.deriveSharedKey(
-    delegateBearerDid,
-    clientDid?.didDocument!
-  );
-
-  logger.log('Encrypting connect response...');
-  const encryptedResponse = await EnboxConnectProtocol.encryptResponse({
-    jwt                  : responseObjectJwt,
-    encryptionKey        : sharedKey,
-    delegatePublicKeyJwk : delegateBearerDid.document.verificationMethod![0].publicKeyJwk!,
-    pin,
-  });
-
-  const formEncodedRequest = new URLSearchParams({
-    id_token : encryptedResponse,
-    state    : connectRequest.state,
-  }).toString();
-
-  logger.log(`Sending connect response to: ${connectRequest.callbackUrl}`);
-  await fetch(connectRequest.callbackUrl, {
-    body    : formEncodedRequest,
-    method  : 'POST',
-    headers : {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    signal: AbortSignal.timeout(30_000),
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -739,6 +739,50 @@ describe('enbox connect', () => {
       )).toBe(true);
     });
 
+    it('should fail and log when callback POST returns a non-2xx response', async () => {
+      sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+      sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
+        grant   : {} as any,
+        message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
+      });
+      sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
+      sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+      sinon.stub(testHarness.agent, 'processDwnRequest').resolves({
+        messageCid : '',
+        reply      : { status: { code: 200, detail: 'OK' }, entries: [{ descriptor: { interface: 'Protocols', method: 'Configure' } }] },
+      } as any);
+      sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget').resolves([]);
+      sinon.stub(globalThis, 'fetch').resolves(new Response('server error', { status: 500 }));
+      const logStub = sinon.stub(logger, 'log');
+      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+        baseURL  : 'http://localhost:3000',
+        endpoint : 'callback',
+      });
+      const request = await EnboxConnectProtocol.createConnectRequest({
+        appName            : 'Sample App',
+        clientDid          : clientEphemeralPortableDid.uri,
+        permissionRequests : [{ protocolDefinition, permissionScopes }],
+        callbackUrl,
+      });
+
+      await expect(
+        EnboxConnectProtocol.submitConnectResponse(
+          providerIdentity.did.uri,
+          request,
+          randomPin,
+          testHarness.agent,
+        )
+      ).rejects.toThrow('Connect: callback POST failed with HTTP 500.');
+
+      const logMessages = logStub.getCalls().map((call) => call.args[0]);
+      expect(logMessages.some(
+        (message) => message.includes('[connect.perf] response.callbackPost fail')
+      )).toBe(true);
+      expect(logMessages.some(
+        (message) => message.includes('[connect.perf] submitConnectResponse.total fail')
+      )).toBe(true);
+    });
+
     it('should skip the redundant remote ProtocolsConfigure when the protocol is already installed locally', async () => {
       // Scenario: the wallet's own `prepareProtocol` (in @enbox/web-wallet) ran
       // BEFORE `submitConnectResponse` and pushed the protocol to every owner

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -5,12 +5,12 @@ import sinon from 'sinon';
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 
-import { Convert } from '@enbox/common';
 import { CryptoUtils } from '@enbox/crypto';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
 import { type BearerDid, DidDht, DidJwk } from '@enbox/dids';
+import { Convert, logger } from '@enbox/common';
 
 import { AgentPermissionsApi, DwnInterface } from '../src/index.js';
 import {
@@ -707,6 +707,38 @@ describe('enbox connect', () => {
   });
 
   describe('submitConnectResponse', () => {
+    it('should emit a total perf log when submission fails', async () => {
+      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+        baseURL  : 'http://localhost:3000',
+        endpoint : 'callback',
+      });
+      const request = await EnboxConnectProtocol.createConnectRequest({
+        appName            : 'Sample App',
+        clientDid          : clientEphemeralPortableDid.uri,
+        permissionRequests : [{ protocolDefinition, permissionScopes }],
+        callbackUrl,
+      });
+      const logStub = sinon.stub(logger, 'log');
+      sinon.stub(DidJwk, 'create').rejects(new Error('delegate failed'));
+
+      await expect(
+        EnboxConnectProtocol.submitConnectResponse(
+          providerIdentity.did.uri,
+          request,
+          randomPin,
+          testHarness.agent,
+        )
+      ).rejects.toThrow('delegate failed');
+
+      const logMessages = logStub.getCalls().map((call) => call.args[0]);
+      expect(logMessages.some(
+        (message) => message.includes('[connect.perf] delegateDid.create fail')
+      )).toBe(true);
+      expect(logMessages.some(
+        (message) => message.includes('[connect.perf] submitConnectResponse.total fail')
+      )).toBe(true);
+    });
+
     it('should skip the redundant remote ProtocolsConfigure when the protocol is already installed locally', async () => {
       // Scenario: the wallet's own `prepareProtocol` (in @enbox/web-wallet) ran
       // BEFORE `submitConnectResponse` and pushed the protocol to every owner

--- a/packages/common/src/time.ts
+++ b/packages/common/src/time.ts
@@ -4,6 +4,52 @@
  * @module
  */
 
+import { logger } from './logger.js';
+
+export type TimedOptions = {
+  /** Receives the success/failure timing line. Defaults to the shared Enbox logger. */
+  log?: (message: string) => void;
+};
+
+/**
+ * Returns a high-resolution monotonic timestamp in milliseconds.
+ *
+ * Uses `performance.now()` when available so elapsed durations are not
+ * affected by wall-clock changes. Falls back to `Date.now()` in runtimes
+ * that do not expose `performance`.
+ */
+export function nowMs(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+
+  return Date.now();
+}
+
+/**
+ * Times an async operation and logs a single success/failure duration line.
+ *
+ * The label is intentionally caller-defined so packages can include their own
+ * log namespace, e.g. `[connect.perf] response.sign`.
+ */
+export async function timed<T>(
+  label: string,
+  fn: () => Promise<T>,
+  { log = logger.log.bind(logger) }: TimedOptions = {}
+): Promise<T> {
+  const start = nowMs();
+  try {
+    const result = await fn();
+    const elapsed = nowMs() - start;
+    log(`${label} ok in ${elapsed.toFixed(1)}ms`);
+    return result;
+  } catch (err) {
+    const elapsed = nowMs() - start;
+    log(`${label} fail in ${elapsed.toFixed(1)}ms`);
+    throw err;
+  }
+}
+
 /**
  * Returns a promise that resolves after the given duration.
  *
@@ -27,5 +73,5 @@
  * ```
  */
 export function sleep(durationInMilliseconds: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, durationInMilliseconds));
+  return new Promise(resolve => setTimeout(resolve, Math.max(0, durationInMilliseconds)));
 }

--- a/packages/common/tests/time.test.ts
+++ b/packages/common/tests/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { sleep } from '../src/time.js';
+import { nowMs, sleep, timed } from '../src/time.js';
 
 describe('sleep', () => {
   it('returns a Promise that resolves after at least the given duration', async () => {
@@ -38,5 +38,36 @@ describe('sleep', () => {
   it('returns void on resolution', async () => {
     const result = await sleep(1);
     expect(result).toBeUndefined();
+  });
+});
+
+describe('nowMs', () => {
+  it('returns a numeric timestamp', () => {
+    expect(typeof nowMs()).toBe('number');
+  });
+});
+
+describe('timed', () => {
+  it('returns the operation result and logs success duration', async () => {
+    const messages: string[] = [];
+
+    const result = await timed('test.operation', () => Promise.resolve('ok'), {
+      log: (message) => { messages.push(message); },
+    });
+
+    expect(result).toBe('ok');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].startsWith('test.operation ok in ')).toBe(true);
+  });
+
+  it('rethrows operation errors and logs failure duration', async () => {
+    const messages: string[] = [];
+
+    await expect(timed('test.operation', () => Promise.reject(new Error('boom')), {
+      log: (message) => { messages.push(message); },
+    })).rejects.toThrow('boom');
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].startsWith('test.operation fail in ')).toBe(true);
   });
 });

--- a/packages/dids/src/resolver/universal-resolver.ts
+++ b/packages/dids/src/resolver/universal-resolver.ts
@@ -147,12 +147,6 @@ export class UniversalResolver implements DidResolver, DidUrlDereferencer {
       };
     }
 
-    const cachedResolutionResult = await this.cache.get(parsedDid.uri);
-
-    if (cachedResolutionResult) {
-      return cachedResolutionResult;
-    }
-
     // Single-flight: coalesce concurrent resolutions of the same DID so we
     // never issue more than one network round-trip per cache miss. Without
     // this, parallel callers (e.g. the wallet connect flow which kicks off
@@ -160,19 +154,23 @@ export class UniversalResolver implements DidResolver, DidUrlDereferencer {
     // lookup against the relay, multiplying wall time by N and saturating
     // browser per-host connection limits.
     //
-    // Coalescing is only safe when no per-call `options` are supplied: the
-    // in-flight Map is keyed by DID URI only, so two concurrent callers
-    // with divergent options (e.g. different `gatewayUri` for did:dht)
-    // would silently share the first caller's result. Callers passing
-    // options resolve independently — the common no-options path (the
-    // wallet's parallelized prepareProtocol fan-out) still benefits.
-    const coalesceable = options === undefined || Object.keys(options).length === 0;
+    // Coalescing and DID-only caching are only safe when no per-call `options`
+    // are supplied. Method-specific options (e.g. did:dht `gatewayUri`) can
+    // change the resolution source or representation, so optioned calls must
+    // not share the DID-only in-flight or cache entries.
+    if (options !== undefined) {
+      return resolver.resolve(parsedDid.uri, options);
+    }
 
-    if (coalesceable) {
-      const existing = this._inFlight.get(parsedDid.uri);
-      if (existing) {
-        return existing;
-      }
+    const cachedResolutionResult = await this.cache.get(parsedDid.uri);
+
+    if (cachedResolutionResult) {
+      return cachedResolutionResult;
+    }
+
+    const existing = this._inFlight.get(parsedDid.uri);
+    if (existing) {
+      return existing;
     }
 
     const resolution = (async (): Promise<DidResolutionResult> => {
@@ -189,10 +187,6 @@ export class UniversalResolver implements DidResolver, DidUrlDereferencer {
       }
       return result;
     })();
-
-    if (!coalesceable) {
-      return resolution;
-    }
 
     this._inFlight.set(parsedDid.uri, resolution);
     try {

--- a/packages/dids/src/resolver/universal-resolver.ts
+++ b/packages/dids/src/resolver/universal-resolver.ts
@@ -168,6 +168,9 @@ export class UniversalResolver implements DidResolver, DidUrlDereferencer {
       return cachedResolutionResult;
     }
 
+    // CAUTION: method resolvers must not re-enter `resolve()` for the same
+    // DID while this promise is active; that would await the resolver's own
+    // in-flight promise and deadlock.
     const existing = this._inFlight.get(parsedDid.uri);
     if (existing) {
       return existing;

--- a/packages/dids/src/resolver/universal-resolver.ts
+++ b/packages/dids/src/resolver/universal-resolver.ts
@@ -74,6 +74,17 @@ export class UniversalResolver implements DidResolver, DidUrlDereferencer {
   private readonly didResolvers: Map<string, DidMethodResolver> = new Map();
 
   /**
+   * Tracks in-flight DID resolutions so that concurrent calls for the same
+   * DID share a single underlying network resolution instead of stampeding
+   * the resolver (which, for `did:dht`, means hammering the BEP44 relay).
+   *
+   * The promise is kept until the resolution settles; the entry is removed
+   * regardless of success or failure so that a transient error does not
+   * permanently mask a recoverable DID.
+   */
+  private readonly _inFlight: Map<string, Promise<DidResolutionResult>> = new Map();
+
+  /**
    * Constructs a new `DidResolver`.
    *
    * @param params - The parameters for constructing the `DidResolver`.
@@ -140,14 +151,54 @@ export class UniversalResolver implements DidResolver, DidUrlDereferencer {
 
     if (cachedResolutionResult) {
       return cachedResolutionResult;
-    } else {
-      const resolutionResult = await resolver.resolve(parsedDid.uri, options);
-      if (!resolutionResult.didResolutionMetadata.error) {
-        // Cache the resolution result if it was successful.
-        await this.cache.set(parsedDid.uri, resolutionResult);
-      }
+    }
 
-      return resolutionResult;
+    // Single-flight: coalesce concurrent resolutions of the same DID so we
+    // never issue more than one network round-trip per cache miss. Without
+    // this, parallel callers (e.g. the wallet connect flow which kicks off
+    // N permission preparations at once) each issue an independent BEP44
+    // lookup against the relay, multiplying wall time by N and saturating
+    // browser per-host connection limits.
+    //
+    // Coalescing is only safe when no per-call `options` are supplied: the
+    // in-flight Map is keyed by DID URI only, so two concurrent callers
+    // with divergent options (e.g. different `gatewayUri` for did:dht)
+    // would silently share the first caller's result. Callers passing
+    // options resolve independently — the common no-options path (the
+    // wallet's parallelized prepareProtocol fan-out) still benefits.
+    const coalesceable = options === undefined || Object.keys(options).length === 0;
+
+    if (coalesceable) {
+      const existing = this._inFlight.get(parsedDid.uri);
+      if (existing) {
+        return existing;
+      }
+    }
+
+    const resolution = (async (): Promise<DidResolutionResult> => {
+      const result = await resolver.resolve(parsedDid.uri, options);
+      if (!result.didResolutionMetadata.error) {
+        try {
+          await this.cache.set(parsedDid.uri, result);
+        } catch {
+          // Cache write errors are non-fatal: a transient cache failure
+          // (LevelDB I/O, IndexedDB quota) must not reject every coalesced
+          // caller awaiting this single-flight promise, otherwise they
+          // would all lose an otherwise-successful network resolution.
+        }
+      }
+      return result;
+    })();
+
+    if (!coalesceable) {
+      return resolution;
+    }
+
+    this._inFlight.set(parsedDid.uri, resolution);
+    try {
+      return await resolution;
+    } finally {
+      this._inFlight.delete(parsedDid.uri);
     }
   }
 

--- a/packages/dids/tests/resolver/universal-resolver.test.ts
+++ b/packages/dids/tests/resolver/universal-resolver.test.ts
@@ -2,7 +2,7 @@ import type { UnwrapPromise } from '@enbox/common';
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
-import type { DidResource } from '../../src/types/did-core.js';
+import type { DidResolutionResult, DidResource } from '../../src/types/did-core.js';
 
 import { DidJwk } from '../../src/methods/did-jwk.js';
 import DidJwkResolveTestVector from '../fixtures/web5-spec-vectors/did_jwk/resolve.json' with { type: 'json' };
@@ -137,6 +137,219 @@ describe('UniversalResolver', () => {
 
           expect(didResolutionResult).toEqual(vector.output);
         }
+    });
+
+    describe('single-flight (in-flight coalescing)', () => {
+      it('coalesces concurrent resolutions of the same DID into a single underlying call', async () => {
+        const did = 'did:jwk:single-flight-coalesce-1';
+        let inFlight = 0;
+        let maxConcurrent = 0;
+
+        // Slow resolver: tracks how many simultaneous calls are made.
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockImplementation(async () => {
+          inFlight += 1;
+          maxConcurrent = Math.max(maxConcurrent, inFlight);
+          await new Promise<void>((resolve) => setTimeout(resolve, 25));
+          inFlight -= 1;
+          return {
+            didResolutionMetadata : {},
+            didDocument           : { id: did },
+            didDocumentMetadata   : {},
+          };
+        });
+
+        const results = await Promise.all([
+          didResolver.resolve(did),
+          didResolver.resolve(did),
+          didResolver.resolve(did),
+          didResolver.resolve(did),
+        ]);
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(1);
+        expect(maxConcurrent).toBe(1);
+        for (const r of results) {
+          expect(r.didDocument).toEqual({ id: did });
+        }
+      });
+
+      it('does not coalesce resolutions of different DIDs', async () => {
+        const didA = 'did:jwk:single-flight-different-a';
+        const didB = 'did:jwk:single-flight-different-b';
+
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockImplementation(async (uri: string) => ({
+          didResolutionMetadata : {},
+          didDocument           : { id: uri },
+          didDocumentMetadata   : {},
+        }));
+
+        await Promise.all([didResolver.resolve(didA), didResolver.resolve(didB)]);
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(2);
+      });
+
+      it('serves a follow-up resolution from cache rather than re-issuing the underlying resolve', async () => {
+        const did = 'did:jwk:single-flight-cache-followup';
+
+        // Use an in-memory cache (the default `DidResolverCacheNoop` would
+        // never serve from cache, defeating this test).
+        const cache = new Map<string, DidResolutionResult>();
+        const cachingResolver = new UniversalResolver({
+          didResolvers : [DidJwk],
+          cache        : {
+            open   : (): Promise<void> => Promise.resolve(),
+            close  : (): Promise<void> => Promise.resolve(),
+            get    : (key: string): Promise<DidResolutionResult | undefined> => Promise.resolve(cache.get(key)),
+            set    : (key: string, value: DidResolutionResult): Promise<void> => { cache.set(key, value); return Promise.resolve(); },
+            delete : (key: string): Promise<void> => { cache.delete(key); return Promise.resolve(); },
+            clear  : (): Promise<void> => { cache.clear(); return Promise.resolve(); },
+          },
+        });
+
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockResolvedValue({
+          didResolutionMetadata : {},
+          didDocument           : { id: did },
+          didDocumentMetadata   : {},
+        });
+
+        await cachingResolver.resolve(did);
+        await cachingResolver.resolve(did);
+
+        // First call invokes the resolver and populates the cache; second
+        // call returns the cached result without invoking the resolver again.
+        expect(didMethodResolver).toHaveBeenCalledTimes(1);
+      });
+
+      it('clears the in-flight entry after success so future cache misses re-resolve', async () => {
+        const did = 'did:jwk:single-flight-clears-after-success';
+
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockResolvedValue({
+          didResolutionMetadata : {},
+          didDocument           : { id: did },
+          didDocumentMetadata   : {},
+        });
+
+        // Two sequential calls (no concurrency) — with the default no-op
+        // cache, both calls must hit the underlying resolver, proving the
+        // in-flight entry was cleared after the first resolution settled.
+        await didResolver.resolve(did);
+        await didResolver.resolve(did);
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(2);
+      });
+
+      it('clears the in-flight entry after failure so a retry re-resolves', async () => {
+        const did = 'did:jwk:single-flight-clears-after-failure';
+
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockRejectedValueOnce(
+          new Error('transient network error'),
+        ).mockResolvedValueOnce({
+          didResolutionMetadata : {},
+          didDocument           : { id: did },
+          didDocumentMetadata   : {},
+        });
+
+        await expect(didResolver.resolve(did)).rejects.toThrow('transient network error');
+
+        // The next call should not be poisoned by the failed in-flight entry.
+        const result = await didResolver.resolve(did);
+        expect(result.didDocument).toEqual({ id: did });
+        expect(didMethodResolver).toHaveBeenCalledTimes(2);
+      });
+
+      it('all concurrent callers reject with the same error if the underlying resolver fails', async () => {
+        const did = 'did:jwk:single-flight-shared-failure';
+
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockImplementation(async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 10));
+          throw new Error('shared underlying failure');
+        });
+
+        const settled = await Promise.allSettled([
+          didResolver.resolve(did),
+          didResolver.resolve(did),
+          didResolver.resolve(did),
+        ]);
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(1);
+        for (const s of settled) {
+          expect(s.status).toBe('rejected');
+          if (s.status === 'rejected') {
+            expect((s.reason as Error).message).toBe('shared underlying failure');
+          }
+        }
+      });
+
+      it('does NOT coalesce when callers pass per-call options — each gets its own resolution', async () => {
+        const did = 'did:jwk:single-flight-bypassed-with-options';
+
+        const seenOptions: any[] = [];
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockImplementation(async (_uri: string, opts?: any) => {
+          seenOptions.push(opts);
+          await new Promise<void>((resolve) => setTimeout(resolve, 5));
+          return {
+            didResolutionMetadata : {},
+            didDocument           : { id: did },
+            didDocumentMetadata   : {},
+          };
+        });
+
+        // Two concurrent callers with different `options` payloads. Single-flight
+        // is keyed by DID URI only, so coalescing here would silently hand
+        // caller B caller A's options — a real correctness/security hazard if
+        // options ever carries a gateway URI, accept header, or signal. The
+        // implementation must bypass single-flight when options are present.
+        await Promise.all([
+          didResolver.resolve(did, { gatewayUri: 'A' } as any),
+          didResolver.resolve(did, { gatewayUri: 'B' } as any),
+        ]);
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(2);
+        expect(seenOptions).toHaveLength(2);
+        expect(seenOptions[0]).toEqual({ gatewayUri: 'A' });
+        expect(seenOptions[1]).toEqual({ gatewayUri: 'B' });
+      });
+
+      it('does not poison concurrent callers when cache.set throws after a successful resolution', async () => {
+        const did = 'did:jwk:single-flight-cache-set-throws';
+
+        const failingCache = {
+          open   : (): Promise<void> => Promise.resolve(),
+          close  : (): Promise<void> => Promise.resolve(),
+          get    : (): Promise<undefined> => Promise.resolve(undefined),
+          set    : (): Promise<void> => Promise.reject(new Error('cache write failed')),
+          delete : (): Promise<void> => Promise.resolve(),
+          clear  : (): Promise<void> => Promise.resolve(),
+        };
+        const resolverWithFailingCache = new UniversalResolver({
+          didResolvers : [DidJwk],
+          cache        : failingCache,
+        });
+
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockImplementation(async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 5));
+          return {
+            didResolutionMetadata : {},
+            didDocument           : { id: did },
+            didDocumentMetadata   : {},
+          };
+        });
+
+        // Three concurrent callers share one in-flight resolution. The underlying
+        // network resolve succeeds; only the cache write fails. All three must
+        // receive the successful result — a cache-write error must not cascade
+        // across coalesced callers.
+        const results = await Promise.all([
+          resolverWithFailingCache.resolve(did),
+          resolverWithFailingCache.resolve(did),
+          resolverWithFailingCache.resolve(did),
+        ]);
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(1);
+        for (const r of results) {
+          expect(r.didDocument).toEqual({ id: did });
+          expect(r.didResolutionMetadata.error).toBeUndefined();
+        }
+      });
     });
   });
 

--- a/packages/dids/tests/resolver/universal-resolver.test.ts
+++ b/packages/dids/tests/resolver/universal-resolver.test.ts
@@ -309,6 +309,70 @@ describe('UniversalResolver', () => {
         expect(seenOptions[1]).toEqual({ gatewayUri: 'B' });
       });
 
+      it('does not serve optioned resolutions from the DID-only cache', async () => {
+        const did = 'did:jwk:single-flight-optioned-cache-read-bypass';
+        const cache = new Map<string, DidResolutionResult>();
+        cache.set(did, {
+          didResolutionMetadata : {},
+          didDocument           : { id: `${did}#cached-default` },
+          didDocumentMetadata   : {},
+        });
+        const cachingResolver = new UniversalResolver({
+          didResolvers : [DidJwk],
+          cache        : {
+            open   : (): Promise<void> => Promise.resolve(),
+            close  : (): Promise<void> => Promise.resolve(),
+            get    : (key: string): Promise<DidResolutionResult | undefined> => Promise.resolve(cache.get(key)),
+            set    : (key: string, value: DidResolutionResult): Promise<void> => { cache.set(key, value); return Promise.resolve(); },
+            delete : (key: string): Promise<void> => { cache.delete(key); return Promise.resolve(); },
+            clear  : (): Promise<void> => { cache.clear(); return Promise.resolve(); },
+          },
+        });
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockResolvedValue({
+          didResolutionMetadata : {},
+          didDocument           : { id: `${did}#optioned` },
+          didDocumentMetadata   : {},
+        });
+
+        const result = await cachingResolver.resolve(did, { gatewayUri: 'https://dht.example' } as any);
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(1);
+        expect(result.didDocument).toEqual({ id: `${did}#optioned` });
+      });
+
+      it('does not write optioned resolutions to the DID-only cache', async () => {
+        const did = 'did:jwk:single-flight-optioned-cache-write-bypass';
+        const cache = new Map<string, DidResolutionResult>();
+        const cachingResolver = new UniversalResolver({
+          didResolvers : [DidJwk],
+          cache        : {
+            open   : (): Promise<void> => Promise.resolve(),
+            close  : (): Promise<void> => Promise.resolve(),
+            get    : (key: string): Promise<DidResolutionResult | undefined> => Promise.resolve(cache.get(key)),
+            set    : (key: string, value: DidResolutionResult): Promise<void> => { cache.set(key, value); return Promise.resolve(); },
+            delete : (key: string): Promise<void> => { cache.delete(key); return Promise.resolve(); },
+            clear  : (): Promise<void> => { cache.clear(); return Promise.resolve(); },
+          },
+        });
+        const didMethodResolver = spyOn(DidJwk, 'resolve')
+          .mockResolvedValueOnce({
+            didResolutionMetadata : {},
+            didDocument           : { id: `${did}#optioned` },
+            didDocumentMetadata   : {},
+          })
+          .mockResolvedValueOnce({
+            didResolutionMetadata : {},
+            didDocument           : { id: `${did}#default` },
+            didDocumentMetadata   : {},
+          });
+
+        await cachingResolver.resolve(did, { gatewayUri: 'https://dht.example' } as any);
+        const result = await cachingResolver.resolve(did);
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(2);
+        expect(result.didDocument).toEqual({ id: `${did}#default` });
+      });
+
       it('does not poison concurrent callers when cache.set throws after a successful resolution', async () => {
         const did = 'did:jwk:single-flight-cache-set-throws';
 

--- a/packages/dids/tests/resolver/universal-resolver.test.ts
+++ b/packages/dids/tests/resolver/universal-resolver.test.ts
@@ -309,6 +309,54 @@ describe('UniversalResolver', () => {
         expect(seenOptions[1]).toEqual({ gatewayUri: 'B' });
       });
 
+      it('does not let an optioned caller consume an existing no-options in-flight resolution', async () => {
+        const did = 'did:jwk:single-flight-optioned-bypasses-default-inflight';
+
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockImplementation(async (_uri: string, opts?: any) => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 5));
+          const suffix = opts?.gatewayUri ?? 'default';
+          return {
+            didResolutionMetadata : {},
+            didDocument           : { id: `${did}#${suffix}` },
+            didDocumentMetadata   : {},
+          };
+        });
+
+        const noOptionsPromise = didResolver.resolve(did);
+        await Promise.resolve();
+
+        const optionedResult = await didResolver.resolve(did, { gatewayUri: 'optioned' } as any);
+        const noOptionsResult = await noOptionsPromise;
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(2);
+        expect(noOptionsResult.didDocument).toEqual({ id: `${did}#default` });
+        expect(optionedResult.didDocument).toEqual({ id: `${did}#optioned` });
+      });
+
+      it('does not let a no-options caller consume an existing optioned resolution', async () => {
+        const did = 'did:jwk:single-flight-default-bypasses-optioned-inflight';
+
+        const didMethodResolver = spyOn(DidJwk, 'resolve').mockImplementation(async (_uri: string, opts?: any) => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 5));
+          const suffix = opts?.gatewayUri ?? 'default';
+          return {
+            didResolutionMetadata : {},
+            didDocument           : { id: `${did}#${suffix}` },
+            didDocumentMetadata   : {},
+          };
+        });
+
+        const optionedPromise = didResolver.resolve(did, { gatewayUri: 'optioned' } as any);
+        await Promise.resolve();
+
+        const noOptionsResult = await didResolver.resolve(did);
+        const optionedResult = await optionedPromise;
+
+        expect(didMethodResolver).toHaveBeenCalledTimes(2);
+        expect(optionedResult.didDocument).toEqual({ id: `${did}#optioned` });
+        expect(noOptionsResult.didDocument).toEqual({ id: `${did}#default` });
+      });
+
       it('does not serve optioned resolutions from the DID-only cache', async () => {
         const did = 'did:jwk:single-flight-optioned-cache-read-bypass';
         const cache = new Map<string, DidResolutionResult>();


### PR DESCRIPTION
## Summary

> **Rebased on 2026-05-24** then **reviewed and remedied on 2026-05-24**. The original PR had three components; one (skip redundant agent-side `prepareProtocol`) was superseded by [#914](https://github.com/enboxorg/enbox/pull/914). The remaining changes are below.

### 1. `UniversalResolver` single-flight (`@enbox/dids`)

When the wallet runs `Promise.all(permissionRequests.map(prepareProtocol))`, each `prepareProtocol` independently resolves the same owner DID via `did:dht`. With N permission requests and M owner DWN endpoints, this previously fired N parallel BEP44 lookups against the relay, multiplying wall-time and saturating per-host browser connection limits.

The fix tracks in-flight no-options resolutions in a `Map<didUri, Promise<DidResolutionResult>>`. A second concurrent no-options call for the same DID awaits the first and shares its result. The entry is cleared on settle (success or failure) so transient errors do not poison the resolver.

**Review fixes folded in:**

- **Options-aware bypass:** coalescing and DID-only cache reads/writes only apply when the caller passes no per-call `options`. Two concurrent callers with divergent options, such as different `gatewayUri` values, resolve independently because the in-flight map is keyed by DID URI only.
- **Optioned/no-options isolation:** regression tests now cover both directions: an optioned caller cannot consume a no-options in-flight promise, and a no-options caller cannot consume an optioned resolution.
- **Cache-write failure isolation:** `cache.set()` is wrapped inside the in-flight closure. A transient cache failure no longer cascades to every coalesced caller; they all receive the successful network resolution.
- **Re-entrancy caution:** the in-flight block now documents that method resolvers must not re-enter `resolve()` for the same DID while their own promise is active.

### 2. `[connect.perf]` instrumentation (`@enbox/agent`)

`submitConnectResponse` wraps each major phase with the shared `timed(label, fn)` helper:

- `delegateDid.create`
- `permissionGrants.fanout (protocols=N)`
- `revocationGrants.create (n=...)`
- `revocationGrants.fanout (sends=..., endpoints=...)`
- `response.build`
- `response.sign`
- `clientDid.resolve`
- `response.deriveSharedKey`
- `response.encrypt`
- `response.callbackPost`
- `submitConnectResponse.start` / `submitConnectResponse.total` (with protocol/scope/grant counts)

Operators can bisect remaining "Authorizing" wall-time directly from wallet debug logs without additional tooling. The instrumentation composes cleanly with the per-request budget cap (`signal: AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS)`) added by #914.

**Review fixes folded in:**

- **Total log on failure path:** the function body is wrapped in `try/finally` so `submitConnectResponse.total` emits with `ok in ...ms` on success or `fail in ...ms` on failure.
- **Fan-out timer coverage:** `permissionGrants.fanout` timing now starts before the async work is launched, so it measures the full phase.
- **Callback POST status check:** non-2xx callback responses now throw `Connect: callback POST failed with HTTP ${status}.` instead of being logged as success. This is covered by a regression test.
- **Callback partial-state note:** the callback failure path documents that delegate grants have already been written/fanned out, so callers can observe partial owner-side state if final response delivery fails.
- **Consistent logging:** redundant legacy phase logs were removed; the `[connect.perf]` lines now carry the phase information consistently.

### 3. Shared timing helpers (`@enbox/common`)

The generic `nowMs()` and `timed()` helpers moved into `@enbox/common` so future instrumentation does not need to reach into agent internals. `sleep()` now explicitly clamps negative durations to `0`, matching its documented behavior without relying on runtime timeout coercion.

### Dropped: skip redundant agent-side `prepareProtocol`

[#914](https://github.com/enboxorg/enbox/pull/914) (merged 2026-04-28) already ships this short-circuit on main. The rebase keeps `prepareProtocol`'s behavior at main's version.

### Residual work surfaced by review (not in this PR)

- **F2 (P2):** No timeout on coalesced resolution. A hang in the underlying resolver now cascades to all concurrent callers instead of each timing out independently. This needs an `AbortSignal.timeout` wired into `UniversalResolver.resolve` or a per-method timeout default.

## Test plan

- [x] `bun run lint` — 15/15 tasks clean
- [x] `bun run --filter @enbox/dids build` — clean
- [x] `bun run --filter @enbox/agent build` — clean
- [x] `bun run --filter @enbox/dids test:node` — 331 pass, 0 fail
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 bun test tests/connect.spec.ts` (agent) — 45 pass, 0 fail
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 bun run test:node` (agent full suite) — 1509 pass, 10 skip, 0 fail
- [x] `bunx changeset status` — valid
- [x] `git diff --check` — clean
- [ ] After merge: bump `@enbox/agent`, `@enbox/dids`, and `@enbox/common` in `web-wallet` and verify "Authorizing" wall-time on a real device with multiple permission requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
