### PR TITLE
fix(agent,auth): sync push resilience + recovery KeyDeliveryProtocol

### DIFF
--- a/.changeset/sync-push-resilience.md
+++ b/.changeset/sync-push-resilience.md
@@ -1,0 +1,10 @@
+---
+"@enbox/agent": patch
+"@enbox/auth": patch
+---
+
+Fix three sync issues that caused cascading errors during identity creation and seed phrase recovery:
+
+- **Push retry for protocol dependencies**: Protocol dependency 400 errors (`ComposedProtocolNotInstalled`, `ProtocolNotFound`) are now classified as transient and retried instead of permanently dead-lettered. This makes out-of-order protocol pushes self-healing.
+- **Push stream buffering**: `pushMessages()` now buffers data streams before sending, preventing `ReadableStream is disturbed` errors when the underlying HTTP fetch retries.
+- **Recovery KeyDeliveryProtocol**: `recoverIdentitiesFromRemote()` installs the KeyDeliveryProtocol for the agent DID before the first sync pull, so encrypted JwkProtocol records (private keys) can be committed by the closure resolver.

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -55,16 +55,27 @@ export function syncMessageReplyIsSuccessful(reply: UnionMessageReply, pushedMes
 
 /**
  * Determines whether a failed push reply represents a permanent failure that
- * should NOT be retried. Permanent failures include protocol violations (400),
- * authorization errors (401/403), and schema validation errors that will never
- * succeed regardless of retry.
+ * should NOT be retried.
  *
- * Transient failures (5xx, network errors) are worth retrying.
+ * 400 errors are generally permanent (schema violations, record limit exceeded),
+ * but protocol dependency errors are transient — the dependency may arrive
+ * shortly (e.g. SocialGraph ProtocolsConfigure arrives before Profile's push
+ * is retried). These are retried so that out-of-order pushes self-heal.
+ *
+ * 401/403 are permanent (auth errors that won't resolve on retry).
  */
 export function isPermanentPushFailure(reply: UnionMessageReply): boolean {
-  return reply.status.code === 400 ||
-    reply.status.code === 401 ||
-    reply.status.code === 403;
+  if (reply.status.code === 401 || reply.status.code === 403) {
+    return true;
+  }
+  if (reply.status.code === 400) {
+    const detail = reply.status.detail ?? '';
+    if (detail.includes('ComposedProtocolNotInstalled') || detail.includes('ProtocolNotFound')) {
+      return false;
+    }
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -368,14 +379,25 @@ export async function pushMessages({ did, dwnUrl, delegateDid, protocol, message
   // Step 2: Sort in dependency order using topological sort.
   const sorted = topologicalSort(fetched);
 
-  // Step 3: Push messages in dependency order, consuming each stream as we go.
+  // Step 3: Buffer data streams so they survive fetch retries.
+  // ReadableStream is single-use — if sendDwnRequest's underlying fetch
+  // retries the HTTP request, the original stream is already consumed.
+  await bufferSmallStreams(sorted);
+
+  // Step 4: Push messages in dependency order.
   for (const entry of sorted) {
     const cid = await getMessageCid(entry.message);
+
+    // Create a fresh stream from the buffer for each send attempt.
+    const data = entry.bufferedData
+      ? new ReadableStream<Uint8Array>({ start(c): void { c.enqueue(entry.bufferedData!); c.close(); } })
+      : entry.dataStream;
+
     try {
       const reply = await agent.rpc.sendDwnRequest({
         dwnUrl,
         targetDid : did,
-        data      : entry.dataStream,
+        data,
         message   : entry.message
       });
 

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -54,27 +54,32 @@ export function syncMessageReplyIsSuccessful(reply: UnionMessageReply, pushedMes
 }
 
 /**
- * Determines whether a failed push reply represents a permanent failure that
- * should NOT be retried.
+ * 400 detail substrings that indicate a protocol dependency hasn't
+ * arrived on the remote yet. These resolve on retry once the
+ * dependency is pushed, so they must NOT be treated as permanent.
+ */
+const TRANSIENT_DEPENDENCY_PATTERNS = [
+  'ComposedProtocolNotInstalled',
+  'ProtocolNotFound',
+];
+
+/**
+ * Classifies a failed push reply as permanent (dead-letter) or
+ * transient (retry with backoff).
  *
- * 400 errors are generally permanent (schema violations, record limit exceeded),
- * but protocol dependency errors are transient — the dependency may arrive
- * shortly (e.g. SocialGraph ProtocolsConfigure arrives before Profile's push
- * is retried). These are retried so that out-of-order pushes self-heal.
- *
- * 401/403 are permanent (auth errors that won't resolve on retry).
+ * Permanent: 401/403 auth errors, most 400 validation errors.
+ * Transient: 5xx, network errors, and 400 protocol-dependency errors
+ * that self-heal once the dependency arrives on the remote.
  */
 export function isPermanentPushFailure(reply: UnionMessageReply): boolean {
-  if (reply.status.code === 401 || reply.status.code === 403) {
-    return true;
+  const { code, detail } = reply.status;
+
+  if (code === 401 || code === 403) { return true; }
+
+  if (code === 400) {
+    return !TRANSIENT_DEPENDENCY_PATTERNS.some(pattern => detail?.includes(pattern));
   }
-  if (reply.status.code === 400) {
-    const detail = reply.status.detail ?? '';
-    if (detail.includes('ComposedProtocolNotInstalled') || detail.includes('ProtocolNotFound')) {
-      return false;
-    }
-    return true;
-  }
+
   return false;
 }
 

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -521,7 +521,10 @@ describe('sync-messages', () => {
     });
 
     it('should include dataStream for RecordsWrite with data', async () => {
-      const mockStream = new ReadableStream();
+      const payload = new TextEncoder().encode('test-data');
+      const mockStream = new ReadableStream<Uint8Array>({
+        start(controller): void { controller.enqueue(payload); controller.close(); },
+      });
       const sendStub = sinon.stub().resolves({ status: { code: 202, detail: 'Accepted' } });
       const mockAgent = {
         dwn: {
@@ -548,7 +551,7 @@ describe('sync-messages', () => {
 
       expect(sendStub.calledOnce).toBe(true);
       const callArgs = sendStub.firstCall.args[0];
-      expect(callArgs.data).toBe(mockStream);
+      expect(callArgs.data).toBeInstanceOf(ReadableStream);
     });
   });
 

--- a/packages/agent/tests/sync-push-resilience.spec.ts
+++ b/packages/agent/tests/sync-push-resilience.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isPermanentPushFailure } from '../src/sync-messages.js';
+import type { UnionMessageReply } from '@enbox/dwn-sdk-js';
+
+describe('isPermanentPushFailure', () => {
+  test('401 is permanent', () => {
+    expect(isPermanentPushFailure({ status: { code: 401, detail: 'Unauthorized' } } as UnionMessageReply)).toBe(true);
+  });
+
+  test('403 is permanent', () => {
+    expect(isPermanentPushFailure({ status: { code: 403, detail: 'Forbidden' } } as UnionMessageReply)).toBe(true);
+  });
+
+  test('400 with generic detail is permanent', () => {
+    expect(isPermanentPushFailure({ status: { code: 400, detail: 'RecordLimitExceeded' } } as UnionMessageReply)).toBe(true);
+  });
+
+  test('400 with ComposedProtocolNotInstalled is transient', () => {
+    const reply = {
+      status: {
+        code   : 400,
+        detail : 'ProtocolsConfigureComposedProtocolNotInstalled: composed protocol \'social-graph\' not installed',
+      },
+    } as UnionMessageReply;
+    expect(isPermanentPushFailure(reply)).toBe(false);
+  });
+
+  test('400 with ProtocolNotFound is transient', () => {
+    const reply = {
+      status: {
+        code   : 400,
+        detail : 'ProtocolAuthorizationProtocolNotFound: unable to find protocol definition for https://identity.foundation/protocols/profile',
+      },
+    } as UnionMessageReply;
+    expect(isPermanentPushFailure(reply)).toBe(false);
+  });
+
+  test('500 is transient (not permanent)', () => {
+    expect(isPermanentPushFailure({ status: { code: 500, detail: 'Internal Server Error' } } as UnionMessageReply)).toBe(false);
+  });
+
+  test('200 is not permanent', () => {
+    expect(isPermanentPushFailure({ status: { code: 200, detail: 'OK' } } as UnionMessageReply)).toBe(false);
+  });
+
+  test('400 with no detail is permanent', () => {
+    expect(isPermanentPushFailure({ status: { code: 400 } } as UnionMessageReply)).toBe(true);
+  });
+});

--- a/packages/auth/src/connect/recovery.ts
+++ b/packages/auth/src/connect/recovery.ts
@@ -71,6 +71,13 @@ export async function recoverIdentitiesFromRemote(params: {
   const { userAgent, dwnEndpoints, registration, storage } = params;
   const agentDid = userAgent.agentDid.uri;
 
+  // Install the KeyDeliveryProtocol for the agent DID before pulling.
+  // Encrypted JwkProtocol records (private keys) require this protocol
+  // to be present locally for the sync engine's closure resolver to
+  // accept them. Without it, the encrypted records are skipped during
+  // pull and private keys are never recovered.
+  await userAgent.dwn.ensureKeyDeliveryProtocol(agentDid);
+
   // Phase 1: pull identity metadata + encrypted DID keys.
   await userAgent.sync.sync('pull');
 

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -76,6 +76,7 @@ export interface MockAgentOverrides {
   dwnExportDelegateContextKeys?: (delegateDid: string) => any[];
   dwnExportDelegateMultiPartyProtocols?: (delegateDid: string) => string[];
   dwnClearDelegateDecryptionKeys?: (delegateDid?: string) => void;
+  dwnEnsureKeyDeliveryProtocol?: (tenantDid: string) => Promise<void>;
   syncRegisterIdentity?: (params: any) => Promise<void>;
   syncUnregisterIdentity?: (did: string) => Promise<void>;
   syncUpdateIdentityOptions?: (params: any) => Promise<void>;
@@ -150,6 +151,7 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
       exportDelegateContextKeys         : overrides.dwnExportDelegateContextKeys ?? ((): any[] => []),
       exportDelegateMultiPartyProtocols : overrides.dwnExportDelegateMultiPartyProtocols ?? ((): string[] => []),
       clearDelegateDecryptionKeys       : overrides.dwnClearDelegateDecryptionKeys ?? ((): void => {}),
+      ensureKeyDeliveryProtocol         : overrides.dwnEnsureKeyDeliveryProtocol ?? (async (): Promise<void> => {}),
     },
 
     processDwnRequest: overrides.processDwnRequest ?? (async (params: any): Promise<any> => {


### PR DESCRIPTION
## Summary

Three fixes that together eliminate the cascade of sync errors during identity creation and seed phrase recovery. Supersedes #943.

### 1. Protocol dependency pushes are now retryable (`@enbox/agent`)

`isPermanentPushFailure` previously classified ALL 400 errors as permanent failures that go to the dead letter queue. But `ComposedProtocolNotInstalled` and `ProtocolNotFound` are transient — the dependency protocol will arrive shortly (e.g., SocialGraph ProtocolsConfigure arrives before Profile's push is retried).

Now these specific 400 errors are classified as transient and retried via the normal backoff mechanism. Out-of-order protocol pushes self-heal instead of permanently failing.

### 2. Push data streams are buffered (`@enbox/agent`)

`pushMessages()` now calls `bufferSmallStreams()` (the same buffering used by the pull path) before sending. This prevents `ReadableStream is disturbed` errors when `sendDwnRequest`'s underlying `fetch` retries the HTTP request — the original stream was already consumed by the first attempt.

### 3. KeyDeliveryProtocol installed before recovery pull (`@enbox/auth`)

`recoverIdentitiesFromRemote()` now calls `ensureKeyDeliveryProtocol(agentDid)` before the first `sync('pull')`. On a fresh device, the sync engine's closure resolver needs this protocol to accept encrypted JwkProtocol records (private keys). The proactive install in `DwnDataStore.installProtocol()` (#941) only covers the local-install path — during recovery, protocols arrive via sync pull and that path isn't triggered.

## Test plan

- [x] 8 new tests for `isPermanentPushFailure` (permanent vs transient classification)
- [x] All 493 auth tests pass
- [x] Lint clean across both packages
- [x] Full monorepo build clean
- [ ] Manual: create identity → no 400/500 console errors
- [ ] Manual: restore from seed phrase → identity + profile data recovered, no closure errors
- [ ] Manual: create 2nd identity on restored wallet → syncs to other wallet instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)