### PR TITLE
Fix protocol-set sync ordering for composed protocols

### DIFF
--- a/.changeset/composed-protocol-sync-order.md
+++ b/.changeset/composed-protocol-sync-order.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Order composed protocol configurations after their referenced protocol configurations during sync apply.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -21,14 +21,14 @@ import { DwnInterface } from './types/dwn.js';
 import { evaluateClosure } from './sync-closure-resolver.js';
 import { isRecordsWrite } from './utils.js';
 import { ReplicationLedger } from './sync-replication-ledger.js';
-import { SyncLinkReconciler } from './sync-link-reconciler.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { buildLegacyCursorKey, buildLinkId } from './sync-link-id.js';
 import { classifySyncEventScope, classifySyncMessageScope } from './sync-scope-acceptance.js';
 import { computeAuthorizationEpoch, computeProjectionId, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { createClosureContext, invalidateClosureCache, isTerminalClosureFailureCode } from './sync-closure-types.js';
-import { fetchRemoteMessages, getMessageCid, pullMessages, pushMessages } from './sync-messages.js';
+import { fetchRemoteMessages, getMessageCid, pullMessages, pushMessages, SyncPullAbortedError } from './sync-messages.js';
 import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
+import { partitionRemoteEntries, SyncLinkReconciler } from './sync-link-reconciler.js';
 
 export type SyncEngineLevelParams = {
   agent?: EnboxPlatformAgent;
@@ -108,6 +108,32 @@ type LinkInitializationResult =
 type PullAcceptanceResult =
   | { accepted: true }
   | { accepted: false; classification: Exclude<SyncScopeClassification, 'in-scope'> };
+
+type ProjectionReconcileTarget = {
+  did: string;
+  dwnUrl: string;
+  delegateDid?: string;
+  scope: SyncScope;
+  authorization: SyncAuthorization;
+};
+
+type ProjectionReconcileOptions = {
+  direction?: 'push' | 'pull';
+  verifyConvergence?: boolean;
+};
+
+type ProjectionReconcileResult = {
+  aborted?: boolean;
+  converged?: boolean;
+};
+
+type ProtocolSetScope = Extract<SyncScope, { kind: 'protocolSet' }>;
+
+type ProtocolSetDiffPlan = {
+  changedProtocols: string[];
+  onlyRemote: MessagesSyncDiffEntry[];
+  onlyLocal: string[];
+};
 
 // ---------------------------------------------------------------------------
 // Per-link in-memory delivery-order tracking (not persisted to ledger)
@@ -2645,16 +2671,14 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private async reconcileProjectionTarget(
-    target: {
-      did: string;
-      dwnUrl: string;
-      delegateDid?: string;
-      scope: SyncScope;
-      authorization: SyncAuthorization;
-    },
-    options?: { direction?: 'push' | 'pull'; verifyConvergence?: boolean },
+    target: ProjectionReconcileTarget,
+    options?: ProjectionReconcileOptions,
     shouldContinue?: () => boolean,
-  ): Promise<{ aborted?: boolean; converged?: boolean }> {
+  ): Promise<ProjectionReconcileResult> {
+    if (target.scope.kind === 'protocolSet' && target.scope.protocols.length > 1) {
+      return this.reconcileProtocolSetProjectionTarget(target, options, shouldContinue);
+    }
+
     let converged = true;
     const permissionGrantIds = this.getAuthorizationGrantIds(target.authorization);
     const reconciler = this.createLinkReconciler(shouldContinue);
@@ -2678,11 +2702,199 @@ export class SyncEngineLevel implements SyncEngine {
     return options?.verifyConvergence === true ? { converged } : {};
   }
 
+  private async reconcileProtocolSetProjectionTarget(
+    target: ProjectionReconcileTarget,
+    options?: ProjectionReconcileOptions,
+    shouldContinue?: () => boolean,
+  ): Promise<ProjectionReconcileResult> {
+    if (target.scope.kind !== 'protocolSet') {
+      return {};
+    }
+
+    const scope = target.scope;
+    const permissionGrantIds = this.getAuthorizationGrantIds(target.authorization);
+    const diffPlan = await this.collectProtocolSetDiffPlan(target, scope, permissionGrantIds, shouldContinue);
+    if (!diffPlan) {
+      return { aborted: true };
+    }
+
+    if (diffPlan.changedProtocols.length === 0) {
+      return options?.verifyConvergence === true ? { converged: true } : {};
+    }
+
+    const aborted = await this.applyProtocolSetDiffPlan(target, scope, diffPlan, permissionGrantIds, options, shouldContinue);
+    if (aborted) {
+      return { aborted: true };
+    }
+
+    if (options?.verifyConvergence !== true) {
+      return {};
+    }
+
+    return this.verifyProtocolSetConvergence(target, diffPlan.changedProtocols, permissionGrantIds, shouldContinue);
+  }
+
+  private async collectProtocolSetDiffPlan(
+    target: ProjectionReconcileTarget,
+    scope: ProtocolSetScope,
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    shouldContinue?: () => boolean,
+  ): Promise<ProtocolSetDiffPlan | undefined> {
+    const plan: ProtocolSetDiffPlan = { changedProtocols: [], onlyRemote: [], onlyLocal: [] };
+
+    for (const protocol of scope.protocols) {
+      const roots = await this.getProtocolRoots(target, protocol, permissionGrantIds, shouldContinue);
+      if (!roots) { return undefined; }
+
+      if (roots.localRoot === roots.remoteRoot) {
+        continue;
+      }
+
+      plan.changedProtocols.push(protocol);
+      const diff = await this.diffWithRemote({
+        did         : target.did,
+        dwnUrl      : target.dwnUrl,
+        delegateDid : target.delegateDid,
+        protocol,
+        permissionGrantIds,
+      });
+      if (shouldContinue?.() === false) { return undefined; }
+
+      plan.onlyRemote.push(...diff.onlyRemote);
+      plan.onlyLocal.push(...diff.onlyLocal);
+    }
+
+    return plan;
+  }
+
+  private async getProtocolRoots(
+    target: ProjectionReconcileTarget,
+    protocol: string,
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    shouldContinue?: () => boolean,
+  ): Promise<{ localRoot: string; remoteRoot: string } | undefined> {
+    const localRoot = await this.getLocalRoot(target.did, target.delegateDid, protocol, permissionGrantIds);
+    if (shouldContinue?.() === false) { return undefined; }
+
+    const remoteRoot = await this.getRemoteRoot(target.did, target.dwnUrl, target.delegateDid, protocol, permissionGrantIds);
+    if (shouldContinue?.() === false) { return undefined; }
+
+    return { localRoot, remoteRoot };
+  }
+
+  private async applyProtocolSetDiffPlan(
+    target: ProjectionReconcileTarget,
+    scope: ProtocolSetScope,
+    diffPlan: ProtocolSetDiffPlan,
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    options?: ProjectionReconcileOptions,
+    shouldContinue?: () => boolean,
+  ): Promise<boolean> {
+    if (await this.pullProtocolSetRemoteDiff(target, scope, diffPlan.onlyRemote, permissionGrantIds, options, shouldContinue)) {
+      return true;
+    }
+
+    return this.pushProtocolSetLocalDiff(target, diffPlan.onlyLocal, permissionGrantIds, options, shouldContinue);
+  }
+
+  private async pullProtocolSetRemoteDiff(
+    target: ProjectionReconcileTarget,
+    scope: ProtocolSetScope,
+    onlyRemote: MessagesSyncDiffEntry[],
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    options?: ProjectionReconcileOptions,
+    shouldContinue?: () => boolean,
+  ): Promise<boolean> {
+    if (options?.direction === 'push' || onlyRemote.length === 0) {
+      return false;
+    }
+
+    const { prefetched, needsFetchCids } = partitionRemoteEntries(SyncEngineLevel.dedupeRemoteEntries(onlyRemote));
+    try {
+      await this.pullMessages({
+        did                : target.did,
+        dwnUrl             : target.dwnUrl,
+        delegateDid        : target.delegateDid,
+        scope              : scope,
+        permissionGrantIds : permissionGrantIds,
+        messageCids        : needsFetchCids,
+        prefetched         : prefetched,
+        shouldContinue     : shouldContinue,
+      });
+    } catch (error) {
+      if (error instanceof SyncPullAbortedError) {
+        return true;
+      }
+      throw error;
+    }
+    return shouldContinue?.() === false;
+  }
+
+  private async pushProtocolSetLocalDiff(
+    target: ProjectionReconcileTarget,
+    onlyLocal: string[],
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    options?: ProjectionReconcileOptions,
+    shouldContinue?: () => boolean,
+  ): Promise<boolean> {
+    if (options?.direction === 'pull' || onlyLocal.length === 0) {
+      return false;
+    }
+
+    await this.pushMessages({
+      did         : target.did,
+      dwnUrl      : target.dwnUrl,
+      delegateDid : target.delegateDid,
+      permissionGrantIds,
+      messageCids : SyncEngineLevel.dedupeStrings(onlyLocal),
+    });
+    return shouldContinue?.() === false;
+  }
+
+  private async verifyProtocolSetConvergence(
+    target: ProjectionReconcileTarget,
+    changedProtocols: string[],
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    shouldContinue?: () => boolean,
+  ): Promise<ProjectionReconcileResult> {
+    for (const protocol of changedProtocols) {
+      const roots = await this.getProtocolRoots(target, protocol, permissionGrantIds, shouldContinue);
+      if (!roots) { return { aborted: true }; }
+
+      if (roots.localRoot !== roots.remoteRoot) {
+        return { converged: false };
+      }
+    }
+
+    return { converged: true };
+  }
+
+  private static dedupeRemoteEntries(entries: MessagesSyncDiffEntry[]): MessagesSyncDiffEntry[] {
+    const seen = new Set<string>();
+    const unique: MessagesSyncDiffEntry[] = [];
+    for (const entry of entries) {
+      if (seen.has(entry.messageCid)) {
+        continue;
+      }
+      seen.add(entry.messageCid);
+      unique.push(entry);
+    }
+    return unique;
+  }
+
+  private static dedupeStrings(values: string[]): string[] {
+    return [...new Set(values)];
+  }
+
   private async clearRootConvergenceDeadLettersForScope(
     tenantDid: string,
     remoteEndpoint: string,
     scope: SyncScope,
   ): Promise<void> {
+    if (scope.kind === 'protocolSet' && scope.protocols.length > 1) {
+      await this.clearRootConvergenceDeadLetters(tenantDid, remoteEndpoint);
+    }
+
     for (const protocol of this.getReconcileProtocols(scope)) {
       await this.clearRootConvergenceDeadLetters(tenantDid, remoteEndpoint, protocol);
     }
@@ -3252,19 +3464,20 @@ export class SyncEngineLevel implements SyncEngine {
    * they are processed directly without additional HTTP round-trips.
    * Only `messageCids` that were NOT prefetched are fetched individually.
    */
-  private async pullMessages({ did, dwnUrl, delegateDid, protocol, permissionGrantIds, messageCids, prefetched, shouldContinue }: {
+  private async pullMessages({ did, dwnUrl, delegateDid, protocol, scope, permissionGrantIds, messageCids, prefetched, shouldContinue }: {
     did: string;
     dwnUrl: string;
     delegateDid?: string;
     protocol?: string;
+    scope?: SyncScope;
     permissionGrantIds?: string[];
     messageCids: string[];
     prefetched?: MessagesSyncDiffEntry[];
     shouldContinue?: () => boolean;
   }): Promise<void> {
-    const scope: SyncScope = protocol === undefined
+    const acceptanceScope: SyncScope = scope ?? (protocol === undefined
       ? { kind: 'full' }
-      : { kind: 'protocolSet', protocols: [protocol] };
+      : { kind: 'protocolSet', protocols: [protocol] });
     const rejectedPullEntries = new Map<string, Extract<PullAcceptanceResult, { accepted: false }>>();
     const failedCids = await pullMessages({
       did,
@@ -3276,7 +3489,7 @@ export class SyncEngineLevel implements SyncEngine {
       shouldContinue,
       agent       : this.agent,
       acceptEntry : async (entry, entries) => {
-        const result = await this.acceptPulledSyncEntry(did, scope, entry, entries);
+        const result = await this.acceptPulledSyncEntry(did, acceptanceScope, entry, entries);
         if (!result.accepted) {
           rejectedPullEntries.set(await getMessageCid(entry.message), result);
         }

--- a/packages/agent/src/sync-link-reconciler.ts
+++ b/packages/agent/src/sync-link-reconciler.ts
@@ -63,7 +63,7 @@ type ReconcileDeps = {
   shouldContinue?: () => boolean;
 };
 
-function partitionRemoteEntries(entries: MessagesSyncDiffEntry[]): {
+export function partitionRemoteEntries(entries: MessagesSyncDiffEntry[]): {
   prefetched: (MessagesSyncDiffEntry & { message: GenericMessage })[];
   needsFetchCids: string[];
 } {

--- a/packages/agent/src/sync-topological-sort.ts
+++ b/packages/agent/src/sync-topological-sort.ts
@@ -1,15 +1,71 @@
-import type { GenericMessage } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, ProtocolDefinition } from '@enbox/dwn-sdk-js';
 
 import { getInvokedPermissionGrantIds } from './sync-permission-grants.js';
 import { DwnInterfaceName, DwnMethodName, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+
+type DescriptorWithRecordId = GenericMessage['descriptor'] & {
+  recordId?: string;
+};
+
+type RecordsDescriptor = GenericMessage['descriptor'] & {
+  dateCreated?: string;
+  parentId?: string;
+  protocol?: string;
+  protocolPath?: string;
+};
+
+type ProtocolsConfigureDescriptor = GenericMessage['descriptor'] & {
+  definition?: Partial<ProtocolDefinition>;
+};
+
+function isRecordsDescriptor(descriptor: GenericMessage['descriptor']): descriptor is RecordsDescriptor {
+  return descriptor.interface === DwnInterfaceName.Records;
+}
+
+function isRecordsWriteDescriptor(descriptor: GenericMessage['descriptor']): descriptor is RecordsDescriptor {
+  return descriptor.interface === DwnInterfaceName.Records && descriptor.method === DwnMethodName.Write;
+}
+
+function isRecordsDeleteDescriptor(descriptor: GenericMessage['descriptor']): descriptor is DescriptorWithRecordId {
+  return descriptor.interface === DwnInterfaceName.Records && descriptor.method === DwnMethodName.Delete;
+}
+
+function isProtocolsConfigureDescriptor(
+  descriptor: GenericMessage['descriptor']
+): descriptor is ProtocolsConfigureDescriptor {
+  return descriptor.interface === DwnInterfaceName.Protocols && descriptor.method === DwnMethodName.Configure;
+}
+
+function getRecordId(message: GenericMessage): string | undefined {
+  return (message as GenericMessage & { recordId?: string }).recordId;
+}
+
+function getProtocolDefinition(message: GenericMessage): Partial<ProtocolDefinition> | undefined {
+  const { descriptor } = message;
+  return isProtocolsConfigureDescriptor(descriptor) ? descriptor.definition : undefined;
+}
+
+function getConfiguredProtocol(message: GenericMessage): string | undefined {
+  const protocol = getProtocolDefinition(message)?.protocol;
+  return typeof protocol === 'string' ? protocol : undefined;
+}
+
+function getComposedProtocolDependencies(message: GenericMessage): string[] {
+  const uses = getProtocolDefinition(message)?.uses;
+  if (!uses) {
+    return [];
+  }
+
+  return Object.values(uses).filter((protocol): protocol is string => typeof protocol === 'string');
+}
 
 /**
  * Checks whether a message is an initial RecordsWrite (not an update).
  * An initial write has dateCreated === messageTimestamp (first write for this recordId).
  */
 function isInitialWrite(message: GenericMessage): boolean {
-  const desc = message.descriptor as any;
-  if (desc.interface !== DwnInterfaceName.Records || desc.method !== DwnMethodName.Write) {
+  const desc = message.descriptor;
+  if (!isRecordsWriteDescriptor(desc)) {
     return false;
   }
   // A RecordsWrite is initial if dateCreated === messageTimestamp (first write for this recordId).
@@ -22,6 +78,7 @@ function isInitialWrite(message: GenericMessage): boolean {
  *
  * Dependencies:
  * - ProtocolsConfigure must come before any RecordsWrite using that protocol
+ * - Composed ProtocolsConfigure must come after ProtocolsConfigure messages for protocols in `uses`
  * - Parent record must come before child record (via parentId)
  * - Initial write must come before update writes (same recordId, not initial)
  * - Permission grants must come before messages that invoke them
@@ -45,14 +102,14 @@ export function topologicalSort<T extends { message: GenericMessage }>(
     const desc = entry.message.descriptor;
 
     if (desc.interface === DwnInterfaceName.Protocols && desc.method === DwnMethodName.Configure) {
-      const protocolUrl = (desc as any).definition?.protocol;
+      const protocolUrl = getConfiguredProtocol(entry.message);
       if (protocolUrl) {
         protocolConfigureIndex.set(protocolUrl, i);
       }
     }
 
-    if (desc.interface === DwnInterfaceName.Records && desc.method === DwnMethodName.Write) {
-      const recordId = (entry.message as any).recordId;
+    if (isRecordsWriteDescriptor(desc)) {
+      const recordId = getRecordId(entry.message);
       const initial = isInitialWrite(entry.message);
       if (initial && recordId) {
         initialWriteIndex.set(recordId, i);
@@ -60,8 +117,8 @@ export function topologicalSort<T extends { message: GenericMessage }>(
 
       // Index permission grants by recordId so dependents can reference them.
       if (
-        (desc as any).protocol === PermissionsProtocol.uri &&
-        (desc as any).protocolPath === PermissionsProtocol.grantPath &&
+        desc.protocol === PermissionsProtocol.uri &&
+        desc.protocolPath === PermissionsProtocol.grantPath &&
         recordId
       ) {
         grantIndex.set(recordId, i);
@@ -90,33 +147,42 @@ export function topologicalSort<T extends { message: GenericMessage }>(
   for (let i = 0; i < messages.length; i++) {
     const desc = messages[i].message.descriptor;
 
+    // Composition dependency: a composed protocol depends on its referenced protocol definitions.
+    if (isProtocolsConfigureDescriptor(desc)) {
+      for (const protocol of getComposedProtocolDependencies(messages[i].message)) {
+        if (protocolConfigureIndex.has(protocol)) {
+          addEdge(protocolConfigureIndex.get(protocol)!, i);
+        }
+      }
+    }
+
     // Protocol dependency: RecordsWrite depends on ProtocolsConfigure for its protocol.
-    if (desc.interface === DwnInterfaceName.Records) {
-      const protocol = (desc as any).protocol;
+    if (isRecordsDescriptor(desc)) {
+      const protocol = desc.protocol;
       if (protocol && protocolConfigureIndex.has(protocol)) {
         addEdge(protocolConfigureIndex.get(protocol)!, i);
       }
     }
 
     // Parent dependency: child record depends on parent record.
-    if (desc.interface === DwnInterfaceName.Records && (desc as any).parentId) {
-      const parentId = (desc as any).parentId;
+    if (isRecordsDescriptor(desc) && desc.parentId) {
+      const parentId = desc.parentId;
       if (initialWriteIndex.has(parentId)) {
         addEdge(initialWriteIndex.get(parentId)!, i);
       }
     }
 
     // Initial write dependency: update depends on initial write.
-    if (desc.interface === DwnInterfaceName.Records && desc.method === DwnMethodName.Write) {
-      const recordId = (messages[i].message as any).recordId;
+    if (isRecordsWriteDescriptor(desc)) {
+      const recordId = getRecordId(messages[i].message);
       if (recordId && !isInitialWrite(messages[i].message) && initialWriteIndex.has(recordId)) {
         addEdge(initialWriteIndex.get(recordId)!, i);
       }
     }
 
     // Delete depends on initial write.
-    if (desc.interface === DwnInterfaceName.Records && desc.method === DwnMethodName.Delete) {
-      const recordId = (desc as any).recordId;
+    if (isRecordsDeleteDescriptor(desc)) {
+      const recordId = desc.recordId;
       if (recordId && initialWriteIndex.has(recordId)) {
         addEdge(initialWriteIndex.get(recordId)!, i);
       }

--- a/packages/agent/tests/e2e/owner-profile-sync.e2e.spec.ts
+++ b/packages/agent/tests/e2e/owner-profile-sync.e2e.spec.ts
@@ -16,12 +16,15 @@ import { DataStream } from '@enbox/dwn-sdk-js';
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 
 import type { BearerIdentity } from '../../src/bearer-identity.js';
+import type { EnboxUserAgent } from '../../src/enbox-user-agent.js';
 import type { PlatformAgentTestHarness } from '../../src/test-harness.js';
 
 import { PlatformAgentTestHarness as AgentTestHarness } from '../../src/test-harness.js';
 import { DwnInterface } from '../../src/types/dwn.js';
 import { TestAgent } from '../utils/test-agent.js';
 import { testDwnUrl } from '../utils/test-config.js';
+import { EnboxUserAgent as UserAgent } from '../../src/enbox-user-agent.js';
+import { IdentityProtocolDefinition, JwkProtocolDefinition } from '../../src/store-data-protocols.js';
 
 const testDwnUrls = [testDwnUrl];
 
@@ -149,6 +152,7 @@ const profileProtocol: ProtocolDefinition = {
 };
 
 const profileSyncProtocols: [string, ...string[]] = [socialGraphProtocol.protocol, profileProtocol.protocol];
+const agentDidSyncProtocols: [string, ...string[]] = [IdentityProtocolDefinition.protocol, JwkProtocolDefinition.protocol];
 
 async function setupHarness(testDataLocation: string): Promise<PlatformAgentTestHarness> {
   const harness = await AgentTestHarness.setup({
@@ -159,6 +163,31 @@ async function setupHarness(testDataLocation: string): Promise<PlatformAgentTest
   await harness.clearStorage();
   await harness.createAgentDid();
   return harness;
+}
+
+async function setupWalletHarness(testDataLocation: string): Promise<PlatformAgentTestHarness> {
+  const harness = await AgentTestHarness.setup({
+    agentClass       : UserAgent,
+    agentStores      : 'dwn',
+    testDataLocation : testDataLocation,
+  });
+  await harness.clearStorage();
+  return harness;
+}
+
+async function initializeWalletFromPhrase(
+  harness: PlatformAgentTestHarness,
+  password: string,
+  recoveryPhrase?: string
+): Promise<string | undefined> {
+  const agent = harness.agent as EnboxUserAgent;
+  const phrase = await agent.initialize({
+    password,
+    recoveryPhrase,
+    dwnEndpoints: testDwnUrls,
+  });
+  await agent.start({ password });
+  return phrase;
 }
 
 function isFreshDidResolutionFailure(status: { code: number; detail: string }): boolean {
@@ -292,6 +321,18 @@ async function readRecordBytes(
   return DataStream.toBytes(result.reply.entry!.data!);
 }
 
+async function expectIdentityDiscovered(
+  harness: PlatformAgentTestHarness,
+  did: string,
+  expectedName: string
+): Promise<BearerIdentity> {
+  const identities = await harness.agent.identity.list();
+  const identity = identities.find(candidate => candidate.did.uri === did);
+  expect(identity).toBeDefined();
+  expect(identity!.metadata.name).toBe(expectedName);
+  return identity!;
+}
+
 describe('E2E: same-owner profile sync convergence', () => {
   let walletA: PlatformAgentTestHarness;
   let walletB: PlatformAgentTestHarness;
@@ -406,4 +447,141 @@ describe('E2E: same-owner profile sync convergence', () => {
     expect(await readRecordBytes(walletA, did, avatarRecord.recordId)).toEqual(avatarBytes);
     expect(await readRecordBytes(walletA, did, heroRecord.recordId)).toEqual(heroBytes);
   }, 60_000);
+});
+
+describe('E2E: same-owner identity discovery and profile sync convergence', () => {
+  const password = 'track-a-identity-discovery-password';
+  const discoveredIdentityName = 'Track A Discovered Identity';
+
+  let walletA: PlatformAgentTestHarness;
+  let walletB: PlatformAgentTestHarness;
+  let discoveredIdentity: BearerIdentity;
+
+  beforeAll(async () => {
+    walletA = await setupWalletHarness('__TESTDATA__/e2e-owner-identity-discovery-wallet-a');
+    const recoveryPhrase = await initializeWalletFromPhrase(walletA, password);
+    expect(recoveryPhrase).toBeDefined();
+
+    walletB = await setupWalletHarness('__TESTDATA__/e2e-owner-identity-discovery-wallet-b');
+    await initializeWalletFromPhrase(walletB, password, recoveryPhrase);
+    expect(walletB.agent.agentDid.uri).toBe(walletA.agent.agentDid.uri);
+
+    for (const wallet of [walletA, walletB]) {
+      await wallet.agent.dwn.ensureKeyDeliveryProtocol(wallet.agent.agentDid.uri);
+      await wallet.agent.sync.registerIdentity({
+        did     : wallet.agent.agentDid.uri,
+        options : { protocols: agentDidSyncProtocols },
+      });
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    await walletA?.agent.sync.stopSync();
+    await walletB?.agent.sync.stopSync();
+    await walletA?.clearStorage();
+    await walletB?.clearStorage();
+    await walletA?.closeStorage();
+    await walletB?.closeStorage();
+  });
+
+  it('discovers a new identity from the agent identity index and then pulls its profile subtree', async () => {
+    discoveredIdentity = await walletB.createIdentity({
+      name: discoveredIdentityName,
+      testDwnUrls,
+    });
+
+    expect((await walletA.agent.identity.list()).map(identity => identity.did.uri))
+      .not.toContain(discoveredIdentity.did.uri);
+
+    await walletB.agent.sync.sync('push');
+
+    const pulledIdentities = await walletA.agent.sync.sync('pull')
+      .then(() => walletA.agent.identity.list());
+    expect(pulledIdentities.map(identity => identity.did.uri)).toContain(discoveredIdentity.did.uri);
+
+    const walletADiscoveredIdentity = await expectIdentityDiscovered(
+      walletA,
+      discoveredIdentity.did.uri,
+      discoveredIdentityName,
+    );
+    expect(walletADiscoveredIdentity.metadata.tenant).toBe(walletA.agent.agentDid.uri);
+
+    const did = discoveredIdentity.did.uri;
+    for (const definition of [socialGraphProtocol, profileProtocol]) {
+      await installProtocolLocalAndRemote(walletB, did, definition);
+    }
+
+    const profileData = {
+      displayName : 'Discovered Wallet Identity',
+      tagline     : 'Created on wallet B, discovered by wallet A',
+      bio         : 'Identity metadata and profile data converged across same-owner wallets.',
+    };
+    const profileBytes = Convert.string(JSON.stringify(profileData)).toUint8Array();
+    const avatarBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 9, 10, 11, 12]);
+    const heroBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 13, 14, 15, 16]);
+
+    const profileRecord = await writeRecordLocalAndRemote(walletB, did, {
+      protocol     : profileProtocol.protocol,
+      protocolPath : 'profile',
+      schema       : profileProtocol.types.profile.schema,
+      dataFormat   : 'application/json',
+      published    : true,
+    }, profileBytes);
+
+    const avatarRecord = await writeRecordLocalAndRemote(walletB, did, {
+      protocol        : profileProtocol.protocol,
+      protocolPath    : 'profile/avatar',
+      parentContextId : profileRecord.contextId,
+      dataFormat      : 'image/png',
+      published       : true,
+    }, avatarBytes);
+
+    const heroRecord = await writeRecordLocalAndRemote(walletB, did, {
+      protocol        : profileProtocol.protocol,
+      protocolPath    : 'profile/hero',
+      parentContextId : profileRecord.contextId,
+      dataFormat      : 'image/png',
+      published       : true,
+    }, heroBytes);
+
+    await walletA.agent.sync.registerIdentity({
+      did     : did,
+      options : { protocols: profileSyncProtocols },
+    });
+    await walletB.agent.sync.registerIdentity({
+      did     : did,
+      options : { protocols: profileSyncProtocols },
+    });
+
+    await walletA.agent.sync.sync('pull');
+
+    await expectProtocolInstalled(walletA, did, socialGraphProtocol.protocol);
+    await expectProtocolInstalled(walletA, did, profileProtocol.protocol);
+
+    const pulledProfile = await expectRecord(walletA, did, {
+      protocol : profileProtocol.protocol,
+      recordId : profileRecord.recordId,
+    });
+    expect(pulledProfile.contextId).toBe(profileRecord.contextId);
+
+    const pulledAvatar = await expectRecord(walletA, did, {
+      protocol     : profileProtocol.protocol,
+      protocolPath : 'profile/avatar',
+      recordId     : avatarRecord.recordId,
+    });
+    expect(pulledAvatar.descriptor.parentId).toBe(profileRecord.recordId);
+
+    const pulledHero = await expectRecord(walletA, did, {
+      protocol     : profileProtocol.protocol,
+      protocolPath : 'profile/hero',
+      recordId     : heroRecord.recordId,
+    });
+    expect(pulledHero.descriptor.parentId).toBe(profileRecord.recordId);
+
+    const pulledProfileBytes = await readRecordBytes(walletA, did, profileRecord.recordId);
+    const pulledProfileData = JSON.parse(Convert.uint8Array(pulledProfileBytes).toString()) as typeof profileData;
+    expect(pulledProfileData).toEqual(profileData);
+    expect(await readRecordBytes(walletA, did, avatarRecord.recordId)).toEqual(avatarBytes);
+    expect(await readRecordBytes(walletA, did, heroRecord.recordId)).toEqual(heroBytes);
+  }, 90_000);
 });

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -2381,6 +2381,73 @@ describe('SyncEngineLevel — private methods', () => {
   // pullMessages / pushMessages delegate wrappers
   // ---------------------------------------------------------------------------
 
+  describe('protocol-set reconciliation', () => {
+    it('batches changed protocol diffs before pulling and pushing messages', async () => {
+      const profileProtocol = 'https://example.com/profile';
+      const socialProtocol = 'https://example.com/social';
+      const scope = { kind: 'protocolSet', protocols: [profileProtocol, socialProtocol] };
+      const profileEntry = {
+        messageCid : 'cid-profile',
+        message    : {
+          descriptor: {
+            interface        : 'Protocols',
+            method           : 'Configure',
+            messageTimestamp : '2026-01-01T00:00:00.000000Z',
+            definition       : {
+              protocol : profileProtocol,
+              uses     : { social: socialProtocol },
+            },
+          },
+        },
+      };
+      const socialEntry = {
+        messageCid : 'cid-social',
+        message    : {
+          descriptor: {
+            interface        : 'Protocols',
+            method           : 'Configure',
+            messageTimestamp : '2026-01-01T00:00:00.000000Z',
+            definition       : { protocol: socialProtocol },
+          },
+        },
+      };
+      const engine = createEngine({ db, agent: {} as any });
+      const getLocalRoot = sinon.stub(engine as any, 'getLocalRoot')
+        .callsFake(async (_did: string, _delegateDid: string | undefined, protocol: string) => `local-${protocol}`);
+      const getRemoteRoot = sinon.stub(engine as any, 'getRemoteRoot')
+        .callsFake(async (_did: string, _dwnUrl: string, _delegateDid: string | undefined, protocol: string) => `remote-${protocol}`);
+      const diffWithRemote = sinon.stub(engine as any, 'diffWithRemote')
+        .callsFake(async ({ protocol }: { protocol: string }) => protocol === profileProtocol
+          ? { onlyRemote: [profileEntry], onlyLocal: ['local-profile'] }
+          : { onlyRemote: [socialEntry], onlyLocal: ['local-social'] });
+      const pullMessagesStub = sinon.stub(engine as any, 'pullMessages').resolves();
+      const pushMessagesStub = sinon.stub(engine as any, 'pushMessages')
+        .resolves({ succeeded: [], failed: [], permanentlyFailed: [] });
+
+      await (engine as any).reconcileProjectionTarget({
+        did           : 'did:example:alice',
+        dwnUrl        : 'https://dwn.example.com',
+        scope,
+        authorization : { kind: 'owner' },
+      });
+
+      expect(getLocalRoot.callCount).toBe(2);
+      expect(getRemoteRoot.callCount).toBe(2);
+      expect(diffWithRemote.callCount).toBe(2);
+      expect(diffWithRemote.secondCall.calledBefore(pullMessagesStub.firstCall)).toBe(true);
+      expect(pullMessagesStub.calledOnce).toBe(true);
+      expect(pushMessagesStub.calledOnce).toBe(true);
+
+      const pullArgs = pullMessagesStub.firstCall.args[0];
+      expect(pullArgs.scope).toEqual(scope);
+      expect(pullArgs.messageCids).toEqual([]);
+      expect(pullArgs.prefetched.map((entry: { messageCid: string }) => entry.messageCid))
+        .toEqual(['cid-profile', 'cid-social']);
+
+      expect(pushMessagesStub.firstCall.args[0].messageCids).toEqual(['local-profile', 'local-social']);
+    });
+  });
+
   describe('pullMessages / pushMessages delegate wrappers', () => {
     const profileProtocol = 'https://example.com/profile';
     const socialProtocol = 'https://example.com/social';

--- a/packages/agent/tests/sync-topological-sort.spec.ts
+++ b/packages/agent/tests/sync-topological-sort.spec.ts
@@ -70,6 +70,44 @@ describe('topologicalSort', () => {
     expect(result[1]).toBe(recordsWriteMsg);
   });
 
+  it('should place referenced ProtocolsConfigure before composed ProtocolsConfigure and records', () => {
+    const socialProtocol = 'https://identity.foundation/protocols/social-graph';
+    const profileProtocol = 'https://identity.foundation/protocols/profile';
+
+    const socialConfigure: SortEntry = {
+      message: makeMessage({
+        interface  : DwnInterfaceName.Protocols,
+        method     : DwnMethodName.Configure,
+        definition : { protocol: socialProtocol },
+      }),
+    };
+    const profileConfigure: SortEntry = {
+      message: makeMessage({
+        interface  : DwnInterfaceName.Protocols,
+        method     : DwnMethodName.Configure,
+        definition : {
+          protocol : profileProtocol,
+          uses     : { social: socialProtocol },
+        },
+      }),
+    };
+    const profileRecord: SortEntry = {
+      message: {
+        ...makeMessage({
+          protocol         : profileProtocol,
+          dateCreated      : '2024-01-01T00:00:00.000000Z',
+          messageTimestamp : '2024-01-01T00:00:00.000000Z',
+        }),
+        recordId: 'profile-rec',
+      } as unknown as GenericMessage,
+    };
+
+    const result = topologicalSort([profileRecord, profileConfigure, socialConfigure]);
+    expect(result[0]).toBe(socialConfigure);
+    expect(result[1]).toBe(profileConfigure);
+    expect(result[2]).toBe(profileRecord);
+  });
+
   it('should place initial write before update write for same recordId', () => {
     const initialWrite: SortEntry = {
       message: {


### PR DESCRIPTION
## Summary
- Batch changed protocol diffs for multi-protocol reconciliation before applying pull/push messages.
- Order composed protocol configs after referenced protocol configs in the sync topological sorter.
- Add two-wallet E2E coverage for identity-index discovery followed by profile/avatar/hero convergence.

## Verification
- bun run --filter @enbox/agent lint
- bun test packages/agent/tests/sync-topological-sort.spec.ts packages/agent/tests/sync-engine-private.spec.ts
- DID_DHT_ALLOW_PRIVATE_GATEWAY=1 DID_DHT_GATEWAY_URI=http://localhost:7527 bun test --timeout 120000 packages/agent/tests/e2e/owner-profile-sync.e2e.spec.ts
- bun run --filter @enbox/agent build
- bun run build