### PR TITLE
fix(dwn): handle duplicate large record writes

### DIFF
--- a/.changeset/calm-keys-race.md
+++ b/.changeset/calm-keys-race.md
@@ -1,0 +1,8 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/dwn-sql-store": patch
+---
+
+Handle duplicate large `RecordsWrite` delivery idempotently in SQL-backed DWNs.
+
+Exact duplicate writes now return `409 Conflict` before reprocessing large data streams, while SQL data and block stores tolerate overlapping duplicate inserts for the same content-addressed data.

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -58,6 +58,31 @@ export class RecordsWriteHandler implements MethodHandler {
     };
     const { messages: existingMessages } = await this.deps.messageStore.query(tenant, [ query ]);
 
+    // If the exact same message already exists, return 409 immediately.
+    // This prevents duplicate delivery races from re-processing large data
+    // streams and hitting unique constraints in SQL-backed data stores.
+    //
+    // Exception: an initial write may have been stored earlier without data
+    // (204). A later delivery of the same message with data must be allowed
+    // to complete the record.
+    const incomingCid = await Message.getCid(message);
+    for (const existingMessage of existingMessages) {
+      if (await Message.getCid(existingMessage) !== incomingCid) {
+        continue;
+      }
+
+      const canCompleteMissingData = await this.existingInitialWriteLacksData(
+        tenant,
+        existingMessage as RecordsWriteMessage,
+        message,
+        dataStream !== undefined,
+      );
+
+      if (!canCompleteMissingData) {
+        return { status: { code: 409, detail: 'Conflict' } };
+      }
+    }
+
     // if the incoming write is not the initial write, then it must not modify any immutable properties defined by the initial write
     const newMessageIsInitialWrite = await recordsWrite.isInitialWrite();
     let initialWrite: RecordsWriteMessage | undefined;
