### PR TITLE
fix(agent): install KeyDeliveryProtocol proactively with encrypted protocols

### DIFF
--- a/.changeset/proactive-key-delivery.md
+++ b/.changeset/proactive-key-delivery.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Install KeyDeliveryProtocol proactively when a protocol with `encryptionRequired: true` is first installed, rather than lazily on the first encrypted write. This fixes a race condition where the sync engine's closure resolver couldn't find the dependency because the DWN event fired before `postWriteKeyDelivery` completed, and a recovery issue where encrypted JWK records couldn't be pulled on a fresh device.

--- a/packages/agent/src/store-data.ts
+++ b/packages/agent/src/store-data.ts
@@ -379,6 +379,16 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
       throw new Error(`Failed to install protocol: ${status.code} - ${status.detail}`);
     }
 
+    // When the protocol has encrypted types, install the KeyDeliveryProtocol
+    // proactively. The sync engine's closure resolver requires it to be
+    // present before encrypted records can be committed (pull) or pushed.
+    // Without this, there's a race: postWriteKeyDelivery installs it lazily
+    // after the first encrypted write, but the DWN event fires before that
+    // completes and the sync engine sees a missing dependency.
+    if (encryptionActive) {
+      await agent.dwn.ensureKeyDeliveryProtocol(tenant);
+    }
+
     return { encryptionActive };
   }
 


### PR DESCRIPTION
## Summary

When `DwnDataStore.installProtocol()` installs a protocol that has `encryptionRequired: true` (e.g., JwkProtocol for private key storage), it now also installs the KeyDeliveryProtocol in the same operation via `agent.dwn.ensureKeyDeliveryProtocol()`.

Previously, the KeyDeliveryProtocol was installed lazily by `postWriteKeyDelivery()` after the first encrypted record was written. This caused two issues:

### 1. Push race condition on identity creation

When an encrypted JWK record is written to the local DWN:
1. The DWN processes the write and emits a local event
2. The sync engine's live subscription fires and evaluates the closure
3. `postWriteKeyDelivery` hasn't completed yet — KeyDeliveryProtocol isn't installed
4. Closure resolver fails: `ClosureEncryptionDependencyMissing — dependency 'keyDeliveryProtocol' not found locally`

The record is eventually pushed on the next sync cycle (after `postWriteKeyDelivery` completes), but the console error is noisy and the first push is delayed.

### 2. Recovery pull failure on seed phrase restore

On a fresh device, `sync('pull')` tries to pull encrypted JWK records from the remote DWN. The closure resolver checks if the KeyDeliveryProtocol is installed locally — it's not, because no encrypted writes have happened on this device. The records can't be committed, which means private keys aren't recovered during the first pull.

### The fix

One line in `DwnDataStore.installProtocol()`: after installing a protocol with encryption keys, call `agent.dwn.ensureKeyDeliveryProtocol(tenant)`. This ensures the dependency exists before any encrypted records are written or pulled, eliminating the race and the recovery gap.

## Test plan

- [x] All 493 auth tests pass
- [x] Agent test failures unchanged from baseline (339 vs 343 — pre-existing, require running DWN server)
- [x] Full monorepo build clean
- [x] Lint clean
- [ ] Manual: create identity → no `ClosureEncryptionDependencyMissing` in console
- [ ] Manual: restore from seed phrase → encrypted private keys pulled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)