### PR TITLE
Tighten MessagesSync protocol diff payload handling

### DIFF
--- a/.changeset/messages-sync-protocol-diff.md
+++ b/.changeset/messages-sync-protocol-diff.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Ensure MessagesSync diff responses can inline small DataStore-backed RecordsWrite payloads and cover delegated protocol-scoped diff filtering.

--- a/packages/dwn-sdk-js/src/handlers/messages-sync.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-sync.ts
@@ -11,6 +11,7 @@ import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { MessagesGrantAuthorization } from '../core/messages-grant-authorization.js';
 import { MessagesSync } from '../interfaces/messages-sync.js';
+import { Records } from '../utils/records.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
 /**
@@ -21,6 +22,8 @@ import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
  * separately via MessagesRead.
  */
 const DEFAULT_MAX_INLINE_DATA_SIZE = DwnConstant.maxDataSizeAllowedToBeEncoded;
+
+type StoredMessageWithEncodedData = GenericMessage & { encodedData?: string };
 
 
 export class MessagesSyncHandler implements MethodHandler {
@@ -309,34 +312,34 @@ export class MessagesSyncHandler implements MethodHandler {
     // It must not be included in the wire-format message (the recipient's
     // DWN would reject it as an unexpected top-level property).
     let inlineEncodedData: string | undefined;
-    if ('encodedData' in storedMessage) {
-      inlineEncodedData = (storedMessage as any).encodedData as string;
-      delete (storedMessage as any).encodedData;
+    if (MessagesSyncHandler.hasEncodedData(storedMessage)) {
+      inlineEncodedData = storedMessage.encodedData;
+      delete storedMessage.encodedData;
     }
 
     let data: ReadableStream<Uint8Array> | undefined;
 
-    // Check if this is a RecordsWrite with data.
-    if (storedMessage.descriptor.interface === 'Records' &&
-        storedMessage.descriptor.method === 'Write') {
-      const dataCid = (storedMessage as any).descriptor?.dataCid as string | undefined;
-      if (dataCid) {
-        // Try DataStore first (for large payloads stored externally).
+    // Check if this is a RecordsWrite with data that is small enough to inline.
+    if (inlineEncodedData === undefined && Records.isRecordsWrite(storedMessage)) {
+      const { dataCid, dataSize } = storedMessage.descriptor;
+      if (dataSize <= DEFAULT_MAX_INLINE_DATA_SIZE) {
+        // Some stores may have small payload bytes in DataStore instead of encodedData.
         if (this.deps.dataStore) {
-          // DataStore uses recordId, not messageCid. For RecordsWrite, the
-          // recordId is in the descriptor.
-          const recordId = (storedMessage as any).descriptor?.recordId as string | undefined;
-          if (recordId) {
-            const dataResult = await this.deps.dataStore.get(tenant, recordId, dataCid);
-            if (dataResult?.dataStream) {
-              data = dataResult.dataStream;
-            }
+          // DataStore uses recordId, not messageCid. For RecordsWrite,
+          // recordId is a top-level message property.
+          const dataResult = await this.deps.dataStore.get(tenant, storedMessage.recordId, dataCid);
+          if (dataResult?.dataStream) {
+            data = dataResult.dataStream;
           }
         }
       }
     }
 
     return { message: storedMessage, encodedData: inlineEncodedData, data };
+  }
+
+  private static hasEncodedData(message: GenericMessage): message is StoredMessageWithEncodedData {
+    return 'encodedData' in message && typeof message.encodedData === 'string';
   }
 
   /**

--- a/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
@@ -18,7 +18,7 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { DataStream, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, PermissionGrant, PermissionsProtocol, Time } from '../../src/index.js';
+import { DataStream, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, PermissionGrant, PermissionsProtocol, Time } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 
 
@@ -729,6 +729,71 @@ export function testMessagesSyncHandler(): void {
             expect(reply.status.detail).toContain(DwnErrorCode.MessagesGrantAuthorizationMismatchedProtocol);
           }
         });
+
+        it('returns only protocol-scoped diff entries for a delegated protocol grant', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+          const protocolA: ProtocolDefinition = { ...freeForAll, protocol: 'http://delegated-diff-protocol-a' };
+          const protocolB: ProtocolDefinition = { ...freeForAll, protocol: 'http://delegated-diff-protocol-b' };
+
+          for (const protocolDefinition of [protocolA, protocolB]) {
+            const { message: protocolMessage } = await TestDataGenerator.generateProtocolsConfigure({
+              author: alice,
+              protocolDefinition,
+            });
+            expect((await dwn.processMessage(alice.did, protocolMessage)).status.code).toBe(202);
+          }
+
+          const { message: recordA, dataStream: dataStreamA } = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolA.protocol,
+            protocolPath : 'post',
+            schema       : protocolA.types.post.schema,
+          });
+          expect((await dwn.processMessage(alice.did, recordA, { dataStream: dataStreamA })).status.code).toBe(202);
+
+          const { message: recordB, dataStream: dataStreamB } = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolB.protocol,
+            protocolPath : 'post',
+            schema       : protocolB.types.post.schema,
+          });
+          expect((await dwn.processMessage(alice.did, recordB, { dataStream: dataStreamB })).status.code).toBe(202);
+
+          const { message: grantMessage, dataStream: grantDataStream } = await TestDataGenerator.generateGrantCreate({
+            author    : alice,
+            grantedTo : bob,
+            scope     : {
+              interface : DwnInterfaceName.Messages,
+              method    : DwnMethodName.Read,
+              protocol  : protocolA.protocol,
+            },
+          });
+          expect((await dwn.processMessage(alice.did, grantMessage, { dataStream: grantDataStream })).status.code).toBe(202);
+
+          const { message: diffMsg } = await MessagesSync.create({
+            signer             : Jws.createSigner(bob),
+            action             : 'diff',
+            hashes             : {},
+            depth              : 2,
+            protocol           : protocolA.protocol,
+            permissionGrantIds : [grantMessage.recordId],
+          });
+
+          const reply = await dwn.processMessage(alice.did, diffMsg);
+          expect(reply.status.code).toBe(200);
+
+          const remoteCids = reply.onlyRemote!.map(entry => entry.messageCid);
+          expect(remoteCids).toContain(await Message.getCid(recordA));
+          expect(remoteCids).not.toContain(await Message.getCid(recordB));
+          expect(reply.onlyRemote!.every(entry => {
+            if (entry.message?.descriptor.interface !== DwnInterfaceName.Records) {
+              return true;
+            }
+            const recordsMessage = entry.message as { descriptor: { protocol?: string } };
+            return recordsMessage.descriptor.protocol === protocolA.protocol;
+          })).toBe(true);
+        });
       });
     });
 
@@ -947,6 +1012,43 @@ export function testMessagesSyncHandler(): void {
         expect(recordEntry).toBeDefined();
         expect(recordEntry!.encodedData).toBeDefined();
         expect(typeof recordEntry!.encodedData).toBe('string');
+      });
+
+      it('inlines small dataStore-backed payloads using the RecordsWrite recordId', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+        const dataBytes = new TextEncoder().encode('small data-store payload');
+        const { message: recordMessage, recordsWrite } = await TestDataGenerator.generateRecordsWrite({
+          author     : alice,
+          data       : dataBytes,
+          dataFormat : 'text/plain',
+        });
+        const indexes = await recordsWrite.constructIndexes(true);
+        const messageCid = await Message.getCid(recordMessage);
+
+        await dataStore.put(
+          alice.did,
+          recordMessage.recordId,
+          recordMessage.descriptor.dataCid,
+          DataStream.fromBytes(dataBytes)
+        );
+        await messageStore.put(alice.did, recordMessage, indexes);
+        await stateIndex.insert(alice.did, messageCid, indexes);
+
+        const { message: diffMsg } = await MessagesSync.create({
+          signer : Jws.createSigner(alice),
+          action : 'diff',
+          hashes : {},
+          depth  : 2,
+        });
+
+        const reply = await dwn.processMessage(alice.did, diffMsg);
+        expect(reply.status.code).toBe(200);
+
+        const recordEntry = reply.onlyRemote!.find(entry => entry.messageCid === messageCid);
+        expect(recordEntry).toBeDefined();
+        expect(recordEntry!.encodedData).toBe(Encoder.bytesToBase64Url(dataBytes));
       });
 
       it('returns 400 when hashes or depth are missing', async () => {


### PR DESCRIPTION
## Summary
- add delegated protocol-scoped MessagesSync diff coverage to ensure sibling protocol CIDs are not returned
- fix diff payload lookup for small DataStore-backed RecordsWrite payloads by using the top-level recordId
- keep large payloads out of diff inlining so they are fetched via MessagesRead

## Tests
- bun run --cwd packages/dwn-sdk-js build
- GREP='MessagesSyncHandler.handle' bun run --cwd packages/dwn-sdk-js test:node-grep
- bun run --cwd packages/dwn-sdk-js lint