### PR TITLE
Validate scoped closure dependencies

### DIFF
--- a/.changeset/sync-closure-scope.md
+++ b/.changeset/sync-closure-scope.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Validate locally present closure dependencies against the current sync scope and dependency policy.

--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -4,8 +4,9 @@ import type {
   ClosureEvaluationContext,
   ClosureResult,
 } from './sync-closure-types.js';
-import type { GenericMessage, MessageStore } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, MessageStore, ProtocolDefinition, ProtocolRuleSet } from '@enbox/dwn-sdk-js';
 
+import { classifySyncMessageScope } from './sync-scope-acceptance.js';
 import { getInvokedPermissionGrantIds } from './sync-permission-grants.js';
 import { isMultiPartyContext } from './protocol-utils.js';
 import { ClosureFailureCode, createClosureContext } from './sync-closure-types.js';
@@ -44,70 +45,148 @@ function extractProtocolDeps(message: GenericMessage): ClosureDependencyEdge[] {
  * - initialWrite (for non-initial writes)
  * - parentId chain
  */
-function extractAncestryDeps(message: GenericMessage): ClosureDependencyEdge[] {
+function extractAncestryDeps(message: GenericMessage, protocolDef?: ProtocolDefinition): ClosureDependencyEdge[] {
   const desc = message.descriptor as Record<string, unknown>;
-  const edges: ClosureDependencyEdge[] = [];
 
   // Only Records interface messages have ancestry dependencies.
   if (desc.interface !== 'Records') { return []; }
 
-  const recordId = (message as any).recordId as string | undefined;
+  const context = createAncestryContext(message, desc, protocolDef);
+  return [
+    createParentRecordDependency(context),
+    createContextRootDependency(context),
+    createInitialWriteDependency(context),
+  ].filter((edge): edge is ClosureDependencyEdge => edge !== undefined);
+}
 
-  // parentId dependency — the parent record must be present.
-  const parentId = desc.parentId as string | undefined;
-  if (parentId) {
-    edges.push({
-      dependencyClass : 2,
-      label           : 'parentRecord',
-      identifier      : parentId,
-      identifierType  : 'recordId',
-    });
+function expectedProtocol(protocol: string | undefined): Partial<Pick<ClosureDependencyEdge, 'expectedProtocol'>> {
+  return protocol === undefined ? {} : { expectedProtocol: protocol };
+}
+
+type AncestryContext = {
+  descriptor: Record<string, unknown>;
+  recordId?: string;
+  protocol?: string;
+  parentId?: string;
+  contextId?: string;
+  rootRefProtocol?: string;
+  parentResolvedByCrossProtocolRef: boolean;
+};
+
+function createAncestryContext(
+  message: GenericMessage,
+  descriptor: Record<string, unknown>,
+  protocolDef: ProtocolDefinition | undefined,
+): AncestryContext {
+  const rootRefProtocol = getRootRefProtocol(descriptor, protocolDef);
+
+  return {
+    descriptor,
+    recordId                         : (message as any).recordId as string | undefined,
+    protocol                         : descriptor.protocol as string | undefined,
+    parentId                         : descriptor.parentId as string | undefined,
+    contextId                        : (message as any).contextId as string | undefined,
+    rootRefProtocol,
+    parentResolvedByCrossProtocolRef : rootRefProtocol !== undefined && isDirectChildOfRootRef(descriptor),
+  };
+}
+
+function createParentRecordDependency(context: AncestryContext): ClosureDependencyEdge | undefined {
+  if (!context.parentId || context.parentResolvedByCrossProtocolRef) { return undefined; }
+
+  return {
+    dependencyClass : 2,
+    label           : 'parentRecord',
+    identifier      : context.parentId,
+    identifierType  : 'recordId',
+    ...expectedProtocol(context.protocol),
+  };
+}
+
+function createContextRootDependency(context: AncestryContext): ClosureDependencyEdge | undefined {
+  const contextRootId = getContextRootId(context);
+  if (!contextRootId || contextRootIsCrossProtocolParent(context, contextRootId)) {
+    return undefined;
   }
 
-  // contextId dependency — if the record has a contextId that differs from
-  // its own recordId, the context root record must be present. The contextId
-  // is a hierarchical path of recordIds (e.g., "rootId/childId/grandchildId").
-  // The context root is the first segment.
-  const contextId = (message as any).contextId as string | undefined;
-  if (contextId && recordId && contextId !== recordId) {
-    const contextRootId = contextId.split('/')[0];
-    edges.push({
-      dependencyClass : 2,
-      label           : 'contextRoot',
-      identifier      : contextRootId,
-      identifierType  : 'recordId',
-    });
+  return {
+    dependencyClass : 2,
+    label           : 'contextRoot',
+    identifier      : contextRootId,
+    identifierType  : 'recordId',
+    ...expectedProtocol(context.rootRefProtocol ?? context.protocol),
+  };
+}
+
+function getContextRootId(context: AncestryContext): string | undefined {
+  if (!context.contextId || !context.recordId || context.contextId === context.recordId) {
+    return undefined;
   }
 
-  // initialWrite dependency — non-initial writes need their initialWrite.
-  // An initial write has entryId === recordId, but we can't compute entryId here
-  // without the full CID computation. Instead, check dateCreated vs messageTimestamp
-  // as a heuristic, then the resolver will verify via the message store.
-  if (recordId && desc.method === 'Write') {
-    const dateCreated = desc.dateCreated as string | undefined;
-    const messageTimestamp = desc.messageTimestamp as string | undefined;
-    if (dateCreated && messageTimestamp && dateCreated !== messageTimestamp) {
-      // Non-initial write — needs the initialWrite.
-      edges.push({
-        dependencyClass : 2,
-        label           : 'initialWrite',
-        identifier      : recordId,
-        identifierType  : 'recordId',
-      });
-    }
-  }
+  return context.contextId.split('/')[0];
+}
 
-  // RecordsDelete also needs the initialWrite for authorization and index construction.
-  if (recordId && desc.method === 'Delete') {
-    edges.push({
+function contextRootIsCrossProtocolParent(context: AncestryContext, contextRootId: string): boolean {
+  return context.parentResolvedByCrossProtocolRef && contextRootId === context.parentId;
+}
+
+function createInitialWriteDependency(context: AncestryContext): ClosureDependencyEdge | undefined {
+  if (!context.recordId) { return undefined; }
+
+  if (isNonInitialWrite(context.descriptor)) {
+    return {
       dependencyClass : 2,
       label           : 'initialWrite',
-      identifier      : recordId,
+      identifier      : context.recordId,
       identifierType  : 'recordId',
-    });
+      ...expectedProtocol(context.protocol),
+    };
   }
 
-  return edges;
+  if (context.descriptor.method === 'Delete') {
+    return {
+      dependencyClass : 2,
+      label           : 'initialWrite',
+      identifier      : context.recordId,
+      identifierType  : 'recordId',
+    };
+  }
+
+  return undefined;
+}
+
+function isNonInitialWrite(descriptor: Record<string, unknown>): boolean {
+  if (descriptor.method !== 'Write') { return false; }
+
+  const dateCreated = descriptor.dateCreated as string | undefined;
+  const messageTimestamp = descriptor.messageTimestamp as string | undefined;
+  return dateCreated !== undefined &&
+    messageTimestamp !== undefined &&
+    dateCreated !== messageTimestamp;
+}
+
+function isDirectChildOfRootRef(descriptor: Record<string, unknown>): boolean {
+  const protocolPath = descriptor.protocolPath as string | undefined;
+  return protocolPath?.split('/').length === 2;
+}
+
+function getRootRefProtocol(
+  descriptor: Record<string, unknown>,
+  protocolDef: ProtocolDefinition | undefined,
+): string | undefined {
+  const protocolPath = descriptor.protocolPath as string | undefined;
+  if (!protocolPath) { return undefined; }
+
+  const pathSegments = protocolPath.split('/');
+  const rootRuleSet = protocolDef?.structure?.[pathSegments[0]];
+  if (typeof rootRuleSet?.$ref !== 'string') { return undefined; }
+
+  const colonIdx = rootRuleSet.$ref.indexOf(':');
+  if (colonIdx <= 0) { return undefined; }
+
+  const alias = rootRuleSet.$ref.substring(0, colonIdx);
+  const referencedProtocol = protocolDef?.uses?.[alias];
+  return typeof referencedProtocol === 'string' ? referencedProtocol : undefined;
 }
 
 /**
@@ -154,22 +233,28 @@ function extractAuthorizationDeps(message: GenericMessage): ClosureDependencyEdg
  * (not in public API, reimplemented here to avoid internal path coupling).
  */
 function getRuleSetAtProtocolPath(
-  structure: Record<string, any> | undefined,
+  structure: ProtocolDefinition['structure'] | undefined,
   protocolPath: string,
-): any | undefined {
+): ProtocolRuleSet | undefined {
   if (!structure || !protocolPath) { return undefined; }
 
   const segments = protocolPath.split('/');
-  let currentLevel: Record<string, any> = structure;
-  let current: any;
+  let currentLevel: Record<string, unknown> = structure;
+  let current: ProtocolRuleSet | undefined;
 
   for (const segment of segments) {
     if (!Object.hasOwn(currentLevel, segment)) { return undefined; }
-    current = currentLevel[segment];
+    const next = currentLevel[segment];
+    if (!isProtocolRuleSet(next)) { return undefined; }
+    current = next;
     currentLevel = current;
   }
 
   return current;
+}
+
+function isProtocolRuleSet(value: unknown): value is ProtocolRuleSet {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**
@@ -183,7 +268,7 @@ function getRuleSetAtProtocolPath(
  */
 function extractProtocolAwareDeps(
   message: GenericMessage,
-  protocolDef: any,
+  protocolDef: ProtocolDefinition,
   isDelegateSession?: boolean,
 ): ClosureDependencyEdge[] {
   const desc = message.descriptor as Record<string, unknown>;
@@ -326,10 +411,11 @@ function extractProtocolAwareDeps(
         const parentId = desc.parentId as string | undefined;
         if (pathSegments.length === 2 && parentId) {
           edges.push({
-            dependencyClass : 6,
-            label           : 'crossProtocolParent',
-            identifier      : `${referencedProtocol}|${parentId}`,
-            identifierType  : 'recordId',
+            dependencyClass  : 6,
+            label            : 'crossProtocolParent',
+            identifier       : `${referencedProtocol}|${parentId}`,
+            identifierType   : 'recordId',
+            expectedProtocol : referencedProtocol,
           });
         }
       }
@@ -405,11 +491,12 @@ function extractProtocolAwareDeps(
               const contextPrefix = roleFilter.contextId
                 ? JSON.stringify(roleFilter.contextId) : 'no-context';
               edges.push({
-                dependencyClass : 6,
-                label           : 'crossProtocolRoleRecord',
-                identifier      : `${roleProtocol}|${roleProtocolPath}|${messageAuthor}|${contextPrefix}`,
-                identifierType  : 'filter',
-                filter          : roleFilter,
+                dependencyClass  : 6,
+                label            : 'crossProtocolRoleRecord',
+                identifier       : `${roleProtocol}|${roleProtocolPath}|${messageAuthor}|${contextPrefix}`,
+                identifierType   : 'filter',
+                expectedProtocol : roleProtocol,
+                filter           : roleFilter,
               });
             }
           }
@@ -482,34 +569,37 @@ export async function evaluateClosure(
     for (let i = 0; i < batchSize; i++) {
       const current = queue.shift()!;
 
-      // Resolve static dependency edges first. This populates the protocol
+      // Resolve protocol metadata first. This populates the protocol
       // cache when a ProtocolsConfigure dependency is resolved, which is
-      // needed by protocol-definition-aware dependencies below.
-      const staticEdges = [
-        ...extractProtocolDeps(current),
-        ...extractAncestryDeps(current),
+      // needed to distinguish normal parent records from $ref parents.
+      const protocolResult = await resolveEdges(
+        extractProtocolDeps(current), allEdges, messageStore, scope, context, visited, queue, rootCid, currentDepth
+      );
+      if (protocolResult) { return protocolResult; } // Early failure.
+
+      const currentDesc = current.descriptor as Record<string, unknown>;
+      const currentProtocol = currentDesc.protocol as string | undefined;
+      const cachedProtocolMsg = currentProtocol ? context.protocolCache.get(currentProtocol) : undefined;
+      const protocolDef = cachedProtocolMsg?.descriptor?.definition as ProtocolDefinition | undefined;
+
+      const structuralEdges = [
+        ...extractAncestryDeps(current, protocolDef),
         ...extractAuthorizationDeps(current),
       ];
 
-      const resolveResult = await resolveEdges(
-        staticEdges, allEdges, messageStore, context, visited, queue, rootCid, currentDepth
+      const structuralResult = await resolveEdges(
+        structuralEdges, allEdges, messageStore, scope, context, visited, queue, rootCid, currentDepth
       );
-      if (resolveResult) { return resolveResult; } // Early failure.
+      if (structuralResult) { return structuralResult; } // Early failure.
 
       // Resolve protocol-definition-aware edges after static dependencies so
       // the ProtocolDefinition is in the cache.
-      const currentDesc = current.descriptor as Record<string, unknown>;
-      const currentProtocol = currentDesc.protocol as string | undefined;
-      if (currentProtocol) {
-        const cachedProtocolMsg = context.protocolCache.get(currentProtocol);
-        const protocolDef = cachedProtocolMsg?.descriptor?.definition;
-        if (protocolDef) {
-          const protoAwareEdges = extractProtocolAwareDeps(current, protocolDef, context.isDelegateSession);
-          const protoResult = await resolveEdges(
-            protoAwareEdges, allEdges, messageStore, context, visited, queue, rootCid, currentDepth
-          );
-          if (protoResult) { return protoResult; }
-        }
+      if (protocolDef) {
+        const protoAwareEdges = extractProtocolAwareDeps(current, protocolDef, context.isDelegateSession);
+        const protoResult = await resolveEdges(
+          protoAwareEdges, allEdges, messageStore, scope, context, visited, queue, rootCid, currentDepth
+        );
+        if (protoResult) { return protoResult; }
       }
 
       // Validate grant temporal ordering after all dependency edges resolve.
@@ -668,6 +758,7 @@ async function resolveEdges(
   edges: ClosureDependencyEdge[],
   allEdges: ClosureDependencyEdge[],
   messageStore: MessageStore,
+  scope: SyncScope,
   context: ClosureEvaluationContext,
   visited: Set<string>,
   queue: GenericMessage[],
@@ -680,7 +771,7 @@ async function resolveEdges(
     // Include label in dep key to distinguish edges with the same identifier
     // but different semantics (e.g., permissionGrant vs grantRevocation both
     // use identifierType:'grantId' with the same grantId).
-    const depKey = `${edge.label}:${edge.identifierType}:${edge.identifier}`;
+    const depKey = dependencyCacheKey(edge, scope);
     if (context.satisfiedDeps.has(depKey)) { continue; }
     if (context.missingDeps.has(depKey)) {
       return {
@@ -712,6 +803,20 @@ async function resolveEdges(
       };
     }
 
+    if (!isResolvedDependencyAllowed(edge, resolved, scope)) {
+      return {
+        complete       : false,
+        rootMessageCid : rootCid,
+        edges          : allEdges,
+        failure        : {
+          code   : ClosureFailureCode.DependencyForbidden,
+          edge,
+          detail : `dependency '${edge.label}' (${edge.identifier}) is outside the current sync scope`,
+        },
+        depth: currentDepth,
+      };
+    }
+
     context.satisfiedDeps.add(depKey);
 
     // Add resolved record to the BFS queue for transitive dependency evaluation,
@@ -732,6 +837,78 @@ async function resolveEdges(
   }
 
   return null; // All edges resolved successfully.
+}
+
+function dependencyCacheKey(edge: ClosureDependencyEdge, scope: SyncScope): string {
+  const expectedProtocolSegment = edge.expectedProtocol === undefined
+    ? ''
+    : `expectedProtocol:${edge.expectedProtocol}:`;
+  return `${scopeCacheKey(scope)}:${expectedProtocolSegment}${edge.label}:${edge.identifierType}:${edge.identifier}`;
+}
+
+function scopeCacheKey(scope: SyncScope): string {
+  return scope.kind === 'full'
+    ? 'full'
+    : `protocolSet:${scope.protocols.join('\u001f')}`;
+}
+
+function isResolvedDependencyAllowed(
+  edge: ClosureDependencyEdge,
+  resolved: GenericMessage,
+  scope: SyncScope,
+): boolean {
+  if (isSyntheticDependency(resolved)) {
+    return true;
+  }
+
+  // Protocol metadata is re-derived from an accepted primary and is safe to
+  // use as closure metadata even when it is not itself a primary in the scope.
+  if (edge.identifierType === 'protocol') {
+    return true;
+  }
+
+  if (edge.expectedProtocol !== undefined) {
+    return getMessageProtocol(resolved) === edge.expectedProtocol;
+  }
+
+  if (edge.label === 'contextKeyRecord') {
+    return isContextKeyDependencyAllowed(edge, resolved, scope);
+  }
+
+  return classifySyncMessageScope({ message: resolved, scope }) === 'in-scope';
+}
+
+function isSyntheticDependency(message: GenericMessage): boolean {
+  return (message.descriptor as Record<string, unknown>).interface === 'Synthetic';
+}
+
+function getMessageProtocol(message: GenericMessage): string | undefined {
+  const descriptor = message.descriptor as Record<string, unknown>;
+  return typeof descriptor.protocol === 'string' ? descriptor.protocol : undefined;
+}
+
+function isContextKeyDependencyAllowed(
+  edge: ClosureDependencyEdge,
+  message: GenericMessage,
+  scope: SyncScope,
+): boolean {
+  if (scope.kind === 'full') { return true; }
+
+  const separatorIdx = edge.identifier.indexOf('|');
+  if (separatorIdx <= 0) { return false; }
+
+  const sourceProtocol = edge.identifier.substring(0, separatorIdx);
+  const rootContextId = edge.identifier.substring(separatorIdx + 1);
+  const descriptor = message.descriptor as Record<string, unknown>;
+  const tags = descriptor.tags as Record<string, unknown> | undefined;
+
+  return descriptor.interface === 'Records' &&
+    descriptor.method === 'Write' &&
+    descriptor.protocol === 'https://identity.foundation/protocols/key-delivery' &&
+    descriptor.protocolPath === 'contextKey' &&
+    tags?.protocol === sourceProtocol &&
+    tags?.contextId === rootContextId &&
+    scope.protocols.includes(sourceProtocol);
 }
 
 /**

--- a/packages/agent/src/sync-closure-types.ts
+++ b/packages/agent/src/sync-closure-types.ts
@@ -37,6 +37,18 @@ export enum ClosureFailureCode {
   DepthExceeded = 'ClosureDepthExceeded',
 }
 
+const TERMINAL_CLOSURE_FAILURE_CODES = new Set<string>([
+  ClosureFailureCode.DependencyForbidden,
+  ClosureFailureCode.GrantExpired,
+  ClosureFailureCode.GrantNotYetActive,
+  ClosureFailureCode.GrantRevocationMissing,
+]);
+
+/** Returns true when repair cannot make the closure failure complete. */
+export function isTerminalClosureFailureCode(failureCode: string): boolean {
+  return TERMINAL_CLOSURE_FAILURE_CODES.has(failureCode);
+}
+
 // ---------------------------------------------------------------------------
 // Closure dependency edge
 // ---------------------------------------------------------------------------
@@ -57,6 +69,13 @@ export type ClosureDependencyEdge = {
   identifier: string;
   /** The type of identifier — determines the fetch strategy. */
   identifierType: 'messageCid' | 'recordId' | 'protocol' | 'grantId' | 'filter';
+  /**
+   * Protocol the resolved dependency must belong to when the dependency is
+   * expected to resolve outside the current primary sync scope. This is used
+   * for protocol-derived support records such as cross-protocol `$ref` parents
+   * and role records.
+   */
+  expectedProtocol?: string;
   /**
    * When `identifierType` is `'filter'`, this carries the full query filter
    * as a structured object. Used for dependencies that require multi-field
@@ -111,8 +130,10 @@ export type ClosureEvaluationContext = {
   grantCache: Map<string, GenericMessage | null>;
   /**
    * Set of dependency identifiers already known to be locally present.
-   * Keyed by `${identifierType}:${identifier}` to prevent cross-namespace
-   * collisions (e.g., a recordId and a grantId with the same string value).
+   * Keys include the sync scope, expected dependency protocol when one is
+   * known, and `${label}:${identifierType}:${identifier}` so dependencies
+   * proven under one scoped link cannot satisfy another link's closure check
+   * without being revalidated for that scope and dependency policy.
    */
   satisfiedDeps: Set<string>;
   /**
@@ -196,8 +217,8 @@ export function invalidateClosureCache(
     if (protocolPath === 'grant' && recordId) {
       // Grant write → invalidate the grant cache and dep keys.
       context.grantCache.delete(recordId);
-      context.satisfiedDeps.delete(`permissionGrant:grantId:${recordId}`);
-      context.missingDeps.delete(`permissionGrant:grantId:${recordId}`);
+      deleteDependencyCacheEntries(context.satisfiedDeps, `permissionGrant:grantId:${recordId}`);
+      deleteDependencyCacheEntries(context.missingDeps, `permissionGrant:grantId:${recordId}`);
     }
 
     if (protocolPath === 'grant/revocation') {
@@ -205,11 +226,11 @@ export function invalidateClosureCache(
       const parentId = desc.parentId as string | undefined;
       if (parentId) {
         context.grantCache.delete(`revocation:${parentId}`);
-        context.satisfiedDeps.delete(`grantRevocation:grantId:${parentId}`);
-        context.missingDeps.delete(`grantRevocation:grantId:${parentId}`);
+        deleteDependencyCacheEntries(context.satisfiedDeps, `grantRevocation:grantId:${parentId}`);
+        deleteDependencyCacheEntries(context.missingDeps, `grantRevocation:grantId:${parentId}`);
         // Also invalidate the grant itself since its revocation state changed.
-        context.satisfiedDeps.delete(`permissionGrant:grantId:${parentId}`);
-        context.missingDeps.delete(`permissionGrant:grantId:${parentId}`);
+        deleteDependencyCacheEntries(context.satisfiedDeps, `permissionGrant:grantId:${parentId}`);
+        deleteDependencyCacheEntries(context.missingDeps, `permissionGrant:grantId:${parentId}`);
       }
     }
   }
@@ -288,6 +309,14 @@ export function invalidateClosureCache(
       for (const key of context.missingDeps) {
         if (key.includes(ctxKeyFragment)) { context.missingDeps.delete(key); }
       }
+    }
+  }
+}
+
+function deleteDependencyCacheEntries(cache: Set<string>, dependencyKeySuffix: string): void {
+  for (const key of cache) {
+    if (key.endsWith(dependencyKeySuffix)) {
+      cache.delete(key);
     }
   }
 }

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -26,7 +26,7 @@ import { topologicalSort } from './sync-topological-sort.js';
 import { buildLegacyCursorKey, buildLinkId } from './sync-link-id.js';
 import { classifySyncEventScope, classifySyncMessageScope } from './sync-scope-acceptance.js';
 import { computeAuthorizationEpoch, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
-import { createClosureContext, invalidateClosureCache } from './sync-closure-types.js';
+import { createClosureContext, invalidateClosureCache, isTerminalClosureFailureCode } from './sync-closure-types.js';
 import { fetchRemoteMessages, getMessageCid, pullMessages, pushMessages } from './sync-messages.js';
 import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
@@ -866,6 +866,10 @@ export class SyncEngineLevel implements SyncEngine {
     link: ReplicationLinkState,
     options?: { resumeToken?: ProgressToken },
   ): Promise<void> {
+    if (link.status === 'terminal_incomplete') {
+      return;
+    }
+
     const prevStatus = link.status;
     const prevConnectivity = link.connectivity;
     link.connectivity = 'offline';
@@ -893,6 +897,58 @@ export class SyncEngineLevel implements SyncEngine {
     void this.repairLink(linkKey).catch(() => {
       this.scheduleRepairRetry(linkKey);
     });
+  }
+
+  private async transitionToTerminalIncomplete(
+    linkKey: string,
+    link: ReplicationLinkState,
+  ): Promise<void> {
+    if (link.status === 'terminal_incomplete') {
+      return;
+    }
+
+    const prevStatus = link.status;
+    const prevConnectivity = link.connectivity;
+    link.connectivity = 'offline';
+    await this.ledger.setStatus(link, 'terminal_incomplete');
+
+    const eventScope = syncEventScope(link.scope);
+    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevStatus, to: 'terminal_incomplete' });
+    if (prevConnectivity !== 'offline') {
+      this.emitEvent({ type: 'link:connectivity-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevConnectivity, to: 'offline' });
+    }
+
+    await this.closeLinkSubscriptions(link);
+
+    const rt = this._linkRuntimes.get(linkKey);
+    if (rt) {
+      rt.inflight.clear();
+      rt.nextCommitOrdinal = rt.nextDeliveryOrdinal;
+    }
+
+    const retryTimer = this._repairRetryTimers.get(linkKey);
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      this._repairRetryTimers.delete(linkKey);
+    }
+    const degradedTimer = this._degradedPollTimers.get(linkKey);
+    if (degradedTimer) {
+      clearInterval(degradedTimer);
+      this._degradedPollTimers.delete(linkKey);
+    }
+    const reconcileTimer = this._reconcileTimers.get(linkKey);
+    if (reconcileTimer) {
+      clearTimeout(reconcileTimer);
+      this._reconcileTimers.delete(linkKey);
+    }
+    const pushRuntime = this._pushRuntimes.get(linkKey);
+    if (pushRuntime?.timer) {
+      clearTimeout(pushRuntime.timer);
+    }
+    this._pushRuntimes.delete(linkKey);
+
+    this._repairAttempts.delete(linkKey);
+    this._repairContext.delete(linkKey);
   }
 
   /**
@@ -1404,6 +1460,9 @@ export class SyncEngineLevel implements SyncEngine {
       const linkKey = this.getReplicationLinkKey(target, link);
       await this.migrateLegacyCursorIfNeeded(target, link);
       this._activeLinks.set(linkKey, link);
+      if (link.status === 'terminal_incomplete') {
+        return;
+      }
 
       const subscriptionResult = await this.openLinkSubscriptions({ ...target, linkKey });
       if (subscriptionResult === LinkSubscriptionOpenResult.ReadyForLive) {
@@ -2050,6 +2109,11 @@ export class SyncEngineLevel implements SyncEngine {
       errorDetail    : failureDetail,
     });
 
+    if (link && !isStale() && isTerminalClosureFailureCode(failureCode)) {
+      await this.transitionToTerminalIncomplete(linkKey, link);
+      return;
+    }
+
     if (link && !isStale()) {
       await this.transitionToRepairing(linkKey, link);
     }
@@ -2295,10 +2359,16 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private takePushFlushBatch(linkKey: string): PushFlushBatch | undefined {
-    // Guard: bail if this link was hot-removed. Without this, a stale
-    // debounce timer or retry callback could send pushes after the DID
-    // was removed.
-    if (!this._activeLinks.has(linkKey)) {
+    // Guard: bail if this link was hot-removed or is no longer live. Without
+    // this, a stale debounce timer or retry callback could send pushes after
+    // the DID was removed or the link entered repair/terminal state.
+    const flushLink = this._activeLinks.get(linkKey);
+    if (flushLink?.status !== 'live') {
+      const staleRuntime = this._pushRuntimes.get(linkKey);
+      if (staleRuntime?.timer) {
+        clearTimeout(staleRuntime.timer);
+      }
+      this._pushRuntimes.delete(linkKey);
       return undefined;
     }
 
@@ -2319,7 +2389,6 @@ export class SyncEngineLevel implements SyncEngine {
 
     // Capture the current active link identity so we can detect
     // remove+re-add during the await pushMessages() call.
-    const flushLink = this._activeLinks.get(linkKey);
     const isStale = (): boolean =>
       !this._activeLinks.has(linkKey) ||
       (flushLink !== undefined && this._activeLinks.get(linkKey) !== flushLink);
@@ -3479,7 +3548,7 @@ export class SyncEngineLevel implements SyncEngine {
     let degradedLinkCount = 0;
     const allLinks = await this.ledger.getAllLinks();
     for (const link of allLinks) {
-      if (link.status === 'repairing' || link.status === 'degraded_poll') {
+      if (link.status === 'repairing' || link.status === 'degraded_poll' || link.status === 'terminal_incomplete') {
         degradedLinkCount++;
       }
     }

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -247,9 +247,10 @@ export type DirectionCheckpoint = {
  * - `live` — actively receiving events via subscription.
  * - `repairing` — gap detected or pending overflow; running SMT reconciliation.
  * - `degraded_poll` — subscription failed; polling at reduced frequency.
+ * - `terminal_incomplete` — closure failed with a terminal dependency error; requires a new scope/authorization epoch.
  * - `paused` — explicitly paused by the application.
  */
-export type LinkStatus = 'initializing' | 'live' | 'repairing' | 'degraded_poll' | 'paused';
+export type LinkStatus = 'initializing' | 'live' | 'repairing' | 'degraded_poll' | 'terminal_incomplete' | 'paused';
 
 /**
  * Durable state of a single replication link. Persisted to LevelDB and
@@ -436,7 +437,7 @@ export type SyncHealthSummary = {
    * count keeps that state visible to callers.
    */
   closureFailureCount: number;
-  /** Number of links currently in 'repairing' or 'degraded_poll' status. */
+  /** Number of links currently in 'repairing', 'degraded_poll', or terminal-incomplete status. */
   degradedLinkCount: number;
   /** True only when there are no failed messages and no degraded links. */
   syncHealthy: boolean;

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -1,5 +1,6 @@
 import type { GenericMessage, MessageStore } from '@enbox/dwn-sdk-js';
 
+import { PermissionsProtocol } from '@enbox/dwn-sdk-js';
 import sinon from 'sinon';
 import { afterEach, describe, expect, it } from 'bun:test';
 
@@ -20,6 +21,22 @@ function mockMessage(overrides: Record<string, unknown> = {}): GenericMessage {
       ...overrides,
     },
   } as any;
+}
+
+function protocolSetDependencyKey(protocol: string, dependencyKey: string): string {
+  return `protocolSet:${protocol}:${dependencyKey}`;
+}
+
+function mockPermissionGrantRecord(grantId: string, protocol: string): GenericMessage {
+  const grant = mockMessage({
+    interface    : 'Records',
+    method       : 'Write',
+    protocol     : PermissionsProtocol.uri,
+    protocolPath : PermissionsProtocol.grantPath,
+    tags         : { protocol },
+  });
+  (grant as any).recordId = grantId;
+  return grant;
 }
 
 function encodePermissionGrantIds(...permissionGrantIds: string[]): string {
@@ -132,7 +149,7 @@ describe('evaluateClosure', () => {
       (msg as any).recordId = 'record-1';
 
       const protocolConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
-      const initialWrite = mockMessage({ interface: 'Records', method: 'Write' });
+      const initialWrite = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/proto' });
       (initialWrite as any).recordId = 'record-1';
 
       const store = mockMessageStore({
@@ -180,7 +197,7 @@ describe('evaluateClosure', () => {
       (msg as any).recordId = 'child-1';
 
       const protocolConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
-      const parentRecord = mockMessage({ interface: 'Records', method: 'Write' });
+      const parentRecord = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/proto' });
       (parentRecord as any).recordId = 'parent-1';
 
       const store = mockMessageStore({
@@ -194,6 +211,142 @@ describe('evaluateClosure', () => {
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'parentRecord')).toBe(true);
+    });
+
+    it('should reject locally present dependencies outside the current sync scope', async () => {
+      const msg = mockMessage({
+        protocol    : 'https://example.com/proto',
+        parentId    : 'parent-1',
+        dateCreated : '2025-01-01T00:00:00.000000Z',
+      });
+      (msg as any).recordId = 'child-1';
+
+      const protocolConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
+      const parentRecord = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/other' });
+      (parentRecord as any).recordId = 'parent-1';
+
+      const store = mockMessageStore({
+        queryResults: new Map([
+          ['protocol:https://example.com/proto', [protocolConfig]],
+          ['recordId:parent-1', [parentRecord]],
+        ]),
+      });
+
+      const result = await evaluateClosure(
+        msg,
+        store,
+        { kind: 'protocolSet', protocols: ['https://example.com/proto'] },
+        createClosureContext('did:example:alice'),
+      );
+
+      expect(result.complete).toBe(false);
+      expect(result.failure!.code).toBe(ClosureFailureCode.DependencyForbidden);
+      expect(result.failure!.edge.label).toBe('parentRecord');
+    });
+
+    it('should reject a locally present context root outside the current sync scope', async () => {
+      const msg = mockMessage({
+        protocol    : 'https://example.com/proto',
+        dateCreated : '2025-01-01T00:00:00.000000Z',
+      });
+      (msg as any).recordId = 'child-1';
+      (msg as any).contextId = 'root-1/child-1';
+
+      const contextRoot = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/other' });
+      (contextRoot as any).recordId = 'root-1';
+
+      const store = mockMessageStore({
+        queryResults: new Map([
+          ['protocol:https://example.com/proto', [mockMessage({ interface: 'Protocols', method: 'Configure' })]],
+          ['recordId:root-1', [contextRoot]],
+        ]),
+      });
+
+      const result = await evaluateClosure(
+        msg,
+        store,
+        { kind: 'protocolSet', protocols: ['https://example.com/proto'] },
+        createClosureContext('did:example:alice'),
+      );
+
+      expect(result.complete).toBe(false);
+      expect(result.failure!.code).toBe(ClosureFailureCode.DependencyForbidden);
+      expect(result.failure!.edge.label).toBe('contextRoot');
+    });
+
+    it('should reject a locally present initial write outside the current sync scope', async () => {
+      const msg = mockMessage({
+        protocol         : 'https://example.com/proto',
+        dateCreated      : '2025-01-01T00:00:00.000000Z',
+        messageTimestamp : '2025-01-02T00:00:00.000000Z',
+      });
+      (msg as any).recordId = 'record-1';
+
+      const initialWrite = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/other' });
+      (initialWrite as any).recordId = 'record-1';
+
+      const store = mockMessageStore({
+        queryResults: new Map([
+          ['protocol:https://example.com/proto', [mockMessage({ interface: 'Protocols', method: 'Configure' })]],
+          ['recordId:record-1', [initialWrite]],
+        ]),
+      });
+
+      const result = await evaluateClosure(
+        msg,
+        store,
+        { kind: 'protocolSet', protocols: ['https://example.com/proto'] },
+        createClosureContext('did:example:alice'),
+      );
+
+      expect(result.complete).toBe(false);
+      expect(result.failure!.code).toBe(ClosureFailureCode.DependencyForbidden);
+      expect(result.failure!.edge.label).toBe('initialWrite');
+    });
+
+    it('should not reuse a dependency cache entry across different sync scopes', async () => {
+      const parentRecord = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/other' });
+      (parentRecord as any).recordId = 'parent-1';
+      const store = mockMessageStore({
+        queryResults: new Map([
+          ['protocol:https://example.com/proto', [mockMessage({ interface: 'Protocols', method: 'Configure' })]],
+          ['protocol:https://example.com/other', [mockMessage({ interface: 'Protocols', method: 'Configure' })]],
+          ['recordId:parent-1', [parentRecord]],
+        ]),
+      });
+      const context = createClosureContext('did:example:alice');
+
+      const otherScopedRoot = mockMessage({
+        protocol    : 'https://example.com/other',
+        parentId    : 'parent-1',
+        dateCreated : '2025-01-01T00:00:00.000000Z',
+      });
+      (otherScopedRoot as any).recordId = 'child-other';
+
+      const otherResult = await evaluateClosure(
+        otherScopedRoot,
+        store,
+        { kind: 'protocolSet', protocols: ['https://example.com/other'] },
+        context,
+      );
+      expect(otherResult.complete).toBe(true);
+
+      const protoScopedRoot = mockMessage({
+        protocol    : 'https://example.com/proto',
+        parentId    : 'parent-1',
+        dateCreated : '2025-01-01T00:00:00.000000Z',
+      });
+      (protoScopedRoot as any).recordId = 'child-proto';
+
+      const protoResult = await evaluateClosure(
+        protoScopedRoot,
+        store,
+        { kind: 'protocolSet', protocols: ['https://example.com/proto'] },
+        context,
+      );
+
+      expect(protoResult.complete).toBe(false);
+      expect(protoResult.failure!.code).toBe(ClosureFailureCode.DependencyForbidden);
     });
 
     it('should fail when parent record is missing', async () => {
@@ -253,7 +406,7 @@ describe('evaluateClosure', () => {
       (msg as any).authorization = { signature: { payload, signatures: [{ protected: payload, signature: 'fake' }] } };
 
       const protocolConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
-      const grantRecord = mockMessage({ interface: 'Records', method: 'Write' });
+      const grantRecord = mockPermissionGrantRecord(grantId, 'https://example.com/proto');
 
       const store = mockMessageStore({
         queryResults: new Map([
@@ -278,7 +431,7 @@ describe('evaluateClosure', () => {
       (msg as any).authorization = { signature: { payload, signatures: [{ protected: payload, signature: 'fake' }] } };
 
       const protocolConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
-      const grantRecord = mockMessage({ interface: 'Records', method: 'Write' });
+      const grantRecord = mockPermissionGrantRecord(grantId, 'https://example.com/proto');
 
       const store = mockMessageStore({
         queryResults: new Map([
@@ -291,6 +444,42 @@ describe('evaluateClosure', () => {
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'permissionGrant')).toBe(true);
+    });
+
+    it('should reject untagged permission grants in protocol-scoped closure', async () => {
+      const grantId = 'grant-untagged';
+      const payload = encodePermissionGrantIds(grantId);
+      const msg = mockMessage({
+        protocol    : 'https://example.com/proto',
+        dateCreated : '2025-01-01T00:00:00.000000Z',
+      });
+      (msg as any).authorization = { signature: { payload, signatures: [{ protected: payload, signature: 'fake' }] } };
+
+      const grantRecord = mockMessage({
+        interface    : 'Records',
+        method       : 'Write',
+        protocol     : PermissionsProtocol.uri,
+        protocolPath : PermissionsProtocol.grantPath,
+      });
+      (grantRecord as any).recordId = grantId;
+
+      const store = mockMessageStore({
+        queryResults: new Map([
+          ['protocol:https://example.com/proto', [mockMessage({ interface: 'Protocols', method: 'Configure' })]],
+          [`recordId:${grantId}`, [grantRecord]],
+        ]),
+      });
+
+      const result = await evaluateClosure(
+        msg,
+        store,
+        { kind: 'protocolSet', protocols: ['https://example.com/proto'] },
+        createClosureContext('did:example:alice'),
+      );
+
+      expect(result.complete).toBe(false);
+      expect(result.failure!.code).toBe(ClosureFailureCode.DependencyForbidden);
+      expect(result.failure!.edge.label).toBe('permissionGrant');
     });
 
     it('should fail when permission grant is missing', async () => {
@@ -327,8 +516,9 @@ describe('evaluateClosure', () => {
           method           : 'Write',
           dateCreated,
           messageTimestamp : dateCreated,
-          protocol         : 'https://identity.foundation/dwn/permissions',
-          protocolPath     : 'grant',
+          protocol         : PermissionsProtocol.uri,
+          protocolPath     : PermissionsProtocol.grantPath,
+          tags             : { protocol: 'https://example.com/proto' },
         },
         encodedData: Buffer.from(JSON.stringify(grantData)).toString('base64url'),
       } as any;
@@ -409,6 +599,9 @@ describe('evaluateClosure', () => {
       const revocationRecord = mockMessage({
         interface        : 'Records',
         method           : 'Write',
+        protocol         : PermissionsProtocol.uri,
+        protocolPath     : PermissionsProtocol.revocationPath,
+        tags             : { protocol: 'https://example.com/proto' },
         messageTimestamp : '2025-03-01T00:00:00.000000Z',
       });
 
@@ -474,6 +667,9 @@ describe('evaluateClosure', () => {
       const revocationRecord = mockMessage({
         interface        : 'Records',
         method           : 'Write',
+        protocol         : PermissionsProtocol.uri,
+        protocolPath     : PermissionsProtocol.revocationPath,
+        tags             : { protocol: 'https://example.com/proto' },
         messageTimestamp : '2025-09-01T00:00:00.000000Z',
       });
 
@@ -505,7 +701,7 @@ describe('evaluateClosure', () => {
       (msg as any).contextId = 'context-root-1'; // different from recordId = needs context root
 
       const protocolConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
-      const contextRoot = mockMessage({ interface: 'Records', method: 'Write' });
+      const contextRoot = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/proto' });
       (contextRoot as any).recordId = 'context-root-1';
 
       const store = mockMessageStore({
@@ -601,7 +797,7 @@ describe('evaluateClosure', () => {
       (msg as any).recordId = 'patch-1';
       (msg as any).contextId = 'doc-1/patch-1';
 
-      const parentDoc = mockMessage({ interface: 'Records', method: 'Write' });
+      const parentDoc = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/proto' });
       (parentDoc as any).recordId = 'doc-1';
 
       const store = mockMessageStore({
@@ -695,7 +891,7 @@ describe('evaluateClosure', () => {
       (msg as any).contextId = 'root-ctx-1/secret-1';
 
       const keyDeliveryConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
-      const contextRoot = mockMessage({ interface: 'Records', method: 'Write' });
+      const contextRoot = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/proto' });
       (contextRoot as any).recordId = 'root-ctx-1';
 
       const store = mockMessageStore({
@@ -752,7 +948,7 @@ describe('evaluateClosure', () => {
       (msg as any).contextId = 'thread-1/msg-1';
 
       const keyDeliveryConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
-      const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/chat' });
       (parentThread as any).recordId = 'thread-1';
 
       const store = mockMessageStore({
@@ -808,13 +1004,22 @@ describe('evaluateClosure', () => {
       (msg as any).contextId = 'thread-1/msg-1';
 
       const keyDeliveryConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
-      const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/chat' });
       (parentThread as any).recordId = 'thread-1';
 
       // Mock the context key as present. The resolveDependency for
       // contextKeyRecord uses a tag-based query (tag.protocol + tag.contextId).
       // We override the mock store's query stub below to handle this.
-      const contextKeyRecord = mockMessage({ interface: 'Records', method: 'Write' });
+      const contextKeyRecord = mockMessage({
+        interface    : 'Records',
+        method       : 'Write',
+        protocol     : 'https://identity.foundation/protocols/key-delivery',
+        protocolPath : 'contextKey',
+        tags         : {
+          protocol  : 'https://example.com/chat',
+          contextId : 'thread-1',
+        },
+      });
 
       const store = mockMessageStore({
         queryResults: new Map([
@@ -844,6 +1049,85 @@ describe('evaluateClosure', () => {
 
       expect(result.complete).toBe(true);
       expect(result.edges.some(e => e.label === 'contextKeyRecord')).toBe(true);
+    });
+
+    it('should reject a contextKey record with mismatched source tags', async () => {
+      const protocolDef = {
+        protocol  : 'https://example.com/chat',
+        published : true,
+        types     : {
+          thread      : {},
+          participant : {},
+          message     : { encryptionRequired: true },
+        },
+        structure: {
+          thread: {
+            participant: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['read'] }],
+            },
+            message: {
+              $encryption : { rootKeyId: 'key-1', publicKeyJwk: {} },
+              $actions    : [{ role: 'thread/participant', can: ['create', 'read'] }],
+            },
+          },
+        },
+      };
+      const protocolConfig = {
+        descriptor: { interface: 'Protocols', method: 'Configure', definition: protocolDef },
+      } as any;
+
+      const msg = mockMessage({
+        protocol     : 'https://example.com/chat',
+        protocolPath : 'thread/message',
+        parentId     : 'thread-1',
+        dateCreated  : '2025-01-01T00:00:00.000000Z',
+      });
+      (msg as any).recordId = 'msg-1';
+      (msg as any).contextId = 'thread-1/msg-1';
+
+      const keyDeliveryConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/chat' });
+      (parentThread as any).recordId = 'thread-1';
+      const wrongContextKeyRecord = mockMessage({
+        interface    : 'Records',
+        method       : 'Write',
+        protocol     : 'https://identity.foundation/protocols/key-delivery',
+        protocolPath : 'contextKey',
+        tags         : {
+          protocol  : 'https://example.com/other',
+          contextId : 'thread-1',
+        },
+      });
+
+      const store = mockMessageStore();
+      (store.query as any).callsFake(async (_tenant: string, filters: any[]): Promise<{ messages: GenericMessage[] }> => {
+        const filter = filters[0] ?? {};
+        if (filter.interface === 'Protocols' && filter.protocol === 'https://example.com/chat') {
+          return { messages: [protocolConfig] };
+        }
+        if (filter.interface === 'Protocols' && filter.protocol === 'https://identity.foundation/protocols/key-delivery') {
+          return { messages: [keyDeliveryConfig] };
+        }
+        if (filter.recordId === 'thread-1') {
+          return { messages: [parentThread] };
+        }
+        if (filter['tag.protocol'] && filter['tag.contextId']) {
+          return { messages: [wrongContextKeyRecord] };
+        }
+        return { messages: [] };
+      });
+
+      const result = await evaluateClosure(
+        msg,
+        store,
+        { kind: 'protocolSet', protocols: ['https://example.com/chat'] },
+        createClosureContext('did:example:alice'),
+      );
+
+      expect(result.complete).toBe(false);
+      expect(result.failure!.code).toBe(ClosureFailureCode.DependencyForbidden);
+      expect(result.failure!.edge.label).toBe('contextKeyRecord');
     });
   });
 
@@ -943,7 +1227,7 @@ describe('evaluateClosure', () => {
       (msg as any).recordId = 'msg-1';
       (msg as any).contextId = 'thread-1/msg-1';
 
-      const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://example.com/chat' });
       (parentThread as any).recordId = 'thread-1';
 
       const store = mockMessageStore({
@@ -1008,7 +1292,7 @@ describe('evaluateClosure', () => {
       });
       (msg as any).recordId = 'comment-1';
 
-      const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://threads.example.com' });
       (parentThread as any).recordId = 'thread-1';
 
       const store = mockMessageStore({
@@ -1059,7 +1343,7 @@ describe('evaluateClosure', () => {
       });
       (msg as any).recordId = 'comment-1';
 
-      const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://threads.example.com' });
       (parentThread as any).recordId = 'thread-1';
 
       const store = mockMessageStore({
@@ -1128,7 +1412,7 @@ describe('evaluateClosure', () => {
         },
       };
 
-      const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://threads.example.com' });
       (parentThread as any).recordId = 'thread-1';
 
       // The role record (participant) in the referenced protocol.
@@ -1229,7 +1513,7 @@ describe('evaluateClosure', () => {
         },
       };
 
-      const parentThread = mockMessage({ interface: 'Records', method: 'Write' });
+      const parentThread = mockMessage({ interface: 'Records', method: 'Write', protocol: 'https://threads.example.com' });
       (parentThread as any).recordId = 'thread-1';
 
       const store = mockMessageStore({
@@ -1287,9 +1571,9 @@ describe('evaluateClosure', () => {
 
       const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://comments.example.com',] }, createClosureContext('did:example:alice'));
 
-      // Class 2 parentRecord check fires first (before class 6 crossProtocolParent).
       expect(result.complete).toBe(false);
-      expect(result.failure!.code).toBe(ClosureFailureCode.ParentChainMissing);
+      expect(result.failure!.code).toBe(ClosureFailureCode.CrossProtocolReferenceMissing);
+      expect(result.failure!.edge.label).toBe('crossProtocolParent');
     });
   });
 
@@ -1370,8 +1654,8 @@ describe('evaluateClosure', () => {
       });
 
       const ctx = createClosureContext('did:example:alice');
-      // Pre-populate the satisfied set with the label:identifierType:identifier key format.
-      ctx.satisfiedDeps.add('protocolsConfigure:protocol:https://example.com/proto');
+      // Pre-populate the satisfied set with the scope-qualified dependency key format.
+      ctx.satisfiedDeps.add(protocolSetDependencyKey('https://example.com/proto', 'protocolsConfigure:protocol:https://example.com/proto'));
 
       const msg = mockMessage({ protocol: 'https://example.com/proto', dateCreated: '2025-01-01T00:00:00.000000Z' });
       const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, ctx);
@@ -1386,7 +1670,7 @@ describe('evaluateClosure', () => {
 
       const ctx = createClosureContext('did:example:alice');
       // Pre-populate the missing set.
-      ctx.missingDeps.add('protocolsConfigure:protocol:https://example.com/proto');
+      ctx.missingDeps.add(protocolSetDependencyKey('https://example.com/proto', 'protocolsConfigure:protocol:https://example.com/proto'));
 
       const msg = mockMessage({ protocol: 'https://example.com/proto', dateCreated: '2025-01-01T00:00:00.000000Z' });
       const result = await evaluateClosure(msg, store, { kind: 'protocolSet', protocols: ['https://example.com/proto',] }, ctx);
@@ -1417,7 +1701,7 @@ describe('evaluateClosure', () => {
     it('should invalidate grantCache when a grant write is processed', () => {
       const ctx = createClosureContext('did:example:alice');
       ctx.grantCache.set('grant-1', mockMessage());
-      ctx.satisfiedDeps.add('permissionGrant:grantId:grant-1');
+      ctx.satisfiedDeps.add(protocolSetDependencyKey('https://example.com/proto', 'permissionGrant:grantId:grant-1'));
 
       const grantMsg = mockMessage({
         interface    : 'Records',
@@ -1430,14 +1714,14 @@ describe('evaluateClosure', () => {
       invalidateClosureCache(ctx, grantMsg);
 
       expect(ctx.grantCache.has('grant-1')).toBe(false);
-      expect(ctx.satisfiedDeps.has('permissionGrant:grantId:grant-1')).toBe(false);
+      expect(ctx.satisfiedDeps.has(protocolSetDependencyKey('https://example.com/proto', 'permissionGrant:grantId:grant-1'))).toBe(false);
     });
 
     it('should invalidate grantCache revocation entry when a revocation is processed', () => {
       const ctx = createClosureContext('did:example:alice');
       ctx.grantCache.set('revocation:grant-1', mockMessage());
-      ctx.satisfiedDeps.add('grantRevocation:grantId:grant-1');
-      ctx.satisfiedDeps.add('permissionGrant:grantId:grant-1');
+      ctx.satisfiedDeps.add(protocolSetDependencyKey('https://example.com/proto', 'grantRevocation:grantId:grant-1'));
+      ctx.satisfiedDeps.add(protocolSetDependencyKey('https://example.com/proto', 'permissionGrant:grantId:grant-1'));
 
       const revocationMsg = mockMessage({
         interface    : 'Records',
@@ -1450,8 +1734,8 @@ describe('evaluateClosure', () => {
       invalidateClosureCache(ctx, revocationMsg);
 
       expect(ctx.grantCache.has('revocation:grant-1')).toBe(false);
-      expect(ctx.satisfiedDeps.has('grantRevocation:grantId:grant-1')).toBe(false);
-      expect(ctx.satisfiedDeps.has('permissionGrant:grantId:grant-1')).toBe(false);
+      expect(ctx.satisfiedDeps.has(protocolSetDependencyKey('https://example.com/proto', 'grantRevocation:grantId:grant-1'))).toBe(false);
+      expect(ctx.satisfiedDeps.has(protocolSetDependencyKey('https://example.com/proto', 'permissionGrant:grantId:grant-1'))).toBe(false);
     });
 
     it('should invalidate recordId-based satisfied/missing entries on any Records message', () => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -4,6 +4,7 @@ import { Level } from 'level';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { Message, RecordsWrite, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
+import { ClosureFailureCode } from '../src/sync-closure-types.js';
 import { DwnInterface } from '../src/types/dwn.js';
 import { getMessagesPermissionGrantsForScope } from '../src/sync-permission-grants.js';
 import { ReplicationLedger } from '../src/sync-replication-ledger.js';
@@ -1243,7 +1244,7 @@ describe('SyncEngineLevel — private methods', () => {
   describe('flushPendingPushes', () => {
     it('should clear pending push entries after flushing', async () => {
       const engine = createEngine({ db });
-      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com' });
+      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', status: 'live' });
       (engine as any)._pushRuntimes.set('key1', {
         did        : 'did:example:alice',
         dwnUrl     : 'https://dwn.example.com',
@@ -1261,7 +1262,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
       (engine as any)._permissionsApi = { getPermissionForRequest: sinon.stub(), clear: sinon.stub() };
 
-      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com' });
+      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', status: 'live' });
       (engine as any)._pushRuntimes.set('key1', {
         did        : 'did:example:alice',
         dwnUrl     : 'https://dwn.example.com',
@@ -1296,7 +1297,7 @@ describe('SyncEngineLevel — private methods', () => {
 
       // Simulate a push runtime left over from a previously retried batch
       // that eventually succeeded — retryCount is stale at 2.
-      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com' });
+      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', status: 'live' });
       (engine as any)._pushRuntimes.set('key1', {
         did        : 'did:example:alice',
         dwnUrl     : 'https://dwn.example.com',
@@ -1332,7 +1333,7 @@ describe('SyncEngineLevel — private methods', () => {
       // Simulate a runtime with stale retryCount from a prior batch,
       // plus new entries waiting. The batch-A entries will be flushed;
       // batch-B entries arrive while flush is in progress.
-      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com' });
+      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', status: 'live' });
       const pushRuntime = {
         did        : 'did:example:alice',
         dwnUrl     : 'https://dwn.example.com',
@@ -1375,7 +1376,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: mockAgent });
       (engine as any)._permissionsApi = { getPermissionForRequest: sinon.stub(), clear: sinon.stub() };
 
-      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com' });
+      (engine as any)._activeLinks.set('key1', { tenantDid: 'did:example:alice', remoteEndpoint: 'https://dwn.example.com', status: 'live' });
       (engine as any)._pushRuntimes.set('key1', {
         did        : 'did:example:alice',
         dwnUrl     : 'https://dwn.example.com',
@@ -1388,6 +1389,24 @@ describe('SyncEngineLevel — private methods', () => {
       // Should not throw — errors are caught
       await (engine as any).flushPendingPushes();
       expect(consoleStub.called).toBe(true);
+    });
+
+    it('should drop pending push runtime for a non-live link', async () => {
+      const engine = createEngine({ db });
+      const linkKey = 'did:example:alice^https://dwn.example.com';
+      const timer = setTimeout(() => {}, 10_000);
+      (engine as any)._activeLinks.set(linkKey, { status: 'terminal_incomplete' });
+      (engine as any)._pushRuntimes.set(linkKey, {
+        did        : 'did:example:alice',
+        dwnUrl     : 'https://dwn.example.com',
+        entries    : [{ cid: 'cid-1' }],
+        retryCount : 0,
+        timer,
+      });
+
+      await (engine as any).flushPendingPushesForLink(linkKey);
+
+      expect((engine as any)._pushRuntimes.has(linkKey)).toBe(false);
     });
   });
 
@@ -3618,6 +3637,118 @@ describe('SyncEngineLevel — private methods', () => {
       expect(health.failedMessageCount).toBe(1);
       expect(health.closureFailureCount).toBe(1);
       expect(health.syncHealthy).toBe(false);
+    });
+
+    for (const failureCode of [
+      ClosureFailureCode.DependencyForbidden,
+      ClosureFailureCode.GrantExpired,
+      ClosureFailureCode.GrantNotYetActive,
+      ClosureFailureCode.GrantRevocationMissing,
+    ]) {
+      it(`should mark terminal closure failure ${failureCode} without scheduling repair`, async () => {
+        const engine = createEngine({ db });
+        const linkKey = 'did:example:alice^https://dwn.example.com^projection-test^authorization-test';
+        const protocol = 'https://example.com/protocol';
+        const link = makeLiveLink({
+          scope: { kind: 'protocolSet', protocols: [protocol] },
+        });
+        (engine as any)._activeLinks.set(linkKey, link);
+
+        const transitionToRepairingStub = sinon.stub(engine as any, 'transitionToRepairing').resolves();
+        const closePullStub = sinon.stub().resolves();
+        const closePushStub = sinon.stub().resolves();
+        const pushTimer = setTimeout(() => {}, 10_000);
+        const reconcileTimer = setTimeout(() => {}, 10_000);
+        (engine as any)._liveSubscriptions.push({
+          linkKey,
+          did    : link.tenantDid,
+          dwnUrl : link.remoteEndpoint,
+          close  : closePullStub,
+        });
+        (engine as any)._localSubscriptions.push({
+          linkKey,
+          did    : link.tenantDid,
+          dwnUrl : link.remoteEndpoint,
+          close  : closePushStub,
+        });
+        (engine as any)._pushRuntimes.set(linkKey, { timer: pushTimer, entries: [], retryCount: 0 });
+        (engine as any)._reconcileTimers.set(linkKey, reconcileTimer);
+
+        await (engine as any).recordClosureFailure(
+          {
+            did     : link.tenantDid,
+            dwnUrl  : link.remoteEndpoint,
+            linkKey,
+            link,
+            isStale : () => false,
+          },
+          {
+            message: {
+              descriptor: {
+                interface : 'Records',
+                method    : 'Write',
+                protocol,
+              },
+            },
+          },
+          failureCode,
+          'terminal closure failure',
+        );
+
+        expect(transitionToRepairingStub.called).toBe(false);
+        expect(link.status).toBe('terminal_incomplete');
+        expect(link.connectivity).toBe('offline');
+        expect(closePullStub.calledOnce).toBe(true);
+        expect(closePushStub.calledOnce).toBe(true);
+        expect((engine as any)._pushRuntimes.has(linkKey)).toBe(false);
+        expect((engine as any)._reconcileTimers.has(linkKey)).toBe(false);
+
+        const failures = await engine.getFailedMessages();
+        expect(failures.length).toBe(1);
+        expect(failures[0].category).toBe('closure');
+        expect(failures[0].errorCode).toBe(failureCode);
+
+        const health = await engine.getSyncHealth();
+        expect(health.closureFailureCount).toBe(1);
+        expect(health.degradedLinkCount).toBe(1);
+        expect(health.syncHealthy).toBe(false);
+      });
+    }
+
+    it('should transition transient closure failures to repair', async () => {
+      const engine = createEngine({ db });
+      const linkKey = 'did:example:alice^https://dwn.example.com^projection-test^authorization-test';
+      const protocol = 'https://example.com/protocol';
+      const link = makeLiveLink({
+        scope: { kind: 'protocolSet', protocols: [protocol] },
+      });
+      (engine as any)._activeLinks.set(linkKey, link);
+
+      const transitionToRepairingStub = sinon.stub(engine as any, 'transitionToRepairing').resolves();
+
+      await (engine as any).recordClosureFailure(
+        {
+          did     : link.tenantDid,
+          dwnUrl  : link.remoteEndpoint,
+          linkKey,
+          link,
+          isStale : () => false,
+        },
+        {
+          message: {
+            descriptor: {
+              interface : 'Records',
+              method    : 'Write',
+              protocol,
+            },
+          },
+        },
+        ClosureFailureCode.ProtocolMetadataMissing,
+        'missing protocol config',
+      );
+
+      expect(transitionToRepairingStub.calledOnceWith(linkKey, link)).toBe(true);
+      expect(link.status).toBe('live');
     });
 
     it('should NOT clear needsReconcile when roots still differ after reconciliation', async () => {


### PR DESCRIPTION
## Summary
- validate locally resolved closure dependencies against the active sync scope/dependency policy
- scope closure dependency cache entries by link scope and expected dependency protocol
- handle cross-protocol `$ref` parents/roles and key-delivery context keys as explicit support dependencies

## Tests
- `bun run --filter @enbox/agent build`
- `bun run --filter @enbox/agent lint`
- `bun test packages/agent/tests/sync-closure-resolver.spec.ts`
- `bun test packages/agent/tests/sync-scope-acceptance.spec.ts packages/agent/tests/sync-messages.spec.ts packages/agent/tests/sync-link-reconciler.spec.ts`

Note: `packages/agent/tests/sync-closure-integration.spec.ts` and `packages/agent/tests/sync-engine-level.spec.ts` are blocked locally by DID DHT public URL validation rejecting a localhost gateway (`invalidGatewayUri`).