### PR TITLE
fix(agent): retry live sync on DID propagation delay + use Blob for push

### DIFF
--- a/.changeset/sync-did-propagation.md
+++ b/.changeset/sync-did-propagation.md
@@ -1,0 +1,8 @@
+---
+"@enbox/agent": patch
+---
+
+Fix two sync engine issues:
+
+- **DID propagation retry**: When a newly created `did:dht` identity is hot-added to live sync, the remote DWN may not be able to resolve the DID yet (DHT propagation delay). `initializeLinkTarget` now retries with exponential backoff (2s, 4s, 8s) on DID resolution failures instead of giving up immediately.
+- **Push stream reuse**: Buffered push data is now sent as a `Blob` instead of a `ReadableStream`. `Blob` is replayable by `fetchWithRetry`, eliminating `ReadableStream is disturbed` errors on HTTP retry.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1396,6 +1396,39 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
+  /**
+   * Wrapper around {@link initializeLinkTarget} that retries on DID
+   * resolution failures. Newly published `did:dht` DIDs take a few
+   * seconds to propagate through the DHT network. During this window,
+   * the remote DWN can't resolve the DID to verify request signatures,
+   * causing a 401. Retrying with exponential backoff lets the
+   * propagation settle before giving up.
+   */
+  private async initializeLinkTargetWithRetry(target: {
+    did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
+  }): Promise<void> {
+    try {
+      await this.initializeLinkTarget(target);
+    } catch (error: any) {
+      const msg = error.message ?? '';
+      const isDidResolutionFailure = msg.includes('GetPublicKeyNotFound') || msg.includes('notFound');
+      if (!isDidResolutionFailure) { throw error; }
+
+      const delays = [2000, 4000, 8000];
+      for (const delay of delays) {
+        await sleep(delay);
+        try {
+          await this.initializeLinkTarget(target);
+          return;
+        } catch {
+          // Continue to next attempt.
+        }
+      }
+      // All retries exhausted — the original error was already logged
+      // by initializeLinkTarget's catch block.
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Hot-add / hot-remove: per-identity live sync management
   // ---------------------------------------------------------------------------
@@ -1430,7 +1463,7 @@ export class SyncEngineLevel implements SyncEngine {
       }
     }
 
-    await Promise.allSettled(targets.map(t => this.initializeLinkTarget(t)));
+    await Promise.allSettled(targets.map(t => this.initializeLinkTargetWithRetry(t)));
   }
 
   /** Hot-remove a single identity from the active live sync session. */

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -393,9 +393,10 @@ export async function pushMessages({ did, dwnUrl, delegateDid, protocol, message
   for (const entry of sorted) {
     const cid = await getMessageCid(entry.message);
 
-    // Create a fresh stream from the buffer for each send attempt.
+    // Use a Blob for buffered data — unlike ReadableStream, Blob is
+    // replayable so fetchWithRetry can retry the HTTP request on failure.
     const data = entry.bufferedData
-      ? new ReadableStream<Uint8Array>({ start(c): void { c.enqueue(entry.bufferedData!); c.close(); } })
+      ? new Blob([entry.bufferedData] as BlobPart[], { type: 'application/octet-stream' })
       : entry.dataStream;
 
     try {

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -551,7 +551,7 @@ describe('sync-messages', () => {
 
       expect(sendStub.calledOnce).toBe(true);
       const callArgs = sendStub.firstCall.args[0];
-      expect(callArgs.data).toBeInstanceOf(ReadableStream);
+      expect(callArgs.data).toBeInstanceOf(Blob);
     });
   });
 


### PR DESCRIPTION
## Summary

Two sync engine fixes that address the remaining errors during identity creation.

### 1. DID propagation retry for live sync hot-add

When a newly created `did:dht` identity is registered for sync while live sync is running, the sync engine immediately tries to open a `MessagesSubscribe` on the remote DWN. But the DID may not have propagated through the DHT network yet — the remote can't resolve it to verify the request signature:

```
401 GeneralJwsVerifierGetPublicKeyNotFound: Pkarr record not found
```

New `initializeLinkTargetWithRetry()` wraps the existing `initializeLinkTarget()` with exponential backoff (2s → 4s → 8s) specifically for DID resolution failures. Only used for the hot-add path (`addIdentityToLiveSync`), not for `startLiveSync` where DIDs should already be published.

### 2. Blob instead of ReadableStream for push data

The previous fix (#945) buffered push data into `Uint8Array` but then wrapped it in a new `ReadableStream` for sending. Problem: `fetchWithRetry` in `@enbox/dwn-clients` retries HTTP requests on transient failures, but `ReadableStream` is single-use — the retry gets "The provided ReadableStream is disturbed".

Fix: send buffered data as a `Blob` instead. `Blob` is replayable by `fetch()`, so HTTP retries work correctly.

## Test plan

- [x] 537 tests pass (sync-messages + sync-push-resilience + auth)
- [x] Lint clean, build clean
- [ ] Manual: create identity → no 401 DID resolution errors in console
- [ ] Manual: push retries succeed after transient 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)