### PR TITLE
Abort stale reconciliation pulls

### DIFF
--- a/.changeset/sync-epoch-recheck.md
+++ b/.changeset/sync-epoch-recheck.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Abort in-flight reconciliation pulls when their sync link is no longer current.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -2625,6 +2625,10 @@ export class SyncEngineLevel implements SyncEngine {
     // closure's captured `link` reference may no longer be the active
     // link object. Bail before mutating the replacement's state.
     const isStaleLink = (): boolean => this._activeLinks.get(linkKey) !== link;
+    const shouldContinue = (): boolean =>
+      this._engineGeneration === generation &&
+      !isStaleLink() &&
+      link.status === 'live';
 
     const { tenantDid: did, remoteEndpoint: dwnUrl, delegateDid, scope, authorization } = link;
     const eventScope = syncEventScope(scope);
@@ -2636,7 +2640,7 @@ export class SyncEngineLevel implements SyncEngine {
         delegateDid,
         scope,
         authorization,
-      }, { verifyConvergence: true }, () => this._engineGeneration === generation && !isStaleLink());
+      }, { verifyConvergence: true }, shouldContinue);
       if (reconcileOutcome.aborted || isStaleLink()) { return; }
 
       if (reconcileOutcome.converged) {
@@ -3110,7 +3114,7 @@ export class SyncEngineLevel implements SyncEngine {
    * they are processed directly without additional HTTP round-trips.
    * Only `messageCids` that were NOT prefetched are fetched individually.
    */
-  private async pullMessages({ did, dwnUrl, delegateDid, protocol, permissionGrantIds, messageCids, prefetched }: {
+  private async pullMessages({ did, dwnUrl, delegateDid, protocol, permissionGrantIds, messageCids, prefetched, shouldContinue }: {
     did: string;
     dwnUrl: string;
     delegateDid?: string;
@@ -3118,6 +3122,7 @@ export class SyncEngineLevel implements SyncEngine {
     permissionGrantIds?: string[];
     messageCids: string[];
     prefetched?: MessagesSyncDiffEntry[];
+    shouldContinue?: () => boolean;
   }): Promise<void> {
     const scope: SyncScope = protocol === undefined
       ? { kind: 'full' }
@@ -3130,6 +3135,7 @@ export class SyncEngineLevel implements SyncEngine {
       permissionGrantIds,
       messageCids,
       prefetched,
+      shouldContinue,
       agent       : this.agent,
       acceptEntry : async (entry, entries) => {
         const result = await this.acceptPulledSyncEntry(did, scope, entry, entries);

--- a/packages/agent/src/sync-link-reconciler.ts
+++ b/packages/agent/src/sync-link-reconciler.ts
@@ -2,6 +2,8 @@ import type { GenericMessage, MessagesSyncDiffEntry } from '@enbox/dwn-sdk-js';
 
 import type { PushResult } from './types/sync.js';
 
+import { SyncPullAbortedError } from './sync-messages.js';
+
 export type ReconcileDirection = 'pull' | 'push';
 
 export type ReconcileTarget = {
@@ -48,6 +50,7 @@ type ReconcileDeps = {
     permissionGrantIds?: string[];
     messageCids: string[];
     prefetched: (MessagesSyncDiffEntry & { message: GenericMessage })[];
+    shouldContinue?: () => boolean;
   }) => Promise<void>;
   pushMessages: (params: {
     did: string;
@@ -117,7 +120,23 @@ export class SyncLinkReconciler {
 
       if ((!direction || direction === 'pull') && diff.onlyRemote.length > 0) {
         const { prefetched, needsFetchCids } = partitionRemoteEntries(diff.onlyRemote);
-        await this._deps.pullMessages({ did, dwnUrl, delegateDid, protocol, permissionGrantIds, messageCids: needsFetchCids, prefetched });
+        try {
+          await this._deps.pullMessages({
+            did,
+            dwnUrl,
+            delegateDid,
+            protocol,
+            permissionGrantIds,
+            messageCids: needsFetchCids,
+            prefetched,
+            shouldContinue,
+          });
+        } catch (error) {
+          if (error instanceof SyncPullAbortedError) {
+            return { aborted: true, changed: true, didPull: false, didPush: false, localRoot, remoteRoot };
+          }
+          throw error;
+        }
         if (shouldContinue && !shouldContinue()) { return { aborted: true, changed: true, didPull: true, didPush: false, localRoot, remoteRoot }; }
         didPull = true;
       }

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -27,6 +27,20 @@ export type PullMessageAcceptance = (
   entries: SyncMessageEntry[],
 ) => Promise<boolean>;
 
+/** Raised when an in-flight pull is cancelled before local apply can continue. */
+export class SyncPullAbortedError extends Error {
+  constructor() {
+    super('Sync pull aborted because the sync target is no longer current.');
+    this.name = 'SyncPullAbortedError';
+  }
+}
+
+function assertShouldContinue(shouldContinue: (() => boolean) | undefined): void {
+  if (shouldContinue?.() === false) {
+    throw new SyncPullAbortedError();
+  }
+}
+
 /**
  * 202: message was successfully written to the remote DWN
  * 204: an initial write message was written without any data
@@ -109,7 +123,7 @@ export async function getMessageCid(message: GenericMessage): Promise<string> {
  * Large payloads are re-fetched on retry since buffering them would consume
  * too much memory.
  */
-export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, prefetched, acceptEntry, agent }: {
+export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, prefetched, acceptEntry, shouldContinue, agent }: {
   did: string;
   dwnUrl: string;
   delegateDid?: string;
@@ -118,33 +132,41 @@ export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantId
   /** Pre-fetched message entries from the batched diff response (already have message + data). */
   prefetched?: MessagesSyncDiffEntry[];
   acceptEntry?: PullMessageAcceptance;
+  shouldContinue?: () => boolean;
   agent: EnboxPlatformAgent;
 }): Promise<string[]> {
+  assertShouldContinue(shouldContinue);
+
   // Step 1: Fetch remaining messages (not prefetched) from the remote.
   const fetched = messageCids.length > 0
     ? await fetchRemoteMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids, agent })
     : [];
+  assertShouldContinue(shouldContinue);
 
   // Merge prefetched entries with remotely fetched ones.
   const allFetched = [...syncEntriesFromPrefetchedDiff(prefetched), ...fetched];
 
-  const { accepted, rejectedCids } = await applyPullAcceptanceGate(allFetched, acceptEntry);
+  const { accepted, rejectedCids } = await applyPullAcceptanceGate(allFetched, acceptEntry, shouldContinue);
+  assertShouldContinue(shouldContinue);
 
   // Step 2: Build dependency graph and topological sort.
   const sorted = topologicalSort(accepted);
 
   // Step 3: Buffer small data streams so they can be replayed on retry.
-  await bufferSmallStreams(sorted);
+  await bufferSmallStreams(sorted, shouldContinue);
+  assertShouldContinue(shouldContinue);
 
   // Step 4: Process messages in dependency order with multi-pass retry.
   const MAX_RETRY_PASSES = 3;
   let pending = sorted;
 
   for (let pass = 0; pass <= MAX_RETRY_PASSES && pending.length > 0; pass++) {
-    const failed = await processPullPass({ did, entries: pending, agent });
+    assertShouldContinue(shouldContinue);
+    const failed = await processPullPass({ did, entries: pending, shouldContinue, agent });
+    assertShouldContinue(shouldContinue);
     pending = failed.length === 0
       ? []
-      : await preparePullRetry({ did, dwnUrl, delegateDid, permissionGrantIds, failed, agent });
+      : await preparePullRetry({ did, dwnUrl, delegateDid, permissionGrantIds, failed, shouldContinue, agent });
   }
 
   // Return CIDs that permanently failed after all retry passes.
@@ -154,6 +176,7 @@ export async function pullMessages({ did, dwnUrl, delegateDid, permissionGrantId
 async function applyPullAcceptanceGate(
   entries: SyncMessageEntry[],
   acceptEntry: PullMessageAcceptance | undefined,
+  shouldContinue?: () => boolean,
 ): Promise<{ accepted: SyncMessageEntry[]; rejectedCids: string[] }> {
   if (!acceptEntry) {
     return { accepted: entries, rejectedCids: [] };
@@ -162,11 +185,13 @@ async function applyPullAcceptanceGate(
   const accepted: SyncMessageEntry[] = [];
   const rejectedCids: string[] = [];
   for (const entry of entries) {
+    assertShouldContinue(shouldContinue);
     if (await acceptEntry(entry, entries)) {
       accepted.push(entry);
     } else {
       rejectedCids.push(await getMessageCid(entry.message));
     }
+    assertShouldContinue(shouldContinue);
   }
 
   return { accepted, rejectedCids };
@@ -203,17 +228,20 @@ function replayableDataStream(entry: SyncMessageEntry): ReadableStream<Uint8Arra
   return entry.bufferedData ? dataStreamFromBytes(entry.bufferedData) : entry.dataStream;
 }
 
-async function processPullPass({ did, entries, agent }: {
+async function processPullPass({ did, entries, shouldContinue, agent }: {
   did: string;
   entries: SyncMessageEntry[];
+  shouldContinue?: () => boolean;
   agent: EnboxPlatformAgent;
 }): Promise<SyncMessageEntry[]> {
   const failed: SyncMessageEntry[] = [];
 
   for (const entry of entries) {
+    assertShouldContinue(shouldContinue);
     const pullReply = await agent.dwn.processRawMessage(did, entry.message, {
       dataStream: replayableDataStream(entry),
     });
+    assertShouldContinue(shouldContinue);
 
     if (!syncMessageReplyIsSuccessful(pullReply)) {
       failed.push(entry);
@@ -223,12 +251,13 @@ async function processPullPass({ did, entries, agent }: {
   return failed;
 }
 
-async function preparePullRetry({ did, dwnUrl, delegateDid, permissionGrantIds, failed, agent }: {
+async function preparePullRetry({ did, dwnUrl, delegateDid, permissionGrantIds, failed, shouldContinue, agent }: {
   did: string;
   dwnUrl: string;
   delegateDid?: string;
   permissionGrantIds?: string[];
   failed: SyncMessageEntry[];
+  shouldContinue?: () => boolean;
   agent: EnboxPlatformAgent;
 }): Promise<SyncMessageEntry[]> {
   const canRetry: SyncMessageEntry[] = [];
@@ -243,6 +272,7 @@ async function preparePullRetry({ did, dwnUrl, delegateDid, permissionGrantIds, 
   }
 
   if (needsRefetch.length > 0) {
+    assertShouldContinue(shouldContinue);
     canRetry.push(...await fetchRemoteMessages({
       did,
       dwnUrl,
@@ -251,6 +281,7 @@ async function preparePullRetry({ did, dwnUrl, delegateDid, permissionGrantIds, 
       messageCids: needsRefetch,
       agent,
     }));
+    assertShouldContinue(shouldContinue);
   }
 
   return topologicalSort(canRetry);
@@ -268,8 +299,9 @@ async function getMessageCids(entries: SyncMessageEntry[]): Promise<string[]> {
  * Buffers small data streams into `Uint8Array` so they can be replayed on retry.
  * Streams larger than `MAX_BUFFER_SIZE` are left as-is (will be re-fetched on retry).
  */
-async function bufferSmallStreams(entries: SyncMessageEntry[]): Promise<void> {
+async function bufferSmallStreams(entries: SyncMessageEntry[], shouldContinue?: () => boolean): Promise<void> {
   for (const entry of entries) {
+    assertShouldContinue(shouldContinue);
     if (!entry.dataStream) {
       continue;
     }
@@ -285,6 +317,7 @@ async function bufferSmallStreams(entries: SyncMessageEntry[]): Promise<void> {
       for (;;) {
         const { done, value } = await reader.read();
         if (done) { break; }
+        assertShouldContinue(shouldContinue);
         totalSize += value.byteLength;
         if (totalSize > MAX_BUFFER_SIZE) {
           exceededThreshold = true;
@@ -314,6 +347,7 @@ async function bufferSmallStreams(entries: SyncMessageEntry[]): Promise<void> {
     entry.bufferedData = buffer;
     // Create a fresh ReadableStream from the buffer for the first processing attempt.
     entry.dataStream = dataStreamFromBytes(buffer);
+    assertShouldContinue(shouldContinue);
   }
 }
 

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -3759,6 +3759,41 @@ describe('SyncEngineLevel — private methods', () => {
       const pushArgs = pushStub.firstCall.args[0];
       expect(pushArgs.messageCids).toEqual(['local-cid-1']);
     });
+
+    it('doReconcileLink should abort if the active link epoch changes during pull', async () => {
+      const engine = createEngine({ db });
+      const linkKey = 'did:example:alice^https://dwn.example.com^projection-test^authorization-test';
+      const link = makeLiveLink();
+      (engine as any)._activeLinks.set(linkKey, link);
+
+      let rootCallCount = 0;
+      sinon.stub(engine as any, 'getLocalRoot').callsFake(async () => {
+        rootCallCount++;
+        return rootCallCount <= 1 ? 'root-A' : 'root-converged';
+      });
+      sinon.stub(engine as any, 'getRemoteRoot').callsFake(async () => {
+        return rootCallCount <= 1 ? 'root-B' : 'root-converged';
+      });
+      sinon.stub(engine as any, 'diffWithRemote').resolves({
+        onlyRemote : [{ messageCid: 'remote-cid-1' }],
+        onlyLocal  : ['local-cid-1'],
+      });
+      const pullStub = sinon.stub(engine as any, 'pullMessages').callsFake(async (params: any) => {
+        expect(params.shouldContinue()).toBe(true);
+        (engine as any)._activeLinks.delete(linkKey);
+        expect(params.shouldContinue()).toBe(false);
+      });
+      const pushStub = sinon.stub(engine as any, 'pushMessages').resolves();
+      const clearStub = sinon.stub().callsFake(async (l: any): Promise<void> => { l.needsReconcile = false; });
+      (engine as any)._ledger = { clearNeedsReconcile: clearStub, saveLink: sinon.stub().resolves() };
+
+      await (engine as any).doReconcileLink(linkKey);
+
+      expect(pullStub.calledOnce).toBe(true);
+      expect(pushStub.called).toBe(false);
+      expect(clearStub.called).toBe(false);
+      expect(link.needsReconcile).toBe(true);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -8,6 +8,7 @@ import { DwnInterface } from '../src/types/dwn.js';
 import { getMessagesPermissionGrantsForScope } from '../src/sync-permission-grants.js';
 import { ReplicationLedger } from '../src/sync-replication-ledger.js';
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
+import { SyncPullAbortedError } from '../src/sync-messages.js';
 
 describe('SyncEngineLevel — private methods', () => {
   let db: Level<string, string>;
@@ -2377,6 +2378,36 @@ describe('SyncEngineLevel — private methods', () => {
       expect(mockAgent.dwn.processRawMessage.called).toBe(true);
     });
 
+    it('pullMessages should not record dead letters when the stale-target guard aborts', async () => {
+      const shouldContinue = sinon.stub()
+        .onFirstCall().returns(true)
+        .onSecondCall().returns(false);
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        processDwnRequest : sinon.stub().resolves({ message: {} }),
+        dwn               : {
+          processRawMessage: sinon.stub().resolves({ status: { code: 202 } }),
+        },
+        rpc: {
+          sendDwnRequest: sinon.stub().resolves({
+            status : { code: 200 },
+            entry  : { message: { descriptor: { interface: 'Protocols', method: 'Configure' } } },
+          }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+
+      await expect((engine as any).pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        shouldContinue,
+      })).rejects.toThrow(SyncPullAbortedError);
+
+      expect(mockAgent.dwn.processRawMessage.called).toBe(false);
+      expect(await engine.getFailedMessages()).toHaveLength(0);
+    });
+
     it('pullMessages should reject prefetched entries outside the requested protocol', async () => {
       sinon.stub(console, 'warn');
       const mockAgent = {
@@ -3180,6 +3211,44 @@ describe('SyncEngineLevel — private methods', () => {
       // Clean up the timer.
       const timer = (engine as any)._reconcileTimers.get(linkKey);
       if (timer) { clearTimeout(timer); }
+    });
+
+    it('should not abort repair reconciliation when link status changes during pull', async () => {
+      const engine = createEngine({ db });
+      const linkKey = 'did:example:alice^https://dwn.example.com';
+
+      const link = {
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
+        pull               : {},
+        needsReconcile     : false,
+      } as any;
+      (engine as any)._activeLinks.set(linkKey, link);
+      (engine as any).getOrCreateRuntime(linkKey);
+
+      sinon.stub(engine as any, 'closeLinkSubscriptions').resolves();
+      sinon.stub(engine as any, 'getLocalRoot').resolves('root-a');
+      sinon.stub(engine as any, 'getRemoteRoot').resolves('root-b');
+      sinon.stub(engine as any, 'diffWithRemote').resolves({
+        onlyRemote : [{ messageCid: 'remote-cid-1' }],
+        onlyLocal  : [],
+      });
+      const pullStub = sinon.stub(engine as any, 'pullMessages').callsFake(async (): Promise<void> => {
+        link.status = 'degraded_poll';
+      });
+      const openPullStub = sinon.stub(engine as any, 'openLivePullSubscription').resolves();
+      const openPushStub = sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
+
+      const saveStub = sinon.stub().resolves();
+      const setStatusStub = sinon.stub().callsFake(async (l: any, s: string): Promise<void> => { l.status = s; });
+      (engine as any)._ledger = { setStatus: setStatusStub, saveLink: saveStub };
+
+      await (engine as any).doRepairLink(linkKey);
+
+      expect(pullStub.calledOnce).toBe(true);
+      expect(openPullStub.calledOnce).toBe(true);
+      expect(openPushStub.calledOnce).toBe(true);
+      expect(link.status).toBe('live');
     });
   });
 

--- a/packages/agent/tests/sync-link-reconciler.spec.ts
+++ b/packages/agent/tests/sync-link-reconciler.spec.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'bun:test';
 import type { ReconcileTarget } from '../src/sync-link-reconciler.js';
 
 import { SyncLinkReconciler } from '../src/sync-link-reconciler.js';
+import { SyncPullAbortedError } from '../src/sync-messages.js';
 
 const target: ReconcileTarget = {
   did    : 'did:example:alice',
@@ -285,6 +286,22 @@ describe('SyncLinkReconciler', () => {
       expect(outcome.localRoot).toBe('rootA');
       expect(outcome.remoteRoot).toBe('rootB');
       expect(deps.pullMessages.called).toBe(false);
+    });
+
+    it('should abort when pullMessages detects a stale target before apply', async () => {
+      const deps = makeDeps({
+        getLocalRoot   : sinon.stub().resolves('rootA'),
+        getRemoteRoot  : sinon.stub().resolves('rootB'),
+        diffWithRemote : sinon.stub().resolves({ onlyRemote: [{ messageCid: 'cid-1' }], onlyLocal: ['cid-2'] }),
+        pullMessages   : sinon.stub().rejects(new SyncPullAbortedError()),
+      });
+      const reconciler = new SyncLinkReconciler(deps);
+
+      const outcome = await reconciler.reconcile(target);
+
+      expect(outcome.aborted).toBe(true);
+      expect(outcome.didPull).toBe(false);
+      expect(deps.pushMessages.called).toBe(false);
     });
   });
 

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -416,6 +416,92 @@ describe('sync-messages', () => {
       expect(mockAgent.dwn.processRawMessage.called).toBe(false);
     });
 
+    it('should not apply later messages after shouldContinue turns false after local apply', async () => {
+      let shouldAbort = false;
+      const firstMessage = {
+        descriptor: {
+          interface  : DwnInterfaceName.Protocols,
+          method     : DwnMethodName.Configure,
+          definition : { protocol: 'https://example.com/first' },
+        },
+      } as any;
+      const secondMessage = {
+        descriptor: {
+          interface  : DwnInterfaceName.Protocols,
+          method     : DwnMethodName.Configure,
+          definition : { protocol: 'https://example.com/second' },
+        },
+      } as any;
+      const processRawMessage = sinon.stub().callsFake(async () => {
+        shouldAbort = true;
+        return { status: { code: 202 } };
+      });
+      const shouldContinue = (): boolean => !shouldAbort;
+      const mockAgent = {
+        processDwnRequest : sinon.stub(),
+        rpc               : { sendDwnRequest: sinon.stub() },
+        dwn               : { processRawMessage },
+      } as any;
+
+      await expect(pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : [],
+        agent       : mockAgent,
+        prefetched  : [
+          { messageCid: 'cid-1', message: firstMessage },
+          { messageCid: 'cid-2', message: secondMessage },
+        ],
+        shouldContinue,
+      })).rejects.toThrow(SyncPullAbortedError);
+
+      expect(processRawMessage.callCount).toBe(1);
+      expect(processRawMessage.firstCall.args[1]).toBe(firstMessage);
+    });
+
+    it('should release data stream reader lock when aborting during buffering', async () => {
+      let shouldAbort = false;
+      const recordsWriteMessage = {
+        recordId   : 'record-1',
+        descriptor : {
+          interface        : DwnInterfaceName.Records,
+          method           : DwnMethodName.Write,
+          dateCreated      : '2026-01-01T00:00:00.000000Z',
+          messageTimestamp : '2026-01-01T00:00:00.000000Z',
+        },
+      } as any;
+      const dataStream = new ReadableStream<Uint8Array>({
+        pull(controller): void {
+          shouldAbort = true;
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      });
+      const mockAgent = {
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: {} } }),
+        rpc               : {
+          sendDwnRequest: sinon.stub().resolves({
+            status : { code: 200 },
+            entry  : { message: recordsWriteMessage, data: dataStream },
+          }),
+        },
+        dwn: {
+          processRawMessage: sinon.stub().resolves({ status: { code: 202 } }),
+        },
+      } as any;
+
+      await expect(pullMessages({
+        did            : 'did:example:alice',
+        dwnUrl         : 'https://dwn.example.com',
+        messageCids    : ['cid-1'],
+        shouldContinue : () => !shouldAbort,
+        agent          : mockAgent,
+      })).rejects.toThrow(SyncPullAbortedError);
+
+      expect(dataStream.locked).toBe(false);
+      expect(mockAgent.dwn.processRawMessage.called).toBe(false);
+    });
+
     it('should reject prefetched messages before local apply when the acceptance gate fails', async () => {
       const message = {
         descriptor: {

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -12,6 +12,7 @@ import {
   pullMessages,
   pushMessages,
   syncMessageReplyIsSuccessful,
+  SyncPullAbortedError,
 } from '../src/sync-messages.js';
 
 describe('sync-messages', () => {
@@ -383,6 +384,35 @@ describe('sync-messages', () => {
       });
 
       // No messages to process
+      expect(mockAgent.dwn.processRawMessage.called).toBe(false);
+    });
+
+    it('should abort after remote fetch when shouldContinue turns false', async () => {
+      const shouldContinue = sinon.stub()
+        .onFirstCall().returns(true)
+        .onSecondCall().returns(false);
+      const mockAgent = {
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: {} } }),
+        rpc               : {
+          sendDwnRequest: sinon.stub().resolves({
+            status : { code: 200 },
+            entry  : { message: { descriptor: { interface: 'Protocols', method: 'Configure' } } },
+          }),
+        },
+        dwn: {
+          processRawMessage: sinon.stub().resolves({ status: { code: 202 } }),
+        },
+      } as any;
+
+      await expect(pullMessages({
+        did         : 'did:example:alice',
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        shouldContinue,
+        agent       : mockAgent,
+      })).rejects.toThrow(SyncPullAbortedError);
+
+      expect(mockAgent.rpc.sendDwnRequest.calledOnce).toBe(true);
       expect(mockAgent.dwn.processRawMessage.called).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- pass the reconciler continuation predicate into reconciliation pull processing
- abort pulled message fetch/apply work when the active sync link is no longer current
- prevent stale pull aborts from pushing, verifying convergence, or clearing link state

## Test plan
- [x] bun run build:ci
- [x] bun run --filter @enbox/agent lint
- [x] bun run --filter @enbox/agent build:esm
- [x] bun test --timeout 10000 tests/sync-messages.spec.ts tests/sync-link-reconciler.spec.ts tests/sync-engine-private.spec.ts
- [ ] bun run --filter @enbox/agent test:node (fails locally because DID DHT tests reject localhost Pkarr gateway URI; focused sync suites above pass)