### PR TITLE
Prune superseded sync links

### DIFF
--- a/.changeset/sync-link-gc.md
+++ b/.changeset/sync-link-gc.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Prune superseded durable sync links when identity sync scope or authorization epoch changes.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -96,6 +96,15 @@ enum LinkSubscriptionOpenResult {
   Repairing = 'repairing',
 }
 
+enum LinkInitializationStatus {
+  Active = 'active',
+  Failed = 'failed',
+}
+
+type LinkInitializationResult =
+  | { status: LinkInitializationStatus.Active; durableLinkIdentityKey: string }
+  | { status: LinkInitializationStatus.Failed };
+
 type PullAcceptanceResult =
   | { accepted: true }
   | { accepted: false; classification: Exclude<SyncScopeClassification, 'in-scope'> };
@@ -500,7 +509,12 @@ export class SyncEngineLevel implements SyncEngine {
 
     // If live sync is active, hot-add subscriptions for this identity.
     if (this._syncMode === 'live') {
-      await this.addIdentityToLiveSync(did, options);
+      const currentIdentityKeys = await this.addIdentityToLiveSync(did, options);
+      if (currentIdentityKeys.size > 0) {
+        await this.pruneSupersededDurableLinksForIdentity(did, currentIdentityKeys);
+      }
+    } else {
+      await this.tryPruneSupersededDurableLinksForRegisteredIdentity(did, options);
     }
   }
 
