### PR TITLE
chore: add changeset for vault-connect sync fix

### DIFF
--- a/.changeset/vault-connect-sync-fix.md
+++ b/.changeset/vault-connect-sync-fix.md
@@ -1,0 +1,8 @@
+---
+"@enbox/agent": patch
+"@enbox/auth": patch
+"@enbox/api": patch
+"@enbox/browser": patch
+---
+
+Register agent DID for sync in vault connect and import-from-phrase flows to enable seed phrase recovery. Rename `localConnect` to `vaultConnect` and `LocalConnectOptions` to `VaultConnectOptions` (old names preserved as deprecated aliases). Export `IdentityProtocolDefinition` and `JwkProtocolDefinition` from `@enbox/agent`.


### PR DESCRIPTION
## Summary

- Adds patch changeset for `@enbox/agent`, `@enbox/auth`, `@enbox/api`, and `@enbox/browser` covering the changes from #936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)