### PR TITLE
Clarify composed protocol sync scope rules

### DIFF
--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -2809,6 +2809,10 @@ export class SyncEngineLevel implements SyncEngine {
       return false;
     }
 
+    // Keep the remote diff combined across protocols so topologicalSort can
+    // order composed protocol configs before records that use them. Any future
+    // chunking for large protocol sets must preserve this global dependency
+    // order instead of reverting to independent per-protocol chunks.
     const { prefetched, needsFetchCids } = partitionRemoteEntries(SyncEngineLevel.dedupeRemoteEntries(onlyRemote));
     try {
       await this.pullMessages({
@@ -2892,6 +2896,8 @@ export class SyncEngineLevel implements SyncEngine {
     scope: SyncScope,
   ): Promise<void> {
     if (scope.kind === 'protocolSet' && scope.protocols.length > 1) {
+      // Batched multi-protocol pulls pass the full scope to pullMessages, so
+      // pull dead letters can be recorded without a single protocol key.
       await this.clearRootConvergenceDeadLetters(tenantDid, remoteEndpoint);
     }
 

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -21,6 +21,10 @@ export type SyncIdentityOptions = {
    * The protocols that should be synced for this identity.
    * - `'all'` — sync all protocols (full replica).
    * - `string[]` — sync only the listed protocol URIs.
+   *
+   * Composed protocols are not expanded automatically. If a protocol definition
+   * declares `uses`, include every referenced protocol that the local DWN must
+   * install or use while applying that projection.
    */
   protocols: 'all' | [string, ...string[]];
 };
@@ -68,7 +72,9 @@ export type NonEmptyStringArray = [string, ...string[]];
  * Sync currently supports full-tenant sync and protocol-set sync. A protocol-set link owns
  * one durable subscription/cursor for the whole set; reconciliation still walks
  * the existing per-protocol roots until dedicated path/context projection roots
- * are implemented.
+ * are implemented. For composed protocols, the scope must include the composed
+ * protocol and any `uses` targets required for local protocol installation and
+ * closure evaluation.
  */
 export type SyncScope = {
   /** Full-tenant projection. Valid only for owner sync or unscoped delegated grants. */

--- a/packages/agent/tests/sync-topological-sort.spec.ts
+++ b/packages/agent/tests/sync-topological-sort.spec.ts
@@ -70,7 +70,7 @@ describe('topologicalSort', () => {
     expect(result[1]).toBe(recordsWriteMsg);
   });
 
-  it('should place referenced ProtocolsConfigure before composed ProtocolsConfigure and records', () => {
+  it('should place ProtocolsConfigure uses targets before composed ProtocolsConfigure and records', () => {
     const socialProtocol = 'https://identity.foundation/protocols/social-graph';
     const profileProtocol = 'https://identity.foundation/protocols/profile';
 


### PR DESCRIPTION
## Summary
- Document that protocol sync scopes do not auto-expand composed protocol `uses` dependencies.
- Clarify why batched multi-protocol sync keeps a no-protocol dead-letter clear and must preserve global dependency ordering if chunked later.
- Rename the sorter regression test to explicitly call out `uses` target ordering.

## Verification
- bun run build:ci
- bun run --filter @enbox/agent lint
- bun test packages/agent/tests/sync-topological-sort.spec.ts packages/agent/tests/sync-engine-private.spec.ts