### PR TITLE
feat(auth): automatic seed phrase recovery in vaultConnect and importFromPhrase

### DIFF
--- a/.changeset/seed-phrase-recovery.md
+++ b/.changeset/seed-phrase-recovery.md
@@ -1,0 +1,5 @@
+---
+"@enbox/auth": patch
+---
+
+Seed phrase recovery now happens automatically inside `vaultConnect()` and `importFromPhrase()`. When a recovery phrase is provided and no identities exist locally, the SDK pulls identity metadata, keys, and profile data from the remote DWN in a two-phase sequence. Wallets no longer need to manually orchestrate stop/pull/register/pull/push/restart after connecting with a recovery phrase.

--- a/packages/auth/src/connect/import.ts
+++ b/packages/auth/src/connect/import.ts
@@ -13,6 +13,7 @@ import type { ImportFromPhraseOptions, ImportFromPortableOptions } from '../type
 import { IdentityProtocolDefinition, JwkProtocolDefinition } from '@enbox/agent';
 
 import { DEFAULT_DWN_ENDPOINTS } from '../types.js';
+import { recoverIdentitiesFromRemote } from './recovery.js';
 import { registerWithDwnEndpoints } from '../registration.js';
 import { createDefaultIdentity, ensureVaultReady, finalizeSession, registerSyncScopeForIdentity, resolveIdentityDids, startSyncIfEnabled } from './lifecycle.js';
 
