### PR TITLE
Gate pulled sync messages by scope

### DIFF
--- a/.changeset/sync-preapply-scope-gate.md
+++ b/.changeset/sync-preapply-scope-gate.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Reject pulled sync messages that fall outside a protocol-scoped link before applying them locally.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -13,6 +13,7 @@ import type { ClosureEvaluationContext } from './sync-closure-types.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
 import type { SyncMessageEntry } from './sync-messages.js';
+import type { SyncScopeClassification } from './sync-scope-acceptance.js';
 import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
@@ -92,6 +93,10 @@ enum LinkSubscriptionOpenResult {
   ReadyForLive = 'readyForLive',
   Repairing = 'repairing',
 }
+
+type PullAcceptanceResult =
+  | { accepted: true }
+  | { accepted: false; classification: Exclude<SyncScopeClassification, 'in-scope'> };
 
 // ---------------------------------------------------------------------------
 // Per-link in-memory delivery-order tracking (not persisted to ledger)
@@ -2408,7 +2413,7 @@ export class SyncEngineLevel implements SyncEngine {
   /** Push retry backoff schedule: immediate, 250ms, 1s, 2s, then give up. */
   private static readonly PUSH_RETRY_BACKOFF_MS = [0, 250, 1000, 2000];
   private static readonly ROOT_CONVERGENCE_CLEARABLE_DEAD_LETTER_CATEGORIES: ReadonlySet<DeadLetterCategory> =
-    new Set(['push-permanent', 'push-exhausted', 'pull-processing']);
+    new Set(['push-permanent', 'push-exhausted', 'pull-processing', 'pull-scope-rejected']);
 
   /**
    * Re-queues a failed push batch for retry, or marks the link
@@ -3117,6 +3122,7 @@ export class SyncEngineLevel implements SyncEngine {
     const scope: SyncScope = protocol === undefined
       ? { kind: 'full' }
       : { kind: 'protocolSet', protocols: [protocol] };
+    const rejectedPullEntries = new Map<string, Extract<PullAcceptanceResult, { accepted: false }>>();
     const failedCids = await pullMessages({
       did,
       dwnUrl,
@@ -3125,18 +3131,28 @@ export class SyncEngineLevel implements SyncEngine {
       messageCids,
       prefetched,
       agent       : this.agent,
-      acceptEntry : (entry, entries) => this.acceptPulledSyncEntry(did, scope, entry, entries),
+      acceptEntry : async (entry, entries) => {
+        const result = await this.acceptPulledSyncEntry(did, scope, entry, entries);
+        if (!result.accepted) {
+          rejectedPullEntries.set(await getMessageCid(entry.message), result);
+        }
+        return result.accepted;
+      },
     });
 
     // Record permanently failed pull entries in the dead letter store.
     for (const cid of failedCids) {
+      const rejection = rejectedPullEntries.get(cid);
       await this.recordDeadLetter({
         messageCid     : cid,
         tenantDid      : did,
         remoteEndpoint : dwnUrl,
         protocol,
-        category       : 'pull-processing',
-        errorDetail    : 'pull processing failed after retry passes exhausted',
+        category       : rejection ? 'pull-scope-rejected' : 'pull-processing',
+        errorCode      : rejection?.classification,
+        errorDetail    : rejection
+          ? `pulled message rejected by ${rejection.classification} sync scope gate`
+          : 'pull processing failed after retry passes exhausted',
       });
     }
   }
@@ -3146,9 +3162,9 @@ export class SyncEngineLevel implements SyncEngine {
     scope: SyncScope,
     entry: SyncMessageEntry,
     entries: SyncMessageEntry[],
-  ): Promise<boolean> {
+  ): Promise<PullAcceptanceResult> {
     if (scope.kind === 'full') {
-      return true;
+      return { accepted: true };
     }
 
     const initialWrite = await this.resolvePulledDeleteInitialWrite(did, entry.message, entries);
@@ -3159,12 +3175,12 @@ export class SyncEngineLevel implements SyncEngine {
     });
 
     if (classification === 'in-scope') {
-      return true;
+      return { accepted: true };
     }
 
     const messageCid = await getMessageCid(entry.message);
     console.warn(`SyncEngineLevel: refusing to apply ${classification} pulled message ${messageCid}`);
-    return false;
+    return { accepted: false, classification };
   }
 
   private async resolvePulledDeleteInitialWrite(
@@ -3181,20 +3197,21 @@ export class SyncEngineLevel implements SyncEngine {
       return undefined;
     }
 
-    const batchInitialWrite = await this.findInitialWriteInPullBatch(descriptor.recordId, entries);
-    if (batchInitialWrite) {
-      return batchInitialWrite;
+    if (!this.agent.dwn.isRemoteMode) {
+      const localInitialWrite = await RecordsWrite.fetchInitialRecordsWriteMessage(
+        this.agent.dwn.node.storage.messageStore,
+        did,
+        descriptor.recordId,
+      );
+      if (localInitialWrite) {
+        return localInitialWrite;
+      }
     }
 
-    if (this.agent.dwn.isRemoteMode) {
-      return undefined;
-    }
-
-    return RecordsWrite.fetchInitialRecordsWriteMessage(
-      this.agent.dwn.node.storage.messageStore,
-      did,
-      descriptor.recordId,
-    );
+    // Batch entries are only used when the initial write has not been applied
+    // locally yet. The eventual processRawMessage call still authenticates the
+    // delete before any local mutation occurs.
+    return this.findInitialWriteInPullBatch(descriptor.recordId, entries);
   }
 
   private async findInitialWriteInPullBatch(

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1,17 +1,18 @@
 import type { AbstractLevel } from 'abstract-level';
 
 import type { DwnSubscriptionHandler, ResubscribeFactory } from '@enbox/dwn-clients';
-import type { GenericMessage, MessageEvent, MessagesSubscribeReply, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, MessageEvent, MessagesSubscribeReply, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, RecordsWriteMessage, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
 import ms from 'ms';
 
 import { Level } from 'level';
 import { sleep } from '@enbox/common';
-import { Encoder, hashToHex, initDefaultHashes, Message, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName, Encoder, hashToHex, initDefaultHashes, Message, RecordsWrite } from '@enbox/dwn-sdk-js';
 
 import type { ClosureEvaluationContext } from './sync-closure-types.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
+import type { SyncMessageEntry } from './sync-messages.js';
 import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
@@ -22,9 +23,10 @@ import { ReplicationLedger } from './sync-replication-ledger.js';
 import { SyncLinkReconciler } from './sync-link-reconciler.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { buildLegacyCursorKey, buildLinkId } from './sync-link-id.js';
+import { classifySyncEventScope, classifySyncMessageScope } from './sync-scope-acceptance.js';
 import { computeAuthorizationEpoch, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { createClosureContext, invalidateClosureCache } from './sync-closure-types.js';
-import { fetchRemoteMessages, pullMessages, pushMessages } from './sync-messages.js';
+import { fetchRemoteMessages, getMessageCid, pullMessages, pushMessages } from './sync-messages.js';
 import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
 export type SyncEngineLevelParams = {
@@ -109,64 +111,6 @@ type InFlightCommit = {
   /** Whether processRawMessage has completed successfully. */
   committed: boolean;
 };
