### PR TITLE
harden DID gateway/web SSRF surface (follow-up to PR #926)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,9 @@ jobs:
           export DWN_STORAGE_STATE_INDEX=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DWN_STORAGE_RESUMABLE_TASKS=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          # The DWN server itself talks to the local Pkarr relay; opt in to private gateways for
+          # this dev/CI process. Production deployments leave this unset.
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           export DWN_RATE_LIMIT_REQUESTS_PER_SECOND=0
           export DWN_RATE_LIMIT_TENANT_REQUESTS_PER_SECOND=0
 
@@ -498,6 +501,9 @@ jobs:
       - name: Run tests with coverage
         run: |
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          # Opt-in for the test process so the agent / DWN can talk to the local Pkarr relay
+          # without each call site having to pass `allowPrivateGatewayUri: true`.
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           bun run --filter @enbox/dids         test:node:coverage
           bun run --filter @enbox/dwn-clients  test:node:coverage
           bun run --filter @enbox/agent        test:node:coverage
@@ -605,6 +611,7 @@ jobs:
           export DWN_STORAGE_STATE_INDEX=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DWN_STORAGE_RESUMABLE_TASKS=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           export DWN_RATE_LIMIT_REQUESTS_PER_SECOND=0
           export DWN_RATE_LIMIT_TENANT_REQUESTS_PER_SECOND=0
 
@@ -623,6 +630,7 @@ jobs:
       - name: Run e2e tests
         run: |
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           bun run --filter @enbox/agent test:e2e
 
       - name: Stop services

--- a/.github/workflows/e2e-identity-lifecycle.yml
+++ b/.github/workflows/e2e-identity-lifecycle.yml
@@ -85,6 +85,9 @@ jobs:
           export DWN_STORAGE_STATE_INDEX=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DWN_STORAGE_RESUMABLE_TASKS=postgres://dwn_user:dwn_password@localhost:5433/dwn
           export DID_DHT_GATEWAY_URI=http://localhost:7527
+          # The DWN server itself talks to the local Pkarr relay; opt in to private gateways for
+          # this dev/CI process. Production deployments leave this unset.
+          export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           export DWN_RATE_LIMIT_REQUESTS_PER_SECOND=0
           export DWN_RATE_LIMIT_TENANT_REQUESTS_PER_SECOND=0
 
@@ -118,11 +121,12 @@ jobs:
         run: |
           export TEST_DWN_URL="${{ steps.dwn.outputs.url }}"
 
-          # For local server: use the local Pkarr relay for DID resolution.
-          # For remote server: use the production DHT gateway (default) so the
-          # remote DWN can resolve the DIDs we publish.
+          # For local server: use the local Pkarr relay for DID resolution and explicitly opt in
+          # to private gateways. For remote server: use the production DHT gateway (default) so
+          # the remote DWN can resolve the DIDs we publish.
           if [ "${{ inputs.use_local_server }}" = "true" ]; then
             export DID_DHT_GATEWAY_URI=http://localhost:7527
+            export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
           fi
 
           # Admin token is needed when the remote DWN has tenant registration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ Before any commits get pushed and PRs opened, ALL of the following MUST pass:
 
 1. **Lint** — `bun run lint` (use `bun run lint:fix` to auto-fix issues)
 2. **Build** — `bun run --filter @enbox/agent build` (rebuild `dwn-sdk-js` first if changed)
-3. **Tests** — `export DID_DHT_GATEWAY_URI=http://localhost:7527 && bun run test:node` from `packages/agent/`
+3. **Tests** — `export DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 && bun run test:node` from `packages/agent/`
 
 Do not push or open a PR until all three checks pass locally. See [Local Test Infrastructure](#local-test-infrastructure) for required services.
 
@@ -209,10 +209,11 @@ Most packages use **`bun test`** (Bun’s native test runner). **`@enbox/browser
 
 #### Agent / API / Auth tests (bun:test)
 
-**Important:** Always set `DID_DHT_GATEWAY_URI` before running **agent**, **api**, or **auth** tests. Without it, a large subset of tests will fail with Pkarr / `did:dht` publishing errors.
+**Important:** Always set `DID_DHT_GATEWAY_URI` *and* `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` before running **agent**, **api**, or **auth** tests. Without `DID_DHT_GATEWAY_URI`, a large subset of tests will fail with Pkarr / `did:dht` publishing errors. Without `DID_DHT_ALLOW_PRIVATE_GATEWAY=1`, the `did:dht` SSRF check rejects the local relay because it targets a loopback host (the env var is the dev/CI opt-in for the documented `allowPrivateGatewayUri: false` default; production deployments leave it unset).
 
 ```bash
 export DID_DHT_GATEWAY_URI=http://localhost:7527
+export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
 
 # Full agent test suite (from packages/agent/):
 bun run test:node
@@ -248,14 +249,16 @@ Several packages (`dids`, `agent`, `api`, `dwn-server`, `dwn-sql-store`) require
 # Start all test services (Pkarr relay, Postgres, MySQL, NATS):
 docker compose -f docker-compose.test.yaml up -d --wait
 
-# Set the Pkarr gateway env var (REQUIRED for did:dht tests):
+# Set the Pkarr gateway env vars (REQUIRED for did:dht tests):
 export DID_DHT_GATEWAY_URI=http://localhost:7527
+# Opt in to the local (loopback) Pkarr relay; production code paths leave this unset.
+export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
 
 # Set the NATS URL (REQUIRED for dwn-server NatsEventLog tests):
 export NATS_URL=nats://localhost:4222
 ```
 
-Without `DID_DHT_GATEWAY_URI`, tests in `agent`, `api`, `auth`, and `dids` that publish `did:dht` will fail with `DidError: internalError: Failed to put Pkarr record`. These are NOT real test failures — the tests are correct, they just need the gateway.
+Without `DID_DHT_GATEWAY_URI`, tests in `agent`, `api`, `auth`, and `dids` that publish `did:dht` will fail with `DidError: internalError: Failed to put Pkarr record`. Without `DID_DHT_ALLOW_PRIVATE_GATEWAY=1`, the same tests will fail with `invalidGatewayUri: Pkarr gateway URL must not target a private, loopback, or link-local host: localhost` because the SSRF check rejects the local relay. These are NOT real test failures — the tests are correct, they just need the gateway.
 
 ### Services provided by `docker-compose.test.yaml`
 
@@ -279,6 +282,7 @@ If not running, start it (requires built packages):
 
 ```bash
 export DID_DHT_GATEWAY_URI=http://localhost:7527
+export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
 export DS_PORT=3000
 export DWN_BASE_URL=http://localhost:3000
 export DWN_TTL_CACHE_URL="postgres://dwn_user:dwn_password@localhost:5433/dwn"
@@ -295,6 +299,7 @@ bun packages/dwn-server/dist/esm/src/main.js &
 # Ensure services are up:
 docker compose -f docker-compose.test.yaml up -d --wait
 export DID_DHT_GATEWAY_URI=http://localhost:7527
+export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
 
 # Now run tests — these will all pass:
 bun run --filter @enbox/agent test:node       # 748 pass, 0 fail

--- a/packages/common/src/url.ts
+++ b/packages/common/src/url.ts
@@ -35,24 +35,113 @@ export function isPrivateHostname(hostname: string): boolean {
   return false;
 }
 
+/** Default protocols accepted by {@link assertPublicUrl} when no explicit list is given. */
+const DEFAULT_PUBLIC_URL_PROTOCOLS: readonly string[] = ['http:', 'https:'];
+
 /**
- * Parses and validates that a URL does not target a private hostname.
- *
- * This intentionally does not perform DNS resolution, so callers handling
- * high-risk server-side fetches should still consider DNS rebinding defenses.
+ * Thrown by {@link assertPublicUrl} (and surfaced by {@link fetchPublicUrl}) when a URL — or a
+ * redirect target — fails public-URL validation. Distinct from generic `Error` so callers can
+ * map validation failures to a specific error code (e.g. `invalidGatewayUri`) without
+ * accidentally also mapping unrelated network failures.
  */
-export function assertPublicUrl(url: string | URL, description = 'URL'): URL {
+export class PublicUrlValidationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'PublicUrlValidationError';
+  }
+}
+
+/**
+ * Parses and validates that a URL targets a routable public host over an allowed network scheme.
+ *
+ * Rejects:
+ * - URLs whose protocol is not in `allowedProtocols` (defaults to `http:` / `https:`), so callers
+ *   cannot smuggle `file:`, `javascript:`, `data:`, `ws:`, etc. past a downstream `fetch()`.
+ * - URLs without a hostname.
+ * - URLs whose hostname is a loopback, private, link-local, or otherwise non-routable literal per
+ *   {@link isPrivateHostname}.
+ *
+ * This intentionally does not perform DNS resolution, so callers handling high-risk server-side
+ * fetches should still consider DNS rebinding defenses (and use {@link fetchPublicUrl} to also
+ * validate every redirect target).
+ */
+export function assertPublicUrl(url: string | URL, description = 'URL', options?: { allowedProtocols?: readonly string[] }): URL {
   const parsedUrl = typeof url === 'string' ? new URL(url) : new URL(url.toString());
+  const allowedProtocols = options?.allowedProtocols ?? DEFAULT_PUBLIC_URL_PROTOCOLS;
+
+  if (!allowedProtocols.includes(parsedUrl.protocol)) {
+    throw new PublicUrlValidationError(`${description} must use one of the allowed schemes (${allowedProtocols.join(', ')}): ${parsedUrl.protocol}`);
+  }
+
+  if (parsedUrl.hostname === '') {
+    throw new PublicUrlValidationError(`${description} must specify a hostname.`);
+  }
 
   if (isPrivateHostname(parsedUrl.hostname)) {
-    throw new Error(`${description} must not target a private, loopback, or link-local host: ${parsedUrl.hostname}`);
+    throw new PublicUrlValidationError(`${description} must not target a private, loopback, or link-local host: ${parsedUrl.hostname}`);
   }
 
   return parsedUrl;
 }
 
-/** Concatenates a base URL and a path ensuring that there is exactly one slash between them. */
+/**
+ * Maximum number of HTTP redirects {@link fetchPublicUrl} will follow before giving up. Public
+ * relays and DID document servers should rarely chain more than 1–2 redirects; this leaves enough
+ * headroom for those while still bounding worst-case behavior.
+ */
+const DEFAULT_MAX_REDIRECTS = 5;
+
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Performs a `fetch()` whose target — and every subsequent redirect target — is validated by
+ * {@link assertPublicUrl}. Defends against SSRF via redirect-based bypasses where a public
+ * gateway returns `Location: http://127.0.0.1/...` after the initial validation succeeded.
+ *
+ * Manually drives the redirect loop so each `Location` is re-validated. A 3xx response without a
+ * `Location` header (e.g. `304 Not Modified`) is returned to the caller unchanged.
+ */
+export async function fetchPublicUrl(url: string | URL, init?: RequestInit, options?: {
+  description?: string;
+  allowedProtocols?: readonly string[];
+  maxRedirects?: number;
+}): Promise<Response> {
+  const description = options?.description ?? 'URL';
+  const maxRedirects = options?.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  let currentUrl = assertPublicUrl(url, description, { allowedProtocols: options?.allowedProtocols }).href;
+
+  for (let attempt = 0; attempt <= maxRedirects; attempt++) {
+    const response = await fetch(currentUrl, { ...init, redirect: 'manual' });
+
+    if (!REDIRECT_STATUS_CODES.has(response.status)) {
+      return response;
+    }
+
+    const location = response.headers.get('location');
+    if (location === null) {
+      return response;
+    }
+
+    currentUrl = assertPublicUrl(new URL(location, currentUrl), description, { allowedProtocols: options?.allowedProtocols }).href;
+  }
+
+  throw new Error(`${description} exceeded the maximum number of redirects (${maxRedirects}).`);
+}
+
+/**
+ * Concatenates a base URL and a path ensuring that there is exactly one slash between them.
+ *
+ * The `path` argument must be a pure URL pathname — raw `?` (query) and `#` (fragment) delimiters
+ * are rejected because they are silently percent-encoded by the WHATWG URL parser when assigned
+ * to `pathname`, which would otherwise change the endpoint a caller meant to reach. Callers that
+ * need to attach a query string or fragment should construct the URL explicitly. Percent-encoded
+ * `%3F` / `%23` are preserved so genuine path segments containing those characters work.
+ */
 export function concatenateUrl(baseUrl: string, path: string): string {
+  if (path.includes('?') || path.includes('#')) {
+    throw new Error('Path must not contain a raw query string or fragment; build the URL explicitly instead.');
+  }
+
   const sanitizedPath = path.replaceAll(/^\/+/g, '');
   const segments = sanitizedPath.split('/');
 

--- a/packages/common/tests/url.test.ts
+++ b/packages/common/tests/url.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, mock } from 'bun:test';
 
-import { assertPublicUrl, concatenateUrl, isPrivateHostname } from '../src/url.js';
+import { assertPublicUrl, concatenateUrl, fetchPublicUrl, isPrivateHostname } from '../src/url.js';
 
 describe('url utilities', () => {
   describe('isPrivateHostname()', () => {
@@ -48,6 +48,111 @@ describe('url utilities', () => {
     it('throws for private hosts', () => {
       expect(() => assertPublicUrl('http://127.0.0.1:3000')).toThrow('private, loopback, or link-local');
     });
+
+    it('rejects non-network schemes by default so callers cannot smuggle file:/javascript:/etc through fetch', () => {
+      expect(() => assertPublicUrl('file:///etc/hosts')).toThrow('allowed schemes');
+      expect(() => assertPublicUrl('javascript:alert(1)')).toThrow('allowed schemes');
+      expect(() => assertPublicUrl('data:text/plain,hello')).toThrow('allowed schemes');
+      expect(() => assertPublicUrl('ws://example.com')).toThrow('allowed schemes');
+    });
+
+    it('rejects URLs without a hostname', () => {
+      expect(() => assertPublicUrl('http://')).toThrow();
+    });
+
+    it('honors a custom allowedProtocols list when callers really do want non-default schemes', () => {
+      expect(assertPublicUrl('ws://example.com/socket', 'WebSocket URL', { allowedProtocols: ['ws:', 'wss:'] }).href).toBe('ws://example.com/socket');
+      expect(() => assertPublicUrl('http://example.com', 'WebSocket URL', { allowedProtocols: ['ws:', 'wss:'] })).toThrow('allowed schemes');
+    });
+  });
+
+  describe('fetchPublicUrl()', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('passes through a successful response without following or re-fetching', async () => {
+      const response = new Response('ok', { status: 200 });
+      const fetchMock = mock(async () => response);
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await fetchPublicUrl('https://example.com/path');
+
+      expect(result).toBe(response);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect((fetchMock.mock.calls[0]![1] as RequestInit).redirect).toBe('manual');
+    });
+
+    it('follows redirects to other public hosts', async () => {
+      const finalResponse = new Response('done', { status: 200 });
+      const fetchMock = mock(async (url: string | URL) => {
+        const target = url.toString();
+        if (target === 'https://example.com/start') {
+          return new Response(null, { status: 302, headers: { location: 'https://other.example.com/end' } });
+        }
+        return finalResponse;
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await fetchPublicUrl('https://example.com/start');
+
+      expect(result).toBe(finalResponse);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1]![0]).toBe('https://other.example.com/end');
+    });
+
+    it('blocks redirects to private hosts (the SSRF-via-redirect attack)', async () => {
+      const fetchMock = mock(async () =>
+        new Response(null, { status: 302, headers: { location: 'http://169.254.169.254/latest/meta-data/' } }),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(fetchPublicUrl('https://example.com/redirect-me')).rejects.toThrow('private, loopback, or link-local');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('blocks redirects that switch to a non-network scheme', async () => {
+      const fetchMock = mock(async () =>
+        new Response(null, { status: 302, headers: { location: 'file:///etc/hosts' } }),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(fetchPublicUrl('https://example.com/redirect-me')).rejects.toThrow('allowed schemes');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 3xx responses with no Location header unchanged (e.g. 304 Not Modified)', async () => {
+      const response = new Response(null, { status: 304 });
+      const fetchMock = mock(async () => response);
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await fetchPublicUrl('https://example.com/cached');
+
+      expect(result).toBe(response);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up after maxRedirects to bound worst-case behavior', async () => {
+      let counter = 0;
+      const fetchMock = mock(async () => {
+        counter += 1;
+        return new Response(null, { status: 302, headers: { location: `https://example.com/hop-${counter}` } });
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(fetchPublicUrl('https://example.com/start', undefined, { maxRedirects: 2 })).rejects.toThrow('maximum number of redirects');
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects the initial URL itself when it targets a private host', async () => {
+      const fetchMock = mock(async () => new Response('should not happen'));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(fetchPublicUrl('http://127.0.0.1:3000/foo')).rejects.toThrow('private, loopback, or link-local');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
   describe('concatenateUrl()', () => {
@@ -67,6 +172,17 @@ describe('url utilities', () => {
     it('rejects malformed percent-encoded segments rather than surfacing URIError', () => {
       expect(() => concatenateUrl('https://example.com/api', '%E0%A4')).toThrow('parent directory');
       expect(() => concatenateUrl('https://example.com/api', '%')).toThrow('parent directory');
+    });
+
+    it('rejects raw `?` and `#` in the path so they are not silently percent-encoded into the pathname', () => {
+      expect(() => concatenateUrl('https://example.com/api', 'items?limit=1')).toThrow('query string or fragment');
+      expect(() => concatenateUrl('https://example.com/api', 'items#fragment')).toThrow('query string or fragment');
+      expect(() => concatenateUrl('https://example.com/api', 'items?a=1#frag')).toThrow('query string or fragment');
+    });
+
+    it('preserves percent-encoded `%3F` and `%23` so legitimate path segments containing those characters work', () => {
+      expect(concatenateUrl('https://example.com/api', 'items%3Flimit=1')).toBe('https://example.com/api/items%3Flimit=1');
+      expect(concatenateUrl('https://example.com/api', 'items%23fragment')).toBe('https://example.com/api/items%23fragment');
     });
   });
 });

--- a/packages/dids/src/methods/did-dht-pkarr.ts
+++ b/packages/dids/src/methods/did-dht-pkarr.ts
@@ -5,7 +5,7 @@ import type { Bep44Message } from './did-dht-types.js';
 
 import bencode from 'bencode';
 import { Ed25519 } from '@enbox/crypto';
-import { assertPublicUrl, Convert } from '@enbox/common';
+import { Convert, fetchPublicUrl, PublicUrlValidationError } from '@enbox/common';
 import { DidError, DidErrorCode } from '../did-error.js';
 import { decode as dnsPacketDecode, encode as dnsPacketEncode } from '@dnsquery/dns-packet';
 
@@ -21,15 +21,28 @@ function pkarrUrl(publicKeyBytes: Uint8Array, gatewayUri: string): string {
   return new URL(identifier, gatewayUri).href;
 }
 
-function validatePkarrUrl(url: string, allowPrivateGatewayUri = false): void {
+/**
+ * Wraps {@link fetchPublicUrl} so URL / redirect-validation failures surface as the typed
+ * {@link DidErrorCode.InvalidGatewayUri} regardless of whether the offending host appeared in
+ * the original URL or in a redirect `Location` header. Other failures (network errors, fetch
+ * timeouts, etc.) propagate unchanged so callers can map them to `internalError` as before.
+ *
+ * `allowPrivateGatewayUri` widens the validator to accept loopback / private targets — useful
+ * for development and CI relays — but native `fetch()` will still refuse non-network schemes
+ * for redirect targets, so `file:`, `javascript:`, etc. cannot be smuggled through.
+ */
+async function pkarrFetch(url: string, init: RequestInit, allowPrivateGatewayUri: boolean): Promise<Response> {
   if (allowPrivateGatewayUri) {
-    return;
+    return fetch(url, init);
   }
 
   try {
-    assertPublicUrl(url, 'Pkarr gateway URL');
+    return await fetchPublicUrl(url, init, { description: 'Pkarr gateway URL' });
   } catch (error: any) {
-    throw new DidError(DidErrorCode.InvalidGatewayUri, error.message);
+    if (error instanceof PublicUrlValidationError) {
+      throw new DidError(DidErrorCode.InvalidGatewayUri, error.message);
+    }
+    throw error;
   }
 }
 
@@ -53,12 +66,13 @@ export async function pkarrGet({ gatewayUri, publicKeyBytes, allowPrivateGateway
 
   // Concatenate the gateway URI with the identifier to form the full URL.
   const url = pkarrUrl(publicKeyBytes, gatewayUri);
-  validatePkarrUrl(url, allowPrivateGatewayUri);
 
   // Transmit the Get request to the DID DHT Gateway or Pkarr Relay and get the response.
+  // Redirects are followed manually so each `Location` is re-validated and cannot smuggle a
+  // private host past the initial gateway check.
   let response: Response;
   try {
-    response = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(30_000) });
+    response = await pkarrFetch(url, { method: 'GET', signal: AbortSignal.timeout(30_000) }, allowPrivateGatewayUri);
 
     if (!response.ok) {
       throw new DidError(DidErrorCode.NotFound, `Pkarr record not found for: ${identifier}`);
@@ -115,7 +129,6 @@ export async function pkarrPut({ gatewayUri, bep44Message, allowPrivateGatewayUr
 
   // Concatenate the gateway URI with the identifier to form the full URL.
   const url = pkarrUrl(bep44Message.k, gatewayUri);
-  validatePkarrUrl(url, allowPrivateGatewayUri);
 
   // Construct the body of the request according to the Pkarr relay specification.
   const body = new Uint8Array(bep44Message.v.length + 72);
@@ -123,17 +136,19 @@ export async function pkarrPut({ gatewayUri, bep44Message, allowPrivateGatewayUr
   new DataView(body.buffer).setBigUint64(bep44Message.sig.length, BigInt(bep44Message.seq));
   body.set(bep44Message.v, bep44Message.sig.length + 8);
 
-  // Transmit the Put request to the Pkarr relay and get the response.
+  // Transmit the Put request to the Pkarr relay and get the response. Redirects are followed
+  // manually so each `Location` is re-validated.
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await pkarrFetch(url, {
       method  : 'PUT',
       headers : { 'Content-Type': 'application/octet-stream' },
       body,
       signal  : AbortSignal.timeout(30_000),
-    });
+    }, allowPrivateGatewayUri);
 
   } catch (error: any) {
+    if (error instanceof DidError) {throw error;}
     throw new DidError(DidErrorCode.InternalError, `Failed to put Pkarr record for identifier ${identifier}: ${error.message}`);
   }
 

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -89,31 +89,50 @@ import {
   validatePreviousDidProof,
 } from './did-dht-utils.js';
 
-/**
- * The default DID DHT Gateway or Pkarr Relay server to use when publishing and resolving DID
- * documents.
- */
-const DEFAULT_GATEWAY_URI_FROM_ENV = process.env.DID_DHT_GATEWAY_URI !== undefined;
-const DEFAULT_GATEWAY_URI = process.env.DID_DHT_GATEWAY_URI || 'https://enbox-did-dht.fly.dev';
+/** The default DID DHT Gateway / Pkarr Relay used when no `gatewayUri` is supplied. */
+const FALLBACK_GATEWAY_URI = 'https://enbox-did-dht.fly.dev';
 
 /**
- * Applies the default gateway URI when none is supplied and decides whether private hosts are
- * allowed for the resulting URI.
+ * Returns the default gateway URI, deferring the `DID_DHT_GATEWAY_URI` env lookup until call
+ * time so the env var reflects late mutations (e.g. test setup) rather than the value captured
+ * at module load.
  *
- * The caller's explicit `allowPrivateGatewayUri` always wins. As an additional convenience,
- * private hosts are allowed whenever the resolved URI exactly matches the `DID_DHT_GATEWAY_URI`
- * environment variable so local development and CI workflows can target a private gateway
- * without sprinkling `allowPrivateGatewayUri: true` through their call sites.
+ * Setting `DID_DHT_GATEWAY_URI` only changes the default *URI*. It deliberately does NOT widen
+ * `allowPrivateGatewayUri`: dev/CI workflows that target a private Pkarr relay must opt in via
+ * the separate `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` env var, or by passing
+ * `allowPrivateGatewayUri: true` per call.
+ */
+function getDefaultGatewayUri(): string {
+  return process.env.DID_DHT_GATEWAY_URI || FALLBACK_GATEWAY_URI;
+}
+
+/**
+ * Returns the default value for `allowPrivateGatewayUri` when the caller does not supply one.
+ * Dev/CI shells set `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` to opt in to local Pkarr relays without
+ * sprinkling `allowPrivateGatewayUri: true` through every call site; production deployments
+ * leave it unset so the documented default of `false` applies.
+ *
+ * This env var is intentionally *separate* from `DID_DHT_GATEWAY_URI` so that simply pointing
+ * at a different (possibly private) relay does not silently disable SSRF protection.
+ */
+function getDefaultAllowPrivateGatewayUri(): boolean {
+  return process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY === '1';
+}
+
+/**
+ * Applies the default gateway URI when none is supplied. The caller's explicit
+ * `allowPrivateGatewayUri` (including an explicit `false`) always wins over the env-driven
+ * default — this is the contract pinned by the regression tests in `did-dht.test.ts`.
  */
 function resolveGatewayUri(gatewayUri: string | undefined, allowPrivateGatewayUri: boolean | undefined): {
   gatewayUri: string;
   allowPrivateGatewayUri: boolean;
 } {
-  const resolvedUri = gatewayUri ?? DEFAULT_GATEWAY_URI;
-  const matchesEnvDefault = DEFAULT_GATEWAY_URI_FROM_ENV && resolvedUri === DEFAULT_GATEWAY_URI;
+  // Use `??` (not `||`) so an explicit `false` from the caller short-circuits the env-default
+  // bypass instead of being OR-ed away.
   return {
-    gatewayUri             : resolvedUri,
-    allowPrivateGatewayUri : (allowPrivateGatewayUri ?? false) || matchesEnvDefault,
+    gatewayUri             : gatewayUri ?? getDefaultGatewayUri(),
+    allowPrivateGatewayUri : allowPrivateGatewayUri ?? getDefaultAllowPrivateGatewayUri(),
   };
 }
 

--- a/packages/dids/src/methods/did-web.ts
+++ b/packages/dids/src/methods/did-web.ts
@@ -24,7 +24,7 @@ import { Did } from '../did.js';
 import { DidMethod } from './did-method.js';
 import { EMPTY_DID_RESOLUTION_RESULT } from '../types/did-resolution.js';
 import { extractDidFragment } from '../utils.js';
-import { isPrivateHostname } from '@enbox/common';
+import { fetchPublicUrl } from '@enbox/common';
 import { DidError, DidErrorCode } from '../did-error.js';
 
 /** Default fetch timeout for DID document retrieval (30 seconds). */
@@ -387,19 +387,13 @@ export class DidWeb extends DidMethod {
       `${baseUrl}/.well-known/did.json`;
 
     try {
-      // Block requests to private/loopback/link-local addresses (SSRF protection).
-      const parsedUrl = new URL(didDocumentUrl);
-      if (isPrivateHostname(parsedUrl.hostname)) {
-        return {
-          ...EMPTY_DID_RESOLUTION_RESULT,
-          didResolutionMetadata: { error: 'notFound' }
-        };
-      }
-
-      // Perform an HTTP GET request to obtain the DID document.
-      const response = await fetch(didDocumentUrl, {
+      // Perform an HTTP GET request to obtain the DID document. `fetchPublicUrl` blocks the
+      // initial URL — and every redirect target — from pointing at a private/loopback/link-local
+      // host or a non-http(s) scheme, so a public hosting domain cannot 302 us to 127.0.0.1 or
+      // file:///etc/hosts after the first check passes.
+      const response = await fetchPublicUrl(didDocumentUrl, {
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      });
+      }, { description: 'did:web document URL' });
 
       // If the response status code is not 200, return an error.
       if (!response.ok) {throw new Error('HTTP error status code returned');}

--- a/packages/dids/tests/methods/did-dht.test.ts
+++ b/packages/dids/tests/methods/did-dht.test.ts
@@ -18,6 +18,43 @@ const fetchNotFoundResponse = (): { status: number; statusText: string; ok: bool
   ok         : false
 });
 
+/**
+ * Pins the DID DHT gateway env defaults to a *public* mock host (and clears the dev-mode
+ * private-gateway bypass) for the duration of each test in the surrounding describe block. This
+ * insulates the suite from however the CI / dev shell happens to have configured the env: the
+ * happy-path tests below all stub `fetch()` and just need the URL to pass `assertPublicUrl()`
+ * without each test having to opt in to private hosts, and the blocking-behavior tests need the
+ * dev-mode bypass to be off so the documented default of `false` actually applies.
+ *
+ * The `beforeEach`/`afterEach` calls below are intentional — they register hooks on whichever
+ * `describe()` block is active when this helper is invoked. ESLint's static analysis cannot
+ * follow that, hence the targeted disables.
+ */
+function pinPublicGatewayDefault(): void {
+  let originalUri: string | undefined;
+  let originalAllow: string | undefined;
+  // eslint-disable-next-line mocha/no-top-level-hooks
+  beforeEach(() => {
+    originalUri = process.env.DID_DHT_GATEWAY_URI;
+    originalAllow = process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY;
+    process.env.DID_DHT_GATEWAY_URI = 'https://test-mock-gateway.example.com';
+    delete process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY;
+  });
+  // eslint-disable-next-line mocha/no-top-level-hooks
+  afterEach(() => {
+    if (originalUri === undefined) {
+      delete process.env.DID_DHT_GATEWAY_URI;
+    } else {
+      process.env.DID_DHT_GATEWAY_URI = originalUri;
+    }
+    if (originalAllow === undefined) {
+      delete process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY;
+    } else {
+      process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY = originalAllow;
+    }
+  });
+}
+
 // Helper function to create a mocked fetch response that is successful and returns the given
 // response.
 const fetchOkResponse = (response?: any): {
@@ -30,6 +67,8 @@ const fetchOkResponse = (response?: any): {
 });
 
 describe('DidDht', () => {
+  pinPublicGatewayDefault();
+
   let fetchStub: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
@@ -851,6 +890,90 @@ describe('DidDht', () => {
       expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.NotFound);
     });
 
+    it('blocks a private gateway URI even when it matches DID_DHT_GATEWAY_URI (env is not a trust boundary)', async () => {
+      // Setting DID_DHT_GATEWAY_URI is a *URI* default only. It must not silently widen
+      // `allowPrivateGatewayUri` from its documented default of `false`, because env vars are
+      // not a meaningful trust boundary against SSRF. Callers wanting to talk to a private
+      // gateway must opt in explicitly. This test pins that contract by overriding the env to a
+      // private URI, calling resolve with that same URI, and asserting the request is still
+      // blocked without ever invoking fetch.
+      process.env.DID_DHT_GATEWAY_URI = 'http://127.0.0.1:7527';
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did, { gatewayUri: 'http://127.0.0.1:7527' });
+
+      expect(fetchStub).not.toHaveBeenCalled();
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+    });
+
+    it('also blocks a private URI taken implicitly from DID_DHT_GATEWAY_URI when no gatewayUri is supplied', async () => {
+      // Same regression as above but without an explicit `gatewayUri`. The env-supplied default
+      // must NOT be auto-trusted: a caller that simply omits `gatewayUri` should still get the
+      // documented `false` default for `allowPrivateGatewayUri` and be blocked.
+      process.env.DID_DHT_GATEWAY_URI = 'http://127.0.0.1:7527';
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did);
+
+      expect(fetchStub).not.toHaveBeenCalled();
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+    });
+
+    it('treats DID_DHT_ALLOW_PRIVATE_GATEWAY=1 as the dev/CI default opt-in (still overridable per call)', async () => {
+      // Dev/CI shells set DID_DHT_ALLOW_PRIVATE_GATEWAY=1 so local Pkarr relays work without
+      // sprinkling `allowPrivateGatewayUri: true` through every call site. Production deployments
+      // leave it unset.
+      process.env.DID_DHT_GATEWAY_URI = 'http://127.0.0.1:7527';
+      process.env.DID_DHT_ALLOW_PRIVATE_GATEWAY = '1';
+      fetchStub.mockResolvedValue(fetchNotFoundResponse());
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const allowed = await DidDht.resolve(did);
+
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(allowed.didResolutionMetadata.error).toBe(DidErrorCode.NotFound);
+
+      // An explicit `false` from the caller still wins, even with the env opt-in active.
+      fetchStub.mockClear();
+      const blocked = await DidDht.resolve(did, { allowPrivateGatewayUri: false });
+      expect(fetchStub).not.toHaveBeenCalled();
+      expect(blocked.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+    });
+
+    it('blocks Pkarr gateway redirects to private hosts (SSRF via redirect)', async () => {
+      // A "public" gateway returns a 302 pointing at the AWS instance metadata service. The initial
+      // URL passes validation, but every redirect target must be re-validated.
+      fetchStub.mockResolvedValue(new Response(null, {
+        status  : 302,
+        headers : { location: 'http://169.254.169.254/latest/meta-data/' },
+      }));
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did, {
+        gatewayUri: 'https://public-gateway.example.com',
+      });
+
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+      expect(didResolutionResult.didResolutionMetadata.errorMessage).toContain('private, loopback, or link-local');
+    });
+
+    it('blocks Pkarr gateway redirects to non-http(s) schemes (SSRF via redirect)', async () => {
+      fetchStub.mockResolvedValue(new Response(null, {
+        status  : 302,
+        headers : { location: 'file:///etc/hosts' },
+      }));
+
+      const did = 'did:dht:5634graogy41ow91cc78up6i45a9mcscccruwer9o4ah5wcc1xmy';
+      const didResolutionResult = await DidDht.resolve(did, {
+        gatewayUri: 'https://public-gateway.example.com',
+      });
+
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(didResolutionResult.didResolutionMetadata.error).toBe(DidErrorCode.InvalidGatewayUri);
+      expect(didResolutionResult.didResolutionMetadata.errorMessage).toContain('allowed schemes');
+    });
+
     it('returns a invalidDidDocumentLength error if the Pkarr relay returns smaller than the 72 byte minimum', async () => {
       // Mock the response from the Pkarr relay rather than calling over the network.
       fetchStub.mockResolvedValue(fetchOkResponse(
@@ -1363,6 +1486,10 @@ describe('DidDhtDocument', () => {
 
   describe('Web5TestVectorsDidDht', () => {
     it('resolve', async () => {
+      // These vectors hit the real (CI / local) Pkarr relay configured via DID_DHT_GATEWAY_URI,
+      // which is typically a private host (e.g. http://localhost:7527). Dev/CI shells set
+      // DID_DHT_ALLOW_PRIVATE_GATEWAY=1 to opt into private hosts; this integration test relies
+      // on that env opt-in.
       for (const vector of resolveTestVectors.vectors as any[]) {
         const didResolutionResult = await DidDht.resolve(vector.input.didUri);
         expect(didResolutionResult.didResolutionMetadata.error).toBe(vector.output.didResolutionMetadata.error);
@@ -1372,6 +1499,8 @@ describe('DidDhtDocument', () => {
 });
 
 describe('DidDhtUtils', () => {
+  pinPublicGatewayDefault();
+
   let fetchStub: ReturnType<typeof spyOn>;
 
   beforeEach(() => {

--- a/packages/dids/tests/methods/did-web.test.ts
+++ b/packages/dids/tests/methods/did-web.test.ts
@@ -41,6 +41,51 @@ describe('DidWeb', () => {
 
       fetchStub.mockRestore();
     });
+
+    it('does not fetch for did:web identifiers that resolve to private hosts (SSRF protection)', async () => {
+      const fetchStub = spyOn(globalThis as any, 'fetch');
+      fetchStub.mockImplementation(() => Promise.resolve(fetchNotFoundResponse()));
+
+      const resolutionResult = await DidWeb.resolve('did:web:127.0.0.1');
+
+      expect(resolutionResult.didResolutionMetadata.error).toBe('notFound');
+      expect(fetchStub).not.toHaveBeenCalled();
+
+      fetchStub.mockRestore();
+    });
+
+    it('blocks did:web document fetches that redirect to a private host (SSRF via redirect)', async () => {
+      // The initial public domain passes the URL check, but the server returns a 302 pointing at
+      // a metadata-service IP. `fetchPublicUrl` must re-validate every Location header, so this
+      // resolves to `notFound` and only the first fetch is performed.
+      const fetchStub = spyOn(globalThis as any, 'fetch');
+      fetchStub.mockResolvedValue(new Response(null, {
+        status  : 302,
+        headers : { location: 'http://169.254.169.254/latest/meta-data/' },
+      }));
+
+      const resolutionResult = await DidWeb.resolve('did:web:public.example.com');
+
+      expect(resolutionResult.didResolutionMetadata.error).toBe('notFound');
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+
+      fetchStub.mockRestore();
+    });
+
+    it('blocks did:web document fetches that redirect to a non-http(s) scheme', async () => {
+      const fetchStub = spyOn(globalThis as any, 'fetch');
+      fetchStub.mockResolvedValue(new Response(null, {
+        status  : 302,
+        headers : { location: 'file:///etc/hosts' },
+      }));
+
+      const resolutionResult = await DidWeb.resolve('did:web:public.example.com');
+
+      expect(resolutionResult.didResolutionMetadata.error).toBe('notFound');
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+
+      fetchStub.mockRestore();
+    });
   });
 
   describe('create()', () => {


### PR DESCRIPTION
## Summary

Follow-up review of PR #926 surfaced four additional issues in the DID gateway / `did:web` / URL-utility code paths. This PR addresses all four against the PR #926 branch so they ship together with the original consolidation.

### 1. SSRF via redirects (high)

Private-host validation was running before `fetch()`, but `fetch()` follows redirects by default — so a public `did:web` host or Pkarr gateway could pass validation and then 302 to `127.0.0.1`, `169.254.169.254`, or another internal host.

Added `fetchPublicUrl` in `@enbox/common` that drives redirects manually (`redirect: 'manual'`) and re-runs `assertPublicUrl` on every `Location` header. `did:web` document fetches and Pkarr GET / PUT now route through it. URL / redirect validation failures throw a typed `PublicUrlValidationError` so `pkarrFetch` can map them to `InvalidGatewayUri` without mis-classifying genuine network errors as SSRF.

### 2. Explicit `allowPrivateGatewayUri: false` ignored when env matches (high)

`resolveGatewayUri` was OR-ing `matchesEnvDefault` over the caller's value, so an explicit `false` was silently ignored when the resolved URI happened to match `DID_DHT_GATEWAY_URI`. This contradicted both the ``\"explicit wins\"`` comment and the `\"defaults to false\"` JSDoc on the option.

Switched the combinator to `??` so an explicit `false` short-circuits the env default. Removed the implicit URI-matching env bypass entirely (env vars aren't a meaningful trust boundary against SSRF) and replaced it with a separately-named `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` env var that contributors / CI set when they need to talk to a local Pkarr relay. Updated CI workflows and `CLAUDE.md`.

User's reproducer now passes:

\`\`\`
DID_DHT_GATEWAY_URI=http://127.0.0.1:7527 bun test packages/dids/tests/methods/did-dht.test.ts
# 61 pass, 0 fail
\`\`\`

### 3. `assertPublicUrl` allowed non-network schemes / empty hostnames (medium)

`assertPublicUrl('file:///etc/hosts')` and `assertPublicUrl('javascript:alert(1)')` both passed because the loopback / private check only inspected the hostname (which was empty). Added an `allowedProtocols` option (defaults to `['http:', 'https:']`) and an empty-hostname check, so `file:`, `javascript:`, `data:`, `ws:`, etc. are now rejected before they can reach `fetch()`.

### 4. `concatenateUrl` silently percent-encoded `?` and `#` (medium)

Writing the appended path through `URL.pathname` percent-encoded raw `?` / `#` markers, so `concatenateUrl('https://x.com', 'items?limit=1#top')` quietly became `…/items%3Flimit=1%23top` — changing the endpoint that callers reached. Now rejects raw `?` and `#` in the path argument while still preserving `%3F` / `%23` for legitimate path segments.

## Test plan

- [x] `bun test packages/common/tests/url.test.ts` — 21 pass (new redirect / scheme / `?` `#` cases)
- [x] `DID_DHT_GATEWAY_URI=http://127.0.0.1:7527 bun test packages/dids/tests/methods/did-dht.test.ts` — 61 pass, 0 fail (user's exact reproducer)
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run --filter @enbox/dids test:node` — 332 pass
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run --filter @enbox/agent test:node` — 1511 pass
- [x] `bun run --filter @enbox/dwn-clients test:node` — 151 pass
- [x] `bun run --filter @enbox/dwn-sdk-js test:node` — 1375 pass
- [x] `bun run lint` — clean

## New regression tests

- `did:web` document fetch blocked when redirect target is a private host
- `did:web` document fetch blocked when redirect target is a non-http(s) scheme
- Pkarr gateway redirect to private host blocked (returns `InvalidGatewayUri`)
- Pkarr gateway redirect to non-http(s) scheme blocked
- `fetchPublicUrl` exhausts `maxRedirects` and gives up
- `fetchPublicUrl` returns `304 Not Modified` (no `Location`) unchanged
- `assertPublicUrl` rejects `file:`, `javascript:`, `data:`, `ws:` and empty hostnames
- `assertPublicUrl` honors a custom `allowedProtocols` list
- `did:dht` blocks a private gateway URI even when it matches `DID_DHT_GATEWAY_URI` (env is not a trust boundary)
- `did:dht` env-default opt-in via `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` is overridable by an explicit `allowPrivateGatewayUri: false`
- `concatenateUrl` rejects raw `?` / `#` and preserves `%3F` / `%23`


Made with [Cursor](https://cursor.com)