@@ -25,7 +26,9 @@ const AGENT_DID_SYNC_PROTOCOLS: [string, ...string[]] = [
  * Import (or recover) an identity from a BIP-39 recovery phrase.
  *
  * This re-initializes the vault with the given phrase and password,
- * recovering the agent DID and all derived keys.
+ * recovering the agent DID and all derived keys. If the recovery phrase
+ * was previously used to create identities, they are pulled from the
+ * remote DWN. Otherwise a new default identity is created.
  */
 export async function importFromPhrase(
   ctx: FlowContext,
@@ -47,47 +50,20 @@ export async function importFromPhrase(
     dwnEndpoints,
   });
 
-  // The recovery phrase re-derives the same agent DID,
-  // but the user identity might not exist yet — create one if needed.
-  const identities = await userAgent.identity.list();
-  let identity = identities[0];
-  let isNewIdentity = false;
-
-  if (!identity) {
-    isNewIdentity = true;
-    identity = await createDefaultIdentity(userAgent, dwnEndpoints);
-  }
-
-  const { connectedDid, delegateDid } = resolveIdentityDids(identity);
-
-  // Register with DWN endpoints (if registration options are provided).
+  // Register agent DID as tenant and for sync — prerequisites for recovery.
   if (ctx.registration) {
     await registerWithDwnEndpoints(
       {
-        userAgent   : userAgent,
+        userAgent,
         dwnEndpoints,
-        agentDid    : userAgent.agentDid.uri,
-        connectedDid,
-        secretStore : userAgent.secrets,
-        storage     : storage,
+        agentDid     : userAgent.agentDid.uri,
+        connectedDid : userAgent.agentDid.uri,
+        secretStore  : userAgent.secrets,
+        storage,
       },
       ctx.registration,
     );
   }
-
-  // Register sync. For delegate identities, always repair the registration
-  // (derive scope from active grants — revoked grants must not remain in a
-  // stale registration), regardless of whether the identity was just
-  // created or restored from storage. For local identities, register
-  // `protocols: 'all'` only on first creation; a pre-existing local
-  // identity was already registered during its initial flow.
-  if (delegateDid) {
-    await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
-  } else if (isNewIdentity && sync !== 'off') {
-    await registerSyncScopeForIdentity({ userAgent, connectedDid });
-  }
-
-  // Register the agent DID for sync (same rationale as vaultConnect).
   if (sync !== 'off') {
     try {
       await userAgent.sync.registerIdentity({
@@ -97,6 +73,55 @@ export async function importFromPhrase(
     } catch {
       // Already registered from a previous session.
     }
+  }
+
+  // Try to recover identities from the remote DWN before falling back
+  // to creating a new one.
+  let identities = await userAgent.identity.list();
+  let identity = identities[0];
+  let isNewIdentity = false;
+
+  if (!identity && sync !== 'off') {
+    try {
+      identities = await recoverIdentitiesFromRemote({ userAgent, dwnEndpoints, registration: ctx.registration, storage });
+      identity = identities[0];
+    } catch (err) {
+      console.warn('[@enbox/auth] Seed phrase recovery failed:', err);
+    }
+  }
+
+  if (!identity) {
+    isNewIdentity = true;
+    identity = await createDefaultIdentity(userAgent, dwnEndpoints);
+  }
+
+  const { connectedDid, delegateDid } = resolveIdentityDids(identity);
+
+  // Register sync for the identity DID.
+  if (isNewIdentity) {
+    // New identity: register as tenant first, then for sync.
+    if (ctx.registration) {
+      await registerWithDwnEndpoints(
+        {
+          userAgent,
+          dwnEndpoints,
+          agentDid    : userAgent.agentDid.uri,
+          connectedDid,
+          secretStore : userAgent.secrets,
+          storage,
+        },
+        ctx.registration,
+      );
+    }
+    if (delegateDid) {
+      await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
+    } else if (sync !== 'off') {
+      await registerSyncScopeForIdentity({ userAgent, connectedDid });
+    }
+  } else if (delegateDid) {
+    // Pre-existing delegate identity: repair sync scope so revoked
+    // grants don't remain in a stale registration.
+    await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
   }
 
   // Start sync.

--- a/packages/auth/src/connect/import.ts
+++ b/packages/auth/src/connect/import.ts
@@ -10,17 +10,10 @@ import type { AuthSession } from '../identity-session.js';
 import type { FlowContext } from './lifecycle.js';
 import type { ImportFromPhraseOptions, ImportFromPortableOptions } from '../types.js';
 
-import { IdentityProtocolDefinition, JwkProtocolDefinition } from '@enbox/agent';
-
 import { DEFAULT_DWN_ENDPOINTS } from '../types.js';
-import { recoverIdentitiesFromRemote } from './recovery.js';
 import { registerWithDwnEndpoints } from '../registration.js';
 import { createDefaultIdentity, ensureVaultReady, finalizeSession, registerSyncScopeForIdentity, resolveIdentityDids, startSyncIfEnabled } from './lifecycle.js';
-
-const AGENT_DID_SYNC_PROTOCOLS: [string, ...string[]] = [
-  IdentityProtocolDefinition.protocol,
-  JwkProtocolDefinition.protocol,
-];
+import { recoverIdentitiesFromRemote, registerAgentDidForSync } from './recovery.js';
 
 /**
  * Import (or recover) an identity from a BIP-39 recovery phrase.
@@ -65,14 +58,7 @@ export async function importFromPhrase(
     );
   }
   if (sync !== 'off') {
-    try {
-      await userAgent.sync.registerIdentity({
-        did     : userAgent.agentDid.uri,
-        options : { protocols: AGENT_DID_SYNC_PROTOCOLS },
-      });
-    } catch {
-      // Already registered from a previous session.
-    }
+    await registerAgentDidForSync(userAgent);
   }
 
   // Try to recover identities from the remote DWN before falling back

--- a/packages/auth/src/connect/recovery.ts
+++ b/packages/auth/src/connect/recovery.ts
@@ -1,9 +1,10 @@
 /**
- * Seed phrase recovery flow.
+ * Seed phrase recovery helpers.
  *
  * When a vault is re-derived from a recovery phrase on a new device,
- * the local DWN is empty. This module pulls identity metadata, keys,
- * and user data from the remote DWN in a controlled two-phase sequence.
+ * the local DWN is empty. This module provides the building blocks
+ * for pulling identity metadata, keys, and user data from the remote
+ * DWN in a controlled two-phase sequence.
  *
  * @module
  * @internal
@@ -11,15 +12,45 @@
 
 import type { BearerIdentity, EnboxUserAgent } from '@enbox/agent';
 
+import { IdentityProtocolDefinition, JwkProtocolDefinition } from '@enbox/agent';
+
 import type { RegistrationOptions, StorageAdapter } from '../types.js';
 
 import { registerWithDwnEndpoints } from '../registration.js';
 
 /**
+ * Internal protocols that store recovery-critical data in the agent DID's DWN.
+ * Syncing these ensures that seed phrase recovery can pull identity metadata,
+ * portable DIDs, and encrypted private keys from the remote.
+ */
+export const AGENT_DID_SYNC_PROTOCOLS: [string, ...string[]] = [
+  IdentityProtocolDefinition.protocol,
+  JwkProtocolDefinition.protocol,
+];
+
+/**
+ * Register the agent DID for sync with the recovery-critical protocols.
+ *
+ * This is a prerequisite for both normal operation (pushing identity
+ * metadata to the remote) and seed phrase recovery (pulling it back).
+ * Silently succeeds if the agent DID is already registered.
+ */
+export async function registerAgentDidForSync(userAgent: EnboxUserAgent): Promise<void> {
+  try {
+    await userAgent.sync.registerIdentity({
+      did     : userAgent.agentDid.uri,
+      options : { protocols: AGENT_DID_SYNC_PROTOCOLS },
+    });
+  } catch {
+    // Already registered from a previous session.
+  }
+}
+
+/**
  * Recover identities and their data from remote DWN endpoints.
  *
- * Assumes the agent DID is already registered for sync (with the
- * IdentityProtocol + JwkProtocol) and as a DWN tenant.
+ * Assumes the agent DID is already registered for sync (via
+ * {@link registerAgentDidForSync}) and as a DWN tenant.
  *
  * Phase 1 — pull identity metadata and DID private keys stored in the
  *   agent DID's DWN.

--- a/packages/auth/src/connect/recovery.ts
+++ b/packages/auth/src/connect/recovery.ts
@@ -1,0 +1,80 @@
+/**
+ * Seed phrase recovery flow.
+ *
+ * When a vault is re-derived from a recovery phrase on a new device,
+ * the local DWN is empty. This module pulls identity metadata, keys,
+ * and user data from the remote DWN in a controlled two-phase sequence.
+ *
+ * @module
+ * @internal
+ */
+
+import type { BearerIdentity, EnboxUserAgent } from '@enbox/agent';
+
+import type { RegistrationOptions, StorageAdapter } from '../types.js';
+
+import { registerWithDwnEndpoints } from '../registration.js';
+
+/**
+ * Recover identities and their data from remote DWN endpoints.
+ *
+ * Assumes the agent DID is already registered for sync (with the
+ * IdentityProtocol + JwkProtocol) and as a DWN tenant.
+ *
+ * Phase 1 — pull identity metadata and DID private keys stored in the
+ *   agent DID's DWN.
+ *
+ * Phase 2 — register each recovered identity DID as a tenant and for
+ *   sync, then pull their profile data, protocol configurations, and
+ *   records.
+ *
+ * Returns the recovered identities, or an empty array if the remote
+ * had nothing (e.g. first-ever setup with a pre-generated phrase).
+ */
+export async function recoverIdentitiesFromRemote(params: {
+  userAgent: EnboxUserAgent;
+  dwnEndpoints: string[];
+  registration?: RegistrationOptions;
+  storage: StorageAdapter;
+}): Promise<BearerIdentity[]> {
+  const { userAgent, dwnEndpoints, registration, storage } = params;
+  const agentDid = userAgent.agentDid.uri;
+
+  // Phase 1: pull identity metadata + encrypted DID keys.
+  await userAgent.sync.sync('pull');
+
+  const identities = await userAgent.identity.list();
+  if (identities.length === 0) {
+    return [];
+  }
+
+  // Register each recovered identity DID as a DWN tenant, then for sync.
+  // Tenant registration must come first — sync('pull') issues
+  // MessagesSync which requires the DID to be a recognised tenant.
+  for (const identity of identities) {
+    const did = identity.metadata.connectedDid ?? identity.did.uri;
+
+    if (registration) {
+      try {
+        await registerWithDwnEndpoints(
+          { userAgent, dwnEndpoints, agentDid, connectedDid: did, secretStore: userAgent.secrets, storage },
+          registration,
+        );
+      } catch {
+        // Best effort — the DID may already be registered, or the
+        // endpoint may be temporarily unreachable.
+      }
+    }
+
+    try {
+      await userAgent.sync.registerIdentity({ did, options: { protocols: 'all' } });
+    } catch {
+      // Already registered from a previous session.
+    }
+  }
+
+  // Phase 2: pull profile data, protocol configurations, and records.
+  await userAgent.sync.sync('pull');
+
+  return userAgent.identity.list();
+}

--- a/packages/auth/src/connect/vault.ts
+++ b/packages/auth/src/connect/vault.ts
@@ -17,6 +17,7 @@ import { IdentityProtocolDefinition, JwkProtocolDefinition } from '@enbox/agent'
 
 import { applyLocalDwnDiscovery } from '../discovery.js';
 import { DEFAULT_DWN_ENDPOINTS } from '../types.js';
+import { recoverIdentitiesFromRemote } from './recovery.js';
 import { registerWithDwnEndpoints } from '../registration.js';
 import { createDefaultIdentity, ensureVaultReady, finalizeSession, resolveIdentityDids, resolvePassword, startSyncIfEnabled } from './lifecycle.js';
 
@@ -36,6 +37,9 @@ const AGENT_DID_SYNC_PROTOCOLS: [string, ...string[]] = [
  * - On first launch: initializes the vault. Identity creation is opt-in via
  *   `options.createIdentity: true`.
  * - On subsequent launches: unlocks the vault and reconnects to the existing identity.
+ * - On recovery: when `recoveryPhrase` is provided on a fresh vault, pulls
+ *   identities and their data from the remote DWN before falling back to
+ *   identity creation.
  *
  * When no identities exist and `createIdentity` is not `true`, the session
  * is returned with the **agent DID** as the connected DID. This allows apps to
@@ -71,11 +75,50 @@ export async function vaultConnect(
     await applyLocalDwnDiscovery(userAgent, storage, emitter);
   }
 
-  // Find or create the user identity.
-  const identities = await userAgent.identity.list();
+  // Register the agent DID as a DWN tenant and for sync early — both are
+  // prerequisites for seed phrase recovery and for normal push/pull of
+  // identity metadata after identity creation.
+  if (ctx.registration) {
+    await registerWithDwnEndpoints(
+      {
+        userAgent,
+        dwnEndpoints,
+        agentDid     : userAgent.agentDid.uri,
+        connectedDid : userAgent.agentDid.uri,
+        secretStore  : userAgent.secrets,
+        storage,
+      },
+      ctx.registration,
+    );
+  }
+  if (sync !== 'off') {
+    try {
+      await userAgent.sync.registerIdentity({
+        did     : userAgent.agentDid.uri,
+        options : { protocols: AGENT_DID_SYNC_PROTOCOLS },
+      });
+    } catch {
+      // Already registered from a previous session.
+    }
+  }
+
+  // Find existing identities.
+  let identities = await userAgent.identity.list();
   let identity = identities[0];
   let isNewIdentity = false;
 
+  // Seed phrase recovery: when a recovery phrase was provided on a fresh
+  // vault and no identities exist locally, pull them from the remote DWN.
+  if (!identity && isFirstLaunch && options.recoveryPhrase && sync !== 'off') {
+    try {
+      identities = await recoverIdentitiesFromRemote({ userAgent, dwnEndpoints, registration: ctx.registration, storage });
+      identity = identities[0];
+    } catch (err) {
+      console.warn('[@enbox/auth] Seed phrase recovery failed:', err);
+    }
+  }
+
+  // Create a default identity if none were found or recovered.
   if (!identity && shouldCreateIdentity) {
     isNewIdentity = true;
     identity = await createDefaultIdentity(userAgent, dwnEndpoints, options.metadata?.name ?? 'Default');
@@ -92,41 +135,28 @@ export async function vaultConnect(
     ? resolveIdentityDids(identity).delegateDid
     : undefined;
 
-  // Register with DWN endpoints (if registration options are provided).
-  if (ctx.registration) {
+  // Register the new identity DID as a tenant and for sync.
+  // Tenant registration must come before sync registration — with live
+  // sync active, registerIdentity hot-adds a subscription that needs
+  // the DID to be a recognised tenant on the remote DWN.
+  if (isNewIdentity && ctx.registration) {
     await registerWithDwnEndpoints(
       {
-        userAgent   : userAgent,
+        userAgent,
         dwnEndpoints,
         agentDid    : userAgent.agentDid.uri,
         connectedDid,
         secretStore : userAgent.secrets,
-        storage     : storage,
+        storage,
       },
       ctx.registration,
     );
   }
-
-  // Register sync for new identities.
   if (isNewIdentity && sync !== 'off') {
     await userAgent.sync.registerIdentity({
       did     : connectedDid,
       options : { delegateDid, protocols: 'all' },
     });
-  }
-
-  // Register the agent DID for sync so that identity metadata, portable
-  // DIDs, and encrypted private keys are pushed to the remote DWN. Without
-  // this, seed phrase recovery on a new device has nothing to pull.
-  if (sync !== 'off') {
-    try {
-      await userAgent.sync.registerIdentity({
-        did     : userAgent.agentDid.uri,
-        options : { protocols: AGENT_DID_SYNC_PROTOCOLS },
-      });
-    } catch {
-      // Already registered from a previous session — no action needed.
-    }
   }
 
   // Start sync.

--- a/packages/auth/src/connect/vault.ts
+++ b/packages/auth/src/connect/vault.ts
@@ -13,23 +13,11 @@ import type { AuthSession } from '../identity-session.js';
 import type { FlowContext } from './lifecycle.js';
 import type { VaultConnectOptions } from '../types.js';
 
-import { IdentityProtocolDefinition, JwkProtocolDefinition } from '@enbox/agent';
-
 import { applyLocalDwnDiscovery } from '../discovery.js';
 import { DEFAULT_DWN_ENDPOINTS } from '../types.js';
-import { recoverIdentitiesFromRemote } from './recovery.js';
 import { registerWithDwnEndpoints } from '../registration.js';
 import { createDefaultIdentity, ensureVaultReady, finalizeSession, resolveIdentityDids, resolvePassword, startSyncIfEnabled } from './lifecycle.js';
-
-/**
- * Internal protocols that store recovery-critical data in the agent DID's DWN.
- * These must be synced so that seed phrase recovery can pull identity metadata,
- * portable DIDs, and encrypted private keys from the remote DWN.
- */
-const AGENT_DID_SYNC_PROTOCOLS: [string, ...string[]] = [
-  IdentityProtocolDefinition.protocol,
-  JwkProtocolDefinition.protocol,
-];
+import { recoverIdentitiesFromRemote, registerAgentDidForSync } from './recovery.js';
 
 /**
  * Execute the vault connect flow.
@@ -92,14 +80,7 @@ export async function vaultConnect(
     );
   }
   if (sync !== 'off') {
-    try {
-      await userAgent.sync.registerIdentity({
-        did     : userAgent.agentDid.uri,
-        options : { protocols: AGENT_DID_SYNC_PROTOCOLS },
-      });
-    } catch {
-      // Already registered from a previous session.
-    }
+    await registerAgentDidForSync(userAgent);
   }
 
   // Find existing identities.

--- a/packages/auth/tests/import-identity.spec.ts
+++ b/packages/auth/tests/import-identity.spec.ts
@@ -106,14 +106,14 @@ describe('importFromPhrase', () => {
       { recoveryPhrase: 'phrase', password: 'pass' },
     );
 
-    // Two registrations: identity DID + agent DID
+    // Two registrations: agent DID (early) + new identity DID
     expect(syncCalls).toHaveLength(2);
-    expect(syncCalls[0].options.protocols).toBe('all');
-    expect(syncCalls[1].did).toBe('did:dht:testagent');
-    expect(syncCalls[1].options.protocols).toEqual([
+    expect(syncCalls[0].did).toBe('did:dht:testagent');
+    expect(syncCalls[0].options.protocols).toEqual([
       'https://identity.foundation/protocols/web5/identity-store',
       'https://identity.foundation/protocols/web5/jwk-store',
     ]);
+    expect(syncCalls[1].options.protocols).toBe('all');
   });
 
   test('skips sync when disabled', async () => {
@@ -239,11 +239,11 @@ describe('importFromPhrase', () => {
       { recoveryPhrase: 'phrase', password: 'pass' },
     );
 
-    // Two registrations: delegate identity DID + agent DID
+    // Two registrations: agent DID (early) + delegate identity DID (scope repair)
     expect(syncCalls).toHaveLength(2);
-    expect(syncCalls[0].options.protocols).toEqual(['https://proto.example/chat']);
-    expect(syncCalls[0].options.delegateDid).toBe('did:dht:testuser123');
-    expect(syncCalls[1].did).toBe('did:dht:testagent');
+    expect(syncCalls[0].did).toBe('did:dht:testagent');
+    expect(syncCalls[1].options.protocols).toEqual(['https://proto.example/chat']);
+    expect(syncCalls[1].options.delegateDid).toBe('did:dht:testuser123');
     expect(createCallCount).toBe(0);
   });
 
@@ -336,11 +336,11 @@ describe('importFromPhrase', () => {
       { recoveryPhrase: 'phrase', password: 'pass' },
     );
 
-    // Two registrations: delegate DID (all) + agent DID
+    // Two registrations: agent DID (early) + delegate DID (scope repair, all)
     expect(syncCalls).toHaveLength(2);
-    expect(syncCalls[0].options.protocols).toBe('all');
-    expect(syncCalls[0].options.delegateDid).toBe('did:dht:testuser123');
-    expect(syncCalls[1].did).toBe('did:dht:testagent');
+    expect(syncCalls[0].did).toBe('did:dht:testagent');
+    expect(syncCalls[1].options.protocols).toBe('all');
+    expect(syncCalls[1].options.delegateDid).toBe('did:dht:testuser123');
     expect(createCallCount).toBe(0);
   });
 

--- a/packages/auth/tests/recovery.spec.ts
+++ b/packages/auth/tests/recovery.spec.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from 'bun:test';
+
+import { MemoryStorage } from '../src/storage/storage.js';
+import { AGENT_DID_SYNC_PROTOCOLS, recoverIdentitiesFromRemote, registerAgentDidForSync } from '../src/connect/recovery.js';
+import { createMockAgent, createMockIdentity } from './helpers/mock-agent.js';
+
+describe('AGENT_DID_SYNC_PROTOCOLS', () => {
+  test('contains identity store and JWK store protocol URIs', () => {
+    expect(AGENT_DID_SYNC_PROTOCOLS).toEqual([
+      'https://identity.foundation/protocols/web5/identity-store',
+      'https://identity.foundation/protocols/web5/jwk-store',
+    ]);
+  });
+});
+
+describe('registerAgentDidForSync', () => {
+  test('registers agent DID with recovery protocols', async () => {
+    const syncCalls: any[] = [];
+    const agent = createMockAgent({
+      syncRegisterIdentity: async (params) => { syncCalls.push(params); },
+    });
+
+    await registerAgentDidForSync(agent);
+
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].did).toBe('did:dht:testagent');
+    expect(syncCalls[0].options.protocols).toEqual(AGENT_DID_SYNC_PROTOCOLS);
+  });
+
+  test('silently succeeds when already registered', async () => {
+    const agent = createMockAgent({
+      syncRegisterIdentity: async () => { throw new Error('already registered'); },
+    });
+
+    await expect(registerAgentDidForSync(agent)).resolves.toBeUndefined();
+  });
+});
+
+describe('recoverIdentitiesFromRemote', () => {
+  test('returns recovered identities after two-phase pull', async () => {
+    const identity = createMockIdentity();
+    let pullCount = 0;
+    const syncCalls: any[] = [];
+
+    const agent = createMockAgent({
+      identityList: async () => {
+        // Phase 1 pull recovers the identity; phase 2 pull is a no-op.
+        return pullCount > 0 ? [identity] : [];
+      },
+      syncSync             : async () => { pullCount++; },
+      syncRegisterIdentity : async (params) => { syncCalls.push(params); },
+    });
+
+    const result = await recoverIdentitiesFromRemote({
+      userAgent    : agent,
+      dwnEndpoints : ['https://dwn.example.com'],
+      storage      : new MemoryStorage(),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].did.uri).toBe('did:dht:testuser123');
+    expect(pullCount).toBe(2);
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].did).toBe('did:dht:testuser123');
+    expect(syncCalls[0].options.protocols).toBe('all');
+  });
+
+  test('returns empty array when remote has no identities', async () => {
+    let pullCount = 0;
+    const agent = createMockAgent({
+      identityList : async () => [],
+      syncSync     : async () => { pullCount++; },
+    });
+
+    const result = await recoverIdentitiesFromRemote({
+      userAgent    : agent,
+      dwnEndpoints : ['https://dwn.example.com'],
+      storage      : new MemoryStorage(),
+    });
+
+    expect(result).toEqual([]);
+    expect(pullCount).toBe(1);
+  });
+
+  test('registers recovered identity DIDs as DWN tenants when registration is provided', async () => {
+    const identity = createMockIdentity();
+    let pullCount = 0;
+    let registrationSucceeded = false;
+
+    const agent = createMockAgent({
+      identityList     : async () => (pullCount > 0 ? [identity] : []),
+      syncSync         : async () => { pullCount++; },
+      rpcGetServerInfo : async () => ({
+        registrationRequirements : [],
+        maxFileSize              : 10_000_000,
+      }),
+    });
+
+    await recoverIdentitiesFromRemote({
+      userAgent    : agent,
+      dwnEndpoints : ['https://dwn.example.com'],
+      registration : {
+        onSuccess : () => { registrationSucceeded = true; },
+        onFailure : () => {},
+      },
+      storage: new MemoryStorage(),
+    });
+
+    expect(registrationSucceeded).toBe(true);
+  });
+
+  test('continues recovery when DWN tenant registration fails', async () => {
+    const identity = createMockIdentity();
+    let pullCount = 0;
+    const syncCalls: any[] = [];
+
+    const agent = createMockAgent({
+      identityList         : async () => (pullCount > 0 ? [identity] : []),
+      syncSync             : async () => { pullCount++; },
+      syncRegisterIdentity : async (params) => { syncCalls.push(params); },
+      rpcGetServerInfo     : async () => { throw new Error('network error'); },
+    });
+
+    const result = await recoverIdentitiesFromRemote({
+      userAgent    : agent,
+      dwnEndpoints : ['https://dwn.example.com'],
+      registration : {
+        onSuccess : () => {},
+        onFailure : () => {},
+      },
+      storage: new MemoryStorage(),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(syncCalls).toHaveLength(1);
+    expect(pullCount).toBe(2);
+  });
+
+  test('uses connectedDid for delegate identities', async () => {
+    const delegateIdentity = createMockIdentity({
+      metadata: { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:external' },
+    });
+    let pullCount = 0;
+    const syncCalls: any[] = [];
+
+    const agent = createMockAgent({
+      identityList         : async () => (pullCount > 0 ? [delegateIdentity] : []),
+      syncSync             : async () => { pullCount++; },
+      syncRegisterIdentity : async (params) => { syncCalls.push(params); },
+    });
+
+    await recoverIdentitiesFromRemote({
+      userAgent    : agent,
+      dwnEndpoints : ['https://dwn.example.com'],
+      storage      : new MemoryStorage(),
+    });
+
+    expect(syncCalls[0].did).toBe('did:dht:external');
+  });
+
+  test('tolerates already-registered sync identity', async () => {
+    const identity = createMockIdentity();
+    let pullCount = 0;
+
+    const agent = createMockAgent({
+      identityList         : async () => (pullCount > 0 ? [identity] : []),
+      syncSync             : async () => { pullCount++; },
+      syncRegisterIdentity : async () => { throw new Error('already registered'); },
+    });
+
+    const result = await recoverIdentitiesFromRemote({
+      userAgent    : agent,
+      dwnEndpoints : ['https://dwn.example.com'],
+      storage      : new MemoryStorage(),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(pullCount).toBe(2);
+  });
+});

--- a/packages/auth/tests/vault-connect.spec.ts
+++ b/packages/auth/tests/vault-connect.spec.ts
@@ -141,15 +141,15 @@ describe('vaultConnect', () => {
       { createIdentity: true },
     );
 
-    // Two registrations: the new identity DID + the agent DID
+    // Two registrations: agent DID (early, for recovery support) + new identity DID
     expect(syncCalls).toHaveLength(2);
-    expect(syncCalls[0].did).toBe('did:dht:testuser123');
-    expect(syncCalls[0].options.protocols).toBe('all');
-    expect(syncCalls[1].did).toBe('did:dht:testagent');
-    expect(syncCalls[1].options.protocols).toEqual([
+    expect(syncCalls[0].did).toBe('did:dht:testagent');
+    expect(syncCalls[0].options.protocols).toEqual([
       'https://identity.foundation/protocols/web5/identity-store',
       'https://identity.foundation/protocols/web5/jwk-store',
     ]);
+    expect(syncCalls[1].did).toBe('did:dht:testuser123');
+    expect(syncCalls[1].options.protocols).toBe('all');
   });
 
   test('registers agent DID for sync even without identity creation', async () => {


### PR DESCRIPTION
## Summary

Moves seed phrase recovery orchestration from wallet code into the SDK. When `vaultConnect()` or `importFromPhrase()` is called with a recovery phrase and no identities exist locally, the SDK now automatically:

1. Pulls identity metadata + encrypted DID keys from the agent DID's remote DWN
2. Registers each recovered identity DID as a tenant on the remote endpoints
3. Registers each recovered identity DID for sync (`protocols: 'all'`)
4. Pulls profile data, protocol configurations, and records for each identity

The two-phase pull is encapsulated in a new `recoverIdentitiesFromRemote()` helper in `recovery.ts`.

**Before:** wallets had to manually orchestrate ~50 lines of stop → pull → register → pull → install → push → restart after every `auth.connect({ recoveryPhrase })`.

**After:** `auth.connect({ recoveryPhrase, password })` returns a session with recovered identities. No manual sync orchestration needed.

Also fixes the tenant-before-sync ordering for new identity creation in `vaultConnect()` — `registerWithDwnEndpoints` now runs before `registerIdentity` to prevent 401 errors from live sync hot-adds.

## Test plan

- [x] All 484 existing auth tests pass
- [x] Lint clean
- [x] Full monorepo build succeeds
- [ ] Manual: create identity on wallet A → restore seed phrase on wallet B → identity + profile data recovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)