-
-type EventScopeClassification = 'in-scope' | 'out-of-scope' | 'unknown';
-
-/**
- * Classifies whether an event belongs to the link's current sync scope.
- *
- * Full links accept every message. Protocol-set links accept protocol
- * records, protocol configures, and permission records tagged for a covered
- * protocol. RecordsDelete has no descriptor protocol, so it must be classified
- * from the event's initial write. If that metadata is missing, the caller must
- * repair/reconcile instead of advancing past the event.
- */
-function classifyEventScope(event: MessageEvent, scope: SyncScope): EventScopeClassification {
-  if (scope.kind === 'full') { return 'in-scope'; }
-
-  const descriptor = event.message.descriptor as Record<string, unknown>;
-  const scopedDescriptor = getScopedEventDescriptor(event);
-  if (scopedDescriptor === undefined) {
-    return 'unknown';
-  }
-
-  const protocol = scopedDescriptor.protocol;
-  if (protocol === PermissionsProtocol.uri && typeof scopedDescriptor.tags === 'object' && scopedDescriptor.tags !== null) {
-    const taggedProtocol = (scopedDescriptor.tags as Record<string, unknown>).protocol;
-    return typeof taggedProtocol === 'string' && scope.protocols.includes(taggedProtocol)
-      ? 'in-scope'
-      : 'out-of-scope';
-  }
-
-  if (typeof protocol === 'string' && scope.protocols.includes(protocol)) {
-    return 'in-scope';
-  }
-  if (typeof protocol === 'string') {
-    return 'out-of-scope';
-  }
-
-  if (
-    descriptor.interface === 'Protocols' &&
-    descriptor.method === 'Configure' &&
-    typeof descriptor.definition === 'object' &&
-    descriptor.definition !== null
-  ) {
-    const definitionProtocol = (descriptor.definition as Record<string, unknown>).protocol;
-    return typeof definitionProtocol === 'string' && scope.protocols.includes(definitionProtocol)
-      ? 'in-scope'
-      : 'out-of-scope';
-  }
-
-  return 'out-of-scope';
-}
-
-function getScopedEventDescriptor(event: MessageEvent): Record<string, unknown> | undefined {
-  const descriptor = event.message.descriptor as Record<string, unknown>;
-  if (descriptor.interface === 'Records' && descriptor.method === 'Delete') {
-    return event.initialWrite?.descriptor as Record<string, unknown> | undefined;
-  }
-  return descriptor;
-}
 
 /**
  * Per-link runtime state held in memory. Not persisted — on crash,
@@ -1966,7 +1910,7 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     if (link) {
-      const scopeClassification = classifyEventScope(subMessage.event, link.scope);
+      const scopeClassification = classifySyncEventScope(subMessage.event, link.scope);
       if (scopeClassification === 'out-of-scope') {
         await this.skipOutOfScopePullEvent({ link, cursor: subMessage.cursor, isStale });
         return true;
@@ -2232,7 +2176,7 @@ export class SyncEngineLevel implements SyncEngine {
       const pushLinkKey = target.linkKey;
       const pushLink = this._activeLinks.get(pushLinkKey);
       if (pushLink) {
-        const scopeClassification = classifyEventScope(subMessage.event, pushLink.scope);
+        const scopeClassification = classifySyncEventScope(subMessage.event, pushLink.scope);
         if (scopeClassification === 'out-of-scope') {
           return;
         }
@@ -3170,9 +3114,18 @@ export class SyncEngineLevel implements SyncEngine {
     messageCids: string[];
     prefetched?: MessagesSyncDiffEntry[];
   }): Promise<void> {
+    const scope: SyncScope = protocol === undefined
+      ? { kind: 'full' }
+      : { kind: 'protocolSet', protocols: [protocol] };
     const failedCids = await pullMessages({
-      did, dwnUrl, delegateDid, permissionGrantIds, messageCids, prefetched,
-      agent: this.agent,
+      did,
+      dwnUrl,
+      delegateDid,
+      permissionGrantIds,
+      messageCids,
+      prefetched,
+      agent       : this.agent,
+      acceptEntry : (entry, entries) => this.acceptPulledSyncEntry(did, scope, entry, entries),
     });
 
     // Record permanently failed pull entries in the dead letter store.
@@ -3186,6 +3139,81 @@ export class SyncEngineLevel implements SyncEngine {
         errorDetail    : 'pull processing failed after retry passes exhausted',
       });
     }
+  }
+
+  private async acceptPulledSyncEntry(
+    did: string,
+    scope: SyncScope,
+    entry: SyncMessageEntry,
+    entries: SyncMessageEntry[],
+  ): Promise<boolean> {
+    if (scope.kind === 'full') {
+      return true;
+    }
+
+    const initialWrite = await this.resolvePulledDeleteInitialWrite(did, entry.message, entries);
+    const classification = classifySyncMessageScope({
+      message: entry.message,
+      initialWrite,
+      scope,
+    });
+
+    if (classification === 'in-scope') {
+      return true;
+    }
+
+    const messageCid = await getMessageCid(entry.message);
+    console.warn(`SyncEngineLevel: refusing to apply ${classification} pulled message ${messageCid}`);
+    return false;
+  }
+
+  private async resolvePulledDeleteInitialWrite(
+    did: string,
+    message: GenericMessage,
+    entries: SyncMessageEntry[],
+  ): Promise<RecordsWriteMessage | undefined> {
+    const descriptor = message.descriptor as Record<string, unknown>;
+    if (
+      descriptor.interface !== DwnInterfaceName.Records ||
+      descriptor.method !== DwnMethodName.Delete ||
+      typeof descriptor.recordId !== 'string'
+    ) {
+      return undefined;
+    }
+
+    const batchInitialWrite = await this.findInitialWriteInPullBatch(descriptor.recordId, entries);
+    if (batchInitialWrite) {
+      return batchInitialWrite;
+    }
+
+    if (this.agent.dwn.isRemoteMode) {
+      return undefined;
+    }
+
+    return RecordsWrite.fetchInitialRecordsWriteMessage(
+      this.agent.dwn.node.storage.messageStore,
+      did,
+      descriptor.recordId,
+    );
+  }
+
+  private async findInitialWriteInPullBatch(
+    recordId: string,
+    entries: SyncMessageEntry[],
+  ): Promise<RecordsWriteMessage | undefined> {
+    for (const entry of entries) {
+      if (entry.message.descriptor.interface !== DwnInterfaceName.Records ||
+        entry.message.descriptor.method !== DwnMethodName.Write) {
+        continue;
+      }
+
+      const candidate = entry.message as RecordsWriteMessage;
+      if (candidate.recordId === recordId && await RecordsWrite.isInitialWrite(candidate)) {
+        return candidate;
+      }
+    }
+
+    return undefined;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -21,6 +21,12 @@ export type SyncMessageEntry = {
   bufferedData?: Uint8Array;
 };
 
+/** Optional pre-apply gate for inbound sync entries. */
+export type PullMessageAcceptance = (
+  entry: SyncMessageEntry,
+  entries: SyncMessageEntry[],
+) => Promise<boolean>;
+
 /**
  * 202: message was successfully written to the remote DWN
  * 204: an initial write message was written without any data
@@ -103,7 +109,7 @@ export async function getMessageCid(message: GenericMessage): Promise<string> {
  * Large payloads are re-fetched on retry since buffering them would consume
  * too much memory.
  */
