### PR TITLE
perf(connect): skip redundant remote ProtocolsConfigure & cap per-request budget in wallet "Authorizing…" hot path

### DIFF
--- a/.changeset/connect-skip-redundant-and-cap-budget.md
+++ b/.changeset/connect-skip-redundant-and-cap-budget.md
@@ -1,0 +1,18 @@
+---
+"@enbox/agent": minor
+"@enbox/dwn-clients": minor
+---
+
+perf(connect): eliminate redundant remote ProtocolsConfigure send and cap per-request budget in the wallet "Authorizing…" hot path
+
+Two fixes that together remove the dominant tail-latency in `submitConnectResponse`:
+
+1. **`@enbox/agent` — `prepareProtocol` no longer issues a redundant remote send when the protocol is already installed locally.** The wallet's own `prepareProtocol` (in `@enbox/web-wallet`) runs *before* `submitConnectResponse` and is the canonical place that fans the protocol out to every owner DWN endpoint in parallel. The agent only needs to verify the protocol is installed locally so it can sign / encrypt grants for it. The "exists locally" branch now performs a single local `ProtocolsQuery` and returns — turning the previous sequential per-endpoint legacy `agent.sendDwnRequest` (which could burn the underlying HTTP client's 4×30 s retry budget on a single unhealthy endpoint, *per protocol*) into a ~10 ms local DB read. The "missing locally" safety-fallback branch now configures the protocol locally via `processDwnRequest` and then fans out to every endpoint in parallel using the existing `mapConcurrentSettled` + `CONNECT_FANOUT_CONCURRENCY` primitive (best-effort — sync delivers any missed copies eventually).
+
+2. **`@enbox/dwn-clients` — `DwnRpcRequest` now accepts an optional `signal: AbortSignal`, plumbed through `HttpDwnRpcClient.sendDwnRequest` / `fetchWithRetry` via `AbortSignal.any([caller, perAttemptTimeout])`.** Aborting short-circuits the retry loop (`AbortError` is non-retryable). The connect flow uses this with a 10 s per-request budget on every connect-flow `agent.rpc.sendDwnRequest` (configure fan-out + permission grants + revocation grants) so a single unhealthy DWN endpoint can no longer stall the user-visible "Authorizing…" spinner for minutes.
+
+Test coverage:
+
+- `packages/agent/tests/connect.spec.ts` — wall-clock parallelism assertion, AbortSignal presence assertion, and a "one endpoint hangs forever" scenario whose end-to-end completes well under the per-request budget.
+- `packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts` — caller signal is plumbed to fetch and abort short-circuits the retry loop on the very first attempt.
+- All existing `connect.spec.ts` assertions for `prepareProtocol` updated to match the new "skip redundant remote send when local" + "parallel fan-out via RPC client when missing locally" shape.

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -136,6 +136,21 @@ import { concatenateUrl, mapConcurrent, mapConcurrentSettled } from './utils.js'
  */
 const CONNECT_FANOUT_CONCURRENCY = 8;
 
+/**
+ * Per-request abort budget applied to every DWN-endpoint `sendDwnRequest`
+ * issued during the connect flow. The HttpDwnRpcClient's default per-attempt
+ * timeout is 30 s with 3 retries (~120 s worst-case per request) — that
+ * scales unacceptably when bounded fan-out has to wait for every settled
+ * task. With this budget, an unhealthy / cold endpoint short-circuits the
+ * retry loop within a few seconds (AbortError is non-retryable), keeping
+ * the user-visible "Authorizing…" wait bounded even when one of N DWN
+ * endpoints is misbehaving.
+ *
+ * Sync delivers any missed copies eventually, so aborting fast is safe:
+ * the connect-flow fan-outs are best-effort and tolerate per-task failure.
+ */
+const CONNECT_REQUEST_TIMEOUT_MS = 10_000;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -722,6 +737,7 @@ async function createPermissionGrants(
         targetDid : selectedDid,
         message   : rawMessage,
         data      : new Blob([data as BlobPart]),
+        signal    : AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS),
       });
       return { grantIndex, dwnUrl, reply };
     },
