### PR TITLE
Preserve closure sync health on root convergence

### DIFF
--- a/.changeset/sync-health-closure-state.md
+++ b/.changeset/sync-health-closure-state.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Preserve closure dead letters when sync roots converge and expose closure failure state in sync health.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1016,9 +1016,7 @@ export class SyncEngineLevel implements SyncEngine {
       // Root convergence proves primary CID membership matches, but it does
       // not prove dependencies are usable. Keep closure failures until a later
       // successful apply/closure pass clears the specific CID.
-      void this.clearDeadLettersForLink(did, dwnUrl, protocol, {
-        categories: SyncEngineLevel.ROOT_CONVERGENCE_CLEARABLE_DEAD_LETTER_CATEGORIES,
-      });
+      await this.clearRootConvergenceDeadLetters(did, dwnUrl, protocol);
       this.emitEvent({ type: 'repair:completed', tenantDid: did, remoteEndpoint: dwnUrl, protocol });
       if (prevRepairConnectivity !== 'online') {
         this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, protocol, from: prevRepairConnectivity, to: 'online' });
@@ -2293,9 +2291,7 @@ export class SyncEngineLevel implements SyncEngine {
         await this.ledger.clearNeedsReconcile(link);
         // SMT roots match, so transport/apply failures for this link may no
         // longer be current. Closure failures are not cleared by root equality.
-        void this.clearDeadLettersForLink(did, dwnUrl, protocol, {
-          categories: SyncEngineLevel.ROOT_CONVERGENCE_CLEARABLE_DEAD_LETTER_CATEGORIES,
-        });
+        await this.clearRootConvergenceDeadLetters(did, dwnUrl, protocol);
         this.emitEvent({ type: 'reconcile:completed', tenantDid: did, remoteEndpoint: dwnUrl, protocol });
       } else {
         // Roots still differ — retry after a delay. This can happen when
@@ -2898,6 +2894,20 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
+  private async clearRootConvergenceDeadLetters(
+    tenantDid: string,
+    remoteEndpoint: string,
+    protocol?: string,
+  ): Promise<void> {
+    try {
+      await this.clearDeadLettersForLink(tenantDid, remoteEndpoint, protocol, {
+        categories: SyncEngineLevel.ROOT_CONVERGENCE_CLEARABLE_DEAD_LETTER_CATEGORIES,
+      });
+    } catch (error) {
+      console.warn(`SyncEngineLevel: Failed to clear root-convergence dead letters for ${tenantDid} -> ${remoteEndpoint}`, error);
+    }
+  }
+
   /**
    * Build a compound dead letter key. Different remotes can fail the same CID
    * for different reasons, so the key includes the remote endpoint.
@@ -3016,11 +3026,11 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     return {
-      connectivity: this.connectivityState,
-      failedMessageCount,
-      closureFailureCount,
-      degradedLinkCount,
-      syncHealthy: failedMessageCount === 0 && degradedLinkCount === 0,
+      connectivity        : this.connectivityState,
+      failedMessageCount  : failedMessageCount,
+      closureFailureCount : closureFailureCount,
+      degradedLinkCount   : degradedLinkCount,
+      syncHealthy         : failedMessageCount === 0 && degradedLinkCount === 0,
     };
   }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1013,11 +1013,12 @@ export class SyncEngineLevel implements SyncEngine {
       link.connectivity = 'online';
       await this.ledger.setStatus(link, 'live');
 
-      // Auto-clear dead letters for this link — repair has verified
-      // convergence via SMT reconciliation so any previously recorded
-      // failures (closure, push-exhausted, pull-processing) for this
-      // specific link are no longer current.
-      void this.clearDeadLettersForLink(did, dwnUrl, protocol);
+      // Root convergence proves primary CID membership matches, but it does
+      // not prove dependencies are usable. Keep closure failures until a later
+      // successful apply/closure pass clears the specific CID.
+      void this.clearDeadLettersForLink(did, dwnUrl, protocol, {
+        categories: SyncEngineLevel.ROOT_CONVERGENCE_CLEARABLE_DEAD_LETTER_CATEGORIES,
+      });
       this.emitEvent({ type: 'repair:completed', tenantDid: did, remoteEndpoint: dwnUrl, protocol });
       if (prevRepairConnectivity !== 'online') {
         this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, protocol, from: prevRepairConnectivity, to: 'online' });
@@ -2137,6 +2138,8 @@ export class SyncEngineLevel implements SyncEngine {
 
   /** Push retry backoff schedule: immediate, 250ms, 1s, 2s, then give up. */
   private static readonly PUSH_RETRY_BACKOFF_MS = [0, 250, 1000, 2000];
+  private static readonly ROOT_CONVERGENCE_CLEARABLE_DEAD_LETTER_CATEGORIES: ReadonlySet<DeadLetterCategory> =
+    new Set(['push-permanent', 'push-exhausted', 'pull-processing']);
 
   /**
    * Re-queues a failed push batch for retry, or marks the link
@@ -2288,9 +2291,11 @@ export class SyncEngineLevel implements SyncEngine {
 
       if (reconcileOutcome.converged) {
         await this.ledger.clearNeedsReconcile(link);
-        // SMT roots match — this link is converged. Clear dead letters
-        // scoped to this specific link (tenantDid, remoteEndpoint, protocol).
-        void this.clearDeadLettersForLink(did, dwnUrl, protocol);
+        // SMT roots match, so transport/apply failures for this link may no
+        // longer be current. Closure failures are not cleared by root equality.
+        void this.clearDeadLettersForLink(did, dwnUrl, protocol, {
+          categories: SyncEngineLevel.ROOT_CONVERGENCE_CLEARABLE_DEAD_LETTER_CATEGORIES,
+        });
         this.emitEvent({ type: 'reconcile:completed', tenantDid: did, remoteEndpoint: dwnUrl, protocol });
       } else {
         // Roots still differ — retry after a delay. This can happen when
@@ -2867,14 +2872,20 @@ export class SyncEngineLevel implements SyncEngine {
    * When `protocol` is undefined (full-tenant link), clears entries that
    * also have no protocol.
    */
-  private async clearDeadLettersForLink(tenantDid: string, remoteEndpoint: string, protocol?: string): Promise<void> {
+  private async clearDeadLettersForLink(
+    tenantDid: string,
+    remoteEndpoint: string,
+    protocol?: string,
+    options: { categories?: ReadonlySet<DeadLetterCategory> } = {},
+  ): Promise<void> {
     const batch: { type: 'del'; key: string }[] = [];
     try {
       for await (const [key, value] of this._deadLetters.iterator()) {
         const entry = JSON.parse(value) as DeadLetterEntry;
         if (entry.tenantDid === tenantDid &&
             entry.remoteEndpoint === remoteEndpoint &&
-            entry.protocol === protocol) {
+            entry.protocol === protocol &&
+            (options.categories === undefined || options.categories.has(entry.category))) {
           batch.push({ type: 'del', key });
         }
       }
@@ -2984,8 +2995,13 @@ export class SyncEngineLevel implements SyncEngine {
 
   public async getSyncHealth(): Promise<SyncHealthSummary> {
     let failedMessageCount = 0;
-    for await (const _ of this._deadLetters.iterator()) {
+    let closureFailureCount = 0;
+    for await (const [, value] of this._deadLetters.iterator()) {
       failedMessageCount++;
+      const entry = JSON.parse(value) as DeadLetterEntry;
+      if (entry.category === 'closure') {
+        closureFailureCount++;
+      }
     }
 
     // Count degraded links from the durable ledger, not just in-memory
@@ -3002,7 +3018,9 @@ export class SyncEngineLevel implements SyncEngine {
     return {
       connectivity: this.connectivityState,
       failedMessageCount,
+      closureFailureCount,
       degradedLinkCount,
+      syncHealthy: failedMessageCount === 0 && degradedLinkCount === 0,
     };
   }
 

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -312,8 +312,16 @@ export type SyncHealthSummary = {
    * the engine self-heals — entries are auto-cleared on later success.
    */
   failedMessageCount: number;
+  /**
+   * Number of current closure failures. A link can have matching sync roots
+   * while still being unusable because required dependencies are missing; this
+   * count keeps that state visible to callers.
+   */
+  closureFailureCount: number;
   /** Number of links currently in 'repairing' or 'degraded_poll' status. */
   degradedLinkCount: number;
+  /** True only when there are no failed messages and no degraded links. */
+  syncHealthy: boolean;
 };
 
 export interface SyncEngine {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -3894,8 +3894,10 @@ describe('SyncEngineLevel — private methods', () => {
 
       const health = await engine.getSyncHealth();
       expect(health.failedMessageCount).toBe(2);
+      expect(health.closureFailureCount).toBe(1);
       expect(health.connectivity).toBeDefined();
       expect(health.degradedLinkCount).toBe(0);
+      expect(health.syncHealthy).toBe(false);
     });
 
     it('should clear dead letters scoped to protocol — sibling protocol failures survive', async () => {
@@ -3934,6 +3936,45 @@ describe('SyncEngineLevel — private methods', () => {
       expect(remaining.length).toBe(1);
       expect(remaining[0].messageCid).toBe('dl-proto-b');
       expect(remaining[0].protocol).toBe('https://example.com/proto-b');
+    });
+
+    it('should not clear closure dead letters when only root-convergence-clearable categories are requested', async () => {
+      const engine = createEngine({ db });
+
+      await engine.recordDeadLetter({
+        messageCid     : 'dl-closure',
+        tenantDid      : 'did:example:closure-health',
+        remoteEndpoint : 'https://dwn.example.com',
+        protocol       : 'https://example.com/proto',
+        category       : 'closure',
+        errorCode      : 'ClosureProtocolMetadataMissing',
+        errorDetail    : 'missing dependency after root convergence',
+      });
+      await engine.recordDeadLetter({
+        messageCid     : 'dl-pull',
+        tenantDid      : 'did:example:closure-health',
+        remoteEndpoint : 'https://dwn.example.com',
+        protocol       : 'https://example.com/proto',
+        category       : 'pull-processing',
+        errorDetail    : 'transient pull failure before root convergence',
+      });
+
+      await (engine as any).clearDeadLettersForLink(
+        'did:example:closure-health',
+        'https://dwn.example.com',
+        'https://example.com/proto',
+        { categories: new Set(['push-permanent', 'push-exhausted', 'pull-processing']) },
+      );
+
+      const remaining = await engine.getFailedMessages();
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].messageCid).toBe('dl-closure');
+      expect(remaining[0].category).toBe('closure');
+
+      const health = await engine.getSyncHealth();
+      expect(health.failedMessageCount).toBe(1);
+      expect(health.closureFailureCount).toBe(1);
+      expect(health.syncHealthy).toBe(false);
     });
 
     it('should clear dead letters for full-tenant link without affecting protocol-scoped entries', async () => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -3024,6 +3024,58 @@ describe('SyncEngineLevel — private methods', () => {
       expect(events.some(e => e.type === 'reconcile:completed')).toBe(true);
     });
 
+    it('should preserve closure failures when roots converge after reconciliation', async () => {
+      const engine = createEngine({ db });
+      const linkKey = 'did:example:alice^https://dwn.example.com';
+      const protocol = 'https://example.com/protocol';
+      const link = makeLiveLink({
+        protocol,
+        scope: { kind: 'protocol', protocol },
+      });
+      (engine as any)._activeLinks.set(linkKey, link);
+
+      await engine.recordDeadLetter({
+        messageCid     : 'dl-closure',
+        tenantDid      : 'did:example:alice',
+        remoteEndpoint : 'https://dwn.example.com',
+        protocol,
+        category       : 'closure',
+        errorCode      : 'ClosureProtocolMetadataMissing',
+        errorDetail    : 'dependency missing despite matching roots',
+      });
+      await engine.recordDeadLetter({
+        messageCid     : 'dl-pull',
+        tenantDid      : 'did:example:alice',
+        remoteEndpoint : 'https://dwn.example.com',
+        protocol,
+        category       : 'pull-processing',
+        errorDetail    : 'pull failed before roots converged',
+      });
+
+      sinon.stub(engine as any, 'getLocalRoot').resolves('same-root');
+      sinon.stub(engine as any, 'getRemoteRoot').resolves('same-root');
+      sinon.stub(engine as any, 'diffWithRemote');
+
+      const clearStub = sinon.stub().callsFake(async (l: any): Promise<void> => { l.needsReconcile = false; });
+      (engine as any)._ledger = {
+        clearNeedsReconcile : clearStub,
+        saveLink            : sinon.stub().resolves(),
+        getAllLinks         : sinon.stub().resolves([]),
+      };
+
+      await (engine as any).doReconcileLink(linkKey);
+
+      const remaining = await engine.getFailedMessages();
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].messageCid).toBe('dl-closure');
+      expect(remaining[0].category).toBe('closure');
+
+      const health = await engine.getSyncHealth();
+      expect(health.failedMessageCount).toBe(1);
+      expect(health.closureFailureCount).toBe(1);
+      expect(health.syncHealthy).toBe(false);
+    });
+
     it('should NOT clear needsReconcile when roots still differ after reconciliation', async () => {
       const engine = createEngine({ db });
       const linkKey = 'did:example:alice^https://dwn.example.com';


### PR DESCRIPTION
## Summary
- preserve closure dead letters when repair/reconcile reaches root convergence
- clear only root-convergence-clearable transport/apply dead letters after convergence
- expose closureFailureCount and syncHealthy in SyncHealthSummary
- add focused regressions for health reporting and reconcile cleanup behavior

## Verification
- PASS: bun test --timeout 10000 packages/agent/tests/sync-engine-private.spec.ts
- PASS: bunx turbo run lint build --filter=@enbox/agent...
- FAIL unrelated/local env: bun run --filter @enbox/agent test:node
  - Many tests fail because DID-DHT rejects localhost Pkarr gateway URLs: invalidGatewayUri: Pkarr gateway URL must not target a private, loopback, or link-local host: localhost
  - The focused sync-engine regression file passes in the same worktree.