### PR TITLE
Add sync projection authorization epochs

### DIFF
--- a/.changeset/sync-projection-epoch.md
+++ b/.changeset/sync-projection-epoch.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": minor
+---
+
+Use canonical sync projection IDs and authorization epochs for B1 sync links. Protocol-list sync now uses one protocol-set link per tenant, endpoint, projection, and authorization epoch while delegated sync invokes the active Messages.Read grant set.

--- a/.changeset/sync-projection-epoch.md
+++ b/.changeset/sync-projection-epoch.md
@@ -2,4 +2,4 @@
 "@enbox/agent": minor
 ---
 
-Use canonical sync projection IDs and authorization epochs for B1 sync links. Protocol-list sync now uses one protocol-set link per tenant, endpoint, projection, and authorization epoch while delegated sync invokes the active Messages.Read grant set.
+Use canonical sync projection IDs and authorization epochs for full/protocol sync links. Protocol-list sync now uses one protocol-set link per tenant, endpoint, projection, and authorization epoch while delegated sync invokes the active Messages.Read grant set.

--- a/.changeset/sync-projection-epoch.md
+++ b/.changeset/sync-projection-epoch.md
@@ -1,5 +1,5 @@
 ---
-"@enbox/agent": minor
+"@enbox/agent": patch
 ---
 
 Use canonical sync projection IDs and authorization epochs for full/protocol sync links. Protocol-list sync now uses one protocol-set link per tenant, endpoint, projection, and authorization epoch while delegated sync invokes the active Messages.Read grant set.

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -1482,7 +1482,7 @@ async function submitConnectResponse(
     // below, but we must NOT iterate over them (they are meta-grants, not session grants).
     sessionGrantCount = delegateGrants.length;
 
-    // Phase 1: create all revocation grants locally with bounded concurrency.
+    // Create all revocation grants locally with bounded concurrency.
     // createGrant is local-only (storage + signing) so it's cheap, but we still
     // cap parallelism to avoid head-of-line blocking when sessionGrantCount is
     // large (e.g. dapp requesting many scopes at once).
@@ -1508,10 +1508,10 @@ async function submitConnectResponse(
       ),
     );
 
-    // Phase 2: fan out every revocation grant to every owner DWN endpoint with
-    // a single global concurrency cap so that (grants × endpoints) cannot blow
-    // up. This is best-effort (sync delivers eventually) so individual failures
-    // are tolerated by `mapConcurrentSettled`.
+    // Fan out every revocation grant to every owner DWN endpoint with a single
+    // global concurrency cap so that (grants × endpoints) cannot blow up. This
+    // is best-effort (sync delivers eventually) so individual failures are
+    // tolerated by `mapConcurrentSettled`.
     const revSendTasks = revGrantResults.flatMap(({ grantMessage, revGrant }) => {
       sessionRevocations.push({
         grantId           : grantMessage.recordId,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5,7 +5,15 @@ export type * from './types/identity-vault.js';
 export type * from './types/key-manager.js';
 export type * from './types/permissions.js';
 export type * from './types/sync.js';
-export { computeScopeId, MAX_PENDING_TOKENS } from './types/sync.js';
+export {
+  computeAuthorizationEpoch,
+  computeProjectionId,
+  MAX_PENDING_TOKENS,
+  normalizeSyncProtocols,
+  protocolsForSyncScope,
+  singleProtocolForSyncScope,
+  syncScopeFromProtocols,
+} from './types/sync.js';
 export { ReplicationLedger } from './sync-replication-ledger.js';
 export { ClosureFailureCode, createClosureContext } from './sync-closure-types.js';
 export type { ClosureDependencyEdge, ClosureEvaluationContext, ClosureResult } from './sync-closure-types.js';

--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -482,9 +482,9 @@ export async function evaluateClosure(
     for (let i = 0; i < batchSize; i++) {
       const current = queue.shift()!;
 
-      // Phase 1: Extract and resolve static dependency edges (classes 1-3).
-      // This populates the protocolCache when class 1 (ProtocolsConfigure)
-      // is resolved, which is needed by classes 4-6.
+      // Resolve static dependency edges first. This populates the protocol
+      // cache when a ProtocolsConfigure dependency is resolved, which is
+      // needed by protocol-definition-aware dependencies below.
       const staticEdges = [
         ...extractProtocolDeps(current),
         ...extractAncestryDeps(current),
@@ -496,8 +496,8 @@ export async function evaluateClosure(
       );
       if (resolveResult) { return resolveResult; } // Early failure.
 
-      // Phase 2: Extract protocol-definition-aware edges (classes 4-6).
-      // Runs AFTER static resolution so the ProtocolDefinition is in the cache.
+      // Resolve protocol-definition-aware edges after static dependencies so
+      // the ProtocolDefinition is in the cache.
       const currentDesc = current.descriptor as Record<string, unknown>;
       const currentProtocol = currentDesc.protocol as string | undefined;
       if (currentProtocol) {
@@ -512,8 +512,8 @@ export async function evaluateClosure(
         }
       }
 
-      // Phase 3: Validate grant temporal ordering (causal grant check).
-      // After all edges are resolved, if this message uses a grant, verify
+      // Validate grant temporal ordering after all dependency edges resolve.
+      // If this message uses a grant, verify
       // that the grant is temporally valid at the message's commit point:
       //   - grant.dateGranted <= message.messageTimestamp < grant.dateExpires
       //   - no revocation exists with revocation.messageTimestamp <= message.messageTimestamp

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -12,7 +12,7 @@ import { Encoder, hashToHex, initDefaultHashes, Message, PermissionsProtocol } f
 import type { ClosureEvaluationContext } from './sync-closure-types.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
-import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncProtocolSet, SyncScope } from './types/sync.js';
+import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
@@ -22,7 +22,7 @@ import { ReplicationLedger } from './sync-replication-ledger.js';
 import { SyncLinkReconciler } from './sync-link-reconciler.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { buildLegacyCursorKey, buildLinkId } from './sync-link-id.js';
-import { computeAuthorizationEpoch, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
+import { computeAuthorizationEpoch, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { createClosureContext, invalidateClosureCache } from './sync-closure-types.js';
 import { fetchRemoteMessages, pullMessages, pushMessages } from './sync-messages.js';
 import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
@@ -62,8 +62,6 @@ type LiveSubscription = {
   did: string;
   dwnUrl: string;
   delegateDid?: string;
-  protocol?: string;
-  protocols?: SyncProtocolSet;
   close: () => Promise<void>;
 };
 
@@ -73,8 +71,6 @@ type LocalSubscription = {
   did: string;
   dwnUrl: string;
   delegateDid?: string;
-  protocol?: string;
-  protocols?: SyncProtocolSet;
   close: () => Promise<void>;
 };
 
@@ -109,21 +105,39 @@ type InFlightCommit = {
   committed: boolean;
 };
 
-/**
- * Checks whether an event belongs to the link's current sync scope.
- *
- * Full links accept every message. Protocol-set links accept only messages
- * whose descriptor protocol is in the canonical set. ProtocolPath/contextId
- * filtering is deliberately absent here; add a projection-root builder before
- * those scopes become valid sync projections.
- */
-function isEventInScope(message: GenericMessage, scope: SyncScope): boolean {
-  if (scope.kind === 'full') { return true; }
+type EventScopeClassification = 'in-scope' | 'out-of-scope' | 'unknown';
 
-  const descriptor = message.descriptor as Record<string, unknown>;
-  const protocol = descriptor.protocol;
+/**
+ * Classifies whether an event belongs to the link's current sync scope.
+ *
+ * Full links accept every message. Protocol-set links accept protocol
+ * records, protocol configures, and permission records tagged for a covered
+ * protocol. RecordsDelete has no descriptor protocol, so it must be classified
+ * from the event's initial write. If that metadata is missing, the caller must
+ * repair/reconcile instead of advancing past the event.
+ */
+function classifyEventScope(event: MessageEvent, scope: SyncScope): EventScopeClassification {
+  if (scope.kind === 'full') { return 'in-scope'; }
+
+  const descriptor = event.message.descriptor as Record<string, unknown>;
+  const scopedDescriptor = getScopedEventDescriptor(event);
+  if (scopedDescriptor === undefined) {
+    return 'unknown';
+  }
+
+  const protocol = scopedDescriptor.protocol;
+  if (protocol === PermissionsProtocol.uri && typeof scopedDescriptor.tags === 'object' && scopedDescriptor.tags !== null) {
+    const taggedProtocol = (scopedDescriptor.tags as Record<string, unknown>).protocol;
+    return typeof taggedProtocol === 'string' && scope.protocols.includes(taggedProtocol)
+      ? 'in-scope'
+      : 'out-of-scope';
+  }
+
   if (typeof protocol === 'string' && scope.protocols.includes(protocol)) {
-    return true;
+    return 'in-scope';
+  }
+  if (typeof protocol === 'string') {
+    return 'out-of-scope';
   }
 
   if (
@@ -133,15 +147,20 @@ function isEventInScope(message: GenericMessage, scope: SyncScope): boolean {
     descriptor.definition !== null
   ) {
     const definitionProtocol = (descriptor.definition as Record<string, unknown>).protocol;
-    return typeof definitionProtocol === 'string' && scope.protocols.includes(definitionProtocol);
+    return typeof definitionProtocol === 'string' && scope.protocols.includes(definitionProtocol)
+      ? 'in-scope'
+      : 'out-of-scope';
   }
 
-  if (protocol === PermissionsProtocol.uri && typeof descriptor.tags === 'object' && descriptor.tags !== null) {
-    const taggedProtocol = (descriptor.tags as Record<string, unknown>).protocol;
-    return typeof taggedProtocol === 'string' && scope.protocols.includes(taggedProtocol);
-  }
+  return 'out-of-scope';
+}
 
-  return false;
+function getScopedEventDescriptor(event: MessageEvent): Record<string, unknown> | undefined {
+  const descriptor = event.message.descriptor as Record<string, unknown>;
+  if (descriptor.interface === 'Records' && descriptor.method === 'Delete') {
+    return event.initialWrite?.descriptor as Record<string, unknown> | undefined;
+  }
+  return descriptor;
 }
 
 /**
@@ -164,7 +183,6 @@ type PushRuntimeState = {
   dwnUrl: string;
   delegateDid?: string;
   protocol?: string;
-  protocols?: SyncProtocolSet;
   permissionGrantIds?: NonEmptyStringArray;
   entries: PushRuntimeEntry[];
   retryCount: number;
@@ -373,6 +391,9 @@ export class SyncEngineLevel implements SyncEngine {
 
   /** TTL for the sync targets cache (30 seconds). */
   private static readonly SYNC_TARGETS_CACHE_TTL_MS = 30_000;
+
+  /** Backoff schedule for recently published did:dht records. */
+  private static readonly DID_RESOLUTION_RETRY_BACKOFF_MS = [2000, 4000, 8000];
 
   /** Count of consecutive SMT sync failures (for backoff in poll mode). */
   private _consecutiveFailures = 0;
@@ -1537,8 +1558,7 @@ export class SyncEngineLevel implements SyncEngine {
     } catch (error: any) {
       if (!this.isDidResolutionFailure(error)) { throw error; }
 
-      const delays = [2000, 4000, 8000];
-      for (const delay of delays) {
+      for (const delay of SyncEngineLevel.DID_RESOLUTION_RETRY_BACKOFF_MS) {
         await sleep(delay);
         try {
           await this.initializeLinkTarget(target);
@@ -1554,7 +1574,7 @@ export class SyncEngineLevel implements SyncEngine {
 
   private isDidResolutionFailure(error: any): boolean {
     const message = error.message ?? '';
-    return message.includes('GetPublicKeyNotFound') || message.includes('notFound');
+    return message.includes('GetPublicKeyNotFound');
   }
 
   // ---------------------------------------------------------------------------
@@ -1740,14 +1760,14 @@ export class SyncEngineLevel implements SyncEngine {
       throw new Error(`SyncEngineLevel: MessagesSubscribe failed for ${did} -> ${dwnUrl}: ${reply.status.code} ${reply.status.detail}`);
     }
 
+    const linkKey = cursorKey;
+    const close = async (): Promise<void> => { await reply.subscription!.close(); };
     this._liveSubscriptions.push({
-      linkKey   : cursorKey,
+      linkKey,
       did,
       dwnUrl,
       delegateDid,
-      protocol,
-      protocols : protocolsForSyncScope(target.scope),
-      close     : async (): Promise<void> => { await reply.subscription!.close(); },
+      close,
     });
 
     // Set per-link connectivity to online after successful subscription setup.
@@ -1904,9 +1924,17 @@ export class SyncEngineLevel implements SyncEngine {
       return true;
     }
 
-    if (link && !isEventInScope(subMessage.event.message, link.scope)) {
-      await this.skipOutOfScopePullEvent({ link, cursor: subMessage.cursor, isStale });
-      return true;
+    if (link) {
+      const scopeClassification = classifyEventScope(subMessage.event, link.scope);
+      if (scopeClassification === 'out-of-scope') {
+        await this.skipOutOfScopePullEvent({ link, cursor: subMessage.cursor, isStale });
+        return true;
+      }
+      if (scopeClassification === 'unknown') {
+        console.warn(`SyncEngineLevel: Unable to classify scoped pull event for ${did} -> ${dwnUrl}, transitioning to repair`);
+        if (!isStale()) { await this.transitionToRepairing(linkKey, link); }
+        return true;
+      }
     }
 
     return false;
@@ -2162,8 +2190,15 @@ export class SyncEngineLevel implements SyncEngine {
       // Events outside the scope are not this link's responsibility.
       const pushLinkKey = target.linkKey;
       const pushLink = this._activeLinks.get(pushLinkKey);
-      if (pushLink && !isEventInScope(subMessage.event.message, pushLink.scope)) {
-        return;
+      if (pushLink) {
+        const scopeClassification = classifyEventScope(subMessage.event, pushLink.scope);
+        if (scopeClassification === 'out-of-scope') {
+          return;
+        }
+        if (scopeClassification === 'unknown') {
+          this.markLinkNeedsReconcile(pushLinkKey, pushLink, 'push-scope-unclassified');
+          return;
+        }
       }
 
       // Accumulate the message CID for a debounced push.
@@ -2185,8 +2220,7 @@ export class SyncEngineLevel implements SyncEngine {
         dwnUrl,
         delegateDid,
         protocol,
-        protocols          : protocolsForSyncScope(target.scope),
-        permissionGrantIds : target.permissionGrantIds,
+        permissionGrantIds: target.permissionGrantIds,
       });
       pushRuntime.entries.push({ cid });
 
@@ -2215,14 +2249,14 @@ export class SyncEngineLevel implements SyncEngine {
       throw new Error(`SyncEngineLevel: Local MessagesSubscribe failed for ${did}: ${reply.status.code} ${reply.status.detail}`);
     }
 
+    const linkKey = target.linkKey ?? buildLegacyCursorKey(did, dwnUrl, protocol);
+    const close = async (): Promise<void> => { await reply.subscription!.close(); };
     this._localSubscriptions.push({
-      linkKey   : target.linkKey ?? buildLegacyCursorKey(did, dwnUrl, protocol),
+      linkKey,
       did,
       dwnUrl,
       delegateDid,
-      protocol,
-      protocols : protocolsForSyncScope(target.scope),
-      close     : async (): Promise<void> => { await reply.subscription!.close(); },
+      close,
     });
   }
 
@@ -2423,12 +2457,8 @@ export class SyncEngineLevel implements SyncEngine {
       }
       this._pushRuntimes.delete(targetKey);
       const link = this._activeLinks.get(targetKey);
-      if (link && !link.needsReconcile) {
-        link.needsReconcile = true;
-        void this.ledger.saveLink(link).then(() => {
-          this.emitEvent({ type: 'reconcile:needed', tenantDid: pending.did, remoteEndpoint: pending.dwnUrl, protocol: pending.protocol, reason: 'push-retry-exhausted' });
-          this.scheduleReconcile(targetKey);
-        });
+      if (link) {
+        this.markLinkNeedsReconcile(targetKey, link, 'push-retry-exhausted');
       }
       return;
     }
@@ -2443,6 +2473,28 @@ export class SyncEngineLevel implements SyncEngine {
       pushRuntime.timer = undefined;
       void this.flushPendingPushesForLink(targetKey);
     }, delayMs);
+  }
+
+  private markLinkNeedsReconcile(linkKey: string, link: ReplicationLinkState, reason: string): void {
+    if (link.needsReconcile) {
+      this.scheduleReconcile(linkKey);
+      return;
+    }
+
+    link.needsReconcile = true;
+    void this.ledger.saveLink(link).then(() => {
+      const protocol = link.scope === undefined ? undefined : singleProtocolForSyncScope(link.scope);
+      this.emitEvent({
+        type           : 'reconcile:needed',
+        tenantDid      : link.tenantDid,
+        remoteEndpoint : link.remoteEndpoint,
+        protocol,
+        reason,
+      });
+      this.scheduleReconcile(linkKey);
+    }).catch((error: unknown) => {
+      console.error(`SyncEngineLevel: Failed to mark link for reconciliation ${link.tenantDid} -> ${link.remoteEndpoint}`, error);
+    });
   }
 
   private createLinkReconciler(shouldContinue?: () => boolean): SyncLinkReconciler {
@@ -2623,7 +2675,6 @@ export class SyncEngineLevel implements SyncEngine {
     dwnUrl: string;
     delegateDid?: string;
     protocol?: string;
-    protocols?: SyncProtocolSet;
     permissionGrantIds?: NonEmptyStringArray;
   }): PushRuntimeState {
     let pushRuntime = this._pushRuntimes.get(linkKey);
@@ -3267,7 +3318,7 @@ export class SyncEngineLevel implements SyncEngine {
       }
     }
     // Deterministic ordering: newest first so apps see the most recent failures.
-    entries.sort((a, b) => b.failedAt.localeCompare(a.failedAt));
+    entries.sort((a, b) => lexicographicalCompare(b.failedAt, a.failedAt));
     return entries;
   }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -88,6 +88,8 @@ type SyncTarget = {
   permissionGrantIds?: NonEmptyStringArray;
 };
 
+type LinkSyncTarget = SyncTarget & { linkKey: string };
+
 // ---------------------------------------------------------------------------
 // Per-link in-memory delivery-order tracking (not persisted to ledger)
 // ---------------------------------------------------------------------------
@@ -155,6 +157,8 @@ type LinkRuntimeState = {
   inflight: Map<number, InFlightCommit>;
 };
 
+type PushRuntimeEntry = { cid: string };
+
 type PushRuntimeState = {
   did: string;
   dwnUrl: string;
@@ -162,11 +166,33 @@ type PushRuntimeState = {
   protocol?: string;
   protocols?: SyncProtocolSet;
   permissionGrantIds?: NonEmptyStringArray;
-  entries: { cid: string }[];
+  entries: PushRuntimeEntry[];
   retryCount: number;
   timer?: ReturnType<typeof setTimeout>;
   /** True while a push HTTP request is in flight for this link. */
   flushing?: boolean;
+};
+
+type PushFlushBatch = {
+  pushRuntime: PushRuntimeState;
+  pushEntries: PushRuntimeEntry[];
+  isStale: () => boolean;
+};
+
+type LivePullContext = {
+  did: string;
+  dwnUrl: string;
+  delegateDid?: string;
+  protocol?: string;
+  linkKey: string;
+  link?: ReplicationLinkState;
+  permissionGrantIds?: NonEmptyStringArray;
+  isStale: () => boolean;
+};
+
+type PullDelivery = {
+  runtime?: LinkRuntimeState;
+  ordinal: number;
 };
 
 export class SyncEngineLevel implements SyncEngine {
@@ -1107,19 +1133,24 @@ export class SyncEngineLevel implements SyncEngine {
     const { tenantDid: did, remoteEndpoint: dwnUrl } = link;
     const linkKey = this.buildLinkKey(did, dwnUrl, link.projectionId, link.authorizationEpoch);
 
-    // Close pull subscription.
-    const pullSub = this._liveSubscriptions.find((s) => s.linkKey === linkKey);
-    if (pullSub) {
-      try { await pullSub.close(); } catch { /* best effort */ }
-      this._liveSubscriptions = this._liveSubscriptions.filter(s => s !== pullSub);
-    }
+    await this.closeLiveSubscription(linkKey);
+    await this.closeLocalSubscription(linkKey);
+  }
 
-    // Close local push subscription.
+  private async closeLiveSubscription(linkKey: string): Promise<void> {
+    const pullSub = this._liveSubscriptions.find((s) => s.linkKey === linkKey);
+    if (!pullSub) { return; }
+
+    try { await pullSub.close(); } catch { /* best effort */ }
+    this._liveSubscriptions = this._liveSubscriptions.filter(s => s !== pullSub);
+  }
+
+  private async closeLocalSubscription(linkKey: string): Promise<void> {
     const pushSub = this._localSubscriptions.find((s) => s.linkKey === linkKey);
-    if (pushSub) {
-      try { await pushSub.close(); } catch { /* best effort */ }
-      this._localSubscriptions = this._localSubscriptions.filter(s => s !== pushSub);
-    }
+    if (!pushSub) { return; }
+
+    try { await pushSub.close(); } catch { /* best effort */ }
+    this._localSubscriptions = this._localSubscriptions.filter(s => s !== pushSub);
   }
 
   /**
@@ -1383,70 +1414,112 @@ export class SyncEngineLevel implements SyncEngine {
   private async initializeLinkTarget(target: SyncTarget): Promise<void> {
     let link: ReplicationLinkState | undefined;
     try {
-      link = await this.ledger.getOrCreateLink({
-        tenantDid          : target.did,
-        remoteEndpoint     : target.dwnUrl,
-        scope              : target.scope,
-        authorization      : target.authorization,
-        authorizationEpoch : target.authorizationEpoch,
-        delegateDid        : target.delegateDid,
-      });
-
-      const linkKey = this.buildLinkKey(target.did, target.dwnUrl, link.projectionId, link.authorizationEpoch);
-
-      if (!link.pull.contiguousAppliedToken) {
-        const legacyKey = buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
-        const legacyCursor = await this.getCursor(legacyKey);
-        if (legacyCursor) {
-          ReplicationLedger.resetCheckpoint(link.pull, legacyCursor);
-          await this.ledger.saveLink(link);
-          await this.deleteLegacyCursor(legacyKey);
-        }
-      }
-
+      link = await this.getOrCreateReplicationLink(target);
+      const linkKey = this.getReplicationLinkKey(target, link);
+      await this.migrateLegacyCursorIfNeeded(target, link);
       this._activeLinks.set(linkKey, link);
 
-      const targetWithKey = { ...target, linkKey };
-      await this.openLivePullSubscription(targetWithKey);
-      try {
-        await this.openLocalPushSubscription(targetWithKey);
-      } catch (pushError) {
-        const pullSub = this._liveSubscriptions.find((s) => s.linkKey === linkKey);
-        if (pullSub) {
-          try { await pullSub.close(); } catch { /* best effort */ }
-          this._liveSubscriptions = this._liveSubscriptions.filter(s => s !== pullSub);
-        }
-        throw pushError;
-      }
-
-      this.emitEvent({ type: 'link:status-change', tenantDid: target.did, remoteEndpoint: target.dwnUrl, protocol: singleProtocolForSyncScope(target.scope), from: 'initializing', to: 'live' });
-      await this.ledger.setStatus(link, 'live');
-
-      if (link.needsReconcile) {
-        this.scheduleReconcile(linkKey, 1000);
-      }
+      await this.openLinkSubscriptions({ ...target, linkKey });
+      await this.markLinkLive(target, link, linkKey);
     } catch (error: any) {
-      const linkKey = link
-        ? this.buildLinkKey(target.did, target.dwnUrl, link.projectionId, link.authorizationEpoch)
-        : buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
+      await this.handleInitializeLinkTargetError(target, link, error);
+    }
+  }
 
-      if (error.isProgressGap && link) {
-        console.warn(`SyncEngineLevel: ProgressGap detected for ${target.did} -> ${target.dwnUrl}, initiating repair`);
-        this.emitEvent({ type: 'gap:detected', tenantDid: target.did, remoteEndpoint: target.dwnUrl, protocol: singleProtocolForSyncScope(target.scope), reason: 'ProgressGap' });
-        await this.transitionToRepairing(linkKey, link, {
-          resumeToken: error.gapInfo?.latestAvailable,
-        });
-        return;
-      }
+  private async getOrCreateReplicationLink(target: SyncTarget): Promise<ReplicationLinkState> {
+    return this.ledger.getOrCreateLink({
+      tenantDid          : target.did,
+      remoteEndpoint     : target.dwnUrl,
+      scope              : target.scope,
+      authorization      : target.authorization,
+      authorizationEpoch : target.authorizationEpoch,
+      delegateDid        : target.delegateDid,
+    });
+  }
 
-      console.error(`SyncEngineLevel: Failed to open live subscription for ${target.did} -> ${target.dwnUrl}`, error);
+  private getReplicationLinkKey(target: SyncTarget, link: ReplicationLinkState): string {
+    return this.buildLinkKey(target.did, target.dwnUrl, link.projectionId, link.authorizationEpoch);
+  }
 
-      this._activeLinks.delete(linkKey);
-      this._linkRuntimes.delete(linkKey);
+  private async migrateLegacyCursorIfNeeded(target: SyncTarget, link: ReplicationLinkState): Promise<void> {
+    if (link.pull.contiguousAppliedToken) {
+      return;
+    }
 
-      if (this._liveSubscriptions.length === 0) {
-        this._connectivityState = 'unknown';
-      }
+    const legacyKey = buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
+    const legacyCursor = await this.getCursor(legacyKey);
+    if (!legacyCursor) {
+      return;
+    }
+
+    ReplicationLedger.resetCheckpoint(link.pull, legacyCursor);
+    await this.ledger.saveLink(link);
+    await this.deleteLegacyCursor(legacyKey);
+  }
+
+  private async openLinkSubscriptions(target: LinkSyncTarget): Promise<void> {
+    await this.openLivePullSubscription(target);
+    try {
+      await this.openLocalPushSubscription(target);
+    } catch (error) {
+      await this.closeLiveSubscription(target.linkKey);
+      throw error;
+    }
+  }
+
+  private async markLinkLive(target: SyncTarget, link: ReplicationLinkState, linkKey: string): Promise<void> {
+    this.emitEvent({
+      type           : 'link:status-change',
+      tenantDid      : target.did,
+      remoteEndpoint : target.dwnUrl,
+      protocol       : singleProtocolForSyncScope(target.scope),
+      from           : 'initializing',
+      to             : 'live'
+    });
+    await this.ledger.setStatus(link, 'live');
+
+    if (link.needsReconcile) {
+      this.scheduleReconcile(linkKey, 1000);
+    }
+  }
+
+  private async handleInitializeLinkTargetError(
+    target: SyncTarget,
+    link: ReplicationLinkState | undefined,
+    error: any,
+  ): Promise<void> {
+    const linkKey = link
+      ? this.getReplicationLinkKey(target, link)
+      : buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
+
+    if (error.isProgressGap && link) {
+      console.warn(`SyncEngineLevel: ProgressGap detected for ${target.did} -> ${target.dwnUrl}, initiating repair`);
+      this.emitEvent({
+        type           : 'gap:detected',
+        tenantDid      : target.did,
+        remoteEndpoint : target.dwnUrl,
+        protocol       : singleProtocolForSyncScope(target.scope),
+        reason         : 'ProgressGap'
+      });
+      await this.transitionToRepairing(linkKey, link, {
+        resumeToken: error.gapInfo?.latestAvailable,
+      });
+      return;
+    }
+
+    console.error(`SyncEngineLevel: Failed to open live subscription for ${target.did} -> ${target.dwnUrl}`, error);
+    this.cleanupFailedLinkInitialization(linkKey);
+    if (this.isDidResolutionFailure(error)) {
+      throw error;
+    }
+  }
+
+  private cleanupFailedLinkInitialization(linkKey: string): void {
+    this._activeLinks.delete(linkKey);
+    this._linkRuntimes.delete(linkKey);
+
+    if (this._liveSubscriptions.length === 0) {
+      this._connectivityState = 'unknown';
     }
   }
 
@@ -1462,9 +1535,7 @@ export class SyncEngineLevel implements SyncEngine {
     try {
       await this.initializeLinkTarget(target);
     } catch (error: any) {
-      const msg = error.message ?? '';
-      const isDidResolutionFailure = msg.includes('GetPublicKeyNotFound') || msg.includes('notFound');
-      if (!isDidResolutionFailure) { throw error; }
+      if (!this.isDidResolutionFailure(error)) { throw error; }
 
       const delays = [2000, 4000, 8000];
       for (const delay of delays) {
@@ -1479,6 +1550,11 @@ export class SyncEngineLevel implements SyncEngine {
       // All retries exhausted — the original error was already logged
       // by initializeLinkTarget's catch block.
     }
+  }
+
+  private isDidResolutionFailure(error: any): boolean {
+    const message = error.message ?? '';
+    return message.includes('GetPublicKeyNotFound') || message.includes('notFound');
   }
 
   // ---------------------------------------------------------------------------
@@ -1565,27 +1641,13 @@ export class SyncEngineLevel implements SyncEngine {
    * Opens a MessagesSubscribe WebSocket subscription to a remote DWN.
    * Incoming events are processed locally as they arrive.
    */
-  private async openLivePullSubscription(target: SyncTarget & { linkKey: string }): Promise<void> {
+  private async openLivePullSubscription(target: LinkSyncTarget): Promise<void> {
     const { did, delegateDid, dwnUrl } = target;
     const protocol = singleProtocolForSyncScope(target.scope);
 
-    // Resolve the cursor from the link's durable pull checkpoint.
-    // Legacy syncCursors migration happens at link load time in startLiveSync().
     const cursorKey = target.linkKey;
     const link = this._activeLinks.get(cursorKey);
-    let cursor = link?.pull.contiguousAppliedToken;
-
-    // Guard against corrupted tokens with empty fields — these would fail
-    // MessagesSubscribe JSON schema validation (minLength: 1). Discard and
-    // start from the beginning rather than crash the subscription.
-    if (cursor && (!cursor.streamId || !cursor.messageCid || !cursor.epoch || !cursor.position)) {
-      console.warn(`SyncEngineLevel: Discarding stored cursor with empty field(s) for ${did} -> ${dwnUrl}`);
-      cursor = undefined;
-      if (link) {
-        ReplicationLedger.resetCheckpoint(link.pull);
-        await this.ledger.saveLink(link);
-      }
-    }
+    const cursor = await this.getInitialPullCursor({ did, dwnUrl, link });
 
     const filters = target.scope.kind === 'protocolSet'
       ? target.scope.protocols.map(protocol => ({ protocol }))
@@ -1599,249 +1661,20 @@ export class SyncEngineLevel implements SyncEngine {
     // ensures the checkpoint advances only when all earlier deliveries are committed.
     // Capture the link reference at subscription-open time so we can
     // detect remove+re-add via object identity, not just key existence.
-    const capturedLink = link;
-    const isStale = (): boolean =>
-      this._engineGeneration !== handlerGeneration ||
-      !this._activeLinks.has(cursorKey) ||
-      (capturedLink !== undefined && this._activeLinks.get(cursorKey) !== capturedLink);
+    const isStale = this.createLinkStalePredicate(cursorKey, link, handlerGeneration);
+    const pullContext: LivePullContext = {
+      did,
+      dwnUrl,
+      delegateDid,
+      protocol,
+      linkKey            : cursorKey,
+      link,
+      permissionGrantIds : target.permissionGrantIds,
+      isStale,
+    };
 
     const subscriptionHandler = async (subMessage: SubscriptionMessage): Promise<void> => {
-      if (isStale()) {
-        return;
-      }
-
-      if (subMessage.type === 'eose') {
-        // End-of-stored-events — catch-up complete.
-        if (link) {
-          // Guard: if the link transitioned to repairing while catch-up events
-          // were being processed, skip all mutations — repair owns the state now.
-          if (link.status !== 'live' && link.status !== 'initializing') {
-            return;
-          }
-
-          if (!ReplicationLedger.validateTokenDomain(link.pull, subMessage.cursor)) {
-            console.warn(`SyncEngineLevel: Token domain mismatch on EOSE for ${did} -> ${dwnUrl}, transitioning to repairing`);
-            if (!isStale()) { await this.transitionToRepairing(cursorKey, link); }
-            return;
-          }
-          ReplicationLedger.setReceivedToken(link.pull, subMessage.cursor);
-          this.drainCommittedPull(cursorKey);
-          if (isStale()) { return; }
-          await this.ledger.saveLink(link);
-        }
-        // Transport is reachable — set connectivity to online.
-        if (link) {
-          const prevEoseConnectivity = link.connectivity;
-          link.connectivity = 'online';
-          if (prevEoseConnectivity !== 'online') {
-            this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, protocol, from: prevEoseConnectivity, to: 'online' });
-          }
-          // If the link was marked dirty, schedule reconciliation now that it's healthy.
-          if (link.needsReconcile) {
-            this.scheduleReconcile(cursorKey, 500);
-          }
-        } else {
-          this._connectivityState = 'online';
-        }
-        return;
-      }
-
-      if (subMessage.type === 'event') {
-        const event: MessageEvent = subMessage.event;
-
-        // Guard: if the link is not live (e.g., repairing, degraded_poll, paused),
-        // skip all processing. Old subscription handlers may still fire after the
-        // link transitions — these events should be ignored entirely, not just
-        // skipped at the checkpoint level.
-        if (link && link.status !== 'live' && link.status !== 'initializing') {
-          return;
-        }
-
-        // Domain validation: reject tokens from a different stream/epoch.
-        if (link && !ReplicationLedger.validateTokenDomain(link.pull, subMessage.cursor)) {
-          console.warn(`SyncEngineLevel: Token domain mismatch for ${did} -> ${dwnUrl}, transitioning to repairing`);
-          if (!isStale()) { await this.transitionToRepairing(cursorKey, link); }
-          return;
-        }
-
-        // Subset scope filtering: if the link has protocolPath/contextId prefixes,
-        // skip events that don't match. This is agent-side filtering because
-        // MessagesSubscribe only supports protocol-level filtering today.
-        //
-        // Skipped events MUST advance contiguousAppliedToken — otherwise the
-        // link would replay the same filtered-out events indefinitely after
-        // reconnect/repair. This is safe because the event is intentionally
-        // excluded from this scope and doesn't need processing.
-        if (link && !isEventInScope(event.message, link.scope)) {
-          if (!isStale()) {
-            ReplicationLedger.setReceivedToken(link.pull, subMessage.cursor);
-            ReplicationLedger.commitContiguousToken(link.pull, subMessage.cursor);
-            await this.ledger.saveLink(link);
-          }
-          return;
-        }
-
-        // Assign a delivery ordinal BEFORE async processing begins.
-        // This captures the delivery order even if processing completes out of order.
-        const rt = link ? this.getOrCreateRuntime(cursorKey) : undefined;
-        const ordinal = rt ? rt.nextDeliveryOrdinal++ : -1;
-        if (rt) {
-          rt.inflight.set(ordinal, { ordinal, token: subMessage.cursor, committed: false });
-        }
-
-        try {
-          const eventProtocol = (event.message.descriptor as Record<string, unknown>).protocol as string | undefined;
-
-          // Extract inline data from the event (available for records <= 30 KB).
-          let dataStream = this.extractDataStream(event);
-
-          // For large RecordsWrite messages (no inline data), fetch the data
-          // from the remote DWN via MessagesRead before storing locally.
-          if (!dataStream && isRecordsWrite(event) && (event.message.descriptor as any).dataCid) {
-            const messageCid = await Message.getCid(event.message);
-            const fetched = await fetchRemoteMessages({
-              did, dwnUrl, delegateDid,
-              permissionGrantIds : target.permissionGrantIds,
-              messageCids        : [messageCid],
-              agent              : this.agent,
-            });
-            if (fetched.length > 0 && fetched[0].dataStream) {
-              dataStream = fetched[0].dataStream;
-            }
-          }
-
-          await this.agent.dwn.processRawMessage(did, event.message, { dataStream });
-          if (isStale()) { return; }
-
-          // Invalidate closure cache entries that may be affected by this message.
-          // Must run before closure validation so subsequent evaluations in the
-          // same session see the updated local state.
-          const closureCtxForInvalidation = this._closureContexts.get(did);
-          if (closureCtxForInvalidation) {
-            invalidateClosureCache(closureCtxForInvalidation, event.message);
-          }
-
-          // Closure validation for B1 protocol-set sync. Full-tenant scope
-          // bypasses this entirely because all message dependencies are in scope.
-          if (link?.scope.kind === 'protocolSet') {
-            const messageStore = this.agent.dwn.node.storage.messageStore;
-            let closureCtx = this._closureContexts.get(did);
-            if (!closureCtx) {
-              closureCtx = createClosureContext(did, undefined, {
-                isDelegateSession: !!delegateDid,
-              });
-              this._closureContexts.set(did, closureCtx);
-            }
-
-            const closureResult = await evaluateClosure(
-              event.message, messageStore, link.scope, closureCtx
-            );
-
-            if (isStale()) { return; }
-
-            if (!closureResult.complete) {
-              const failureCode = closureResult.failure!.code;
-              const failureDetail = closureResult.failure!.detail;
-              console.warn(
-                `SyncEngineLevel: Closure incomplete for ${did} -> ${dwnUrl}: ` +
-                `${failureCode} — ${failureDetail}`
-              );
-
-              // Record the message that triggered the closure failure.
-              const closureCid = await Message.getCid(event.message);
-              void this.recordDeadLetter({
-                messageCid     : closureCid,
-                tenantDid      : did,
-                remoteEndpoint : dwnUrl,
-                protocol       : eventProtocol,
-                category       : 'closure',
-                errorCode      : failureCode,
-                errorDetail    : failureDetail,
-              });
-
-              if (!isStale()) { await this.transitionToRepairing(cursorKey, link); }
-              return;
-            }
-          }
-
-          // Squash convergence: processRawMessage triggers the DWN's built-in
-          // squash resumable task (performRecordsSquash) which runs inline and
-          // handles subset consumers correctly:
-          // - If older siblings are locally present → purges them
-          // - If squash arrives before older siblings → backstop rejects them (409)
-          // - If no older siblings are local → no-op (correct)
-          // Both sync orderings (squash-first or siblings-first) converge to
-          // the same final state. No additional sync-engine side-effect is needed.
-
-          // Track this CID for echo-loop suppression, scoped to the source endpoint.
-          const pulledCid = await Message.getCid(event.message);
-          this._recentlyPulledCids.set(`${pulledCid}|${dwnUrl}`, Date.now() + SyncEngineLevel.ECHO_SUPPRESS_TTL_MS);
-          this.evictExpiredEchoEntries();
-
-          // Auto-clear any dead letter for this CID — it was processed
-          // successfully, so a previous failure has been self-healed.
-          this.clearFailedMessage(pulledCid, dwnUrl).catch(() => { /* teardown race */ });
-
-          // Mark this ordinal as committed and drain the checkpoint.
-          // Guard: if the link transitioned to repairing while this handler was
-          // in-flight (e.g., an earlier ordinal's handler failed concurrently),
-          // skip all state mutations — the repair process owns progression now.
-          if (link && rt && link.status === 'live' && !isStale()) {
-            const entry = rt.inflight.get(ordinal);
-            if (entry) { entry.committed = true; }
-
-            ReplicationLedger.setReceivedToken(link.pull, subMessage.cursor);
-            const drained = this.drainCommittedPull(cursorKey);
-            if (drained > 0) {
-              await this.ledger.saveLink(link);
-              // Emit after durable save — "advanced" means persisted.
-              if (link.pull.contiguousAppliedToken) {
-                this.emitEvent({
-                  type           : 'checkpoint:pull-advance',
-                  tenantDid      : link.tenantDid,
-                  remoteEndpoint : link.remoteEndpoint,
-                  protocol       : singleProtocolForSyncScope(link.scope),
-                  position       : link.pull.contiguousAppliedToken.position,
-                  messageCid     : link.pull.contiguousAppliedToken.messageCid,
-                });
-              }
-            }
-
-            // Overflow: too many in-flight ordinals without draining.
-            if (rt.inflight.size > MAX_PENDING_TOKENS) {
-              console.warn(`SyncEngineLevel: Pull in-flight overflow for ${did} -> ${dwnUrl}, transitioning to repairing`);
-              await this.transitionToRepairing(cursorKey, link);
-            }
-          }
-        } catch (error: any) {
-          console.error(`SyncEngineLevel: Error processing live-pull event for ${did}`, error);
-
-          // Record the failing message in the dead letter store before
-          // transitioning to repair. The CID identifies which specific
-          // message caused the transition.
-          try {
-            const failedCid = await Message.getCid(event.message);
-            void this.recordDeadLetter({
-              messageCid     : failedCid,
-              tenantDid      : did,
-              remoteEndpoint : dwnUrl,
-              protocol       : (event.message.descriptor as Record<string, unknown>).protocol as string | undefined,
-              category       : 'pull-processing',
-              errorDetail    : error.message ?? String(error),
-            });
-          } catch {
-            // Best effort — don't let dead letter recording block repair.
-          }
-
-          // A failed processRawMessage means local state is incomplete.
-          // Transition to repairing immediately — do NOT advance the checkpoint
-          // past this failure or let later ordinals commit past it. SMT
-          // reconciliation will discover and fill the gap.
-          if (link && !isStale()) {
-            await this.transitionToRepairing(cursorKey, link);
-          }
-        }
-      }
+      await this.handleLivePullMessage(pullContext, subMessage);
     };
 
     // Construct the subscribe message and send it directly to the specific
@@ -1928,6 +1761,368 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
+  private async getInitialPullCursor({ did, dwnUrl, link }: {
+    did: string;
+    dwnUrl: string;
+    link?: ReplicationLinkState;
+  }): Promise<ProgressToken | undefined> {
+    // Resolve the cursor from the link's durable pull checkpoint. Legacy
+    // syncCursors migration happens during link initialization.
+    if (!link) {
+      return undefined;
+    }
+
+    const cursor = link.pull.contiguousAppliedToken;
+    if (!cursor || this.isValidProgressToken(cursor)) {
+      return cursor;
+    }
+
+    // Guard against corrupted tokens with empty fields — these would fail
+    // MessagesSubscribe JSON schema validation (minLength: 1). Discard and
+    // start from the beginning rather than crash the subscription.
+    console.warn(`SyncEngineLevel: Discarding stored cursor with empty field(s) for ${did} -> ${dwnUrl}`);
+    ReplicationLedger.resetCheckpoint(link.pull);
+    await this.ledger.saveLink(link);
+    return undefined;
+  }
+
+  private isValidProgressToken(token: ProgressToken): boolean {
+    return !!(token.streamId && token.messageCid && token.epoch && token.position);
+  }
+
+  private createLinkStalePredicate(
+    linkKey: string,
+    capturedLink: ReplicationLinkState | undefined,
+    generation: number,
+  ): () => boolean {
+    return (): boolean =>
+      this._engineGeneration !== generation ||
+      !this._activeLinks.has(linkKey) ||
+      (capturedLink !== undefined && this._activeLinks.get(linkKey) !== capturedLink);
+  }
+
+  private async handleLivePullMessage(context: LivePullContext, subMessage: SubscriptionMessage): Promise<void> {
+    if (context.isStale()) {
+      return;
+    }
+
+    if (subMessage.type === 'eose') {
+      await this.handleLivePullEose(context, subMessage);
+      return;
+    }
+
+    if (subMessage.type === 'event') {
+      await this.handleLivePullEvent(context, subMessage);
+    }
+  }
+
+  private async handleLivePullEose(
+    { did, dwnUrl, protocol, linkKey, link, isStale }: LivePullContext,
+    subMessage: Extract<SubscriptionMessage, { type: 'eose' }>,
+  ): Promise<void> {
+    if (link) {
+      // Guard: if the link transitioned to repairing while catch-up events
+      // were being processed, skip all mutations — repair owns the state now.
+      if (link.status !== 'live' && link.status !== 'initializing') {
+        return;
+      }
+
+      if (!ReplicationLedger.validateTokenDomain(link.pull, subMessage.cursor)) {
+        console.warn(`SyncEngineLevel: Token domain mismatch on EOSE for ${did} -> ${dwnUrl}, transitioning to repairing`);
+        if (!isStale()) { await this.transitionToRepairing(linkKey, link); }
+        return;
+      }
+      ReplicationLedger.setReceivedToken(link.pull, subMessage.cursor);
+      this.drainCommittedPull(linkKey);
+      if (isStale()) { return; }
+      await this.ledger.saveLink(link);
+    }
+
+    this.markPullLinkOnline({ did, dwnUrl, protocol, linkKey, link });
+  }
+
+  private markPullLinkOnline({ did, dwnUrl, protocol, linkKey, link }: {
+    did: string;
+    dwnUrl: string;
+    protocol?: string;
+    linkKey: string;
+    link?: ReplicationLinkState;
+  }): void {
+    if (!link) {
+      this._connectivityState = 'online';
+      return;
+    }
+
+    const previous = link.connectivity;
+    link.connectivity = 'online';
+    if (previous !== 'online') {
+      this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, protocol, from: previous, to: 'online' });
+    }
+    if (link.needsReconcile) {
+      this.scheduleReconcile(linkKey, 500);
+    }
+  }
+
+  private async handleLivePullEvent(
+    context: LivePullContext,
+    subMessage: Extract<SubscriptionMessage, { type: 'event' }>,
+  ): Promise<void> {
+    const event = subMessage.event;
+    if (await this.shouldSkipLivePullEvent(context, subMessage)) {
+      return;
+    }
+
+    const delivery = this.startPullDelivery(context, subMessage.cursor);
+    try {
+      const pulledCid = await this.processLivePullEvent(context, event);
+      if (!pulledCid) { return; }
+
+      this.trackRecentlyPulledMessage(pulledCid, context.dwnUrl);
+      this.clearFailedMessage(pulledCid, context.dwnUrl).catch(() => { /* teardown race */ });
+      await this.commitPullDelivery(context, subMessage.cursor, delivery);
+    } catch (error: any) {
+      await this.handleLivePullProcessingError(context, event, error);
+    }
+  }
+
+  private async shouldSkipLivePullEvent(
+    { did, dwnUrl, linkKey, link, isStale }: LivePullContext,
+    subMessage: Extract<SubscriptionMessage, { type: 'event' }>,
+  ): Promise<boolean> {
+    // Guard: if the link is not live (e.g., repairing, degraded_poll, paused),
+    // skip all processing. Old subscription handlers may still fire after the
+    // link transitions — these events should be ignored entirely, not just
+    // skipped at the checkpoint level.
+    if (link && link.status !== 'live' && link.status !== 'initializing') {
+      return true;
+    }
+
+    // Domain validation: reject tokens from a different stream/epoch.
+    if (link && !ReplicationLedger.validateTokenDomain(link.pull, subMessage.cursor)) {
+      console.warn(`SyncEngineLevel: Token domain mismatch for ${did} -> ${dwnUrl}, transitioning to repairing`);
+      if (!isStale()) { await this.transitionToRepairing(linkKey, link); }
+      return true;
+    }
+
+    if (link && !isEventInScope(subMessage.event.message, link.scope)) {
+      await this.skipOutOfScopePullEvent({ link, cursor: subMessage.cursor, isStale });
+      return true;
+    }
+
+    return false;
+  }
+
+  private async skipOutOfScopePullEvent({ link, cursor, isStale }: {
+    link: ReplicationLinkState;
+    cursor: ProgressToken;
+    isStale: () => boolean;
+  }): Promise<void> {
+    // Skipped events MUST advance contiguousAppliedToken — otherwise the link
+    // would replay the same filtered-out events indefinitely after reconnect or
+    // repair. This is safe because the event is intentionally excluded from
+    // this scope and doesn't need processing.
+    if (isStale()) { return; }
+
+    ReplicationLedger.setReceivedToken(link.pull, cursor);
+    ReplicationLedger.commitContiguousToken(link.pull, cursor);
+    await this.ledger.saveLink(link);
+  }
+
+  private startPullDelivery({ linkKey, link }: LivePullContext, cursor: ProgressToken): PullDelivery {
+    // Assign a delivery ordinal BEFORE async processing begins. This captures
+    // delivery order even if processing completes out of order.
+    const runtime = link ? this.getOrCreateRuntime(linkKey) : undefined;
+    const ordinal = runtime ? runtime.nextDeliveryOrdinal++ : -1;
+    if (runtime) {
+      runtime.inflight.set(ordinal, { ordinal, token: cursor, committed: false });
+    }
+    return { runtime, ordinal };
+  }
+
+  private async processLivePullEvent(context: LivePullContext, event: MessageEvent): Promise<string | undefined> {
+    const dataStream = await this.getLivePullDataStream(context, event);
+    await this.agent.dwn.processRawMessage(context.did, event.message, { dataStream });
+    if (context.isStale()) { return undefined; }
+
+    this.invalidateClosureCacheForMessage(context.did, event.message);
+    if (!await this.ensureClosureComplete(context, event)) {
+      return undefined;
+    }
+
+    // Squash convergence: processRawMessage triggers the DWN's built-in
+    // squash resumable task (performRecordsSquash), so no additional
+    // sync-engine side effect is needed here.
+    return Message.getCid(event.message);
+  }
+
+  private async getLivePullDataStream(
+    { did, dwnUrl, delegateDid, permissionGrantIds }: LivePullContext,
+    event: MessageEvent,
+  ): Promise<ReadableStream<Uint8Array> | undefined> {
+    const inlineData = this.extractDataStream(event);
+    if (inlineData || !isRecordsWrite(event) || !(event.message.descriptor as any).dataCid) {
+      return inlineData;
+    }
+
+    // For large RecordsWrite messages (no inline data), fetch the data from
+    // the remote DWN via MessagesRead before storing locally.
+    const messageCid = await Message.getCid(event.message);
+    const fetched = await fetchRemoteMessages({
+      did,
+      dwnUrl,
+      delegateDid,
+      permissionGrantIds,
+      messageCids : [messageCid],
+      agent       : this.agent,
+    });
+    return fetched[0]?.dataStream;
+  }
+
+  private invalidateClosureCacheForMessage(did: string, message: GenericMessage): void {
+    // Must run before closure validation so subsequent evaluations in the same
+    // session see the updated local state.
+    const closureCtx = this._closureContexts.get(did);
+    if (closureCtx) {
+      invalidateClosureCache(closureCtx, message);
+    }
+  }
+
+  private async ensureClosureComplete(context: LivePullContext, event: MessageEvent): Promise<boolean> {
+    const { did, delegateDid, link, isStale } = context;
+    if (link?.scope.kind !== 'protocolSet') {
+      return true;
+    }
+
+    let closureCtx = this._closureContexts.get(did);
+    if (!closureCtx) {
+      closureCtx = createClosureContext(did, undefined, {
+        isDelegateSession: !!delegateDid,
+      });
+      this._closureContexts.set(did, closureCtx);
+    }
+
+    const messageStore = this.agent.dwn.node.storage.messageStore;
+    const closureResult = await evaluateClosure(event.message, messageStore, link.scope, closureCtx);
+    if (isStale()) { return false; }
+    if (closureResult.complete) { return true; }
+
+    await this.recordClosureFailure(context, event, closureResult.failure!.code, closureResult.failure!.detail);
+    return false;
+  }
+
+  private async recordClosureFailure(
+    { did, dwnUrl, linkKey, link, isStale }: LivePullContext,
+    event: MessageEvent,
+    failureCode: string,
+    failureDetail: string,
+  ): Promise<void> {
+    console.warn(
+      `SyncEngineLevel: Closure incomplete for ${did} -> ${dwnUrl}: ` +
+      `${failureCode} — ${failureDetail}`
+    );
+
+    const closureCid = await Message.getCid(event.message);
+    void this.recordDeadLetter({
+      messageCid     : closureCid,
+      tenantDid      : did,
+      remoteEndpoint : dwnUrl,
+      protocol       : (event.message.descriptor as Record<string, unknown>).protocol as string | undefined,
+      category       : 'closure',
+      errorCode      : failureCode,
+      errorDetail    : failureDetail,
+    });
+
+    if (link && !isStale()) {
+      await this.transitionToRepairing(linkKey, link);
+    }
+  }
+
+  private trackRecentlyPulledMessage(messageCid: string, dwnUrl: string): void {
+    this._recentlyPulledCids.set(`${messageCid}|${dwnUrl}`, Date.now() + SyncEngineLevel.ECHO_SUPPRESS_TTL_MS);
+    this.evictExpiredEchoEntries();
+  }
+
+  private async commitPullDelivery(
+    { did, dwnUrl, linkKey, link, isStale }: LivePullContext,
+    cursor: ProgressToken,
+    delivery: PullDelivery,
+  ): Promise<void> {
+    // Guard: if the link transitioned to repairing while this handler was
+    // in-flight, skip all state mutations — the repair process owns progression.
+    if (!link || !delivery.runtime || link.status !== 'live' || isStale()) {
+      return;
+    }
+
+    const entry = delivery.runtime.inflight.get(delivery.ordinal);
+    if (entry) { entry.committed = true; }
+
+    ReplicationLedger.setReceivedToken(link.pull, cursor);
+    const drained = this.drainCommittedPull(linkKey);
+    if (drained > 0) {
+      await this.ledger.saveLink(link);
+      this.emitPullCheckpointAdvance(link);
+    }
+
+    if (delivery.runtime.inflight.size > MAX_PENDING_TOKENS) {
+      console.warn(`SyncEngineLevel: Pull in-flight overflow for ${did} -> ${dwnUrl}, transitioning to repairing`);
+      await this.transitionToRepairing(linkKey, link);
+    }
+  }
+
+  private emitPullCheckpointAdvance(link: ReplicationLinkState): void {
+    if (!link.pull.contiguousAppliedToken) {
+      return;
+    }
+
+    // Emit after durable save — "advanced" means persisted.
+    this.emitEvent({
+      type           : 'checkpoint:pull-advance',
+      tenantDid      : link.tenantDid,
+      remoteEndpoint : link.remoteEndpoint,
+      protocol       : singleProtocolForSyncScope(link.scope),
+      position       : link.pull.contiguousAppliedToken.position,
+      messageCid     : link.pull.contiguousAppliedToken.messageCid,
+    });
+  }
+
+  private async handleLivePullProcessingError(
+    { did, dwnUrl, linkKey, link, isStale }: LivePullContext,
+    event: MessageEvent,
+    error: any,
+  ): Promise<void> {
+    console.error(`SyncEngineLevel: Error processing live-pull event for ${did}`, error);
+    await this.recordPullProcessingFailure({ did, dwnUrl, event, error });
+
+    // A failed processRawMessage means local state is incomplete. Transition
+    // to repairing immediately — do NOT advance the checkpoint past this
+    // failure or let later ordinals commit past it. SMT reconciliation will
+    // discover and fill the gap.
+    if (link && !isStale()) {
+      await this.transitionToRepairing(linkKey, link);
+    }
+  }
+
+  private async recordPullProcessingFailure({ did, dwnUrl, event, error }: {
+    did: string;
+    dwnUrl: string;
+    event: MessageEvent;
+    error: any;
+  }): Promise<void> {
+    try {
+      const failedCid = await Message.getCid(event.message);
+      void this.recordDeadLetter({
+        messageCid     : failedCid,
+        tenantDid      : did,
+        remoteEndpoint : dwnUrl,
+        protocol       : (event.message.descriptor as Record<string, unknown>).protocol as string | undefined,
+        category       : 'pull-processing',
+        errorDetail    : error.message ?? String(error),
+      });
+    } catch {
+      // Best effort — don't let dead letter recording block repair.
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Live push: local EventLog subscription for immediate push
   // ---------------------------------------------------------------------------
@@ -1936,7 +2131,7 @@ export class SyncEngineLevel implements SyncEngine {
    * Subscribes to the local DWN's EventLog so that writes by the user are
    * immediately pushed to the remote DWN instead of waiting for the next poll.
    */
-  private async openLocalPushSubscription(target: SyncTarget & { linkKey: string }): Promise<void> {
+  private async openLocalPushSubscription(target: LinkSyncTarget): Promise<void> {
     const { did, delegateDid, dwnUrl } = target;
     const protocol = singleProtocolForSyncScope(target.scope);
 
@@ -2041,106 +2236,153 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private async flushPendingPushesForLink(linkKey: string): Promise<void> {
+    const batch = this.takePushFlushBatch(linkKey);
+    if (!batch) { return; }
+
+    const { pushRuntime, pushEntries, isStale } = batch;
+    const { did, dwnUrl, delegateDid, protocol, permissionGrantIds, retryCount } = pushRuntime;
+
+    try {
+      const result = await pushMessages({
+        did,
+        dwnUrl,
+        delegateDid,
+        permissionGrantIds,
+        messageCids : pushEntries.map((entry) => entry.cid),
+        agent       : this.agent,
+      });
+
+      await this.handlePushBatchResult(linkKey, batch, result);
+    } catch (error: any) {
+      if (isStale()) { return; }
+      console.error(`SyncEngineLevel: Push batch failed for ${did} -> ${dwnUrl}`, error);
+      this.requeueOrReconcile(linkKey, {
+        did,
+        dwnUrl,
+        delegateDid,
+        protocol,
+        permissionGrantIds,
+        entries    : pushEntries,
+        retryCount : retryCount + 1,
+      });
+    } finally {
+      this.finishPushFlush(linkKey, pushRuntime);
+    }
+  }
+
+  private takePushFlushBatch(linkKey: string): PushFlushBatch | undefined {
     // Guard: bail if this link was hot-removed. Without this, a stale
     // debounce timer or retry callback could send pushes after the DID
     // was removed.
     if (!this._activeLinks.has(linkKey)) {
-      return;
+      return undefined;
     }
 
     const pushRuntime = this._pushRuntimes.get(linkKey);
     if (!pushRuntime) {
-      return;
+      return undefined;
     }
 
-    // Capture the current active link identity so we can detect
-    // remove+re-add during the await pushMessages() call.
-    const flushLink = this._activeLinks.get(linkKey);
-    const isFlushStale = (): boolean =>
-      !this._activeLinks.has(linkKey) ||
-      (flushLink !== undefined && this._activeLinks.get(linkKey) !== flushLink);
-
-    const { did, dwnUrl, delegateDid, protocol, permissionGrantIds, entries: pushEntries, retryCount } = pushRuntime;
+    const { entries: pushEntries, retryCount } = pushRuntime;
     pushRuntime.entries = [];
 
     if (pushEntries.length === 0) {
       if (!pushRuntime.timer && !pushRuntime.flushing && retryCount === 0) {
         this._pushRuntimes.delete(linkKey);
       }
+      return undefined;
+    }
+
+    // Capture the current active link identity so we can detect
+    // remove+re-add during the await pushMessages() call.
+    const flushLink = this._activeLinks.get(linkKey);
+    const isStale = (): boolean =>
+      !this._activeLinks.has(linkKey) ||
+      (flushLink !== undefined && this._activeLinks.get(linkKey) !== flushLink);
+
+    pushRuntime.flushing = true;
+    return { pushRuntime, pushEntries, isStale };
+  }
+
+  private async handlePushBatchResult(
+    linkKey: string,
+    batch: PushFlushBatch,
+    result: PushResult,
+  ): Promise<void> {
+    if (batch.isStale()) { return; }
+
+    this.clearSucceededPushFailures(result.succeeded, batch.pushRuntime.dwnUrl);
+    await this.recordPermanentPushFailures(batch.pushRuntime, result.permanentlyFailed);
+
+    if (result.failed.length > 0) {
+      this.requeueFailedPushes(linkKey, batch, result.failed);
       return;
     }
 
-    const cids = pushEntries.map((entry) => entry.cid);
-    pushRuntime.flushing = true;
+    this.cleanupSuccessfulPushRuntime(linkKey, batch.pushRuntime);
+  }
 
-    try {
-      const result = await pushMessages({
-        did, dwnUrl, delegateDid, permissionGrantIds,
-        messageCids : cids,
-        agent       : this.agent,
+  private clearSucceededPushFailures(cids: string[], dwnUrl: string): void {
+    for (const cid of cids) {
+      this.clearFailedMessage(cid, dwnUrl).catch(() => { /* teardown race */ });
+    }
+  }
+
+  private async recordPermanentPushFailures(
+    pushRuntime: PushRuntimeState,
+    permanentlyFailed: PushResult['permanentlyFailed'],
+  ): Promise<void> {
+    for (const entry of permanentlyFailed) {
+      await this.recordDeadLetter({
+        messageCid     : entry.cid,
+        tenantDid      : pushRuntime.did,
+        remoteEndpoint : pushRuntime.dwnUrl,
+        protocol       : pushRuntime.protocol,
+        category       : 'push-permanent',
+        errorCode      : String(entry.statusCode ?? ''),
+        errorDetail    : entry.detail ?? 'permanent push failure',
       });
+    }
+  }
 
-      // If the link was replaced during pushMessages, abandon all
-      // post-push state mutations — the replacement session owns this key.
-      if (isFlushStale()) { return; }
+  private requeueFailedPushes(linkKey: string, batch: PushFlushBatch, failedCids: string[]): void {
+    if (batch.isStale()) { return; }
 
-      // Auto-clear dead letters for CIDs that succeeded — a previously
-      // failed message may have been repaired by reconciliation.
-      for (const cid of result.succeeded) {
-        this.clearFailedMessage(cid, dwnUrl).catch(() => { /* teardown race */ });
-      }
+    const { did, dwnUrl, delegateDid, protocol, permissionGrantIds, retryCount } = batch.pushRuntime;
+    const failedSet = new Set(failedCids);
+    const failedEntries = batch.pushEntries.filter((entry) => failedSet.has(entry.cid));
+    this.requeueOrReconcile(linkKey, {
+      did,
+      dwnUrl,
+      delegateDid,
+      protocol,
+      permissionGrantIds,
+      entries    : failedEntries,
+      retryCount : retryCount + 1,
+    });
+  }
 
-      // Record permanently failed messages in the dead letter store.
-      for (const entry of result.permanentlyFailed) {
-        await this.recordDeadLetter({
-          messageCid     : entry.cid,
-          tenantDid      : did,
-          remoteEndpoint : dwnUrl,
-          protocol,
-          category       : 'push-permanent',
-          errorCode      : String(entry.statusCode ?? ''),
-          errorDetail    : entry.detail ?? 'permanent push failure',
-        });
-      }
+  private cleanupSuccessfulPushRuntime(linkKey: string, pushRuntime: PushRuntimeState): void {
+    // Successful push — reset retry count so subsequent unrelated batches on
+    // this link start with a fresh budget.
+    pushRuntime.retryCount = 0;
+    if (!pushRuntime.timer && pushRuntime.entries.length === 0) {
+      this._pushRuntimes.delete(linkKey);
+    }
+  }
 
-      if (result.failed.length > 0) {
-        if (isFlushStale()) { return; }
-        const failedSet = new Set(result.failed);
-        const failedEntries = pushEntries.filter((entry) => failedSet.has(entry.cid));
-        this.requeueOrReconcile(linkKey, {
-          did, dwnUrl, delegateDid, protocol, permissionGrantIds,
-          entries    : failedEntries,
-          retryCount : retryCount + 1,
-        });
-      } else {
-        // Successful push — reset retry count so subsequent unrelated
-        // batches on this link start with a fresh budget.
-        pushRuntime.retryCount = 0;
-        if (!pushRuntime.timer && pushRuntime.entries.length === 0) {
-          this._pushRuntimes.delete(linkKey);
-        }
-      }
-    } catch (error: any) {
-      if (isFlushStale()) { return; }
-      console.error(`SyncEngineLevel: Push batch failed for ${did} -> ${dwnUrl}`, error);
-      this.requeueOrReconcile(linkKey, {
-        did, dwnUrl, delegateDid, protocol, permissionGrantIds,
-        entries    : pushEntries,
-        retryCount : retryCount + 1,
-      });
-    } finally {
-      pushRuntime.flushing = false;
+  private finishPushFlush(linkKey: string, pushRuntime: PushRuntimeState): void {
+    pushRuntime.flushing = false;
 
-      // If new entries accumulated while this push was in flight, schedule
-      // a short drain to flush them. This gives a brief batching window
-      // for burst writes while keeping single-write latency low.
-      const rt = this._pushRuntimes.get(linkKey);
-      if (rt && rt.entries.length > 0 && !rt.timer) {
-        rt.timer = setTimeout((): void => {
-          rt.timer = undefined;
-          void this.flushPendingPushesForLink(linkKey);
-        }, PUSH_DEBOUNCE_MS);
-      }
+    // If new entries accumulated while this push was in flight, schedule a
+    // short drain to flush them. This gives a brief batching window for burst
+    // writes while keeping single-write latency low.
+    const rt = this._pushRuntimes.get(linkKey);
+    if (rt && rt.entries.length > 0 && !rt.timer) {
+      rt.timer = setTimeout((): void => {
+        rt.timer = undefined;
+        void this.flushPendingPushesForLink(linkKey);
+      }, PUSH_DEBOUNCE_MS);
     }
   }
 
@@ -2157,7 +2399,7 @@ export class SyncEngineLevel implements SyncEngine {
   private requeueOrReconcile(targetKey: string, pending: {
     did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
     permissionGrantIds?: NonEmptyStringArray;
-    entries: { cid: string }[];
+    entries: PushRuntimeEntry[];
     retryCount: number;
   }): void {
     const maxRetries = SyncEngineLevel.PUSH_RETRY_BACKOFF_MS.length;

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -110,12 +110,12 @@ type InFlightCommit = {
 };
 
 /**
- * Checks whether an event belongs to a B1 link scope.
+ * Checks whether an event belongs to the link's current sync scope.
  *
  * Full links accept every message. Protocol-set links accept only messages
  * whose descriptor protocol is in the canonical set. ProtocolPath/contextId
- * filtering is deliberately absent here; B2 will add a projection-root builder
- * before those scopes become valid sync projections.
+ * filtering is deliberately absent here; add a projection-root builder before
+ * those scopes become valid sync projections.
  */
 function isEventInScope(message: GenericMessage, scope: SyncScope): boolean {
   if (scope.kind === 'full') { return true; }
@@ -837,7 +837,7 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   // ---------------------------------------------------------------------------
-  // Per-link repair and degraded-poll orchestration (Phase 2)
+  // Per-link repair and degraded-poll orchestration
   // ---------------------------------------------------------------------------
 
   /** Maximum consecutive repair attempts before falling back to degraded_poll. */

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -12,7 +12,7 @@ import { Encoder, hashToHex, initDefaultHashes, Message, PermissionsProtocol } f
 import type { ClosureEvaluationContext } from './sync-closure-types.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
-import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
+import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncProtocolSet, SyncScope } from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
@@ -201,7 +201,7 @@ type LivePullContext = {
   did: string;
   dwnUrl: string;
   delegateDid?: string;
-  protocol?: string;
+  eventScope: SyncEventScope;
   linkKey: string;
   link?: ReplicationLinkState;
   permissionGrantIds?: NonEmptyStringArray;
@@ -212,6 +212,17 @@ type PullDelivery = {
   runtime?: LinkRuntimeState;
   ordinal: number;
 };
+
+function syncEventScope(scope: SyncScope | undefined): SyncEventScope {
+  if (scope === undefined || scope.kind === 'full') {
+    return {};
+  }
+
+  const protocols = [...scope.protocols] as SyncProtocolSet;
+  return protocols.length === 1
+    ? { protocol: protocols[0], protocols }
+    : { protocols };
+}
 
 export class SyncEngineLevel implements SyncEngine {
   /**
@@ -906,10 +917,10 @@ export class SyncEngineLevel implements SyncEngine {
     link.connectivity = 'offline';
     await this.ledger.setStatus(link, 'repairing');
 
-    const protocol = singleProtocolForSyncScope(link.scope);
-    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol, from: prevStatus, to: 'repairing' });
+    const eventScope = syncEventScope(link.scope);
+    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevStatus, to: 'repairing' });
     if (prevConnectivity !== 'offline') {
-      this.emitEvent({ type: 'link:connectivity-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol, from: prevConnectivity, to: 'offline' });
+      this.emitEvent({ type: 'link:connectivity-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevConnectivity, to: 'offline' });
     }
 
     if (options?.resumeToken) {
@@ -1017,9 +1028,9 @@ export class SyncEngineLevel implements SyncEngine {
     const isStaleLink = (): boolean => this._activeLinks.get(linkKey) !== link;
 
     const { tenantDid: did, remoteEndpoint: dwnUrl, delegateDid, scope, authorization } = link;
-    const protocol = singleProtocolForSyncScope(scope);
+    const eventScope = syncEventScope(scope);
 
-    this.emitEvent({ type: 'repair:started', tenantDid: did, remoteEndpoint: dwnUrl, protocol, attempt: (this._repairAttempts.get(linkKey) ?? 0) + 1 });
+    this.emitEvent({ type: 'repair:started', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, attempt: (this._repairAttempts.get(linkKey) ?? 0) + 1 });
     const attempts = (this._repairAttempts.get(linkKey) ?? 0) + 1;
     this._repairAttempts.set(linkKey, attempts);
 
@@ -1122,11 +1133,11 @@ export class SyncEngineLevel implements SyncEngine {
       // not prove dependencies are usable. Keep closure failures until a later
       // successful apply/closure pass clears the specific CID.
       await this.clearRootConvergenceDeadLettersForScope(did, dwnUrl, scope);
-      this.emitEvent({ type: 'repair:completed', tenantDid: did, remoteEndpoint: dwnUrl, protocol });
+      this.emitEvent({ type: 'repair:completed', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope });
       if (prevRepairConnectivity !== 'online') {
-        this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, protocol, from: prevRepairConnectivity, to: 'online' });
+        this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, from: prevRepairConnectivity, to: 'online' });
       }
-      this.emitEvent({ type: 'link:status-change', tenantDid: did, remoteEndpoint: dwnUrl, protocol, from: 'repairing', to: 'live' });
+      this.emitEvent({ type: 'link:status-change', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, from: 'repairing', to: 'live' });
 
     } catch (error: any) {
       // If teardown occurred during repair or the link was replaced by a
@@ -1134,7 +1145,7 @@ export class SyncEngineLevel implements SyncEngine {
       if (this._engineGeneration !== generation || isStaleLink()) { return; }
 
       console.error(`SyncEngineLevel: Repair failed for ${did} -> ${dwnUrl} (attempt ${attempts})`, error);
-      this.emitEvent({ type: 'repair:failed', tenantDid: did, remoteEndpoint: dwnUrl, protocol, attempt: attempts, error: String(error.message ?? error) });
+      this.emitEvent({ type: 'repair:failed', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, attempt: attempts, error: String(error.message ?? error) });
 
       if (attempts >= SyncEngineLevel.MAX_REPAIR_ATTEMPTS) {
         console.warn(`SyncEngineLevel: Max repair attempts reached for ${did} -> ${dwnUrl}, entering degraded_poll`);
@@ -1187,9 +1198,9 @@ export class SyncEngineLevel implements SyncEngine {
     const prevDegradedStatus = link.status;
     await this.ledger.setStatus(link, 'degraded_poll');
     this._repairAttempts.delete(linkKey);
-    const protocol = singleProtocolForSyncScope(link.scope);
-    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol, from: prevDegradedStatus, to: 'degraded_poll' });
-    this.emitEvent({ type: 'degraded-poll:entered', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol });
+    const eventScope = syncEventScope(link.scope);
+    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevDegradedStatus, to: 'degraded_poll' });
+    this.emitEvent({ type: 'degraded-poll:entered', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope });
 
     // Clear any existing timer for this link.
     const existing = this._degradedPollTimers.get(linkKey);
@@ -1304,7 +1315,7 @@ export class SyncEngineLevel implements SyncEngine {
             type           : 'link:connectivity-change',
             tenantDid      : link.tenantDid,
             remoteEndpoint : link.remoteEndpoint,
-            protocol       : singleProtocolForSyncScope(link.scope),
+            ...syncEventScope(link.scope),
             from           : prev,
             to             : 'offline',
           });
@@ -1493,7 +1504,7 @@ export class SyncEngineLevel implements SyncEngine {
       type           : 'link:status-change',
       tenantDid      : target.did,
       remoteEndpoint : target.dwnUrl,
-      protocol       : singleProtocolForSyncScope(target.scope),
+      ...syncEventScope(target.scope),
       from           : 'initializing',
       to             : 'live'
     });
@@ -1519,7 +1530,7 @@ export class SyncEngineLevel implements SyncEngine {
         type           : 'gap:detected',
         tenantDid      : target.did,
         remoteEndpoint : target.dwnUrl,
-        protocol       : singleProtocolForSyncScope(target.scope),
+        ...syncEventScope(target.scope),
         reason         : 'ProgressGap'
       });
       await this.transitionToRepairing(linkKey, link, {
@@ -1663,7 +1674,7 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private async openLivePullSubscription(target: LinkSyncTarget): Promise<void> {
     const { did, delegateDid, dwnUrl } = target;
-    const protocol = singleProtocolForSyncScope(target.scope);
+    const eventScope = syncEventScope(target.scope);
 
     const cursorKey = target.linkKey;
     const link = this._activeLinks.get(cursorKey);
@@ -1686,7 +1697,7 @@ export class SyncEngineLevel implements SyncEngine {
       did,
       dwnUrl,
       delegateDid,
-      protocol,
+      eventScope,
       linkKey            : cursorKey,
       link,
       permissionGrantIds : target.permissionGrantIds,
@@ -1776,7 +1787,7 @@ export class SyncEngineLevel implements SyncEngine {
       const prevPullConnectivity = pullLink.connectivity;
       pullLink.connectivity = 'online';
       if (prevPullConnectivity !== 'online') {
-        this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, protocol, from: prevPullConnectivity, to: 'online' });
+        this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, from: prevPullConnectivity, to: 'online' });
       }
     }
   }
@@ -1837,7 +1848,7 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private async handleLivePullEose(
-    { did, dwnUrl, protocol, linkKey, link, isStale }: LivePullContext,
+    { did, dwnUrl, eventScope, linkKey, link, isStale }: LivePullContext,
     subMessage: Extract<SubscriptionMessage, { type: 'eose' }>,
   ): Promise<void> {
     if (link) {
@@ -1858,13 +1869,13 @@ export class SyncEngineLevel implements SyncEngine {
       await this.ledger.saveLink(link);
     }
 
-    this.markPullLinkOnline({ did, dwnUrl, protocol, linkKey, link });
+    this.markPullLinkOnline({ did, dwnUrl, eventScope, linkKey, link });
   }
 
-  private markPullLinkOnline({ did, dwnUrl, protocol, linkKey, link }: {
+  private markPullLinkOnline({ did, dwnUrl, eventScope, linkKey, link }: {
     did: string;
     dwnUrl: string;
-    protocol?: string;
+    eventScope: SyncEventScope;
     linkKey: string;
     link?: ReplicationLinkState;
   }): void {
@@ -1876,7 +1887,7 @@ export class SyncEngineLevel implements SyncEngine {
     const previous = link.connectivity;
     link.connectivity = 'online';
     if (previous !== 'online') {
-      this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, protocol, from: previous, to: 'online' });
+      this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, from: previous, to: 'online' });
     }
     if (link.needsReconcile) {
       this.scheduleReconcile(linkKey, 500);
@@ -2107,7 +2118,7 @@ export class SyncEngineLevel implements SyncEngine {
       type           : 'checkpoint:pull-advance',
       tenantDid      : link.tenantDid,
       remoteEndpoint : link.remoteEndpoint,
-      protocol       : singleProtocolForSyncScope(link.scope),
+      ...syncEventScope(link.scope),
       position       : link.pull.contiguousAppliedToken.position,
       messageCid     : link.pull.contiguousAppliedToken.messageCid,
     });
@@ -2483,12 +2494,11 @@ export class SyncEngineLevel implements SyncEngine {
 
     link.needsReconcile = true;
     void this.ledger.saveLink(link).then(() => {
-      const protocol = link.scope === undefined ? undefined : singleProtocolForSyncScope(link.scope);
       this.emitEvent({
         type           : 'reconcile:needed',
         tenantDid      : link.tenantDid,
         remoteEndpoint : link.remoteEndpoint,
-        protocol,
+        ...syncEventScope(link.scope),
         reason,
       });
       this.scheduleReconcile(linkKey);
@@ -2638,7 +2648,7 @@ export class SyncEngineLevel implements SyncEngine {
     const isStaleLink = (): boolean => this._activeLinks.get(linkKey) !== link;
 
     const { tenantDid: did, remoteEndpoint: dwnUrl, delegateDid, scope, authorization } = link;
-    const protocol = singleProtocolForSyncScope(scope);
+    const eventScope = syncEventScope(scope);
 
     try {
       const reconcileOutcome = await this.reconcileProjectionTarget({
@@ -2655,7 +2665,7 @@ export class SyncEngineLevel implements SyncEngine {
         // SMT roots match, so transport/apply failures for this link may no
         // longer be current. Closure failures are not cleared by root equality.
         await this.clearRootConvergenceDeadLettersForScope(did, dwnUrl, scope);
-        this.emitEvent({ type: 'reconcile:completed', tenantDid: did, remoteEndpoint: dwnUrl, protocol });
+        this.emitEvent({ type: 'reconcile:completed', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope });
       } else {
         // Roots still differ — retry after a delay. This can happen when
         // pushMessages() had permanent failures, pullMessages() partially

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -12,7 +12,7 @@ import { Encoder, hashToHex, initDefaultHashes, Message, PermissionsProtocol } f
 import type { ClosureEvaluationContext } from './sync-closure-types.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
-import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncProtocolSet, SyncScope } from './types/sync.js';
+import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
@@ -218,7 +218,7 @@ function syncEventScope(scope: SyncScope | undefined): SyncEventScope {
     return {};
   }
 
-  const protocols = [...scope.protocols] as SyncProtocolSet;
+  const protocols = [...scope.protocols] as NonEmptyStringArray;
   return protocols.length === 1
     ? { protocol: protocols[0], protocols }
     : { protocols };

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -7,26 +7,25 @@ import ms from 'ms';
 
 import { Level } from 'level';
 import { sleep } from '@enbox/common';
-import { Encoder, hashToHex, initDefaultHashes, Message } from '@enbox/dwn-sdk-js';
+import { Encoder, hashToHex, initDefaultHashes, Message, PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
 import type { ClosureEvaluationContext } from './sync-closure-types.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
-import type { DeadLetterCategory, DeadLetterEntry, PushResult, ReplicationLinkState, StartSyncParams, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
-
-import { evaluateClosure } from './sync-closure-resolver.js';
-import { MAX_PENDING_TOKENS } from './types/sync.js';
-import { ReplicationLedger } from './sync-replication-ledger.js';
-import { createClosureContext, invalidateClosureCache } from './sync-closure-types.js';
+import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncProtocolSet, SyncScope } from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
+import { evaluateClosure } from './sync-closure-resolver.js';
 import { isRecordsWrite } from './utils.js';
+import { ReplicationLedger } from './sync-replication-ledger.js';
 import { SyncLinkReconciler } from './sync-link-reconciler.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { buildLegacyCursorKey, buildLinkId } from './sync-link-id.js';
+import { computeAuthorizationEpoch, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
+import { createClosureContext, invalidateClosureCache } from './sync-closure-types.js';
 import { fetchRemoteMessages, pullMessages, pushMessages } from './sync-messages.js';
-import { getMessagesPermissionGrantId, toMessagesPermissionGrantIds } from './sync-permission-grants.js';
+import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
 export type SyncEngineLevelParams = {
   agent?: EnboxPlatformAgent;
@@ -64,6 +63,7 @@ type LiveSubscription = {
   dwnUrl: string;
   delegateDid?: string;
   protocol?: string;
+  protocols?: SyncProtocolSet;
   close: () => Promise<void>;
 };
 
@@ -74,7 +74,18 @@ type LocalSubscription = {
   dwnUrl: string;
   delegateDid?: string;
   protocol?: string;
+  protocols?: SyncProtocolSet;
   close: () => Promise<void>;
+};
+
+type SyncTarget = {
+  did: string;
+  dwnUrl: string;
+  delegateDid?: string;
+  scope: SyncScope;
+  authorization: SyncAuthorization;
+  authorizationEpoch: string;
+  permissionGrantIds?: NonEmptyStringArray;
 };
 
 // ---------------------------------------------------------------------------
@@ -97,45 +108,38 @@ type InFlightCommit = {
 };
 
 /**
- * Checks whether a message's protocolPath and contextId match the link's
- * subset scope prefixes. Returns true if the message is in scope.
+ * Checks whether an event belongs to a B1 link scope.
  *
- * When the scope has no prefixes (or is kind:'full'), all messages match.
- * When protocolPathPrefixes or contextIdPrefixes are specified, the message
- * must match at least one prefix in each specified set.
- *
- * This is agent-side filtering for subset scopes. The underlying
- * MessagesSubscribe filter only supports protocol-level scoping today —
- * protocolPath/contextId prefix filtering at the EventLog level is a
- * follow-up (requires dwn-sdk-js MessagesFilter extension).
+ * Full links accept every message. Protocol-set links accept only messages
+ * whose descriptor protocol is in the canonical set. ProtocolPath/contextId
+ * filtering is deliberately absent here; B2 will add a projection-root builder
+ * before those scopes become valid sync projections.
  */
 function isEventInScope(message: GenericMessage, scope: SyncScope): boolean {
   if (scope.kind === 'full') { return true; }
-  if (!scope.protocolPathPrefixes && !scope.contextIdPrefixes) { return true; }
 
-  const desc = message.descriptor as Record<string, unknown>;
-
-  // Check protocolPath prefix.
-  if (scope.protocolPathPrefixes && scope.protocolPathPrefixes.length > 0) {
-    const protocolPath = desc.protocolPath as string | undefined;
-    if (!protocolPath) { return false; }
-    const matches = scope.protocolPathPrefixes.some(
-      prefix => protocolPath === prefix || protocolPath.startsWith(prefix + '/')
-    );
-    if (!matches) { return false; }
+  const descriptor = message.descriptor as Record<string, unknown>;
+  const protocol = descriptor.protocol;
+  if (typeof protocol === 'string' && scope.protocols.includes(protocol)) {
+    return true;
   }
 
-  // Check contextId prefix.
-  if (scope.contextIdPrefixes && scope.contextIdPrefixes.length > 0) {
-    const contextId = (message as any).contextId as string | undefined;
-    if (!contextId) { return false; }
-    const matches = scope.contextIdPrefixes.some(
-      prefix => contextId === prefix || contextId.startsWith(prefix + '/')
-    );
-    if (!matches) { return false; }
+  if (
+    descriptor.interface === 'Protocols' &&
+    descriptor.method === 'Configure' &&
+    typeof descriptor.definition === 'object' &&
+    descriptor.definition !== null
+  ) {
+    const definitionProtocol = (descriptor.definition as Record<string, unknown>).protocol;
+    return typeof definitionProtocol === 'string' && scope.protocols.includes(definitionProtocol);
   }
 
-  return true;
+  if (protocol === PermissionsProtocol.uri && typeof descriptor.tags === 'object' && descriptor.tags !== null) {
+    const taggedProtocol = (descriptor.tags as Record<string, unknown>).protocol;
+    return typeof taggedProtocol === 'string' && scope.protocols.includes(taggedProtocol);
+  }
+
+  return false;
 }
 
 /**
@@ -156,6 +160,8 @@ type PushRuntimeState = {
   dwnUrl: string;
   delegateDid?: string;
   protocol?: string;
+  protocols?: SyncProtocolSet;
+  permissionGrantIds?: NonEmptyStringArray;
   entries: { cid: string }[];
   retryCount: number;
   timer?: ReturnType<typeof setTimeout>;
@@ -274,13 +280,59 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
+  private async buildSyncTarget(did: string, dwnUrl: string, options: SyncIdentityOptions): Promise<SyncTarget> {
+    const scope = syncScopeFromProtocols(options.protocols);
+    const protocols = protocolsForSyncScope(scope);
+    const { delegateDid } = options;
+
+    if (delegateDid === undefined) {
+      return {
+        did,
+        dwnUrl,
+        scope,
+        authorization      : { kind: 'owner' },
+        authorizationEpoch : await computeAuthorizationEpoch({ kind: 'owner' }),
+      };
+    }
+
+    const permissionGrants = await getMessagesPermissionGrantsForScope({
+      did,
+      delegateDid,
+      protocols,
+      messageType    : DwnInterface.MessagesSync,
+      permissionsApi : this._permissionsApi,
+    });
+    const permissionGrantIds = permissionGrantIdsFromEntries(permissionGrants);
+    if (permissionGrantIds === undefined) {
+      throw new Error(`SyncEngineLevel: delegate ${delegateDid} has no active sync grants for ${did}.`);
+    }
+
+    return {
+      did,
+      dwnUrl,
+      delegateDid,
+      scope,
+      authorization: {
+        kind: 'delegate',
+        delegateDid,
+        permissionGrantIds,
+      },
+      authorizationEpoch: await computeAuthorizationEpoch({
+        kind   : 'delegate',
+        delegateDid,
+        grants : toSyncAuthorizationGrants(permissionGrants),
+      }),
+      permissionGrantIds,
+    };
+  }
+
   /**
    * Cached sync targets result from the last {@link getSyncTargets} call.
    * Invalidated on identity registration/unregistration/update.
    * TTL-based: cleared after 30 seconds to pick up DID document changes.
    */
   private _syncTargetsCache?: {
-    targets: { did: string; dwnUrl: string; delegateDid?: string; protocol?: string }[];
+    targets: SyncTarget[];
     timestamp: number;
   };
 
@@ -481,16 +533,9 @@ export class SyncEngineLevel implements SyncEngine {
     this._syncTargetsCache = undefined;
     this._syncTargetsCacheGeneration++;
 
-    // Always persist the new delegate to durable links, regardless of
-    // sync mode. If sync is stopped or polling, existing persisted links
-    // would otherwise keep the old delegateDid. When live sync starts
-    // later, initializeLinkTarget() loads the link from LevelDB without
-    // normalizing delegateDid, so repair/reconcile paths could use stale
-    // delegate data.
-    await this.ledger.updateDelegateDid(did, options.delegateDid);
-
     // If live sync is active, tear down and rebuild subscriptions with
-    // the new options.
+    // the new options. Delegate/scope changes derive a new authorization
+    // epoch, so existing durable links are not mutated in place.
     if (this._syncMode === 'live' && this.hasActiveLinksForDid(did)) {
       await this.removeIdentityFromLiveSync(did);
       await this.addIdentityToLiveSync(did, options);
@@ -527,15 +572,12 @@ export class SyncEngineLevel implements SyncEngine {
 
       const results = await Promise.allSettled([...byUrl.entries()].map(async ([dwnUrl, targets]) => {
         for (const target of targets) {
-          const { did, delegateDid, protocol } = target;
           try {
-            await this.createLinkReconciler().reconcile({
-              did, dwnUrl, delegateDid, protocol,
-            }, { direction });
+            await this.reconcileProjectionTarget(target, { direction });
           } catch (error: any) {
             // Skip remaining targets for this DWN endpoint.
             groupsFailed++;
-            console.error(`SyncEngineLevel: Error syncing ${did} with ${dwnUrl}`, error);
+            console.error(`SyncEngineLevel: Error syncing ${target.did} with ${dwnUrl}`, error);
             return;
           }
         }
@@ -817,9 +859,10 @@ export class SyncEngineLevel implements SyncEngine {
     link.connectivity = 'offline';
     await this.ledger.setStatus(link, 'repairing');
 
-    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol: link.protocol, from: prevStatus, to: 'repairing' });
+    const protocol = singleProtocolForSyncScope(link.scope);
+    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol, from: prevStatus, to: 'repairing' });
     if (prevConnectivity !== 'offline') {
-      this.emitEvent({ type: 'link:connectivity-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol: link.protocol, from: prevConnectivity, to: 'offline' });
+      this.emitEvent({ type: 'link:connectivity-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol, from: prevConnectivity, to: 'offline' });
     }
 
     if (options?.resumeToken) {
@@ -926,7 +969,8 @@ export class SyncEngineLevel implements SyncEngine {
     // The old repair closure must not mutate the replacement link's state.
     const isStaleLink = (): boolean => this._activeLinks.get(linkKey) !== link;
 
-    const { tenantDid: did, remoteEndpoint: dwnUrl, delegateDid, protocol } = link;
+    const { tenantDid: did, remoteEndpoint: dwnUrl, delegateDid, scope, authorization } = link;
+    const protocol = singleProtocolForSyncScope(scope);
 
     this.emitEvent({ type: 'repair:started', tenantDid: did, remoteEndpoint: dwnUrl, protocol, attempt: (this._repairAttempts.get(linkKey) ?? 0) + 1 });
     const attempts = (this._repairAttempts.get(linkKey) ?? 0) + 1;
@@ -946,9 +990,13 @@ export class SyncEngineLevel implements SyncEngine {
 
     try {
       // Step 3: Run SMT reconciliation for this link.
-      const reconcileOutcome = await this.createLinkReconciler(
-        () => this._engineGeneration === generation && !isStaleLink()
-      ).reconcile({ did, dwnUrl, delegateDid, protocol });
+      const reconcileOutcome = await this.reconcileProjectionTarget({
+        did,
+        dwnUrl,
+        delegateDid,
+        scope,
+        authorization,
+      }, undefined, () => this._engineGeneration === generation && !isStaleLink());
       if (reconcileOutcome.aborted) { return; }
 
       // Step 4: Determine the post-repair pull resume token.
@@ -973,7 +1021,16 @@ export class SyncEngineLevel implements SyncEngine {
       await this.ledger.saveLink(link);
       if (this._engineGeneration !== generation || isStaleLink()) { return; }
 
-      const target = { did, dwnUrl, delegateDid, protocol, linkKey };
+      const target = {
+        did,
+        dwnUrl,
+        delegateDid,
+        scope,
+        authorization,
+        authorizationEpoch : link.authorizationEpoch,
+        permissionGrantIds : this.getAuthorizationGrantIds(authorization),
+        linkKey,
+      };
       try {
         await this.openLivePullSubscription(target);
       } catch (pullErr: any) {
@@ -1017,7 +1074,7 @@ export class SyncEngineLevel implements SyncEngine {
       // Root convergence proves primary CID membership matches, but it does
       // not prove dependencies are usable. Keep closure failures until a later
       // successful apply/closure pass clears the specific CID.
-      await this.clearRootConvergenceDeadLetters(did, dwnUrl, protocol);
+      await this.clearRootConvergenceDeadLettersForScope(did, dwnUrl, scope);
       this.emitEvent({ type: 'repair:completed', tenantDid: did, remoteEndpoint: dwnUrl, protocol });
       if (prevRepairConnectivity !== 'online') {
         this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, protocol, from: prevRepairConnectivity, to: 'online' });
@@ -1048,7 +1105,7 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private async closeLinkSubscriptions(link: ReplicationLinkState): Promise<void> {
     const { tenantDid: did, remoteEndpoint: dwnUrl } = link;
-    const linkKey = this.buildLinkKey(did, dwnUrl, link.scopeId);
+    const linkKey = this.buildLinkKey(did, dwnUrl, link.projectionId, link.authorizationEpoch);
 
     // Close pull subscription.
     const pullSub = this._liveSubscriptions.find((s) => s.linkKey === linkKey);
@@ -1078,8 +1135,9 @@ export class SyncEngineLevel implements SyncEngine {
     const prevDegradedStatus = link.status;
     await this.ledger.setStatus(link, 'degraded_poll');
     this._repairAttempts.delete(linkKey);
-    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol: link.protocol, from: prevDegradedStatus, to: 'degraded_poll' });
-    this.emitEvent({ type: 'degraded-poll:entered', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol: link.protocol });
+    const protocol = singleProtocolForSyncScope(link.scope);
+    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol, from: prevDegradedStatus, to: 'degraded_poll' });
+    this.emitEvent({ type: 'degraded-poll:entered', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, protocol });
 
     // Clear any existing timer for this link.
     const existing = this._degradedPollTimers.get(linkKey);
@@ -1194,7 +1252,7 @@ export class SyncEngineLevel implements SyncEngine {
             type           : 'link:connectivity-change',
             tenantDid      : link.tenantDid,
             remoteEndpoint : link.remoteEndpoint,
-            protocol       : link.protocol,
+            protocol       : singleProtocolForSyncScope(link.scope),
             from           : prev,
             to             : 'offline',
           });
@@ -1322,26 +1380,22 @@ export class SyncEngineLevel implements SyncEngine {
    * link, migrate legacy cursors, open pull + push subscriptions, and
    * transition the link to `'live'`.
    */
-  private async initializeLinkTarget(target: {
-    did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
-  }): Promise<void> {
+  private async initializeLinkTarget(target: SyncTarget): Promise<void> {
     let link: ReplicationLinkState | undefined;
     try {
-      const linkScope: SyncScope = target.protocol
-        ? { kind: 'protocol', protocol: target.protocol }
-        : { kind: 'full' };
       link = await this.ledger.getOrCreateLink({
-        tenantDid      : target.did,
-        remoteEndpoint : target.dwnUrl,
-        scope          : linkScope,
-        delegateDid    : target.delegateDid,
-        protocol       : target.protocol,
+        tenantDid          : target.did,
+        remoteEndpoint     : target.dwnUrl,
+        scope              : target.scope,
+        authorization      : target.authorization,
+        authorizationEpoch : target.authorizationEpoch,
+        delegateDid        : target.delegateDid,
       });
 
-      const linkKey = this.buildLinkKey(target.did, target.dwnUrl, link.scopeId);
+      const linkKey = this.buildLinkKey(target.did, target.dwnUrl, link.projectionId, link.authorizationEpoch);
 
       if (!link.pull.contiguousAppliedToken) {
-        const legacyKey = buildLegacyCursorKey(target.did, target.dwnUrl, target.protocol);
+        const legacyKey = buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
         const legacyCursor = await this.getCursor(legacyKey);
         if (legacyCursor) {
           ReplicationLedger.resetCheckpoint(link.pull, legacyCursor);
@@ -1365,7 +1419,7 @@ export class SyncEngineLevel implements SyncEngine {
         throw pushError;
       }
 
-      this.emitEvent({ type: 'link:status-change', tenantDid: target.did, remoteEndpoint: target.dwnUrl, protocol: target.protocol, from: 'initializing', to: 'live' });
+      this.emitEvent({ type: 'link:status-change', tenantDid: target.did, remoteEndpoint: target.dwnUrl, protocol: singleProtocolForSyncScope(target.scope), from: 'initializing', to: 'live' });
       await this.ledger.setStatus(link, 'live');
 
       if (link.needsReconcile) {
@@ -1373,12 +1427,12 @@ export class SyncEngineLevel implements SyncEngine {
       }
     } catch (error: any) {
       const linkKey = link
-        ? this.buildLinkKey(target.did, target.dwnUrl, link.scopeId)
-        : buildLegacyCursorKey(target.did, target.dwnUrl, target.protocol);
+        ? this.buildLinkKey(target.did, target.dwnUrl, link.projectionId, link.authorizationEpoch)
+        : buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
 
       if (error.isProgressGap && link) {
         console.warn(`SyncEngineLevel: ProgressGap detected for ${target.did} -> ${target.dwnUrl}, initiating repair`);
-        this.emitEvent({ type: 'gap:detected', tenantDid: target.did, remoteEndpoint: target.dwnUrl, protocol: target.protocol, reason: 'ProgressGap' });
+        this.emitEvent({ type: 'gap:detected', tenantDid: target.did, remoteEndpoint: target.dwnUrl, protocol: singleProtocolForSyncScope(target.scope), reason: 'ProgressGap' });
         await this.transitionToRepairing(linkKey, link, {
           resumeToken: error.gapInfo?.latestAvailable,
         });
@@ -1404,9 +1458,7 @@ export class SyncEngineLevel implements SyncEngine {
    * causing a 401. Retrying with exponential backoff lets the
    * propagation settle before giving up.
    */
-  private async initializeLinkTargetWithRetry(target: {
-    did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
-  }): Promise<void> {
+  private async initializeLinkTargetWithRetry(target: SyncTarget): Promise<void> {
     try {
       await this.initializeLinkTarget(target);
     } catch (error: any) {
@@ -1448,19 +1500,12 @@ export class SyncEngineLevel implements SyncEngine {
 
   /** Hot-add a single identity to the active live sync session. */
   private async addIdentityToLiveSync(did: string, options: SyncIdentityOptions): Promise<void> {
-    const { protocols, delegateDid } = options;
     const dwnEndpointUrls = await this.agent.dwn.getDwnEndpointUrlsForTarget(did);
     if (dwnEndpointUrls.length === 0) { return; }
 
-    const targets: { did: string; dwnUrl: string; delegateDid?: string; protocol?: string }[] = [];
+    const targets: SyncTarget[] = [];
     for (const dwnUrl of dwnEndpointUrls) {
-      if (protocols === 'all') {
-        targets.push({ did, delegateDid, dwnUrl });
-      } else {
-        for (const protocol of protocols) {
-          targets.push({ did, delegateDid, dwnUrl, protocol });
-        }
-      }
+      targets.push(await this.buildSyncTarget(did, dwnUrl, options));
     }
 
     await Promise.allSettled(targets.map(t => this.initializeLinkTargetWithRetry(t)));
@@ -1520,11 +1565,9 @@ export class SyncEngineLevel implements SyncEngine {
    * Opens a MessagesSubscribe WebSocket subscription to a remote DWN.
    * Incoming events are processed locally as they arrive.
    */
-  private async openLivePullSubscription(target: {
-    did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
-    linkKey: string;
-  }): Promise<void> {
-    const { did, delegateDid, dwnUrl, protocol } = target;
+  private async openLivePullSubscription(target: SyncTarget & { linkKey: string }): Promise<void> {
+    const { did, delegateDid, dwnUrl } = target;
+    const protocol = singleProtocolForSyncScope(target.scope);
 
     // Resolve the cursor from the link's durable pull checkpoint.
     // Legacy syncCursors migration happens at link load time in startLiveSync().
@@ -1544,27 +1587,9 @@ export class SyncEngineLevel implements SyncEngine {
       }
     }
 
-    // Build the MessagesSubscribe filters.
-    // When the link has protocolPathPrefixes, include them in the filter so the
-    // EventLog delivers only matching events (server-side filtering). This replaces
-    // the less efficient agent-side isEventInScope filtering for the pull path.
-    // Note: only the first prefix is used as the MessagesFilter field because
-    // MessagesFilter.protocolPathPrefix is a single string. Multiple prefixes
-    // would need multiple filters (OR semantics) — for now we use the first one.
-    const protocolPathPrefix = link?.scope.kind === 'protocol'
-      ? link.scope.protocolPathPrefixes?.[0]
-      : undefined;
-    const filters = protocol
-      ? [{ protocol, ...(protocolPathPrefix ? { protocolPathPrefix } : {}) }]
+    const filters = target.scope.kind === 'protocolSet'
+      ? target.scope.protocols.map(protocol => ({ protocol }))
       : [];
-
-    const permissionGrantId = await getMessagesPermissionGrantId({
-      did,
-      delegateDid,
-      protocol,
-      messageType    : DwnInterface.MessagesSubscribe,
-      permissionsApi : this._permissionsApi,
-    });
 
     const handlerGeneration = this._engineGeneration;
 
@@ -1665,6 +1690,8 @@ export class SyncEngineLevel implements SyncEngine {
         }
 
         try {
+          const eventProtocol = (event.message.descriptor as Record<string, unknown>).protocol as string | undefined;
+
           // Extract inline data from the event (available for records <= 30 KB).
           let dataStream = this.extractDataStream(event);
 
@@ -1673,10 +1700,10 @@ export class SyncEngineLevel implements SyncEngine {
           if (!dataStream && isRecordsWrite(event) && (event.message.descriptor as any).dataCid) {
             const messageCid = await Message.getCid(event.message);
             const fetched = await fetchRemoteMessages({
-              did, dwnUrl, delegateDid, protocol,
-              messageCids    : [messageCid],
-              agent          : this.agent,
-              permissionsApi : this._permissionsApi,
+              did, dwnUrl, delegateDid,
+              permissionGrantIds : target.permissionGrantIds,
+              messageCids        : [messageCid],
+              agent              : this.agent,
             });
             if (fetched.length > 0 && fetched[0].dataStream) {
               dataStream = fetched[0].dataStream;
@@ -1694,11 +1721,9 @@ export class SyncEngineLevel implements SyncEngine {
             invalidateClosureCache(closureCtxForInvalidation, event.message);
           }
 
-          // Closure validation for scoped subset sync (Phase 3).
-          // For protocol-scoped links, verify that all hard dependencies for
-          // this operation are locally present before considering it committed.
-          // Full-tenant scope bypasses this entirely (returns complete with 0 queries).
-          if (link?.scope.kind === 'protocol') {
+          // Closure validation for B1 protocol-set sync. Full-tenant scope
+          // bypasses this entirely because all message dependencies are in scope.
+          if (link?.scope.kind === 'protocolSet') {
             const messageStore = this.agent.dwn.node.storage.messageStore;
             let closureCtx = this._closureContexts.get(did);
             if (!closureCtx) {
@@ -1728,7 +1753,7 @@ export class SyncEngineLevel implements SyncEngine {
                 messageCid     : closureCid,
                 tenantDid      : did,
                 remoteEndpoint : dwnUrl,
-                protocol,
+                protocol       : eventProtocol,
                 category       : 'closure',
                 errorCode      : failureCode,
                 errorDetail    : failureDetail,
@@ -1775,7 +1800,7 @@ export class SyncEngineLevel implements SyncEngine {
                   type           : 'checkpoint:pull-advance',
                   tenantDid      : link.tenantDid,
                   remoteEndpoint : link.remoteEndpoint,
-                  protocol       : link.protocol,
+                  protocol       : singleProtocolForSyncScope(link.scope),
                   position       : link.pull.contiguousAppliedToken.position,
                   messageCid     : link.pull.contiguousAppliedToken.messageCid,
                 });
@@ -1800,7 +1825,7 @@ export class SyncEngineLevel implements SyncEngine {
               messageCid     : failedCid,
               tenantDid      : did,
               remoteEndpoint : dwnUrl,
-              protocol,
+              protocol       : (event.message.descriptor as Record<string, unknown>).protocol as string | undefined,
               category       : 'pull-processing',
               errorDetail    : error.message ?? String(error),
             });
@@ -1829,7 +1854,7 @@ export class SyncEngineLevel implements SyncEngine {
       target        : did,
       messageType   : DwnInterface.MessagesSubscribe as const,
       granteeDid    : delegateDid,
-      messageParams : { filters, cursor, permissionGrantIds: toMessagesPermissionGrantIds(permissionGrantId) },
+      messageParams : { filters, cursor, permissionGrantIds: toMessagesPermissionGrantIds(target.permissionGrantIds) },
     };
 
     const { message } = await this.agent.dwn.processRequest(subscribeRequest);
@@ -1883,12 +1908,13 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     this._liveSubscriptions.push({
-      linkKey : cursorKey,
+      linkKey   : cursorKey,
       did,
       dwnUrl,
       delegateDid,
       protocol,
-      close   : async (): Promise<void> => { await reply.subscription!.close(); },
+      protocols : protocolsForSyncScope(target.scope),
+      close     : async (): Promise<void> => { await reply.subscription!.close(); },
     });
 
     // Set per-link connectivity to online after successful subscription setup.
@@ -1910,22 +1936,13 @@ export class SyncEngineLevel implements SyncEngine {
    * Subscribes to the local DWN's EventLog so that writes by the user are
    * immediately pushed to the remote DWN instead of waiting for the next poll.
    */
-  private async openLocalPushSubscription(target: {
-    did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
-    linkKey: string;
-  }): Promise<void> {
-    const { did, delegateDid, dwnUrl, protocol } = target;
+  private async openLocalPushSubscription(target: SyncTarget & { linkKey: string }): Promise<void> {
+    const { did, delegateDid, dwnUrl } = target;
+    const protocol = singleProtocolForSyncScope(target.scope);
 
-    // Build filters scoped to the protocol (if any).
-    const filters = protocol ? [{ protocol }] : [];
-
-    const permissionGrantId = await getMessagesPermissionGrantId({
-      did,
-      delegateDid,
-      protocol,
-      messageType    : DwnInterface.MessagesSubscribe,
-      permissionsApi : this._permissionsApi,
-    });
+    const filters = target.scope.kind === 'protocolSet'
+      ? target.scope.protocols.map(protocol => ({ protocol }))
+      : [];
 
     const handlerGeneration = this._engineGeneration;
 
@@ -1946,8 +1963,8 @@ export class SyncEngineLevel implements SyncEngine {
         return;
       }
 
-      // Subset scope filtering: only push events that match the link's
-      // scope prefixes. Events outside the scope are not our responsibility.
+      // Subset scope filtering: only push events that match the link scope.
+      // Events outside the scope are not this link's responsibility.
       const pushLinkKey = target.linkKey;
       const pushLink = this._activeLinks.get(pushLinkKey);
       if (pushLink && !isEventInScope(subMessage.event.message, pushLink.scope)) {
@@ -1969,7 +1986,12 @@ export class SyncEngineLevel implements SyncEngine {
       }
 
       const pushRuntime = this.getOrCreatePushRuntime(targetKey, {
-        did, dwnUrl, delegateDid, protocol,
+        did,
+        dwnUrl,
+        delegateDid,
+        protocol,
+        protocols          : protocolsForSyncScope(target.scope),
+        permissionGrantIds : target.permissionGrantIds,
       });
       pushRuntime.entries.push({ cid });
 
@@ -1989,7 +2011,7 @@ export class SyncEngineLevel implements SyncEngine {
       target              : did,
       messageType         : DwnInterface.MessagesSubscribe,
       granteeDid          : delegateDid,
-      messageParams       : { filters, permissionGrantIds: toMessagesPermissionGrantIds(permissionGrantId) },
+      messageParams       : { filters, permissionGrantIds: toMessagesPermissionGrantIds(target.permissionGrantIds) },
       subscriptionHandler : subscriptionHandler as any,
     });
 
@@ -1999,12 +2021,13 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     this._localSubscriptions.push({
-      linkKey : target.linkKey ?? buildLegacyCursorKey(did, dwnUrl, protocol),
+      linkKey   : target.linkKey ?? buildLegacyCursorKey(did, dwnUrl, protocol),
       did,
       dwnUrl,
       delegateDid,
       protocol,
-      close   : async (): Promise<void> => { await reply.subscription!.close(); },
+      protocols : protocolsForSyncScope(target.scope),
+      close     : async (): Promise<void> => { await reply.subscription!.close(); },
     });
   }
 
@@ -2037,7 +2060,7 @@ export class SyncEngineLevel implements SyncEngine {
       !this._activeLinks.has(linkKey) ||
       (flushLink !== undefined && this._activeLinks.get(linkKey) !== flushLink);
 
-    const { did, dwnUrl, delegateDid, protocol, entries: pushEntries, retryCount } = pushRuntime;
+    const { did, dwnUrl, delegateDid, protocol, permissionGrantIds, entries: pushEntries, retryCount } = pushRuntime;
     pushRuntime.entries = [];
 
     if (pushEntries.length === 0) {
@@ -2052,10 +2075,9 @@ export class SyncEngineLevel implements SyncEngine {
 
     try {
       const result = await pushMessages({
-        did, dwnUrl, delegateDid, protocol,
-        messageCids    : cids,
-        agent          : this.agent,
-        permissionsApi : this._permissionsApi,
+        did, dwnUrl, delegateDid, permissionGrantIds,
+        messageCids : cids,
+        agent       : this.agent,
       });
 
       // If the link was replaced during pushMessages, abandon all
@@ -2086,7 +2108,7 @@ export class SyncEngineLevel implements SyncEngine {
         const failedSet = new Set(result.failed);
         const failedEntries = pushEntries.filter((entry) => failedSet.has(entry.cid));
         this.requeueOrReconcile(linkKey, {
-          did, dwnUrl, delegateDid, protocol,
+          did, dwnUrl, delegateDid, protocol, permissionGrantIds,
           entries    : failedEntries,
           retryCount : retryCount + 1,
         });
@@ -2102,7 +2124,7 @@ export class SyncEngineLevel implements SyncEngine {
       if (isFlushStale()) { return; }
       console.error(`SyncEngineLevel: Push batch failed for ${did} -> ${dwnUrl}`, error);
       this.requeueOrReconcile(linkKey, {
-        did, dwnUrl, delegateDid, protocol,
+        did, dwnUrl, delegateDid, protocol, permissionGrantIds,
         entries    : pushEntries,
         retryCount : retryCount + 1,
       });
@@ -2134,6 +2156,7 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private requeueOrReconcile(targetKey: string, pending: {
     did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
+    permissionGrantIds?: NonEmptyStringArray;
     entries: { cid: string }[];
     retryCount: number;
   }): void {
@@ -2182,13 +2205,66 @@ export class SyncEngineLevel implements SyncEngine {
 
   private createLinkReconciler(shouldContinue?: () => boolean): SyncLinkReconciler {
     return new SyncLinkReconciler({
-      getLocalRoot   : async (did, delegateDid, protocol) => this.getLocalRoot(did, delegateDid, protocol),
-      getRemoteRoot  : async (did, dwnUrl, delegateDid, protocol) => this.getRemoteRoot(did, dwnUrl, delegateDid, protocol),
+      getLocalRoot  : async (did, delegateDid, protocol, permissionGrantIds) => this.getLocalRoot(did, delegateDid, protocol, permissionGrantIds),
+      getRemoteRoot : async (did, dwnUrl, delegateDid, protocol, permissionGrantIds) =>
+        this.getRemoteRoot(did, dwnUrl, delegateDid, protocol, permissionGrantIds),
       diffWithRemote : async (target) => this.diffWithRemote(target),
       pullMessages   : async (params) => this.pullMessages(params),
       pushMessages   : async (params) => this.pushMessages(params),
       shouldContinue,
     });
+  }
+
+  private getReconcileProtocols(scope: SyncScope): (string | undefined)[] {
+    return scope.kind === 'full' ? [undefined] : scope.protocols;
+  }
+
+  private getAuthorizationGrantIds(authorization: SyncAuthorization): NonEmptyStringArray | undefined {
+    return authorization.kind === 'delegate' ? authorization.permissionGrantIds : undefined;
+  }
+
+  private async reconcileProjectionTarget(
+    target: {
+      did: string;
+      dwnUrl: string;
+      delegateDid?: string;
+      scope: SyncScope;
+      authorization: SyncAuthorization;
+    },
+    options?: { direction?: 'push' | 'pull'; verifyConvergence?: boolean },
+    shouldContinue?: () => boolean,
+  ): Promise<{ aborted?: boolean; converged?: boolean }> {
+    let converged = true;
+    const permissionGrantIds = this.getAuthorizationGrantIds(target.authorization);
+    const reconciler = this.createLinkReconciler(shouldContinue);
+
+    for (const protocol of this.getReconcileProtocols(target.scope)) {
+      const outcome = await reconciler.reconcile({
+        did         : target.did,
+        dwnUrl      : target.dwnUrl,
+        delegateDid : target.delegateDid,
+        protocol,
+        permissionGrantIds,
+      }, options);
+      if (outcome.aborted) {
+        return { aborted: true };
+      }
+      if (options?.verifyConvergence === true && outcome.converged !== true) {
+        converged = false;
+      }
+    }
+
+    return options?.verifyConvergence === true ? { converged } : {};
+  }
+
+  private async clearRootConvergenceDeadLettersForScope(
+    tenantDid: string,
+    remoteEndpoint: string,
+    scope: SyncScope,
+  ): Promise<void> {
+    for (const protocol of this.getReconcileProtocols(scope)) {
+      await this.clearRootConvergenceDeadLetters(tenantDid, remoteEndpoint, protocol);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -2267,19 +2343,24 @@ export class SyncEngineLevel implements SyncEngine {
     // link object. Bail before mutating the replacement's state.
     const isStaleLink = (): boolean => this._activeLinks.get(linkKey) !== link;
 
-    const { tenantDid: did, remoteEndpoint: dwnUrl, delegateDid, protocol } = link;
+    const { tenantDid: did, remoteEndpoint: dwnUrl, delegateDid, scope, authorization } = link;
+    const protocol = singleProtocolForSyncScope(scope);
 
     try {
-      const reconcileOutcome = await this.createLinkReconciler(
-        () => this._engineGeneration === generation && !isStaleLink()
-      ).reconcile({ did, dwnUrl, delegateDid, protocol }, { verifyConvergence: true });
+      const reconcileOutcome = await this.reconcileProjectionTarget({
+        did,
+        dwnUrl,
+        delegateDid,
+        scope,
+        authorization,
+      }, { verifyConvergence: true }, () => this._engineGeneration === generation && !isStaleLink());
       if (reconcileOutcome.aborted || isStaleLink()) { return; }
 
       if (reconcileOutcome.converged) {
         await this.ledger.clearNeedsReconcile(link);
         // SMT roots match, so transport/apply failures for this link may no
         // longer be current. Closure failures are not cleared by root equality.
-        await this.clearRootConvergenceDeadLetters(did, dwnUrl, protocol);
+        await this.clearRootConvergenceDeadLettersForScope(did, dwnUrl, scope);
         this.emitEvent({ type: 'reconcile:completed', tenantDid: did, remoteEndpoint: dwnUrl, protocol });
       } else {
         // Roots still differ — retry after a delay. This can happen when
@@ -2300,6 +2381,8 @@ export class SyncEngineLevel implements SyncEngine {
     dwnUrl: string;
     delegateDid?: string;
     protocol?: string;
+    protocols?: SyncProtocolSet;
+    permissionGrantIds?: NonEmptyStringArray;
   }): PushRuntimeState {
     let pushRuntime = this._pushRuntimes.get(linkKey);
     if (!pushRuntime) {
@@ -2324,13 +2407,11 @@ export class SyncEngineLevel implements SyncEngine {
    * Live-mode subscription methods (`openLivePullSubscription`,
    * `openLocalPushSubscription`) receive `linkKey` directly and never
    * call this. The remaining callers are poll-mode `sync()` and the
-   * live-mode startup/error paths that already have `link.scopeId`.
-   *
-   * The `undefined` fallback (which produces a legacy cursor key) exists
-   * only for the no-protocol full-tenant targets in poll mode.
+   * live-mode startup/error paths that already have a projection ID and
+   * authorization epoch.
    */
-  private buildLinkKey(did: string, dwnUrl: string, scopeIdOrProtocol?: string): string {
-    return scopeIdOrProtocol ? buildLinkId(did, dwnUrl, scopeIdOrProtocol) : buildLegacyCursorKey(did, dwnUrl);
+  private buildLinkKey(did: string, dwnUrl: string, projectionId: string, authorizationEpoch: string): string {
+    return buildLinkId(did, dwnUrl, projectionId, authorizationEpoch);
   }
 
   /**
@@ -2481,7 +2562,12 @@ export class SyncEngineLevel implements SyncEngine {
    *
    * Returns a hex-encoded root hash string.
    */
-  private async getLocalRoot(did: string, delegateDid?: string, protocol?: string): Promise<string> {
+  private async getLocalRoot(
+    did: string,
+    delegateDid?: string,
+    protocol?: string,
+    permissionGrantIds?: string[],
+  ): Promise<string> {
     const si = this.stateIndex;
     if (si) {
       const rootHash = protocol === undefined
@@ -2491,13 +2577,6 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     // Remote mode fallback: go through processRequest → RPC.
-    const permissionGrantId = await getMessagesPermissionGrantId({
-      did,
-      delegateDid,
-      protocol,
-      messageType    : DwnInterface.MessagesSync,
-      permissionsApi : this._permissionsApi,
-    });
     const response = await this.agent.dwn.processRequest({
       author        : did,
       target        : did,
@@ -2506,7 +2585,7 @@ export class SyncEngineLevel implements SyncEngine {
       messageParams : {
         action             : 'root',
         protocol,
-        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantId)
+        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantIds),
       }
     });
     const reply = response.reply as MessagesSyncReply;
@@ -2517,15 +2596,13 @@ export class SyncEngineLevel implements SyncEngine {
    * Get the SMT root hash from a remote DWN via a MessagesSync 'root' action.
    * Returns a hex-encoded root hash string.
    */
-  private async getRemoteRoot(did: string, dwnUrl: string, delegateDid?: string, protocol?: string): Promise<string> {
-    const permissionGrantId = await getMessagesPermissionGrantId({
-      did,
-      delegateDid,
-      protocol,
-      messageType    : DwnInterface.MessagesSync,
-      permissionsApi : this._permissionsApi,
-    });
-
+  private async getRemoteRoot(
+    did: string,
+    dwnUrl: string,
+    delegateDid?: string,
+    protocol?: string,
+    permissionGrantIds?: string[],
+  ): Promise<string> {
     const syncMessage = await this.agent.dwn.processRequest({
       store         : false,
       author        : did,
@@ -2535,7 +2612,7 @@ export class SyncEngineLevel implements SyncEngine {
       messageParams : {
         action             : 'root',
         protocol,
-        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantId)
+        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantIds)
       }
     });
 
@@ -2566,24 +2643,17 @@ export class SyncEngineLevel implements SyncEngine {
    *
    * This replaces `walkTreeDiff()` which required one HTTP call per tree node.
    */
-  private async diffWithRemote({ did, dwnUrl, delegateDid, protocol }: {
+  private async diffWithRemote({ did, dwnUrl, delegateDid, protocol, permissionGrantIds }: {
     did: string;
     dwnUrl: string;
     delegateDid?: string;
     protocol?: string;
+    permissionGrantIds?: string[];
   }): Promise<{ onlyRemote: MessagesSyncDiffEntry[]; onlyLocal: string[] }> {
     // Step 1: Collect local subtree hashes at BATCHED_DIFF_DEPTH directly from StateIndex.
-    const localHashes = await this.collectLocalSubtreeHashes(did, protocol, BATCHED_DIFF_DEPTH);
+    const localHashes = await this.collectLocalSubtreeHashes(did, protocol, BATCHED_DIFF_DEPTH, permissionGrantIds);
 
     // Step 2: Send a single 'diff' request to the remote with our hashes.
-    const permissionGrantId = await getMessagesPermissionGrantId({
-      did,
-      delegateDid,
-      protocol,
-      messageType    : DwnInterface.MessagesSync,
-      permissionsApi : this._permissionsApi,
-    });
-
     const syncMessage = await this.agent.dwn.processRequest({
       store         : false,
       author        : did,
@@ -2595,7 +2665,7 @@ export class SyncEngineLevel implements SyncEngine {
         protocol,
         hashes             : localHashes,
         depth              : BATCHED_DIFF_DEPTH,
-        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantId),
+        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantIds),
       }
     });
 
@@ -2610,10 +2680,10 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     // Step 3: Enumerate local leaves for prefixes the remote reported as onlyLocal.
-    // Reuse the same grant from step 2 (avoids redundant lookup).
+    // Reuse the same grant set from step 2.
     const onlyLocalCids: string[] = [];
     for (const prefix of reply.onlyLocal ?? []) {
-      const leaves = await this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantId);
+      const leaves = await this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantIds);
       onlyLocalCids.push(...leaves);
     }
 
@@ -2635,6 +2705,7 @@ export class SyncEngineLevel implements SyncEngine {
     did: string,
     protocol: string | undefined,
     depth: number,
+    permissionGrantIds?: string[],
   ): Promise<Record<string, string>> {
     const result: Record<string, string> = {};
     const defaultHash = await this.getDefaultHashHex(depth);
@@ -2652,7 +2723,7 @@ export class SyncEngineLevel implements SyncEngine {
         hexHash = hashToHex(hash);
       } else {
         // Remote mode fallback.
-        hexHash = await this.getLocalSubtreeHash(did, prefix, undefined, protocol);
+        hexHash = await this.getLocalSubtreeHash(did, prefix, undefined, protocol, permissionGrantIds);
       }
 
       if (hexHash === defaultHash) {
@@ -2683,7 +2754,7 @@ export class SyncEngineLevel implements SyncEngine {
    * In remote mode: constructs a signed MessagesSync message and routes through RPC.
    */
   private async getLocalSubtreeHash(
-    did: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantId?: string
+    did: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantIds?: string[]
   ): Promise<string> {
     const si = this.stateIndex;
     if (si) {
@@ -2704,7 +2775,7 @@ export class SyncEngineLevel implements SyncEngine {
         action             : 'subtree',
         prefix,
         protocol,
-        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantId)
+        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantIds)
       }
     });
     const reply = response.reply as MessagesSyncReply;
@@ -2718,7 +2789,7 @@ export class SyncEngineLevel implements SyncEngine {
    * In remote mode: constructs a signed MessagesSync message and routes through RPC.
    */
   private async getLocalLeaves(
-    did: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantId?: string
+    did: string, prefix: string, delegateDid?: string, protocol?: string, permissionGrantIds?: string[]
   ): Promise<string[]> {
     const si = this.stateIndex;
     if (si) {
@@ -2738,7 +2809,7 @@ export class SyncEngineLevel implements SyncEngine {
         action             : 'leaves',
         prefix,
         protocol,
-        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantId)
+        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantIds)
       }
     });
     const reply = response.reply as MessagesSyncReply;
@@ -2757,18 +2828,18 @@ export class SyncEngineLevel implements SyncEngine {
    * they are processed directly without additional HTTP round-trips.
    * Only `messageCids` that were NOT prefetched are fetched individually.
    */
-  private async pullMessages({ did, dwnUrl, delegateDid, protocol, messageCids, prefetched }: {
+  private async pullMessages({ did, dwnUrl, delegateDid, protocol, permissionGrantIds, messageCids, prefetched }: {
     did: string;
     dwnUrl: string;
     delegateDid?: string;
     protocol?: string;
+    permissionGrantIds?: string[];
     messageCids: string[];
     prefetched?: MessagesSyncDiffEntry[];
   }): Promise<void> {
     const failedCids = await pullMessages({
-      did, dwnUrl, delegateDid, protocol, messageCids, prefetched,
-      agent          : this.agent,
-      permissionsApi : this._permissionsApi,
+      did, dwnUrl, delegateDid, permissionGrantIds, messageCids, prefetched,
+      agent: this.agent,
     });
 
     // Record permanently failed pull entries in the dead letter store.
@@ -2834,17 +2905,16 @@ export class SyncEngineLevel implements SyncEngine {
    * Reads missing messages from the local DWN and pushes them to the remote DWN
    * in dependency order (topological sort).
    */
-  private async pushMessages({ did, dwnUrl, delegateDid, protocol, messageCids }: {
+  private async pushMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids }: {
     did: string;
     dwnUrl: string;
     delegateDid?: string;
-    protocol?: string;
+    permissionGrantIds?: string[];
     messageCids: string[];
   }): Promise<PushResult> {
     return pushMessages({
-      did, dwnUrl, delegateDid, protocol, messageCids,
-      agent          : this.agent,
-      permissionsApi : this._permissionsApi,
+      did, dwnUrl, delegateDid, permissionGrantIds, messageCids,
+      agent: this.agent,
     });
   }
 
@@ -3044,17 +3114,13 @@ export class SyncEngineLevel implements SyncEngine {
   // ---------------------------------------------------------------------------
 
   /**
-   * Returns the list of sync targets: (did, dwnUrl, delegateDid?, protocol?) tuples.
+   * Returns the list of sync targets: one canonical projection target per
+   * registered DID and resolved DWN endpoint.
    * Results are cached for up to 30 seconds to avoid redundant DID resolution
    * on every sync tick. The cache is invalidated when identities are registered,
    * unregistered, or updated.
    */
-  private async getSyncTargets(): Promise<{
-    did: string;
-    dwnUrl: string;
-    delegateDid?: string;
-    protocol?: string;
-  }[]> {
+  private async getSyncTargets(): Promise<SyncTarget[]> {
     // Return cached targets if still valid.
     if (this._syncTargetsCache
         && (Date.now() - this._syncTargetsCache.timestamp) < SyncEngineLevel.SYNC_TARGETS_CACHE_TTL_MS) {
@@ -3066,7 +3132,7 @@ export class SyncEngineLevel implements SyncEngine {
     // make our result stale.
     const generationAtStart = this._syncTargetsCacheGeneration;
 
-    const targets: { did: string; dwnUrl: string; delegateDid?: string; protocol?: string }[] = [];
+    const targets: SyncTarget[] = [];
     let hasRegisteredIdentities = false;
     let anyEndpointMissing = false;
 
@@ -3080,8 +3146,6 @@ export class SyncEngineLevel implements SyncEngine {
         continue;
       }
 
-      const { protocols, delegateDid } = parsed;
-
       const dwnEndpointUrls = await this.agent.dwn.getDwnEndpointUrlsForTarget(did);
       if (dwnEndpointUrls.length === 0) {
         anyEndpointMissing = true;
@@ -3089,14 +3153,7 @@ export class SyncEngineLevel implements SyncEngine {
       }
 
       for (const dwnUrl of dwnEndpointUrls) {
-        if (protocols === 'all') {
-          // Sync all protocols (global tree).
-          targets.push({ did, delegateDid, dwnUrl });
-        } else {
-          for (const protocol of protocols) {
-            targets.push({ did, delegateDid, dwnUrl, protocol });
-          }
-        }
+        targets.push(await this.buildSyncTarget(did, dwnUrl, parsed));
       }
     }
 

--- a/packages/agent/src/sync-link-id.ts
+++ b/packages/agent/src/sync-link-id.ts
@@ -21,7 +21,7 @@ export function buildLinkId(
 /**
  * Build the legacy cursor key used by the deprecated `syncCursors` sublevel.
  *
- * This remains only for one-time migration of pre-Phase-1f data.
+ * This remains only for one-time migration from the legacy cursor-key format.
  */
 export function buildLegacyCursorKey(tenantDid: string, remoteEndpoint: string, protocol?: string): string {
   const base = `${tenantDid}${LINK_ID_SEPARATOR}${remoteEndpoint}`;

--- a/packages/agent/src/sync-link-id.ts
+++ b/packages/agent/src/sync-link-id.ts
@@ -7,10 +7,15 @@ export type LinkId = string;
 /**
  * Build the runtime identifier for a replication link.
  *
- * Runtime identity is `(tenantDid, remoteEndpoint, scopeId)`.
+ * Runtime identity is `(tenantDid, remoteEndpoint, projectionId, authorizationEpoch)`.
  */
-export function buildLinkId(tenantDid: string, remoteEndpoint: string, scopeId: string): LinkId {
-  return `${tenantDid}${LINK_ID_SEPARATOR}${remoteEndpoint}${LINK_ID_SEPARATOR}${scopeId}`;
+export function buildLinkId(
+  tenantDid: string,
+  remoteEndpoint: string,
+  projectionId: string,
+  authorizationEpoch: string,
+): LinkId {
+  return `${tenantDid}${LINK_ID_SEPARATOR}${remoteEndpoint}${LINK_ID_SEPARATOR}${projectionId}${LINK_ID_SEPARATOR}${authorizationEpoch}`;
 }
 
 /**

--- a/packages/agent/src/sync-link-reconciler.ts
+++ b/packages/agent/src/sync-link-reconciler.ts
@@ -9,6 +9,7 @@ export type ReconcileTarget = {
   dwnUrl: string;
   delegateDid?: string;
   protocol?: string;
+  permissionGrantIds?: string[];
 };
 
 export type ReconcileOutcome = {
@@ -25,14 +26,26 @@ export type ReconcileOutcome = {
 };
 
 type ReconcileDeps = {
-  getLocalRoot: (did: string, delegateDid?: string, protocol?: string) => Promise<string>;
-  getRemoteRoot: (did: string, dwnUrl: string, delegateDid?: string, protocol?: string) => Promise<string>;
+  getLocalRoot: (
+    did: string,
+    delegateDid?: string,
+    protocol?: string,
+    permissionGrantIds?: string[],
+  ) => Promise<string>;
+  getRemoteRoot: (
+    did: string,
+    dwnUrl: string,
+    delegateDid?: string,
+    protocol?: string,
+    permissionGrantIds?: string[],
+  ) => Promise<string>;
   diffWithRemote: (target: ReconcileTarget) => Promise<{ onlyRemote: MessagesSyncDiffEntry[]; onlyLocal: string[] }>;
   pullMessages: (params: {
     did: string;
     dwnUrl: string;
     delegateDid?: string;
     protocol?: string;
+    permissionGrantIds?: string[];
     messageCids: string[];
     prefetched: (MessagesSyncDiffEntry & { message: GenericMessage })[];
   }) => Promise<void>;
@@ -41,6 +54,7 @@ type ReconcileDeps = {
     dwnUrl: string;
     delegateDid?: string;
     protocol?: string;
+    permissionGrantIds?: string[];
     messageCids: string[];
   }) => Promise<PushResult>;
   shouldContinue?: () => boolean;
@@ -82,15 +96,15 @@ export class SyncLinkReconciler {
     direction?: ReconcileDirection;
     verifyConvergence?: boolean;
   }): Promise<ReconcileOutcome> {
-    const { did, dwnUrl, delegateDid, protocol } = target;
+    const { did, dwnUrl, delegateDid, protocol, permissionGrantIds } = target;
     const direction = options?.direction;
     const verifyConvergence = options?.verifyConvergence ?? false;
     const shouldContinue = this._deps.shouldContinue;
 
-    const localRoot = await this._deps.getLocalRoot(did, delegateDid, protocol);
+    const localRoot = await this._deps.getLocalRoot(did, delegateDid, protocol, permissionGrantIds);
     if (shouldContinue && !shouldContinue()) { return { aborted: true, changed: false, didPull: false, didPush: false }; }
 
-    const remoteRoot = await this._deps.getRemoteRoot(did, dwnUrl, delegateDid, protocol);
+    const remoteRoot = await this._deps.getRemoteRoot(did, dwnUrl, delegateDid, protocol, permissionGrantIds);
     if (shouldContinue && !shouldContinue()) { return { aborted: true, changed: false, didPull: false, didPush: false }; }
 
     let didPull = false;
@@ -103,14 +117,14 @@ export class SyncLinkReconciler {
 
       if ((!direction || direction === 'pull') && diff.onlyRemote.length > 0) {
         const { prefetched, needsFetchCids } = partitionRemoteEntries(diff.onlyRemote);
-        await this._deps.pullMessages({ did, dwnUrl, delegateDid, protocol, messageCids: needsFetchCids, prefetched });
+        await this._deps.pullMessages({ did, dwnUrl, delegateDid, protocol, permissionGrantIds, messageCids: needsFetchCids, prefetched });
         if (shouldContinue && !shouldContinue()) { return { aborted: true, changed: true, didPull: true, didPush: false, localRoot, remoteRoot }; }
         didPull = true;
       }
 
       if ((!direction || direction === 'push') && diff.onlyLocal.length > 0) {
         pushResult = await this._deps.pushMessages({
-          did, dwnUrl, delegateDid, protocol, messageCids: diff.onlyLocal,
+          did, dwnUrl, delegateDid, protocol, permissionGrantIds, messageCids: diff.onlyLocal,
         });
         if (shouldContinue && !shouldContinue()) {
           return { aborted: true, changed: true, didPull, didPush: true, localRoot, remoteRoot, pushResult };
@@ -130,12 +144,12 @@ export class SyncLinkReconciler {
       };
     }
 
-    const postLocalRoot = await this._deps.getLocalRoot(did, delegateDid, protocol);
+    const postLocalRoot = await this._deps.getLocalRoot(did, delegateDid, protocol, permissionGrantIds);
     if (shouldContinue && !shouldContinue()) {
       return { aborted: true, changed: localRoot !== remoteRoot, didPull, didPush, localRoot, remoteRoot, pushResult };
     }
 
-    const postRemoteRoot = await this._deps.getRemoteRoot(did, dwnUrl, delegateDid, protocol);
+    const postRemoteRoot = await this._deps.getRemoteRoot(did, dwnUrl, delegateDid, protocol, permissionGrantIds);
     if (shouldContinue && !shouldContinue()) {
       return { aborted: true, changed: localRoot !== remoteRoot, didPull, didPush, localRoot, remoteRoot, pushResult };
     }

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -113,34 +113,13 @@ export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantId
   prefetched?: MessagesSyncDiffEntry[];
   agent: EnboxPlatformAgent;
 }): Promise<string[]> {
-  // Convert prefetched diff entries into SyncMessageEntry format.
-  const prefetchedEntries: SyncMessageEntry[] = [];
-  if (prefetched) {
-    for (const entry of prefetched) {
-      if (!entry.message) { continue; }
-      const syncEntry: SyncMessageEntry = { message: entry.message };
-      if (entry.encodedData) {
-        // Convert base64url-encoded data to a ReadableStream.
-        const bytes = Encoder.base64UrlToBytes(entry.encodedData);
-        syncEntry.bufferedData = bytes;
-        syncEntry.dataStream = new ReadableStream<Uint8Array>({
-          start(controller): void {
-            controller.enqueue(bytes);
-            controller.close();
-          }
-        });
-      }
-      prefetchedEntries.push(syncEntry);
-    }
-  }
-
   // Step 1: Fetch remaining messages (not prefetched) from the remote.
   const fetched = messageCids.length > 0
     ? await fetchRemoteMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, agent })
     : [];
 
   // Merge prefetched entries with remotely fetched ones.
-  const allFetched = [...prefetchedEntries, ...fetched];
+  const allFetched = [...syncEntriesFromPrefetchedDiff(prefetched), ...fetched];
 
   // Step 2: Build dependency graph and topological sort.
   const sorted = topologicalSort(allFetched);
@@ -153,57 +132,106 @@ export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantId
   let pending = sorted;
 
   for (let pass = 0; pass <= MAX_RETRY_PASSES && pending.length > 0; pass++) {
-    const failed: SyncMessageEntry[] = [];
-
-    for (const entry of pending) {
-      // Create a fresh ReadableStream from the buffer if available (stream is single-use).
-      const dataStream = entry.bufferedData
-        ? new ReadableStream<Uint8Array>({ start(c): void { c.enqueue(entry.bufferedData!); c.close(); } })
-        : entry.dataStream;
-
-      const pullReply = await agent.dwn.processRawMessage(did, entry.message, { dataStream });
-
-      if (!syncMessageReplyIsSuccessful(pullReply)) {
-        failed.push(entry);
-      }
-    }
-
-    if (failed.length > 0) {
-      // Separate entries that have a buffer (can retry locally) from those
-      // that need a fresh fetch (large payloads whose stream was consumed).
-      const needsRefetch: string[] = [];
-      const canRetry: SyncMessageEntry[] = [];
-
-      for (const entry of failed) {
-        if (entry.bufferedData || !entry.dataStream) {
-          // Has a buffer or has no data — can retry without re-fetching.
-          canRetry.push(entry);
-        } else {
-          // Large payload whose stream was consumed — must re-fetch.
-          const cid = await getMessageCid(entry.message);
-          needsRefetch.push(cid);
-        }
-      }
-
-      // Re-fetch only the large-payload messages that we couldn't buffer.
-      if (needsRefetch.length > 0) {
-        const reFetched = await fetchRemoteMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids: needsRefetch, agent });
-        canRetry.push(...reFetched);
-      }
-
-      pending = topologicalSort(canRetry);
-    } else {
-      pending = [];
-    }
+    const failed = await processPullPass({ did, entries: pending, agent });
+    pending = failed.length === 0
+      ? []
+      : await preparePullRetry({ did, dwnUrl, delegateDid, permissionGrantIds, failed, agent });
   }
 
   // Return CIDs that permanently failed after all retry passes.
-  const permanentlyFailed: string[] = [];
-  for (const entry of pending) {
-    const cid = await getMessageCid(entry.message);
-    permanentlyFailed.push(cid);
+  return getMessageCids(pending);
+}
+
+function syncEntriesFromPrefetchedDiff(prefetched?: MessagesSyncDiffEntry[]): SyncMessageEntry[] {
+  if (!prefetched) { return []; }
+
+  const entries: SyncMessageEntry[] = [];
+  for (const entry of prefetched) {
+    if (!entry.message) { continue; }
+
+    const syncEntry: SyncMessageEntry = { message: entry.message };
+    if (entry.encodedData) {
+      const bytes = Encoder.base64UrlToBytes(entry.encodedData);
+      syncEntry.bufferedData = bytes;
+      syncEntry.dataStream = dataStreamFromBytes(bytes);
+    }
+    entries.push(syncEntry);
   }
-  return permanentlyFailed;
+  return entries;
+}
+
+function dataStreamFromBytes(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller): void {
+      controller.enqueue(bytes);
+      controller.close();
+    }
+  });
+}
+
+function replayableDataStream(entry: SyncMessageEntry): ReadableStream<Uint8Array> | undefined {
+  return entry.bufferedData ? dataStreamFromBytes(entry.bufferedData) : entry.dataStream;
+}
+
+async function processPullPass({ did, entries, agent }: {
+  did: string;
+  entries: SyncMessageEntry[];
+  agent: EnboxPlatformAgent;
+}): Promise<SyncMessageEntry[]> {
+  const failed: SyncMessageEntry[] = [];
+
+  for (const entry of entries) {
+    const pullReply = await agent.dwn.processRawMessage(did, entry.message, {
+      dataStream: replayableDataStream(entry),
+    });
+
+    if (!syncMessageReplyIsSuccessful(pullReply)) {
+      failed.push(entry);
+    }
+  }
+
+  return failed;
+}
+
+async function preparePullRetry({ did, dwnUrl, delegateDid, permissionGrantIds, failed, agent }: {
+  did: string;
+  dwnUrl: string;
+  delegateDid?: string;
+  permissionGrantIds?: string[];
+  failed: SyncMessageEntry[];
+  agent: EnboxPlatformAgent;
+}): Promise<SyncMessageEntry[]> {
+  const canRetry: SyncMessageEntry[] = [];
+  const needsRefetch: string[] = [];
+
+  for (const entry of failed) {
+    if (entry.bufferedData || !entry.dataStream) {
+      canRetry.push(entry);
+    } else {
+      needsRefetch.push(await getMessageCid(entry.message));
+    }
+  }
+
+  if (needsRefetch.length > 0) {
+    canRetry.push(...await fetchRemoteMessages({
+      did,
+      dwnUrl,
+      delegateDid,
+      permissionGrantIds,
+      messageCids: needsRefetch,
+      agent,
+    }));
+  }
+
+  return topologicalSort(canRetry);
+}
+
+async function getMessageCids(entries: SyncMessageEntry[]): Promise<string[]> {
+  const cids: string[] = [];
+  for (const entry of entries) {
+    cids.push(await getMessageCid(entry.message));
+  }
+  return cids;
 }
 
 /**
@@ -255,12 +283,7 @@ async function bufferSmallStreams(entries: SyncMessageEntry[]): Promise<void> {
 
     entry.bufferedData = buffer;
     // Create a fresh ReadableStream from the buffer for the first processing attempt.
-    entry.dataStream = new ReadableStream<Uint8Array>({
-      start(controller): void {
-        controller.enqueue(buffer);
-        controller.close();
-      }
-    });
+    entry.dataStream = dataStreamFromBytes(buffer);
   }
 }
 
@@ -351,20 +374,14 @@ export async function pushMessages({ did, dwnUrl, delegateDid, permissionGrantId
   agent: EnboxPlatformAgent;
 }): Promise<PushResult> {
   const succeeded: string[] = [];
-  const failed: string[] = [];
   const permanentlyFailed: PermanentPushFailure[] = [];
-
-  // Step 1: Fetch all local messages (streams are pull-based, not yet consumed).
-  const fetched: SyncMessageEntry[] = [];
-  for (const messageCid of messageCids) {
-    const dwnMessage = await getLocalMessage({ author: did, messageCid, delegateDid, permissionGrantIds, agent });
-    if (dwnMessage) {
-      fetched.push(dwnMessage);
-    } else {
-      // Message could not be fetched locally — mark as failed.
-      failed.push(messageCid);
-    }
-  }
+  const { fetched, failed } = await fetchLocalMessagesForPush({
+    did,
+    delegateDid,
+    permissionGrantIds,
+    messageCids,
+    agent,
+  });
 
   // Step 2: Sort in dependency order using topological sort.
   const sorted = topologicalSort(fetched);
@@ -376,50 +393,101 @@ export async function pushMessages({ did, dwnUrl, delegateDid, permissionGrantId
 
   // Step 4: Push messages in dependency order.
   for (const entry of sorted) {
-    const cid = await getMessageCid(entry.message);
-
-    // Use a Blob for buffered data — unlike ReadableStream, Blob is
-    // replayable so fetchWithRetry can retry the HTTP request on failure.
-    const data = entry.bufferedData
-      ? new Blob([entry.bufferedData] as BlobPart[], { type: 'application/octet-stream' })
-      : entry.dataStream;
-
-    try {
-      const reply = await agent.rpc.sendDwnRequest({
-        dwnUrl,
-        targetDid : did,
-        data,
-        message   : entry.message
-      });
-
-      if (syncMessageReplyIsSuccessful(reply, entry.message)) {
-        succeeded.push(cid);
-      } else if (isPermanentPushFailure(reply)) {
-        // Permanent failures (400/401/403) will never succeed — do NOT retry.
-        // These include protocol violations (RecordLimitExceeded), auth errors,
-        // and schema validation failures.
-        if (reply.status.code === 400 && reply.status.detail?.includes('record limit')) {
-          // Expected for singleton convergence in multi-device scenarios:
-          // one device created a singleton record, this device has a
-          // different one, and the remote rejects the duplicate.
-          console.debug(`SyncEngineLevel: singleton already exists on remote, skipping push for ${cid}`);
-        } else {
-          console.warn(`SyncEngineLevel: push permanently failed for ${cid}: ${reply.status.code} ${reply.status.detail}`);
-        }
-        permanentlyFailed.push({ cid, statusCode: reply.status.code, detail: reply.status.detail ?? '' });
-      } else {
-        // Transient failures (5xx, etc.) — worth retrying.
-        console.error(`SyncEngineLevel: push failed for ${cid}: ${reply.status.code} ${reply.status.detail}`);
-        failed.push(cid);
-      }
-    } catch (error: any) {
-      // Network errors — transient, worth retrying.
-      console.error(`SyncEngineLevel: push error for ${cid}: ${error.message ?? error}`);
-      failed.push(cid);
+    const outcome = await pushSingleMessage({ did, dwnUrl, entry, agent });
+    if (outcome.status === 'succeeded') {
+      succeeded.push(outcome.cid);
+    } else if (outcome.status === 'permanent') {
+      permanentlyFailed.push(outcome.failure);
+    } else {
+      failed.push(outcome.cid);
     }
   }
 
   return { succeeded, failed, permanentlyFailed };
+}
+
+async function fetchLocalMessagesForPush({ did, delegateDid, permissionGrantIds, messageCids, agent }: {
+  did: string;
+  delegateDid?: string;
+  permissionGrantIds?: string[];
+  messageCids: string[];
+  agent: EnboxPlatformAgent;
+}): Promise<{ fetched: SyncMessageEntry[]; failed: string[] }> {
+  const fetched: SyncMessageEntry[] = [];
+  const failed: string[] = [];
+
+  for (const messageCid of messageCids) {
+    const dwnMessage = await getLocalMessage({ author: did, messageCid, delegateDid, permissionGrantIds, agent });
+    if (dwnMessage) {
+      fetched.push(dwnMessage);
+    } else {
+      failed.push(messageCid);
+    }
+  }
+
+  return { fetched, failed };
+}
+
+type PushSingleMessageOutcome =
+  | { status: 'succeeded'; cid: string }
+  | { status: 'failed'; cid: string }
+  | { status: 'permanent'; cid: string; failure: PermanentPushFailure };
+
+async function pushSingleMessage({ did, dwnUrl, entry, agent }: {
+  did: string;
+  dwnUrl: string;
+  entry: SyncMessageEntry;
+  agent: EnboxPlatformAgent;
+}): Promise<PushSingleMessageOutcome> {
+  const cid = await getMessageCid(entry.message);
+
+  try {
+    const reply = await agent.rpc.sendDwnRequest({
+      dwnUrl,
+      targetDid : did,
+      data      : pushData(entry),
+      message   : entry.message
+    });
+
+    if (syncMessageReplyIsSuccessful(reply, entry.message)) {
+      return { status: 'succeeded', cid };
+    }
+
+    if (isPermanentPushFailure(reply)) {
+      logPermanentPushFailure(cid, reply);
+      return {
+        status  : 'permanent',
+        cid,
+        failure : { cid, statusCode: reply.status.code, detail: reply.status.detail ?? '' },
+      };
+    }
+
+    console.error(`SyncEngineLevel: push failed for ${cid}: ${reply.status.code} ${reply.status.detail}`);
+    return { status: 'failed', cid };
+  } catch (error: any) {
+    console.error(`SyncEngineLevel: push error for ${cid}: ${error.message ?? error}`);
+    return { status: 'failed', cid };
+  }
+}
+
+function pushData(entry: SyncMessageEntry): Blob | ReadableStream<Uint8Array> | undefined {
+  // Use a Blob for buffered data: unlike ReadableStream, Blob is replayable,
+  // so fetchWithRetry can retry the HTTP request after a transport failure.
+  return entry.bufferedData
+    ? new Blob([entry.bufferedData] as BlobPart[], { type: 'application/octet-stream' })
+    : entry.dataStream;
+}
+
+function logPermanentPushFailure(cid: string, reply: UnionMessageReply): void {
+  if (reply.status.code === 400 && reply.status.detail?.includes('record limit')) {
+    // Expected for singleton convergence in multi-device scenarios: one device
+    // created a singleton record, this device has another, and the remote
+    // rejects the duplicate.
+    console.debug(`SyncEngineLevel: singleton already exists on remote, skipping push for ${cid}`);
+    return;
+  }
+
+  console.warn(`SyncEngineLevel: push permanently failed for ${cid}: ${reply.status.code} ${reply.status.detail}`);
 }
 
 /**

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -1,15 +1,14 @@
 import type { GenericMessage, MessagesReadReply, MessagesSyncDiffEntry, UnionMessageReply } from '@enbox/dwn-sdk-js';
 
 import type { EnboxPlatformAgent } from './types/agent.js';
-import type { PermissionsApi } from './types/permissions.js';
 import type { PermanentPushFailure, PushResult } from './types/sync.js';
 
 import { DwnInterfaceName, DwnMethodName, Encoder, Message } from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from './types/dwn.js';
 import { isRecordsWrite } from './utils.js';
+import { toMessagesPermissionGrantIds } from './sync-permission-grants.js';
 import { topologicalSort } from './sync-topological-sort.js';
-import { getMessagesPermissionGrantId, toMessagesPermissionGrantIds } from './sync-permission-grants.js';
 
 /** Maximum data size (in bytes) to buffer in memory for retry. Larger payloads are re-fetched. */
 const MAX_BUFFER_SIZE = 1_048_576; // 1 MB
@@ -104,16 +103,15 @@ export async function getMessageCid(message: GenericMessage): Promise<string> {
  * Large payloads are re-fetched on retry since buffering them would consume
  * too much memory.
  */
-export async function pullMessages({ did, dwnUrl, delegateDid, protocol, messageCids, prefetched, agent, permissionsApi }: {
+export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, prefetched, agent }: {
   did: string;
   dwnUrl: string;
   delegateDid?: string;
-  protocol?: string;
+  permissionGrantIds?: string[];
   messageCids: string[];
   /** Pre-fetched message entries from the batched diff response (already have message + data). */
   prefetched?: MessagesSyncDiffEntry[];
   agent: EnboxPlatformAgent;
-  permissionsApi: PermissionsApi;
 }): Promise<string[]> {
   // Convert prefetched diff entries into SyncMessageEntry format.
   const prefetchedEntries: SyncMessageEntry[] = [];
@@ -138,7 +136,7 @@ export async function pullMessages({ did, dwnUrl, delegateDid, protocol, message
 
   // Step 1: Fetch remaining messages (not prefetched) from the remote.
   const fetched = messageCids.length > 0
-    ? await fetchRemoteMessages({ did, dwnUrl, delegateDid, protocol, messageCids, agent, permissionsApi })
+    ? await fetchRemoteMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, agent })
     : [];
 
   // Merge prefetched entries with remotely fetched ones.
@@ -189,7 +187,7 @@ export async function pullMessages({ did, dwnUrl, delegateDid, protocol, message
 
       // Re-fetch only the large-payload messages that we couldn't buffer.
       if (needsRefetch.length > 0) {
-        const reFetched = await fetchRemoteMessages({ did, dwnUrl, delegateDid, protocol, messageCids: needsRefetch, agent, permissionsApi });
+        const reFetched = await fetchRemoteMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids: needsRefetch, agent });
         canRetry.push(...reFetched);
       }
 
@@ -269,24 +267,15 @@ async function bufferSmallStreams(entries: SyncMessageEntry[]): Promise<void> {
 /**
  * Fetches messages from a remote DWN by their CIDs using MessagesRead.
  */
-export async function fetchRemoteMessages({ did, dwnUrl, delegateDid, protocol, messageCids, agent, permissionsApi }: {
+export async function fetchRemoteMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, agent }: {
   did: string;
   dwnUrl: string;
   delegateDid?: string;
-  protocol?: string;
+  permissionGrantIds?: string[];
   messageCids: string[];
   agent: EnboxPlatformAgent;
-  permissionsApi: PermissionsApi;
 }): Promise<SyncMessageEntry[]> {
   const results: SyncMessageEntry[] = [];
-
-  const permissionGrantId = await getMessagesPermissionGrantId({
-    did,
-    delegateDid,
-    protocol,
-    messageType: DwnInterface.MessagesRead,
-    permissionsApi,
-  });
 
   // Fetch messages in parallel with bounded concurrency.  Keep this low
   // to avoid bursting through the remote server's rate limits during sync.
@@ -305,7 +294,7 @@ export async function fetchRemoteMessages({ did, dwnUrl, delegateDid, protocol, 
         target        : did,
         messageType   : DwnInterface.MessagesRead,
         granteeDid    : delegateDid,
-        messageParams : { messageCid, permissionGrantIds: toMessagesPermissionGrantIds(permissionGrantId) }
+        messageParams : { messageCid, permissionGrantIds: toMessagesPermissionGrantIds(permissionGrantIds) }
       });
 
       let reply: MessagesReadReply;
@@ -353,14 +342,13 @@ export async function fetchRemoteMessages({ did, dwnUrl, delegateDid, protocol, 
  * on the first failure. Callers use this to advance the push checkpoint
  * incrementally — only up to the highest contiguous success.
  */
-export async function pushMessages({ did, dwnUrl, delegateDid, protocol, messageCids, agent, permissionsApi }: {
+export async function pushMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, agent }: {
   did: string;
   dwnUrl: string;
   delegateDid?: string;
-  protocol?: string;
+  permissionGrantIds?: string[];
   messageCids: string[];
   agent: EnboxPlatformAgent;
-  permissionsApi: PermissionsApi;
 }): Promise<PushResult> {
   const succeeded: string[] = [];
   const failed: string[] = [];
@@ -369,7 +357,7 @@ export async function pushMessages({ did, dwnUrl, delegateDid, protocol, message
   // Step 1: Fetch all local messages (streams are pull-based, not yet consumed).
   const fetched: SyncMessageEntry[] = [];
   for (const messageCid of messageCids) {
-    const dwnMessage = await getLocalMessage({ author: did, messageCid, delegateDid, protocol, agent, permissionsApi });
+    const dwnMessage = await getLocalMessage({ author: did, messageCid, delegateDid, permissionGrantIds, agent });
     if (dwnMessage) {
       fetched.push(dwnMessage);
     } else {
@@ -437,28 +425,19 @@ export async function pushMessages({ did, dwnUrl, delegateDid, protocol, message
 /**
  * Reads a message from the local DWN by its CID using MessagesRead.
  */
-export async function getLocalMessage({ author, delegateDid, protocol, messageCid, agent, permissionsApi }: {
+export async function getLocalMessage({ author, delegateDid, permissionGrantIds, messageCid, agent }: {
   author: string;
   delegateDid?: string;
-  protocol?: string;
+  permissionGrantIds?: string[];
   messageCid: string;
   agent: EnboxPlatformAgent;
-  permissionsApi: PermissionsApi;
 }): Promise<SyncMessageEntry | undefined> {
-  const permissionGrantId = await getMessagesPermissionGrantId({
-    did         : author,
-    delegateDid,
-    protocol,
-    messageType : DwnInterface.MessagesRead,
-    permissionsApi,
-  });
-
   const { reply } = await agent.dwn.processRequest({
     author,
     target        : author,
     messageType   : DwnInterface.MessagesRead,
     granteeDid    : delegateDid,
-    messageParams : { messageCid, permissionGrantIds: toMessagesPermissionGrantIds(permissionGrantId) }
+    messageParams : { messageCid, permissionGrantIds: toMessagesPermissionGrantIds(permissionGrantIds) }
   });
 
   if (reply.status.code !== 200 || !reply.entry) {

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -1,50 +1,123 @@
 import type { DwnInterface } from './types/dwn.js';
-import type { PermissionsApi } from './types/permissions.js';
 import type { GenericMessage, GenericSignaturePayload } from '@enbox/dwn-sdk-js';
+import type { NonEmptyStringArray, SyncAuthorizationGrant, SyncProtocolSet } from './types/sync.js';
+import type { PermissionGrantEntry, PermissionsApi } from './types/permissions.js';
 
-import { Jws, Message } from '@enbox/dwn-sdk-js';
+import { Jws, Message, PermissionScopeMatcher } from '@enbox/dwn-sdk-js';
 
-/**
- * Converts the sync planner's current single selected grant into the Messages
- * wire shape. MessagesRead, MessagesSubscribe, and MessagesSync always carry
- * grant invocations as `permissionGrantIds`.
- */
-export function toMessagesPermissionGrantIds(permissionGrantId: string | undefined): string[] | undefined {
-  // TODO(sync Phase 5): current sync requests resolve one grant per scoped request.
-  // Replace this boundary adapter when canonical scope-union sync builds true grant sets.
-  return permissionGrantId === undefined ? undefined : [permissionGrantId];
+/** Returns a sorted, duplicate-free grant ID set, or `undefined` for owner requests. */
+export function toMessagesPermissionGrantIds(permissionGrantIds: string[] | undefined): NonEmptyStringArray | undefined {
+  if (permissionGrantIds === undefined || permissionGrantIds.length === 0) {
+    return undefined;
+  }
+  return [...new Set(permissionGrantIds)].sort((a, b) => a.localeCompare(b)) as NonEmptyStringArray;
 }
 
 /**
- * Gets the permission grant ID for a single-scope Messages operation.
- * Owner-authored requests do not need a grant, so no delegate DID returns
- * `undefined`.
+ * Gets the active permission grant IDs that authorize a Messages operation.
+ *
+ * Owner-authored sync does not invoke grants. Delegate full sync requires at
+ * least one active unscoped Messages.Read grant. Delegate protocol-set sync
+ * requires each requested protocol to be covered by an active Messages.Read
+ * grant, then invokes every active grant that participates in the projection.
+ * This keeps the authorization epoch tied to grant churn without widening the
+ * CID projection being compared.
  */
-export async function getMessagesPermissionGrantId({
+export async function getMessagesPermissionGrantsForScope({
   did,
   delegateDid,
-  protocol,
+  protocols,
   messageType,
   permissionsApi,
 }: {
   did: string;
   delegateDid?: string;
-  protocol?: string;
+  protocols?: SyncProtocolSet;
   messageType: DwnInterface.MessagesRead | DwnInterface.MessagesSubscribe | DwnInterface.MessagesSync;
   permissionsApi: PermissionsApi;
-}): Promise<string | undefined> {
+}): Promise<PermissionGrantEntry[]> {
   if (!delegateDid) {
-    return undefined;
+    return [];
   }
 
-  const grant = await permissionsApi.getPermissionForRequest({
-    connectedDid : did,
-    messageType,
-    delegateDid,
-    protocol,
-    cached       : true
-  });
-  return grant.grant.id;
+  const now = new Date().toISOString();
+  const permissionGrants = (await permissionsApi.fetchGrants({
+    author  : delegateDid,
+    target  : delegateDid,
+    grantor : did,
+    grantee : delegateDid,
+  })).filter(entry => isActiveMessagesGrant(entry, did, delegateDid, now));
+
+  const requestedProtocols = protocols ?? [undefined];
+  for (const protocol of requestedProtocols) {
+    if (!permissionGrants.some(entry => grantMatchesProtocol(entry, protocol))) {
+      throw new Error(`SyncPermissions: No active Messages.Read permission found for ${messageType}: ${protocol ?? 'all protocols'}`);
+    }
+  }
+
+  return permissionGrants
+    .filter(entry => grantParticipatesInProjection(entry, protocols))
+    .sort((a, b) => a.grant.id.localeCompare(b.grant.id));
+}
+
+/** Converts permission grant entries into authorization epoch inputs. */
+export function toSyncAuthorizationGrants(permissionGrants: PermissionGrantEntry[]): [SyncAuthorizationGrant, ...SyncAuthorizationGrant[]] {
+  if (permissionGrants.length === 0) {
+    throw new Error('SyncPermissions: delegate authorization requires at least one grant.');
+  }
+  return permissionGrants
+    .map(({ grant }) => ({
+      dateExpires : grant.dateExpires,
+      dateGranted : grant.dateGranted,
+      id          : grant.id,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id)) as [SyncAuthorizationGrant, ...SyncAuthorizationGrant[]];
+}
+
+function isActiveMessagesGrant(
+  entry: PermissionGrantEntry,
+  grantor: string,
+  grantee: string,
+  now: string,
+): boolean {
+  const { grant } = entry;
+  if (grant.grantor !== grantor || grant.grantee !== grantee) {
+    return false;
+  }
+
+  if (grant.dateGranted > now || grant.dateExpires <= now) {
+    return false;
+  }
+
+  const scope = grant.scope;
+  return scope.interface === 'Messages' &&
+    scope.method === 'Read';
+}
+
+function grantMatchesProtocol(
+  entry: PermissionGrantEntry,
+  protocol: string | undefined,
+): boolean {
+  return PermissionScopeMatcher.matches(entry.grant.scope, { protocol });
+}
+
+function grantParticipatesInProjection(
+  entry: PermissionGrantEntry,
+  protocols: SyncProtocolSet | undefined,
+): boolean {
+  const { scope } = entry.grant;
+
+  if (protocols === undefined) {
+    return scope.protocol === undefined;
+  }
+
+  return scope.protocol === undefined ||
+    (typeof scope.protocol === 'string' && protocols.includes(scope.protocol));
+}
+
+/** Returns sorted grant IDs from permission grant entries. */
+export function permissionGrantIdsFromEntries(permissionGrants: PermissionGrantEntry[]): NonEmptyStringArray | undefined {
+  return toMessagesPermissionGrantIds(permissionGrants.map(entry => entry.grant.id));
 }
 
 /**

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -5,12 +5,13 @@ import type { PermissionGrantEntry, PermissionsApi } from './types/permissions.j
 
 import { Jws, Message, PermissionScopeMatcher } from '@enbox/dwn-sdk-js';
 
+import { lexicographicalCompare } from './types/sync.js';
 /** Returns a sorted, duplicate-free grant ID set, or `undefined` for owner requests. */
 export function toMessagesPermissionGrantIds(permissionGrantIds: string[] | undefined): NonEmptyStringArray | undefined {
   if (permissionGrantIds === undefined || permissionGrantIds.length === 0) {
     return undefined;
   }
-  return [...new Set(permissionGrantIds)].sort((a, b) => a.localeCompare(b)) as NonEmptyStringArray;
+  return [...new Set(permissionGrantIds)].sort(lexicographicalCompare) as NonEmptyStringArray;
 }
 
 /**
@@ -57,7 +58,7 @@ export async function getMessagesPermissionGrantsForScope({
 
   return permissionGrants
     .filter(entry => grantParticipatesInProjection(entry, protocols))
-    .sort((a, b) => a.grant.id.localeCompare(b.grant.id));
+    .sort((a, b) => lexicographicalCompare(a.grant.id, b.grant.id));
 }
 
 /** Converts permission grant entries into authorization epoch inputs. */
@@ -71,7 +72,7 @@ export function toSyncAuthorizationGrants(permissionGrants: PermissionGrantEntry
       dateGranted : grant.dateGranted,
       id          : grant.id,
     }))
-    .sort((a, b) => a.id.localeCompare(b.id)) as [SyncAuthorizationGrant, ...SyncAuthorizationGrant[]];
+    .sort((a, b) => lexicographicalCompare(a.id, b.id)) as [SyncAuthorizationGrant, ...SyncAuthorizationGrant[]];
 }
 
 function isActiveMessagesGrant(

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -125,12 +125,10 @@ export function permissionGrantIdsFromEntries(permissionGrants: PermissionGrantE
  * Returns the permission grant IDs invoked by a message.
  *
  * Real DWN messages use the author signature payload as the source of truth.
- * Unsigned in-memory fixtures fall back to descriptor fields so dependency
- * helpers can remain small and deterministic in unit tests.
  */
 export function getInvokedPermissionGrantIds(message: GenericMessage): string[] {
   if (message.authorization === undefined) {
-    return Message.getPermissionGrantIds(message.descriptor as unknown as GenericSignaturePayload);
+    return [];
   }
 
   try {

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -1,6 +1,6 @@
 import type { DwnInterface } from './types/dwn.js';
 import type { GenericMessage, GenericSignaturePayload } from '@enbox/dwn-sdk-js';
-import type { NonEmptyStringArray, SyncAuthorizationGrant, SyncProtocolSet } from './types/sync.js';
+import type { NonEmptyStringArray, SyncAuthorizationGrant } from './types/sync.js';
 import type { PermissionGrantEntry, PermissionsApi } from './types/permissions.js';
 
 import { Jws, Message, PermissionScopeMatcher } from '@enbox/dwn-sdk-js';
@@ -33,7 +33,7 @@ export async function getMessagesPermissionGrantsForScope({
 }: {
   did: string;
   delegateDid?: string;
-  protocols?: SyncProtocolSet;
+  protocols?: NonEmptyStringArray;
   messageType: DwnInterface.MessagesRead | DwnInterface.MessagesSubscribe | DwnInterface.MessagesSync;
   permissionsApi: PermissionsApi;
 }): Promise<PermissionGrantEntry[]> {
@@ -104,7 +104,7 @@ function grantMatchesProtocol(
 
 function grantParticipatesInProjection(
   entry: PermissionGrantEntry,
-  protocols: SyncProtocolSet | undefined,
+  protocols: NonEmptyStringArray | undefined,
 ): boolean {
   const { scope } = entry.grant;
 

--- a/packages/agent/src/sync-replication-ledger.ts
+++ b/packages/agent/src/sync-replication-ledger.ts
@@ -1,9 +1,9 @@
 import type { AbstractLevel } from 'abstract-level';
 import type { ProgressToken } from '@enbox/dwn-sdk-js';
 
-import type { DirectionCheckpoint, LinkStatus, ReplicationLinkState, SyncScope } from './types/sync.js';
+import type { DirectionCheckpoint, LinkStatus, ReplicationLinkState, SyncAuthorization, SyncScope } from './types/sync.js';
 
-import { computeScopeId } from './types/sync.js';
+import { canonicalizeSyncScope, computeProjectionId } from './types/sync.js';
 
 /** Separator used in compound LevelDB keys. */
 const KEY_SEP = '^';
@@ -13,7 +13,7 @@ const KEY_SEP = '^';
  * sync link in a LevelDB sublevel. Provides CRUD operations and replication
  * checkpoint helpers.
  *
- * Key format: `{tenantDid}^{remoteEndpoint}^{scopeId}`
+ * Key format: `{tenantDid}^{remoteEndpoint}^{projectionId}^{authorizationEpoch}`
  *
  * Each link tracks independent pull and push {@link DirectionCheckpoint}s.
  * The ledger does not own subscriptions or timers — it is a passive state
@@ -33,13 +33,19 @@ export class ReplicationLedger {
   // ---------------------------------------------------------------------------
 
   /** Build the compound key for a link. */
-  private static buildKey(tenantDid: string, remoteEndpoint: string, scopeId: string): string {
-    return `${tenantDid}${KEY_SEP}${remoteEndpoint}${KEY_SEP}${scopeId}`;
+  private static buildKey(
+    tenantDid: string,
+    remoteEndpoint: string,
+    projectionId: string,
+    authorizationEpoch: string,
+  ): string {
+    return `${tenantDid}${KEY_SEP}${remoteEndpoint}${KEY_SEP}${projectionId}${KEY_SEP}${authorizationEpoch}`;
   }
 
   // Note: compound keys use raw '^' separator. This is safe because tenantDid
-  // (DID URI), remoteEndpoint (URL), and scopeId (base64url hash) cannot
-  // contain '^'. If future fields can contain '^', keys must be escaped.
+  // (DID URI), remoteEndpoint (URL), projectionId (base64url hash), and
+  // authorizationEpoch (base64url hash) cannot contain '^'. If future fields
+  // can contain '^', keys must be escaped.
 
   // ---------------------------------------------------------------------------
   // CRUD
@@ -53,11 +59,18 @@ export class ReplicationLedger {
     tenantDid : string;
     remoteEndpoint : string;
     scope : SyncScope;
+    authorizationEpoch : string;
+    authorization : SyncAuthorization;
     delegateDid? : string;
-    protocol? : string;
   }): Promise<ReplicationLinkState> {
-    const scopeId = await computeScopeId(params.scope);
-    const key = ReplicationLedger.buildKey(params.tenantDid, params.remoteEndpoint, scopeId);
+    const scope = canonicalizeSyncScope(params.scope);
+    const projectionId = await computeProjectionId(params.tenantDid, scope);
+    const key = ReplicationLedger.buildKey(
+      params.tenantDid,
+      params.remoteEndpoint,
+      projectionId,
+      params.authorizationEpoch,
+    );
 
     try {
       const raw = await this.sublevel.get(key);
@@ -76,16 +89,17 @@ export class ReplicationLedger {
 
     // Create a new link with empty checkpoints.
     const link: ReplicationLinkState = {
-      tenantDid      : params.tenantDid,
-      remoteEndpoint : params.remoteEndpoint,
-      scopeId,
-      scope          : params.scope,
-      status         : 'initializing',
-      connectivity   : 'unknown',
-      pull           : {},
-      needsReconcile : false,
-      delegateDid    : params.delegateDid,
-      protocol       : params.protocol,
+      tenantDid          : params.tenantDid,
+      remoteEndpoint     : params.remoteEndpoint,
+      projectionId,
+      authorizationEpoch : params.authorizationEpoch,
+      scope,
+      authorization      : params.authorization,
+      status             : 'initializing',
+      connectivity       : 'unknown',
+      pull               : {},
+      needsReconcile     : false,
+      delegateDid        : params.delegateDid,
     };
 
     await this.sublevel.put(key, JSON.stringify(link));
@@ -94,14 +108,24 @@ export class ReplicationLedger {
 
   /** Persist the current state of a link. */
   public async saveLink(link: ReplicationLinkState): Promise<void> {
-    const key = ReplicationLedger.buildKey(link.tenantDid, link.remoteEndpoint, link.scopeId);
+    const key = ReplicationLedger.buildKey(
+      link.tenantDid,
+      link.remoteEndpoint,
+      link.projectionId,
+      link.authorizationEpoch,
+    );
     link.lastActivityAt = new Date().toISOString();
     await this.sublevel.put(key, JSON.stringify(link));
   }
 
   /** Delete a link. */
-  public async deleteLink(tenantDid: string, remoteEndpoint: string, scopeId: string): Promise<void> {
-    const key = ReplicationLedger.buildKey(tenantDid, remoteEndpoint, scopeId);
+  public async deleteLink(
+    tenantDid: string,
+    remoteEndpoint: string,
+    projectionId: string,
+    authorizationEpoch: string,
+  ): Promise<void> {
+    const key = ReplicationLedger.buildKey(tenantDid, remoteEndpoint, projectionId, authorizationEpoch);
     await this.sublevel.del(key);
   }
 
@@ -124,31 +148,6 @@ export class ReplicationLedger {
       links.push(JSON.parse(value) as ReplicationLinkState);
     }
     return links;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Delegate updates
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Update the `delegateDid` on all persisted links for a tenant and persist.
-   * This ensures that repair and reconcile paths — which read `delegateDid`
-   * from the durable {@link ReplicationLinkState} — use the current delegate
-   * after a hot-swap via `updateIdentityOptions()`.
-   *
-   * @returns the links that were updated.
-   */
-  public async updateDelegateDid(tenantDid: string, delegateDid: string | undefined): Promise<ReplicationLinkState[]> {
-    const links = await this.getLinksForTenant(tenantDid);
-    const updated: ReplicationLinkState[] = [];
-    for (const link of links) {
-      if (link.delegateDid !== delegateDid) {
-        link.delegateDid = delegateDid;
-        await this.saveLink(link);
-        updated.push(link);
-      }
-    }
-    return updated;
   }
 
   // ---------------------------------------------------------------------------
@@ -245,4 +244,3 @@ export class ReplicationLedger {
     }
   }
 }
-

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -34,22 +34,23 @@ export type SyncMode = 'poll' | 'live';
 // ---------------------------------------------------------------------------
 
 /**
- * Projection-root algorithm used for B1 sync links.
+ * Projection-root algorithm used by the current full/protocol sync scopes.
  *
- * B1 compares either the existing full-tenant StateIndex root or existing
+ * Sync compares either the existing full-tenant StateIndex root or existing
  * per-protocol StateIndex roots. ProtocolPath/contextId projection roots are
- * intentionally not represented here; they belong to the later B2 root builder.
+ * intentionally not represented here; add a projection-root builder before
+ * enabling those scopes.
  */
-export const SYNC_PROJECTION_ROOT_VERSION = 'b1-state-index-root-v1';
+export const SYNC_PROJECTION_ROOT_VERSION = 'state-index-full-protocol-root-v1';
 
 /**
- * Authorization-epoch algorithm used for B1 sync links.
+ * Authorization-epoch algorithm used by delegated Messages.Read sync links.
  *
  * The authorization epoch is separate from the projection ID: re-granting the
  * same scope or changing delegate grants must invalidate in-flight work without
  * changing the primary CID set being compared.
  */
-export const SYNC_AUTHORIZATION_EPOCH_VERSION = 'b1-messages-read-grants-v1';
+export const SYNC_AUTHORIZATION_EPOCH_VERSION = 'messages-read-grants-v1';
 
 /** A non-empty, sorted, duplicate-free string list. */
 export type NonEmptyStringArray = [string, ...string[]];
@@ -60,9 +61,10 @@ export type SyncProtocolSet = NonEmptyStringArray;
 /**
  * Describes the primary CID set a replication link syncs.
  *
- * B1 supports full-tenant sync and protocol-set sync. A protocol-set link owns
+ * Sync currently supports full-tenant sync and protocol-set sync. A protocol-set link owns
  * one durable subscription/cursor for the whole set; reconciliation still walks
- * the existing per-protocol roots until B2 adds arbitrary projection roots.
+ * the existing per-protocol roots until dedicated path/context projection roots
+ * are implemented.
  */
 export type SyncScope = {
   /** Full-tenant projection. Valid only for owner sync or unscoped delegated grants. */
@@ -103,7 +105,7 @@ export function normalizeSyncProtocols(protocols: [string, ...string[]] | string
   return unique as SyncProtocolSet;
 }
 
-/** Converts persisted identity options into the canonical B1 sync scope. */
+/** Converts persisted identity options into the canonical sync scope. */
 export function syncScopeFromProtocols(protocols: SyncIdentityOptions['protocols']): SyncScope {
   return protocols === 'all'
     ? { kind: 'full' }
@@ -147,7 +149,7 @@ export function canonicalizeSyncScope(scope: SyncScope): SyncScope {
 /**
  * Computes a deterministic, collision-resistant projection ID.
  *
- * The projection ID is derived from tenant DID, normalized scope, and the B1
+ * The projection ID is derived from tenant DID, normalized scope, and the
  * projection-root algorithm version. It intentionally excludes endpoint,
  * grant IDs, authorization epoch, and remote diff contents.
  */

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -359,22 +359,35 @@ export type StartSyncParams = {
 // Sync observability events
 // ---------------------------------------------------------------------------
 
+/** Sync scope metadata attached to observability events. */
+export type SyncEventScope = {
+  /** Present only when the event belongs to a single-protocol link. */
+  protocol?: string;
+  /** Present when the event belongs to a protocol-set link. */
+  protocols?: SyncProtocolSet;
+};
+
+type SyncEventBase = {
+  tenantDid: string;
+  remoteEndpoint: string;
+} & SyncEventScope;
+
 /**
  * Events emitted by the sync engine at key state transitions.
  * Consumers subscribe via `SyncEngine.on('event', handler)` and can
  * hook these into metrics, logging, or UI state.
  */
 export type SyncEvent =
-  | { type: 'link:status-change'; tenantDid: string; remoteEndpoint: string; protocol?: string; from: LinkStatus; to: LinkStatus }
-  | { type: 'link:connectivity-change'; tenantDid: string; remoteEndpoint: string; protocol?: string; from: SyncConnectivityState; to: SyncConnectivityState }
-  | { type: 'checkpoint:pull-advance'; tenantDid: string; remoteEndpoint: string; protocol?: string; position: string; messageCid: string }
-  | { type: 'reconcile:needed'; tenantDid: string; remoteEndpoint: string; protocol?: string; reason: string }
-  | { type: 'reconcile:completed'; tenantDid: string; remoteEndpoint: string; protocol?: string }
-  | { type: 'repair:started'; tenantDid: string; remoteEndpoint: string; protocol?: string; attempt: number }
-  | { type: 'repair:completed'; tenantDid: string; remoteEndpoint: string; protocol?: string }
-  | { type: 'repair:failed'; tenantDid: string; remoteEndpoint: string; protocol?: string; attempt: number; error: string }
-  | { type: 'degraded-poll:entered'; tenantDid: string; remoteEndpoint: string; protocol?: string }
-  | { type: 'gap:detected'; tenantDid: string; remoteEndpoint: string; protocol?: string; reason: string };
+  | SyncEventBase & { type: 'link:status-change'; from: LinkStatus; to: LinkStatus }
+  | SyncEventBase & { type: 'link:connectivity-change'; from: SyncConnectivityState; to: SyncConnectivityState }
+  | SyncEventBase & { type: 'checkpoint:pull-advance'; position: string; messageCid: string }
+  | SyncEventBase & { type: 'reconcile:needed'; reason: string }
+  | SyncEventBase & { type: 'reconcile:completed' }
+  | SyncEventBase & { type: 'repair:started'; attempt: number }
+  | SyncEventBase & { type: 'repair:completed' }
+  | SyncEventBase & { type: 'repair:failed'; attempt: number; error: string }
+  | SyncEventBase & { type: 'degraded-poll:entered' }
+  | SyncEventBase & { type: 'gap:detected'; reason: string };
 
 export type SyncEventListener = (event: SyncEvent) => void;
 

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -62,9 +62,6 @@ export const SYNC_AUTHORIZATION_EPOCH_VERSION = 'messages-read-grants-v1';
 /** A non-empty, sorted, duplicate-free string list. */
 export type NonEmptyStringArray = [string, ...string[]];
 
-/** A non-empty, sorted, duplicate-free protocol URI list. */
-export type SyncProtocolSet = NonEmptyStringArray;
-
 /**
  * Describes the primary CID set a replication link syncs.
  *
@@ -79,7 +76,7 @@ export type SyncScope = {
 } | {
   /** Protocol-set projection over one or more protocol roots. */
   kind: 'protocolSet';
-  protocols: SyncProtocolSet;
+  protocols: NonEmptyStringArray;
 };
 
 /**
@@ -104,12 +101,12 @@ export type SyncAuthorizationGrant = {
 /**
  * Normalizes a protocol list into canonical scope-union order.
  */
-export function normalizeSyncProtocols(protocols: [string, ...string[]] | string[]): SyncProtocolSet {
+export function normalizeSyncProtocols(protocols: [string, ...string[]] | string[]): NonEmptyStringArray {
   const unique = [...new Set(protocols)].sort(lexicographicalCompare);
   if (unique.length === 0) {
     throw new Error('SyncScope: protocol-set scope requires at least one protocol URI.');
   }
-  return unique as SyncProtocolSet;
+  return unique as NonEmptyStringArray;
 }
 
 /** Converts persisted identity options into the canonical sync scope. */
@@ -120,7 +117,7 @@ export function syncScopeFromProtocols(protocols: SyncIdentityOptions['protocols
 }
 
 /** Returns the protocol list covered by a scope, or `undefined` for full scope. */
-export function protocolsForSyncScope(scope: SyncScope): SyncProtocolSet | undefined {
+export function protocolsForSyncScope(scope: SyncScope): NonEmptyStringArray | undefined {
   return scope.kind === 'protocolSet' ? scope.protocols : undefined;
 }
 
@@ -364,7 +361,7 @@ export type SyncEventScope = {
   /** Present only when the event belongs to a single-protocol link. */
   protocol?: string;
   /** Present when the event belongs to a protocol-set link. */
-  protocols?: SyncProtocolSet;
+  protocols?: NonEmptyStringArray;
 };
 
 type SyncEventBase = {

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -2,6 +2,13 @@ import type { ProgressToken } from '@enbox/dwn-sdk-js';
 
 import type { EnboxPlatformAgent } from './agent.js';
 
+/** Deterministic bytewise string comparator for hash inputs and canonical IDs. */
+export function lexicographicalCompare(a: string, b: string): number {
+  if (a > b) { return 1; }
+  if (a < b) { return -1; }
+  return 0;
+}
+
 /**
  * The SyncEngine is responsible for syncing messages between the agent and the platform.
  */
@@ -98,7 +105,7 @@ export type SyncAuthorizationGrant = {
  * Normalizes a protocol list into canonical scope-union order.
  */
 export function normalizeSyncProtocols(protocols: [string, ...string[]] | string[]): SyncProtocolSet {
-  const unique = [...new Set(protocols)].sort((a, b) => a.localeCompare(b));
+  const unique = [...new Set(protocols)].sort(lexicographicalCompare);
   if (unique.length === 0) {
     throw new Error('SyncScope: protocol-set scope requires at least one protocol URI.');
   }
@@ -181,7 +188,7 @@ export async function computeAuthorizationEpoch(input:
   }
 
   const grants = [...input.grants]
-    .sort((a, b) => a.id.localeCompare(b.id))
+    .sort((a, b) => lexicographicalCompare(a.id, b.id))
     .map(grant => ({
       dateExpires : grant.dateExpires,
       dateGranted : grant.dateGranted,

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -34,62 +34,164 @@ export type SyncMode = 'poll' | 'live';
 // ---------------------------------------------------------------------------
 
 /**
- * Describes what a replication link syncs. Currently whole-tenant only
- * (`kind: 'full'`). Scoped subset sync (`kind: 'protocol'` with
- * `protocolPathPrefixes` / `contextIdPrefixes`) is deferred to Phase 3.
+ * Projection-root algorithm used for B1 sync links.
+ *
+ * B1 compares either the existing full-tenant StateIndex root or existing
+ * per-protocol StateIndex roots. ProtocolPath/contextId projection roots are
+ * intentionally not represented here; they belong to the later B2 root builder.
+ */
+export const SYNC_PROJECTION_ROOT_VERSION = 'b1-state-index-root-v1';
+
+/**
+ * Authorization-epoch algorithm used for B1 sync links.
+ *
+ * The authorization epoch is separate from the projection ID: re-granting the
+ * same scope or changing delegate grants must invalidate in-flight work without
+ * changing the primary CID set being compared.
+ */
+export const SYNC_AUTHORIZATION_EPOCH_VERSION = 'b1-messages-read-grants-v1';
+
+/** A non-empty, sorted, duplicate-free string list. */
+export type NonEmptyStringArray = [string, ...string[]];
+
+/** A non-empty, sorted, duplicate-free protocol URI list. */
+export type SyncProtocolSet = NonEmptyStringArray;
+
+/**
+ * Describes the primary CID set a replication link syncs.
+ *
+ * B1 supports full-tenant sync and protocol-set sync. A protocol-set link owns
+ * one durable subscription/cursor for the whole set; reconciliation still walks
+ * the existing per-protocol roots until B2 adds arbitrary projection roots.
  */
 export type SyncScope = {
-  /** Scope kind. Only `'full'` is implemented in Phase 1. */
+  /** Full-tenant projection. Valid only for owner sync or unscoped delegated grants. */
   kind: 'full';
 } | {
-  /**
-   * Protocol-scoped sync. Deferred to Phase 3 — included here for type
-   * forward-compatibility only.
-   */
-  kind: 'protocol';
-  protocol: string;
-  protocolPathPrefixes?: string[];
-  contextIdPrefixes?: string[];
+  /** Protocol-set projection over one or more protocol roots. */
+  kind: 'protocolSet';
+  protocols: SyncProtocolSet;
 };
 
 /**
- * Computes a deterministic, collision-resistant identifier for a {@link SyncScope}.
- *
- * The ID is `base64url(SHA-256(canonicalJSON))` where `canonicalJSON` is the
- * scope object with keys sorted alphabetically and array values sorted
- * lexicographically.
- *
- * Used as part of the LevelDB key for the replication ledger:
- * `{tenantDid}^{remoteEndpoint}^{scopeId}`.
+ * Authorization context for a link. Owner links do not invoke grants. Delegate
+ * links carry the active Messages.Read grants that authorize the scope union.
  */
-export async function computeScopeId(scope: SyncScope): Promise<string> {
-  const canonical: Record<string, unknown> = { kind: scope.kind };
-  if (scope.kind === 'protocol') {
-    canonical.protocol = scope.protocol;
-    if (scope.protocolPathPrefixes !== undefined) {
-      canonical.protocolPathPrefixes = [...new Set(scope.protocolPathPrefixes)].sort((a, b) => a.localeCompare(b));
-    }
-    if (scope.contextIdPrefixes !== undefined) {
-      canonical.contextIdPrefixes = [...new Set(scope.contextIdPrefixes)].sort((a, b) => a.localeCompare(b));
-    }
-  }
+export type SyncAuthorization =
+  | { kind: 'owner' }
+  | {
+    kind: 'delegate';
+    delegateDid: string;
+    permissionGrantIds: NonEmptyStringArray;
+  };
 
-  // Stable JSON: keys sorted by construction order (kind < protocol < protocolPathPrefixes).
-  const json = JSON.stringify(canonical);
+/** Grant metadata that participates in delegated authorization-epoch hashing. */
+export type SyncAuthorizationGrant = {
+  id: string;
+  dateExpires: string;
+  dateGranted?: string;
+};
+
+/**
+ * Normalizes a protocol list into canonical scope-union order.
+ */
+export function normalizeSyncProtocols(protocols: [string, ...string[]] | string[]): SyncProtocolSet {
+  const unique = [...new Set(protocols)].sort((a, b) => a.localeCompare(b));
+  if (unique.length === 0) {
+    throw new Error('SyncScope: protocol-set scope requires at least one protocol URI.');
+  }
+  return unique as SyncProtocolSet;
+}
+
+/** Converts persisted identity options into the canonical B1 sync scope. */
+export function syncScopeFromProtocols(protocols: SyncIdentityOptions['protocols']): SyncScope {
+  return protocols === 'all'
+    ? { kind: 'full' }
+    : { kind: 'protocolSet', protocols: normalizeSyncProtocols(protocols) };
+}
+
+/** Returns the protocol list covered by a scope, or `undefined` for full scope. */
+export function protocolsForSyncScope(scope: SyncScope): SyncProtocolSet | undefined {
+  return scope.kind === 'protocolSet' ? scope.protocols : undefined;
+}
+
+/** Returns the single covered protocol, or `undefined` for full/multi-protocol scopes. */
+export function singleProtocolForSyncScope(scope: SyncScope): string | undefined {
+  return scope.kind === 'protocolSet' && scope.protocols.length === 1 ? scope.protocols[0] : undefined;
+}
+
+/** Stable base64url SHA-256 hash for canonical JSON objects. */
+async function hashCanonicalObject(value: Record<string, unknown>): Promise<string> {
+  const json = JSON.stringify(value);
   const bytes = new TextEncoder().encode(json);
   const hashBuffer = await crypto.subtle.digest('SHA-256', bytes);
   const hashArray = new Uint8Array(hashBuffer);
 
-  // base64url encode (no padding).
   let base64 = '';
   for (const b of hashArray) {
     base64 += String.fromCharCode(b);
   }
   const result = btoa(base64).replaceAll('+', '-').replaceAll('/', '_');
-  // Strip trailing '=' padding without regex quantifiers (avoids ReDoS scanners).
   let end = result.length;
-  while (end > 0 && result.codePointAt(end - 1) === 61) { end--; } // 61 === '='
+  while (end > 0 && result.codePointAt(end - 1) === 61) { end--; }
   return end === result.length ? result : result.slice(0, end);
+}
+
+/** Returns a canonical JSON-ready representation of a sync scope. */
+export function canonicalizeSyncScope(scope: SyncScope): SyncScope {
+  return scope.kind === 'full'
+    ? { kind: 'full' }
+    : { kind: 'protocolSet', protocols: normalizeSyncProtocols(scope.protocols) };
+}
+
+/**
+ * Computes a deterministic, collision-resistant projection ID.
+ *
+ * The projection ID is derived from tenant DID, normalized scope, and the B1
+ * projection-root algorithm version. It intentionally excludes endpoint,
+ * grant IDs, authorization epoch, and remote diff contents.
+ */
+export async function computeProjectionId(tenantDid: string, scope: SyncScope): Promise<string> {
+  const canonicalScope = canonicalizeSyncScope(scope);
+  return hashCanonicalObject({
+    scope   : canonicalScope,
+    tenantDid,
+    version : SYNC_PROJECTION_ROOT_VERSION,
+  });
+}
+
+/**
+ * Computes the authorization epoch for a link.
+ *
+ * Owner epochs are stable for the owner projection. Delegate epochs are derived
+ * from the delegate DID plus the active grant IDs and expiry metadata. A changed
+ * grant set creates a new link key even when the projection ID is unchanged.
+ */
+export async function computeAuthorizationEpoch(input:
+  | { kind: 'owner' }
+  | { kind: 'delegate'; delegateDid: string; grants: [SyncAuthorizationGrant, ...SyncAuthorizationGrant[]] }
+): Promise<string> {
+  if (input.kind === 'owner') {
+    return hashCanonicalObject({
+      kind    : 'owner',
+      version : SYNC_AUTHORIZATION_EPOCH_VERSION,
+    });
+  }
+
+  const grants = [...input.grants]
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map(grant => ({
+      dateExpires : grant.dateExpires,
+      dateGranted : grant.dateGranted,
+      id          : grant.id,
+    }));
+
+  return hashCanonicalObject({
+    delegateDid : input.delegateDid,
+    grants,
+    kind        : 'delegate',
+    version     : SYNC_AUTHORIZATION_EPOCH_VERSION,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -146,7 +248,7 @@ export type LinkStatus = 'initializing' | 'live' | 'repairing' | 'degraded_poll'
 /**
  * Durable state of a single replication link. Persisted to LevelDB and
  * loaded on startup. Each link is identified by the tuple
- * `(tenantDid, remoteEndpoint, scopeId)`.
+ * `(tenantDid, remoteEndpoint, projectionId, authorizationEpoch)`.
  */
 export type ReplicationLinkState = {
   /** The tenant DID this link syncs for. */
@@ -155,11 +257,17 @@ export type ReplicationLinkState = {
   /** The remote DWN endpoint URL. */
   remoteEndpoint: string;
 
-  /** Deterministic hash of the {@link SyncScope}. See {@link computeScopeId}. */
-  scopeId: string;
+  /** Deterministic hash of tenant DID, normalized scope, and root algorithm version. */
+  projectionId: string;
+
+  /** Deterministic hash of owner/delegate grant context for this link. */
+  authorizationEpoch: string;
 
   /** The scope definition this link covers. */
   scope: SyncScope;
+
+  /** Owner/delegate authorization context used to sign sync messages. */
+  authorization: SyncAuthorization;
 
   /** Current link status. */
   status: LinkStatus;
@@ -180,15 +288,6 @@ export type ReplicationLinkState = {
 
   /** Delegate DID used to sign sync messages, if any. */
   delegateDid?: string;
-
-  /**
-   * Protocol filter for this link, if any. Duplicates the protocol in `scope`
-   * for operational convenience — used by permission lookups and cursor key
-   * building. The scope is the source of truth for what to sync; this field
-   * is the source of truth for how to authenticate. To be consolidated in
-   * Phase 3 when scope resolution is more complex.
-   */
-  protocol?: string;
 
   /** ISO-8601 timestamp of last successful sync activity. */
   lastActivityAt?: string;

--- a/packages/agent/tests/sync-characterization.spec.ts
+++ b/packages/agent/tests/sync-characterization.spec.ts
@@ -56,6 +56,29 @@ function createLiveMockAgent(): LiveMockAgent {
 
 describe('SyncEngineLevel — characterization tests', () => {
   let db: Level<string, string>;
+  const linkKey = 'did:example:alice^https://dwn.example.com^projection-1^authorization-1';
+  const scope = { kind: 'protocolSet', protocols: ['https://proto.example.com'] };
+  const target = {
+    did                : 'did:example:alice',
+    dwnUrl             : 'https://dwn.example.com',
+    scope,
+    authorization      : { kind: 'owner' },
+    authorizationEpoch : 'authorization-1',
+  };
+
+  const makeLink = (overrides: Record<string, unknown> = {}): any => ({
+    tenantDid          : 'did:example:alice',
+    remoteEndpoint     : 'https://dwn.example.com',
+    projectionId       : 'projection-1',
+    authorizationEpoch : 'authorization-1',
+    authorization      : { kind: 'owner' },
+    scope,
+    status             : 'initializing',
+    pull               : {},
+    connectivity       : 'unknown',
+    needsReconcile     : false,
+    ...overrides,
+  });
 
   beforeAll(async () => {
     db = new Level<string, string>('__TESTDATA__/sync-characterization-spec');
@@ -74,17 +97,7 @@ describe('SyncEngineLevel — characterization tests', () => {
     const { agent, getRemoteHandler } = createLiveMockAgent();
     const engine = new SyncEngineLevel({ db, agent });
 
-    const link = {
-      tenantDid      : 'did:example:alice',
-      remoteEndpoint : 'https://dwn.example.com',
-      scopeId        : 'scope-1',
-      scope          : { kind: 'protocol', protocol: 'https://proto.example.com' },
-      status         : 'initializing',
-      pull           : {},
-      connectivity   : 'unknown',
-      needsReconcile : false,
-      protocol       : 'https://proto.example.com',
-    } as any;
+    const link = makeLink();
 
     const saveLinkStub = sinon.stub().resolves();
     const setStatusStub = sinon.stub().callsFake(async (l: any, status: string): Promise<void> => {
@@ -92,9 +105,7 @@ describe('SyncEngineLevel — characterization tests', () => {
     });
 
     sinon.stub(engine, 'sync').resolves();
-    sinon.stub(engine as any, 'getSyncTargets').resolves([
-      { did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: 'https://proto.example.com' },
-    ]);
+    sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
     sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
     (engine as any)._ledger = {
       getOrCreateLink : sinon.stub().resolves(link),
@@ -125,22 +136,10 @@ describe('SyncEngineLevel — characterization tests', () => {
     const { agent, getLocalHandler } = createLiveMockAgent();
     const engine = new SyncEngineLevel({ db, agent });
 
-    const link = {
-      tenantDid      : 'did:example:alice',
-      remoteEndpoint : 'https://dwn.example.com',
-      scopeId        : 'scope-1',
-      scope          : { kind: 'protocol', protocol: 'https://proto.example.com' },
-      status         : 'initializing',
-      pull           : {},
-      connectivity   : 'unknown',
-      needsReconcile : false,
-      protocol       : 'https://proto.example.com',
-    } as any;
+    const link = makeLink();
 
     sinon.stub(engine, 'sync').resolves();
-    sinon.stub(engine as any, 'getSyncTargets').resolves([
-      { did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: 'https://proto.example.com' },
-    ]);
+    sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
     sinon.stub(engine as any, 'openLivePullSubscription').resolves();
     (engine as any)._ledger = {
       getOrCreateLink : sinon.stub().resolves(link),
@@ -171,22 +170,10 @@ describe('SyncEngineLevel — characterization tests', () => {
     const { agent } = createLiveMockAgent();
     const engine = new SyncEngineLevel({ db, agent });
 
-    const link = {
-      tenantDid      : 'did:example:alice',
-      remoteEndpoint : 'https://dwn.example.com',
-      scopeId        : 'scope-1',
-      scope          : { kind: 'protocol', protocol: 'https://proto.example.com' },
-      status         : 'initializing',
-      pull           : {},
-      connectivity   : 'unknown',
-      needsReconcile : true,
-      protocol       : 'https://proto.example.com',
-    } as any;
+    const link = makeLink({ needsReconcile: true });
 
     sinon.stub(engine, 'sync').resolves();
-    sinon.stub(engine as any, 'getSyncTargets').resolves([
-      { did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: 'https://proto.example.com' },
-    ]);
+    sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
     sinon.stub(engine as any, 'openLivePullSubscription').resolves();
     sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
     const reconcileStub = sinon.stub(engine as any, 'reconcileLink').resolves();
@@ -202,32 +189,20 @@ describe('SyncEngineLevel — characterization tests', () => {
     await clock.tickAsync(1_000);
 
     expect(reconcileStub.calledOnce).toBe(true);
-    expect(reconcileStub.firstCall.args[0]).toBe('did:example:alice^https://dwn.example.com^scope-1');
+    expect(reconcileStub.firstCall.args[0]).toBe(linkKey);
 
     await engine.stopSync();
     clock.restore();
   });
 
-  it('routes ProgressGap startup failures into repair using scopeId-based link identity', async () => {
+  it('routes ProgressGap startup failures into repair using projection authorization link identity', async () => {
     const { agent } = createLiveMockAgent();
     const engine = new SyncEngineLevel({ db, agent });
 
-    const link = {
-      tenantDid      : 'did:example:alice',
-      remoteEndpoint : 'https://dwn.example.com',
-      scopeId        : 'scope-1',
-      scope          : { kind: 'protocol', protocol: 'https://proto.example.com' },
-      status         : 'initializing',
-      pull           : {},
-      connectivity   : 'unknown',
-      needsReconcile : false,
-      protocol       : 'https://proto.example.com',
-    } as any;
+    const link = makeLink();
 
     sinon.stub(engine, 'sync').resolves();
-    sinon.stub(engine as any, 'getSyncTargets').resolves([
-      { did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: 'https://proto.example.com' },
-    ]);
+    sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
     sinon.stub(engine as any, 'openLivePullSubscription').rejects({
       isProgressGap : true,
       gapInfo       : { latestAvailable: { streamId: 's1', epoch: 'e1', position: '7', messageCid: 'cid-7' } },
@@ -242,7 +217,7 @@ describe('SyncEngineLevel — characterization tests', () => {
     await engine.startSync({ mode: 'live', interval: '30s' });
 
     expect(transitionStub.calledOnce).toBe(true);
-    expect(transitionStub.firstCall.args[0]).toBe('did:example:alice^https://dwn.example.com^scope-1');
+    expect(transitionStub.firstCall.args[0]).toBe(linkKey);
     expect(transitionStub.firstCall.args[1]).toBe(link);
   });
 
@@ -250,24 +225,12 @@ describe('SyncEngineLevel — characterization tests', () => {
     const { agent, getRemoteHandler } = createLiveMockAgent();
     const engine = new SyncEngineLevel({ db, agent });
 
-    const link = {
-      tenantDid      : 'did:example:alice',
-      remoteEndpoint : 'https://dwn.example.com',
-      scopeId        : 'scope-1',
-      scope          : { kind: 'protocol', protocol: 'https://proto.example.com' },
-      status         : 'live',
-      pull           : {},
-      connectivity   : 'unknown',
-      needsReconcile : true,
-      protocol       : 'https://proto.example.com',
-    } as any;
+    const link = makeLink({ status: 'live', needsReconcile: true });
 
     const saveLinkStub = sinon.stub().resolves();
     sinon.stub(engine as any, 'scheduleReconcile').callsFake((): void => {});
     sinon.stub(engine, 'sync').resolves();
-    sinon.stub(engine as any, 'getSyncTargets').resolves([
-      { did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: 'https://proto.example.com' },
-    ]);
+    sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
     sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
     (engine as any)._ledger = {
       getOrCreateLink : sinon.stub().resolves(link),
@@ -288,7 +251,7 @@ describe('SyncEngineLevel — characterization tests', () => {
     });
 
     expect((engine as any).scheduleReconcile.called).toBe(true);
-    expect((engine as any).scheduleReconcile.lastCall.args[0]).toBe('did:example:alice^https://dwn.example.com^scope-1');
+    expect((engine as any).scheduleReconcile.lastCall.args[0]).toBe(linkKey);
     expect((engine as any).scheduleReconcile.lastCall.args[1]).toBe(500);
 
     await engine.stopSync();

--- a/packages/agent/tests/sync-closure-integration.spec.ts
+++ b/packages/agent/tests/sync-closure-integration.spec.ts
@@ -91,7 +91,7 @@ describe('evaluateClosure — integration with real DWN', () => {
       const result = await evaluateClosure(
         message as GenericMessage,
         messageStore,
-        { kind: 'protocol', protocol: protocolDef.protocol },
+        { kind: 'protocolSet', protocols: [protocolDef.protocol] },
         createClosureContext(tenant),
       );
 
@@ -117,7 +117,7 @@ describe('evaluateClosure — integration with real DWN', () => {
       const result = await evaluateClosure(
         fakeMessage,
         messageStore,
-        { kind: 'protocol', protocol: 'https://example.com/unknown-protocol' },
+        { kind: 'protocolSet', protocols: ['https://example.com/unknown-protocol'] },
         createClosureContext(tenant),
       );
 
@@ -186,7 +186,7 @@ describe('evaluateClosure — integration with real DWN', () => {
       const result = await evaluateClosure(
         msgMsg as GenericMessage,
         messageStore,
-        { kind: 'protocol', protocol: threadProtocol.protocol },
+        { kind: 'protocolSet', protocols: [threadProtocol.protocol] },
         createClosureContext(tenant),
       );
 
@@ -254,7 +254,7 @@ describe('evaluateClosure — integration with real DWN', () => {
       const result = await evaluateClosure(
         message as GenericMessage,
         messageStore,
-        { kind: 'protocol', protocol: grantProtocol.protocol },
+        { kind: 'protocolSet', protocols: [grantProtocol.protocol] },
         createClosureContext(tenant),
       );
 

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -105,9 +105,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'protocolsConfigure')).toBe(true);
@@ -117,9 +115,7 @@ describe('evaluateClosure', () => {
       const msg = mockMessage({ protocol: 'https://example.com/proto', dateCreated: '2025-01-01T00:00:00.000000Z' });
       const store = mockMessageStore(); // no protocols in store
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.ProtocolMetadataMissing);
@@ -146,9 +142,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'initialWrite')).toBe(true);
@@ -171,9 +165,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.InitialWriteMissing);
@@ -198,9 +190,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'parentRecord')).toBe(true);
@@ -222,9 +212,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.ParentChainMissing);
@@ -247,9 +235,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.InitialWriteMissing);
@@ -276,9 +262,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'permissionGrant')).toBe(true);
@@ -303,9 +287,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'permissionGrant')).toBe(true);
@@ -327,9 +309,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.GrantMissing);
@@ -376,9 +356,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.GrantNotYetActive);
@@ -407,9 +385,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.GrantExpired);
@@ -448,9 +424,7 @@ describe('evaluateClosure', () => {
       ctx.grantCache.set(grantId, grantRecord);
       ctx.grantCache.set(`revocation:${grantId}`, revocationRecord);
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, ctx);
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, ctx);
 
       expect(result.complete).toBe(false);
       expect(result.failure!.detail).toContain('revoked');
@@ -478,9 +452,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
     });
@@ -516,9 +488,7 @@ describe('evaluateClosure', () => {
       ctx.grantCache.set(grantId, grantRecord);
       ctx.grantCache.set(`revocation:${grantId}`, revocationRecord);
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, ctx);
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, ctx);
 
       // Grant was valid at the message's timestamp — revocation came later.
       expect(result.complete).toBe(true);
@@ -545,9 +515,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'contextRoot')).toBe(true);
@@ -569,9 +537,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.ContextChainMissing);
@@ -593,9 +559,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.every(e => e.label !== 'contextRoot')).toBe(true);
@@ -647,9 +611,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       // No class 4 squash edges — squash scope comes from the message itself.
@@ -699,9 +661,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'encryptionKeyMaterial')).toBe(true);
@@ -746,9 +706,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       // keyDeliveryProtocol edge IS present (protocol definition level).
@@ -806,9 +764,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/chat',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/chat',] }, createClosureContext('did:example:alice'));
 
       // Closure should FAIL: multi-party context but no contextKey.
       expect(result.complete).toBe(false);
@@ -884,9 +840,7 @@ describe('evaluateClosure', () => {
         return { messages: [] };
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/chat',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/chat',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'contextKeyRecord')).toBe(true);
@@ -931,9 +885,7 @@ describe('evaluateClosure', () => {
 
       // Non-delegate: closure FAILS because keyDeliveryProtocol is missing.
       const ownerCtx = createClosureContext('did:example:alice');
-      const ownerResult = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/wallet',
-      }, ownerCtx);
+      const ownerResult = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/wallet',] }, ownerCtx);
 
       expect(ownerResult.complete).toBe(false);
       expect(ownerResult.failure!.code).toBe(ClosureFailureCode.EncryptionDependencyMissing);
@@ -943,9 +895,7 @@ describe('evaluateClosure', () => {
       const delegateCtx = createClosureContext('did:example:alice', undefined, {
         isDelegateSession: true,
       });
-      const delegateResult = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/wallet',
-      }, delegateCtx);
+      const delegateResult = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/wallet',] }, delegateCtx);
 
       expect(delegateResult.complete).toBe(true);
       // The edge is suppressed at extraction time — it does not appear in the graph.
@@ -1007,9 +957,7 @@ describe('evaluateClosure', () => {
       const ctx = createClosureContext('did:example:alice', undefined, {
         isDelegateSession: true,
       });
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/chat',
-      }, ctx);
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/chat',] }, ctx);
 
       // Both keyDeliveryProtocol and contextKeyRecord are real dependencies
       // for multi-party delegates.  keyDeliveryProtocol is resolved first
@@ -1072,9 +1020,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://comments.example.com',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://comments.example.com',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'crossProtocolConfig')).toBe(true);
@@ -1124,9 +1070,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://comments.example.com',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://comments.example.com',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.CrossProtocolReferenceMissing);
@@ -1232,9 +1176,7 @@ describe('evaluateClosure', () => {
         }
       );
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://comments.example.com',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://comments.example.com',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'crossProtocolRoleRecord')).toBe(true);
@@ -1300,9 +1242,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://comments.example.com',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://comments.example.com',] }, createClosureContext('did:example:alice'));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.CrossProtocolReferenceMissing);
@@ -1345,9 +1285,7 @@ describe('evaluateClosure', () => {
         ]),
       });
 
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://comments.example.com',
-      }, createClosureContext('did:example:alice'));
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://comments.example.com',] }, createClosureContext('did:example:alice'));
 
       // Class 2 parentRecord check fires first (before class 6 crossProtocolParent).
       expect(result.complete).toBe(false);
@@ -1385,9 +1323,7 @@ describe('evaluateClosure', () => {
       const store = mockMessageStore({ queryResults: messages });
 
       // Set maxDepth to 3 — the chain of 5+ parents should exceed it.
-      const result = await evaluateClosure(root, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, createClosureContext('did:example:alice', 3));
+      const result = await evaluateClosure(root, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, createClosureContext('did:example:alice', 3));
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.DepthExceeded);
@@ -1409,7 +1345,7 @@ describe('evaluateClosure', () => {
       const results = await evaluateClosureBatch(
         [msg1, msg2],
         store,
-        { kind: 'protocol', protocol: 'https://example.com/proto' },
+        { kind: 'protocolSet', protocols: ['https://example.com/proto'] },
         'did:example:alice',
       );
 
@@ -1438,9 +1374,7 @@ describe('evaluateClosure', () => {
       ctx.satisfiedDeps.add('protocolsConfigure:protocol:https://example.com/proto');
 
       const msg = mockMessage({ protocol: 'https://example.com/proto', dateCreated: '2025-01-01T00:00:00.000000Z' });
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, ctx);
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, ctx);
 
       expect(result.complete).toBe(true);
       // No queries should have been made — dependency was pre-satisfied.
@@ -1455,9 +1389,7 @@ describe('evaluateClosure', () => {
       ctx.missingDeps.add('protocolsConfigure:protocol:https://example.com/proto');
 
       const msg = mockMessage({ protocol: 'https://example.com/proto', dateCreated: '2025-01-01T00:00:00.000000Z' });
-      const result = await evaluateClosure(msg, store, {
-        kind: 'protocol', protocol: 'https://example.com/proto',
-      }, ctx);
+      const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, ctx);
 
       expect(result.complete).toBe(false);
       expect(result.failure!.code).toBe(ClosureFailureCode.ProtocolMetadataMissing);

--- a/packages/agent/tests/sync-engine-identity.spec.ts
+++ b/packages/agent/tests/sync-engine-identity.spec.ts
@@ -7,6 +7,17 @@ import { SyncEngineLevel } from '../src/sync-engine-level.js';
 
 describe('SyncEngineLevel — identity management', () => {
   let db: Level<string, string>;
+  const messagesGrantEntry = (id: string, grantor: string, grantee: string, scope: Record<string, unknown>): any => ({
+    grant: {
+      id,
+      grantor,
+      grantee,
+      dateGranted : '2026-01-01T00:00:00.000000Z',
+      dateExpires : '2999-01-01T00:00:00.000000Z',
+      scope,
+    },
+    message: {},
+  });
   let syncEngine: SyncEngineLevel;
 
   beforeAll(async () => {
@@ -215,7 +226,7 @@ describe('SyncEngineLevel — identity management', () => {
       expect(targets[1].dwnUrl).toBe('https://dwn2.example.com');
     });
 
-    it('should produce one target per protocol per URL when protocols is a list', async () => {
+    it('should produce one protocol-set target per URL when protocols is a list', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
@@ -230,9 +241,12 @@ describe('SyncEngineLevel — identity management', () => {
       });
       const targets = await (engine as any).getSyncTargets();
 
-      expect(targets).toHaveLength(2);
-      expect(targets[0].protocol).toBe('https://proto1.example.com');
-      expect(targets[1].protocol).toBe('https://proto2.example.com');
+      expect(targets).toHaveLength(1);
+      expect(targets[0].scope).toEqual({
+        kind      : 'protocolSet',
+        protocols : ['https://proto1.example.com', 'https://proto2.example.com'],
+      });
+      expect(targets[0].authorization).toEqual({ kind: 'owner' });
     });
 
     it('should skip identity when stored JSON is corrupt', async () => {
@@ -265,6 +279,11 @@ describe('SyncEngineLevel — identity management', () => {
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
+      (engine as any)._permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          messagesGrantEntry('grant-1', 'did:example:delegated', 'did:example:delegate', { interface: 'Messages', method: 'Read' }),
+        ]),
+      };
 
       await engine.registerIdentity({
         did     : 'did:example:delegated',
@@ -274,6 +293,11 @@ describe('SyncEngineLevel — identity management', () => {
 
       expect(targets).toHaveLength(1);
       expect(targets[0].delegateDid).toBe('did:example:delegate');
+      expect(targets[0].authorization).toEqual({
+        kind               : 'delegate',
+        delegateDid        : 'did:example:delegate',
+        permissionGrantIds : ['grant-1'],
+      });
     });
 
     it('should handle mixed all and scoped registrations', async () => {
@@ -296,12 +320,15 @@ describe('SyncEngineLevel — identity management', () => {
 
       const targets = await (engine as any).getSyncTargets();
 
-      // Alice produces 1 unscoped target, Bob produces 1 scoped target.
+      // Alice produces 1 full target, Bob produces 1 protocol-set target.
       expect(targets).toHaveLength(2);
       const aliceTarget = targets.find((t: any) => t.did === 'did:example:alice');
       const bobTarget = targets.find((t: any) => t.did === 'did:example:bob');
-      expect(aliceTarget!.protocol).toBeUndefined();
-      expect(bobTarget!.protocol).toBe('https://proto.example.com/chat/1.0');
+      expect(aliceTarget!.scope).toEqual({ kind: 'full' });
+      expect(bobTarget!.scope).toEqual({
+        kind      : 'protocolSet',
+        protocols : ['https://proto.example.com/chat/1.0'],
+      });
     });
   });
 
@@ -722,22 +749,25 @@ describe('SyncEngineLevel — identity management', () => {
       expect(openPushStub.called).toBe(false);
     });
 
-    it('addIdentityToLiveSync should create per-protocol targets when protocols are specified', async () => {
+    it('addIdentityToLiveSync should create one protocol-set target when protocols are specified', async () => {
       const engine = new SyncEngineLevel({ db });
       const mockAgent = {
         dwn: { getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']) },
       };
       (engine as any)._agent = mockAgent;
 
-      const ledgerStub = sinon.stub().resolves({
-        tenantDid      : 'did:example:proto',
-        remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'scope1',
-        scope          : { kind: 'protocol', protocol: '' },
-        status         : 'initializing',
-        pull           : {},
-        connectivity   : 'unknown',
-      });
+      const ledgerStub = sinon.stub().callsFake(async (params: any) => ({
+        tenantDid          : 'did:example:proto',
+        remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-1',
+        authorizationEpoch : params.authorizationEpoch,
+        authorization      : params.authorization,
+        scope              : params.scope,
+        status             : 'initializing',
+        pull               : {},
+        connectivity       : 'unknown',
+        needsReconcile     : false,
+      }));
       sinon.stub(engine as any, 'ledger').get(() => ({
         getOrCreateLink : ledgerStub,
         saveLink        : sinon.stub().resolves(),
@@ -751,9 +781,12 @@ describe('SyncEngineLevel — identity management', () => {
         protocols: ['https://proto1.example', 'https://proto2.example'],
       });
 
-      expect(ledgerStub.callCount).toBe(2);
-      expect(ledgerStub.firstCall.args[0].scope).toEqual({ kind: 'protocol', protocol: 'https://proto1.example' });
-      expect(ledgerStub.secondCall.args[0].scope).toEqual({ kind: 'protocol', protocol: 'https://proto2.example' });
+      expect(ledgerStub.calledOnce).toBe(true);
+      expect(ledgerStub.firstCall.args[0].scope).toEqual({
+        kind      : 'protocolSet',
+        protocols : ['https://proto1.example', 'https://proto2.example'],
+      });
+      expect(ledgerStub.firstCall.args[0].authorization).toEqual({ kind: 'owner' });
     });
 
     it('addIdentityToLiveSync should create a full-tenant link when protocols is all', async () => {
@@ -763,15 +796,18 @@ describe('SyncEngineLevel — identity management', () => {
       };
       (engine as any)._agent = mockAgent;
 
-      const ledgerStub = sinon.stub().resolves({
-        tenantDid      : 'did:example:full',
-        remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'scope-full',
-        scope          : { kind: 'full' },
-        status         : 'initializing',
-        pull           : {},
-        connectivity   : 'unknown',
-      });
+      const ledgerStub = sinon.stub().callsFake(async (params: any) => ({
+        tenantDid          : 'did:example:full',
+        remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-full',
+        authorizationEpoch : params.authorizationEpoch,
+        authorization      : params.authorization,
+        scope              : params.scope,
+        status             : 'initializing',
+        pull               : {},
+        connectivity       : 'unknown',
+        needsReconcile     : false,
+      }));
       sinon.stub(engine as any, 'ledger').get(() => ({
         getOrCreateLink : ledgerStub,
         saveLink        : sinon.stub().resolves(),
@@ -795,15 +831,18 @@ describe('SyncEngineLevel — identity management', () => {
       (engine as any)._agent = mockAgent;
 
       sinon.stub(engine as any, 'ledger').get(() => ({
-        getOrCreateLink: sinon.stub().resolves({
-          tenantDid      : 'did:example:pushfail',
-          remoteEndpoint : 'https://dwn.example.com',
-          scopeId        : 'scope1',
-          scope          : { kind: 'full' },
-          status         : 'initializing',
-          pull           : {},
-          connectivity   : 'unknown',
-        }),
+        getOrCreateLink: sinon.stub().callsFake(async (params: any) => ({
+          tenantDid          : 'did:example:pushfail',
+          remoteEndpoint     : 'https://dwn.example.com',
+          projectionId       : 'projection-1',
+          authorizationEpoch : params.authorizationEpoch,
+          authorization      : params.authorization,
+          scope              : { kind: 'full' },
+          status             : 'initializing',
+          pull               : {},
+          connectivity       : 'unknown',
+          needsReconcile     : false,
+        })),
         saveLink  : sinon.stub().resolves(),
         setStatus : sinon.stub().resolves(),
       }));
@@ -821,7 +860,7 @@ describe('SyncEngineLevel — identity management', () => {
 
       expect(pullCloseSpy.calledOnce).toBe(true);
       expect((engine as any)._liveSubscriptions).toHaveLength(0);
-      expect((engine as any)._activeLinks.has('did:example:pushfail^https://dwn.example.com^scope1')).toBe(false);
+      expect([...((engine as any)._activeLinks.keys())].some((key: string) => key.startsWith('did:example:pushfail^https://dwn.example.com^projection-1^'))).toBe(false);
     });
   });
 

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -3281,6 +3281,25 @@ describe('SyncEngineLevel', () => {
       };
     }
 
+    function withAuthorizationPayload(
+      entry: { message: GenericMessage },
+      payloadProperties: Record<string, unknown>
+    ): { message: GenericMessage } {
+      const payload = Buffer.from(JSON.stringify(payloadProperties)).toString('base64url');
+      return {
+        ...entry,
+        message: {
+          ...entry.message,
+          authorization: {
+            signature: {
+              payload,
+              signatures: [{ protected: payload, signature: 'fake' }],
+            },
+          },
+        } as unknown as GenericMessage,
+      };
+    }
+
     it('returns messages unchanged when there is only one message', () => {
       const msg = mockMessage({});
       const result = SyncEngineLevel.topologicalSort([msg]);
@@ -3333,10 +3352,13 @@ describe('SyncEngineLevel', () => {
         },
         { recordId: grantRecordId }
       );
-      const dependent = mockMessage({
-        permissionGrantId : grantRecordId,
-        messageTimestamp  : '2024-01-02T00:00:00.000000Z',
-      });
+      const dependent = withAuthorizationPayload(
+        mockMessage({
+          permissionGrantId : grantRecordId,
+          messageTimestamp  : '2024-01-02T00:00:00.000000Z',
+        }),
+        { permissionGrantId: grantRecordId }
+      );
       // Pass dependent first, grant second.
       const result = SyncEngineLevel.topologicalSort([dependent, grant]);
       expect(result[0]).toBe(grant);
@@ -3345,10 +3367,13 @@ describe('SyncEngineLevel', () => {
 
     it('does not crash when permissionGrantId references a grant not in the batch', () => {
       const msg1 = mockMessage({ messageTimestamp: '2024-01-01T00:00:00.000000Z' });
-      const msg2 = mockMessage({
-        permissionGrantId : 'grant-not-in-batch',
-        messageTimestamp  : '2024-01-02T00:00:00.000000Z',
-      });
+      const msg2 = withAuthorizationPayload(
+        mockMessage({
+          permissionGrantId : 'grant-not-in-batch',
+          messageTimestamp  : '2024-01-02T00:00:00.000000Z',
+        }),
+        { permissionGrantId: 'grant-not-in-batch' }
+      );
       // Should not throw; no edge is added because the grant is not in the batch.
       const result = SyncEngineLevel.topologicalSort([msg1, msg2]);
       expect(result).toHaveLength(2);
@@ -3382,15 +3407,18 @@ describe('SyncEngineLevel', () => {
         },
         { recordId: parentRecordId }
       );
-      const child = mockMessage(
-        {
-          protocol          : protocolUrl,
-          parentId          : parentRecordId,
-          permissionGrantId : grantRecordId,
-          dateCreated       : '2024-01-03T00:00:00.000000Z',
-          messageTimestamp  : '2024-01-03T00:00:00.000000Z',
-        },
-        { recordId: 'child-1' }
+      const child = withAuthorizationPayload(
+        mockMessage(
+          {
+            protocol          : protocolUrl,
+            parentId          : parentRecordId,
+            permissionGrantId : grantRecordId,
+            dateCreated       : '2024-01-03T00:00:00.000000Z',
+            messageTimestamp  : '2024-01-03T00:00:00.000000Z',
+          },
+          { recordId: 'child-1' }
+        ),
+        { permissionGrantId: grantRecordId }
       );
 
       // Pass in reverse dependency order.

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -2934,48 +2934,48 @@ describe('SyncEngineLevel', () => {
     // -----------------------------------------------------------------------
 
     describe('multi-identity live sync hardening (#898)', () => {
+      const ownerAuthorization = {
+        authorization      : { kind: 'owner' as const },
+        authorizationEpoch : 'owner-epoch',
+      };
+
+      const linkKeyFor = (did: string, dwnUrl: string, link: { projectionId: string; authorizationEpoch: string }): string =>
+        `${did}^${dwnUrl}^${link.projectionId}^${link.authorizationEpoch}`;
 
       // -----------------------------------------------------------------------
-      // Item 1: delegateDid updates persist to durable ReplicationLinkState
+      // Item 1: authorization changes hot-swap links without mutating old epochs
       // -----------------------------------------------------------------------
 
-      describe('delegateDid persistence on existing links', () => {
+      describe('authorization epoch isolation on option updates', () => {
 
-        it('should persist new delegateDid to the ledger before hot-swap during updateIdentityOptions', async () => {
+        it('should hot-swap live links without rewriting existing durable link authorization', async () => {
           const did = alice.did.uri;
 
-          // Register the identity.
           await syncEngine.registerIdentity({
             did,
             options: { protocols: 'all', delegateDid: 'did:example:old-delegate' },
           });
 
-          // Put the engine in live mode but stub out the subscription methods to
-          // avoid real WebSocket connections.
           syncEngine['_syncMode'] = 'live';
 
-          // Manually create a link in the ledger to simulate an already-live link.
           const ledger = syncEngine['ledger'];
           const link = await ledger.getOrCreateLink({
-            tenantDid      : did,
-            remoteEndpoint : testDwnUrls[0],
-            scope          : { kind: 'full' },
-            delegateDid    : 'did:example:old-delegate',
+            tenantDid          : did,
+            remoteEndpoint     : testDwnUrls[0],
+            scope              : { kind: 'full' },
+            authorizationEpoch : 'old-delegate-epoch',
+            authorization      : {
+              kind               : 'delegate',
+              delegateDid        : 'did:example:old-delegate',
+              permissionGrantIds : ['old-grant'],
+            },
+            delegateDid: 'did:example:old-delegate',
           });
           expect(link.delegateDid).toBe('did:example:old-delegate');
 
-          // Set the link as active so hasActiveLinksForDid returns true.
-          const linkKey = `${did}^${testDwnUrls[0]}^${link.scopeId}`;
-          syncEngine['_activeLinks'].set(linkKey, link);
+          syncEngine['_activeLinks'].set(linkKeyFor(did, testDwnUrls[0], link), link);
 
-          // Stub removeIdentityFromLiveSync and addIdentityToLiveSync to capture
-          // the ledger state at the time of the hot-swap.
-          let delegateAtRemoveTime: string | undefined;
-          const removeStub = sinon.stub(syncEngine as any, 'removeIdentityFromLiveSync').callsFake(async (): Promise<void> => {
-            // Read the link from the ledger at remove time.
-            const links = await ledger.getLinksForTenant(did);
-            delegateAtRemoveTime = links[0]?.delegateDid;
-          });
+          const removeStub = sinon.stub(syncEngine as any, 'removeIdentityFromLiveSync').resolves();
           const addStub = sinon.stub(syncEngine as any, 'addIdentityToLiveSync').resolves();
 
           await syncEngine.updateIdentityOptions({
@@ -2983,80 +2983,12 @@ describe('SyncEngineLevel', () => {
             options: { protocols: 'all', delegateDid: 'did:example:new-delegate' },
           });
 
-          // The new delegate should have been persisted BEFORE removeIdentityFromLiveSync.
-          expect(delegateAtRemoveTime).toBe('did:example:new-delegate');
-
-          // Verify the ledger was durably updated.
           const reloadedLinks = await ledger.getLinksForTenant(did);
-          expect(reloadedLinks[0].delegateDid).toBe('did:example:new-delegate');
+          expect(reloadedLinks[0].delegateDid).toBe('did:example:old-delegate');
+          expect(reloadedLinks[0].authorizationEpoch).toBe('old-delegate-epoch');
 
           expect(removeStub.calledOnce).toBe(true);
           expect(addStub.calledOnce).toBe(true);
-        });
-
-        it('should persist delegateDid to durable links even when sync is not in live mode', async () => {
-          const did = alice.did.uri;
-
-          await syncEngine.registerIdentity({
-            did,
-            options: { protocols: 'all', delegateDid: 'did:example:old-delegate' },
-          });
-
-          // Engine is NOT in live mode — _syncMode is undefined.
-          expect(syncEngine['_syncMode']).toBeUndefined();
-
-          // Create a durable link in the ledger to simulate a prior session.
-          const ledger = syncEngine['ledger'];
-          await ledger.getOrCreateLink({
-            tenantDid      : did,
-            remoteEndpoint : testDwnUrls[0],
-            scope          : { kind: 'full' },
-            delegateDid    : 'did:example:old-delegate',
-          });
-
-          // Update options with a new delegate while sync is stopped.
-          await syncEngine.updateIdentityOptions({
-            did,
-            options: { protocols: 'all', delegateDid: 'did:example:new-delegate' },
-          });
-
-          // The durable link should have the new delegate even though
-          // we never entered live mode.
-          const reloadedLinks = await ledger.getLinksForTenant(did);
-          expect(reloadedLinks[0].delegateDid).toBe('did:example:new-delegate');
-        });
-
-        it('should persist cleared delegateDid (undefined) when delegate is removed', async () => {
-          const did = alice.did.uri;
-
-          await syncEngine.registerIdentity({
-            did,
-            options: { protocols: 'all', delegateDid: 'did:example:some-delegate' },
-          });
-
-          syncEngine['_syncMode'] = 'live';
-
-          const ledger = syncEngine['ledger'];
-          const link = await ledger.getOrCreateLink({
-            tenantDid      : did,
-            remoteEndpoint : testDwnUrls[0],
-            scope          : { kind: 'full' },
-            delegateDid    : 'did:example:some-delegate',
-          });
-          const linkKey = `${did}^${testDwnUrls[0]}^${link.scopeId}`;
-          syncEngine['_activeLinks'].set(linkKey, link);
-
-          sinon.stub(syncEngine as any, 'removeIdentityFromLiveSync').resolves();
-          sinon.stub(syncEngine as any, 'addIdentityToLiveSync').resolves();
-
-          // Update with no delegate.
-          await syncEngine.updateIdentityOptions({
-            did,
-            options: { protocols: 'all' },
-          });
-
-          const reloadedLinks = await ledger.getLinksForTenant(did);
-          expect(reloadedLinks[0].delegateDid).toBeUndefined();
         });
       });
 
@@ -3077,8 +3009,9 @@ describe('SyncEngineLevel', () => {
             tenantDid      : did,
             remoteEndpoint : testDwnUrls[0],
             scope          : { kind: 'full' },
+            ...ownerAuthorization,
           });
-          const linkKey = `${did}^${testDwnUrls[0]}^${link.scopeId}`;
+          const linkKey = linkKeyFor(did, testDwnUrls[0], link);
           link.status = 'live';
           syncEngine['_activeLinks'].set(linkKey, link);
 
@@ -3113,8 +3046,9 @@ describe('SyncEngineLevel', () => {
             tenantDid      : did,
             remoteEndpoint : testDwnUrls[0],
             scope          : { kind: 'full' },
+            ...ownerAuthorization,
           });
-          const linkKey = `${did}^${testDwnUrls[0]}^${link.scopeId}`;
+          const linkKey = linkKeyFor(did, testDwnUrls[0], link);
           link.status = 'live';
           syncEngine['_activeLinks'].set(linkKey, link);
 
@@ -3166,8 +3100,9 @@ describe('SyncEngineLevel', () => {
             tenantDid      : did,
             remoteEndpoint : testDwnUrls[0],
             scope          : { kind: 'full' },
+            ...ownerAuthorization,
           });
-          const linkKey = `${did}^${testDwnUrls[0]}^${link.scopeId}`;
+          const linkKey = linkKeyFor(did, testDwnUrls[0], link);
           link.status = 'live';
           syncEngine['_activeLinks'].set(linkKey, link);
 
@@ -3215,8 +3150,9 @@ describe('SyncEngineLevel', () => {
             tenantDid      : did,
             remoteEndpoint : testDwnUrls[0],
             scope          : { kind: 'full' },
+            ...ownerAuthorization,
           });
-          const linkKey = `${did}^${testDwnUrls[0]}^${originalLink.scopeId}`;
+          const linkKey = linkKeyFor(did, testDwnUrls[0], originalLink);
           originalLink.status = 'repairing';
           syncEngine['_activeLinks'].set(linkKey, originalLink);
 
@@ -3225,6 +3161,7 @@ describe('SyncEngineLevel', () => {
             tenantDid      : did,
             remoteEndpoint : testDwnUrls[0],
             scope          : { kind: 'full' },
+            ...ownerAuthorization,
           });
           expect(replacementLink).not.toBe(originalLink);
 
@@ -3247,8 +3184,9 @@ describe('SyncEngineLevel', () => {
             tenantDid      : did,
             remoteEndpoint : testDwnUrls[0],
             scope          : { kind: 'full' },
+            ...ownerAuthorization,
           });
-          const linkKey = `${did}^${testDwnUrls[0]}^${originalLink.scopeId}`;
+          const linkKey = linkKeyFor(did, testDwnUrls[0], originalLink);
           originalLink.status = 'live';
           originalLink.needsReconcile = true;
           syncEngine['_activeLinks'].set(linkKey, originalLink);
@@ -3291,8 +3229,9 @@ describe('SyncEngineLevel', () => {
             tenantDid      : did,
             remoteEndpoint : testDwnUrls[0],
             scope          : { kind: 'full' },
+            ...ownerAuthorization,
           });
-          const linkKey = `${did}^${testDwnUrls[0]}^${link.scopeId}`;
+          const linkKey = linkKeyFor(did, testDwnUrls[0], link);
           link.status = 'repairing';
           syncEngine['_activeLinks'].set(linkKey, link);
 

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -528,13 +528,9 @@ describe('SyncEngineLevel', () => {
           }
         });
 
-        // The missing grant causes an error that propagates to the sync()
-        // catch block which logs it via console.error.
-        const consoleErrorSpy = sinon.stub(console, 'error').resolves();
-
-        await syncEngine.sync('pull');
-        expect(consoleErrorSpy.called).toBe(true);
-        expect(consoleErrorSpy.args[0][0]).toContain('SyncEngineLevel: Error syncing');
+        await expect(
+          syncEngine.sync('pull')
+        ).rejects.toThrow('SyncPermissions: No active Messages.Read permission found for MessagesSync: https://protocol.xyz/foo');
       });
 
       it('succeeds with only a MessagesSync grant when messages are inlined in the diff response', async () => {
@@ -1010,13 +1006,9 @@ describe('SyncEngineLevel', () => {
           }
         });
 
-        // The missing grant causes an error that propagates to the sync()
-        // catch block which logs it via console.error.
-        const consoleErrorSpy = sinon.stub(console, 'error').resolves();
-
-        await syncEngine.sync('push');
-        expect(consoleErrorSpy.called).toBe(true);
-        expect(consoleErrorSpy.args[0][0]).toContain('SyncEngineLevel: Error syncing');
+        await expect(
+          syncEngine.sync('push')
+        ).rejects.toThrow('SyncPermissions: No active Messages.Read permission found for MessagesSync: https://protocol.xyz/foo');
       });
 
       it('logs an error when push fails due to missing permissions on the remote DWN', async () => {
@@ -1712,7 +1704,13 @@ describe('SyncEngineLevel', () => {
         }));
 
         const getSyncTargetsStub = sinon.stub(SyncEngineLevel.prototype as any, 'getSyncTargets');
-        getSyncTargetsStub.resolves([{ did: alice.did.uri, dwnUrl: 'http://localhost:3000', delegateDid: undefined, protocol: undefined }]);
+        getSyncTargetsStub.resolves([{
+          did                : alice.did.uri,
+          dwnUrl             : 'http://localhost:3000',
+          scope              : { kind: 'full' },
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'test-owner-epoch',
+        }]);
 
         const getLocalRootStub = sinon.stub(SyncEngineLevel.prototype as any, 'getLocalRoot');
         getLocalRootStub.resolves('aaa');

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -4,13 +4,35 @@ import { Level } from 'level';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 
 import { DwnInterface } from '../src/types/dwn.js';
-import { getMessagesPermissionGrantId } from '../src/sync-permission-grants.js';
+import { getMessagesPermissionGrantsForScope } from '../src/sync-permission-grants.js';
 import { ReplicationLedger } from '../src/sync-replication-ledger.js';
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 
 describe('SyncEngineLevel — private methods', () => {
   let db: Level<string, string>;
   let syncEngine: SyncEngineLevel;
+
+  const syncTarget = (did: string, dwnUrl: string, overrides: Record<string, unknown> = {}): any => ({
+    did,
+    dwnUrl,
+    scope              : { kind: 'full' },
+    authorization      : { kind: 'owner' },
+    authorizationEpoch : 'owner-epoch',
+    ...overrides,
+  });
+
+  const messagesGrantEntry = (id: string, scope: Record<string, unknown>, overrides: Record<string, unknown> = {}): any => ({
+    grant: {
+      id,
+      grantor     : 'did:example:carol',
+      grantee     : 'did:example:delegate',
+      dateGranted : '2026-01-01T00:00:00.000000Z',
+      dateExpires : '2999-01-01T00:00:00.000000Z',
+      scope,
+      ...overrides,
+    },
+    message: {},
+  });
 
   // Track every SyncEngineLevel created in this suite so `afterEach` can
   // clear any pending timers before the next test (and before `afterAll`
@@ -86,16 +108,14 @@ describe('SyncEngineLevel — private methods', () => {
   // ---------------------------------------------------------------------------
 
   describe('buildLinkKey', () => {
-    it('should build key without scopeId/protocol', () => {
-      const key = (syncEngine as any).buildLinkKey('did:example:alice', 'https://dwn.example.com');
-      expect(key).toBe('did:example:alice^https://dwn.example.com');
-    });
-
-    it('should build key with scopeId or protocol', () => {
+    it('should build key from tenant, endpoint, projection ID, and authorization epoch', () => {
       const key = (syncEngine as any).buildLinkKey(
-        'did:example:alice', 'https://dwn.example.com', 'scope-hash-123',
+        'did:example:alice',
+        'https://dwn.example.com',
+        'projection-hash-123',
+        'authorization-epoch-456',
       );
-      expect(key).toBe('did:example:alice^https://dwn.example.com^scope-hash-123');
+      expect(key).toBe('did:example:alice^https://dwn.example.com^projection-hash-123^authorization-epoch-456');
     });
   });
 
@@ -243,54 +263,111 @@ describe('SyncEngineLevel — private methods', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // getMessagesPermissionGrantId
+  // getMessagesPermissionGrantsForScope
   // ---------------------------------------------------------------------------
 
-  describe('getMessagesPermissionGrantId', () => {
-    it('should return undefined when no delegateDid', async () => {
+  describe('getMessagesPermissionGrantsForScope', () => {
+    const grantEntry = (id: string, scope: Record<string, unknown>, overrides: Record<string, unknown> = {}): any => ({
+      grant: {
+        id,
+        grantor     : 'did:example:alice',
+        grantee     : 'did:example:delegate',
+        dateGranted : '2026-01-01T00:00:00.000000Z',
+        dateExpires : '2999-01-01T00:00:00.000000Z',
+        scope,
+        ...overrides,
+      },
+      message: {},
+    });
+
+    it('should return no grants for owner-authored sync', async () => {
       const permissionsApi = {
-        clear                   : sinon.stub(),
-        getPermissionForRequest : sinon.stub(),
+        fetchGrants: sinon.stub(),
       };
 
-      const result = await getMessagesPermissionGrantId({
+      const result = await getMessagesPermissionGrantsForScope({
         did            : 'did:example:alice',
         messageType    : DwnInterface.MessagesSync,
         permissionsApi : permissionsApi as any,
       });
-      expect(result).toBeUndefined();
-      expect(permissionsApi.getPermissionForRequest.called).toBe(false);
+      expect(result).toEqual([]);
+      expect(permissionsApi.fetchGrants.called).toBe(false);
     });
 
-    it('should throw when permission fetch fails for a delegate DID', async () => {
+    it('should return active unscoped grants for delegated full sync', async () => {
+      const unscoped = grantEntry('grant-b', { interface: 'Messages', method: 'Read' });
+      const expired = grantEntry('grant-expired', { interface: 'Messages', method: 'Read' }, {
+        dateExpires: '2026-01-01T00:00:00.000000Z',
+      });
+      const protocolScoped = grantEntry('grant-a', {
+        interface : 'Messages',
+        method    : 'Read',
+        protocol  : 'https://example.com/profile',
+      });
       const permissionsApi = {
-        getPermissionForRequest : sinon.stub().rejects(new Error('not found')),
-        clear                   : sinon.stub(),
+        fetchGrants: sinon.stub().resolves([protocolScoped, expired, unscoped]),
       };
 
-      await expect(
-        getMessagesPermissionGrantId({
-          did            : 'did:example:alice',
-          delegateDid    : 'did:example:delegate',
-          messageType    : DwnInterface.MessagesSync,
-          permissionsApi : permissionsApi as any,
-        })
-      ).rejects.toThrow('not found');
-    });
-
-    it('should return grant ID when delegate permission is found', async () => {
-      const permissionsApi = {
-        getPermissionForRequest : sinon.stub().resolves({ grant: { id: 'grant-123' } }),
-        clear                   : sinon.stub(),
-      };
-
-      const result = await getMessagesPermissionGrantId({
+      const result = await getMessagesPermissionGrantsForScope({
         did            : 'did:example:alice',
         delegateDid    : 'did:example:delegate',
         messageType    : DwnInterface.MessagesSync,
         permissionsApi : permissionsApi as any,
       });
-      expect(result).toBe('grant-123');
+
+      expect(result.map(entry => entry.grant.id)).toEqual(['grant-b']);
+    });
+
+    it('should return all active grants that participate in a protocol-set projection', async () => {
+      const unscoped = grantEntry('grant-c', { interface: 'Messages', method: 'Read' });
+      const profile = grantEntry('grant-b', {
+        interface : 'Messages',
+        method    : 'Read',
+        protocol  : 'https://example.com/profile',
+      });
+      const social = grantEntry('grant-a', {
+        interface : 'Messages',
+        method    : 'Read',
+        protocol  : 'https://example.com/social',
+      });
+      const unrelated = grantEntry('grant-unrelated', {
+        interface : 'Messages',
+        method    : 'Read',
+        protocol  : 'https://example.com/other',
+      });
+      const permissionsApi = {
+        fetchGrants: sinon.stub().resolves([unrelated, unscoped, profile, social]),
+      };
+
+      const result = await getMessagesPermissionGrantsForScope({
+        did            : 'did:example:alice',
+        delegateDid    : 'did:example:delegate',
+        messageType    : DwnInterface.MessagesSync,
+        protocols      : ['https://example.com/social', 'https://example.com/profile'],
+        permissionsApi : permissionsApi as any,
+      });
+
+      expect(result.map(entry => entry.grant.id)).toEqual(['grant-a', 'grant-b', 'grant-c']);
+    });
+
+    it('should reject protocol-set sync when any requested protocol lacks coverage', async () => {
+      const permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          grantEntry('grant-profile', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : 'https://example.com/profile',
+          }),
+        ]),
+      };
+
+      await expect(getMessagesPermissionGrantsForScope({
+        did            : 'did:example:alice',
+        delegateDid    : 'did:example:delegate',
+        messageType    : DwnInterface.MessagesSync,
+        protocols      : ['https://example.com/profile', 'https://example.com/social'],
+        permissionsApi : permissionsApi as any,
+      })).rejects.toThrow('No active Messages.Read permission found');
     });
   });
 
@@ -341,7 +418,7 @@ describe('SyncEngineLevel — private methods', () => {
       expect(targets[0].protocol).toBeUndefined();
     });
 
-    it('should produce one target per protocol per DWN URL', async () => {
+    it('should produce one protocol-set target per DWN URL', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
@@ -355,9 +432,12 @@ describe('SyncEngineLevel — private methods', () => {
       });
 
       const targets = await (engine as any).getSyncTargets();
-      expect(targets).toHaveLength(2);
-      expect(targets[0].protocol).toBe('https://proto1.example.com');
-      expect(targets[1].protocol).toBe('https://proto2.example.com');
+      expect(targets).toHaveLength(1);
+      expect(targets[0].scope).toEqual({
+        kind      : 'protocolSet',
+        protocols : ['https://proto1.example.com', 'https://proto2.example.com'],
+      });
+      expect(targets[0].authorization).toEqual({ kind: 'owner' });
     });
 
     it('should include delegateDid from identity options', async () => {
@@ -368,6 +448,11 @@ describe('SyncEngineLevel — private methods', () => {
         },
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
+      (engine as any)._permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          messagesGrantEntry('grant-1', { interface: 'Messages', method: 'Read' }),
+        ]),
+      };
       await engine.registerIdentity({
         did     : 'did:example:carol',
         options : { protocols: 'all', delegateDid: 'did:example:delegate' },
@@ -376,6 +461,11 @@ describe('SyncEngineLevel — private methods', () => {
       const targets = await (engine as any).getSyncTargets();
       expect(targets).toHaveLength(1);
       expect(targets[0].delegateDid).toBe('did:example:delegate');
+      expect(targets[0].authorization).toEqual({
+        kind               : 'delegate',
+        delegateDid        : 'did:example:delegate',
+        permissionGrantIds : ['grant-1'],
+      });
     });
 
     it('should handle invalid JSON in identity options gracefully', async () => {
@@ -407,7 +497,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:1', 'https://dwn.example.com'),
       ]);
       sinon.stub(engine as any, 'getLocalRoot').resolves('aabbcc');
       sinon.stub(engine as any, 'getRemoteRoot').resolves('aabbcc');
@@ -423,7 +513,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:1', 'https://dwn.example.com'),
       ]);
       sinon.stub(engine as any, 'getLocalRoot').resolves('aabbcc');
       sinon.stub(engine as any, 'getRemoteRoot').resolves('ddeeff');
@@ -445,7 +535,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:1', 'https://dwn.example.com'),
       ]);
       sinon.stub(engine as any, 'getLocalRoot').resolves('aabbcc');
       sinon.stub(engine as any, 'getRemoteRoot').resolves('ddeeff');
@@ -467,7 +557,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:1', 'https://dwn.example.com'),
       ]);
       sinon.stub(engine as any, 'getLocalRoot').resolves('aabbcc');
       sinon.stub(engine as any, 'getRemoteRoot').resolves('ddeeff');
@@ -489,7 +579,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:1', 'https://dwn.example.com'),
       ]);
       sinon.stub(engine as any, 'getLocalRoot').resolves('aabbcc');
       sinon.stub(engine as any, 'getRemoteRoot').resolves('ddeeff');
@@ -511,8 +601,8 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://dwn.example.com' },
-        { did: 'did:example:2', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:1', 'https://dwn.example.com'),
+        syncTarget('did:example:2', 'https://dwn.example.com'),
       ]);
       const getLocalRootStub = sinon.stub(engine as any, 'getLocalRoot').rejects(new Error('network error'));
       const consoleStub = sinon.stub(console, 'error');
@@ -529,7 +619,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:1', 'https://dwn.example.com'),
       ]);
       sinon.stub(engine as any, 'getLocalRoot').resolves('same');
       sinon.stub(engine as any, 'getRemoteRoot').resolves('same');
@@ -547,7 +637,7 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._connectivityState = 'online';
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:1', 'https://dwn.example.com'),
       ]);
       sinon.stub(engine as any, 'getLocalRoot').rejects(new Error('timeout'));
       sinon.stub(console, 'error');
@@ -564,8 +654,8 @@ describe('SyncEngineLevel — private methods', () => {
 
       // Two targets on different dwnUrls.
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://slow.example.com' },
-        { did: 'did:example:2', dwnUrl: 'https://fast.example.com' },
+        syncTarget('did:example:1', 'https://slow.example.com'),
+        syncTarget('did:example:2', 'https://fast.example.com'),
       ]);
 
       // Track call order to prove overlap.
@@ -601,8 +691,8 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._connectivityState = 'online';
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://healthy.example.com' },
-        { did: 'did:example:2', dwnUrl: 'https://down.example.com' },
+        syncTarget('did:example:1', 'https://healthy.example.com'),
+        syncTarget('did:example:2', 'https://down.example.com'),
       ]);
 
       sinon.stub(engine as any, 'createLinkReconciler').returns({
@@ -654,7 +744,14 @@ describe('SyncEngineLevel — private methods', () => {
 
     it('should set link connectivity to offline on transitionToRepairing', async () => {
       const engine = createEngine({ db });
-      const link = { status: 'live', connectivity: 'online', pull: {} } as any;
+      const link = {
+        tenantDid      : 'did:example:alice',
+        remoteEndpoint : 'https://dwn.example.com',
+        scope          : { kind: 'full' },
+        status         : 'live',
+        connectivity   : 'online',
+        pull           : {},
+      } as any;
       const linkKey = 'test-link';
       (engine as any)._activeLinks.set(linkKey, link);
 
@@ -674,7 +771,7 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._consecutiveFailures = 3;
 
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:1', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:1', 'https://dwn.example.com'),
       ]);
       sinon.stub(engine as any, 'getLocalRoot').resolves('same');
       sinon.stub(engine as any, 'getRemoteRoot').resolves('same');
@@ -835,6 +932,16 @@ describe('SyncEngineLevel — private methods', () => {
   // ---------------------------------------------------------------------------
 
   describe('openLivePullSubscription', () => {
+    const fullPullTarget = (overrides: Record<string, unknown> = {}): any => ({
+      did                : 'did:example:alice',
+      dwnUrl             : 'https://dwn.example.com',
+      linkKey            : 'did:example:alice^https://dwn.example.com^projection-test^authorization-test',
+      scope              : { kind: 'full' },
+      authorization      : { kind: 'owner' },
+      authorizationEpoch : 'authorization-test',
+      ...overrides,
+    });
+
     /**
      * Helper: creates a mock agent with processRequest (construct message)
      * and rpc.sendDwnRequest (send to specific dwnUrl via WS).
@@ -861,9 +968,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent });
       sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
-      await (engine as any).openLivePullSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com',
-      });
+      await (engine as any).openLivePullSubscription(fullPullTarget());
 
       expect((engine as any)._liveSubscriptions.length).toBe(1);
       // The rpc stub was called with a wss:// URL
@@ -880,62 +985,50 @@ describe('SyncEngineLevel — private methods', () => {
       sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       await expect(
-        (engine as any).openLivePullSubscription({
-          did: 'did:example:alice', dwnUrl: 'https://dwn.example.com',
-        })
+        (engine as any).openLivePullSubscription(fullPullTarget())
       ).rejects.toThrow('MessagesSubscribe failed');
 
       expect((engine as any)._liveSubscriptions.length).toBe(0);
     });
 
-    it('should include protocol in subscription filters when provided', async () => {
+    it('should include one subscription filter per protocol in a protocol-set scope', async () => {
       const { agent, processRequestStub } = createPullMockAgent();
       const engine = createEngine({ db, agent });
       sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
-      await (engine as any).openLivePullSubscription({
-        did      : 'did:example:alice',
-        dwnUrl   : 'https://dwn.example.com',
-        protocol : 'https://proto.example.com',
-      });
+      await (engine as any).openLivePullSubscription(fullPullTarget({
+        scope: {
+          kind      : 'protocolSet',
+          protocols : ['https://proto.example.com', 'https://social.example.com'],
+        },
+      }));
 
       const callArgs = processRequestStub.firstCall.args[0];
-      expect(callArgs.messageParams.filters).toEqual([{ protocol: 'https://proto.example.com' }]);
+      expect(callArgs.messageParams.filters).toEqual([
+        { protocol: 'https://proto.example.com' },
+        { protocol: 'https://social.example.com' },
+      ]);
       (engine as any)._liveSubscriptions = [];
     });
 
-    it('should include protocolPathPrefix in subscription filters when link scope has it', async () => {
+    it('should include delegate grant IDs when provided by the sync target', async () => {
       const { agent, processRequestStub } = createPullMockAgent();
       const engine = createEngine({ db, agent });
       sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
-      // Set up a link with protocolPathPrefixes in the scope.
-      const linkKey = (engine as any).buildLinkKey('did:example:alice', 'https://dwn.example.com', 'https://proto.example.com');
-      (engine as any)._activeLinks.set(linkKey, {
-        tenantDid      : 'did:example:alice',
-        remoteEndpoint : 'https://dwn.example.com',
-        scope          : {
-          kind                 : 'protocol',
-          protocol             : 'https://proto.example.com',
-          protocolPathPrefixes : ['thread/message'],
+      await (engine as any).openLivePullSubscription(fullPullTarget({
+        delegateDid   : 'did:example:delegate',
+        authorization : {
+          kind               : 'delegate',
+          delegateDid        : 'did:example:delegate',
+          permissionGrantIds : ['grant-b', 'grant-a'],
         },
-        status   : 'live',
-        pull     : {},
-        protocol : 'https://proto.example.com',
-      });
-
-      await (engine as any).openLivePullSubscription({
-        did      : 'did:example:alice',
-        dwnUrl   : 'https://dwn.example.com',
-        protocol : 'https://proto.example.com',
-        linkKey,
-      });
+        permissionGrantIds: ['grant-b', 'grant-a'],
+      }));
 
       const callArgs = processRequestStub.firstCall.args[0];
-      expect(callArgs.messageParams.filters).toEqual([{
-        protocol           : 'https://proto.example.com',
-        protocolPathPrefix : 'thread/message',
-      }]);
+      expect(callArgs.granteeDid).toBe('did:example:delegate');
+      expect(callArgs.messageParams.permissionGrantIds).toEqual(['grant-a', 'grant-b']);
       (engine as any)._liveSubscriptions = [];
     });
 
@@ -945,63 +1038,22 @@ describe('SyncEngineLevel — private methods', () => {
       const savedCursor = { streamId: 's1', epoch: 'e1', position: '42', messageCid: 'cid-42' };
 
       // Set cursor on the link's pull checkpoint (not legacy getCursor).
-      const linkKey = 'did:example:alice^https://dwn.example.com';
+      const linkKey = 'did:example:alice^https://dwn.example.com^projection-test^authorization-test';
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'live',
-        pull           : { contiguousAppliedToken: savedCursor },
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test',
+        authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : { contiguousAppliedToken: savedCursor },
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
 
-      await (engine as any).openLivePullSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', linkKey,
-      });
+      await (engine as any).openLivePullSubscription(fullPullTarget({ linkKey }));
 
       const callArgs = processRequestStub.firstCall.args[0];
       expect(callArgs.messageParams.cursor).toEqual(savedCursor);
       (engine as any)._liveSubscriptions = [];
     });
 
-    it('should look up delegate permission when delegateDid is provided', async () => {
-      const permStub = sinon.stub().resolves({ grant: { id: 'sub-grant-1' } });
-      const { agent } = createPullMockAgent();
-      const engine = createEngine({ db, agent });
-      (engine as any)._permissionsApi = {
-        getPermissionForRequest : permStub,
-        clear                   : sinon.stub(),
-      };
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
-
-      await (engine as any).openLivePullSubscription({
-        did         : 'did:example:alice',
-        dwnUrl      : 'https://dwn.example.com',
-        delegateDid : 'did:example:delegate',
-      });
-
-      expect(permStub.called).toBe(true);
-      (engine as any)._liveSubscriptions = [];
-    });
-
-    it('should throw when permission grant lookup fails', async () => {
-      const permStub = sinon.stub().rejects(new Error('no grant'));
-      const { agent, rpcStub } = createPullMockAgent();
-      const engine = createEngine({ db, agent });
-      (engine as any)._permissionsApi = {
-        getPermissionForRequest : permStub,
-        clear                   : sinon.stub(),
-      };
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
-
-      await expect(
-        (engine as any).openLivePullSubscription({
-          did         : 'did:example:alice',
-          dwnUrl      : 'https://dwn.example.com',
-          delegateDid : 'did:example:delegate',
-        })
-      ).rejects.toThrow('no grant');
-
-      expect(rpcStub.called).toBe(false);
-    });
   });
 
   // ---------------------------------------------------------------------------
@@ -1009,6 +1061,16 @@ describe('SyncEngineLevel — private methods', () => {
   // ---------------------------------------------------------------------------
 
   describe('openLocalPushSubscription', () => {
+    const fullPushTarget = (overrides: Record<string, unknown> = {}): any => ({
+      did                : 'did:example:alice',
+      dwnUrl             : 'https://dwn.example.com',
+      linkKey            : 'did:example:alice^https://dwn.example.com^projection-test^authorization-test',
+      scope              : { kind: 'full' },
+      authorization      : { kind: 'owner' },
+      authorizationEpoch : 'authorization-test',
+      ...overrides,
+    });
+
     it('should open a local subscription and add it to _localSubscriptions', async () => {
       const closeStub = sinon.stub().resolves();
       const mockAgent = {
@@ -1024,9 +1086,7 @@ describe('SyncEngineLevel — private methods', () => {
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
 
-      await (engine as any).openLocalPushSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com',
-      });
+      await (engine as any).openLocalPushSubscription(fullPushTarget());
 
       expect((engine as any)._localSubscriptions.length).toBe(1);
 
@@ -1049,39 +1109,13 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
 
       await expect(
-        (engine as any).openLocalPushSubscription({
-          did: 'did:example:alice', dwnUrl: 'https://dwn.example.com',
-        })
+        (engine as any).openLocalPushSubscription(fullPushTarget())
       ).rejects.toThrow('Local MessagesSubscribe failed');
 
       expect((engine as any)._localSubscriptions.length).toBe(0);
     });
 
-    it('should throw when delegate permission lookup fails', async () => {
-      const permStub = sinon.stub().rejects(new Error('no grant'));
-      const processRequestStub = sinon.stub();
-      const mockAgent = {
-        agentDid : 'did:example:agent',
-        dwn      : { processRequest: processRequestStub },
-      } as any;
-      const engine = createEngine({ db, agent: mockAgent });
-      (engine as any)._permissionsApi = {
-        getPermissionForRequest : permStub,
-        clear                   : sinon.stub(),
-      };
-
-      await expect(
-        (engine as any).openLocalPushSubscription({
-          did         : 'did:example:alice',
-          dwnUrl      : 'https://dwn.example.com',
-          delegateDid : 'did:example:delegate',
-        })
-      ).rejects.toThrow('no grant');
-
-      expect(processRequestStub.called).toBe(false);
-    });
-
-    it('should include protocol in subscription filters when provided', async () => {
+    it('should include one subscription filter per protocol in a protocol-set scope', async () => {
       const processRequestStub = sinon.stub().resolves({
         reply: {
           status       : { code: 200, detail: 'OK' },
@@ -1094,14 +1128,18 @@ describe('SyncEngineLevel — private methods', () => {
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
 
-      await (engine as any).openLocalPushSubscription({
-        did      : 'did:example:alice',
-        dwnUrl   : 'https://dwn.example.com',
-        protocol : 'https://proto.example.com',
-      });
+      await (engine as any).openLocalPushSubscription(fullPushTarget({
+        scope: {
+          kind      : 'protocolSet',
+          protocols : ['https://proto.example.com', 'https://social.example.com'],
+        },
+      }));
 
       const callArgs = processRequestStub.firstCall.args[0];
-      expect(callArgs.messageParams.filters).toEqual([{ protocol: 'https://proto.example.com' }]);
+      expect(callArgs.messageParams.filters).toEqual([
+        { protocol: 'https://proto.example.com' },
+        { protocol: 'https://social.example.com' },
+      ]);
 
       (engine as any)._localSubscriptions = [];
     });
@@ -1602,7 +1640,7 @@ describe('SyncEngineLevel — private methods', () => {
 
       // Return one sync target.
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:alice', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:alice', 'https://dwn.example.com'),
       ]);
 
       // Pull subscription succeeds (sets connectivity to online).
@@ -1622,9 +1660,8 @@ describe('SyncEngineLevel — private methods', () => {
       await engine.startSync({ mode: 'live', interval: '10s' });
 
       // _activeLinks should not contain the failed link.
-      const linkKey = (engine as any).buildLinkKey('did:example:alice', 'https://dwn.example.com', undefined);
-      expect((engine as any)._activeLinks.has(linkKey)).toBe(false);
-      expect((engine as any)._linkRuntimes.has(linkKey)).toBe(false);
+      expect([...((engine as any)._activeLinks.values())].some((link: any) => link.tenantDid === 'did:example:alice')).toBe(false);
+      expect((engine as any)._linkRuntimes.size).toBe(0);
 
       // Pull subscription should have been closed (the openLivePullSubscription
       // stub added it, and the catch path in startLiveSync should have closed it
@@ -1649,7 +1686,7 @@ describe('SyncEngineLevel — private methods', () => {
 
       sinon.stub(engine, 'sync').resolves();
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:alice', dwnUrl: 'https://dwn.example.com' },
+        syncTarget('did:example:alice', 'https://dwn.example.com'),
       ]);
 
       // Pull subscription fails immediately (no subscriptions added).
@@ -1663,8 +1700,7 @@ describe('SyncEngineLevel — private methods', () => {
       expect((engine as any)._connectivityState).toBe('unknown');
       expect((engine as any)._liveSubscriptions.length).toBe(0);
 
-      const linkKey = (engine as any).buildLinkKey('did:example:alice', 'https://dwn.example.com', undefined);
-      expect((engine as any)._activeLinks.has(linkKey)).toBe(false);
+      expect([...((engine as any)._activeLinks.values())].some((link: any) => link.tenantDid === 'did:example:alice')).toBe(false);
 
       await engine.stopSync();
     });
@@ -1711,9 +1747,9 @@ describe('SyncEngineLevel — private methods', () => {
       // Set up a link so the EOSE handler uses the link path.
       const linkKey = 'did:example:alice^https://dwn.example.com';
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'live',
-        pull           : {}, connectivity   : 'unknown', needsReconcile : false,
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : {}, connectivity       : 'unknown', needsReconcile     : false,
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -1721,9 +1757,7 @@ describe('SyncEngineLevel — private methods', () => {
       const saveStub = sinon.stub().resolves();
       (engine as any)._ledger = { saveLink: saveStub };
 
-      await (engine as any).openLivePullSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', linkKey,
-      });
+      await (engine as any).openLivePullSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey }));
 
       const handler = getHandler();
       expect(handler).toBeDefined();
@@ -1747,9 +1781,9 @@ describe('SyncEngineLevel — private methods', () => {
       // Set up a link so the event handler uses the link path.
       const linkKey = 'did:example:alice^https://dwn.example.com';
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'live',
-        pull           : {}, connectivity   : 'online', needsReconcile : false,
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : {}, connectivity       : 'online', needsReconcile     : false,
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -1757,9 +1791,7 @@ describe('SyncEngineLevel — private methods', () => {
       const saveStub = sinon.stub().resolves();
       (engine as any)._ledger = { saveLink: saveStub };
 
-      await (engine as any).openLivePullSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', linkKey,
-      });
+      await (engine as any).openLivePullSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey }));
 
       const handler = getHandler();
 
@@ -1786,17 +1818,15 @@ describe('SyncEngineLevel — private methods', () => {
       // Set up a link so the event handler passes the _activeLinks guard.
       const linkKey = 'did:example:alice^https://dwn.example.com';
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'live',
-        pull           : {}, connectivity   : 'online', needsReconcile : false,
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : {}, connectivity       : 'online', needsReconcile     : false,
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
       (engine as any)._ledger = { saveLink: sinon.stub().resolves(), setStatus: sinon.stub().resolves() };
 
-      await (engine as any).openLivePullSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', linkKey,
-      });
+      await (engine as any).openLivePullSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey }));
 
       const handler = getHandler();
 
@@ -1836,9 +1866,7 @@ describe('SyncEngineLevel — private methods', () => {
       const pushLinkKey = 'did:example:alice^https://dwn.example.com';
       (engine as any)._activeLinks.set(pushLinkKey, { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', scope: { kind: 'full' } });
 
-      await (engine as any).openLocalPushSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', linkKey: pushLinkKey,
-      });
+      await (engine as any).openLocalPushSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey: pushLinkKey }));
 
       expect(capturedHandler).toBeDefined();
 
@@ -1885,9 +1913,7 @@ describe('SyncEngineLevel — private methods', () => {
       const pushLinkKey = 'did:example:alice^https://dwn.example.com';
       (engine as any)._activeLinks.set(pushLinkKey, { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', scope: { kind: 'full' } });
 
-      await (engine as any).openLocalPushSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', linkKey: pushLinkKey,
-      });
+      await (engine as any).openLocalPushSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey: pushLinkKey }));
 
       capturedHandler({ type: 'eose', cursor: 'some-cursor' });
 
@@ -1916,9 +1942,7 @@ describe('SyncEngineLevel — private methods', () => {
       const pushLinkKey = 'did:example:alice^https://dwn.example.com';
       (engine as any)._activeLinks.set(pushLinkKey, { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', scope: { kind: 'full' } });
 
-      await (engine as any).openLocalPushSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', linkKey: pushLinkKey,
-      });
+      await (engine as any).openLocalPushSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey: pushLinkKey }));
 
       // Event with no messageCid and descriptor that won't sync-resolve
       capturedHandler({
@@ -1958,9 +1982,7 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._permissionsApi = { getPermissionForRequest: sinon.stub(), clear: sinon.stub() };
       (engine as any)._activeLinks.set('test-link', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', scope: { kind: 'full' } });
 
-      await (engine as any).openLocalPushSubscription({
-        did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', linkKey: 'test-link',
-      });
+      await (engine as any).openLocalPushSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey: 'test-link' }));
 
       // First event triggers immediate flush (no timer).
       await capturedHandler({
@@ -2127,9 +2149,9 @@ describe('SyncEngineLevel — private methods', () => {
 
       // Set up link and runtime state.
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'live',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       const rt = (engine as any).getOrCreateRuntime(linkKey);
@@ -2162,9 +2184,9 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'live',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       const rt = (engine as any).getOrCreateRuntime(linkKey);
@@ -2188,9 +2210,9 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'live',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       const rt = (engine as any).getOrCreateRuntime(linkKey);
@@ -2239,9 +2261,9 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -2267,9 +2289,9 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
 
@@ -2300,9 +2322,9 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -2339,9 +2361,9 @@ describe('SyncEngineLevel — private methods', () => {
       sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       try {
-        await (engine as any).openLivePullSubscription({
-          did: 'did:example:alice', dwnUrl: 'https://dwn.example.com',
-        });
+        await (engine as any).openLivePullSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', {
+          linkKey: 'did:example:alice^https://dwn.example.com^projection-test^authorization-test',
+        }));
         throw new Error('expected error');
       } catch (error: any) {
         expect(error.isProgressGap).toBe(true);
@@ -2360,9 +2382,9 @@ describe('SyncEngineLevel — private methods', () => {
       }
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : { contiguousAppliedToken: token(1) },
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : { contiguousAppliedToken: token(1) },
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       const rt = (engine as any).getOrCreateRuntime(linkKey);
@@ -2386,9 +2408,9 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
 
@@ -2414,9 +2436,9 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'live',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -2460,9 +2482,9 @@ describe('SyncEngineLevel — private methods', () => {
 
       const resumeToken = { streamId: 's1', epoch: 'e1', position: '99', messageCid: 'cid-99' };
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'live',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
 
@@ -2487,9 +2509,9 @@ describe('SyncEngineLevel — private methods', () => {
 
       const resumeToken = { streamId: 's1', epoch: 'e1', position: '99', messageCid: 'cid-99' };
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -2521,9 +2543,9 @@ describe('SyncEngineLevel — private methods', () => {
 
       const existingToken = { streamId: 's1', epoch: 'e1', position: '50', messageCid: 'cid-50' };
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : { contiguousAppliedToken: existingToken },
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : { contiguousAppliedToken: existingToken },
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -2551,9 +2573,9 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -2583,9 +2605,9 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : {},
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : {},
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -2622,10 +2644,10 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test', scope          : { kind: 'full' }, status         : 'repairing',
-        pull           : {},
-        needsReconcile : false,
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : {},
+        needsReconcile     : false,
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -2671,17 +2693,19 @@ describe('SyncEngineLevel — private methods', () => {
       const pushClose = sinon.stub().resolves();
 
       (engine as any)._liveSubscriptions = [
-        { linkKey: 'did:example:alice^https://dwn.example.com^scope-a', did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: undefined, close: pullClose },
-        { linkKey: 'did:example:bob^https://other.com^scope-b', did: 'did:example:bob', dwnUrl: 'https://other.com', close: sinon.stub().resolves() },
+        { linkKey: 'did:example:alice^https://dwn.example.com^projection-a^authorization-a', did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: undefined, close: pullClose },
+        { linkKey: 'did:example:bob^https://other.com^projection-b^authorization-b', did: 'did:example:bob', dwnUrl: 'https://other.com', close: sinon.stub().resolves() },
       ];
       (engine as any)._localSubscriptions = [
-        { linkKey: 'did:example:alice^https://dwn.example.com^scope-a', did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: undefined, close: pushClose },
+        { linkKey: 'did:example:alice^https://dwn.example.com^projection-a^authorization-a', did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: undefined, close: pushClose },
       ];
 
       const link = {
-        tenantDid      : 'did:example:alice', remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'scope-a',
-        protocol       : undefined,
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-a',
+        authorizationEpoch : 'authorization-a',
+        authorization      : { kind: 'owner' },
+        protocol           : undefined,
       } as any;
 
       await (engine as any).closeLinkSubscriptions(link);
@@ -2699,7 +2723,9 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._localSubscriptions = [];
 
       const link = {
-        tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', scopeId: 'scope-a',
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com', projectionId       : 'projection-a',
+        authorizationEpoch : 'authorization-a',
+        authorization      : { kind: 'owner' },
       } as any;
 
       // Should not throw.
@@ -2752,125 +2778,40 @@ describe('SyncEngineLevel — private methods', () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Subset scope filtering
-  // ---------------------------------------------------------------------------
-
-  describe('isEventInScope (tested via exported helper)', () => {
-    // isEventInScope is a module-level function. We test it by importing
-    // the module and accessing it, or by testing behavior through the engine.
-    // Since it's not exported, we replicate its logic here for direct testing.
-
-    function isEventInScope(message: any, scope: any): boolean {
-      if (scope.kind === 'full') { return true; }
-      if (!scope.protocolPathPrefixes && !scope.contextIdPrefixes) { return true; }
-      const desc = message.descriptor || {};
-      if (scope.protocolPathPrefixes && scope.protocolPathPrefixes.length > 0) {
-        const protocolPath = desc.protocolPath;
-        if (!protocolPath) { return false; }
-        const matches = scope.protocolPathPrefixes.some(
-          (prefix: string) => protocolPath === prefix || protocolPath.startsWith(prefix + '/')
-        );
-        if (!matches) { return false; }
-      }
-      if (scope.contextIdPrefixes && scope.contextIdPrefixes.length > 0) {
-        const contextId = message.contextId;
-        if (!contextId) { return false; }
-        const matches = scope.contextIdPrefixes.some(
-          (prefix: string) => contextId === prefix || contextId.startsWith(prefix + '/')
-        );
-        if (!matches) { return false; }
-      }
-      return true;
-    }
-
-    it('should accept all events for full-tenant scope', () => {
-      const msg = { descriptor: { protocolPath: 'thread/message' } };
-      expect(isEventInScope(msg, { kind: 'full' })).toBe(true);
-    });
-
-    it('should accept all events when no prefixes are specified', () => {
-      const msg = { descriptor: { protocolPath: 'thread/message' } };
-      expect(isEventInScope(msg, { kind: 'protocol', protocol: 'https://example.com' })).toBe(true);
-    });
-
-    it('should accept events matching protocolPath prefix exactly', () => {
-      const msg = { descriptor: { protocolPath: 'thread/message' } };
-      const scope = { kind: 'protocol', protocol: 'x', protocolPathPrefixes: ['thread/message'] };
-      expect(isEventInScope(msg, scope)).toBe(true);
-    });
-
-    it('should accept events matching protocolPath prefix with child path', () => {
-      const msg = { descriptor: { protocolPath: 'thread/message/attachment' } };
-      const scope = { kind: 'protocol', protocol: 'x', protocolPathPrefixes: ['thread/message'] };
-      expect(isEventInScope(msg, scope)).toBe(true);
-    });
-
-    it('should reject events not matching protocolPath prefix', () => {
-      const msg = { descriptor: { protocolPath: 'thread/participant' } };
-      const scope = { kind: 'protocol', protocol: 'x', protocolPathPrefixes: ['thread/message'] };
-      expect(isEventInScope(msg, scope)).toBe(false);
-    });
-
-    it('should not false-match prefix substrings (thread/message vs thread/messageDraft)', () => {
-      const msg = { descriptor: { protocolPath: 'thread/messageDraft' } };
-      const scope = { kind: 'protocol', protocol: 'x', protocolPathPrefixes: ['thread/message'] };
-      expect(isEventInScope(msg, scope)).toBe(false);
-    });
-
-    it('should accept events matching contextId prefix', () => {
-      const msg = { descriptor: {}, contextId: 'ctx-root/child' };
-      const scope = { kind: 'protocol', protocol: 'x', contextIdPrefixes: ['ctx-root'] };
-      expect(isEventInScope(msg, scope)).toBe(true);
-    });
-
-    it('should reject events not matching contextId prefix', () => {
-      const msg = { descriptor: {}, contextId: 'other-root/child' };
-      const scope = { kind: 'protocol', protocol: 'x', contextIdPrefixes: ['ctx-root'] };
-      expect(isEventInScope(msg, scope)).toBe(false);
-    });
-
-    it('should reject events with no protocolPath when prefixes are required', () => {
-      const msg = { descriptor: {} };
-      const scope = { kind: 'protocol', protocol: 'x', protocolPathPrefixes: ['thread'] };
-      expect(isEventInScope(msg, scope)).toBe(false);
-    });
-
-    it('should require both protocolPath AND contextId match when both are specified', () => {
-      const msg = { descriptor: { protocolPath: 'thread/message' }, contextId: 'wrong-ctx' };
-      const scope = {
-        kind                 : 'protocol',
-        protocol             : 'x',
-        protocolPathPrefixes : ['thread/message'],
-        contextIdPrefixes    : ['ctx-root'],
-      };
-      // protocolPath matches but contextId doesn't → reject.
-      expect(isEventInScope(msg, scope)).toBe(false);
-    });
-  });
-
   describe('subset scope link creation', () => {
-    it('should create protocol-scoped links when target has a protocol', async () => {
+    it('should create one protocol-set link when target has a protocol set', async () => {
       const mockAgent = { agentDid: 'did:example:agent', did: { dereference: sinon.stub() } } as any;
       const engine = createEngine({ db, agent: mockAgent });
 
       sinon.stub(engine, 'sync').resolves();
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:alice', dwnUrl: 'https://dwn.example.com', protocol: 'https://example.com/chat' },
+        {
+          did                : 'did:example:alice',
+          dwnUrl             : 'https://dwn.example.com',
+          scope              : { kind: 'protocolSet', protocols: ['https://example.com/chat', 'https://example.com/profile'] },
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+        },
       ]);
       sinon.stub(engine as any, 'openLivePullSubscription').resolves();
       sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
       sinon.stub(console, 'error');
 
-      // Stub the ledger to capture the scope.
-      let capturedScope: any;
+      let capturedParams: any;
       const setStatusStub = sinon.stub().callsFake(async (l: any, s: string): Promise<void> => { l.status = s; });
       const getOrCreateStub = sinon.stub().callsFake(async (params: any) => {
-        capturedScope = params.scope;
+        capturedParams = params;
         return {
-          tenantDid      : params.tenantDid, remoteEndpoint : params.remoteEndpoint,
-          scopeId        : 'test', scope          : params.scope, status         : 'initializing',
-          pull           : {}, protocol       : params.protocol,
+          tenantDid          : params.tenantDid,
+          remoteEndpoint     : params.remoteEndpoint,
+          projectionId       : 'projection-test',
+          authorizationEpoch : params.authorizationEpoch,
+          authorization      : params.authorization,
+          scope              : params.scope,
+          status             : 'initializing',
+          pull               : {},
+          connectivity       : 'unknown',
+          needsReconcile     : false,
         };
       });
       (engine as any)._ledger = {
@@ -2880,10 +2821,12 @@ describe('SyncEngineLevel — private methods', () => {
 
       await engine.startSync({ mode: 'live', interval: '10s' });
 
-      // Scope should be protocol-scoped, not full.
-      expect(capturedScope).toBeDefined();
-      expect(capturedScope.kind).toBe('protocol');
-      expect(capturedScope.protocol).toBe('https://example.com/chat');
+      expect(capturedParams.scope).toEqual({
+        kind      : 'protocolSet',
+        protocols : ['https://example.com/chat', 'https://example.com/profile'],
+      });
+      expect(capturedParams.authorization).toEqual({ kind: 'owner' });
+      expect(capturedParams.authorizationEpoch).toBe('owner-epoch');
 
       await engine.stopSync();
     });
@@ -2894,7 +2837,13 @@ describe('SyncEngineLevel — private methods', () => {
 
       sinon.stub(engine, 'sync').resolves();
       sinon.stub(engine as any, 'getSyncTargets').resolves([
-        { did: 'did:example:alice', dwnUrl: 'https://dwn.example.com' },
+        {
+          did                : 'did:example:alice',
+          dwnUrl             : 'https://dwn.example.com',
+          scope              : { kind: 'full' },
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+        },
       ]);
       sinon.stub(engine as any, 'openLivePullSubscription').resolves();
       sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
@@ -2906,9 +2855,16 @@ describe('SyncEngineLevel — private methods', () => {
         getOrCreateLink: sinon.stub().callsFake(async (params: any) => {
           capturedScope = params.scope;
           return {
-            tenantDid      : params.tenantDid, remoteEndpoint : params.remoteEndpoint,
-            scopeId        : 'test', scope          : params.scope, status         : 'initializing',
-            pull           : {},
+            tenantDid          : params.tenantDid,
+            remoteEndpoint     : params.remoteEndpoint,
+            projectionId       : 'projection-test',
+            authorizationEpoch : params.authorizationEpoch,
+            authorization      : params.authorization,
+            scope              : params.scope,
+            status             : 'initializing',
+            pull               : {},
+            connectivity       : 'unknown',
+            needsReconcile     : false,
           };
         }),
         setStatus: setStatusStub,
@@ -2997,13 +2953,15 @@ describe('SyncEngineLevel — private methods', () => {
   describe('per-link reconciliation', () => {
     function makeLiveLink(overrides: any = {}): any {
       return {
-        tenantDid      : 'did:example:alice',
-        remoteEndpoint : 'https://dwn.example.com',
-        scopeId        : 'test',
-        scope          : { kind: 'full' },
-        status         : 'live',
-        pull           : {},
-        needsReconcile : true,
+        tenantDid          : 'did:example:alice',
+        remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test',
+        authorizationEpoch : 'authorization-test',
+        authorization      : { kind: 'owner' },
+        scope              : { kind: 'full' },
+        status             : 'live',
+        pull               : {},
+        needsReconcile     : true,
         ...overrides,
       };
     }
@@ -3046,7 +3004,7 @@ describe('SyncEngineLevel — private methods', () => {
       const protocol = 'https://example.com/protocol';
       const link = makeLiveLink({
         protocol,
-        scope: { kind: 'protocol', protocol },
+        scope: { kind: 'protocolSet', protocols: [protocol] },
       });
       (engine as any)._activeLinks.set(linkKey, link);
 
@@ -3313,12 +3271,16 @@ describe('SyncEngineLevel — private methods', () => {
       engine.on((event) => { events.push(event); });
 
       const link = {
-        tenantDid      : 'did:example:alice',
-        remoteEndpoint : 'https://dwn.example.com',
-        status         : 'live',
-        connectivity   : 'online',
-        pull           : {},
-        protocol       : 'https://example.com/chat',
+        tenantDid          : 'did:example:alice',
+        remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test',
+        authorizationEpoch : 'authorization-test',
+        authorization      : { kind: 'owner' },
+        scope              : { kind: 'protocolSet', protocols: ['https://example.com/chat'] },
+        status             : 'live',
+        connectivity       : 'online',
+        pull               : {},
+        protocol           : 'https://example.com/chat',
       } as any;
       const linkKey = 'test-link';
       (engine as any)._activeLinks.set(linkKey, link);
@@ -3487,7 +3449,7 @@ describe('SyncEngineLevel — private methods', () => {
 
       // Simulate two active links that are online.
       const linkA: Record<string, unknown> = { tenantDid: 'did:a', remoteEndpoint: 'https://a.com', protocol: undefined, connectivity: 'online', scope: { kind: 'full' } };
-      const linkB: Record<string, unknown> = { tenantDid: 'did:b', remoteEndpoint: 'https://b.com', protocol: 'proto', connectivity: 'online', scope: { kind: 'protocol', protocol: 'proto' } };
+      const linkB: Record<string, unknown> = { tenantDid: 'did:b', remoteEndpoint: 'https://b.com', protocol: 'proto', connectivity: 'online', scope: { kind: 'protocolSet', protocols: ['proto'] } };
       (engine as any)._activeLinks.set('a', linkA);
       (engine as any)._activeLinks.set('b', linkB);
 
@@ -3615,6 +3577,10 @@ describe('SyncEngineLevel — private methods', () => {
 
   describe('ReplicationLedger', () => {
     let ledger: ReplicationLedger;
+    const ownerAuthorization = {
+      authorization      : { kind: 'owner' as const },
+      authorizationEpoch : 'owner-epoch',
+    };
 
     beforeAll(() => {
       ledger = new ReplicationLedger(db);
@@ -3625,6 +3591,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid      : 'did:example:ledger-test',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       expect(link.tenantDid).toBe('did:example:ledger-test');
@@ -3637,6 +3604,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid      : 'did:example:ledger-test',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
       expect(same.tenantDid).toBe(link.tenantDid);
     });
@@ -3646,6 +3614,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid      : 'did:example:save-test',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       expect(link.lastActivityAt).toBeUndefined();
@@ -3659,6 +3628,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid      : 'did:example:save-test',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
       expect(retrieved.status).toBe('live');
       expect(retrieved.lastActivityAt).toBeDefined();
@@ -3670,15 +3640,17 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid      : 'did:example:delete-test',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
-      await ledger.deleteLink(link.tenantDid, link.remoteEndpoint, link.scopeId);
+      await ledger.deleteLink(link.tenantDid, link.remoteEndpoint, link.projectionId, link.authorizationEpoch);
 
       // After deletion, getOrCreateLink should create a fresh link.
       const fresh = await ledger.getOrCreateLink({
         tenantDid      : 'did:example:delete-test',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
       expect(fresh.status).toBe('initializing');
     });
@@ -3688,11 +3660,13 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid      : 'did:example:list-test',
         remoteEndpoint : 'https://a.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
       await ledger.getOrCreateLink({
         tenantDid      : 'did:example:list-test',
         remoteEndpoint : 'https://b.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       const links = await ledger.getLinksForTenant('did:example:list-test');
@@ -3704,6 +3678,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid      : 'did:example:all-test',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       const all = await ledger.getAllLinks();
@@ -3715,6 +3690,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid      : 'did:example:status-test',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       expect(link.status).toBe('initializing');
@@ -3728,6 +3704,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid      : 'did:example:reconcile-test',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       expect(link.needsReconcile).toBe(false);

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -318,6 +318,25 @@ describe('SyncEngineLevel — private methods', () => {
       expect(result.map(entry => entry.grant.id)).toEqual(['grant-b']);
     });
 
+    it('should reject delegated full sync without an unscoped grant', async () => {
+      const permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          grantEntry('grant-profile', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : 'https://example.com/profile',
+          }),
+        ]),
+      };
+
+      await expect(getMessagesPermissionGrantsForScope({
+        did            : 'did:example:alice',
+        delegateDid    : 'did:example:delegate',
+        messageType    : DwnInterface.MessagesSync,
+        permissionsApi : permissionsApi as any,
+      })).rejects.toThrow('No active Messages.Read permission found for MessagesSync: all protocols');
+    });
+
     it('should return all active grants that participate in a protocol-set projection', async () => {
       const unscoped = grantEntry('grant-c', { interface: 'Messages', method: 'Read' });
       const profile = grantEntry('grant-b', {
@@ -924,6 +943,34 @@ describe('SyncEngineLevel — private methods', () => {
       await (syncEngine as any).teardownLiveSync();
 
       expect((syncEngine as any)._pushRuntimes.size).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // initializeLinkTargetWithRetry
+  // ---------------------------------------------------------------------------
+
+  describe('initializeLinkTargetWithRetry', () => {
+    it('should retry a DID-resolution verification failure and then succeed', async () => {
+      const engine = createEngine({ db, agent: { agentDid: 'did:example:agent' } as any });
+      const initializeStub = sinon.stub(engine as any, 'initializeLinkTarget');
+      initializeStub.onFirstCall().rejects(new Error('GeneralJwsVerifierGetPublicKeyNotFound: unable to resolve DID'));
+      initializeStub.onSecondCall().resolves();
+
+      const originalDelays = (SyncEngineLevel as any).DID_RESOLUTION_RETRY_BACKOFF_MS;
+      (SyncEngineLevel as any).DID_RESOLUTION_RETRY_BACKOFF_MS = [0];
+      try {
+        await (engine as any).initializeLinkTargetWithRetry(syncTarget('did:example:alice', 'https://dwn.example.com'));
+      } finally {
+        (SyncEngineLevel as any).DID_RESOLUTION_RETRY_BACKOFF_MS = originalDelays;
+      }
+
+      expect(initializeStub.callCount).toBe(2);
+    });
+
+    it('should not classify unrelated notFound errors as DID-resolution failures', () => {
+      const engine = createEngine({ db });
+      expect((engine as any).isDidResolutionFailure(new Error('record notFound in local cache'))).toBe(false);
     });
   });
 
@@ -1809,6 +1856,110 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._liveSubscriptions = [];
     });
 
+    it('should process an in-scope RecordsDelete using its initial write protocol', async () => {
+      const processMessageStub = sinon.stub().resolves({ status: { code: 202 } });
+      const { agent, getHandler } = createCallbackMockAgent(processMessageStub);
+      const engine = createEngine({ db, agent });
+
+      const linkKey = 'did:example:alice^https://dwn.example.com';
+      const link = {
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' },
+        scope              : { kind: 'protocolSet', protocols: ['https://example.com/profile'] }, status             : 'live',
+        pull               : {}, connectivity       : 'online', needsReconcile     : false,
+      } as any;
+      (engine as any)._activeLinks.set(linkKey, link);
+      (engine as any).getOrCreateRuntime(linkKey);
+      sinon.stub(engine as any, 'ensureClosureComplete').resolves(true);
+      (engine as any)._ledger = { saveLink: sinon.stub().resolves() };
+
+      await (engine as any).openLivePullSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey }));
+
+      const cursor = { streamId: 's1', epoch: 'e1', position: '2', messageCid: 'cid-delete' };
+      await getHandler()({
+        type  : 'event',
+        cursor,
+        event : {
+          message      : { descriptor: { interface: 'Records', method: 'Delete', recordId: 'record-1' } },
+          initialWrite : { descriptor: { interface: 'Records', method: 'Write', protocol: 'https://example.com/profile' } },
+        },
+      });
+
+      expect(processMessageStub.calledOnce).toBe(true);
+      expect(link.pull.contiguousAppliedToken).toEqual(cursor);
+      (engine as any)._liveSubscriptions = [];
+    });
+
+    it('should skip and checkpoint an out-of-scope RecordsDelete', async () => {
+      const processMessageStub = sinon.stub().resolves({ status: { code: 202 } });
+      const { agent, getHandler } = createCallbackMockAgent(processMessageStub);
+      const engine = createEngine({ db, agent });
+
+      const linkKey = 'did:example:alice^https://dwn.example.com';
+      const link = {
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' },
+        scope              : { kind: 'protocolSet', protocols: ['https://example.com/profile'] }, status             : 'live',
+        pull               : {}, connectivity       : 'online', needsReconcile     : false,
+      } as any;
+      (engine as any)._activeLinks.set(linkKey, link);
+      (engine as any).getOrCreateRuntime(linkKey);
+      (engine as any)._ledger = { saveLink: sinon.stub().resolves() };
+
+      await (engine as any).openLivePullSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey }));
+
+      const cursor = { streamId: 's1', epoch: 'e1', position: '3', messageCid: 'cid-delete-out' };
+      await getHandler()({
+        type  : 'event',
+        cursor,
+        event : {
+          message      : { descriptor: { interface: 'Records', method: 'Delete', recordId: 'record-1' } },
+          initialWrite : { descriptor: { interface: 'Records', method: 'Write', protocol: 'https://example.com/other' } },
+        },
+      });
+
+      expect(processMessageStub.called).toBe(false);
+      expect(link.pull.contiguousAppliedToken).toEqual(cursor);
+      (engine as any)._liveSubscriptions = [];
+    });
+
+    it('should repair instead of checkpointing an unclassifiable scoped RecordsDelete', async () => {
+      const processMessageStub = sinon.stub().resolves({ status: { code: 202 } });
+      const { agent, getHandler } = createCallbackMockAgent(processMessageStub);
+      const engine = createEngine({ db, agent });
+      sinon.stub(engine as any, 'repairLink').resolves();
+      const consoleStub = sinon.stub(console, 'warn');
+
+      const linkKey = 'did:example:alice^https://dwn.example.com';
+      const link = {
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' },
+        scope              : { kind: 'protocolSet', protocols: ['https://example.com/profile'] }, status             : 'live',
+        pull               : {}, connectivity       : 'online', needsReconcile     : false,
+      } as any;
+      (engine as any)._activeLinks.set(linkKey, link);
+      (engine as any).getOrCreateRuntime(linkKey);
+      (engine as any)._ledger = {
+        setStatus: sinon.stub().callsFake(async (targetLink: any, status: string) => { targetLink.status = status; }),
+      };
+
+      await (engine as any).openLivePullSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey }));
+
+      await getHandler()({
+        type   : 'event',
+        cursor : { streamId: 's1', epoch: 'e1', position: '4', messageCid: 'cid-delete-unknown' },
+        event  : {
+          message: { descriptor: { interface: 'Records', method: 'Delete', recordId: 'record-1' } },
+        },
+      });
+
+      expect(processMessageStub.called).toBe(false);
+      expect(link.pull.contiguousAppliedToken).toBeUndefined();
+      expect(link.status).toBe('repairing');
+      expect(consoleStub.called).toBe(true);
+      (engine as any)._liveSubscriptions = [];
+    });
+
     it('should handle processMessage errors gracefully in event handler', async () => {
       const processMessageStub = sinon.stub().rejects(new Error('process failed'));
       const { agent, getHandler } = createCallbackMockAgent(processMessageStub);
@@ -1953,6 +2104,92 @@ describe('SyncEngineLevel — private methods', () => {
       // CID is undefined, so nothing should be accumulated
       expect((engine as any)._pushRuntimes.size).toBe(0);
 
+      (engine as any)._localSubscriptions = [];
+    });
+
+    it('should push an in-scope RecordsDelete using its initial write protocol', async () => {
+      let capturedHandler: any;
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : {
+          processRequest: sinon.stub().callsFake(async (params: any): Promise<any> => {
+            capturedHandler = params.subscriptionHandler;
+            return {
+              reply: {
+                status       : { code: 200, detail: 'OK' },
+                subscription : { close: sinon.stub().resolves() },
+              },
+            };
+          }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      sinon.stub(engine as any, 'flushPendingPushesForLink').resolves();
+      const pushLinkKey = 'did:example:alice^https://dwn.example.com';
+      (engine as any)._activeLinks.set(pushLinkKey, {
+        tenantDid      : 'did:example:alice',
+        remoteEndpoint : 'https://dwn.example.com',
+        scope          : { kind: 'protocolSet', protocols: ['https://example.com/profile'] },
+      });
+
+      await (engine as any).openLocalPushSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey: pushLinkKey }));
+
+      await capturedHandler({
+        type  : 'event',
+        event : {
+          message      : { descriptor: { interface: 'Records', method: 'Delete', recordId: 'record-1' } },
+          initialWrite : { descriptor: { interface: 'Records', method: 'Write', protocol: 'https://example.com/profile' } },
+        },
+      });
+
+      const runtime = (engine as any)._pushRuntimes.get(pushLinkKey);
+      expect(runtime?.entries).toHaveLength(1);
+      (engine as any)._pushRuntimes.clear();
+      (engine as any)._localSubscriptions = [];
+    });
+
+    it('should mark the link for reconcile when a scoped local RecordsDelete cannot be classified', async () => {
+      let capturedHandler: any;
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : {
+          processRequest: sinon.stub().callsFake(async (params: any): Promise<any> => {
+            capturedHandler = params.subscriptionHandler;
+            return {
+              reply: {
+                status       : { code: 200, detail: 'OK' },
+                subscription : { close: sinon.stub().resolves() },
+              },
+            };
+          }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      sinon.stub(engine as any, 'scheduleReconcile').returns(undefined);
+      const saveLinkStub = sinon.stub().resolves();
+      (engine as any)._ledger = { saveLink: saveLinkStub };
+      const pushLinkKey = 'did:example:alice^https://dwn.example.com';
+      const link = {
+        tenantDid      : 'did:example:alice',
+        remoteEndpoint : 'https://dwn.example.com',
+        scope          : { kind: 'protocolSet', protocols: ['https://example.com/profile'] },
+        needsReconcile : false,
+      };
+      (engine as any)._activeLinks.set(pushLinkKey, link);
+
+      await (engine as any).openLocalPushSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey: pushLinkKey }));
+
+      await capturedHandler({
+        type  : 'event',
+        event : {
+          message: { descriptor: { interface: 'Records', method: 'Delete', recordId: 'record-1' } },
+        },
+      });
+      await Promise.resolve();
+
+      expect(link.needsReconcile).toBe(true);
+      expect(saveLinkStub.calledOnce).toBe(true);
+      expect((engine as any)._pushRuntimes.size).toBe(0);
       (engine as any)._localSubscriptions = [];
     });
 
@@ -2252,7 +2489,7 @@ describe('SyncEngineLevel — private methods', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Phase 2: Repair orchestration and degraded_poll
+  // Repair orchestration and degraded polling
   // ---------------------------------------------------------------------------
 
   describe('repairLink', () => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -1960,7 +1960,7 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._liveSubscriptions = [];
     });
 
-    it('should handle processMessage errors gracefully in event handler', async () => {
+    it('should repair without advancing checkpoint when live pull processing fails', async () => {
       const processMessageStub = sinon.stub().rejects(new Error('process failed'));
       const { agent, getHandler } = createCallbackMockAgent(processMessageStub);
       const engine = createEngine({ db, agent });
@@ -1975,19 +1975,26 @@ describe('SyncEngineLevel — private methods', () => {
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
-      (engine as any)._ledger = { saveLink: sinon.stub().resolves(), setStatus: sinon.stub().resolves() };
+      (engine as any)._ledger = {
+        saveLink  : sinon.stub().resolves(),
+        setStatus : sinon.stub().callsFake(async (targetLink: any, status: string): Promise<void> => { targetLink.status = status; }),
+      };
+      sinon.stub(engine as any, 'repairLink').resolves();
 
       await (engine as any).openLivePullSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', { linkKey }));
 
       const handler = getHandler();
+      const failedCursor = { streamId: 's1', epoch: 'e1', position: '5', messageCid: 'cid-failed' };
 
       await handler({
         type   : 'event',
-        cursor : 'event-cursor-err',
-        event  : { message: { descriptor: {} } },
+        cursor : failedCursor,
+        event  : { message: { descriptor: { interface: 'Records', method: 'Write' } } },
       });
 
       expect(consoleStub.called).toBe(true);
+      expect(link.pull.contiguousAppliedToken).toBeUndefined();
+      expect(link.status).toBe('repairing');
 
       (engine as any)._liveSubscriptions = [];
     });
@@ -3537,6 +3544,36 @@ describe('SyncEngineLevel — private methods', () => {
       expect(connectivityEvent).toBeDefined();
       expect(connectivityEvent.from).toBe('online');
       expect(connectivityEvent.to).toBe('offline');
+    });
+
+    it('should emit protocols for multi-protocol link events', async () => {
+      const engine = createEngine({ db });
+      const events: any[] = [];
+      engine.on((event) => { events.push(event); });
+
+      const link = {
+        tenantDid          : 'did:example:alice',
+        remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test',
+        authorizationEpoch : 'authorization-test',
+        authorization      : { kind: 'owner' },
+        scope              : { kind: 'protocolSet', protocols: ['https://example.com/chat', 'https://example.com/profile'] },
+        status             : 'live',
+        connectivity       : 'online',
+        pull               : {},
+      } as any;
+      const linkKey = 'test-link';
+      (engine as any)._activeLinks.set(linkKey, link);
+
+      const setStatusStub = sinon.stub().callsFake(async (l: any, s: string): Promise<void> => { l.status = s; });
+      (engine as any)._ledger = { setStatus: setStatusStub };
+      sinon.stub(engine as any, 'repairLink').resolves();
+
+      await (engine as any).transitionToRepairing(linkKey, link);
+
+      const statusEvent = events.find(e => e.type === 'link:status-change');
+      expect(statusEvent.protocol).toBeUndefined();
+      expect(statusEvent.protocols).toEqual(['https://example.com/chat', 'https://example.com/profile']);
     });
 
     it('should emit checkpoint:pull-advance only after durable save, not on drain alone', () => {

--- a/packages/agent/tests/sync-live-handler-path.spec.ts
+++ b/packages/agent/tests/sync-live-handler-path.spec.ts
@@ -120,7 +120,11 @@ describe('sync live handler path — real subscriptions via LocalDwnRpcShim', ()
     // Poll until the pull checkpoint has advanced — proves the handler
     // actually processed the live event via processRawMessage.
     const links = (): any[] => [...(syncEngine as any)._activeLinks.values()];
-    const getLink = (): any => links().find((l: any) => l.tenantDid === tenant && l.protocol === testProtocol.protocol);
+    const getLink = (): any => links().find((link: any) =>
+      link.tenantDid === tenant &&
+      link.scope?.kind === 'protocolSet' &&
+      link.scope.protocols.includes(testProtocol.protocol)
+    );
 
     await waitFor(() => {
       const link = getLink();

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -266,7 +266,7 @@ describe('sync-messages', () => {
       expect(callArgs.messageParams.permissionGrantIds).toEqual(['grant-1']);
     });
 
-    it('should process messages in batches of 10', async () => {
+    it('should process all requested messages with bounded concurrency', async () => {
       const mockAgent = {
         processDwnRequest : sinon.stub().resolves({ message: {} }),
         rpc               : {

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -144,11 +144,10 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await fetchRemoteMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(result).toHaveLength(1);
@@ -164,11 +163,10 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await fetchRemoteMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(result).toHaveLength(0);
@@ -184,11 +182,10 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await fetchRemoteMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(result).toHaveLength(0);
@@ -210,11 +207,10 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await fetchRemoteMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(result).toHaveLength(1);
@@ -235,21 +231,20 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await fetchRemoteMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(result).toHaveLength(1);
       expect(result[0].dataStream).toBeUndefined();
     });
 
-    it('should look up delegate permission when delegateDid is provided', async () => {
-      const permStub = sinon.stub().resolves({ grant: { id: 'grant-1' } });
+    it('should pass resolved delegate grant IDs when delegateDid is provided', async () => {
+      const processDwnRequestStub = sinon.stub().resolves({ message: {} });
       const mockAgent = {
-        processDwnRequest : sinon.stub().resolves({ message: {} }),
+        processDwnRequest : processDwnRequestStub,
         rpc               : {
           sendDwnRequest: sinon.stub().resolves({
             status : { code: 200 },
@@ -259,32 +254,16 @@ describe('sync-messages', () => {
       } as any;
 
       await fetchRemoteMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        delegateDid    : 'did:example:delegate',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: permStub } as any,
+        did                : 'did:example:alice',
+        dwnUrl             : 'https://dwn.example.com',
+        delegateDid        : 'did:example:delegate',
+        permissionGrantIds : ['grant-1'],
+        messageCids        : ['cid-1'],
+        agent              : mockAgent,
       });
 
-      expect(permStub.calledOnce).toBe(true);
-    });
-
-    it('should throw when delegate permission lookup fails', async () => {
-      const permStub = sinon.stub().rejects(new Error('no grant'));
-      const mockAgent = {
-        processDwnRequest : sinon.stub(),
-        rpc               : { sendDwnRequest: sinon.stub() },
-      } as any;
-
-      await expect(fetchRemoteMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        delegateDid    : 'did:example:delegate',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: permStub } as any,
-      })).rejects.toThrow('no grant');
+      const callArgs = processDwnRequestStub.firstCall.args[0];
+      expect(callArgs.messageParams.permissionGrantIds).toEqual(['grant-1']);
     });
 
     it('should process messages in batches of 10', async () => {
@@ -301,11 +280,10 @@ describe('sync-messages', () => {
       const cids = Array.from({ length: 15 }, (_, i): string => `cid-${i}`);
 
       const result = await fetchRemoteMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : cids,
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : cids,
+        agent       : mockAgent,
       });
 
       expect(result).toHaveLength(15);
@@ -324,11 +302,10 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await fetchRemoteMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(result).toHaveLength(0);
@@ -355,11 +332,10 @@ describe('sync-messages', () => {
       } as any;
 
       await pullMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(mockAgent.dwn.processRawMessage.calledOnce).toBe(true);
@@ -382,11 +358,10 @@ describe('sync-messages', () => {
       } as any;
 
       await pullMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       // Called at least twice (initial + retry)
@@ -401,11 +376,10 @@ describe('sync-messages', () => {
       } as any;
 
       await pullMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : [],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : [],
+        agent       : mockAgent,
       });
 
       // No messages to process
@@ -433,11 +407,10 @@ describe('sync-messages', () => {
       } as any;
 
       await pushMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(sendStub.calledOnce).toBe(true);
@@ -458,11 +431,10 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await pushMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(result.failed).toHaveLength(1);
@@ -487,11 +459,10 @@ describe('sync-messages', () => {
       } as any;
 
       await pushMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(consoleStub.called).toBe(true);
@@ -509,11 +480,10 @@ describe('sync-messages', () => {
       } as any;
 
       await pushMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-missing'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-missing'],
+        agent       : mockAgent,
       });
 
       // Message not found locally, nothing to push
@@ -542,11 +512,10 @@ describe('sync-messages', () => {
       } as any;
 
       await pushMessages({
-        did            : 'did:example:alice',
-        dwnUrl         : 'https://dwn.example.com',
-        messageCids    : ['cid-1'],
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
       });
 
       expect(sendStub.calledOnce).toBe(true);
@@ -573,10 +542,9 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await getLocalMessage({
-        author         : 'did:example:alice',
-        messageCid     : 'cid-1',
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        author     : 'did:example:alice',
+        messageCid : 'cid-1',
+        agent      : mockAgent,
       });
 
       expect(result).toBeDefined();
@@ -593,10 +561,9 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await getLocalMessage({
-        author         : 'did:example:alice',
-        messageCid     : 'cid-1',
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        author     : 'did:example:alice',
+        messageCid : 'cid-1',
+        agent      : mockAgent,
       });
 
       expect(result).toBeUndefined();
@@ -619,10 +586,9 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await getLocalMessage({
-        author         : 'did:example:alice',
-        messageCid     : 'cid-1',
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        author     : 'did:example:alice',
+        messageCid : 'cid-1',
+        agent      : mockAgent,
       });
 
       expect(result).toBeDefined();
@@ -642,57 +608,16 @@ describe('sync-messages', () => {
       } as any;
 
       const result = await getLocalMessage({
-        author         : 'did:example:alice',
-        messageCid     : 'cid-1',
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: sinon.stub() } as any,
+        author     : 'did:example:alice',
+        messageCid : 'cid-1',
+        agent      : mockAgent,
       });
 
       expect(result).toBeDefined();
       expect(result!.dataStream).toBeUndefined();
     });
 
-    it('should look up delegate permission when delegateDid is provided', async () => {
-      const permStub = sinon.stub().resolves({ grant: { id: 'grant-1' } });
-      const mockAgent = {
-        dwn: {
-          processRequest: sinon.stub().resolves({
-            reply: {
-              status : { code: 200 },
-              entry  : { message: { descriptor: {} } },
-            },
-          }),
-        },
-      } as any;
-
-      await getLocalMessage({
-        author         : 'did:example:alice',
-        delegateDid    : 'did:example:delegate',
-        messageCid     : 'cid-1',
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: permStub } as any,
-      });
-
-      expect(permStub.calledOnce).toBe(true);
-    });
-
-    it('should throw when delegate permission lookup fails', async () => {
-      const permStub = sinon.stub().rejects(new Error('no grant'));
-      const mockAgent = {
-        dwn: { processRequest: sinon.stub() },
-      } as any;
-
-      await expect(getLocalMessage({
-        author         : 'did:example:alice',
-        delegateDid    : 'did:example:delegate',
-        messageCid     : 'cid-1',
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: permStub } as any,
-      })).rejects.toThrow('no grant');
-    });
-
-    it('should pass permissionGrantIds in messageParams when delegate has grant', async () => {
-      const permStub = sinon.stub().resolves({ grant: { id: 'grant-abc' } });
+    it('should pass resolved delegate grant IDs when delegateDid is provided', async () => {
       const processRequestStub = sinon.stub().resolves({
         reply: {
           status : { code: 200 },
@@ -704,15 +629,38 @@ describe('sync-messages', () => {
       } as any;
 
       await getLocalMessage({
-        author         : 'did:example:alice',
-        delegateDid    : 'did:example:delegate',
-        messageCid     : 'cid-1',
-        agent          : mockAgent,
-        permissionsApi : { getPermissionForRequest: permStub } as any,
+        author             : 'did:example:alice',
+        delegateDid        : 'did:example:delegate',
+        permissionGrantIds : ['grant-1'],
+        messageCid         : 'cid-1',
+        agent              : mockAgent,
       });
 
       const callArgs = processRequestStub.firstCall.args[0];
-      expect(callArgs.messageParams.permissionGrantIds).toEqual(['grant-abc']);
+      expect(callArgs.messageParams.permissionGrantIds).toEqual(['grant-1']);
+    });
+
+    it('should sort and dedupe permissionGrantIds in messageParams', async () => {
+      const processRequestStub = sinon.stub().resolves({
+        reply: {
+          status : { code: 200 },
+          entry  : { message: { descriptor: {} } },
+        },
+      });
+      const mockAgent = {
+        dwn: { processRequest: processRequestStub },
+      } as any;
+
+      await getLocalMessage({
+        author             : 'did:example:alice',
+        delegateDid        : 'did:example:delegate',
+        permissionGrantIds : ['grant-b', 'grant-a', 'grant-a'],
+        messageCid         : 'cid-1',
+        agent              : mockAgent,
+      });
+
+      const callArgs = processRequestStub.firstCall.args[0];
+      expect(callArgs.messageParams.permissionGrantIds).toEqual(['grant-a', 'grant-b']);
     });
   });
 });

--- a/packages/agent/tests/sync-replication-ledger.spec.ts
+++ b/packages/agent/tests/sync-replication-ledger.spec.ts
@@ -11,6 +11,11 @@ function token(pos: number, cid?: string): ProgressToken {
   return { streamId: 'stream-1', epoch: 'epoch-1', position: String(pos), messageCid: cid ?? `cid-${pos}` };
 }
 
+const ownerAuthorization = {
+  authorization      : { kind: 'owner' as const },
+  authorizationEpoch : 'owner-epoch',
+};
+
 describe('ReplicationLedger', () => {
   let db: Level<string, string>;
   let ledger: ReplicationLedger;
@@ -38,11 +43,14 @@ describe('ReplicationLedger', () => {
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       expect(link.tenantDid).toBe('did:example:alice');
       expect(link.remoteEndpoint).toBe('https://dwn.example.com');
-      expect(link.scopeId.length).toBeGreaterThan(0);
+      expect(link.projectionId.length).toBeGreaterThan(0);
+      expect(link.authorizationEpoch).toBe('owner-epoch');
+      expect(link.authorization).toEqual({ kind: 'owner' });
       expect(link.status).toBe('initializing');
       expect(link.pull.contiguousAppliedToken).toBeUndefined();
       expect(link.needsReconcile).toBe(false);
@@ -53,6 +61,7 @@ describe('ReplicationLedger', () => {
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       link1.status = 'live';
@@ -62,6 +71,7 @@ describe('ReplicationLedger', () => {
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       expect(link2.status).toBe('live');
@@ -69,27 +79,61 @@ describe('ReplicationLedger', () => {
 
     it('should create separate links for different endpoints', async () => {
       const linkA = await ledger.getOrCreateLink({
-        tenantDid: 'did:example:alice', remoteEndpoint: 'https://a.example.com', scope: { kind: 'full' },
+        tenantDid: 'did:example:alice', remoteEndpoint: 'https://a.example.com', scope: { kind: 'full' }, ...ownerAuthorization,
       });
       const linkB = await ledger.getOrCreateLink({
-        tenantDid: 'did:example:alice', remoteEndpoint: 'https://b.example.com', scope: { kind: 'full' },
+        tenantDid: 'did:example:alice', remoteEndpoint: 'https://b.example.com', scope: { kind: 'full' }, ...ownerAuthorization,
       });
 
-      expect(linkA.scopeId).toBe(linkB.scopeId);
+      expect(linkA.projectionId).toBe(linkB.projectionId);
       expect(linkA.remoteEndpoint).not.toBe(linkB.remoteEndpoint);
     });
 
-    it('should store delegateDid and protocol on creation', async () => {
-      const link = await ledger.getOrCreateLink({
+    it('should create separate links for the same projection with different authorization epochs', async () => {
+      const ownerLink = await ledger.getOrCreateLink({
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
-        scope          : { kind: 'full' },
-        delegateDid    : 'did:example:delegate',
-        protocol       : 'https://protocol.xyz',
+        scope          : { kind: 'protocolSet', protocols: ['https://protocol.xyz'] },
+        ...ownerAuthorization,
+      });
+      const delegateLink = await ledger.getOrCreateLink({
+        tenantDid          : 'did:example:alice',
+        remoteEndpoint     : 'https://dwn.example.com',
+        scope              : { kind: 'protocolSet', protocols: ['https://protocol.xyz'] },
+        authorizationEpoch : 'delegate-epoch',
+        authorization      : {
+          kind               : 'delegate',
+          delegateDid        : 'did:example:delegate',
+          permissionGrantIds : ['grant-1'],
+        },
+        delegateDid: 'did:example:delegate',
+      });
+
+      expect(ownerLink.projectionId).toBe(delegateLink.projectionId);
+      expect(ownerLink.authorizationEpoch).not.toBe(delegateLink.authorizationEpoch);
+      expect((await ledger.getLinksForTenant('did:example:alice'))).toHaveLength(2);
+    });
+
+    it('should store delegate authorization metadata on creation', async () => {
+      const link = await ledger.getOrCreateLink({
+        tenantDid          : 'did:example:alice',
+        remoteEndpoint     : 'https://dwn.example.com',
+        scope              : { kind: 'protocolSet', protocols: ['https://protocol.xyz'] },
+        authorizationEpoch : 'delegate-epoch',
+        authorization      : {
+          kind               : 'delegate',
+          delegateDid        : 'did:example:delegate',
+          permissionGrantIds : ['grant-1'],
+        },
+        delegateDid: 'did:example:delegate',
       });
 
       expect(link.delegateDid).toBe('did:example:delegate');
-      expect(link.protocol).toBe('https://protocol.xyz');
+      expect(link.authorization).toEqual({
+        kind               : 'delegate',
+        delegateDid        : 'did:example:delegate',
+        permissionGrantIds : ['grant-1'],
+      });
     });
 
   });
@@ -100,6 +144,7 @@ describe('ReplicationLedger', () => {
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       link.pull.contiguousAppliedToken = token(42);
@@ -109,6 +154,7 @@ describe('ReplicationLedger', () => {
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       expect(reloaded.pull.contiguousAppliedToken).toEqual(token(42));
@@ -122,14 +168,16 @@ describe('ReplicationLedger', () => {
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
-      await ledger.deleteLink(link.tenantDid, link.remoteEndpoint, link.scopeId);
+      await ledger.deleteLink(link.tenantDid, link.remoteEndpoint, link.projectionId, link.authorizationEpoch);
 
       const fresh = await ledger.getOrCreateLink({
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'full' },
+        ...ownerAuthorization,
       });
 
       expect(fresh.status).toBe('initializing');
@@ -139,13 +187,13 @@ describe('ReplicationLedger', () => {
   describe('getLinksForTenant', () => {
     it('should return only links for the specified tenant', async () => {
       await ledger.getOrCreateLink({
-        tenantDid: 'did:example:alice', remoteEndpoint: 'https://a.example.com', scope: { kind: 'full' },
+        tenantDid: 'did:example:alice', remoteEndpoint: 'https://a.example.com', scope: { kind: 'full' }, ...ownerAuthorization,
       });
       await ledger.getOrCreateLink({
-        tenantDid: 'did:example:alice', remoteEndpoint: 'https://b.example.com', scope: { kind: 'full' },
+        tenantDid: 'did:example:alice', remoteEndpoint: 'https://b.example.com', scope: { kind: 'full' }, ...ownerAuthorization,
       });
       await ledger.getOrCreateLink({
-        tenantDid: 'did:example:bob', remoteEndpoint: 'https://a.example.com', scope: { kind: 'full' },
+        tenantDid: 'did:example:bob', remoteEndpoint: 'https://a.example.com', scope: { kind: 'full' }, ...ownerAuthorization,
       });
 
       const aliceLinks = await ledger.getLinksForTenant('did:example:alice');
@@ -157,10 +205,10 @@ describe('ReplicationLedger', () => {
   describe('getAllLinks', () => {
     it('should return all links', async () => {
       await ledger.getOrCreateLink({
-        tenantDid: 'did:example:alice', remoteEndpoint: 'https://a.example.com', scope: { kind: 'full' },
+        tenantDid: 'did:example:alice', remoteEndpoint: 'https://a.example.com', scope: { kind: 'full' }, ...ownerAuthorization,
       });
       await ledger.getOrCreateLink({
-        tenantDid: 'did:example:bob', remoteEndpoint: 'https://b.example.com', scope: { kind: 'full' },
+        tenantDid: 'did:example:bob', remoteEndpoint: 'https://b.example.com', scope: { kind: 'full' }, ...ownerAuthorization,
       });
 
       const all = await ledger.getAllLinks();
@@ -168,81 +216,10 @@ describe('ReplicationLedger', () => {
     });
   });
 
-  describe('updateDelegateDid', () => {
-    it('should update delegateDid on all links for a tenant and persist', async () => {
-      await ledger.getOrCreateLink({
-        tenantDid      : 'did:example:alice',
-        remoteEndpoint : 'https://a.example.com',
-        scope          : { kind: 'full' },
-        delegateDid    : 'did:example:old-delegate',
-      });
-      await ledger.getOrCreateLink({
-        tenantDid      : 'did:example:alice',
-        remoteEndpoint : 'https://b.example.com',
-        scope          : { kind: 'full' },
-        delegateDid    : 'did:example:old-delegate',
-      });
-
-      // Unrelated tenant — should NOT be updated.
-      await ledger.getOrCreateLink({
-        tenantDid      : 'did:example:bob',
-        remoteEndpoint : 'https://a.example.com',
-        scope          : { kind: 'full' },
-        delegateDid    : 'did:example:bob-delegate',
-      });
-
-      const updated = await ledger.updateDelegateDid('did:example:alice', 'did:example:new-delegate');
-      expect(updated).toHaveLength(2);
-      expect(updated.every(l => l.delegateDid === 'did:example:new-delegate')).toBe(true);
-
-      // Verify persistence by reloading from LevelDB.
-      const reloaded = await ledger.getLinksForTenant('did:example:alice');
-      expect(reloaded.every(l => l.delegateDid === 'did:example:new-delegate')).toBe(true);
-
-      // Verify unrelated tenant was not affected.
-      const bobLinks = await ledger.getLinksForTenant('did:example:bob');
-      expect(bobLinks[0].delegateDid).toBe('did:example:bob-delegate');
-    });
-
-    it('should skip links that already have the target delegateDid', async () => {
-      await ledger.getOrCreateLink({
-        tenantDid      : 'did:example:alice',
-        remoteEndpoint : 'https://a.example.com',
-        scope          : { kind: 'full' },
-        delegateDid    : 'did:example:current',
-      });
-
-      const updated = await ledger.updateDelegateDid('did:example:alice', 'did:example:current');
-      expect(updated).toHaveLength(0);
-    });
-
-    it('should handle clearing delegateDid to undefined', async () => {
-      await ledger.getOrCreateLink({
-        tenantDid      : 'did:example:alice',
-        remoteEndpoint : 'https://a.example.com',
-        scope          : { kind: 'full' },
-        delegateDid    : 'did:example:some-delegate',
-      });
-
-      const updated = await ledger.updateDelegateDid('did:example:alice', undefined);
-      expect(updated).toHaveLength(1);
-      expect(updated[0].delegateDid).toBeUndefined();
-
-      // Verify persistence.
-      const reloaded = await ledger.getLinksForTenant('did:example:alice');
-      expect(reloaded[0].delegateDid).toBeUndefined();
-    });
-
-    it('should return empty array when no links exist for tenant', async () => {
-      const updated = await ledger.updateDelegateDid('did:example:nonexistent', 'did:example:delegate');
-      expect(updated).toHaveLength(0);
-    });
-  });
-
   describe('setStatus', () => {
     it('should update status and persist', async () => {
       const link = await ledger.getOrCreateLink({
-        tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', scope: { kind: 'full' },
+        tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', scope: { kind: 'full' }, ...ownerAuthorization,
       });
 
       expect(link.status).toBe('initializing');
@@ -251,7 +228,7 @@ describe('ReplicationLedger', () => {
       expect(link.status).toBe('live');
 
       const reloaded = await ledger.getOrCreateLink({
-        tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', scope: { kind: 'full' },
+        tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', scope: { kind: 'full' }, ...ownerAuthorization,
       });
       expect(reloaded.status).toBe('live');
     });

--- a/packages/agent/tests/sync-scope.spec.ts
+++ b/packages/agent/tests/sync-scope.spec.ts
@@ -1,77 +1,108 @@
 import { describe, expect, it } from 'bun:test';
 
-import { computeScopeId } from '../src/types/sync.js';
+import {
+  computeAuthorizationEpoch,
+  computeProjectionId,
+  normalizeSyncProtocols,
+  protocolsForSyncScope,
+  singleProtocolForSyncScope,
+  syncScopeFromProtocols,
+} from '../src/types/sync.js';
 
-describe('computeScopeId', () => {
-  it('should produce a deterministic string for a full scope', async () => {
-    const id1 = await computeScopeId({ kind: 'full' });
-    const id2 = await computeScopeId({ kind: 'full' });
+describe('sync scope identity', () => {
+  it('normalizes protocol sets by sorting and deduping', () => {
+    expect(normalizeSyncProtocols([
+      'https://example.com/b',
+      'https://example.com/a',
+      'https://example.com/b',
+    ])).toEqual([
+      'https://example.com/a',
+      'https://example.com/b',
+    ]);
+  });
+
+  it('rejects empty protocol sets', () => {
+    expect(() => normalizeSyncProtocols([])).toThrow('protocol-set scope requires at least one protocol');
+  });
+
+  it('derives full and protocol-set scopes from identity options', () => {
+    expect(syncScopeFromProtocols('all')).toEqual({ kind: 'full' });
+
+    const scope = syncScopeFromProtocols([
+      'https://example.com/b',
+      'https://example.com/a',
+    ]);
+    expect(scope).toEqual({
+      kind      : 'protocolSet',
+      protocols : ['https://example.com/a', 'https://example.com/b'],
+    });
+    expect(protocolsForSyncScope(scope)).toEqual(['https://example.com/a', 'https://example.com/b']);
+    expect(singleProtocolForSyncScope(scope)).toBeUndefined();
+  });
+
+  it('returns a single protocol label only for one-protocol scopes', () => {
+    const scope = syncScopeFromProtocols(['https://example.com/profile']);
+    expect(singleProtocolForSyncScope(scope)).toBe('https://example.com/profile');
+  });
+
+  it('computes projection IDs from tenant and normalized scope', async () => {
+    const tenantDid = 'did:example:alice';
+    const id1 = await computeProjectionId(tenantDid, syncScopeFromProtocols([
+      'https://example.com/b',
+      'https://example.com/a',
+    ]));
+    const id2 = await computeProjectionId(tenantDid, syncScopeFromProtocols([
+      'https://example.com/a',
+      'https://example.com/b',
+    ]));
+    const id3 = await computeProjectionId('did:example:bob', syncScopeFromProtocols([
+      'https://example.com/a',
+      'https://example.com/b',
+    ]));
+
     expect(id1).toBe(id2);
-    expect(typeof id1).toBe('string');
-    expect(id1.length).toBeGreaterThan(0);
+    expect(id1).not.toBe(id3);
+    expect(id1).not.toContain('+');
+    expect(id1).not.toContain('/');
+    expect(id1).not.toContain('=');
   });
 
-  it('should produce different ids for different scope kinds', async () => {
-    const fullId = await computeScopeId({ kind: 'full' });
-    const protoId = await computeScopeId({ kind: 'protocol', protocol: 'https://example.com/proto' });
-    expect(fullId).not.toBe(protoId);
+  it('keeps projection ID independent of authorization epoch', async () => {
+    const scope = syncScopeFromProtocols(['https://example.com/profile']);
+    const projectionId = await computeProjectionId('did:example:alice', scope);
+    const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
+    const delegateEpoch = await computeAuthorizationEpoch({
+      kind        : 'delegate',
+      delegateDid : 'did:example:delegate',
+      grants      : [{
+        id          : 'grant-1',
+        dateGranted : '2026-01-01T00:00:00.000000Z',
+        dateExpires : '2027-01-01T00:00:00.000000Z',
+      }],
+    });
+
+    expect(projectionId).not.toBe(ownerEpoch);
+    expect(ownerEpoch).not.toBe(delegateEpoch);
   });
 
-  it('should produce different ids for different protocols', async () => {
-    const id1 = await computeScopeId({ kind: 'protocol', protocol: 'https://example.com/a' });
-    const id2 = await computeScopeId({ kind: 'protocol', protocol: 'https://example.com/b' });
-    expect(id1).not.toBe(id2);
-  });
+  it('normalizes grant order when computing authorization epochs', async () => {
+    const epoch1 = await computeAuthorizationEpoch({
+      kind        : 'delegate',
+      delegateDid : 'did:example:delegate',
+      grants      : [
+        { id: 'grant-b', dateExpires: '2027-01-01T00:00:00.000000Z' },
+        { id: 'grant-a', dateExpires: '2027-01-01T00:00:00.000000Z' },
+      ],
+    });
+    const epoch2 = await computeAuthorizationEpoch({
+      kind        : 'delegate',
+      delegateDid : 'did:example:delegate',
+      grants      : [
+        { id: 'grant-a', dateExpires: '2027-01-01T00:00:00.000000Z' },
+        { id: 'grant-b', dateExpires: '2027-01-01T00:00:00.000000Z' },
+      ],
+    });
 
-  it('should produce the same id regardless of array order', async () => {
-    const id1 = await computeScopeId({
-      kind                 : 'protocol',
-      protocol             : 'https://example.com/proto',
-      protocolPathPrefixes : ['b', 'a', 'c'],
-    });
-    const id2 = await computeScopeId({
-      kind                 : 'protocol',
-      protocol             : 'https://example.com/proto',
-      protocolPathPrefixes : ['c', 'a', 'b'],
-    });
-    expect(id1).toBe(id2);
-  });
-
-  it('should produce url-safe base64 output (no +, /, or = characters)', async () => {
-    // Run several inputs to increase confidence in the character set.
-    for (let i = 0; i < 10; i++) {
-      const id = await computeScopeId({ kind: 'protocol', protocol: `https://example.com/test-${i}` });
-      expect(id).not.toContain('+');
-      expect(id).not.toContain('/');
-      expect(id).not.toContain('=');
-    }
-  });
-
-  it('should dedupe and sort contextIdPrefixes', async () => {
-    const id1 = await computeScopeId({
-      kind              : 'protocol',
-      protocol          : 'https://example.com/proto',
-      contextIdPrefixes : ['b', 'a', 'b', 'c'],
-    });
-    const id2 = await computeScopeId({
-      kind              : 'protocol',
-      protocol          : 'https://example.com/proto',
-      contextIdPrefixes : ['c', 'a', 'b'],
-    });
-    // Same after dedup + sort.
-    expect(id1).toBe(id2);
-  });
-
-  it('should produce different ids with vs without contextIdPrefixes', async () => {
-    const id1 = await computeScopeId({
-      kind     : 'protocol',
-      protocol : 'https://example.com/proto',
-    });
-    const id2 = await computeScopeId({
-      kind              : 'protocol',
-      protocol          : 'https://example.com/proto',
-      contextIdPrefixes : ['ctx-1'],
-    });
-    expect(id1).not.toBe(id2);
+    expect(epoch1).toBe(epoch2);
   });
 });

--- a/packages/agent/tests/sync-scope.spec.ts
+++ b/packages/agent/tests/sync-scope.spec.ts
@@ -105,4 +105,31 @@ describe('sync scope identity', () => {
 
     expect(epoch1).toBe(epoch2);
   });
+
+  it('keeps projection ID stable while changing authorization epoch for a re-grant of the same scope', async () => {
+    const tenantDid = 'did:example:alice';
+    const scope = syncScopeFromProtocols([
+      'https://example.com/social',
+      'https://example.com/profile',
+    ]);
+    const sameScope = syncScopeFromProtocols([
+      'https://example.com/profile',
+      'https://example.com/social',
+    ]);
+    const projectionId = await computeProjectionId(tenantDid, scope);
+    const sameProjectionId = await computeProjectionId(tenantDid, sameScope);
+    const oldEpoch = await computeAuthorizationEpoch({
+      kind        : 'delegate',
+      delegateDid : 'did:example:delegate',
+      grants      : [{ id: 'grant-old', dateExpires: '2027-01-01T00:00:00.000000Z' }],
+    });
+    const newEpoch = await computeAuthorizationEpoch({
+      kind        : 'delegate',
+      delegateDid : 'did:example:delegate',
+      grants      : [{ id: 'grant-new', dateExpires: '2027-01-01T00:00:00.000000Z' }],
+    });
+
+    expect(projectionId).toBe(sameProjectionId);
+    expect(oldEpoch).not.toBe(newEpoch);
+  });
 });

--- a/packages/agent/tests/sync-topological-sort.spec.ts
+++ b/packages/agent/tests/sync-topological-sort.spec.ts
@@ -18,6 +18,22 @@ function makeMessage(overrides: Record<string, unknown> = {}): GenericMessage {
   } as unknown as GenericMessage;
 }
 
+function makeAuthorizedMessage(
+  descriptorOverrides: Record<string, unknown>,
+  signaturePayload: Record<string, unknown>,
+): GenericMessage {
+  const payload = Buffer.from(JSON.stringify(signaturePayload)).toString('base64url');
+  return {
+    ...makeMessage(descriptorOverrides),
+    authorization: {
+      signature: {
+        payload,
+        signatures: [{ protected: payload, signature: 'fake' }],
+      },
+    },
+  } as unknown as GenericMessage;
+}
+
 describe('topologicalSort', () => {
   it('should return empty array for empty input', () => {
     const result = topologicalSort([]);
@@ -141,9 +157,10 @@ describe('topologicalSort', () => {
       } as unknown as GenericMessage,
     };
     const dependentMsg: SortEntry = {
-      message: makeMessage({
-        permissionGrantId: 'grant-rec-id',
-      }),
+      message: makeAuthorizedMessage(
+        { permissionGrantId: 'grant-rec-id' },
+        { permissionGrantId: 'grant-rec-id' },
+      ),
     };
 
     const result = topologicalSort([dependentMsg, grantMsg]);
@@ -164,11 +181,14 @@ describe('topologicalSort', () => {
       } as unknown as GenericMessage,
     };
     const dependentMsg: SortEntry = {
-      message: makeMessage({
-        interface          : DwnInterfaceName.Messages,
-        method             : DwnMethodName.Sync,
-        permissionGrantIds : ['grant-rec-id'],
-      }),
+      message: makeAuthorizedMessage(
+        {
+          interface          : DwnInterfaceName.Messages,
+          method             : DwnMethodName.Sync,
+          permissionGrantIds : ['grant-rec-id'],
+        },
+        { permissionGrantIds: ['grant-rec-id'] },
+      ),
     };
 
     const result = topologicalSort([dependentMsg, grantMsg]);

--- a/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
@@ -18,8 +18,8 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { DataStream, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, PermissionGrant, PermissionsProtocol, Time } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
-import { Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName } from '../../src/index.js';
 
 
 export function testMessagesSyncHandler(): void {
@@ -540,6 +540,100 @@ export function testMessagesSyncHandler(): void {
           expect(reply.status.code).toBe(200);
           expect(reply.entries).toContain(await Message.getCid(recordMessage));
           expect(syncMsg.descriptor.permissionGrantIds).toEqual([...grantIds].sort());
+        });
+
+        it('rejects sync when any grant in a plural grant set is expired', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+          const protocol = 'http://plural-grant-sync-expired';
+          const now = Time.getCurrentTimestamp();
+
+          const { message: activeGrantMessage, dataStream: activeGrantDataStream } = await TestDataGenerator.generateGrantCreate({
+            author      : alice,
+            grantedTo   : bob,
+            dateExpires : Time.createOffsetTimestamp({ seconds: 60 * 60 }, now),
+            scope       : {
+              interface : DwnInterfaceName.Messages,
+              method    : DwnMethodName.Read,
+              protocol,
+            },
+          });
+          expect((await dwn.processMessage(alice.did, activeGrantMessage, { dataStream: activeGrantDataStream })).status.code).toBe(202);
+
+          const { message: expiredGrantMessage, dataStream: expiredGrantDataStream } = await TestDataGenerator.generateGrantCreate({
+            author      : alice,
+            grantedTo   : bob,
+            dateGranted : Time.createOffsetTimestamp({ seconds: -120 }, now),
+            dateExpires : Time.createOffsetTimestamp({ seconds: -60 }, now),
+            scope       : {
+              interface : DwnInterfaceName.Messages,
+              method    : DwnMethodName.Read,
+              protocol,
+            },
+          });
+          expect((await dwn.processMessage(alice.did, expiredGrantMessage, { dataStream: expiredGrantDataStream })).status.code).toBe(202);
+
+          const { message: syncMsg } = await MessagesSync.create({
+            signer             : Jws.createSigner(bob),
+            action             : 'root',
+            protocol,
+            permissionGrantIds : [activeGrantMessage.recordId, expiredGrantMessage.recordId],
+          });
+
+          const reply = await dwn.processMessage(alice.did, syncMsg);
+          expect(reply.status.code).toBe(401);
+          expect(reply.status.detail).toContain(DwnErrorCode.GrantAuthorizationGrantExpired);
+        });
+
+        it('rejects sync when any grant in a plural grant set is revoked', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+          const protocol = 'http://plural-grant-sync-revoked';
+
+          const { message: activeGrantMessage, dataStream: activeGrantDataStream } = await TestDataGenerator.generateGrantCreate({
+            author    : alice,
+            grantedTo : bob,
+            scope     : {
+              interface : DwnInterfaceName.Messages,
+              method    : DwnMethodName.Read,
+              protocol,
+            },
+          });
+          expect((await dwn.processMessage(alice.did, activeGrantMessage, { dataStream: activeGrantDataStream })).status.code).toBe(202);
+
+          const revokedGrant = await TestDataGenerator.generateGrantCreate({
+            author    : alice,
+            grantedTo : bob,
+            scope     : {
+              interface : DwnInterfaceName.Messages,
+              method    : DwnMethodName.Read,
+              protocol,
+            },
+          });
+          expect((await dwn.processMessage(alice.did, revokedGrant.message, { dataStream: revokedGrant.dataStream })).status.code).toBe(202);
+
+          const revocation = await PermissionsProtocol.createRevocation({
+            signer : Jws.createSigner(alice),
+            grant  : PermissionGrant.parse(revokedGrant.dataEncodedMessage),
+          });
+          const revocationReply = await dwn.processMessage(
+            alice.did,
+            revocation.recordsWrite.message,
+            { dataStream: DataStream.fromBytes(revocation.permissionRevocationBytes) }
+          );
+          expect(revocationReply.status.code).toBe(202);
+          await Time.minimalSleep();
+
+          const { message: syncMsg } = await MessagesSync.create({
+            signer             : Jws.createSigner(bob),
+            action             : 'root',
+            protocol,
+            permissionGrantIds : [activeGrantMessage.recordId, revokedGrant.message.recordId],
+          });
+
+          const reply = await dwn.processMessage(alice.did, syncMsg);
+          expect(reply.status.code).toBe(401);
+          expect(reply.status.detail).toContain(DwnErrorCode.GrantAuthorizationGrantRevoked);
         });
 
         it('rejects sync with mismatching interface grant scope', async () => {


### PR DESCRIPTION
## Summary
- add canonical full/protocol sync scopes with projection IDs and authorization epochs
- use one protocol-set link per tenant, endpoint, projection, and authorization epoch
- resolve delegated Messages.Read grant sets up front and thread permissionGrantIds through sync/read/subscribe paths
- tighten scoped live handling for RecordsDelete, event scope metadata, and signed grant-id dependency extraction

## Testing
- bun run --filter @enbox/agent lint
- bun run --filter @enbox/agent build:esm
- bun run --filter @enbox/dwn-sdk-js lint
- bun test packages/agent/tests/sync-engine-private.spec.ts packages/agent/tests/sync-closure-resolver.spec.ts packages/agent/tests/sync-topological-sort.spec.ts
- GREP='MessagesSyncHandler.handle' bun run --filter @enbox/dwn-sdk-js test:node-grep