### PR TITLE
Scope sync health to current durable links

### DIFF
--- a/.changeset/sync-current-link-health.md
+++ b/.changeset/sync-current-link-health.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Scope sync health degraded-link counts to current durable sync targets.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -25,7 +25,7 @@ import { SyncLinkReconciler } from './sync-link-reconciler.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { buildLegacyCursorKey, buildLinkId } from './sync-link-id.js';
 import { classifySyncEventScope, classifySyncMessageScope } from './sync-scope-acceptance.js';
-import { computeAuthorizationEpoch, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
+import { computeAuthorizationEpoch, computeProjectionId, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { createClosureContext, invalidateClosureCache, isTerminalClosureFailureCode } from './sync-closure-types.js';
 import { fetchRemoteMessages, getMessageCid, pullMessages, pushMessages } from './sync-messages.js';
 import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
@@ -86,6 +86,8 @@ type SyncTarget = {
   authorizationEpoch: string;
   permissionGrantIds?: NonEmptyStringArray;
 };
+
+type SyncTargetAuthorization = Pick<SyncTarget, 'authorization' | 'authorizationEpoch' | 'delegateDid' | 'permissionGrantIds'>;
 
 type LinkSyncTarget = SyncTarget & { linkKey: string };
 
@@ -291,14 +293,22 @@ export class SyncEngineLevel implements SyncEngine {
 
   private async buildSyncTarget(did: string, dwnUrl: string, options: SyncIdentityOptions): Promise<SyncTarget> {
     const scope = syncScopeFromProtocols(options.protocols);
+    const authorization = await this.buildSyncTargetAuthorization(did, scope, options);
+
+    return {
+      did,
+      dwnUrl,
+      scope,
+      ...authorization,
+    };
+  }
+
+  private async buildSyncTargetAuthorization(did: string, scope: SyncScope, options: SyncIdentityOptions): Promise<SyncTargetAuthorization> {
     const protocols = protocolsForSyncScope(scope);
     const { delegateDid } = options;
 
     if (delegateDid === undefined) {
       return {
-        did,
-        dwnUrl,
-        scope,
         authorization      : { kind: 'owner' },
         authorizationEpoch : await computeAuthorizationEpoch({ kind: 'owner' }),
       };
@@ -317,10 +327,7 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     return {
-      did,
-      dwnUrl,
       delegateDid,
-      scope,
       authorization: {
         kind: 'delegate',
         delegateDid,
@@ -3542,13 +3549,15 @@ export class SyncEngineLevel implements SyncEngine {
       }
     }
 
-    // Count degraded links from the durable ledger, not just in-memory
-    // _activeLinks. Links persist across restarts; a repairing/degraded_poll
-    // link from a previous session must still be reported.
+    // Superseded authorization epochs can leave durable link state behind. Only
+    // links that still belong to the current registered projection/epoch should
+    // affect health. Endpoint-level orphan cleanup is a separate GC concern.
+    const currentLinkIdentityKeys = await this.getCurrentDurableLinkIdentityKeys();
     let degradedLinkCount = 0;
     const allLinks = await this.ledger.getAllLinks();
     for (const link of allLinks) {
-      if (link.status === 'repairing' || link.status === 'degraded_poll' || link.status === 'terminal_incomplete') {
+      const isCurrentLink = currentLinkIdentityKeys === undefined || currentLinkIdentityKeys.has(this.getDurableLinkIdentityKey(link));
+      if (isCurrentLink && SyncEngineLevel.isUnhealthyLinkStatus(link.status)) {
         degradedLinkCount++;
       }
     }
@@ -3560,6 +3569,42 @@ export class SyncEngineLevel implements SyncEngine {
       degradedLinkCount   : degradedLinkCount,
       syncHealthy         : failedMessageCount === 0 && degradedLinkCount === 0,
     };
+  }
+
+  private async getCurrentDurableLinkIdentityKeys(): Promise<Set<string> | undefined> {
+    try {
+      const identityKeys = new Set<string>();
+      for await (const [did, options] of this._db.sublevel('registeredIdentities').iterator()) {
+        let parsed: SyncIdentityOptions;
+        try {
+          parsed = JSON.parse(options) as SyncIdentityOptions;
+        } catch (error: unknown) {
+          console.warn(`SyncEngineLevel: Corrupt sync options for ${did}, skipping health target:`, error);
+          continue;
+        }
+
+        const scope = syncScopeFromProtocols(parsed.protocols);
+        const projectionId = await computeProjectionId(did, scope);
+        const { authorizationEpoch } = await this.buildSyncTargetAuthorization(did, scope, parsed);
+        identityKeys.add(SyncEngineLevel.durableLinkIdentityKey(did, projectionId, authorizationEpoch));
+      }
+      return identityKeys;
+    } catch (error: unknown) {
+      console.warn('SyncEngineLevel: Failed to resolve current durable link identity keys for health; falling back to all durable links', error);
+      return undefined;
+    }
+  }
+
+  private getDurableLinkIdentityKey(link: ReplicationLinkState): string {
+    return SyncEngineLevel.durableLinkIdentityKey(link.tenantDid, link.projectionId, link.authorizationEpoch);
+  }
+
+  private static durableLinkIdentityKey(tenantDid: string, projectionId: string, authorizationEpoch: string): string {
+    return `${tenantDid}^${projectionId}^${authorizationEpoch}`;
+  }
+
+  private static isUnhealthyLinkStatus(status: ReplicationLinkState['status']): boolean {
+    return status === 'repairing' || status === 'degraded_poll' || status === 'terminal_incomplete';
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -437,7 +437,7 @@ export type SyncHealthSummary = {
    * count keeps that state visible to callers.
    */
   closureFailureCount: number;
-  /** Number of links currently in 'repairing', 'degraded_poll', or terminal-incomplete status. */
+  /** Number of current sync links in 'repairing', 'degraded_poll', or terminal-incomplete status. */
   degradedLinkCount: number;
   /** True only when there are no failed messages and no degraded links. */
   syncHealthy: boolean;

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { Message, RecordsWrite, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
 import { ClosureFailureCode } from '../src/sync-closure-types.js';
+import { computeAuthorizationEpoch } from '../src/types/sync.js';
 import { DwnInterface } from '../src/types/dwn.js';
 import { getMessagesPermissionGrantsForScope } from '../src/sync-permission-grants.js';
 import { ReplicationLedger } from '../src/sync-replication-ledger.js';
@@ -3653,6 +3654,9 @@ describe('SyncEngineLevel — private methods', () => {
           scope: { kind: 'protocolSet', protocols: [protocol] },
         });
         (engine as any)._activeLinks.set(linkKey, link);
+        sinon.stub(engine as any, 'getCurrentDurableLinkIdentityKeys').resolves(
+          new Set([`${link.tenantDid}^${link.projectionId}^${link.authorizationEpoch}`])
+        );
 
         const transitionToRepairingStub = sinon.stub(engine as any, 'transitionToRepairing').resolves();
         const closePullStub = sinon.stub().resolves();
@@ -4877,31 +4881,123 @@ describe('SyncEngineLevel — private methods', () => {
       ).rejects.toThrow('disk full');
     });
 
-    it('should count degraded links from durable ledger, not just in-memory state', async () => {
-      const engine = createEngine({ db });
+    it('should count current degraded links from durable ledger, not just in-memory state', async () => {
+      const endpointLookupStub = sinon.stub().rejects(new Error('endpoint lookup should not run'));
+      const engine = createEngine({
+        db,
+        agent: {
+          agentDid : 'did:example:agent',
+          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+        } as any,
+      });
+      const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
+      await engine.registerIdentity({
+        did     : 'did:degraded-test',
+        options : { protocols: 'all' },
+      });
 
-      // Create links via the ledger (durable) — these survive restart.
+      const targetA = syncTarget('did:degraded-test', 'https://a.com', { authorizationEpoch: ownerEpoch });
+      const targetB = syncTarget('did:degraded-test', 'https://b.com', { authorizationEpoch: ownerEpoch });
+      const targetC = syncTarget('did:degraded-test', 'https://c.com', { authorizationEpoch: ownerEpoch });
+
+      // Create links via the ledger (durable). These survive restart and
+      // still count when they belong to the current registered projection/epoch.
       const ledger = (engine as any).ledger;
       const link1 = await ledger.getOrCreateLink({
-        tenantDid: 'did:degraded-test', remoteEndpoint: 'https://a.com', scope: { kind: 'full' },
+        tenantDid          : targetA.did,
+        remoteEndpoint     : targetA.dwnUrl,
+        scope              : targetA.scope,
+        authorization      : targetA.authorization,
+        authorizationEpoch : targetA.authorizationEpoch,
       });
       await ledger.setStatus(link1, 'degraded_poll');
 
       const link2 = await ledger.getOrCreateLink({
-        tenantDid: 'did:degraded-test', remoteEndpoint: 'https://b.com', scope: { kind: 'full' },
+        tenantDid          : targetB.did,
+        remoteEndpoint     : targetB.dwnUrl,
+        scope              : targetB.scope,
+        authorization      : targetB.authorization,
+        authorizationEpoch : targetB.authorizationEpoch,
       });
       await ledger.setStatus(link2, 'repairing');
 
       const link3 = await ledger.getOrCreateLink({
-        tenantDid: 'did:degraded-test', remoteEndpoint: 'https://c.com', scope: { kind: 'full' },
+        tenantDid          : targetC.did,
+        remoteEndpoint     : targetC.dwnUrl,
+        scope              : targetC.scope,
+        authorization      : targetC.authorization,
+        authorizationEpoch : targetC.authorizationEpoch,
       });
       await ledger.setStatus(link3, 'live');
 
-      // _activeLinks is empty — simulates a fresh restart.
+      // _activeLinks is empty; this simulates a fresh restart.
       expect((engine as any)._activeLinks.size).toBe(0);
 
       const health = await engine.getSyncHealth();
       expect(health.degradedLinkCount).toBe(2);
+      expect(endpointLookupStub.called).toBe(false);
+    });
+
+    it('should ignore degraded durable links from superseded authorization epochs', async () => {
+      const engine = createEngine({ db });
+      const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
+      await engine.registerIdentity({
+        did     : 'did:epoch-health',
+        options : { protocols: 'all' },
+      });
+      const currentTarget = syncTarget('did:epoch-health', 'https://dwn.example.com', {
+        authorizationEpoch: ownerEpoch,
+      });
+      const oldTarget = syncTarget('did:epoch-health', 'https://dwn.example.com', {
+        authorizationEpoch: 'epoch-old',
+      });
+
+      const ledger = (engine as any).ledger;
+      const oldLink = await ledger.getOrCreateLink({
+        tenantDid          : oldTarget.did,
+        remoteEndpoint     : oldTarget.dwnUrl,
+        scope              : oldTarget.scope,
+        authorization      : oldTarget.authorization,
+        authorizationEpoch : oldTarget.authorizationEpoch,
+      });
+      await ledger.setStatus(oldLink, 'terminal_incomplete');
+
+      const currentLink = await ledger.getOrCreateLink({
+        tenantDid          : currentTarget.did,
+        remoteEndpoint     : currentTarget.dwnUrl,
+        scope              : currentTarget.scope,
+        authorization      : currentTarget.authorization,
+        authorizationEpoch : currentTarget.authorizationEpoch,
+      });
+      await ledger.setStatus(currentLink, 'live');
+
+      const health = await engine.getSyncHealth();
+      expect(health.degradedLinkCount).toBe(0);
+      expect(health.syncHealthy).toBe(true);
+    });
+
+    it('should fall back to all durable links when current link identity keys cannot be resolved', async () => {
+      const engine = createEngine({ db });
+      const target = syncTarget('did:fallback-health', 'https://dwn.example.com');
+      await db.sublevel('registeredIdentities').put(
+        target.did,
+        JSON.stringify({ protocols: 'all', delegateDid: 'did:example:delegate' })
+      );
+      const warnStub = sinon.stub(console, 'warn');
+
+      const ledger = (engine as any).ledger;
+      const link = await ledger.getOrCreateLink({
+        tenantDid          : target.did,
+        remoteEndpoint     : target.dwnUrl,
+        scope              : target.scope,
+        authorization      : target.authorization,
+        authorizationEpoch : target.authorizationEpoch,
+      });
+      await ledger.setStatus(link, 'degraded_poll');
+
+      const health = await engine.getSyncHealth();
+      expect(health.degradedLinkCount).toBe(1);
+      expect(warnStub.calledOnce).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- count degraded/terminal durable links only when they match the current registered projection and authorization epoch
- keep health reporting local-only; it no longer resolves DWN endpoints to classify current links
- keep a conservative all-links fallback if current link identity resolution fails
- cover current durable links, superseded authorization epochs, local-only health, and fallback behavior in sync-engine tests

## Verification
- bun run --filter @enbox/agent build
- bun run --filter @enbox/agent lint
- bun test packages/agent/tests/sync-engine-private.spec.ts
- git diff --check