### PR TITLE
Fix validated findings from analysis review

### DIFF
--- a/.changeset/validated-security-fixes.md
+++ b/.changeset/validated-security-fixes.md
@@ -1,0 +1,11 @@
+---
+"@enbox/common": patch
+"@enbox/dids": patch
+"@enbox/crypto": patch
+---
+
+fix(security): block SSRF via redirects in did:web/did:dht, reject path traversal in concatenateUrl, fix biased randomPin distribution
+
+- `@enbox/common`: new `isPrivateHostname` / `assertPublicUrl` / `fetchPublicUrl` / `PublicUrlValidationError` helpers; `concatenateUrl` now rejects `..`, `%2F`/`%5C`, malformed percent-encoding, and raw `?`/`#` in the path.
+- `@enbox/dids`: new `allowPrivateGatewayUri` option (default `false`) and `DidErrorCode.InvalidGatewayUri`; redirects from Pkarr / did:web are re-validated on every hop.
+- `@enbox/crypto`: `randomPin` now uses proper unbiased rejection sampling and enough random bytes for the full digit range.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,9 @@ jobs:
           export DWN_STORAGE_STATE_INDEX=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DWN_STORAGE_RESUMABLE_TASKS=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          # The DWN server itself talks to the local Pkarr relay; opt in to private gateways for
+          # this dev/CI process. Production deployments leave this unset.
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           export DWN_RATE_LIMIT_REQUESTS_PER_SECOND=0
           export DWN_RATE_LIMIT_TENANT_REQUESTS_PER_SECOND=0
 
@@ -498,6 +501,9 @@ jobs:
       - name: Run tests with coverage
         run: |
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          # Opt-in for the test process so the agent / DWN can talk to the local Pkarr relay
+          # without each call site having to pass `allowPrivateGatewayUri: true`.
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           bun run --filter @enbox/dids         test:node:coverage
           bun run --filter @enbox/dwn-clients  test:node:coverage
           bun run --filter @enbox/agent        test:node:coverage
@@ -605,6 +611,7 @@ jobs:
           export DWN_STORAGE_STATE_INDEX=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DWN_STORAGE_RESUMABLE_TASKS=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           export DWN_RATE_LIMIT_REQUESTS_PER_SECOND=0
           export DWN_RATE_LIMIT_TENANT_REQUESTS_PER_SECOND=0
 
@@ -623,6 +630,7 @@ jobs:
       - name: Run e2e tests
         run: |
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           bun run --filter @enbox/agent test:e2e
 
       - name: Stop services

--- a/.github/workflows/e2e-identity-lifecycle.yml
+++ b/.github/workflows/e2e-identity-lifecycle.yml
@@ -85,6 +85,9 @@ jobs:
           export DWN_STORAGE_STATE_INDEX=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DWN_STORAGE_RESUMABLE_TASKS=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          # The DWN server itself talks to the local Pkarr relay; opt in to private gateways for
+          # this dev/CI process. Production deployments leave this unset.
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           export DWN_RATE_LIMIT_REQUESTS_PER_SECOND=0
           export DWN_RATE_LIMIT_TENANT_REQUESTS_PER_SECOND=0
 
@@ -118,11 +121,12 @@ jobs:
         run: |
           export TEST_DWN_URL="${{ steps.dwn.outputs.url }}"
 
-          # For local server: use the local Pkarr relay for DID resolution.
-          # For remote server: use the production DHT gateway (default) so the
-          # remote DWN can resolve the DIDs we publish.
+          # For local server: use the local Pkarr relay for DID resolution and explicitly opt in
+          # to private gateways. For remote server: use the production DHT gateway (default) so
+          # the remote DWN can resolve the DIDs we publish.
           if [ "${{ inputs.use_local_server }}" = "true" ]; then
             export DID_DHT_GATEWAY_URI=http://localhost:7527
+            export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           fi
 
           # Admin token is needed when the remote DWN has tenant registration

--- a/packages/common/src/url.ts
+++ b/packages/common/src/url.ts
@@ -1,4 +1,10 @@
 /**
+ * URL helpers shared across packages.
+ *
+ * @module
+ */
+
+/**
  * Returns true when the hostname is a loopback, private, link-local, or
  * otherwise non-routable literal that should not be fetched from untrusted
  * input.
@@ -247,7 +253,7 @@ function isPrivateIpv6(hostname: string): boolean {
   return false;
 }
 
-function parseIpv6(hostname: string): number[] | undefined {
+function parseIpv6(hostname: string): [number, number, number, number, number, number, number, number] | undefined {
   const [left, right, extra] = hostname.split('::');
   if (extra !== undefined) {
     return undefined;
@@ -275,7 +281,7 @@ function parseIpv6(hostname: string): number[] | undefined {
   }
 
   if (right === undefined) {
-    return parsedParts;
+    return parsedParts as [number, number, number, number, number, number, number, number];
   }
 
   const fill = new Array(8 - parsedParts.length).fill(0);
@@ -283,7 +289,7 @@ function parseIpv6(hostname: string): number[] | undefined {
     ...parsedParts.slice(0, leftParts.length),
     ...fill,
     ...parsedParts.slice(leftParts.length),
-  ];
+  ] as [number, number, number, number, number, number, number, number];
 }
 
 function expandIpv4Suffix(parts: string[]): string[] | undefined {

--- a/packages/common/src/url.ts
+++ b/packages/common/src/url.ts
@@ -1,32 +1,315 @@
 /**
- * URL helpers shared across packages.
- *
- * @module
+ * Returns true when the hostname is a loopback, private, link-local, or
+ * otherwise non-routable literal that should not be fetched from untrusted
+ * input.
  */
