### PR TITLE
fix(auth): install KeyDeliveryProtocol before recovery pull

### DIFF
--- a/.changeset/recovery-key-delivery.md
+++ b/.changeset/recovery-key-delivery.md
@@ -1,0 +1,5 @@
+---
+"@enbox/auth": patch
+---
+
+Install KeyDeliveryProtocol for the agent DID before the first sync pull in `recoverIdentitiesFromRemote()`. Without this, the sync engine's closure resolver rejects encrypted JwkProtocol records (private keys) during recovery because the dependency protocol isn't present locally yet.

--- a/packages/auth/src/connect/recovery.ts
+++ b/packages/auth/src/connect/recovery.ts
@@ -52,8 +52,10 @@ export async function registerAgentDidForSync(userAgent: EnboxUserAgent): Promis
  * Assumes the agent DID is already registered for sync (via
  * {@link registerAgentDidForSync}) and as a DWN tenant.
  *
- * Phase 1 — pull identity metadata and DID private keys stored in the
- *   agent DID's DWN.
+ * Phase 1 — pull identity metadata, portable DIDs, and encrypted
+ *   private keys from the agent DID's remote DWN. The
+ *   KeyDeliveryProtocol is installed first so that the sync engine's
+ *   closure resolver can accept encrypted JwkProtocol records.
  *
  * Phase 2 — register each recovered identity DID as a tenant and for
  *   sync, then pull their profile data, protocol configurations, and
@@ -71,7 +73,14 @@ export async function recoverIdentitiesFromRemote(params: {
   const { userAgent, dwnEndpoints, registration, storage } = params;
   const agentDid = userAgent.agentDid.uri;
 
-  // Phase 1: pull identity metadata + encrypted DID keys.
+  // Install the KeyDeliveryProtocol for the agent DID before pulling.
+  // Encrypted JwkProtocol records (private keys) require this protocol
+  // to be present locally for the sync engine's closure resolver to
+  // accept them. Without it, the encrypted records are skipped during
+  // pull and private keys are never recovered.
+  await userAgent.dwn.ensureKeyDeliveryProtocol(agentDid);
+
+  // Phase 1: pull identity metadata, portable DIDs, and encrypted keys.
   await userAgent.sync.sync('pull');
 
   const identities = await userAgent.identity.list();

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -76,6 +76,7 @@ export interface MockAgentOverrides {
   dwnExportDelegateContextKeys?: (delegateDid: string) => any[];
   dwnExportDelegateMultiPartyProtocols?: (delegateDid: string) => string[];
   dwnClearDelegateDecryptionKeys?: (delegateDid?: string) => void;
+  dwnEnsureKeyDeliveryProtocol?: (tenantDid: string) => Promise<void>;
   syncRegisterIdentity?: (params: any) => Promise<void>;
   syncUnregisterIdentity?: (did: string) => Promise<void>;
   syncUpdateIdentityOptions?: (params: any) => Promise<void>;
@@ -150,6 +151,7 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
       exportDelegateContextKeys         : overrides.dwnExportDelegateContextKeys ?? ((): any[] => []),
       exportDelegateMultiPartyProtocols : overrides.dwnExportDelegateMultiPartyProtocols ?? ((): string[] => []),
       clearDelegateDecryptionKeys       : overrides.dwnClearDelegateDecryptionKeys ?? ((): void => {}),
+      ensureKeyDeliveryProtocol         : overrides.dwnEnsureKeyDeliveryProtocol ?? (async (): Promise<void> => {}),
     },
 
     processDwnRequest: overrides.processDwnRequest ?? (async (params: any): Promise<any> => {


### PR DESCRIPTION
## Summary

Calls `ensureKeyDeliveryProtocol(agentDid)` in `recoverIdentitiesFromRemote()` before the first `sync('pull')`.

**Why the previous fix (#941) wasn't enough**: `DwnDataStore.installProtocol()` proactively installs KeyDeliveryProtocol when a protocol with `encryptionRequired` is installed locally. But during seed phrase recovery, protocols arrive via sync pull — the DwnDataStore local install path never runs. The sync engine's closure resolver evaluates encrypted JwkProtocol records, finds KeyDeliveryProtocol missing, and rejects them. Private keys are never recovered.

**The fix**: One line before Phase 1 pull — `await userAgent.dwn.ensureKeyDeliveryProtocol(agentDid)`. The agent DID was just created from the seed phrase and has X25519 keyAgreement, so the protocol can be installed immediately. All subsequent sync pulls find the dependency satisfied.

## Test plan

- [x] All 493 auth tests pass
- [x] Lint clean, build clean
- [ ] Manual: restore from seed phrase → no `ClosureEncryptionDependencyMissing` errors, private keys recovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)