### PR TITLE
make Web5TestVectorsDidDht > resolve self-contained (PR #926 follow-up)

### DIFF
--- a/packages/dids/tests/methods/did-dht.test.ts
+++ b/packages/dids/tests/methods/did-dht.test.ts
@@ -1487,11 +1487,12 @@ describe('DidDhtDocument', () => {
   describe('Web5TestVectorsDidDht', () => {
     it('resolve', async () => {
       // These vectors hit the real (CI / local) Pkarr relay configured via DID_DHT_GATEWAY_URI,
-      // which is typically a private host (e.g. http://localhost:7527). Dev/CI shells set
-      // DID_DHT_ALLOW_PRIVATE_GATEWAY=1 to opt into private hosts; this integration test relies
-      // on that env opt-in.
+      // which is typically a private host (e.g. http://localhost:7527). Pass
+      // `allowPrivateGatewayUri: true` explicitly so this integration test is self-contained and
+      // does not depend on the caller having `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` exported in their
+      // shell — talking to a local relay is the documented intent of the test.
       for (const vector of resolveTestVectors.vectors as any[]) {
-        const didResolutionResult = await DidDht.resolve(vector.input.didUri);
+        const didResolutionResult = await DidDht.resolve(vector.input.didUri, { allowPrivateGatewayUri: true });
         expect(didResolutionResult.didResolutionMetadata.error).toBe(vector.output.didResolutionMetadata.error);
       }
     }, 30000); // Set timeout to 30 seconds for this test for did:dht resolution timeout test


### PR DESCRIPTION
## Summary

Re-review surfaced one residual gap in #926: the `Web5TestVectorsDidDht > resolve` integration test sits intentionally outside `pinPublicGatewayDefault()` so it talks to the real Pkarr relay (`DID_DHT_GATEWAY_URI`), but with the new SSRF defaults that relay is private (e.g. `http://localhost:7527`) and the test silently relied on the caller having `DID_DHT_ALLOW_PRIVATE_GATEWAY=1` exported in their shell. Without the env var, the test fails with `invalidGatewayUri` instead of the expected `notFound`.

The user's documented reproducer reproduced exactly that failure:

\`\`\`
$ DID_DHT_GATEWAY_URI=http://127.0.0.1:7527 \
    bun test packages/dids/tests/methods/did-dht.test.ts --timeout 10000
...
expect(received).toBe(expected)
Expected: \"notFound\"
Received: \"invalidGatewayUri\"
60 pass, 1 fail
\`\`\`

This PR makes the integration test self-contained by passing \`allowPrivateGatewayUri: true\` at the call site — talking to a local relay is the documented intent of the test, so the opt-in belongs there rather than as an implicit shell dependency. It also leaves the env-var contract intact for everything *outside* of this one integration test, so the SSRF defaults still get exercised by the regression tests under \`describe('DidDht')\`.

## Test plan

User's exact original reproducer now passes 61 / 0 again:

\`\`\`
$ DID_DHT_GATEWAY_URI=http://127.0.0.1:7527 \
    bun test packages/dids/tests/methods/did-dht.test.ts --timeout 10000
61 pass, 0 fail, 187 expect() calls
\`\`\`

CI scenario (both env vars set) still passes 61 / 0. Full \`@enbox/dids\` suite passes 332 / 0 with only \`DID_DHT_GATEWAY_URI=http://localhost:7527\` set (no \`DID_DHT_ALLOW_PRIVATE_GATEWAY\` opt-in needed). Lint clean.


Made with [Cursor](https://cursor.com)