@@ -519,6 +533,7 @@ export class SyncEngineLevel implements SyncEngine {
     await registeredIdentities.del(did);
     this._syncTargetsCache = undefined;
     this._syncTargetsCacheGeneration++;
+    await this.pruneSupersededDurableLinksForIdentity(did, new Set());
   }
 
   public async getIdentityOptions(did: string): Promise<SyncIdentityOptions | undefined> {
@@ -557,7 +572,12 @@ export class SyncEngineLevel implements SyncEngine {
     // epoch, so existing durable links are not mutated in place.
     if (this._syncMode === 'live' && this.hasActiveLinksForDid(did)) {
       await this.removeIdentityFromLiveSync(did);
-      await this.addIdentityToLiveSync(did, options);
+      const currentIdentityKeys = await this.addIdentityToLiveSync(did, options);
+      if (currentIdentityKeys.size > 0) {
+        await this.pruneSupersededDurableLinksForIdentity(did, currentIdentityKeys);
+      }
+    } else {
+      await this.tryPruneSupersededDurableLinksForRegisteredIdentity(did, options);
     }
   }
 
@@ -1460,7 +1480,7 @@ export class SyncEngineLevel implements SyncEngine {
    * link, migrate legacy cursors, open pull + push subscriptions, and
    * transition the link to `'live'`.
    */
-  private async initializeLinkTarget(target: SyncTarget): Promise<void> {
+  private async initializeLinkTarget(target: SyncTarget): Promise<LinkInitializationResult> {
     let link: ReplicationLinkState | undefined;
     try {
       link = await this.getOrCreateReplicationLink(target);
@@ -1468,15 +1488,16 @@ export class SyncEngineLevel implements SyncEngine {
       await this.migrateLegacyCursorIfNeeded(target, link);
       this._activeLinks.set(linkKey, link);
       if (link.status === 'terminal_incomplete') {
-        return;
+        return this.createActiveLinkInitializationResult(link);
       }
 
       const subscriptionResult = await this.openLinkSubscriptions({ ...target, linkKey });
       if (subscriptionResult === LinkSubscriptionOpenResult.ReadyForLive) {
         await this.markLinkLive(target, link, linkKey);
       }
+      return this.createActiveLinkInitializationResult(link);
     } catch (error: any) {
-      await this.handleInitializeLinkTargetError(target, link, error);
+      return this.handleInitializeLinkTargetError(target, link, error);
     }
   }
 
@@ -1548,7 +1569,7 @@ export class SyncEngineLevel implements SyncEngine {
     target: SyncTarget,
     link: ReplicationLinkState | undefined,
     error: any,
-  ): Promise<void> {
+  ): Promise<LinkInitializationResult> {
     const linkKey = link
       ? this.getReplicationLinkKey(target, link)
       : buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
@@ -1565,7 +1586,7 @@ export class SyncEngineLevel implements SyncEngine {
       await this.transitionToRepairing(linkKey, link, {
         resumeToken: error.gapInfo?.latestAvailable,
       });
-      return;
+      return this.createActiveLinkInitializationResult(link);
     }
 
     console.error(`SyncEngineLevel: Failed to open live subscription for ${target.did} -> ${target.dwnUrl}`, error);
@@ -1573,6 +1594,14 @@ export class SyncEngineLevel implements SyncEngine {
     if (this.isDidResolutionFailure(error)) {
       throw error;
     }
+    return { status: LinkInitializationStatus.Failed };
+  }
+
+  private createActiveLinkInitializationResult(link: ReplicationLinkState): LinkInitializationResult {
+    return {
+      status                 : LinkInitializationStatus.Active,
+      durableLinkIdentityKey : this.getDurableLinkIdentityKey(link),
+    };
   }
 
   private cleanupFailedLinkInitialization(linkKey: string): void {
@@ -1592,23 +1621,23 @@ export class SyncEngineLevel implements SyncEngine {
    * causing a 401. Retrying with exponential backoff lets the
    * propagation settle before giving up.
    */
-  private async initializeLinkTargetWithRetry(target: SyncTarget): Promise<void> {
+  private async initializeLinkTargetWithRetry(target: SyncTarget): Promise<LinkInitializationResult> {
     try {
-      await this.initializeLinkTarget(target);
+      return await this.initializeLinkTarget(target);
     } catch (error: any) {
       if (!this.isDidResolutionFailure(error)) { throw error; }
 
       for (const delay of SyncEngineLevel.DID_RESOLUTION_RETRY_BACKOFF_MS) {
         await sleep(delay);
         try {
-          await this.initializeLinkTarget(target);
-          return;
+          return await this.initializeLinkTarget(target);
         } catch {
           // Continue to next attempt.
         }
       }
       // All retries exhausted — the original error was already logged
       // by initializeLinkTarget's catch block.
+      return { status: LinkInitializationStatus.Failed };
     }
   }
 
@@ -1635,16 +1664,23 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   /** Hot-add a single identity to the active live sync session. */
-  private async addIdentityToLiveSync(did: string, options: SyncIdentityOptions): Promise<void> {
+  private async addIdentityToLiveSync(did: string, options: SyncIdentityOptions): Promise<Set<string>> {
     const dwnEndpointUrls = await this.agent.dwn.getDwnEndpointUrlsForTarget(did);
-    if (dwnEndpointUrls.length === 0) { return; }
+    if (dwnEndpointUrls.length === 0) { return new Set(); }
 
     const targets: SyncTarget[] = [];
     for (const dwnUrl of dwnEndpointUrls) {
       targets.push(await this.buildSyncTarget(did, dwnUrl, options));
     }
 
-    await Promise.allSettled(targets.map(t => this.initializeLinkTargetWithRetry(t)));
+    const results = await Promise.allSettled(targets.map(t => this.initializeLinkTargetWithRetry(t)));
+    const currentIdentityKeys = new Set<string>();
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value.status === LinkInitializationStatus.Active) {
+        currentIdentityKeys.add(result.value.durableLinkIdentityKey);
+      }
+    }
+    return currentIdentityKeys;
   }
 
   /** Hot-remove a single identity from the active live sync session. */
@@ -1691,6 +1727,32 @@ export class SyncEngineLevel implements SyncEngine {
       if (this.isLinkKeyForDid(key, did)) { this._activeLinks.delete(key); this._linkRuntimes.delete(key); }
     }
     this._closureContexts.delete(did);
+  }
+
+  private async tryPruneSupersededDurableLinksForRegisteredIdentity(did: string, options: SyncIdentityOptions): Promise<void> {
+    try {
+      const currentIdentityKeys = await this.getDurableLinkIdentityKeysForRegisteredIdentity(did, options);
+      await this.pruneSupersededDurableLinksForIdentity(did, currentIdentityKeys);
+    } catch (error: unknown) {
+      console.warn(`SyncEngineLevel: Failed to prune superseded durable links for ${did}`, error);
+    }
+  }
+
+  private async getDurableLinkIdentityKeysForRegisteredIdentity(did: string, options: SyncIdentityOptions): Promise<Set<string>> {
+    const scope = syncScopeFromProtocols(options.protocols);
+    const projectionId = await computeProjectionId(did, scope);
+    const { authorizationEpoch } = await this.buildSyncTargetAuthorization(did, scope, options);
+    return new Set([SyncEngineLevel.durableLinkIdentityKey(did, projectionId, authorizationEpoch)]);
+  }
+
+  private async pruneSupersededDurableLinksForIdentity(did: string, currentIdentityKeys: Set<string>): Promise<void> {
+    const links = await this.ledger.getLinksForTenant(did);
+    await Promise.all(links.map(async link => {
+      if (currentIdentityKeys.has(this.getDurableLinkIdentityKey(link))) {
+        return;
+      }
+      await this.ledger.deleteLink(link.tenantDid, link.remoteEndpoint, link.projectionId, link.authorizationEpoch);
+    }));
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/tests/sync-engine-identity.spec.ts
+++ b/packages/agent/tests/sync-engine-identity.spec.ts
@@ -432,7 +432,7 @@ describe('SyncEngineLevel — identity management', () => {
       (engine as any)._syncMode = 'live';
       (engine as any)._liveSubscriptions = [{ linkKey: 'existing', did: 'did:example:existing', dwnUrl: 'https://dwn.example.com', close: sinon.stub() }];
 
-      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves();
+      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves(new Set());
 
       await engine.registerIdentity({ did: 'did:example:hotadd1', options: { protocols: ['https://proto.example'] } });
 
@@ -446,7 +446,7 @@ describe('SyncEngineLevel — identity management', () => {
       (engine as any)._syncMode = 'live';
       (engine as any)._liveSubscriptions = [{ linkKey: 'existing', did: 'did:example:existing', dwnUrl: 'https://dwn.example.com', close: sinon.stub() }];
 
-      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves();
+      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves(new Set());
 
       await engine.registerIdentity({ did: 'did:example:hotadd-default', options: { protocols: 'all' } });
 
@@ -459,7 +459,7 @@ describe('SyncEngineLevel — identity management', () => {
       (engine as any)._syncMode = 'poll';
       (engine as any)._liveSubscriptions = [];
 
-      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves();
+      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves(new Set());
 
       await engine.registerIdentity({ did: 'did:example:nohot-poll', options: { protocols: 'all' } });
 
@@ -471,7 +471,7 @@ describe('SyncEngineLevel — identity management', () => {
       (engine as any)._syncMode = 'live';
       (engine as any)._liveSubscriptions = [];
 
-      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves();
+      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves(new Set());
 
       await engine.registerIdentity({ did: 'did:example:hot-after-removal', options: { protocols: 'all' } });
 
@@ -924,7 +924,7 @@ describe('SyncEngineLevel — identity management', () => {
       (engine as any)._activeLinks.set('did:example:update1^https://dwn.example.com', { tenantDid: 'did:example:update1' });
 
       const hotRemoveStub = sinon.stub(engine as any, 'removeIdentityFromLiveSync').resolves();
-      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves();
+      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves(new Set());
 
       const newOptions = { protocols: ['https://new-proto.example'], delegateDid: 'did:example:delegate' };
       await engine.updateIdentityOptions({ did: 'did:example:update1', options: newOptions });
@@ -943,7 +943,7 @@ describe('SyncEngineLevel — identity management', () => {
       (engine as any)._syncMode = 'poll';
 
       const hotRemoveStub = sinon.stub(engine as any, 'removeIdentityFromLiveSync').resolves();
-      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves();
+      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves(new Set());
 
       await engine.updateIdentityOptions({ did: 'did:example:update-poll', options: { protocols: ['https://new.example'] } });
 
@@ -959,7 +959,7 @@ describe('SyncEngineLevel — identity management', () => {
       // No active links for this DID
 
       const hotRemoveStub = sinon.stub(engine as any, 'removeIdentityFromLiveSync').resolves();
-      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves();
+      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves(new Set());
 
       await engine.updateIdentityOptions({ did: 'did:example:update-nolinks', options: { protocols: ['https://new.example'] } });
 
@@ -992,7 +992,7 @@ describe('SyncEngineLevel — identity management', () => {
       (engine as any)._liveSubscriptions = [];
       (engine as any)._localSubscriptions = [];
 
-      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves();
+      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves(new Set());
 
       await engine.registerIdentity({ did: 'did:example:after-last-removed', options: { protocols: 'all' } });
 
@@ -1025,7 +1025,7 @@ describe('SyncEngineLevel — identity management', () => {
       (engine as any)._syncMode = 'live';
       await engine.stopSync();
 
-      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves();
+      const hotAddStub = sinon.stub(engine as any, 'addIdentityToLiveSync').resolves(new Set());
 
       await engine.registerIdentity({ did: 'did:example:after-stop', options: { protocols: 'all' } });
 

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -2974,7 +2974,7 @@ describe('SyncEngineLevel', () => {
           syncEngine['_activeLinks'].set(linkKeyFor(did, testDwnUrls[0], link), link);
 
           const removeStub = sinon.stub(syncEngine as any, 'removeIdentityFromLiveSync').resolves();
-          const addStub = sinon.stub(syncEngine as any, 'addIdentityToLiveSync').resolves();
+          const addStub = sinon.stub(syncEngine as any, 'addIdentityToLiveSync').resolves(new Set());
 
           await syncEngine.updateIdentityOptions({
             did,

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -25,6 +25,15 @@ describe('SyncEngineLevel — private methods', () => {
     ...overrides,
   });
 
+  const activeInitializationResult = (link: {
+    tenantDid: string;
+    projectionId: string;
+    authorizationEpoch: string;
+  }): any => ({
+    status                 : 'active',
+    durableLinkIdentityKey : `${link.tenantDid}^${link.projectionId}^${link.authorizationEpoch}`,
+  });
+
   const messagesGrantEntry = (id: string, scope: Record<string, unknown>, overrides: Record<string, unknown> = {}): any => ({
     grant: {
       id,
@@ -1001,12 +1010,17 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent: { agentDid: 'did:example:agent' } as any });
       const initializeStub = sinon.stub(engine as any, 'initializeLinkTarget');
       initializeStub.onFirstCall().rejects(new Error('GeneralJwsVerifierGetPublicKeyNotFound: unable to resolve DID'));
-      initializeStub.onSecondCall().resolves();
+      initializeStub.onSecondCall().resolves(activeInitializationResult({
+        tenantDid          : 'did:example:alice',
+        projectionId       : 'projection-test',
+        authorizationEpoch : 'authorization-test',
+      }));
 
       const originalDelays = (SyncEngineLevel as any).DID_RESOLUTION_RETRY_BACKOFF_MS;
       (SyncEngineLevel as any).DID_RESOLUTION_RETRY_BACKOFF_MS = [0];
       try {
-        await (engine as any).initializeLinkTargetWithRetry(syncTarget('did:example:alice', 'https://dwn.example.com'));
+        const result = await (engine as any).initializeLinkTargetWithRetry(syncTarget('did:example:alice', 'https://dwn.example.com'));
+        expect(result.status).toBe('active');
       } finally {
         (SyncEngineLevel as any).DID_RESOLUTION_RETRY_BACKOFF_MS = originalDelays;
       }
@@ -4315,6 +4329,270 @@ describe('SyncEngineLevel — private methods', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // updateIdentityOptions
+  // ---------------------------------------------------------------------------
+
+  describe('updateIdentityOptions', () => {
+    it('should prune durable links from superseded projections when sync is not live', async () => {
+      const engine = createEngine({ db });
+      const ledger = (engine as any).ledger;
+      const did = 'did:example:update-prune';
+      const protocol = 'https://example.com/profile';
+      const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
+      const ownerAuthorization = { kind: 'owner' } as const;
+
+      await engine.registerIdentity({ did, options: { protocols: 'all' } });
+
+      await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : 'https://dwn.example.com',
+        scope              : { kind: 'full' },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+      const currentLink = await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : 'https://dwn.example.com',
+        scope              : { kind: 'protocolSet', protocols: [protocol] },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+
+      await engine.updateIdentityOptions({ did, options: { protocols: [protocol] } });
+
+      const links = await ledger.getLinksForTenant(did);
+      expect(links).toHaveLength(1);
+      expect(links[0].projectionId).toBe(currentLink.projectionId);
+      expect(links[0].authorizationEpoch).toBe(ownerEpoch);
+    });
+
+    it('should keep old durable links when live replacement initialization fails', async () => {
+      const did = 'did:example:update-live-fail';
+      const dwnUrl = 'https://dwn.example.com';
+      const protocol = 'https://example.com/profile';
+      const endpointLookupStub = sinon.stub().resolves([dwnUrl]);
+      const engine = createEngine({
+        db,
+        agent: {
+          agentDid : 'did:example:agent',
+          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+        } as any,
+      });
+      const ledger = (engine as any).ledger;
+      const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
+      const ownerAuthorization = { kind: 'owner' } as const;
+
+      await engine.registerIdentity({ did, options: { protocols: 'all' } });
+      const oldLink = await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : dwnUrl,
+        scope              : { kind: 'full' },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+      const oldLinkKey = (engine as any).buildLinkKey(did, dwnUrl, oldLink.projectionId, oldLink.authorizationEpoch);
+      (engine as any)._syncMode = 'live';
+      (engine as any)._activeLinks.set(oldLinkKey, oldLink);
+      sinon.stub(engine as any, 'initializeLinkTargetWithRetry').resolves({ status: 'failed' });
+
+      await engine.updateIdentityOptions({ did, options: { protocols: [protocol] } });
+
+      const links = await ledger.getLinksForTenant(did);
+      expect(links.some((link: any) => link.projectionId === oldLink.projectionId)).toBe(true);
+    });
+
+    it('should prune superseded durable links after live replacement initialization succeeds', async () => {
+      const did = 'did:example:update-live-prune';
+      const dwnUrl = 'https://dwn.example.com';
+      const protocol = 'https://example.com/profile';
+      const endpointLookupStub = sinon.stub().resolves([dwnUrl]);
+      const engine = createEngine({
+        db,
+        agent: {
+          agentDid : 'did:example:agent',
+          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+        } as any,
+      });
+      const ledger = (engine as any).ledger;
+      const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
+      const ownerAuthorization = { kind: 'owner' } as const;
+
+      await engine.registerIdentity({ did, options: { protocols: 'all' } });
+      const oldLink = await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : dwnUrl,
+        scope              : { kind: 'full' },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+      const currentLink = await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : dwnUrl,
+        scope              : { kind: 'protocolSet', protocols: [protocol] },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+      const oldLinkKey = (engine as any).buildLinkKey(did, dwnUrl, oldLink.projectionId, oldLink.authorizationEpoch);
+      (engine as any)._syncMode = 'live';
+      (engine as any)._activeLinks.set(oldLinkKey, oldLink);
+      sinon.stub(engine as any, 'initializeLinkTargetWithRetry').resolves(activeInitializationResult(currentLink));
+
+      await engine.updateIdentityOptions({ did, options: { protocols: [protocol] } });
+
+      const links = await ledger.getLinksForTenant(did);
+      expect(links).toHaveLength(1);
+      expect(links[0].projectionId).toBe(currentLink.projectionId);
+    });
+
+    it('should keep the exact delegated epoch established during live replacement', async () => {
+      const did = 'did:example:delegate-epoch-prune';
+      const delegateDid = 'did:example:delegate';
+      const dwnUrl = 'https://dwn.example.com';
+      const protocol = 'https://example.com/profile';
+      const endpointLookupStub = sinon.stub().resolves([dwnUrl]);
+      const engine = createEngine({
+        db,
+        agent: {
+          agentDid : 'did:example:agent',
+          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+        } as any,
+      });
+      const grantE1 = messagesGrantEntry('grant-e1', { interface: 'Messages', method: 'Read', protocol }, {
+        grantor : did,
+        grantee : delegateDid,
+      });
+      const grantE2 = messagesGrantEntry('grant-e2', { interface: 'Messages', method: 'Read', protocol }, {
+        grantor : did,
+        grantee : delegateDid,
+      });
+      const fetchGrantsStub = sinon.stub();
+      fetchGrantsStub.onFirstCall().resolves([grantE1]);
+      fetchGrantsStub.onSecondCall().resolves([grantE2]);
+      (engine as any)._permissionsApi = { fetchGrants: fetchGrantsStub };
+
+      await db.sublevel('registeredIdentities').put(
+        did,
+        JSON.stringify({ protocols: 'all', delegateDid })
+      );
+      const ledger = (engine as any).ledger;
+      const oldLink = await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : dwnUrl,
+        scope              : { kind: 'full' },
+        authorization      : { kind: 'owner' },
+        authorizationEpoch : 'old-epoch',
+      });
+      const oldLinkKey = (engine as any).buildLinkKey(did, dwnUrl, oldLink.projectionId, oldLink.authorizationEpoch);
+      (engine as any)._syncMode = 'live';
+      (engine as any)._activeLinks.set(oldLinkKey, oldLink);
+      sinon.stub(engine as any, 'openLinkSubscriptions').resolves('readyForLive');
+
+      await engine.updateIdentityOptions({
+        did,
+        options: { protocols: [protocol], delegateDid },
+      });
+
+      const links = await ledger.getLinksForTenant(did);
+      expect(fetchGrantsStub.callCount).toBe(1);
+      expect(links).toHaveLength(1);
+      expect(links[0].authorization).toEqual({
+        kind               : 'delegate',
+        delegateDid,
+        permissionGrantIds : ['grant-e1'],
+      });
+    });
+
+    it('should keep all endpoints for the current projection and prune superseded projections', async () => {
+      const did = 'did:example:update-live-multi-endpoint';
+      const protocol = 'https://example.com/profile';
+      const endpointA = 'https://a.example.com';
+      const endpointB = 'https://b.example.com';
+      const endpointLookupStub = sinon.stub().resolves([endpointA, endpointB]);
+      const engine = createEngine({
+        db,
+        agent: {
+          agentDid : 'did:example:agent',
+          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+        } as any,
+      });
+      const ledger = (engine as any).ledger;
+      const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
+      const ownerAuthorization = { kind: 'owner' } as const;
+
+      await db.sublevel('registeredIdentities').put(
+        did,
+        JSON.stringify({ protocols: 'all' })
+      );
+      const oldLink = await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : endpointA,
+        scope              : { kind: 'full' },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+      const oldLinkKey = (engine as any).buildLinkKey(did, endpointA, oldLink.projectionId, oldLink.authorizationEpoch);
+      (engine as any)._syncMode = 'live';
+      (engine as any)._activeLinks.set(oldLinkKey, oldLink);
+      sinon.stub(engine as any, 'openLinkSubscriptions').resolves('readyForLive');
+
+      await engine.updateIdentityOptions({ did, options: { protocols: [protocol] } });
+
+      const links = await ledger.getLinksForTenant(did);
+      expect(links).toHaveLength(2);
+      expect(links.map((link: any) => link.remoteEndpoint).sort()).toEqual([endpointA, endpointB]);
+      expect(links.every((link: any) => link.scope.kind === 'protocolSet')).toBe(true);
+    });
+
+    it('should keep a current terminal-incomplete link while pruning superseded links', async () => {
+      const did = 'did:example:update-live-terminal';
+      const dwnUrl = 'https://dwn.example.com';
+      const protocol = 'https://example.com/profile';
+      const endpointLookupStub = sinon.stub().resolves([dwnUrl]);
+      const engine = createEngine({
+        db,
+        agent: {
+          agentDid : 'did:example:agent',
+          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+        } as any,
+      });
+      const ledger = (engine as any).ledger;
+      const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
+      const ownerAuthorization = { kind: 'owner' } as const;
+
+      await db.sublevel('registeredIdentities').put(
+        did,
+        JSON.stringify({ protocols: 'all' })
+      );
+      const oldLink = await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : dwnUrl,
+        scope              : { kind: 'full' },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+      const currentLink = await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : dwnUrl,
+        scope              : { kind: 'protocolSet', protocols: [protocol] },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+      await ledger.setStatus(currentLink, 'terminal_incomplete');
+      const oldLinkKey = (engine as any).buildLinkKey(did, dwnUrl, oldLink.projectionId, oldLink.authorizationEpoch);
+      (engine as any)._syncMode = 'live';
+      (engine as any)._activeLinks.set(oldLinkKey, oldLink);
+      sinon.stub(engine as any, 'openLinkSubscriptions').rejects(new Error('terminal link should not open subscriptions'));
+
+      await engine.updateIdentityOptions({ did, options: { protocols: [protocol] } });
+
+      const links = await ledger.getLinksForTenant(did);
+      expect(links).toHaveLength(1);
+      expect(links[0].projectionId).toBe(currentLink.projectionId);
+      expect(links[0].status).toBe('terminal_incomplete');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // unregisterIdentity
   // ---------------------------------------------------------------------------
 
@@ -4330,6 +4608,43 @@ describe('SyncEngineLevel — private methods', () => {
 
       const after = await engine.getIdentityOptions('did:example:unreg-test');
       expect(after).toBeUndefined();
+    });
+
+    it('should prune durable links for the unregistered identity only', async () => {
+      const engine = createEngine({ db });
+      const ledger = (engine as any).ledger;
+      const did = 'did:example:unreg-links';
+      const otherDid = 'did:example:other-links';
+      const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
+      const ownerAuthorization = { kind: 'owner' } as const;
+
+      await engine.registerIdentity({ did, options: { protocols: 'all' } });
+      await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : 'https://dwn.example.com',
+        scope              : { kind: 'full' },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+      await ledger.getOrCreateLink({
+        tenantDid          : did,
+        remoteEndpoint     : 'https://dwn-2.example.com',
+        scope              : { kind: 'protocolSet', protocols: ['https://example.com/profile'] },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : 'old-epoch',
+      });
+      await ledger.getOrCreateLink({
+        tenantDid          : otherDid,
+        remoteEndpoint     : 'https://dwn.example.com',
+        scope              : { kind: 'full' },
+        authorization      : ownerAuthorization,
+        authorizationEpoch : ownerEpoch,
+      });
+
+      await engine.unregisterIdentity(did);
+
+      expect(await ledger.getLinksForTenant(did)).toEqual([]);
+      expect(await ledger.getLinksForTenant(otherDid)).toHaveLength(1);
     });
 
     it('should throw when unregistering an identity that is not registered', async () => {


### PR DESCRIPTION
## Summary
- delete durable sync links for superseded projection/authorization epochs after an identity has a current replacement or is unregistered
- keep live-prune decisions tied to the exact durable link identity keys returned by initialized links, avoiding a second delegate grant/epoch resolution
- preserve old durable links when live replacement setup fails
- cover delegate epoch changes, multi-endpoint current links, and terminal current links in sync-engine tests

## Verification
- bun run build
- bun run --filter @enbox/agent build
- bun run --filter @enbox/agent lint
- bun test packages/agent/tests/sync-engine-private.spec.ts
- git diff --check