-export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, prefetched, agent }: {
+export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, prefetched, acceptEntry, agent }: {
   did: string;
   dwnUrl: string;
   delegateDid?: string;
@@ -111,6 +117,7 @@ export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantId
   messageCids: string[];
   /** Pre-fetched message entries from the batched diff response (already have message + data). */
   prefetched?: MessagesSyncDiffEntry[];
+  acceptEntry?: PullMessageAcceptance;
   agent: EnboxPlatformAgent;
 }): Promise<string[]> {
   // Step 1: Fetch remaining messages (not prefetched) from the remote.
@@ -121,8 +128,10 @@ export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantId
   // Merge prefetched entries with remotely fetched ones.
   const allFetched = [...syncEntriesFromPrefetchedDiff(prefetched), ...fetched];
 
+  const { accepted, rejectedCids } = await applyPullAcceptanceGate(allFetched, acceptEntry);
+
   // Step 2: Build dependency graph and topological sort.
-  const sorted = topologicalSort(allFetched);
+  const sorted = topologicalSort(accepted);
 
   // Step 3: Buffer small data streams so they can be replayed on retry.
   await bufferSmallStreams(sorted);
@@ -139,7 +148,28 @@ export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantId
   }
 
   // Return CIDs that permanently failed after all retry passes.