@@ -100,17 +125,14 @@ export class RecordsWriteHandler implements MethodHandler {
       // We detect the incomplete state by checking whether the existing
       // message is an initial write that lacks both inline encodedData and
       // DataStore data — indicating it was stored without data.
-      let existingLacksData = false;
-      if (newestExistingMessage !== undefined && dataStream !== undefined) {
-        const isInitial = await RecordsWrite.isInitialWrite(newestExistingMessage);
-        if (isInitial) {
-          const hasInlineData = !!(newestExistingMessage as any).encodedData;
-          const hasStoredData = this.deps.dataStore
-            ? !!(await this.deps.dataStore.get(tenant, recordsWrite.message.recordId, message.descriptor.dataCid))
-            : false;
-          existingLacksData = !hasInlineData && !hasStoredData;
-        }
-      }
+      const existingLacksData = newestExistingMessage !== undefined
+        ? await this.existingInitialWriteLacksData(
+          tenant,
+          newestExistingMessage as RecordsWriteMessage,
+          message,
+          dataStream !== undefined,
+        )
+        : false;
 
       if (!existingLacksData) {
         return {
@@ -286,6 +308,33 @@ export class RecordsWriteHandler implements MethodHandler {
     }
 
     return messageWithOptionalEncodedData;
+  }
+
+  private async existingInitialWriteLacksData(
+    tenant: string,
+    existingMessage: RecordsWriteMessage,
+    incomingMessage: RecordsWriteMessage,
+    incomingHasData: boolean,
+  ): Promise<boolean> {
+    if (!incomingHasData) {
+      return false;
+    }
+
+    const isInitial = await RecordsWrite.isInitialWrite(existingMessage);
+    if (!isInitial) {
+      return false;
+    }
+
+    const hasInlineData = !!(existingMessage as RecordsQueryReplyEntry).encodedData;
+    const hasStoredData = this.deps.dataStore
+      ? !!(await this.deps.dataStore.get(
+        tenant,
+        existingMessage.recordId,
+        incomingMessage.descriptor.dataCid,
+      ))
+      : false;
+
+    return !hasInlineData && !hasStoredData;
   }
 
   private async processMessageWithoutDataStream(

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -125,14 +125,15 @@ export class RecordsWriteHandler implements MethodHandler {
       // We detect the incomplete state by checking whether the existing
       // message is an initial write that lacks both inline encodedData and
       // DataStore data — indicating it was stored without data.
-      const existingLacksData = newestExistingMessage !== undefined
-        ? await this.existingInitialWriteLacksData(
+      let existingLacksData = false;
+      if (newestExistingMessage) {
+        existingLacksData = await this.existingInitialWriteLacksData(
           tenant,
           newestExistingMessage as RecordsWriteMessage,
           message,
           dataStream !== undefined,
-        )
-        : false;
+        );
+      }
 
       if (!existingLacksData) {
         return {

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -188,6 +188,24 @@ export function testRecordsWriteHandler(): void {
         expect(thirdRecordsQueryReply.entries![0].encodedData).toBe(newDataEncoded);
       });
 
+      it('should return 409 for an exact duplicate initial RecordsWrite with large data', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+        const dataBytes = TestDataGenerator.randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1);
+        const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({
+          author : alice,
+          data   : dataBytes,
+        });
+
+        const firstReply = await dwn.processMessage(alice.did, message, { dataStream });
+        expect(firstReply.status.code).toBe(202);
+
+        const duplicateReply = await dwn.processMessage(alice.did, message, {
+          dataStream: DataStream.fromBytes(dataBytes),
+        });
+        expect(duplicateReply.status.code).toBe(409);
+      });
+
       it('should only be able to overwrite existing record if new message CID is larger when `messageTimestamp` value is the same', async () => {
       // start by writing an originating message
         const author = await TestDataGenerator.generatePersona();

--- a/packages/dwn-sql-store/src/blockstore-sql.ts
+++ b/packages/dwn-sql-store/src/blockstore-sql.ts
@@ -4,6 +4,7 @@ import type { AbortOptions, AwaitIterable } from 'interface-store';
 import type { Blockstore, Pair } from 'interface-blockstore';
 
 import { CID } from 'multiformats';
+import { isDuplicateKeyError } from './utils/duplicate-key-error.js';
 
 /**
  * SQL-backed implementation of the `Blockstore` v5 interface, scoped to a
@@ -36,14 +37,22 @@ export class BlockstoreSql implements Blockstore {
   public async put(key: CID, val: Uint8Array, _options?: AbortOptions): Promise<CID> {
     const blockCid = key.toString();
 
-    await this.#db
-      .insertInto('dataBlocks')
-      .values({
-        rootDataCid : this.#rootDataCid,
-        blockCid,
-        data        : Buffer.from(val),
-      })
-      .execute();
+    try {
+      await this.#db
+        .insertInto('dataBlocks')
+        .values({
+          rootDataCid : this.#rootDataCid,
+          blockCid,
+          data        : Buffer.from(val),
+        })
+        .execute();
+    } catch (error: unknown) {
+      if (!isDuplicateKeyError(error)) {
+        throw error;
+      }
+      // Idempotent block put: overlapping writes of the same dataCid can
+      // import the same content-addressed block concurrently.
+    }
 
     return key;
   }

--- a/packages/dwn-sql-store/src/data-store-s3.ts
+++ b/packages/dwn-sql-store/src/data-store-s3.ts
@@ -3,6 +3,7 @@ import type { DwnDatabaseType } from './types.js';
 import type { DataStore, DataStoreGetResult, DataStorePutResult } from '@enbox/dwn-sdk-js';
 
 import { DataStream } from '@enbox/dwn-sdk-js';
+import { isDuplicateKeyError } from './utils/duplicate-key-error.js';
 import { Readable } from 'stream';
 import { Upload } from '@aws-sdk/lib-storage';
 import {
@@ -142,11 +143,32 @@ export class DataStoreS3 implements DataStore {
       dataSize = await this.#uploadToS3(dataCid, dataStream);
     }
 
-    // Insert the reference.
-    await db
-      .insertInto('dataRefs')
-      .values({ tenant, recordId, dataCid, dataSize })
-      .execute();
+    // Insert the reference. If an overlapping identical write inserted the
+    // ref first, treat it as an idempotent put and return the stored size.
+    try {
+      await db
+        .insertInto('dataRefs')
+        .values({ tenant, recordId, dataCid, dataSize })
+        .execute();
+    } catch (error: unknown) {
+      if (!isDuplicateKeyError(error)) {
+        throw error;
+      }
+
+      const racedRef = await db
+        .selectFrom('dataRefs')
+        .select('dataSize')
+        .where('tenant', '=', tenant)
+        .where('recordId', '=', recordId)
+        .where('dataCid', '=', dataCid)
+        .executeTakeFirst();
+
+      if (!racedRef) {
+        throw error;
+      }
+
+      dataSize = Number(racedRef.dataSize);
+    }
 
     return { dataSize };
   }

--- a/packages/dwn-sql-store/src/data-store-s3.ts
+++ b/packages/dwn-sql-store/src/data-store-s3.ts
@@ -2,8 +2,8 @@ import type { Dialect } from './dialect/dialect.js';
 import type { DwnDatabaseType } from './types.js';
 import type { DataStore, DataStoreGetResult, DataStorePutResult } from '@enbox/dwn-sdk-js';
 
+import * as DataRefs from './utils/data-refs.js';
 import { DataStream } from '@enbox/dwn-sdk-js';
-import { isDuplicateKeyError } from './utils/duplicate-key-error.js';
 import { Readable } from 'stream';
 import { Upload } from '@aws-sdk/lib-storage';
 import {
@@ -74,15 +74,8 @@ export class DataStoreS3 implements DataStore {
   ): Promise<DataStoreGetResult | undefined> {
     const db = this.#getDb('get');
 
-    const ref = await db
-      .selectFrom('dataRefs')
-      .select('dataSize')
-      .where('tenant', '=', tenant)
-      .where('recordId', '=', recordId)
-      .where('dataCid', '=', dataCid)
-      .executeTakeFirst();
-
-    if (!ref) {
+    const dataSize = await DataRefs.getDataRefSize(db, { tenant, recordId, dataCid });
+    if (dataSize === undefined) {
       return undefined;
     }
 
@@ -98,7 +91,7 @@ export class DataStoreS3 implements DataStore {
     const dataStream = response.Body.transformToWebStream() as ReadableStream<Uint8Array>;
 
     return {
-      dataSize: Number(ref.dataSize),
+      dataSize,
       dataStream,
     };
   }
@@ -111,65 +104,27 @@ export class DataStoreS3 implements DataStore {
   ): Promise<DataStorePutResult> {
     const db = this.#getDb('put');
 
-    // Check if this exact ref already exists (idempotent put).
-    const existingRef = await db
-      .selectFrom('dataRefs')
-      .select('dataSize')
-      .where('tenant', '=', tenant)
-      .where('recordId', '=', recordId)
-      .where('dataCid', '=', dataCid)
-      .executeTakeFirst();
-
-    if (existingRef) {
+    const existingDataSize = await DataRefs.getDataRefSize(db, { tenant, recordId, dataCid });
+    if (existingDataSize !== undefined) {
       await DataStream.toBytes(dataStream);
-      return { dataSize: Number(existingRef.dataSize) };
+      return { dataSize: existingDataSize };
     }
 
     // Check if another ref for this dataCid already exists (dedup path).
-    const otherRef = await db
-      .selectFrom('dataRefs')
-      .select('dataSize')
-      .where('dataCid', '=', dataCid)
-      .executeTakeFirst();
+    const otherDataSize = await DataRefs.getAnyDataRefSize(db, dataCid);
 
     let dataSize: number;
 
-    if (otherRef) {
+    if (otherDataSize !== undefined) {
       // S3 object already exists — skip upload.
       await DataStream.toBytes(dataStream);
-      dataSize = Number(otherRef.dataSize);
+      dataSize = otherDataSize;
     } else {
       // New data — upload to S3 with a counting passthrough.
       dataSize = await this.#uploadToS3(dataCid, dataStream);
     }
 
-    // Insert the reference. If an overlapping identical write inserted the
-    // ref first, treat it as an idempotent put and return the stored size.
-    try {
-      await db
-        .insertInto('dataRefs')
-        .values({ tenant, recordId, dataCid, dataSize })
-        .execute();
-    } catch (error: unknown) {
-      if (!isDuplicateKeyError(error)) {
-        throw error;
-      }
-
-      const racedRef = await db
-        .selectFrom('dataRefs')
-        .select('dataSize')
-        .where('tenant', '=', tenant)
-        .where('recordId', '=', recordId)
-        .where('dataCid', '=', dataCid)
-        .executeTakeFirst();
-
-      if (!racedRef) {
-        throw error;
-      }
-
-      dataSize = Number(racedRef.dataSize);
-    }
-
+    dataSize = await DataRefs.insertDataRef(db, { tenant, recordId, dataCid }, dataSize);
     return { dataSize };
   }
 
@@ -180,22 +135,10 @@ export class DataStoreS3 implements DataStore {
   ): Promise<void> {
     const db = this.#getDb('delete');
 
-    // Remove the reference.
-    await db
-      .deleteFrom('dataRefs')
-      .where('tenant', '=', tenant)
-      .where('recordId', '=', recordId)
-      .where('dataCid', '=', dataCid)
-      .execute();
+    await DataRefs.deleteDataRef(db, { tenant, recordId, dataCid });
 
     // Garbage-collect the S3 object if no more refs point to this dataCid.
-    const remaining = await db
-      .selectFrom('dataRefs')
-      .select('dataCid')
-      .where('dataCid', '=', dataCid)
-      .executeTakeFirst();
-
-    if (!remaining) {
+    if (!await DataRefs.hasAnyDataRef(db, dataCid)) {
       await this.#s3.send(new DeleteObjectCommand({
         Bucket : this.#bucket,
         Key    : dataCid,

--- a/packages/dwn-sql-store/src/data-store-s3.ts
+++ b/packages/dwn-sql-store/src/data-store-s3.ts
@@ -115,13 +115,13 @@ export class DataStoreS3 implements DataStore {
 
     let dataSize: number;
 
-    if (otherDataSize !== undefined) {
+    if (otherDataSize === undefined) {
+      // New data — upload to S3 with a counting passthrough.
+      dataSize = await this.#uploadToS3(dataCid, dataStream);
+    } else {
       // S3 object already exists — skip upload.
       await DataStream.toBytes(dataStream);
       dataSize = otherDataSize;
-    } else {
-      // New data — upload to S3 with a counting passthrough.
-      dataSize = await this.#uploadToS3(dataCid, dataStream);
     }
 
     dataSize = await DataRefs.insertDataRef(db, { tenant, recordId, dataCid }, dataSize);

--- a/packages/dwn-sql-store/src/data-store-sql.ts
+++ b/packages/dwn-sql-store/src/data-store-sql.ts
@@ -3,12 +3,12 @@ import type { DwnDatabaseType } from './types.js';
 import type { ImportResult } from 'ipfs-unixfs-importer';
 import type { DataStore, DataStoreGetResult, DataStorePutResult } from '@enbox/dwn-sdk-js';
 
+import * as DataRefs from './utils/data-refs.js';
 import { BlockstoreSql } from './blockstore-sql.js';
 import { CID } from 'multiformats';
 import { DataStream } from '@enbox/dwn-sdk-js';
 import { exporter } from 'ipfs-unixfs-exporter';
 import { importer } from 'ipfs-unixfs-importer';
-import { isDuplicateKeyError } from './utils/duplicate-key-error.js';
 import { Kysely, sql } from 'kysely';
 
 /**
@@ -54,16 +54,8 @@ export class DataStoreSql implements DataStore {
   ): Promise<DataStoreGetResult | undefined> {
     const db = this.#getDb('get');
 
-    // Look up the reference to confirm this tenant+record has this data.
-    const ref = await db
-      .selectFrom('dataRefs')
-      .select('dataSize')
-      .where('tenant', '=', tenant)
-      .where('recordId', '=', recordId)
-      .where('dataCid', '=', dataCid)
-      .executeTakeFirst();
-
-    if (!ref) {
+    const dataSize = await DataRefs.getDataRefSize(db, { tenant, recordId, dataCid });
+    if (dataSize === undefined) {
       return undefined;
     }
 
@@ -85,7 +77,7 @@ export class DataStoreSql implements DataStore {
     });
 
     return {
-      dataSize: Number(ref.dataSize),
+      dataSize,
       dataStream,
     };
   }
@@ -98,19 +90,11 @@ export class DataStoreSql implements DataStore {
   ): Promise<DataStorePutResult> {
     const db = this.#getDb('put');
 
-    // Check if this exact ref already exists (idempotent put).
-    const existingRef = await db
-      .selectFrom('dataRefs')
-      .select('dataSize')
-      .where('tenant', '=', tenant)
-      .where('recordId', '=', recordId)
-      .where('dataCid', '=', dataCid)
-      .executeTakeFirst();
-
-    if (existingRef) {
+    const existingDataSize = await DataRefs.getDataRefSize(db, { tenant, recordId, dataCid });
+    if (existingDataSize !== undefined) {
       // Drain the stream — caller expects it to be consumed.
       await DataStream.toBytes(dataStream);
-      return { dataSize: Number(existingRef.dataSize) };
+      return { dataSize: existingDataSize };
     }
 
     // Check if blocks for this dataCid already exist (dedup path).
@@ -123,14 +107,9 @@ export class DataStoreSql implements DataStore {
     if (blocksExist) {
       // Blocks already stored by a previous ref with the same dataCid.
       // Get the data size from that existing ref.
-      const otherRef = await db
-        .selectFrom('dataRefs')
-        .select('dataSize')
-        .where('dataCid', '=', dataCid)
-        .executeTakeFirst();
-
-      if (otherRef) {
-        dataSize = Number(otherRef.dataSize);
+      const otherDataSize = await DataRefs.getAnyDataRefSize(db, dataCid);
+      if (otherDataSize !== undefined) {
+        dataSize = otherDataSize;
         // Drain the stream — caller expects it to be consumed.
         await DataStream.toBytes(dataStream);
       } else {
@@ -156,33 +135,7 @@ export class DataStoreSql implements DataStore {
       dataSize = Number(dataDagRoot.unixfs?.fileSize() ?? dataDagRoot.size);
     }
 
-    // Insert the reference. If an overlapping identical write inserted the
-    // ref first, treat it as an idempotent put and return the stored size.
-    try {
-      await db
-        .insertInto('dataRefs')
-        .values({ tenant, recordId, dataCid, dataSize })
-        .execute();
-    } catch (error: unknown) {
-      if (!isDuplicateKeyError(error)) {
-        throw error;
-      }
-
-      const racedRef = await db
-        .selectFrom('dataRefs')
-        .select('dataSize')
-        .where('tenant', '=', tenant)
-        .where('recordId', '=', recordId)
-        .where('dataCid', '=', dataCid)
-        .executeTakeFirst();
-
-      if (!racedRef) {
-        throw error;
-      }
-
-      dataSize = Number(racedRef.dataSize);
-    }
-
+    dataSize = await DataRefs.insertDataRef(db, { tenant, recordId, dataCid }, dataSize);
     return { dataSize };
   }
 
@@ -193,22 +146,10 @@ export class DataStoreSql implements DataStore {
   ): Promise<void> {
     const db = this.#getDb('delete');
 
-    // Remove the reference.
-    await db
-      .deleteFrom('dataRefs')
-      .where('tenant', '=', tenant)
-      .where('recordId', '=', recordId)
-      .where('dataCid', '=', dataCid)
-      .execute();
+    await DataRefs.deleteDataRef(db, { tenant, recordId, dataCid });
 
     // Garbage-collect blocks if no more refs point to this dataCid.
-    const remaining = await db
-      .selectFrom('dataRefs')
-      .select('dataCid')
-      .where('dataCid', '=', dataCid)
-      .executeTakeFirst();
-
-    if (!remaining) {
+    if (!await DataRefs.hasAnyDataRef(db, dataCid)) {
       await db
         .deleteFrom('dataBlocks')
         .where('rootDataCid', '=', dataCid)

--- a/packages/dwn-sql-store/src/data-store-sql.ts
+++ b/packages/dwn-sql-store/src/data-store-sql.ts
@@ -108,14 +108,14 @@ export class DataStoreSql implements DataStore {
       // Blocks already stored by a previous ref with the same dataCid.
       // Get the data size from that existing ref.
       const otherDataSize = await DataRefs.getAnyDataRefSize(db, dataCid);
-      if (otherDataSize !== undefined) {
-        dataSize = otherDataSize;
-        // Drain the stream — caller expects it to be consumed.
-        await DataStream.toBytes(dataStream);
-      } else {
+      if (otherDataSize === undefined) {
         // Edge case: blocks exist but no ref (interrupted previous put).
         // Count bytes without full buffering.
         dataSize = await DataStoreSql.#countStreamBytes(dataStream);
+      } else {
+        dataSize = otherDataSize;
+        // Drain the stream — caller expects it to be consumed.
+        await DataStream.toBytes(dataStream);
       }
     } else {
       // New data — clean up any partial blocks from interrupted imports,

--- a/packages/dwn-sql-store/src/data-store-sql.ts
+++ b/packages/dwn-sql-store/src/data-store-sql.ts
@@ -8,6 +8,7 @@ import { CID } from 'multiformats';
 import { DataStream } from '@enbox/dwn-sdk-js';
 import { exporter } from 'ipfs-unixfs-exporter';
 import { importer } from 'ipfs-unixfs-importer';
+import { isDuplicateKeyError } from './utils/duplicate-key-error.js';
 import { Kysely, sql } from 'kysely';
 
 /**
@@ -155,11 +156,32 @@ export class DataStoreSql implements DataStore {
       dataSize = Number(dataDagRoot.unixfs?.fileSize() ?? dataDagRoot.size);
     }
 
-    // Insert the reference.
-    await db
-      .insertInto('dataRefs')
-      .values({ tenant, recordId, dataCid, dataSize })
-      .execute();
+    // Insert the reference. If an overlapping identical write inserted the
+    // ref first, treat it as an idempotent put and return the stored size.
+    try {
+      await db
+        .insertInto('dataRefs')
+        .values({ tenant, recordId, dataCid, dataSize })
+        .execute();
+    } catch (error: unknown) {
+      if (!isDuplicateKeyError(error)) {
+        throw error;
+      }
+
+      const racedRef = await db
+        .selectFrom('dataRefs')
+        .select('dataSize')
+        .where('tenant', '=', tenant)
+        .where('recordId', '=', recordId)
+        .where('dataCid', '=', dataCid)
+        .executeTakeFirst();
+
+      if (!racedRef) {
+        throw error;
+      }
+
+      dataSize = Number(racedRef.dataSize);
+    }
 
     return { dataSize };
   }

--- a/packages/dwn-sql-store/src/message-store-sql.ts
+++ b/packages/dwn-sql-store/src/message-store-sql.ts
@@ -15,6 +15,7 @@ import * as cbor from '@ipld/dag-cbor';
 import { executeWithTransaction } from './utils/transaction.js';
 import { extractTagsAndSanitizeIndexes } from './utils/sanitize.js';
 import { filterSelectQuery } from './utils/filter.js';
+import { isDuplicateKeyError } from './utils/duplicate-key-error.js';
 import { sha256 } from 'multiformats/hashes/sha2';
 import { TagTables } from './utils/tags.js';
 import {
@@ -398,57 +399,4 @@ export class MessageStoreSql implements MessageStore {
   }
 }
 
-/**
- * Detect whether an error is a unique constraint violation from any
- * supported database dialect.
- *
- * Each dialect surfaces the error differently:
- *
- * | Dialect    | Error code / errno             | Message pattern                                    |
- * |------------|-------------------------------|----------------------------------------------------|
- * | PostgreSQL | `code === '23505'`            | "duplicate key value violates unique constraint"   |
- * | MySQL      | `errno === 1062`              | "Duplicate entry '...' for key '...'"              |
- * | SQLite     | `code === 'SQLITE_CONSTRAINT'`| "UNIQUE constraint failed: ..."                    |
- * | bun:sqlite | `code === 'SQLITE_CONSTRAINT_PRIMARYKEY'` or includes "UNIQUE" | same as above |
- *
- * @internal Exported for testing.
- */
-export function isDuplicateKeyError(error: unknown): boolean {
-  if (error == null || typeof error !== 'object') {
-    return false;
-  }
-
-  const err = error as Record<string, unknown>;
-  const code = err.code;
-  const errno = err.errno;
-  const message = typeof err.message === 'string' ? err.message : '';
-
-  // PostgreSQL: error code 23505 = unique_violation
-  if (code === '23505') {
-    return true;
-  }
-
-  // MySQL: errno 1062 = ER_DUP_ENTRY
-  if (errno === 1062) {
-    return true;
-  }
-
-  // SQLite (better-sqlite3 / bun:sqlite): SQLITE_CONSTRAINT with UNIQUE
-  if (
-    typeof code === 'string' &&
-    code.startsWith('SQLITE_CONSTRAINT') &&
-    message.includes('UNIQUE')
-  ) {
-    return true;
-  }
-
-  // Fallback: message-based detection for unknown drivers
-  if (
-    (message.includes('duplicate key') || message.includes('Duplicate entry')) &&
-    (message.includes('messageCid') || message.includes('unique constraint'))
-  ) {
-    return true;
-  }
-
-  return false;
-}
+export { isDuplicateKeyError } from './utils/duplicate-key-error.js';

--- a/packages/dwn-sql-store/src/utils/data-refs.ts
+++ b/packages/dwn-sql-store/src/utils/data-refs.ts
@@ -1,0 +1,89 @@
+import type { DwnDatabaseType } from '../types.js';
+import type { Kysely } from 'kysely';
+
+import { isDuplicateKeyError } from './duplicate-key-error.js';
+
+export type DataRefKey = {
+  tenant: string;
+  recordId: string;
+  dataCid: string;
+};
+
+export async function getDataRefSize(
+  db: Kysely<DwnDatabaseType>,
+  { tenant, recordId, dataCid }: DataRefKey,
+): Promise<number | undefined> {
+  const ref = await db
+    .selectFrom('dataRefs')
+    .select('dataSize')
+    .where('tenant', '=', tenant)
+    .where('recordId', '=', recordId)
+    .where('dataCid', '=', dataCid)
+    .executeTakeFirst();
+
+  return ref === undefined ? undefined : Number(ref.dataSize);
+}
+
+export async function getAnyDataRefSize(
+  db: Kysely<DwnDatabaseType>,
+  dataCid: string,
+): Promise<number | undefined> {
+  const ref = await db
+    .selectFrom('dataRefs')
+    .select('dataSize')
+    .where('dataCid', '=', dataCid)
+    .executeTakeFirst();
+
+  return ref === undefined ? undefined : Number(ref.dataSize);
+}
+
+export async function insertDataRef(
+  db: Kysely<DwnDatabaseType>,
+  key: DataRefKey,
+  dataSize: number,
+): Promise<number> {
+  try {
+    await db
+      .insertInto('dataRefs')
+      .values({ ...key, dataSize })
+      .execute();
+
+    return dataSize;
+  } catch (error: unknown) {
+    if (!isDuplicateKeyError(error)) {
+      throw error;
+    }
+
+    const racedDataSize = await getDataRefSize(db, key);
+    if (racedDataSize === undefined) {
+      throw error;
+    }
+
+    return racedDataSize;
+  }
+}
+
+export async function deleteDataRef(
+  db: Kysely<DwnDatabaseType>,
+  { tenant, recordId, dataCid }: DataRefKey,
+): Promise<void> {
+  await db
+    .deleteFrom('dataRefs')
+    .where('tenant', '=', tenant)
+    .where('recordId', '=', recordId)
+    .where('dataCid', '=', dataCid)
+    .execute();
+}
+
+export async function hasAnyDataRef(
+  db: Kysely<DwnDatabaseType>,
+  dataCid: string,
+): Promise<boolean> {
+  const ref = await db
+    .selectFrom('dataRefs')
+    .select('dataCid')
+    .where('dataCid', '=', dataCid)
+    .executeTakeFirst();
+
+  return ref !== undefined;
+}

--- a/packages/dwn-sql-store/src/utils/duplicate-key-error.ts
+++ b/packages/dwn-sql-store/src/utils/duplicate-key-error.ts
@@ -1,0 +1,42 @@
+/**
+ * Detect whether an error is a unique constraint violation from any
+ * supported database dialect.
+ */
+export function isDuplicateKeyError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') {
+    return false;
+  }
+
+  const err = error as Record<string, unknown>;
+  const code = err.code;
+  const errno = err.errno;
+  const message = typeof err.message === 'string' ? err.message : '';
+
+  if (code === '23505') {
+    return true;
+  }
+
+  if (errno === 1062) {
+    return true;
+  }
+
+  if (
+    typeof code === 'string' &&
+    code.startsWith('SQLITE_CONSTRAINT') &&
+    message.includes('UNIQUE')
+  ) {
+    return true;
+  }
+
+  if (
+    (message.includes('duplicate key') || message.includes('Duplicate entry')) &&
+    (message.includes('messageCid') ||
+      message.includes('dataRefs') ||
+      message.includes('dataBlocks') ||
+      message.includes('unique constraint'))
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/dwn-sql-store/tests/blockstore-sql.spec.ts
+++ b/packages/dwn-sql-store/tests/blockstore-sql.spec.ts
@@ -44,6 +44,13 @@ describe('BlockstoreSql', () => {
       .addColumn('blockCid', 'varchar(60)', (col) => col.notNull())
       .addColumn('data', 'blob', (col) => col.notNull())
       .execute();
+
+    await db.schema
+      .createIndex('index_dataBlocks_rootDataCid_blockCid')
+      .on('dataBlocks')
+      .columns(['rootDataCid', 'blockCid'])
+      .unique()
+      .execute();
   });
 
   beforeEach(async () => {
@@ -72,6 +79,16 @@ describe('BlockstoreSql', () => {
       const cid = fakeCid(1);
       const data = new Uint8Array([10, 20, 30]);
 
+      const result = await blockstore.put(cid, data);
+
+      expect(result.toString()).toBe(cid.toString());
+    });
+
+    it('should be idempotent when the same block is put twice', async () => {
+      const cid = fakeCid(6);
+      const data = new Uint8Array([1, 2, 3]);
+
+      await blockstore.put(cid, data);
       const result = await blockstore.put(cid, data);
 
       expect(result.toString()).toBe(cid.toString());

--- a/packages/dwn-sql-store/tests/data-store-dedup.spec.ts
+++ b/packages/dwn-sql-store/tests/data-store-dedup.spec.ts
@@ -120,6 +120,21 @@ describe('DataStoreSql — content-addressed dedup', () => {
         expect(refs.length).toBe(1);
       });
 
+      it('should be idempotent when duplicate puts overlap', async () => {
+        const { dataCid, bytes } = await prepareData('overlapping idempotent data');
+
+        const [result1, result2] = await Promise.all([
+          store.put('did:example:alice', 'rec-1', dataCid, streamFrom(bytes)),
+          store.put('did:example:alice', 'rec-1', dataCid, streamFrom(bytes)),
+        ]);
+
+        expect(result1.dataSize).toBe(bytes.length);
+        expect(result2.dataSize).toBe(bytes.length);
+
+        const refs = await db.selectFrom('dataRefs').selectAll().execute();
+        expect(refs.length).toBe(1);
+      });
+
       // ─── GC on delete ──────────────────────────────────────────────
 
       it('should keep blocks when deleting one ref but another ref still exists', async () => {


### PR DESCRIPTION
## Summary
- return 409 for exact duplicate RecordsWrite messages before reprocessing large data streams
- make SQL data/block stores tolerate overlapping duplicate content-addressed inserts
- add a patch changeset for @enbox/dwn-sdk-js and @enbox/dwn-sql-store

## Tests
- cd packages/dwn-sdk-js && bun test tests/store-dependent-tests.spec.ts -t "RecordsWriteHandler.handle"
- cd packages/dwn-sql-store && bun test tests/blockstore-sql.spec.ts tests/data-store-dedup.spec.ts tests/message-store-duplicate.spec.ts
- cd packages/dwn-sdk-js && bun run build:esm
- cd packages/dwn-sql-store && bun run build:esm
- cd packages/dwn-sdk-js && bun run lint
- cd packages/dwn-sql-store && bun run lint