+export function isPrivateHostname(hostname: string): boolean {
+  let h = hostname.trim().toLowerCase();
+
+  if (h.startsWith('[') && h.endsWith(']')) {
+    h = h.slice(1, -1);
+  }
+
+  const zoneIndex = h.indexOf('%');
+  if (zoneIndex !== -1) {
+    h = h.slice(0, zoneIndex);
+  }
+
+  if (h.endsWith('.')) {
+    h = h.slice(0, -1);
+  }
+
+  if (h === 'localhost' || h.endsWith('.localhost')) {
+    return true;
+  }
+
+  const ipv4 = parseIpv4(h);
+  if (ipv4 !== undefined) {
+    return isPrivateIpv4(ipv4);
+  }
+
+  if (h.includes(':')) {
+    return isPrivateIpv6(h);
+  }
+
+  return false;
+}
+
+/** Default protocols accepted by {@link assertPublicUrl} when no explicit list is given. */
+const DEFAULT_PUBLIC_URL_PROTOCOLS: readonly string[] = ['http:', 'https:'];
 
 /**
- * Concatenates a base URL and a path ensuring that there is exactly one slash
- * between them. Handles every combination of trailing/leading slashes on the
- * inputs.
+ * Thrown by {@link assertPublicUrl} (and surfaced by {@link fetchPublicUrl}) when a URL — or a
+ * redirect target — fails public-URL validation. Distinct from generic `Error` so callers can
+ * map validation failures to a specific error code (e.g. `invalidGatewayUri`) without
+ * accidentally also mapping unrelated network failures.
+ */
+export class PublicUrlValidationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'PublicUrlValidationError';
+  }
+}
+
+/**
+ * Parses and validates that a URL targets a routable public host over an allowed network scheme.
  *
- * @example
- * ```ts
- * concatenateUrl('https://example.com',  'api/v1');  // 'https://example.com/api/v1'
- * concatenateUrl('https://example.com/', 'api/v1');  // 'https://example.com/api/v1'
- * concatenateUrl('https://example.com',  '/api/v1'); // 'https://example.com/api/v1'
- * concatenateUrl('https://example.com/', '/api/v1'); // 'https://example.com/api/v1'
- * ```
+ * Rejects:
+ * - URLs whose protocol is not in `allowedProtocols` (defaults to `http:` / `https:`), so callers
+ *   cannot smuggle `file:`, `javascript:`, `data:`, `ws:`, etc. past a downstream `fetch()`.
+ * - URLs without a hostname.
+ * - URLs whose hostname is a loopback, private, link-local, or otherwise non-routable literal per
+ *   {@link isPrivateHostname}.
+ *
+ * This intentionally does not perform DNS resolution, so callers handling high-risk server-side
+ * fetches should still consider DNS rebinding defenses (and use {@link fetchPublicUrl} to also
+ * validate every redirect target).
+ */
+export function assertPublicUrl(url: string | URL, description = 'URL', options?: { allowedProtocols?: readonly string[] }): URL {
+  const parsedUrl = typeof url === 'string' ? new URL(url) : new URL(url.toString());
+  const allowedProtocols = options?.allowedProtocols ?? DEFAULT_PUBLIC_URL_PROTOCOLS;
+
+  if (!allowedProtocols.includes(parsedUrl.protocol)) {
+    throw new PublicUrlValidationError(`${description} must use one of the allowed schemes (${allowedProtocols.join(', ')}): ${parsedUrl.protocol}`);
+  }
+
+  if (parsedUrl.hostname === '') {
+    throw new PublicUrlValidationError(`${description} must specify a hostname.`);
+  }
+
+  if (isPrivateHostname(parsedUrl.hostname)) {
+    throw new PublicUrlValidationError(`${description} must not target a private, loopback, or link-local host: ${parsedUrl.hostname}`);
+  }
+
+  return parsedUrl;
+}
+
+/**
+ * Maximum number of HTTP redirects {@link fetchPublicUrl} will follow before giving up. Public
+ * relays and DID document servers should rarely chain more than 1–2 redirects; this leaves enough
+ * headroom for those while still bounding worst-case behavior.
+ */
+const DEFAULT_MAX_REDIRECTS = 5;
+
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Performs a `fetch()` whose target — and every subsequent redirect target — is validated by
+ * {@link assertPublicUrl}. Defends against SSRF via redirect-based bypasses where a public
+ * gateway returns `Location: http://127.0.0.1/...` after the initial validation succeeded.
+ *
+ * Manually drives the redirect loop so each `Location` is re-validated. A 3xx response without a
+ * `Location` header (e.g. `304 Not Modified`) is returned to the caller unchanged.
+ */
+export async function fetchPublicUrl(url: string | URL, init?: RequestInit, options?: {
+  description?: string;
+  allowedProtocols?: readonly string[];
+  maxRedirects?: number;
+}): Promise<Response> {
+  const description = options?.description ?? 'URL';
+  const maxRedirects = options?.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  let currentUrl = assertPublicUrl(url, description, { allowedProtocols: options?.allowedProtocols }).href;
+
+  for (let attempt = 0; attempt <= maxRedirects; attempt++) {
+    const response = await fetch(currentUrl, { ...init, redirect: 'manual' });
+
+    if (!REDIRECT_STATUS_CODES.has(response.status)) {
+      return response;
+    }
+
+    const location = response.headers.get('location');
+    if (location === null) {
+      return response;
+    }
+
+    currentUrl = assertPublicUrl(new URL(location, currentUrl), description, { allowedProtocols: options?.allowedProtocols }).href;
+  }
+
+  throw new Error(`${description} exceeded the maximum number of redirects (${maxRedirects}).`);
+}
+
+/**
+ * Concatenates a base URL and a path ensuring that there is exactly one slash between them.
+ *
+ * The `path` argument must be a pure URL pathname — raw `?` (query) and `#` (fragment) delimiters
+ * are rejected because they are silently percent-encoded by the WHATWG URL parser when assigned
+ * to `pathname`, which would otherwise change the endpoint a caller meant to reach. Callers that
+ * need to attach a query string or fragment should construct the URL explicitly. Percent-encoded
+ * `%3F` / `%23` are preserved so genuine path segments containing those characters work.
  */
 export function concatenateUrl(baseUrl: string, path: string): string {
-  // Remove trailing slash from baseUrl if it exists
-  if (baseUrl.endsWith('/')) {
-    baseUrl = baseUrl.slice(0, -1);
+  if (path.includes('?') || path.includes('#')) {
+    throw new Error('Path must not contain a raw query string or fragment; build the URL explicitly instead.');
   }
 
-  // Remove leading slash from path if it exists
-  if (path.startsWith('/')) {
-    path = path.slice(1);
+  const sanitizedPath = path.replaceAll(/^\/+/g, '');
+  const segments = sanitizedPath.split('/');
+
+  if (segments.some(isUnsafePathSegment)) {
+    throw new Error('Path must not contain parent directory segments.');
   }
 
-  return `${baseUrl}/${path}`;
+  const url = new URL(baseUrl);
+  const basePath = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`;
+  url.pathname = `${basePath}${sanitizedPath}`.replaceAll(/\/{2,}/g, '/');
+
+  if (url.pathname.includes('/../') || url.pathname.endsWith('/..')) {
+    throw new Error('Path must not escape the base URL path.');
+  }
+
+  return url.toString();
+}
+
+/**
+ * Returns true when a single path segment is unsafe to append to a base URL.
+ *
+ * A segment is unsafe when it contains parent-directory traversal (`..`), embedded path
+ * separators (`/` or `\`) — including any percent-encoded variants — or malformed percent
+ * encoding (which is always rejected so callers cannot smuggle traversal past `decodeURIComponent`
+ * by triggering a `URIError`).
+ */
+function isUnsafePathSegment(segment: string): boolean {
+  if (segment === '..') {
+    return true;
+  }
+
+  let decodedSegment: string;
+  try {
+    decodedSegment = decodeURIComponent(segment);
+  } catch {
+    return true;
+  }
+
+  return decodedSegment === '..' || decodedSegment.includes('/') || decodedSegment.includes('\\');
+}
+
+function parseIpv4(hostname: string): [number, number, number, number] | undefined {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) {
+    return undefined;
+  }
+
+  const octets = parts.map((part) => {
+    if (!/^\d+$/.test(part)) {
+      return Number.NaN;
+    }
+    return Number(part);
+  });
+
+  if (!octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255)) {
+    return undefined;
+  }
+
+  return octets as [number, number, number, number];
+}
+
+function isPrivateIpv4([a, b]: [number, number, number, number]): boolean {
+  if (a === 0) { return true; } // 0.0.0.0/8
+  if (a === 10) { return true; } // 10.0.0.0/8
+  if (a === 100 && b >= 64 && b <= 127) { return true; } // 100.64.0.0/10
+  if (a === 127) { return true; } // 127.0.0.0/8
+  if (a === 169 && b === 254) { return true; } // 169.254.0.0/16
+  if (a === 172 && b >= 16 && b <= 31) { return true; } // 172.16.0.0/12
+  if (a === 192 && b === 168) { return true; } // 192.168.0.0/16
+  if (a >= 224) { return true; } // multicast/reserved
+
+  return false;
+}
+
+function isPrivateIpv6(hostname: string): boolean {
+  const hextets = parseIpv6(hostname);
+  if (hextets === undefined) {
+    return false;
+  }
+
+  const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets;
+  const firstSixZero = h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0;
+
+  if (hextets.every((hextet) => hextet === 0)) { return true; } // ::/128
+  if (firstSixZero && h6 === 0 && h7 === 1) { return true; } // ::1/128
+
+  if ((h0 & 0xfe00) === 0xfc00) { return true; } // fc00::/7
+  if ((h0 & 0xffc0) === 0xfe80) { return true; } // fe80::/10
+  if ((h0 & 0xff00) === 0xff00) { return true; } // ff00::/8
+
+  if (h0 === 0x0064 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return isPrivateIpv4(ipv6HextetsToIpv4(h6, h7)); // 64:ff9b::/96
+  }
+
+  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0xffff) {
+    return isPrivateIpv4(ipv6HextetsToIpv4(h6, h7)); // ::ffff:0:0/96
+  }
+
+  if (firstSixZero) {
+    return true; // deprecated IPv4-compatible ::/96
+  }
+
+  return false;
+}
+
+function parseIpv6(hostname: string): number[] | undefined {
+  const [left, right, extra] = hostname.split('::');
+  if (extra !== undefined) {
+    return undefined;
+  }
+
+  const leftParts = left === '' ? [] : left.split(':');
+  const rightParts = right === undefined || right === '' ? [] : right.split(':');
+  const parts = expandIpv4Suffix([...leftParts, ...rightParts]);
+  if (parts === undefined) {
+    return undefined;
+  }
+
+  if (parts.length > 8 || (right === undefined && parts.length !== 8) || (right !== undefined && parts.length >= 8)) {
+    return undefined;
+  }
+
+  const parsedParts = parts.map((part) => {
+    if (!/^[0-9a-f]{1,4}$/.test(part)) {
+      return Number.NaN;
+    }
+    return Number.parseInt(part, 16);
+  });
+  if (!parsedParts.every((part) => Number.isInteger(part) && part >= 0 && part <= 0xffff)) {
+    return undefined;
+  }
+
+  if (right === undefined) {
+    return parsedParts;
+  }
+
+  const fill = new Array(8 - parsedParts.length).fill(0);
+  return [
+    ...parsedParts.slice(0, leftParts.length),
+    ...fill,
+    ...parsedParts.slice(leftParts.length),
+  ];
+}
+
+function expandIpv4Suffix(parts: string[]): string[] | undefined {
+  const last = parts.at(-1);
+  if (!last?.includes('.')) {
+    return parts;
+  }
+
+  const ipv4 = parseIpv4(last);
+  if (ipv4 === undefined) {
+    return undefined;
+  }
+
+  const [a, b, c, d] = ipv4;
+  return [
+    ...parts.slice(0, -1),
+    (((a << 8) | b) & 0xffff).toString(16),
+    (((c << 8) | d) & 0xffff).toString(16),
+  ];
+}
+
+function ipv6HextetsToIpv4(high: number, low: number): [number, number, number, number] {
+  return [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff,
+  ];
 }

--- a/packages/common/tests/url.test.ts
+++ b/packages/common/tests/url.test.ts
@@ -1,54 +1,188 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, mock } from 'bun:test';
 
-import { concatenateUrl } from '../src/url.js';
+import { assertPublicUrl, concatenateUrl, fetchPublicUrl, isPrivateHostname } from '../src/url.js';
 
-describe('concatenateUrl', () => {
-  it('joins base URL and path with a single slash', () => {
-    expect(concatenateUrl('https://example.com', 'api/v1')).toBe('https://example.com/api/v1');
+describe('url utilities', () => {
+  describe('isPrivateHostname()', () => {
+    it('detects localhost names', () => {
+      expect(isPrivateHostname('localhost')).toBe(true);
+      expect(isPrivateHostname('LOCALHOST.')).toBe(true);
+      expect(isPrivateHostname('wallet.localhost')).toBe(true);
+    });
+
+    it('detects private and loopback IPv4 literals', () => {
+      expect(isPrivateHostname('10.1.2.3')).toBe(true);
+      expect(isPrivateHostname('127.0.0.1')).toBe(true);
+      expect(isPrivateHostname('169.254.169.254')).toBe(true);
+      expect(isPrivateHostname('172.16.0.1')).toBe(true);
+      expect(isPrivateHostname('172.31.255.255')).toBe(true);
+      expect(isPrivateHostname('192.168.1.1')).toBe(true);
+      expect(isPrivateHostname('100.64.0.1')).toBe(true);
+      expect(isPrivateHostname('224.0.0.1')).toBe(true);
+    });
+
+    it('allows public hostnames and IP literals', () => {
+      expect(isPrivateHostname('example.com')).toBe(false);
+      expect(isPrivateHostname('8.8.8.8')).toBe(false);
+      expect(isPrivateHostname('1.1.1.1')).toBe(false);
+      expect(isPrivateHostname('[2001:4860:4860::8888]')).toBe(false);
+    });
+
+    it('detects private and loopback IPv6 literals', () => {
+      expect(isPrivateHostname('[::]')).toBe(true);
+      expect(isPrivateHostname('[::1]')).toBe(true);
+      expect(isPrivateHostname('[fe80::1]')).toBe(true);
+      expect(isPrivateHostname('[fd00::1]')).toBe(true);
+      expect(isPrivateHostname('[::ffff:7f00:1]')).toBe(true);
+      expect(isPrivateHostname('[::ffff:c0a8:101]')).toBe(true);
+      expect(isPrivateHostname('[::c0a8:101]')).toBe(true);
+      expect(isPrivateHostname('[64:ff9b::a00:1]')).toBe(true);
+    });
   });
 
-  it('removes trailing slash from base URL', () => {
-    expect(concatenateUrl('https://example.com/', 'api/v1')).toBe('https://example.com/api/v1');
+  describe('assertPublicUrl()', () => {
+    it('returns a URL for public hosts', () => {
+      expect(assertPublicUrl('https://example.com/path').href).toBe('https://example.com/path');
+    });
+
+    it('throws for private hosts', () => {
+      expect(() => assertPublicUrl('http://127.0.0.1:3000')).toThrow('private, loopback, or link-local');
+    });
+
+    it('rejects non-network schemes by default so callers cannot smuggle file:/javascript:/etc through fetch', () => {
+      expect(() => assertPublicUrl('file:///etc/hosts')).toThrow('allowed schemes');
+      expect(() => assertPublicUrl('javascript:alert(1)')).toThrow('allowed schemes');
+      expect(() => assertPublicUrl('data:text/plain,hello')).toThrow('allowed schemes');
+      expect(() => assertPublicUrl('ws://example.com')).toThrow('allowed schemes');
+    });
+
+    it('rejects URLs without a hostname', () => {
+      expect(() => assertPublicUrl('http://')).toThrow();
+    });
+
+    it('honors a custom allowedProtocols list when callers really do want non-default schemes', () => {
+      expect(assertPublicUrl('ws://example.com/socket', 'WebSocket URL', { allowedProtocols: ['ws:', 'wss:'] }).href).toBe('ws://example.com/socket');
+      expect(() => assertPublicUrl('http://example.com', 'WebSocket URL', { allowedProtocols: ['ws:', 'wss:'] })).toThrow('allowed schemes');
+    });
   });
 
-  it('removes leading slash from path', () => {
-    expect(concatenateUrl('https://example.com', '/api/v1')).toBe('https://example.com/api/v1');
+  describe('fetchPublicUrl()', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('passes through a successful response without following or re-fetching', async () => {
+      const response = new Response('ok', { status: 200 });
+      const fetchMock = mock(async () => response);
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await fetchPublicUrl('https://example.com/path');
+
+      expect(result).toBe(response);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect((fetchMock.mock.calls[0]![1] as RequestInit).redirect).toBe('manual');
+    });
+
+    it('follows redirects to other public hosts', async () => {
+      const finalResponse = new Response('done', { status: 200 });
+      const fetchMock = mock(async (url: string | URL) => {
+        const target = url.toString();
+        if (target === 'https://example.com/start') {
+          return new Response(null, { status: 302, headers: { location: 'https://other.example.com/end' } });
+        }
+        return finalResponse;
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await fetchPublicUrl('https://example.com/start');
+
+      expect(result).toBe(finalResponse);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1]![0]).toBe('https://other.example.com/end');
+    });
+
+    it('blocks redirects to private hosts (the SSRF-via-redirect attack)', async () => {
+      const fetchMock = mock(async () =>
+        new Response(null, { status: 302, headers: { location: 'http://169.254.169.254/latest/meta-data/' } }),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(fetchPublicUrl('https://example.com/redirect-me')).rejects.toThrow('private, loopback, or link-local');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('blocks redirects that switch to a non-network scheme', async () => {
+      const fetchMock = mock(async () =>
+        new Response(null, { status: 302, headers: { location: 'file:///etc/hosts' } }),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(fetchPublicUrl('https://example.com/redirect-me')).rejects.toThrow('allowed schemes');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 3xx responses with no Location header unchanged (e.g. 304 Not Modified)', async () => {
+      const response = new Response(null, { status: 304 });
+      const fetchMock = mock(async () => response);
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await fetchPublicUrl('https://example.com/cached');
+
+      expect(result).toBe(response);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up after maxRedirects to bound worst-case behavior', async () => {
+      let counter = 0;
+      const fetchMock = mock(async () => {
+        counter += 1;
+        return new Response(null, { status: 302, headers: { location: `https://example.com/hop-${counter}` } });
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(fetchPublicUrl('https://example.com/start', undefined, { maxRedirects: 2 })).rejects.toThrow('maximum number of redirects');
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects the initial URL itself when it targets a private host', async () => {
+      const fetchMock = mock(async () => new Response('should not happen'));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(fetchPublicUrl('http://127.0.0.1:3000/foo')).rejects.toThrow('private, loopback, or link-local');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
-  it('handles both trailing and leading slashes', () => {
-    expect(concatenateUrl('https://example.com/', '/api/v1')).toBe('https://example.com/api/v1');
-  });
+  describe('concatenateUrl()', () => {
+    it('joins base URLs and relative paths', () => {
+      expect(concatenateUrl('https://example.com', 'path')).toBe('https://example.com/path');
+      expect(concatenateUrl('https://example.com/', '/path')).toBe('https://example.com/path');
+      expect(concatenateUrl('https://example.com/api', 'v1/resource')).toBe('https://example.com/api/v1/resource');
+    });
 
-  it('handles multi-segment paths', () => {
-    expect(concatenateUrl('https://example.com/api', 'v1/resource')).toBe('https://example.com/api/v1/resource');
-  });
+    it('rejects path traversal segments', () => {
+      expect(() => concatenateUrl('https://example.com/api', '../admin')).toThrow('parent directory');
+      expect(() => concatenateUrl('https://example.com/api', '%2e%2e/admin')).toThrow('parent directory');
+      expect(() => concatenateUrl('https://example.com/api', '..%2fadmin')).toThrow('parent directory');
+      expect(() => concatenateUrl('https://example.com/api', '..%5cadmin')).toThrow('parent directory');
+    });
 
-  it('preserves the path verbatim when it has no leading slash and base has no trailing slash', () => {
-    expect(concatenateUrl('https://example.com/api', 'v1/resource')).toBe('https://example.com/api/v1/resource');
-  });
+    it('rejects malformed percent-encoded segments rather than surfacing URIError', () => {
+      expect(() => concatenateUrl('https://example.com/api', '%E0%A4')).toThrow('parent directory');
+      expect(() => concatenateUrl('https://example.com/api', '%')).toThrow('parent directory');
+    });
 
-  it('handles deeply-nested paths', () => {
-    expect(concatenateUrl('https://example.com', 'a/b/c/d')).toBe('https://example.com/a/b/c/d');
-    expect(concatenateUrl('https://example.com/', '/a/b/c/d')).toBe('https://example.com/a/b/c/d');
-  });
+    it('rejects raw `?` and `#` in the path so they are not silently percent-encoded into the pathname', () => {
+      expect(() => concatenateUrl('https://example.com/api', 'items?limit=1')).toThrow('query string or fragment');
+      expect(() => concatenateUrl('https://example.com/api', 'items#fragment')).toThrow('query string or fragment');
+      expect(() => concatenateUrl('https://example.com/api', 'items?a=1#frag')).toThrow('query string or fragment');
+    });
 
-  it('handles query strings and fragments on the path', () => {
-    expect(concatenateUrl('https://example.com', 'search?q=1#frag')).toBe('https://example.com/search?q=1#frag');
-    expect(concatenateUrl('https://example.com/', '/search?q=1#frag')).toBe('https://example.com/search?q=1#frag');
-  });
-
-  it('does not strip slashes from inside the path', () => {
-    // Only the leading slash on `path` is removed — internal slashes survive.
-    expect(concatenateUrl('https://example.com', 'a//b')).toBe('https://example.com/a//b');
-  });
-
-  it('handles localhost / port URLs', () => {
-    expect(concatenateUrl('http://localhost:3000', '/info')).toBe('http://localhost:3000/info');
-    expect(concatenateUrl('http://localhost:3000/', 'info')).toBe('http://localhost:3000/info');
-  });
-
-  it('handles non-http schemes', () => {
-    expect(concatenateUrl('ws://localhost:3000', 'ws')).toBe('ws://localhost:3000/ws');
-    expect(concatenateUrl('did:dht:example/', '/resolve')).toBe('did:dht:example/resolve');
+    it('preserves percent-encoded `%3F` and `%23` so legitimate path segments containing those characters work', () => {
+      expect(concatenateUrl('https://example.com/api', 'items%3Flimit=1')).toBe('https://example.com/api/items%3Flimit=1');
+      expect(concatenateUrl('https://example.com/api', 'items%23fragment')).toBe('https://example.com/api/items%23fragment');
+    });
   });
 });

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -141,12 +141,12 @@ export class CryptoUtils {
    * @memberof CryptoUtils
    * @param options - The options object containing the desired length of the generated PIN.
    * @param options.length - The desired length of the generated PIN. The value should be
-   *                         an integer between 3 and 8 inclusive.
+   *                         an integer between 3 and 10 inclusive.
    *
    * @returns A string representing the generated PIN. The PIN will be zero-padded
    *          to match the specified length, if necessary.
    *
-   * @throws Will throw an error if the requested PIN length is less than 3 or greater than 8.
+   * @throws Will throw an error if the requested PIN length is less than 3 or greater than 10.
    */
   static randomPin({ length }: { length: number }): string {
     if (3 > length || length > 10) {

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -153,30 +153,21 @@ export class CryptoUtils {
       throw new Error('randomPin() can securely generate a PIN between 3 to 10 digits.');
     }
 
-    const max = Math.pow(10, length) - 1;
+    const pinRange = 10 ** length;
+    const byteLength = Math.ceil(Math.log2(pinRange) / 8);
+    const randomSpace = 2 ** (byteLength * 8);
+    const unbiasedLimit = randomSpace - (randomSpace % pinRange);
 
-    let pin;
+    let randomValue: number;
+    do {
+      randomValue = 0;
+      const randomBuffer = CryptoUtils.randomBytes(byteLength);
+      for (const byte of randomBuffer) {
+        randomValue = (randomValue * 256) + byte;
+      }
+    } while (randomValue >= unbiasedLimit);
 
-    if (length <= 6) {
-      const rejectionRange = Math.pow(10, length);
-      do {
-        // Adjust the byte generation based on length.
-        const randomBuffer = CryptoUtils.randomBytes(Math.ceil(length / 2) ); // 2 digits per byte.
-        const view = new DataView(randomBuffer.buffer);
-        // Convert the buffer to integer and take modulus based on length.
-        pin = view.getUint16(0, false) % rejectionRange;
-      } while (pin > max);
-    } else {
-      const rejectionRange = Math.pow(10, 10); // For max 10 digit number.
-      do {
-      // Generates 4 random bytes.
-        const randomBuffer = CryptoUtils.randomBytes(4);
-        // Create a DataView to read from the randomBuffer.
-        const view = new DataView(randomBuffer.buffer);
-        // Transform bytes to number (big endian).
-        pin = view.getUint32(0, false) % rejectionRange;
-      } while (pin > max); // Reject if the number is outside the desired range.
-    }
+    const pin = randomValue % pinRange;
 
     // Pad the PIN with leading zeros to the desired length.
     return pin.toString().padStart(length, '0');

--- a/packages/crypto/tests/utils.test.ts
+++ b/packages/crypto/tests/utils.test.ts
@@ -126,6 +126,38 @@ describe('Crypto Utils', () => {
       expect(pin).toMatch(/^\d{10}$/);
     });
 
+    it('uses enough random bytes to generate the full 10-digit PIN range', () => {
+      const originalRandomBytes = CryptoUtils.randomBytes;
+      const observedLengths: number[] = [];
+
+      try {
+        CryptoUtils.randomBytes = (bytesLength: number): Uint8Array => {
+          observedLengths.push(bytesLength);
+          return numberToBytes(5_000_000_000, bytesLength);
+        };
+
+        expect(CryptoUtils.randomPin({ length: 10 })).toBe('5000000000');
+        expect(observedLengths).toEqual([5]);
+      } finally {
+        CryptoUtils.randomBytes = originalRandomBytes;
+      }
+    });
+
+    it('rejects random values outside the unbiased sampling range', () => {
+      const originalRandomBytes = CryptoUtils.randomBytes;
+      const values = [65535, 999];
+
+      try {
+        CryptoUtils.randomBytes = (bytesLength: number): Uint8Array => {
+          return numberToBytes(values.shift()!, bytesLength);
+        };
+
+        expect(CryptoUtils.randomPin({ length: 3 })).toBe('999');
+      } finally {
+        CryptoUtils.randomBytes = originalRandomBytes;
+      }
+    });
+
     it('throws an error for a PIN length less than 3', () => {
       expect(
         () => CryptoUtils.randomPin({ length: 2 })
@@ -252,3 +284,12 @@ describe('Crypto Utils', () => {
     });
   });
 });
+
+function numberToBytes(value: number, byteLength: number): Uint8Array {
+  const bytes = new Uint8Array(byteLength);
+  for (let index = byteLength - 1; index >= 0; index--) {
+    bytes[index] = value & 0xff;
+    value = Math.floor(value / 256);
+  }
+  return bytes;
+}

--- a/packages/dids/src/did-error.ts
+++ b/packages/dids/src/did-error.ts
@@ -46,6 +46,9 @@ export enum DidErrorCode {
   /** The DID URL supplied to the dereferencing function does not conform to valid syntax. */
   InvalidDidUrl = 'invalidDidUrl',
 
+  /** The gateway URI supplied to a DID method targets a private, loopback, or otherwise non-routable host. */
+  InvalidGatewayUri = 'invalidGatewayUri',
+
   /** The given proof of a previous DID is invalid */
   InvalidPreviousDidProof = 'invalidPreviousDidProof',
 

--- a/packages/dids/src/methods/did-dht-pkarr.ts
+++ b/packages/dids/src/methods/did-dht-pkarr.ts
@@ -4,8 +4,8 @@ import type { Signer } from '@enbox/crypto';
 import type { Bep44Message } from './did-dht-types.js';
 
 import bencode from 'bencode';
-import { Convert } from '@enbox/common';
 import { Ed25519 } from '@enbox/crypto';
+import { Convert, fetchPublicUrl, PublicUrlValidationError } from '@enbox/common';
 import { DidError, DidErrorCode } from '../did-error.js';
 import { decode as dnsPacketDecode, encode as dnsPacketEncode } from '@dnsquery/dns-packet';
 
@@ -22,6 +22,31 @@ function pkarrUrl(publicKeyBytes: Uint8Array, gatewayUri: string): string {
 }
 
 /**
+ * Wraps {@link fetchPublicUrl} so URL / redirect-validation failures surface as the typed
+ * {@link DidErrorCode.InvalidGatewayUri} regardless of whether the offending host appeared in
+ * the original URL or in a redirect `Location` header. Other failures (network errors, fetch
+ * timeouts, etc.) propagate unchanged so callers can map them to `internalError` as before.
+ *
+ * `allowPrivateGatewayUri` widens the validator to accept loopback / private targets — useful
+ * for development and CI relays — but native `fetch()` will still refuse non-network schemes
+ * for redirect targets, so `file:`, `javascript:`, etc. cannot be smuggled through.
+ */
+async function pkarrFetch(url: string, init: RequestInit, allowPrivateGatewayUri: boolean): Promise<Response> {
+  if (allowPrivateGatewayUri) {
+    return fetch(url, init);
+  }
+
+  try {
+    return await fetchPublicUrl(url, init, { description: 'Pkarr gateway URL' });
+  } catch (error: any) {
+    if (error instanceof PublicUrlValidationError) {
+      throw new DidError(DidErrorCode.InvalidGatewayUri, error.message);
+    }
+    throw error;
+  }
+}
+
+/**
  * Retrieves a signed BEP44 message from a DID DHT Gateway or Pkarr Relay server.
  *
  * @see {@link https://github.com/Nuhvi/pkarr/blob/main/design/relays.md | Pkarr Relay design}
@@ -31,9 +56,10 @@ function pkarrUrl(publicKeyBytes: Uint8Array, gatewayUri: string): string {
  * @param params.publicKeyBytes - The public key bytes of the Identity Key, z-base-32 encoded.
  * @returns A promise resolving to a BEP44 message containing the signed DNS packet.
  */
-export async function pkarrGet({ gatewayUri, publicKeyBytes }: {
+export async function pkarrGet({ gatewayUri, publicKeyBytes, allowPrivateGatewayUri = false }: {
   publicKeyBytes: Uint8Array;
   gatewayUri: string;
+  allowPrivateGatewayUri?: boolean;
 }): Promise<Bep44Message> {
   // The identifier (key in the DHT) is the z-base-32 encoding of the Identity Key.
   const identifier = Convert.uint8Array(publicKeyBytes).toBase32Z();
@@ -42,9 +68,11 @@ export async function pkarrGet({ gatewayUri, publicKeyBytes }: {
   const url = pkarrUrl(publicKeyBytes, gatewayUri);
 
   // Transmit the Get request to the DID DHT Gateway or Pkarr Relay and get the response.
+  // Redirects are followed manually so each `Location` is re-validated and cannot smuggle a
+  // private host past the initial gateway check.
   let response: Response;
   try {
-    response = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(30_000) });
+    response = await pkarrFetch(url, { method: 'GET', signal: AbortSignal.timeout(30_000) }, allowPrivateGatewayUri);
 
     if (!response.ok) {
       throw new DidError(DidErrorCode.NotFound, `Pkarr record not found for: ${identifier}`);
@@ -91,9 +119,10 @@ export async function pkarrGet({ gatewayUri, publicKeyBytes }: {
  * @param params.bep44Message - The BEP44 message to be published, containing the signed DNS packet.
  * @returns A promise resolving to `true` if the message was successfully published, otherwise `false`.
  */
-export async function pkarrPut({ gatewayUri, bep44Message }: {
+export async function pkarrPut({ gatewayUri, bep44Message, allowPrivateGatewayUri = false }: {
   bep44Message: Bep44Message;
   gatewayUri: string;
+  allowPrivateGatewayUri?: boolean;
 }): Promise<boolean> {
   // The identifier (key in the DHT) is the z-base-32 encoding of the Identity Key.
   const identifier = Convert.uint8Array(bep44Message.k).toBase32Z();
@@ -107,17 +136,19 @@ export async function pkarrPut({ gatewayUri, bep44Message }: {
   new DataView(body.buffer).setBigUint64(bep44Message.sig.length, BigInt(bep44Message.seq));
   body.set(bep44Message.v, bep44Message.sig.length + 8);
 
-  // Transmit the Put request to the Pkarr relay and get the response.
+  // Transmit the Put request to the Pkarr relay and get the response. Redirects are followed
+  // manually so each `Location` is re-validated.
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await pkarrFetch(url, {
       method  : 'PUT',
       headers : { 'Content-Type': 'application/octet-stream' },
       body,
       signal  : AbortSignal.timeout(30_000),
-    });
+    }, allowPrivateGatewayUri);
 
   } catch (error: any) {
+    if (error instanceof DidError) {throw error;}
     throw new DidError(DidErrorCode.InternalError, `Failed to put Pkarr record for identifier ${identifier}: ${error.message}`);
   }
 

--- a/packages/dids/src/methods/did-dht-pkarr.ts
+++ b/packages/dids/src/methods/did-dht-pkarr.ts
@@ -30,6 +30,7 @@ function pkarrUrl(publicKeyBytes: Uint8Array, gatewayUri: string): string {
  * `allowPrivateGatewayUri` widens the validator to accept loopback / private targets — useful
  * for development and CI relays — but native `fetch()` will still refuse non-network schemes
  * for redirect targets, so `file:`, `javascript:`, etc. cannot be smuggled through.
+ * Enabling the bypass also disables per-hop redirect validation; only opt in for trusted local relays.
  */
 async function pkarrFetch(url: string, init: RequestInit, allowPrivateGatewayUri: boolean): Promise<Response> {
   if (allowPrivateGatewayUri) {

--- a/packages/dids/src/methods/did-dht-types.ts
+++ b/packages/dids/src/methods/did-dht-types.ts
@@ -91,6 +91,14 @@ export interface DidDhtCreateOptions<TKms> extends DidCreateOptions<TKms> {
   gatewayUri?: string;
 
   /**
+   * Allows a private, loopback, or link-local `gatewayUri`.
+   *
+   * This defaults to `false` and is intended for local development and tests only.
+   * Leave unset when the gateway URI is derived from untrusted input.
+   */
+  allowPrivateGatewayUri?: boolean;
+
+  /**
    * Optional. Determines whether the created DID should be published to the DHT network.
    *
    * If set to `true` or omitted, the DID is publicly discoverable. If `false`, the DID is not

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -89,11 +89,52 @@ import {
   validatePreviousDidProof,
 } from './did-dht-utils.js';
 
+/** The default DID DHT Gateway / Pkarr Relay used when no `gatewayUri` is supplied. */
+const FALLBACK_GATEWAY_URI = 'https://enbox-did-dht.fly.dev';
+
 /**
- * The default DID DHT Gateway or Pkarr Relay server to use when publishing and resolving DID
- * documents.
+ * Returns the default gateway URI, deferring the `DID_DHT_GATEWAY_URI` env lookup until call
+ * time so the env var reflects late mutations (e.g. test setup) rather than the value captured
+ * at module load.
+ *
+ * Setting `DID_DHT_GATEWAY_URI` only changes the default *URI*. It deliberately does NOT widen
+ * `allowPrivateGatewayUri`: dev/CI workflows that target a private Pkarr relay must opt in via
+ * the separate `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` env var, or by passing
+ * `allowPrivateGatewayUri: true` per call.
  */
-const DEFAULT_GATEWAY_URI = process.env.DID_DHT_GATEWAY_URI || 'https://enbox-did-dht.fly.dev';
+function getDefaultGatewayUri(): string {
+  return process.env.DID_DHT_GATEWAY_URI || FALLBACK_GATEWAY_URI;
+}
+
+/**
+ * Returns the default value for `allowPrivateGatewayUri` when the caller does not supply one.
+ * Dev/CI shells set `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` to opt in to local Pkarr relays without
+ * sprinkling `allowPrivateGatewayUri: true` through every call site; production deployments
+ * leave it unset so the documented default of `false` applies.
+ *
+ * This env var is intentionally *separate* from `DID_DHT_GATEWAY_URI` so that simply pointing
+ * at a different (possibly private) relay does not silently disable SSRF protection.
+ */
+function getDefaultAllowPrivateGatewayUri(): boolean {
+  return process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY === '1';
+}
+
+/**
+ * Applies the default gateway URI when none is supplied. The caller's explicit
+ * `allowPrivateGatewayUri` (including an explicit `false`) always wins over the env-driven
+ * default — this is the contract pinned by the regression tests in `did-dht.test.ts`.
+ */
+function resolveGatewayUri(gatewayUri: string | undefined, allowPrivateGatewayUri: boolean | undefined): {
+  gatewayUri: string;
+  allowPrivateGatewayUri: boolean;
+} {
+  // Use `??` (not `||`) so an explicit `false` from the caller short-circuits the env-default
+  // bypass instead of being OR-ed away.
+  return {
+    gatewayUri             : gatewayUri ?? getDefaultGatewayUri(),
+    allowPrivateGatewayUri : allowPrivateGatewayUri ?? getDefaultAllowPrivateGatewayUri(),
+  };
+}
 
 /**
  * The `DidDht` class provides an implementation of the `did:dht` DID method.
@@ -288,7 +329,11 @@ export class DidDht extends DidMethod {
 
     // By default, publish the DID document to a DHT Gateway unless explicitly disabled.
     if (options.publish ?? true) {
-      const registrationResult = await DidDht.publish({ did, gatewayUri: options.gatewayUri });
+      const registrationResult = await DidDht.publish({
+        did,
+        gatewayUri             : options.gatewayUri,
+        allowPrivateGatewayUri : options.allowPrivateGatewayUri,
+      });
       did.metadata = registrationResult.didDocumentMetadata;
     }
 
@@ -381,15 +426,18 @@ export class DidDht extends DidMethod {
    * @param params - The parameters for the `publish` operation.
    * @param params.did - The `BearerDid` object representing the DID to be published.
    * @param params.gatewayUri - Optional. The URI of a DID DHT Gateway or Pkarr Relay.
+   * @param params.allowPrivateGatewayUri - Optional. Allow the resulting gateway URI to target a
+   *                                        private, loopback, or link-local host. See
+   *                                        {@link DidDhtCreateOptions} for guidance on safe usage.
    * @returns A promise that resolves to a {@link DidRegistrationResult} object.
    */
-  public static async publish({ did, gatewayUri = DEFAULT_GATEWAY_URI }: {
+  public static async publish({ did, gatewayUri, allowPrivateGatewayUri }: {
     did: BearerDid;
     gatewayUri?: string;
+    allowPrivateGatewayUri?: boolean;
   }): Promise<DidRegistrationResult> {
-    const registrationResult = await DidDhtDocument.put({ did, gatewayUri });
-
-    return registrationResult;
+    const resolved = resolveGatewayUri(gatewayUri, allowPrivateGatewayUri);
+    return DidDhtDocument.put({ did, ...resolved });
   }
 
   /**
@@ -401,14 +449,18 @@ export class DidDht extends DidMethod {
    */
   public static async resolve(didUri: string, options: DidResolutionOptions = {}): Promise<DidResolutionResult> {
     // To execute the read method operation, use the given gateway URI or a default.
-    const gatewayUri = options?.gatewayUri ?? DEFAULT_GATEWAY_URI;
+    const { gatewayUri, allowPrivateGatewayUri } = resolveGatewayUri(options.gatewayUri, options.allowPrivateGatewayUri);
 
     try {
       // Attempt to decode the z-base-32-encoded identifier.
       await DidDhtUtils.identifierToIdentityKey({ didUri });
 
       // Attempt to retrieve the DID document and metadata from the DHT network.
-      const { didDocument, didDocumentMetadata } = await DidDhtDocument.get({ didUri, gatewayUri });
+      const { didDocument, didDocumentMetadata } = await DidDhtDocument.get({
+        didUri,
+        gatewayUri,
+        allowPrivateGatewayUri,
+      });
 
       // If the DID document was retrieved successfully, return it.
       return {
@@ -450,15 +502,20 @@ export class DidDhtDocument {
    * @param params.gatewayUri - The DID DHT Gateway or Pkarr Relay URI.
    * @returns A Promise resolving to a {@link DidResolutionResult} object.
    */
-  public static async get({ didUri, gatewayUri }: {
+  public static async get({ didUri, gatewayUri, allowPrivateGatewayUri = false }: {
     didUri: string;
     gatewayUri: string;
+    allowPrivateGatewayUri?: boolean;
   }): Promise<DidResolutionResult> {
     // Decode the z-base-32 DID identifier to public key as a byte array.
     const publicKeyBytes = DidDhtUtils.identifierToIdentityKeyBytes({ didUri });
 
     // Retrieve the signed BEP44 message from a DID DHT Gateway or Pkarr relay.
-    const bep44Message = await DidDhtDocument.pkarrGet({ gatewayUri, publicKeyBytes });
+    const bep44Message = await DidDhtDocument.pkarrGet({
+      gatewayUri,
+      publicKeyBytes,
+      allowPrivateGatewayUri,
+    });
 
     // Verify the signature of the BEP44 message and parse the value to a DNS packet.
     const dnsPacket = await DidDhtUtils.parseBep44GetMessage({ bep44Message });
@@ -480,9 +537,10 @@ export class DidDhtDocument {
    * @param params.gatewayUri - The DID DHT Gateway or Pkarr Relay URI.
    * @returns A promise that resolves to a {@link DidRegistrationResult} object.
    */
-  public static async put({ did, gatewayUri }: {
+  public static async put({ did, gatewayUri, allowPrivateGatewayUri = false }: {
     did: BearerDid;
     gatewayUri: string;
+    allowPrivateGatewayUri?: boolean;
   }): Promise<DidRegistrationResult> {
     // Convert the DID document and DID metadata (such as DID types) to a DNS packet.
     const dnsPacket = await DidDhtDocument.toDnsPacket({
@@ -499,7 +557,11 @@ export class DidDhtDocument {
     });
 
     // Publish the DNS packet to the DHT network.
-    const putResult = await DidDhtDocument.pkarrPut({ gatewayUri, bep44Message });
+    const putResult = await DidDhtDocument.pkarrPut({
+      gatewayUri,
+      bep44Message,
+      allowPrivateGatewayUri,
+    });
 
     // Return the result of processing the PUT operation, including the updated DID metadata with
     // the version ID and the publishing result.
@@ -518,6 +580,7 @@ export class DidDhtDocument {
   private static async pkarrGet(params: {
     publicKeyBytes: Uint8Array;
     gatewayUri: string;
+    allowPrivateGatewayUri?: boolean;
   }): Promise<Bep44Message> {
     return pkarrGet(params);
   }
@@ -526,6 +589,7 @@ export class DidDhtDocument {
   private static async pkarrPut(params: {
     bep44Message: Bep44Message;
     gatewayUri: string;
+    allowPrivateGatewayUri?: boolean;
   }): Promise<boolean> {
     return pkarrPut(params);
   }

--- a/packages/dids/src/methods/did-web.ts
+++ b/packages/dids/src/methods/did-web.ts
@@ -24,47 +24,11 @@ import { Did } from '../did.js';
 import { DidMethod } from './did-method.js';
 import { EMPTY_DID_RESOLUTION_RESULT } from '../types/did-resolution.js';
 import { extractDidFragment } from '../utils.js';
+import { fetchPublicUrl } from '@enbox/common';
 import { DidError, DidErrorCode } from '../did-error.js';
 
 /** Default fetch timeout for DID document retrieval (30 seconds). */
 const FETCH_TIMEOUT_MS = 30_000;
-
-/**
- * Returns `true` when the hostname is a private, loopback, or link-local
- * address.  Used to block SSRF via crafted `did:web` identifiers such as
- * `did:web:169.254.169.254` or `did:web:localhost`.
- */
-function isPrivateHostname(hostname: string): boolean {
-  const h = hostname.toLowerCase();
-
-  if (h === 'localhost' || h === 'localhost.') { return true; }
-
-  // IPv4 literal check
-  const parts = h.split('.');
-  if (parts.length === 4) {
-    const octets = parts.map(Number);
-    if (octets.every((o) => !Number.isNaN(o) && o >= 0 && o <= 255)) {
-      const [a, b] = octets;
-      if (a === 10) { return true; } // 10.0.0.0/8
-      if (a === 172 && b >= 16 && b <= 31) { return true; } // 172.16.0.0/12
-      if (a === 192 && b === 168) { return true; } // 192.168.0.0/16
-      if (a === 127) { return true; } // 127.0.0.0/8
-      if (a === 169 && b === 254) { return true; } // 169.254.0.0/16
-      if (a === 0) { return true; } // 0.0.0.0/8
-    }
-  }
-
-  // IPv6 literal check (bracket-wrapped by URL parser)
-  let v6 = h;
-  if (v6.startsWith('[') && v6.endsWith(']')) { v6 = v6.slice(1, -1); }
-  if (v6.includes(':')) {
-    if (v6 === '::1' || v6 === '::') { return true; }
-    if (v6.startsWith('fe80:') || v6.startsWith('fe80%')) { return true; }
-    if (v6.startsWith('fc') || v6.startsWith('fd')) { return true; }
-  }
-
-  return false;
-}
 
 /**
  * Defines the set of options available when creating a new Decentralized Identifier (DID) with the
@@ -423,19 +387,13 @@ export class DidWeb extends DidMethod {
       `${baseUrl}/.well-known/did.json`;
 
     try {
-      // Block requests to private/loopback/link-local addresses (SSRF protection).
-      const parsedUrl = new URL(didDocumentUrl);
-      if (isPrivateHostname(parsedUrl.hostname)) {
-        return {
-          ...EMPTY_DID_RESOLUTION_RESULT,
-          didResolutionMetadata: { error: 'notFound' }
-        };
-      }
-
-      // Perform an HTTP GET request to obtain the DID document.
-      const response = await fetch(didDocumentUrl, {
+      // Perform an HTTP GET request to obtain the DID document. `fetchPublicUrl` blocks the
+      // initial URL — and every redirect target — from pointing at a private/loopback/link-local
+      // host or a non-http(s) scheme, so a public hosting domain cannot 302 us to 127.0.0.1 or
+      // file:///etc/hosts after the first check passes.
+      const response = await fetchPublicUrl(didDocumentUrl, {
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      });
+      }, { description: 'did:web document URL' });
 
       // If the response status code is not 200, return an error.
       if (!response.ok) {throw new Error('HTTP error status code returned');}

--- a/packages/dids/tests/methods/did-dht.test.ts
+++ b/packages/dids/tests/methods/did-dht.test.ts
@@ -18,6 +18,43 @@ const fetchNotFoundResponse = (): { status: number; statusText: string; ok: bool
   ok         : false
 });
 
+/**
+ * Pins the DID DHT gateway env defaults to a *public* mock host (and clears the dev-mode
+ * private-gateway bypass) for the duration of each test in the surrounding describe block. This
+ * insulates the suite from however the CI / dev shell happens to have configured the env: the
+ * happy-path tests below all stub `fetch()` and just need the URL to pass `assertPublicUrl()`
+ * without each test having to opt in to private hosts, and the blocking-behavior tests need the
+ * dev-mode bypass to be off so the documented default of `false` actually applies.
+ *
+ * The `beforeEach`/`afterEach` calls below are intentional — they register hooks on whichever
+ * `describe()` block is active when this helper is invoked. ESLint's static analysis cannot
+ * follow that, hence the targeted disables.
+ */
+function pinPublicGatewayDefault(): void {
+  let originalUri: string | undefined;
+  let originalAllow: string | undefined;
+  // eslint-disable-next-line mocha/no-top-level-hooks
+  beforeEach(() => {
+    originalUri = process.env.DID_DHT_GATEWAY_URI;
+    originalAllow = process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY;
+    process.env.DID_DHT_GATEWAY_URI = 'https://test-mock-gateway.example.com';
+    delete process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY;
+  });
+  // eslint-disable-next-line mocha/no-top-level-hooks
+  afterEach(() => {
+    if (originalUri === undefined) {
+      delete process.env.DID_DHT_GATEWAY_URI;
+    } else {
+      process.env.DID_DHT_GATEWAY_URI = originalUri;
+    }
+    if (originalAllow === undefined) {
+      delete process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY;
+    } else {
+      process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY = originalAllow;
+    }
+  });
+}
+
 // Helper function to create a mocked fetch response that is successful and returns the given
 // response.
 const fetchOkResponse = (response?: any): {
@@ -30,6 +67,8 @@ const fetchOkResponse = (response?: any): {
 });
 
 describe('DidDht', () => {
+  pinPublicGatewayDefault();
+
   let fetchStub: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
@@ -319,6 +358,30 @@ describe('DidDht', () => {
 
       expect(did.metadata).toHaveProperty('published', false);
       expect(fetchStub).not.toHaveBeenCalled();
+    });
+
+    it('does not publish to a private gateway URI by default', async () => {
+      try {
+        await DidDht.create({ options: { gatewayUri: 'http://127.0.0.1:7527' } });
+        throw new Error('Expected DidDht.create() to throw.');
+      } catch (error: any) {
+        expect(error.code).toBe(DidErrorCode.InvalidGatewayUri);
+        expect(error.message).toContain('private, loopback, or link-local');
+        expect(fetchStub).not.toHaveBeenCalled();
+      }
+    });
+
+    it('allows publishing to a private gateway URI when explicitly enabled', async () => {
+      const did = await DidDht.create({
+        options: {
+          gatewayUri             : 'http://127.0.0.1:7527',
+          allowPrivateGatewayUri : true,
+        }
+      });
+
+      expect(did.metadata).toHaveProperty('published', true);
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(fetchStub.mock.calls[0][0]).toContain('http://127.0.0.1:7527/');
     });
 
     it('returns a version ID in DID metadata when published', async () => {
@@ -789,6 +852,126 @@ describe('DidDht', () => {
       const didResolutionResult = await DidDht.resolve(did);
 
       expect(didResolutionResult.didResolutionMetadata).toHaveProperty('error', 'notFound');
+    });
+
+    it('does not fetch from a private gateway URI by default', async () => {
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did, {
+        gatewayUri: 'http://127.0.0.1:7527',
+      });
+
+      expect(fetchStub).not.toHaveBeenCalled();
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+      expect(didResolutionResult.didResolutionMetadata.errorMessage).toContain('private, loopback, or link-local');
+    });
+
+    it('does not fetch from a private gateway URI when explicitly disabled', async () => {
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did, {
+        gatewayUri             : 'http://127.0.0.1:7527',
+        allowPrivateGatewayUri : false,
+      });
+
+      expect(fetchStub).not.toHaveBeenCalled();
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+      expect(didResolutionResult.didResolutionMetadata.errorMessage).toContain('private, loopback, or link-local');
+    });
+
+    it('allows private gateway URI fetches when explicitly requested', async () => {
+      fetchStub.mockResolvedValue(fetchNotFoundResponse());
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did, {
+        gatewayUri             : 'http://127.0.0.1:7527',
+        allowPrivateGatewayUri : true,
+      });
+
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.NotFound);
+    });
+
+    it('blocks a private gateway URI even when it matches DID_DHT_GATEWAY_URI (env is not a trust boundary)', async () => {
+      // Setting DID_DHT_GATEWAY_URI is a *URI* default only. It must not silently widen
+      // `allowPrivateGatewayUri` from its documented default of `false`, because env vars are
+      // not a meaningful trust boundary against SSRF. Callers wanting to talk to a private
+      // gateway must opt in explicitly. This test pins that contract by overriding the env to a
+      // private URI, calling resolve with that same URI, and asserting the request is still
+      // blocked without ever invoking fetch.
+      process.env.DID_DHT_GATEWAY_URI = 'http://127.0.0.1:7527';
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did, { gatewayUri: 'http://127.0.0.1:7527' });
+
+      expect(fetchStub).not.toHaveBeenCalled();
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+    });
+
+    it('also blocks a private URI taken implicitly from DID_DHT_GATEWAY_URI when no gatewayUri is supplied', async () => {
+      // Same regression as above but without an explicit `gatewayUri`. The env-supplied default
+      // must NOT be auto-trusted: a caller that simply omits `gatewayUri` should still get the
+      // documented `false` default for `allowPrivateGatewayUri` and be blocked.
+      process.env.DID_DHT_GATEWAY_URI = 'http://127.0.0.1:7527';
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did);
+
+      expect(fetchStub).not.toHaveBeenCalled();
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+    });
+
+    it('treats DID_DHT_ALLOW_PRIVATE_GATEWAY=1 as the dev/CI default opt-in (still overridable per call)', async () => {
+      // Dev/CI shells set DID_DHT_ALLOW_PRIVATE_GATEWAY=1 so local Pkarr relays work without
+      // sprinkling `allowPrivateGatewayUri: true` through every call site. Production deployments
+      // leave it unset.
+      process.env.DID_DHT_GATEWAY_URI = 'http://127.0.0.1:7527';
+      process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY = '1';
+      fetchStub.mockResolvedValue(fetchNotFoundResponse());
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const allowed = await DidDht.resolve(did);
+
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(allowed.didResolutionMetadata.error).toBe(DidErrorCode.NotFound);
+
+      // An explicit `false` from the caller still wins, even with the env opt-in active.
+      fetchStub.mockClear();
+      const blocked = await DidDht.resolve(did, { allowPrivateGatewayUri: false });
+      expect(fetchStub).not.toHaveBeenCalled();
+      expect(blocked.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+    });
+
+    it('blocks Pkarr gateway redirects to private hosts (SSRF via redirect)', async () => {
+      // A "public" gateway returns a 302 pointing at the AWS instance metadata service. The initial
+      // URL passes validation, but every redirect target must be re-validated.
+      fetchStub.mockResolvedValue(new Response(null, {
+        status  : 302,
+        headers : { location: 'http://169.254.169.254/latest/meta-data/' },
+      }));
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did, {
+        gatewayUri: 'https://public-gateway.example.com',
+      });
+
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+      expect(didResolutionResult.didResolutionMetadata.errorMessage).toContain('private, loopback, or link-local');
+    });
+
+    it('blocks Pkarr gateway redirects to non-http(s) schemes (SSRF via redirect)', async () => {
+      fetchStub.mockResolvedValue(new Response(null, {
+        status  : 302,
+        headers : { location: 'file:///etc/hosts' },
+      }));
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did, {
+        gatewayUri: 'https://public-gateway.example.com',
+      });
+
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+      expect(didResolutionResult.didResolutionMetadata.errorMessage).toContain('allowed schemes');
     });
 
     it('returns a invalidDidDocumentLength error if the Pkarr relay returns smaller than the 72 byte minimum', async () => {
@@ -1303,8 +1486,13 @@ describe('DidDhtDocument', () => {
 
   describe('Web5TestVectorsDidDht', () => {
     it('resolve', async () => {
+      // These vectors hit the real (CI / local) Pkarr relay configured via DID_DHT_GATEWAY_URI,
+      // which is typically a private host (e.g. http://localhost:7527). Pass
+      // `allowPrivateGatewayUri: true` explicitly so this integration test is self-contained and
+      // does not depend on the caller having `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` exported in their
+      // shell — talking to a local relay is the documented intent of the test.
       for (const vector of resolveTestVectors.vectors as any[]) {
-        const didResolutionResult = await DidDht.resolve(vector.input.didUri);
+        const didResolutionResult = await DidDht.resolve(vector.input.didUri, { allowPrivateGatewayUri: true });
         expect(didResolutionResult.didResolutionMetadata.error).toBe(vector.output.didResolutionMetadata.error);
       }
     }, 30000); // Set timeout to 30 seconds for this test for did:dht resolution timeout test
@@ -1312,6 +1500,8 @@ describe('DidDhtDocument', () => {
 });
 
 describe('DidDhtUtils', () => {
+  pinPublicGatewayDefault();
+
   let fetchStub: ReturnType<typeof spyOn>;
 
   beforeEach(() => {

--- a/packages/dids/tests/methods/did-web.test.ts
+++ b/packages/dids/tests/methods/did-web.test.ts
@@ -41,6 +41,51 @@ describe('DidWeb', () => {
 
       fetchStub.mockRestore();
     });
+
+    it('does not fetch for did:web identifiers that resolve to private hosts (SSRF protection)', async () => {
+      const fetchStub = spyOn(globalThis as any, 'fetch');
+      fetchStub.mockImplementation(() => Promise.resolve(fetchNotFoundResponse()));
+
+      const resolutionResult = await DidWeb.resolve('did:web:127.0.0.1');
+
+      expect(resolutionResult.didResolutionMetadata.error).toBe('notFound');
+      expect(fetchStub).not.toHaveBeenCalled();
+
+      fetchStub.mockRestore();
+    });
+
+    it('blocks did:web document fetches that redirect to a private host (SSRF via redirect)', async () => {
+      // The initial public domain passes the URL check, but the server returns a 302 pointing at
+      // a metadata-service IP. `fetchPublicUrl` must re-validate every Location header, so this
+      // resolves to `notFound` and only the first fetch is performed.
+      const fetchStub = spyOn(globalThis as any, 'fetch');
+      fetchStub.mockResolvedValue(new Response(null, {
+        status  : 302,
+        headers : { location: 'http://169.254.169.254/latest/meta-data/' },
+      }));
+
+      const resolutionResult = await DidWeb.resolve('did:web:public.example.com');
+
+      expect(resolutionResult.didResolutionMetadata.error).toBe('notFound');
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+
+      fetchStub.mockRestore();
+    });
+
+    it('blocks did:web document fetches that redirect to a non-http(s) scheme', async () => {
+      const fetchStub = spyOn(globalThis as any, 'fetch');
+      fetchStub.mockResolvedValue(new Response(null, {
+        status  : 302,
+        headers : { location: 'file:///etc/hosts' },
+      }));
+
+      const resolutionResult = await DidWeb.resolve('did:web:public.example.com');
+
+      expect(resolutionResult.didResolutionMetadata.error).toBe('notFound');
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+
+      fetchStub.mockRestore();
+    });
   });
 
   describe('create()', () => {


### PR DESCRIPTION
## Summary

> **Rebased on 2026-05-24** onto current `main` (which now includes the [#928](https://github.com/enboxorg/enbox/pull/928) refactor that consolidated `concatenateUrl` into `@enbox/common`). The 5 original commits — initial analysis fixes, review follow-ups, SSRF redirect hardening (originally [#929](https://github.com/enboxorg/enbox/pull/929) merged into this branch), and test-vector self-contained fix (originally [#930](https://github.com/enboxorg/enbox/pull/930) merged into this branch) — are now squashed into a single commit.

This PR takes the validated findings from the review of `local-reference-notes/enbox-comprehensive-analysis.md` and ships them as a coherent security patch. None of the findings have shipped to main since the original PR was opened.

### What this PR adds to `main`

**Shared SSRF helpers in `@enbox/common/url.ts`:**

- `isPrivateHostname(hostname)` — single source of truth for loopback / RFC1918 / link-local / IPv6 ULA detection. Replaces the inline check that lived only in `did:web`.
- `assertPublicUrl(url, description, options?)` — parses and validates that a URL targets a routable public host over an allowed network scheme (defaults to `http:` / `https:`). Rejects `file:`, `javascript:`, `data:`, `ws:`, empty hostnames, and private hosts.
- `fetchPublicUrl(url, init?, options?)` — drives the redirect loop manually (`redirect: 'manual'`) and re-runs `assertPublicUrl` on every `Location` header, so a public host cannot 302 to `127.0.0.1` / `169.254.169.254` / a non-http(s) scheme after passing initial validation.
- `PublicUrlValidationError` — distinct error type so callers can map validation failures to a specific error code (e.g. `invalidGatewayUri`) without mis-classifying genuine network errors as SSRF.

**`did:dht` Pkarr gateway SSRF hardening:**

- Pkarr GET / PUT routes through `fetchPublicUrl`, so the relay cannot redirect into the private network.
- Wire-visible: `pkarrGet` now re-throws typed `DidError`s instead of wrapping every failure in `internalError`, so missing Pkarr records surface as `notFound`.
- Adds an explicit `allowPrivateGatewayUri?: boolean` option (defaults to `false`) for callers that genuinely need to talk to a local relay (tests, development). An explicit `false` short-circuits the env default — `??` instead of `||` — so `allowPrivateGatewayUri: false` is honored even when the URI matches `DID_DHT_GATEWAY_URI`.
- New env var `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` for contributors / CI to opt into a local Pkarr relay. The old behavior (implicit URI-matching of `DID_DHT_GATEWAY_URI`) is removed because env vars are not a meaningful trust boundary against SSRF.
- CI workflows (`.github/workflows/ci.yml`, `e2e-identity-lifecycle.yml`) updated to set the opt-in.

**`did:web` SSRF hardening:**

- Refactored to use the shared `fetchPublicUrl` so redirect targets are re-validated.

**`@enbox/common/url.ts` `concatenateUrl` traversal/query fix:**

- Breaking: `concatenateUrl` now throws on raw `?` / `#` in the `path` argument and collapses internal `//` path runs (for example `a//b` becomes `a/b`).
- Rejects `..` segments, percent-encoded `..`, encoded slash (`%2F`) / backslash (`%5C`) variants, and malformed percent-encoding that would round-trip to a traversal.
- Rejects raw `?` (query) and `#` (fragment) delimiters in the `path` argument — the WHATWG URL parser silently percent-encodes those when assigned to `pathname`, which previously changed the endpoint a caller meant to reach. Percent-encoded `%3F` / `%23` are preserved for legitimate path segments.

**`CryptoUtils.randomPin()` rejection sampling fix:**

- 7–10 digit PINs now use enough random bytes (4 bytes / `getUint32`) AND a proper unbiased rejection-sampling loop. The old implementation drew 2 bytes (`getUint16`, range `0..65535`) for any length and silently biased the distribution for 5-digit (mod `100000`) and longer PINs.

### What this PR does **not** touch

- Doc-only updates to `CLAUDE.md` from the original branch were already merged into `AGENTS.md` via [#931](https://github.com/enboxorg/enbox/pull/931) — dropped from this rebase to avoid conflict noise.
- Local `concatenateUrl` re-exports in `@enbox/agent` and `@enbox/dwn-clients` — [#928](https://github.com/enboxorg/enbox/pull/928) removed these files entirely; the canonical implementation now lives only in `@enbox/common`.

### Validated findings shipped here

Refs: #918 #919 #920 #921 #922 #923 #924 #925 #692

## Test plan

- [x] `bun run --filter @enbox/common build` — clean
- [x] `bun run --filter @enbox/dids --filter @enbox/agent --filter @enbox/dwn-clients --filter @enbox/crypto build` — clean
- [x] `bun run lint` — 15/15 tasks succeed, no warnings
- [x] `bun run --filter @enbox/common test:node` — 229 pass, 0 fail
- [x] `bun run --filter @enbox/crypto test:node` — 709 pass, 0 fail (covers new randomPin distribution)
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run --filter @enbox/dids test:node` — 332 pass, 0 fail
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run --filter @enbox/agent test:node` — 1507 pass, 10 skip, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