-  return getMessageCids(pending);
+  return [...rejectedCids, ...await getMessageCids(pending)];
+}
+
+async function applyPullAcceptanceGate(
+  entries: SyncMessageEntry[],
+  acceptEntry: PullMessageAcceptance | undefined,
+): Promise<{ accepted: SyncMessageEntry[]; rejectedCids: string[] }> {
+  if (!acceptEntry) {
+    return { accepted: entries, rejectedCids: [] };
+  }
+
+  const accepted: SyncMessageEntry[] = [];
+  const rejectedCids: string[] = [];
+  for (const entry of entries) {
+    if (await acceptEntry(entry, entries)) {
+      accepted.push(entry);
+    } else {
+      rejectedCids.push(await getMessageCid(entry.message));
+    }
+  }
+
+  return { accepted, rejectedCids };
 }
 
 function syncEntriesFromPrefetchedDiff(prefetched?: MessagesSyncDiffEntry[]): SyncMessageEntry[] {

--- a/packages/agent/src/sync-scope-acceptance.ts
+++ b/packages/agent/src/sync-scope-acceptance.ts
@@ -1,0 +1,95 @@
+import type { GenericMessage, MessageEvent, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
+
+import { DwnInterfaceName, DwnMethodName, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+
+import type { SyncScope } from './types/sync.js';
+
+/** Result of testing whether an inbound sync message belongs to a link scope. */
+export type SyncScopeClassification = 'in-scope' | 'out-of-scope' | 'unknown';
+
+type SyncMessageScopeClassificationParams = {
+  message: GenericMessage;
+  initialWrite?: RecordsWriteMessage;
+  scope: SyncScope;
+};
+
+/**
+ * Classifies whether a live event belongs to the link's current sync scope.
+ *
+ * Full links accept every message. Protocol-set links accept records for a
+ * covered protocol, ProtocolsConfigure messages that install a covered
+ * protocol, and permission records tagged for a covered protocol. RecordsDelete
+ * messages carry no protocol in their descriptor, so they must be classified
+ * from the event's initial write metadata.
+ */
+export function classifySyncEventScope(event: MessageEvent, scope: SyncScope): SyncScopeClassification {
+  return classifySyncMessageScope({
+    message      : event.message,
+    initialWrite : event.initialWrite,
+    scope,
+  });
+}
+
+/**
+ * Classifies whether a DWN message belongs to a sync scope before local apply.
+ *
+ * If a RecordsDelete cannot be tied to its initial write, the result is
+ * `unknown` so callers fail closed instead of applying an unclassified delete.
+ */
+export function classifySyncMessageScope({
+  message,
+  initialWrite,
+  scope,
+}: SyncMessageScopeClassificationParams): SyncScopeClassification {
+  if (scope.kind === 'full') { return 'in-scope'; }
+
+  const descriptor = message.descriptor as Record<string, unknown>;
+  const scopedDescriptor = getScopedMessageDescriptor(message, initialWrite);
+  if (scopedDescriptor === undefined) {
+    return 'unknown';
+  }
+
+  const protocol = scopedDescriptor.protocol;
+  if (protocol === PermissionsProtocol.uri && isRecordObject(scopedDescriptor.tags)) {
+    const taggedProtocol = scopedDescriptor.tags.protocol;
+    return typeof taggedProtocol === 'string' && scope.protocols.includes(taggedProtocol)
+      ? 'in-scope'
+      : 'out-of-scope';
+  }
+
+  if (typeof protocol === 'string') {
+    return scope.protocols.includes(protocol) ? 'in-scope' : 'out-of-scope';
+  }
+
+  if (
+    descriptor.interface === DwnInterfaceName.Protocols &&
+    descriptor.method === DwnMethodName.Configure &&
+    isRecordObject(descriptor.definition)
+  ) {
+    const definitionProtocol = descriptor.definition.protocol;
+    return typeof definitionProtocol === 'string' && scope.protocols.includes(definitionProtocol)
+      ? 'in-scope'
+      : 'out-of-scope';
+  }
+
+  return 'out-of-scope';
+}
+
+function getScopedMessageDescriptor(
+  message: GenericMessage,
+  initialWrite: RecordsWriteMessage | undefined,
+): Record<string, unknown> | undefined {
+  const descriptor = message.descriptor as Record<string, unknown>;
+  if (
+    descriptor.interface === DwnInterfaceName.Records &&
+    descriptor.method === DwnMethodName.Delete
+  ) {
+    return initialWrite?.descriptor as Record<string, unknown> | undefined;
+  }
+
+  return descriptor;
+}
+
+function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -393,7 +393,7 @@ export type SyncEventListener = (event: SyncEvent) => void;
 // ---------------------------------------------------------------------------
 
 /** Category of sync failure for dead letter entries. */
-export type DeadLetterCategory = 'push-permanent' | 'push-exhausted' | 'pull-processing' | 'closure';
+export type DeadLetterCategory = 'push-permanent' | 'push-exhausted' | 'pull-processing' | 'pull-scope-rejected' | 'closure';
 
 /** A message that permanently failed to sync. */
 export type DeadLetterEntry = {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import { Level } from 'level';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
+import { Message, RecordsWrite, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from '../src/types/dwn.js';
 import { getMessagesPermissionGrantsForScope } from '../src/sync-permission-grants.js';
@@ -2346,6 +2347,9 @@ describe('SyncEngineLevel — private methods', () => {
   // ---------------------------------------------------------------------------
 
   describe('pullMessages / pushMessages delegate wrappers', () => {
+    const profileProtocol = 'https://example.com/profile';
+    const socialProtocol = 'https://example.com/social';
+
     it('pullMessages should delegate to sync-messages pullMessages', async () => {
       const mockAgent = {
         agentDid          : 'did:example:agent',
@@ -2409,9 +2413,143 @@ describe('SyncEngineLevel — private methods', () => {
       const failedMessages = await engine.getFailedMessages();
       expect(mockAgent.dwn.processRawMessage.called).toBe(false);
       expect(failedMessages).toHaveLength(1);
-      expect(failedMessages[0].category).toBe('pull-processing');
+      expect(failedMessages[0].category).toBe('pull-scope-rejected');
+      expect(failedMessages[0].errorCode).toBe('out-of-scope');
       expect(failedMessages[0].protocol).toBe('https://example.com/profile');
       expect(failedMessages[0].remoteEndpoint).toBe('https://dwn.example.com');
+    });
+
+    it('pullMessages should classify a pulled delete from an in-scope batch initial write', async () => {
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : {
+          isRemoteMode      : true,
+          processRawMessage : sinon.stub().resolves({ status: { code: 202 } }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      const recordsWrite = await TestDataGenerator.generateRecordsWrite({ protocol: profileProtocol });
+      const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+        author   : recordsWrite.author,
+        recordId : recordsWrite.message.recordId,
+      });
+
+      await (engine as any).pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        protocol    : profileProtocol,
+        messageCids : [],
+        prefetched  : [
+          { messageCid: await Message.getCid(recordsWrite.message), message: recordsWrite.message },
+          { messageCid: await Message.getCid(recordsDelete.message), message: recordsDelete.message },
+        ],
+      });
+
+      expect(mockAgent.dwn.processRawMessage.callCount).toBe(2);
+      expect(mockAgent.dwn.processRawMessage.secondCall.args[1]).toBe(recordsDelete.message);
+      expect(await engine.getFailedMessages()).toHaveLength(0);
+    });
+
+    it('pullMessages should reject a pulled delete from an out-of-scope batch initial write', async () => {
+      sinon.stub(console, 'warn');
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : {
+          isRemoteMode      : true,
+          processRawMessage : sinon.stub().resolves({ status: { code: 202 } }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      const recordsWrite = await TestDataGenerator.generateRecordsWrite({ protocol: socialProtocol });
+      const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+        author   : recordsWrite.author,
+        recordId : recordsWrite.message.recordId,
+      });
+      const deleteCid = await Message.getCid(recordsDelete.message);
+
+      await (engine as any).pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        protocol    : profileProtocol,
+        messageCids : [],
+        prefetched  : [
+          { messageCid: await Message.getCid(recordsWrite.message), message: recordsWrite.message },
+          { messageCid: deleteCid, message: recordsDelete.message },
+        ],
+      });
+
+      const failedMessages = await engine.getFailedMessages();
+      const deleteFailure = failedMessages.find(entry => entry.messageCid === deleteCid);
+      expect(mockAgent.dwn.processRawMessage.called).toBe(false);
+      expect(deleteFailure?.category).toBe('pull-scope-rejected');
+      expect(deleteFailure?.errorCode).toBe('out-of-scope');
+    });
+
+    it('pullMessages should classify a pulled delete from the local initial write', async () => {
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : {
+          isRemoteMode      : false,
+          node              : { storage: { messageStore: {} } },
+          processRawMessage : sinon.stub().resolves({ status: { code: 202 } }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      const recordsWrite = await TestDataGenerator.generateRecordsWrite({ protocol: profileProtocol });
+      const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+        author   : recordsWrite.author,
+        recordId : recordsWrite.message.recordId,
+      });
+      const fetchInitialStub = sinon.stub(RecordsWrite, 'fetchInitialRecordsWriteMessage').resolves(recordsWrite.message);
+
+      await (engine as any).pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        protocol    : profileProtocol,
+        messageCids : [],
+        prefetched  : [{ messageCid: await Message.getCid(recordsDelete.message), message: recordsDelete.message }],
+      });
+
+      expect(fetchInitialStub.calledOnce).toBe(true);
+      expect(mockAgent.dwn.processRawMessage.calledOnce).toBe(true);
+      expect(mockAgent.dwn.processRawMessage.firstCall.args[1]).toBe(recordsDelete.message);
+      expect(await engine.getFailedMessages()).toHaveLength(0);
+    });
+
+    it('pullMessages should fail closed for an unknown pulled delete in remote mode', async () => {
+      sinon.stub(console, 'warn');
+      const fetchInitialStub = sinon.stub(RecordsWrite, 'fetchInitialRecordsWriteMessage');
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : {
+          isRemoteMode      : true,
+          processRawMessage : sinon.stub().resolves({ status: { code: 202 } }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      const recordsDelete = await TestDataGenerator.generateRecordsDelete();
+
+      await (engine as any).pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        protocol    : profileProtocol,
+        messageCids : [],
+        prefetched  : [{ messageCid: await Message.getCid(recordsDelete.message), message: recordsDelete.message }],
+      });
+
+      const failedMessages = await engine.getFailedMessages();
+      expect(fetchInitialStub.called).toBe(false);
+      expect(mockAgent.dwn.processRawMessage.called).toBe(false);
+      expect(failedMessages).toHaveLength(1);
+      expect(failedMessages[0].category).toBe('pull-scope-rejected');
+      expect(failedMessages[0].errorCode).toBe('unknown');
+
+      await (engine as any).clearRootConvergenceDeadLettersForScope(
+        'did:example:alice',
+        'https://dwn.example.com',
+        { kind: 'protocolSet', protocols: [profileProtocol] },
+      );
+      expect(await engine.getFailedMessages()).toHaveLength(0);
     });
 
     it('pushMessages should delegate to sync-messages pushMessages', async () => {
@@ -4396,12 +4534,21 @@ describe('SyncEngineLevel — private methods', () => {
         category       : 'pull-processing',
         errorDetail    : 'transient pull failure before root convergence',
       });
+      await engine.recordDeadLetter({
+        messageCid     : 'dl-scope',
+        tenantDid      : 'did:example:closure-health',
+        remoteEndpoint : 'https://dwn.example.com',
+        protocol       : 'https://example.com/proto',
+        category       : 'pull-scope-rejected',
+        errorCode      : 'unknown',
+        errorDetail    : 'transient pull scope rejection before root convergence',
+      });
 
       await (engine as any).clearDeadLettersForLink(
         'did:example:closure-health',
         'https://dwn.example.com',
         'https://example.com/proto',
-        { categories: new Set(['push-permanent', 'push-exhausted', 'pull-processing']) },
+        { categories: new Set(['push-permanent', 'push-exhausted', 'pull-processing', 'pull-scope-rejected']) },
       );
 
       const remaining = await engine.getFailedMessages();

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -2373,6 +2373,47 @@ describe('SyncEngineLevel — private methods', () => {
       expect(mockAgent.dwn.processRawMessage.called).toBe(true);
     });
 
+    it('pullMessages should reject prefetched entries outside the requested protocol', async () => {
+      sinon.stub(console, 'warn');
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        processDwnRequest : sinon.stub().resolves({ message: {} }),
+        dwn               : {
+          processRawMessage: sinon.stub().resolves({ status: { code: 202 } }),
+        },
+        rpc: {
+          sendDwnRequest: sinon.stub(),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      const outOfScopeMessage = {
+        descriptor: {
+          interface        : 'Records',
+          method           : 'Write',
+          protocol         : 'https://example.com/social',
+          protocolPath     : 'profile',
+          dateCreated      : '2026-01-01T00:00:00.000000Z',
+          messageTimestamp : '2026-01-01T00:00:00.000000Z',
+        },
+        recordId: 'record-1',
+      } as any;
+
+      await (engine as any).pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        protocol    : 'https://example.com/profile',
+        messageCids : [],
+        prefetched  : [{ messageCid: 'cid-1', message: outOfScopeMessage }],
+      });
+
+      const failedMessages = await engine.getFailedMessages();
+      expect(mockAgent.dwn.processRawMessage.called).toBe(false);
+      expect(failedMessages).toHaveLength(1);
+      expect(failedMessages[0].category).toBe('pull-processing');
+      expect(failedMessages[0].protocol).toBe('https://example.com/profile');
+      expect(failedMessages[0].remoteEndpoint).toBe('https://dwn.example.com');
+    });
+
     it('pushMessages should delegate to sync-messages pushMessages', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -3,7 +3,7 @@ import type { UnionMessageReply } from '@enbox/dwn-sdk-js';
 import sinon from 'sinon';
 
 import { afterEach, describe, expect, it } from 'bun:test';
-import { DwnInterfaceName, DwnMethodName } from '@enbox/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName, Message } from '@enbox/dwn-sdk-js';
 
 import {
   fetchRemoteMessages,
@@ -384,6 +384,79 @@ describe('sync-messages', () => {
 
       // No messages to process
       expect(mockAgent.dwn.processRawMessage.called).toBe(false);
+    });
+
+    it('should reject prefetched messages before local apply when the acceptance gate fails', async () => {
+      const message = {
+        descriptor: {
+          interface  : DwnInterfaceName.Protocols,
+          method     : DwnMethodName.Configure,
+          definition : { protocol: 'https://example.com/blocked' },
+        },
+      } as any;
+      const expectedCid = await Message.getCid(message);
+      const mockAgent = {
+        processDwnRequest : sinon.stub(),
+        rpc               : { sendDwnRequest: sinon.stub() },
+        dwn               : { processRawMessage: sinon.stub() },
+      } as any;
+
+      const failedCids = await pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : [],
+        prefetched  : [{ messageCid: expectedCid, message }],
+        acceptEntry : sinon.stub().resolves(false),
+        agent       : mockAgent,
+      });
+
+      expect(failedCids).toEqual([expectedCid]);
+      expect(mockAgent.dwn.processRawMessage.called).toBe(false);
+    });
+
+    it('should apply only accepted prefetched messages', async () => {
+      const acceptedMessage = {
+        descriptor: {
+          interface  : DwnInterfaceName.Protocols,
+          method     : DwnMethodName.Configure,
+          definition : { protocol: 'https://example.com/accepted' },
+        },
+      } as any;
+      const rejectedMessage = {
+        descriptor: {
+          interface  : DwnInterfaceName.Protocols,
+          method     : DwnMethodName.Configure,
+          definition : { protocol: 'https://example.com/rejected' },
+        },
+      } as any;
+      const acceptedCid = await Message.getCid(acceptedMessage);
+      const rejectedCid = await Message.getCid(rejectedMessage);
+      const acceptEntry = sinon.stub()
+        .onFirstCall().resolves(true)
+        .onSecondCall().resolves(false);
+      const mockAgent = {
+        processDwnRequest : sinon.stub(),
+        rpc               : { sendDwnRequest: sinon.stub() },
+        dwn               : { processRawMessage: sinon.stub().resolves({ status: { code: 202 } }) },
+      } as any;
+
+      const failedCids = await pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : [],
+        prefetched  : [
+          { messageCid: acceptedCid, message: acceptedMessage },
+          { messageCid: rejectedCid, message: rejectedMessage },
+        ],
+        acceptEntry,
+        agent: mockAgent,
+      });
+
+      expect(failedCids).toEqual([rejectedCid]);
+      expect(acceptEntry.calledTwice).toBe(true);
+      expect(acceptEntry.firstCall.args[1]).toHaveLength(2);
+      expect(mockAgent.dwn.processRawMessage.calledOnce).toBe(true);
+      expect(mockAgent.dwn.processRawMessage.firstCall.args[1]).toBe(acceptedMessage);
     });
   });
 

--- a/packages/agent/tests/sync-scope-acceptance.spec.ts
+++ b/packages/agent/tests/sync-scope-acceptance.spec.ts
@@ -1,0 +1,121 @@
+import type { GenericMessage } from '@enbox/dwn-sdk-js';
+
+import { describe, expect, it } from 'bun:test';
+import { DwnInterfaceName, DwnMethodName, PermissionsProtocol, TestDataGenerator } from '@enbox/dwn-sdk-js';
+
+import type { SyncScope } from '../src/types/sync.js';
+
+import { classifySyncMessageScope } from '../src/sync-scope-acceptance.js';
+
+describe('sync-scope-acceptance', () => {
+  const profileProtocol = 'https://identity.foundation/protocols/profile';
+  const socialProtocol = 'https://identity.foundation/protocols/social-graph';
+  const profileScope: SyncScope = { kind: 'protocolSet', protocols: [profileProtocol] };
+
+  it('accepts RecordsWrite messages for a covered protocol', async () => {
+    const { message } = await TestDataGenerator.generateRecordsWrite({ protocol: profileProtocol });
+
+    const classification = classifySyncMessageScope({ message, scope: profileScope });
+
+    expect(classification).toBe('in-scope');
+  });
+
+  it('rejects RecordsWrite messages for a sibling protocol', async () => {
+    const { message } = await TestDataGenerator.generateRecordsWrite({ protocol: socialProtocol });
+
+    const classification = classifySyncMessageScope({ message, scope: profileScope });
+
+    expect(classification).toBe('out-of-scope');
+  });
+
+  it('returns unknown for RecordsDelete without initial write metadata', async () => {
+    const { message } = await TestDataGenerator.generateRecordsDelete();
+
+    const classification = classifySyncMessageScope({ message, scope: profileScope });
+
+    expect(classification).toBe('unknown');
+  });
+
+  it('accepts RecordsDelete when the initial write protocol is covered', async () => {
+    const recordsWrite = await TestDataGenerator.generateRecordsWrite({ protocol: profileProtocol });
+    const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+      author   : recordsWrite.author,
+      recordId : recordsWrite.message.recordId,
+    });
+
+    const classification = classifySyncMessageScope({
+      message      : recordsDelete.message,
+      initialWrite : recordsWrite.message,
+      scope        : profileScope,
+    });
+
+    expect(classification).toBe('in-scope');
+  });
+
+  it('rejects RecordsDelete when the initial write protocol is outside scope', async () => {
+    const recordsWrite = await TestDataGenerator.generateRecordsWrite({ protocol: socialProtocol });
+    const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+      author   : recordsWrite.author,
+      recordId : recordsWrite.message.recordId,
+    });
+
+    const classification = classifySyncMessageScope({
+      message      : recordsDelete.message,
+      initialWrite : recordsWrite.message,
+      scope        : profileScope,
+    });
+
+    expect(classification).toBe('out-of-scope');
+  });
+
+  it('accepts ProtocolsConfigure messages that install a covered protocol', async () => {
+    const { message } = await TestDataGenerator.generateProtocolsConfigure({
+      protocolDefinition: {
+        protocol  : profileProtocol,
+        published : true,
+        types     : {},
+        structure : {},
+      },
+    });
+
+    const classification = classifySyncMessageScope({ message, scope: profileScope });
+
+    expect(classification).toBe('in-scope');
+  });
+
+  it('accepts permission records tagged for a covered protocol', () => {
+    const message = {
+      recordId   : 'permission-grant-record',
+      descriptor : {
+        interface    : DwnInterfaceName.Records,
+        method       : DwnMethodName.Write,
+        protocol     : PermissionsProtocol.uri,
+        protocolPath : PermissionsProtocol.grantPath,
+        tags         : { protocol: profileProtocol },
+      },
+      authorization: { signature: { payload: '', signatures: [] } },
+    } as unknown as GenericMessage;
+
+    const classification = classifySyncMessageScope({ message, scope: profileScope });
+
+    expect(classification).toBe('in-scope');
+  });
+
+  it('rejects permission records tagged for a sibling protocol', () => {
+    const message = {
+      recordId   : 'permission-grant-record',
+      descriptor : {
+        interface    : DwnInterfaceName.Records,
+        method       : DwnMethodName.Write,
+        protocol     : PermissionsProtocol.uri,
+        protocolPath : PermissionsProtocol.grantPath,
+        tags         : { protocol: socialProtocol },
+      },
+      authorization: { signature: { payload: '', signatures: [] } },
+    } as unknown as GenericMessage;
+
+    const classification = classifySyncMessageScope({ message, scope: profileScope });
+
+    expect(classification).toBe('out-of-scope');
+  });
+});


### PR DESCRIPTION
## Summary
- share the agent sync scope classifier between live events and reconciliation pulls
- reject protocol-scoped pulled messages before local apply when they fall outside the requested scope
- fail closed for pulled RecordsDelete messages when initial-write metadata cannot be resolved

## Test plan
- [x] bun run --filter @enbox/agent lint
- [x] bun test --timeout 10000 tests/sync-scope-acceptance.spec.ts tests/sync-messages.spec.ts tests/sync-engine-private.spec.ts
- [x] bun run --filter @enbox/agent build:esm
- [ ] bun run --filter @enbox/agent test:node (fails in this local worktree because DID DHT tests reject localhost Pkarr gateway URI; targeted sync suites above pass)