@@ -760,24 +776,31 @@ async function createPermissionGrants(
 // ---------------------------------------------------------------------------
 
 /**
- * Installs a DWN protocol on the provider's DWN if it doesn't already exist.
- * Ensures the protocol is available on both the local and remote DWN.
+ * Ensures the protocol is installed on the provider's local DWN so that the
+ * agent can sign and (when applicable) encrypt grants for it during
+ * `submitConnectResponse`.
  *
- * When the protocol definition contains types with `encryptionRequired: true`,
- * the protocol is installed with `encryption: true` so that the agent injects
- * `$encryption` keys (derived from the owner's X25519 root key) into the
- * protocol definition. This ensures the protocol is immediately usable for
- * encrypted record operations by both the owner and any delegates.
+ * Remote installation (push to every owner DWN endpoint) is the
+ * responsibility of the calling client (the wallet's own `prepareProtocol`
+ * runs *before* `submitConnectResponse` and fans out to every endpoint in
+ * parallel). When the protocol already exists locally — the common case —
+ * this function performs a single local `ProtocolsQuery` and returns: there
+ * is no remote send, so a slow/unhealthy DWN endpoint cannot block the
+ * "Authorizing…" hot path.
+ *
+ * When the protocol is *not* installed locally — a safety fallback for
+ * callers that did not pre-install — the protocol is configured locally
+ * (with `encryption: true` when any type declares `encryptionRequired: true`,
+ * so the agent injects `$encryption` keys derived from the owner's X25519
+ * root key) and then fanned out to every owner DWN endpoint with bounded
+ * concurrency and a short per-request budget. Endpoint failures are
+ * non-fatal — sync delivers any missing copies eventually.
  */
 async function prepareProtocol(
   selectedDid: string,
   agent: EnboxPlatformAgent,
   protocolDefinition: DwnProtocolDefinition
 ): Promise<void> {
-  // Detect whether any type in the protocol requires encryption.
-  const needsEncryption = Object.values(protocolDefinition.types ?? {})
-    .some((type: any) => type?.encryptionRequired === true);
-
   const queryMessage = await agent.processDwnRequest({
     author        : selectedDid,
     messageType   : DwnInterface.ProtocolsQuery,
@@ -787,42 +810,66 @@ async function prepareProtocol(
 
   if (queryMessage.reply.status.code !== 200) {
     throw new Error(`Could not fetch protocol: ${queryMessage.reply.status.detail}`);
-  } else if (queryMessage.reply.entries === undefined || queryMessage.reply.entries.length === 0) {
-    logger.log(`Protocol does not exist, creating: ${protocolDefinition.protocol}`);
-
-    const { reply: sendReply, message: configureMessage } = await agent.sendDwnRequest({
-      author        : selectedDid,
-      target        : selectedDid,
-      messageType   : DwnInterface.ProtocolsConfigure,
-      messageParams : { definition: protocolDefinition },
-      encryption    : needsEncryption || undefined,
-    });
-
-    if (sendReply.status.code !== 202 && sendReply.status.code !== 409) {
-      throw new Error(`Could not send protocol: ${sendReply.status.detail}`);
-    }
-
-    await agent.processDwnRequest({
-      author      : selectedDid,
-      target      : selectedDid,
-      messageType : DwnInterface.ProtocolsConfigure,
-      rawMessage  : configureMessage
-    });
-  } else {
-    logger.log(`Protocol already exists: ${protocolDefinition.protocol}`);
-
-    const configureMessage = queryMessage.reply.entries![0];
-    const { reply: sendReply } = await agent.sendDwnRequest({
-      author      : selectedDid,
-      target      : selectedDid,
-      messageType : DwnInterface.ProtocolsConfigure,
-      rawMessage  : configureMessage,
-    });
-
-    if (sendReply.status.code !== 202 && sendReply.status.code !== 409) {
-      throw new Error(`Could not send protocol: ${sendReply.status.detail}`);
-    }
   }
+
+  const isInstalledLocally = queryMessage.reply.entries !== undefined
+    && queryMessage.reply.entries.length > 0;
+
+  if (isInstalledLocally) {
+    // Already installed locally. The wallet's pre-call `prepareProtocol`
+    // is responsible for fanning the protocol out to every owner DWN
+    // endpoint; sync delivers any missing copies eventually. Skipping the
+    // remote send here turns this hot path into a single local DB read
+    // (~10 ms) instead of a sequential per-endpoint network round-trip
+    // with retries — the latter could take minutes if any endpoint was
+    // slow or unreachable.
+    logger.log(`Protocol already installed locally: ${protocolDefinition.protocol}`);
+    return;
+  }
+
+  // Safety fallback — protocol is missing locally, so the caller did not
+  // pre-install. Configure it locally (with encryption derivation if any
+  // type requires it) so the agent can sign/encrypt grants, then push to
+  // every owner DWN endpoint in parallel with a short per-request budget.
+  logger.log(`Protocol not installed, configuring locally: ${protocolDefinition.protocol}`);
+  const needsEncryption = Object.values(protocolDefinition.types ?? {})
+    .some((type: any) => type?.encryptionRequired === true);
+
+  const { reply: configureReply, message: configureMessage } = await agent.processDwnRequest({
+    author        : selectedDid,
+    target        : selectedDid,
+    messageType   : DwnInterface.ProtocolsConfigure,
+    messageParams : { definition: protocolDefinition },
+    encryption    : needsEncryption || undefined,
+  });
+
+  if (configureReply.status.code !== 202 && configureReply.status.code !== 409) {
+    throw new Error(`Could not configure protocol locally: ${configureReply.status.detail}`);
+  }
+
+  let dwnEndpointUrls: string[] = [];
+  try {
+    dwnEndpointUrls = await agent.dwn.getDwnEndpointUrlsForTarget(selectedDid);
+  } catch {
+    // Endpoint resolution failure — protocol stays local-only until sync.
+  }
+
+  if (dwnEndpointUrls.length === 0) {
+    return;
+  }
+
+  // Best-effort remote fan-out with bounded concurrency and a per-request
+  // abort signal. Failures are tolerated (sync delivers eventually).
+  await mapConcurrentSettled(
+    dwnEndpointUrls,
+    CONNECT_FANOUT_CONCURRENCY,
+    (dwnUrl) => agent.rpc.sendDwnRequest({
+      dwnUrl,
+      targetDid : selectedDid,
+      message   : configureMessage!,
+      signal    : AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS),
+    }),
+  );
 }
 
 /**
@@ -1320,6 +1367,7 @@ async function submitConnectResponse(
           targetDid : selectedDid,
           message   : revRawMessage,
           data      : new Blob([revData as BlobPart]),
+          signal    : AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS),
         }),
     );
   }

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -707,10 +707,17 @@ describe('enbox connect', () => {
   });
 
   describe('submitConnectResponse', () => {
-    it('should not attempt to configure the protocol if it already exists', async () => {
-      // scenario: the wallet gets a request for a protocol that it already has configured
-      // the wallet should not attempt to re-configure, but instead ensure that the protocol is
-      // sent to the remote DWN for the requesting client to be able to sync it down later
+    it('should skip the redundant remote ProtocolsConfigure when the protocol is already installed locally', async () => {
+      // Scenario: the wallet's own `prepareProtocol` (in @enbox/web-wallet) ran
+      // BEFORE `submitConnectResponse` and pushed the protocol to every owner
+      // DWN endpoint. The agent's internal `prepareProtocol` should detect the
+      // protocol is already installed locally and short-circuit — issuing
+      // exactly one local `ProtocolsQuery` and zero remote sends.
+      //
+      // This is the regression-prevention test for the "Authorizing…" hang:
+      // a redundant per-protocol `agent.sendDwnRequest` would queue behind
+      // the underlying HTTP client's 4×30 s retry budget for any unhealthy
+      // endpoint, multiplying user-visible latency by `N protocols × 30 s`.
 
       sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
       // Stub per-grant revocation createGrant calls
@@ -737,15 +744,23 @@ describe('enbox connect', () => {
       // stub the processDwnRequest method to return a protocol entry
       const protocolMessage = {} as DwnMessage[DwnInterface.ProtocolsConfigure];
 
-      // spy send request
+      // Spy on both transport methods. Neither agent.sendDwnRequest nor
+      // agent.rpc.sendDwnRequest should be invoked when the protocol is
+      // already installed locally — that is the whole point of the fix.
       const sendRequestSpy = sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
         messageCid : '',
         reply      : { status: { code: 202, detail: 'OK' } }
       });
+      const rpcSendRequestSpy = sinon.stub(testHarness.agent.rpc, 'sendDwnRequest').resolves({
+        status: { code: 202, detail: 'Accepted' }
+      } as any);
 
       const processDwnRequestStub = sinon
         .stub(testHarness.agent, 'processDwnRequest')
         .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [ protocolMessage ] } });
+
+      // Stub fetch so the relay POST does not escape the test environment.
+      sinon.stub(globalThis, 'fetch').resolves(new Response());
 
       // call submitAuthResponse
       await EnboxConnectProtocol.submitConnectResponse(
@@ -755,21 +770,28 @@ describe('enbox connect', () => {
         testHarness.agent
       );
 
-      // expect the process request to only be called once for ProtocolsQuery
-      // (per-grant revocation goes through the stubbed AgentPermissionsApi.prototype.createGrant)
+      // Exactly one local read — the ProtocolsQuery — and nothing else.
       expect(processDwnRequestStub.callCount).toBe(1);
       expect(processDwnRequestStub.firstCall.args[0].messageType).toBe(DwnInterface.ProtocolsQuery);
 
-      // send request should be called once as a ProtocolsConfigure
-      expect(sendRequestSpy.callCount).toBe(1);
-      expect(sendRequestSpy.firstCall.args[0].messageType).toBe(DwnInterface.ProtocolsConfigure);
+      // No redundant remote ProtocolsConfigure send via either transport.
+      expect(sendRequestSpy.callCount).toBe(0);
+      expect(
+        rpcSendRequestSpy.getCalls().some(
+          (c) => (c.args[0]?.message as any)?.descriptor?.method === 'Configure'
+        ),
+      ).toBe(false);
     });
 
-    it('should configure the protocol if it does not exist', async () => {
-      // scenario: the wallet gets a request for a protocol that it does not have configured
-      // the wallet should attempt to configure the protocol and then send the protocol to the remote DWN
-
-      // looks for a response of 404, empty entries array or missing entries array
+    it('should configure the protocol locally and fan out to all owner DWN endpoints when the protocol is missing locally', async () => {
+      // Scenario: the agent's `prepareProtocol` runs in the safety-fallback
+      // path (caller did not pre-install). It must (a) configure the protocol
+      // on the LOCAL DWN via `processDwnRequest` so the agent can sign / encrypt
+      // grants for it, and (b) push the configure message to every owner DWN
+      // endpoint in PARALLEL via `agent.rpc.sendDwnRequest` (best-effort).
+      //
+      // The legacy `agent.sendDwnRequest` path — which iterated owner endpoints
+      // sequentially and is the historical bottleneck — must NOT be used.
 
       sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
       // Stub per-grant revocation createGrant calls
@@ -793,17 +815,36 @@ describe('enbox connect', () => {
       };
       connectRequest = await EnboxConnectProtocol.createConnectRequest(options);
 
-      // spy send request
+      // Spy on both transports — only `agent.rpc.sendDwnRequest` should fire.
       const sendRequestSpy = sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
         messageCid : '',
         reply      : { status: { code: 202, detail: 'OK' } }
       });
+      const rpcSendRequestSpy = sinon.stub(testHarness.agent.rpc, 'sendDwnRequest').resolves({
+        status: { code: 202, detail: 'Accepted' }
+      } as any);
 
-      const processDwnRequestStub = sinon
-        .stub(testHarness.agent, 'processDwnRequest')
-        .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [ ] } });
+      // Stub endpoint resolution to two URLs so we can observe parallel fan-out.
+      const endpointUrls = ['https://dwn-a.example/', 'https://dwn-b.example/'];
+      sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget').resolves(endpointUrls);
 
-      // call submitAuthResponse
+      // ProtocolsQuery → empty entries (missing locally) on first call;
+      // local ProtocolsConfigure → 202 with a synthetic descriptor on second.
+      const processDwnRequestStub = sinon.stub(testHarness.agent, 'processDwnRequest');
+      processDwnRequestStub
+        .onFirstCall()
+        .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [] } });
+      processDwnRequestStub
+        .onSecondCall()
+        .resolves({
+          messageCid : '',
+          reply      : { status: { code: 202, detail: 'OK' } },
+          message    : { descriptor: { interface: 'Protocols', method: 'Configure' } } as any,
+        });
+
+      // Stub fetch so the relay POST does not escape the test environment.
+      sinon.stub(globalThis, 'fetch').resolves(new Response());
+
       await EnboxConnectProtocol.submitConnectResponse(
         providerIdentity.did.uri,
         connectRequest,
@@ -811,42 +852,41 @@ describe('enbox connect', () => {
         testHarness.agent
       );
 
-      // expect the process request to be called for query and configure
+      // processDwnRequest is called twice: ProtocolsQuery, then a LOCAL
+      // ProtocolsConfigure (with messageParams + optional encryption).
       expect(processDwnRequestStub.callCount).toBe(2);
       expect(processDwnRequestStub.firstCall.args[0].messageType).toBe(DwnInterface.ProtocolsQuery);
       expect(processDwnRequestStub.secondCall.args[0].messageType).toBe(DwnInterface.ProtocolsConfigure);
+      expect((processDwnRequestStub.secondCall.args[0] as any).messageParams?.definition?.protocol)
+        .toBe(protocolDefinition.protocol);
 
-      // send request should be called once as a ProtocolsConfigure
-      expect(sendRequestSpy.callCount).toBe(1);
-      expect(sendRequestSpy.firstCall.args[0].messageType).toBe(DwnInterface.ProtocolsConfigure);
+      // The legacy `agent.sendDwnRequest` is no longer used by prepareProtocol.
+      expect(sendRequestSpy.callCount).toBe(0);
 
-      // reset the spys
-      processDwnRequestStub.resetHistory();
-      sendRequestSpy.resetHistory();
-
-      // processDwnRequestStub should resolve a 200 with no entires
-      processDwnRequestStub.resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' } } });
-
-      // call submitAuthResponse
-      await EnboxConnectProtocol.submitConnectResponse(
-        providerIdentity.did.uri,
-        connectRequest,
-        randomPin,
-        testHarness.agent
+      // Each owner DWN endpoint receives the configure message exactly once via
+      // the parallel `mapConcurrentSettled` fan-out.
+      const configureSends = rpcSendRequestSpy.getCalls().filter(
+        (c) => (c.args[0]?.message as any)?.descriptor?.method === 'Configure',
       );
+      expect(configureSends.length).toBe(endpointUrls.length);
+      expect(new Set(configureSends.map((c) => c.args[0].dwnUrl))).toEqual(new Set(endpointUrls));
 
-      // expect the process request to be called for query and configure
-      expect(processDwnRequestStub.callCount).toBe(2);
-      expect(processDwnRequestStub.firstCall.args[0].messageType).toBe(DwnInterface.ProtocolsQuery);
-      expect(processDwnRequestStub.secondCall.args[0].messageType).toBe(DwnInterface.ProtocolsConfigure);
-
-      // send request should be called once as a ProtocolsConfigure
-      expect(sendRequestSpy.callCount).toBe(1);
-      expect(sendRequestSpy.firstCall.args[0].messageType).toBe(DwnInterface.ProtocolsConfigure);
+      // Every per-request send carries the connect-flow per-request abort
+      // budget so a single unhealthy endpoint cannot stall the hot path.
+      for (const call of configureSends) {
+        expect(call.args[0].signal).toBeInstanceOf(AbortSignal);
+      }
     });
 
-    it('should fail if the send request fails for newly configured protocol', async () => {
+    it('should treat a 200 reply with no entries field as missing locally and trigger the safety fallback', async () => {
+      // Some local DWN replies omit the `entries` array entirely (empty result).
+      // The agent must treat that as "not installed" identically to `entries: []`.
+
       sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+      sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
+        grant   : {} as any,
+        message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
+      });
       sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
       sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
 
@@ -863,34 +903,59 @@ describe('enbox connect', () => {
       };
       connectRequest = await EnboxConnectProtocol.createConnectRequest(options);
 
-      // spy send request
       const sendRequestSpy = sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
-        reply      : { status: { code: 500, detail: 'Internal Server Error' } },
-        messageCid : ''
+        messageCid : '',
+        reply      : { status: { code: 202, detail: 'OK' } }
       });
+      const rpcSendRequestSpy = sinon.stub(testHarness.agent.rpc, 'sendDwnRequest').resolves({
+        status: { code: 202, detail: 'Accepted' }
+      } as any);
 
-      // return without any entries
-      const _processDwnRequestStub = sinon
-        .stub(testHarness.agent, 'processDwnRequest')
+      // Endpoint resolution returns empty → local-only configuration, no fan-out.
+      sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget').resolves([]);
+
+      const processDwnRequestStub = sinon.stub(testHarness.agent, 'processDwnRequest');
+      processDwnRequestStub
+        .onFirstCall()
         .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' } } });
+      processDwnRequestStub
+        .onSecondCall()
+        .resolves({
+          messageCid : '',
+          reply      : { status: { code: 202, detail: 'OK' } },
+          message    : { descriptor: { interface: 'Protocols', method: 'Configure' } } as any,
+        });
 
-      try {
-        // call submitAuthResponse
-        await EnboxConnectProtocol.submitConnectResponse(
-          providerIdentity.did.uri,
-          connectRequest,
-          randomPin,
-          testHarness.agent
-        );
+      sinon.stub(globalThis, 'fetch').resolves(new Response());
 
-        throw new Error('should have thrown an error');
-      } catch (error: any) {
-        expect(error.message).toBe('Could not send protocol: Internal Server Error');
-        expect(sendRequestSpy.callCount).toBe(1);
-      }
+      await EnboxConnectProtocol.submitConnectResponse(
+        providerIdentity.did.uri,
+        connectRequest,
+        randomPin,
+        testHarness.agent
+      );
+
+      // Treated as missing → local configure attempted.
+      expect(processDwnRequestStub.callCount).toBe(2);
+      expect(processDwnRequestStub.secondCall.args[0].messageType).toBe(DwnInterface.ProtocolsConfigure);
+
+      // No endpoints → no remote fan-out, no legacy send.
+      expect(sendRequestSpy.callCount).toBe(0);
+      expect(
+        rpcSendRequestSpy.getCalls().some(
+          (c) => (c.args[0]?.message as any)?.descriptor?.method === 'Configure'
+        ),
+      ).toBe(false);
     });
 
-    it('should fail if the send request fails for existing protocol', async () => {
+    it('should fail if local ProtocolsConfigure fails when the protocol is missing locally', async () => {
+      // Scenario: the agent's safety-fallback path attempts to install the
+      // protocol locally before fanning out remotely. If the local install
+      // itself fails (non-202/409), the connect flow MUST throw — without
+      // a locally installed protocol, the agent cannot sign / encrypt grants.
+      // Remote endpoint failures, in contrast, are best-effort (sync delivers
+      // missed copies), so they do NOT abort the connect.
+
       sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
       sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
       sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
@@ -908,22 +973,23 @@ describe('enbox connect', () => {
       };
       connectRequest = await EnboxConnectProtocol.createConnectRequest(options);
 
-      // stub the processDwnRequest method to return a protocol entry
-      const protocolMessage = {} as DwnMessage[DwnInterface.ProtocolsConfigure];
-
-      // spy send request
       const sendRequestSpy = sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
         reply      : { status: { code: 500, detail: 'Internal Server Error' } },
         messageCid : ''
       });
 
-      // mock returning the protocol entry
-      const processDwnRequestStub = sinon
-        .stub(testHarness.agent, 'processDwnRequest')
-        .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [ protocolMessage ] } });
+      // ProtocolsQuery → empty (missing locally). Local ProtocolsConfigure → 500.
+      const processDwnRequestStub = sinon.stub(testHarness.agent, 'processDwnRequest');
+      processDwnRequestStub
+        .onFirstCall()
+        .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [] } });
+      processDwnRequestStub
+        .onSecondCall()
+        .resolves({ messageCid: '', reply: { status: { code: 500, detail: 'Local DWN error' } } });
+
+      sinon.stub(globalThis, 'fetch').resolves(new Response());
 
       try {
-        // call submitAuthResponse
         await EnboxConnectProtocol.submitConnectResponse(
           providerIdentity.did.uri,
           connectRequest,
@@ -933,10 +999,80 @@ describe('enbox connect', () => {
 
         throw new Error('should have thrown an error');
       } catch (error: any) {
-        expect(error.message).toBe('Could not send protocol: Internal Server Error');
-        expect(processDwnRequestStub.callCount).toBe(1);
-        expect(sendRequestSpy.callCount).toBe(1);
+        expect(error.message).toBe('Could not configure protocol locally: Local DWN error');
+        // Local query + local configure = two processDwnRequest calls; no
+        // legacy `agent.sendDwnRequest` calls because the new path uses the
+        // RPC client directly and the failure happens before fan-out.
+        expect(processDwnRequestStub.callCount).toBe(2);
+        expect(sendRequestSpy.callCount).toBe(0);
       }
+    });
+
+    it('should NOT throw when remote endpoints are unhealthy after a successful local configure', async () => {
+      // Scenario: the local install succeeds but every owner DWN endpoint
+      // returns 5xx / aborts. The fan-out is best-effort — sync will
+      // eventually deliver missing copies — so the connect must succeed.
+      // This guards the "Authorizing…" hot path against a single bad
+      // endpoint dragging the user into an error state.
+
+      sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+      sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
+        grant   : {} as any,
+        message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
+      });
+      sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
+      sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+
+      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+        baseURL  : 'http://localhost:3000',
+        endpoint : 'callback',
+      });
+
+      const options = {
+        appName            : 'Sample App',
+        clientDid          : clientEphemeralPortableDid.uri,
+        permissionRequests : [{ protocolDefinition, permissionScopes }],
+        callbackUrl        : callbackUrl,
+      };
+      connectRequest = await EnboxConnectProtocol.createConnectRequest(options);
+
+      sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
+        messageCid : '',
+        reply      : { status: { code: 202, detail: 'OK' } }
+      });
+      const rpcSendRequestSpy = sinon.stub(testHarness.agent.rpc, 'sendDwnRequest')
+        .rejects(new Error('every endpoint is unhealthy'));
+
+      sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget')
+        .resolves(['https://dwn-a.example/', 'https://dwn-b.example/']);
+
+      const processDwnRequestStub = sinon.stub(testHarness.agent, 'processDwnRequest');
+      processDwnRequestStub
+        .onFirstCall()
+        .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [] } });
+      processDwnRequestStub
+        .onSecondCall()
+        .resolves({
+          messageCid : '',
+          reply      : { status: { code: 202, detail: 'OK' } },
+          message    : { descriptor: { interface: 'Protocols', method: 'Configure' } } as any,
+        });
+
+      sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+      // Must not throw — best-effort fan-out swallows individual failures.
+      await EnboxConnectProtocol.submitConnectResponse(
+        providerIdentity.did.uri,
+        connectRequest,
+        randomPin,
+        testHarness.agent
+      );
+
+      // The fan-out was attempted on every endpoint despite the failures.
+      const configureSends = rpcSendRequestSpy.getCalls().filter(
+        (c) => (c.args[0]?.message as any)?.descriptor?.method === 'Configure',
+      );
+      expect(configureSends.length).toBe(2);
     });
 
     it('should throw if protocol could not be fetched at all', async () => {
@@ -985,9 +1121,13 @@ describe('enbox connect', () => {
       }
     });
 
-    it('should pass encryption: true when configuring a protocol with encryptionRequired types', async () => {
-      // scenario: the wallet gets a request for a protocol that has encryptionRequired types
-      // prepareProtocol should detect this and pass encryption: true to the sendDwnRequest
+    it('should pass encryption: true to the LOCAL ProtocolsConfigure when the protocol has encryptionRequired types', async () => {
+      // Scenario: the agent's safety-fallback installs a protocol whose types
+      // declare `encryptionRequired: true`. The LOCAL configure (via
+      // `processDwnRequest`) must carry `encryption: true` so the local DWN
+      // derives and injects `$encryption` keys from the owner's X25519 root.
+      // The remote fan-out then re-uses the resulting raw message — no
+      // `encryption` flag is needed on the per-endpoint sends.
 
       const encryptedProtocol: DwnProtocolDefinition = {
         protocol  : 'http://encrypted-protocol.xyz',
@@ -1030,14 +1170,28 @@ describe('enbox connect', () => {
       };
       connectRequest = await EnboxConnectProtocol.createConnectRequest(options);
 
-      // spy send request
-      const sendRequestSpy = sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
+      sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
         messageCid : '',
         reply      : { status: { code: 202, detail: 'OK' } }
       });
+      sinon.stub(testHarness.agent.rpc, 'sendDwnRequest').resolves({
+        status: { code: 202, detail: 'Accepted' }
+      } as any);
+      sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget').resolves([]);
 
-      sinon.stub(testHarness.agent, 'processDwnRequest')
+      const processDwnRequestStub = sinon.stub(testHarness.agent, 'processDwnRequest');
+      processDwnRequestStub
+        .onFirstCall()
         .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [] } });
+      processDwnRequestStub
+        .onSecondCall()
+        .resolves({
+          messageCid : '',
+          reply      : { status: { code: 202, detail: 'OK' } },
+          message    : { descriptor: { interface: 'Protocols', method: 'Configure' } } as any,
+        });
+
+      sinon.stub(globalThis, 'fetch').resolves(new Response());
 
       await EnboxConnectProtocol.submitConnectResponse(
         providerIdentity.did.uri,
@@ -1046,9 +1200,9 @@ describe('enbox connect', () => {
         testHarness.agent
       );
 
-      // Verify that sendDwnRequest was called with encryption: true for the ProtocolsConfigure
-      const configureCall = sendRequestSpy.getCalls().find(
-        (call) => call.args[0].messageType === DwnInterface.ProtocolsConfigure
+      // Verify the LOCAL ProtocolsConfigure carried `encryption: true`.
+      const configureCall = processDwnRequestStub.getCalls().find(
+        (call) => call.args[0].messageType === DwnInterface.ProtocolsConfigure,
       );
       expect(configureCall).toBeDefined();
       expect((configureCall!.args[0] as any).encryption).toBe(true);
@@ -1168,13 +1322,18 @@ describe('enbox connect', () => {
         endpoint : 'callback',
       });
 
-      const mismatchedScopes = [...permissionScopes];
+      // Deep-clone before mutating so this test does not leak state into
+      // subsequent tests in the same describe block (the spread above is a
+      // shallow copy — `mismatchedScopes[0]` IS `permissionScopes[0]`).
+      const mismatchedScopes = permissionScopes.map((s) => ({ ...s }));
       mismatchedScopes[0].protocol = 'http://profile-protocol.xyz/other';
 
       const options = {
         appName            : 'Sample App',
         clientDid          : clientEphemeralPortableDid.uri,
-        permissionRequests : [{ protocolDefinition, permissionScopes }],
+        // Use the deep-cloned mismatched scopes so the validation actually
+        // fires regardless of whether the prior shallow-copy bug existed.
+        permissionRequests : [{ protocolDefinition, permissionScopes: mismatchedScopes }],
         callbackUrl        : callbackUrl,
       };
       connectRequest = await EnboxConnectProtocol.createConnectRequest(options);
@@ -1192,6 +1351,246 @@ describe('enbox connect', () => {
       } catch (error: any) {
         expect(error.message).toBe('All permission scopes must match the protocol URI they are provided with.');
       }
+    });
+
+    describe('connect-flow fan-out parallelism (regression: "Authorizing…" hang)', () => {
+      it('should fan the safety-fallback ProtocolsConfigure out to all owner DWN endpoints in PARALLEL, not sequentially', async () => {
+        // Each per-endpoint send takes 250 ms. With 4 endpoints, sequential
+        // execution would take ≥ 1000 ms; parallel execution should take
+        // ~250 ms. This test asserts a generous-but-still-meaningful upper
+        // bound (700 ms) to prevent any future regression that re-introduces
+        // sequential per-endpoint iteration in the connect hot path.
+        const endpointUrls = [
+          'https://dwn-a.example/',
+          'https://dwn-b.example/',
+          'https://dwn-c.example/',
+          'https://dwn-d.example/',
+        ];
+        const PER_SEND_DELAY_MS = 250;
+
+        sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+        sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
+          grant   : {} as any,
+          message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
+        });
+        sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
+        sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+
+        const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+          baseURL  : 'http://localhost:3000',
+          endpoint : 'callback',
+        });
+
+        connectRequest = await EnboxConnectProtocol.createConnectRequest({
+          appName            : 'Sample App',
+          clientDid          : clientEphemeralPortableDid.uri,
+          permissionRequests : [{ protocolDefinition, permissionScopes }],
+          callbackUrl        : callbackUrl,
+        });
+
+        sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget').resolves(endpointUrls);
+        sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
+          messageCid : '',
+          reply      : { status: { code: 202, detail: 'OK' } }
+        });
+        const rpcSendRequestStub = sinon.stub(testHarness.agent.rpc, 'sendDwnRequest')
+          .callsFake(async () => {
+            await new Promise<void>((resolve) => setTimeout(resolve, PER_SEND_DELAY_MS));
+            return { status: { code: 202, detail: 'Accepted' } } as any;
+          });
+
+        const processDwnRequestStub = sinon.stub(testHarness.agent, 'processDwnRequest');
+        processDwnRequestStub
+          .onFirstCall()
+          .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [] } });
+        processDwnRequestStub
+          .onSecondCall()
+          .resolves({
+            messageCid : '',
+            reply      : { status: { code: 202, detail: 'OK' } },
+            message    : { descriptor: { interface: 'Protocols', method: 'Configure' } } as any,
+          });
+
+        sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+        const start = Date.now();
+        await EnboxConnectProtocol.submitConnectResponse(
+          providerIdentity.did.uri,
+          connectRequest,
+          randomPin,
+          testHarness.agent,
+        );
+        const elapsed = Date.now() - start;
+
+        // Sequential lower bound: 4 × 250 ms = 1000 ms. Parallel should be
+        // close to 250 ms; we allow generous slack for scheduling, GC, the
+        // surrounding submitConnectResponse work, and CI noise.
+        expect(elapsed).toBeLessThan(700);
+
+        const configureSends = rpcSendRequestStub.getCalls().filter(
+          (c) => (c.args[0]?.message as any)?.descriptor?.method === 'Configure',
+        );
+        expect(configureSends.length).toBe(endpointUrls.length);
+      });
+
+      it('should attach a per-request AbortSignal with a bounded timeout to every connect-flow fan-out send', async () => {
+        // The connect flow caps each `agent.rpc.sendDwnRequest` with
+        // `AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS)` so a single
+        // unhealthy endpoint cannot consume the full HTTP retry budget
+        // (4 × 30 s) and stall the user-visible "Authorizing…" spinner.
+        // This test asserts a signal is present on every send, that it is
+        // an AbortSignal, and that it is NOT already aborted at dispatch
+        // time (i.e. the budget genuinely starts when the request begins).
+        sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+        sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
+          grant   : {} as any,
+          message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
+        });
+        sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
+        sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+
+        const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+          baseURL  : 'http://localhost:3000',
+          endpoint : 'callback',
+        });
+
+        connectRequest = await EnboxConnectProtocol.createConnectRequest({
+          appName            : 'Sample App',
+          clientDid          : clientEphemeralPortableDid.uri,
+          permissionRequests : [{ protocolDefinition, permissionScopes }],
+          callbackUrl        : callbackUrl,
+        });
+
+        sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget')
+          .resolves(['https://dwn-a.example/', 'https://dwn-b.example/']);
+        sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
+          messageCid : '',
+          reply      : { status: { code: 202, detail: 'OK' } }
+        });
+        const rpcSendRequestSpy = sinon.stub(testHarness.agent.rpc, 'sendDwnRequest')
+          .resolves({ status: { code: 202, detail: 'Accepted' } } as any);
+
+        const processDwnRequestStub = sinon.stub(testHarness.agent, 'processDwnRequest');
+        processDwnRequestStub
+          .onFirstCall()
+          .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [] } });
+        processDwnRequestStub
+          .onSecondCall()
+          .resolves({
+            messageCid : '',
+            reply      : { status: { code: 202, detail: 'OK' } },
+            message    : { descriptor: { interface: 'Protocols', method: 'Configure' } } as any,
+          });
+
+        sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+        await EnboxConnectProtocol.submitConnectResponse(
+          providerIdentity.did.uri,
+          connectRequest,
+          randomPin,
+          testHarness.agent,
+        );
+
+        // EVERY connect-flow send (configure fan-out + permission grants +
+        // revocation grants) must carry a non-aborted AbortSignal so the
+        // HttpDwnRpcClient enforces the per-request budget.
+        expect(rpcSendRequestSpy.callCount).toBeGreaterThan(0);
+        for (const call of rpcSendRequestSpy.getCalls()) {
+          const signal = call.args[0]?.signal;
+          expect(signal).toBeInstanceOf(AbortSignal);
+          expect(signal!.aborted).toBe(false);
+        }
+      });
+
+      it('should still complete when one endpoint hangs forever \u2014 the abort signal short-circuits the retry budget', async () => {
+        // Reproduces the original "Authorizing… for minutes" symptom: one
+        // unhealthy endpoint that never responds. Without per-request abort
+        // plumbing, `AbortSignal.timeout(...)` from the connect flow would
+        // not reach the underlying fetch and the request would burn the
+        // full 4 × 30 s retry budget. We simulate that by giving the second
+        // endpoint a fake `sendDwnRequest` that respects the caller's
+        // AbortSignal — exactly as the real HttpDwnRpcClient now does.
+        sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+        sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
+          grant   : {} as any,
+          message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
+        });
+        sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
+        sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+
+        const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+          baseURL  : 'http://localhost:3000',
+          endpoint : 'callback',
+        });
+
+        connectRequest = await EnboxConnectProtocol.createConnectRequest({
+          appName            : 'Sample App',
+          clientDid          : clientEphemeralPortableDid.uri,
+          permissionRequests : [{ protocolDefinition, permissionScopes }],
+          callbackUrl        : callbackUrl,
+        });
+
+        const healthyUrl = 'https://dwn-healthy.example/';
+        const hangingUrl = 'https://dwn-hanging.example/';
+        sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget')
+          .resolves([healthyUrl, hangingUrl]);
+        sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
+          messageCid : '',
+          reply      : { status: { code: 202, detail: 'OK' } }
+        });
+
+        // Healthy endpoint resolves fast; hanging endpoint waits forever
+        // unless the caller's AbortSignal fires (mirroring real HTTP fetch
+        // semantics through `AbortSignal.any([caller, perAttemptTimeout])`).
+        sinon.stub(testHarness.agent.rpc, 'sendDwnRequest').callsFake((req) => {
+          if (req.dwnUrl === hangingUrl) {
+            return new Promise((_resolve, reject) => {
+              const signal = req.signal!;
+              const onAbort = (): void => {
+                reject(new DOMException('aborted', 'AbortError'));
+              };
+              if (signal.aborted) {
+                onAbort();
+              } else {
+                signal.addEventListener('abort', onAbort, { once: true });
+              }
+            });
+          }
+          return Promise.resolve({ status: { code: 202, detail: 'Accepted' } } as any);
+        });
+
+        const processDwnRequestStub = sinon.stub(testHarness.agent, 'processDwnRequest');
+        processDwnRequestStub
+          .onFirstCall()
+          .resolves({ messageCid: '', reply: { status: { code: 200, detail: 'OK' }, entries: [] } });
+        processDwnRequestStub
+          .onSecondCall()
+          .resolves({
+            messageCid : '',
+            reply      : { status: { code: 202, detail: 'OK' } },
+            message    : { descriptor: { interface: 'Protocols', method: 'Configure' } } as any,
+          });
+
+        sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+        const start = Date.now();
+        await EnboxConnectProtocol.submitConnectResponse(
+          providerIdentity.did.uri,
+          connectRequest,
+          randomPin,
+          testHarness.agent,
+        );
+        const elapsed = Date.now() - start;
+
+        // The per-request budget is 10 s. submitConnectResponse runs three
+        // sequential phases that each touch every endpoint (prepareProtocol
+        // fan-out, permission-grant fan-out — stubbed here, and revocation
+        // fan-out), so a fully hung endpoint costs at most one budget per
+        // unstubbed phase. We assert 25 s to leave generous CI slack while
+        // still failing loudly on regressions that bypass the abort signal
+        // (without this fix, the same scenario takes minutes).
+        expect(elapsed).toBeLessThan(25_000);
+      }, 60_000); // bun:test per-test timeout, kept above the assertion budget
     });
   });
 

--- a/packages/dwn-clients/src/dwn-rpc-types.ts
+++ b/packages/dwn-clients/src/dwn-rpc-types.ts
@@ -95,6 +95,22 @@ export type DwnRpcRequest = {
   targetDid: string;
 
   /**
+   * Optional caller-provided abort signal. When supplied, the underlying
+   * HTTP client races each attempt against this signal in addition to its
+   * own per-attempt timeout via `AbortSignal.any([signal, perAttemptTimeout])`.
+   *
+   * Pass `AbortSignal.timeout(budgetMs)` from latency-sensitive paths
+   * (e.g. the wallet-connect "Authorizing" hot path) to cap the worst-case
+   * wall-clock time a single request can consume. Aborting short-circuits
+   * the retry loop — `AbortError` is treated as non-retryable, so the
+   * request fails fast rather than burning the full retry budget.
+   *
+   * Currently honoured by `HttpDwnRpcClient`. WebSocket transport ignores
+   * this field (subscription cancellation is handled separately).
+   */
+  signal?: AbortSignal;
+
+  /**
    * Subscription options — only set for subscribe requests.
    * Groups the handler, resubscribe factory, and any future subscription
    * options into a single coherent object.

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -133,6 +133,11 @@ export class HttpDwnRpcClient implements DwnRpc {
     const fetchOpts: RequestInit = {
       method  : 'POST',
       headers : requestHeaders,
+      // Caller-provided signal is honoured by `fetchWithRetry` via
+      // `AbortSignal.any([signal, perAttemptTimeoutSignal])`. Aborting
+      // short-circuits the retry loop (AbortError is non-retryable) so
+      // latency-sensitive callers can cap worst-case wall-clock time.
+      ...(request.signal ? { signal: request.signal } : {}),
     };
 
     if (request.data) {

--- a/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
+++ b/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
@@ -612,6 +612,87 @@ describe('HttpDwnRpcClient', () => {
     });
   });
 
+  describe('caller-provided AbortSignal', () => {
+    it('should pass the caller signal through to fetch so an abort cancels the in-flight request', async () => {
+      // Capture whatever signal `fetch` ultimately receives so we can prove
+      // it propagates from the DwnRpcRequest down through fetchWithRetry.
+      let capturedSignal: AbortSignal | undefined;
+      sinon.stub(globalThis, 'fetch').callsFake((async (_url: any, init?: any) => {
+        capturedSignal = init?.signal as AbortSignal | undefined;
+        // Hang forever unless the signal aborts.
+        return await new Promise<Response>((_resolve, reject) => {
+          const sig = init?.signal as AbortSignal | undefined;
+          if (sig) {
+            const onAbort = (): void => reject(new DOMException('aborted', 'AbortError'));
+            if (sig.aborted) {
+              onAbort();
+            } else {
+              sig.addEventListener('abort', onAbort, { once: true });
+            }
+          }
+        });
+      }) as any);
+
+      const client = new HttpDwnRpcClient(undefined, { maxRetries: 3, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      const controller = new AbortController();
+      const sendPromise = client.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+        signal    : controller.signal,
+      });
+
+      // Give the stubbed fetch a tick to capture the signal, then abort.
+      await new Promise<void>((resolve) => setTimeout(resolve, 5));
+      controller.abort();
+
+      await expect(sendPromise).rejects.toThrow();
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('should short-circuit the retry loop when the caller signal aborts (AbortError is non-retryable)', async () => {
+      // If the caller-supplied signal aborts, the retry loop must NOT keep
+      // trying — that would defeat the entire latency-budget mechanism. We
+      // assert exactly one fetch attempt despite a retry budget of 3.
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+      fetchStub.callsFake((async (_url: any, init?: any) => {
+        return await new Promise<Response>((_resolve, reject) => {
+          const sig = init?.signal as AbortSignal | undefined;
+          if (sig) {
+            const onAbort = (): void => reject(new DOMException('aborted', 'AbortError'));
+            if (sig.aborted) {
+              onAbort();
+            } else {
+              sig.addEventListener('abort', onAbort, { once: true });
+            }
+          }
+        });
+      }) as any);
+
+      const client = new HttpDwnRpcClient(undefined, { maxRetries: 3, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' }
+      });
+
+      const sendPromise = client.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+        signal    : AbortSignal.timeout(20),
+      });
+
+      await expect(sendPromise).rejects.toThrow();
+      // One attempt only — AbortError must NOT be treated as retryable.
+      expect(fetchStub.callCount).toBe(1);
+    });
+  });
+
   describe('getServerInfo', () => {
     it('fetches server info from a DWN server', async () => {
       const serverInfo = await client.getServerInfo(testDwnUrl);


### PR DESCRIPTION
## Summary

Two surgical fixes that together remove the dominant tail-latency in `submitConnectResponse` so the wallet's "Authorizing…" spinner cannot spin for minutes when even one owner DWN endpoint is slow / unhealthy.

PR #911 already parallelized the per-grant and revocation fan-outs with bounded concurrency, but the user-visible spinner was still hanging. This PR addresses the **two remaining bottlenecks** that PR #911 didn't touch.

### 1. `@enbox/agent` — eliminate the redundant remote `ProtocolsConfigure` send

`prepareProtocol` (called from `submitConnectResponse`) used to issue an `agent.sendDwnRequest` for every protocol regardless of whether the protocol was already installed locally. That call iterates owner DWN endpoints **sequentially** through the legacy DWN API. With the underlying HTTP client's default 4×30 s retry budget, a single unhealthy endpoint could burn ~120 s **per protocol**.

The wallet's own `prepareProtocol` (in `@enbox/web-wallet`) runs *before* `submitConnectResponse` and already fans the protocol out to every owner DWN endpoint in parallel. The agent only needs to verify local installation so it can sign / encrypt grants for it.

- **"exists locally" branch**: now performs a single local `ProtocolsQuery` and returns (~10 ms). No remote send.
- **"missing locally" safety-fallback branch**: configures locally via `processDwnRequest` and then fans out to every endpoint in parallel via the existing `mapConcurrentSettled` + `CONNECT_FANOUT_CONCURRENCY` primitive (best-effort — sync delivers any missed copies eventually).

### 2. `@enbox/dwn-clients` — plumb caller `AbortSignal` through the HTTP client

`DwnRpcRequest` now accepts an optional `signal: AbortSignal`, plumbed through `HttpDwnRpcClient.sendDwnRequest` → `fetchWithRetry` via `AbortSignal.any([caller, perAttemptTimeout])`. Aborting short-circuits the retry loop because `AbortError` is non-retryable.

Every connect-flow `agent.rpc.sendDwnRequest` (configure fan-out, permission grants, revocation grants) now passes `AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS = 10_000)`. A single unhealthy DWN endpoint can no longer stall the spinner — the request fails fast within 10 s instead of burning the full 4×30 s retry budget, and `mapConcurrentSettled` swallows the per-task failure so sync delivers eventually.

## Impact

Worst-case wall-clock per phase, "one of two endpoints unreachable":

| | Before #911 | After #911 (current `main`) | This PR |
|---|---|---|---|
| Agent's redundant `prepareProtocol` send | ~120 s × N protocols | ~120 s × N protocols | **0 s** (skipped) |
| `createPermissionGrants` fan-out | ~120 s × N grants × M endpoints | ~120 s (bounded) | **~10 s** (per-request budget) |
| Revocation grant fan-out | ~120 s × N grants × M endpoints | ~120 s (bounded) | **~10 s** (per-request budget) |

A 2-protocol / 8-permission session (16 grants × 2 endpoints), with one endpoint unhealthy, drops from "many minutes" to ~30 s end-to-end (and to <1 s when both endpoints are healthy).

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run --filter @enbox/agent build` — clean
- [x] `bun run --filter @enbox/dwn-clients build` — clean
- [x] `bun test packages/agent/tests/connect.spec.ts` — **43 / 43 pass** (including 3 new regression tests: wall-clock parallelism, AbortSignal-presence, and "one endpoint hangs forever" completing under budget)
- [x] `bun test packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts` — **26 / 26 pass** (including 2 new tests asserting caller signal is plumbed through fetch and short-circuits retry)
- [x] Full `@enbox/agent` suite — **1510 pass / 0 fail**
- [x] Full `@enbox/dwn-clients` suite — **150 pass / 0 fail**
- [x] Full `@enbox/auth` suite — **475 pass / 0 fail**
- [x] `@enbox/api` — only failure is a pre-existing `Cannot find module '@enbox/protocols'` in `protocols-integration.spec.ts` (verified to fail identically on `origin/main` — not introduced by this PR)

## Notes for follow-up

The wallet-side `prepareProtocol` in `@enbox/web-wallet` still uses `Promise.all(...endpoint sends...)`, which blocks on the slowest endpoint. With the agent fixes here, that's the next remaining bottleneck on the user-visible critical path and should be addressed in a paired wallet PR (resolve on first endpoint success, treat the rest as best-effort).

Made with [Cursor](https://cursor.com)