### PR TITLE
Add scoped Records projection roots

### DIFF
--- a/.changeset/records-projection-root.md
+++ b/.changeset/records-projection-root.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Add scoped Records projection root helpers for path and context primary CID sets.

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -103,6 +103,8 @@ export { SMTStoreLevel } from './smt/smt-store-level.js';
 export { SMTStoreMemory } from './smt/smt-store-memory.js';
 export type { Hash, SMTNode, SMTInternalNode, SMTLeafNode, SMTProof, SMTDiffResult, SMTNodeStore } from './types/smt-types.js';
 export { hashChildren, hashEquals, hashKey, hashLeaf, hashToHex, hexToHash, getBit, initDefaultHashes, getDefaultHashes, SMT_DEPTH, ZERO_HASH } from './smt/smt-utils.js';
+export { RECORDS_PROJECTION_ROOT_VERSION, RecordsProjection } from './sync/records-projection.js';
+export type { NormalizedRecordsProjectionScope, RecordsProjectionInput, RecordsProjectionScope, RecordsProjectionTreeInput } from './sync/records-projection.js';
 
 // test library exports
 export type { GenerateFromRecordsWriteInput, GenerateFromRecordsWriteOut, GenerateGrantCreateInput, GenerateGrantCreateOutput, GenerateMessagesReadInput, GenerateMessagesReadOutput, GenerateMessagesSubscribeInput, GenerateMessagesSubscribeOutput, GenerateProtocolsConfigureInput, GenerateProtocolsConfigureOutput, GenerateProtocolsQueryInput, GenerateProtocolsQueryOutput, GenerateRecordsCountInput, GenerateRecordsCountOutput, GenerateRecordsDeleteInput, GenerateRecordsDeleteOutput, GenerateRecordsQueryInput, GenerateRecordsQueryOutput, GenerateRecordsSubscribeInput, GenerateRecordsSubscribeOutput, GenerateRecordsWriteInput, GenerateRecordsWriteOutput, Persona } from '../tests/utils/test-data-generator.js';

--- a/packages/dwn-sdk-js/src/sync/records-projection.ts
+++ b/packages/dwn-sdk-js/src/sync/records-projection.ts
@@ -1,0 +1,290 @@
+import type { Filter } from '../types/query-types.js';
+import type { Hash } from '../types/smt-types.js';
+import type { MessageStore, MessageStoreOptions } from '../types/message-store.js';
+
+import { DwnInterfaceName } from '../enums/dwn-interface-method.js';
+import { FilterUtility } from '../utils/filter.js';
+import { hashToHex } from '../smt/smt-utils.js';
+import { lexicographicalCompare } from '../utils/string.js';
+import { Message } from '../core/message.js';
+import { SMTStoreMemory } from '../smt/smt-store-memory.js';
+import { SparseMerkleTree } from '../smt/sparse-merkle-tree.js';
+
+/**
+ * Projection-root algorithm for record-primary scoped subsets.
+ *
+ * This version builds an on-demand SMT over latest Records primary message CIDs
+ * selected by protocol plus optional exact protocolPath or context subtree.
+ * Dependency records, protocol configs, and record data payloads are not part
+ * of this root.
+ */
+export const RECORDS_PROJECTION_ROOT_VERSION = 'records-primary-scope-root-v1';
+
+/**
+ * A Records primary projection scope.
+ *
+ * `protocolPath` is an exact type-path match. `contextId` is a boundary-aware
+ * subtree match: the candidate context must equal the scoped context or start
+ * with `${contextId}/`. `protocolPath` and `contextId` are mutually exclusive.
+ */
+export type RecordsProjectionScope = {
+  protocol: string;
+  protocolPath?: string;
+  contextId?: string;
+};
+
+export type RecordsProjectionInput = {
+  tenant: string;
+  messageStore: MessageStore;
+  scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]];
+  options?: MessageStoreOptions;
+};
+
+export type RecordsProjectionTreeInput = RecordsProjectionInput & {
+  prefix: boolean[];
+};
+
+export type NormalizedRecordsProjectionScope = {
+  protocol: string;
+} | {
+  protocol: string;
+  protocolPath: string;
+} | {
+  protocol: string;
+  contextId: string;
+};
+
+/**
+ * Computes deterministic on-demand roots for Records projections.
+ *
+ * Root and leaf lookup methods perform a fresh store query. Production sync
+ * serving still needs to thread a consistent snapshot/high-watermark and
+ * bounded paging through this primitive before using it for large or
+ * concurrently-mutating stores.
+ */
+export class RecordsProjection {
+
+  /**
+   * Returns the sorted latest Records primary message CIDs covered by a scope union.
+   */
+  public static async getPrimaryMessageCids({
+    tenant,
+    messageStore,
+    scopes,
+    options,
+  }: RecordsProjectionInput): Promise<string[]> {
+    const filters = RecordsProjection.normalizeScopes(scopes)
+      .flatMap(scope => RecordsProjection.constructFilters(scope));
+
+    const { messages } = await messageStore.query(tenant, filters, undefined, undefined, options);
+    const messageCids = await Promise.all(messages.map(message => Message.getCid(message)));
+
+    return [...new Set(messageCids)].sort(lexicographicalCompare); // NOSONAR — projection IDs require locale-independent bytewise ordering.
+  }
+
+  /**
+   * Returns the projection root hash.
+   */
+  public static async getRoot(input: RecordsProjectionInput): Promise<Hash> {
+    return RecordsProjection.withTree(input, tree => tree.getRoot());
+  }
+
+  /**
+   * Returns the projection root hash encoded as lowercase hex.
+   */
+  public static async getRootHex(input: RecordsProjectionInput): Promise<string> {
+    return hashToHex(await RecordsProjection.getRoot(input));
+  }
+
+  /**
+   * Returns the subtree hash for a bit prefix within this projection.
+   */
+  public static async getSubtreeHash(input: RecordsProjectionTreeInput): Promise<Hash> {
+    return RecordsProjection.withTree(input, tree => tree.getSubtreeHash(input.prefix));
+  }
+
+  /**
+   * Returns the message CIDs under a bit prefix within this projection.
+   */
+  public static async getLeaves(input: RecordsProjectionTreeInput): Promise<string[]> {
+    return RecordsProjection.withTree(input, tree => tree.getLeaves(input.prefix));
+  }
+
+  /**
+   * Normalizes a scope union into sorted, duplicate-free, subsumption-reduced entries.
+   */
+  public static normalizeScopes(
+    scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]],
+  ): [NormalizedRecordsProjectionScope, ...NormalizedRecordsProjectionScope[]] {
+    if (scopes.length === 0) {
+      throw new Error('RecordsProjection: scopes must contain at least one scope.');
+    }
+
+    const normalized = scopes.map(scope => RecordsProjection.normalizeScope(scope));
+    const deduped = new Map<string, NormalizedRecordsProjectionScope>();
+    for (const scope of normalized) {
+      deduped.set(RecordsProjection.scopeKey(scope), scope);
+    }
+
+    const uniqueScopes = [...deduped.values()];
+    const protocolWide = new Set(
+      uniqueScopes
+        .filter(scope => RecordsProjection.isProtocolWideScope(scope))
+        .map(scope => scope.protocol)
+    );
+
+    const reduced = uniqueScopes.filter(scope => {
+      if (protocolWide.has(scope.protocol)) {
+        return RecordsProjection.isProtocolWideScope(scope);
+      }
+
+      if (RecordsProjection.isContextScope(scope)) {
+        return !uniqueScopes.some(candidate =>
+          candidate !== scope &&
+          RecordsProjection.isContextScope(candidate) &&
+          candidate.protocol === scope.protocol &&
+          RecordsProjection.contextIdSubsumes(candidate.contextId, scope.contextId)
+        );
+      }
+
+      return true;
+    });
+
+    const result = reduced.sort(RecordsProjection.compareScopes);
+    return result as [NormalizedRecordsProjectionScope, ...NormalizedRecordsProjectionScope[]];
+  }
+
+  private static async withTree<T>(
+    input: RecordsProjectionInput,
+    fn: (tree: SparseMerkleTree) => Promise<T>,
+  ): Promise<T> {
+    const tree = new SparseMerkleTree(new SMTStoreMemory());
+    await tree.initialize();
+
+    try {
+      const messageCids = await RecordsProjection.getPrimaryMessageCids(input);
+      for (const messageCid of messageCids) {
+        await tree.insert(messageCid);
+      }
+      return await fn(tree);
+    } finally {
+      await tree.close();
+    }
+  }
+
+  private static normalizeScope(scope: RecordsProjectionScope): NormalizedRecordsProjectionScope {
+    const protocol = RecordsProjection.requireNonEmptyString(scope.protocol, 'protocol');
+
+    if (scope.protocolPath !== undefined && scope.contextId !== undefined) {
+      throw new Error('RecordsProjection: protocolPath and contextId scopes are mutually exclusive.');
+    }
+
+    if (scope.protocolPath !== undefined) {
+      return {
+        protocol,
+        protocolPath: RecordsProjection.requireNonEmptyString(scope.protocolPath, 'protocolPath'),
+      };
+    }
+
+    if (scope.contextId !== undefined) {
+      return {
+        protocol,
+        contextId: RecordsProjection.requireNonEmptyString(scope.contextId, 'contextId'),
+      };
+    }
+
+    return { protocol };
+  }
+
+  private static constructFilters(scope: NormalizedRecordsProjectionScope): Filter[] {
+    const baseFilter: Filter = {
+      interface         : DwnInterfaceName.Records,
+      isLatestBaseState : true,
+      protocol          : scope.protocol,
+    };
+
+    if ('protocolPath' in scope) {
+      return [{ ...baseFilter, protocolPath: scope.protocolPath }];
+    }
+
+    if ('contextId' in scope) {
+      const childContextPrefix = `${scope.contextId}/`;
+      return [
+        { ...baseFilter, contextId: scope.contextId },
+        {
+          ...baseFilter,
+          contextId: FilterUtility.constructPrefixFilterAsRangeFilter(childContextPrefix),
+        },
+      ];
+    }
+
+    return [baseFilter];
+  }
+
+  private static requireNonEmptyString(value: string, field: string): string {
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error(`RecordsProjection: ${field} must be a non-empty string.`);
+    }
+
+    return value;
+  }
+
+  private static scopeKey(scope: NormalizedRecordsProjectionScope): string {
+    if ('protocolPath' in scope) {
+      return `${scope.protocol}\u001fprotocolPath\u001f${scope.protocolPath}`;
+    }
+
+    if ('contextId' in scope) {
+      return `${scope.protocol}\u001fcontextId\u001f${scope.contextId}`;
+    }
+
+    return `${scope.protocol}\u001fprotocol`;
+  }
+
+  private static isProtocolWideScope(
+    scope: NormalizedRecordsProjectionScope,
+  ): scope is { protocol: string } {
+    return !('protocolPath' in scope) && !('contextId' in scope);
+  }
+
+  private static isContextScope(
+    scope: NormalizedRecordsProjectionScope,
+  ): scope is { protocol: string; contextId: string } {
+    return 'contextId' in scope;
+  }
+
+  private static contextIdSubsumes(parentContextId: string, childContextId: string): boolean {
+    return childContextId === parentContextId ||
+      childContextId.startsWith(`${parentContextId}/`);
+  }
+
+  private static compareScopes(
+    a: NormalizedRecordsProjectionScope,
+    b: NormalizedRecordsProjectionScope,
+  ): number {
+    const protocolCompare = lexicographicalCompare(a.protocol, b.protocol);
+    if (protocolCompare !== 0) {
+      return protocolCompare;
+    }
+
+    const aRank = RecordsProjection.scopeRank(a);
+    const bRank = RecordsProjection.scopeRank(b);
+    if (aRank !== bRank) {
+      return aRank - bRank;
+    }
+
+    return lexicographicalCompare(RecordsProjection.scopeValue(a), RecordsProjection.scopeValue(b));
+  }
+
+  private static scopeRank(scope: NormalizedRecordsProjectionScope): number {
+    if ('protocolPath' in scope) { return 1; }
+    if ('contextId' in scope) { return 2; }
+    return 0;
+  }
+
+  private static scopeValue(scope: NormalizedRecordsProjectionScope): string {
+    if ('protocolPath' in scope) { return scope.protocolPath; }
+    if ('contextId' in scope) { return scope.contextId; }
+    return '';
+  }
+}

--- a/packages/dwn-sdk-js/tests/sync/records-projection.spec.ts
+++ b/packages/dwn-sdk-js/tests/sync/records-projection.spec.ts
@@ -1,0 +1,302 @@
+import type { GenerateRecordsWriteOutput, Persona } from '../utils/test-data-generator.js';
+import type { GenericMessage, KeyValues, MessageStore, RecordsWriteMessage } from '../../src/index.js';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { lexicographicalCompare } from '../../src/utils/string.js';
+import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStores } from '../test-stores.js';
+import { getBit, hashKey, hashToHex, Jws, Message, RecordsDelete, RecordsProjection, SMTStoreMemory, SparseMerkleTree } from '../../src/index.js';
+
+export function testRecordsProjection(): void {
+  describe('RecordsProjection', () => {
+    let messageStore: MessageStore;
+    let alice: Persona;
+
+    const tenant = (): string => alice.did;
+
+    beforeAll(async () => {
+      messageStore = TestStores.get().messageStore;
+      await messageStore.open();
+    });
+
+    beforeEach(async () => {
+      alice = await TestDataGenerator.generatePersona();
+      await messageStore.clear();
+    });
+
+    afterAll(async () => {
+      await messageStore.close();
+    });
+
+    it('normalizes duplicate and covered scopes deterministically', () => {
+      const scopes = RecordsProjection.normalizeScopes([
+        { protocol: 'https://example.com/b', protocolPath: 'note' },
+        { protocol: 'https://example.com/a', contextId: 'root' },
+        { protocol: 'https://example.com/b' },
+        { protocol: 'https://example.com/b', protocolPath: 'note' },
+      ]);
+
+      expect(scopes).toEqual([
+        { protocol: 'https://example.com/a', contextId: 'root' },
+        { protocol: 'https://example.com/b' },
+      ]);
+    });
+
+    it('normalizes covered context subtree scopes to the broader context', () => {
+      const scopes = RecordsProjection.normalizeScopes([
+        { protocol: 'https://example.com/a', contextId: 'root/child' },
+        { protocol: 'https://example.com/a', contextId: 'root/child/grandchild' },
+        { protocol: 'https://example.com/a', contextId: 'root' },
+        { protocol: 'https://example.com/a', contextId: 'rootEVIL' },
+        { protocol: 'https://example.com/b', contextId: 'root/child' },
+        { protocol: 'https://example.com/b', contextId: 'root' },
+      ]);
+
+      expect(scopes).toEqual([
+        { protocol: 'https://example.com/a', contextId: 'root' },
+        { protocol: 'https://example.com/a', contextId: 'rootEVIL' },
+        { protocol: 'https://example.com/b', contextId: 'root' },
+      ]);
+    });
+
+    it('rejects scopes that specify both protocolPath and contextId', () => {
+      expect(() => RecordsProjection.normalizeScopes([
+        { protocol: 'https://example.com/a', protocolPath: 'note', contextId: 'root' },
+      ])).toThrow('protocolPath and contextId scopes are mutually exclusive');
+    });
+
+    it('returns primary message CIDs in bytewise order', async () => {
+      const messages: GenericMessage[] = [
+        createGenericMessage('2026-06-05T00:00:00.000000Z'),
+        createGenericMessage('2026-06-05T00:00:01.000000Z'),
+        createGenericMessage('2026-06-05T00:00:02.000000Z'),
+      ];
+      const cidByMessage = new Map<GenericMessage, string>([
+        [messages[0], 'bafyZ'],
+        [messages[1], 'bafya'],
+        [messages[2], 'bafyB'],
+      ]);
+      const getCidSpy = spyOn(Message, 'getCid').mockImplementation(async (message: GenericMessage) => cidByMessage.get(message)!);
+
+      try {
+        const projectedCids = await RecordsProjection.getPrimaryMessageCids({
+          tenant       : tenant(),
+          messageStore : createQueryOnlyMessageStore(messages),
+          scopes       : [{ protocol: 'https://example.com/chat' }],
+        });
+
+        expect(projectedCids).toEqual([...cidByMessage.values()].sort(lexicographicalCompare));
+      } finally {
+        getCidSpy.mockRestore();
+      }
+    });
+
+    it('projects protocolPath scopes by exact path, not prefix', async () => {
+      const protocol = 'https://example.com/chat';
+      const root = await createWrite({ protocol, protocolPath: 'thread' });
+      const child = await createWrite({
+        protocol,
+        protocolPath    : 'thread/message',
+        parentContextId : root.message.contextId,
+      });
+      const siblingType = await createWrite({
+        protocol,
+        protocolPath    : 'thread/messageAttachment',
+        parentContextId : root.message.contextId,
+      });
+
+      const rootCid = await putWrite(root);
+      const childCid = await putWrite(child);
+      await putWrite(siblingType);
+
+      const rootPathCids = await RecordsProjection.getPrimaryMessageCids({
+        tenant : tenant(),
+        messageStore,
+        scopes : [{ protocol, protocolPath: 'thread' }],
+      });
+      expect(rootPathCids).toEqual([rootCid]);
+
+      const childPathCids = await RecordsProjection.getPrimaryMessageCids({
+        tenant : tenant(),
+        messageStore,
+        scopes : [{ protocol, protocolPath: 'thread/message' }],
+      });
+      expect(childPathCids).toEqual([childCid]);
+    });
+
+    it('projects contextId scopes by context subtree boundary', async () => {
+      const protocol = 'https://example.com/chat';
+      const root = await createWrite({ protocol, protocolPath: 'thread' });
+      const child = await createWrite({
+        protocol,
+        protocolPath    : 'thread/message',
+        parentContextId : root.message.contextId,
+      });
+      const falsePrefix = await createWrite({ protocol, protocolPath: 'thread' });
+
+      const rootCid = await putWrite(root);
+      const childCid = await putWrite(child);
+      await putWrite(falsePrefix, true, { contextId: `${root.message.contextId}EVIL` });
+
+      const projectedCids = await RecordsProjection.getPrimaryMessageCids({
+        tenant : tenant(),
+        messageStore,
+        scopes : [{ protocol, contextId: root.message.contextId! }],
+      });
+
+      expect(projectedCids).toEqual([childCid, rootCid].sort(lexicographicalCompare));
+    });
+
+    it('includes RecordsDelete tombstones by indexed initial-write projection metadata', async () => {
+      const protocol = 'https://example.com/chat';
+      const write = await createWrite({ protocol, protocolPath: 'thread/message' });
+      const deleteRecord = await RecordsDelete.create({
+        recordId : write.message.recordId,
+        signer   : Jws.createSigner(alice),
+      });
+
+      await putWrite(write, false);
+      const deleteCid = await putDelete(deleteRecord, write.message);
+
+      const projectedCids = await RecordsProjection.getPrimaryMessageCids({
+        tenant : tenant(),
+        messageStore,
+        scopes : [{ protocol, protocolPath: 'thread/message' }],
+      });
+
+      expect(projectedCids).toEqual([deleteCid]);
+    });
+
+    it('computes the same SMT root, subtree hash, and leaves as the projected CID set', async () => {
+      const protocol = 'https://example.com/chat';
+      const root = await createWrite({ protocol, protocolPath: 'thread' });
+      const child = await createWrite({
+        protocol,
+        protocolPath    : 'thread/message',
+        parentContextId : root.message.contextId,
+      });
+      const otherProtocol = await createWrite({
+        protocol     : 'https://example.com/notes',
+        protocolPath : 'note',
+      });
+
+      const rootCid = await putWrite(root);
+      const childCid = await putWrite(child);
+      await putWrite(otherProtocol);
+
+      const scopes = [{ protocol }] as const;
+      const expectedCids = [childCid, rootCid].sort(lexicographicalCompare);
+      const prefix = await firstBitPrefix(rootCid);
+      const expectedTree = await treeValuesFromCids(expectedCids, prefix);
+      const rootHex = await RecordsProjection.getRootHex({
+        tenant: tenant(),
+        messageStore,
+        scopes,
+      });
+      const subtreeHash = await RecordsProjection.getSubtreeHash({
+        tenant: tenant(),
+        messageStore,
+        scopes,
+        prefix,
+      });
+      const leaves = await RecordsProjection.getLeaves({
+        tenant: tenant(),
+        messageStore,
+        scopes,
+        prefix,
+      });
+
+      expect(rootHex).toBe(expectedTree.rootHex);
+      expect(hashToHex(subtreeHash)).toBe(expectedTree.subtreeHex);
+      expect(leaves.sort(lexicographicalCompare)).toEqual(expectedTree.leaves);
+    });
+
+    async function createWrite(input: {
+      protocol: string;
+      protocolPath: string;
+      parentContextId?: string;
+    }): Promise<GenerateRecordsWriteOutput> {
+      return TestDataGenerator.generateRecordsWrite({
+        author: alice,
+        ...input,
+      });
+    }
+
+    async function putWrite(
+      write: GenerateRecordsWriteOutput,
+      isLatestBaseState = true,
+      indexOverrides: KeyValues = {},
+    ): Promise<string> {
+      const indexes = {
+        ...await write.recordsWrite.constructIndexes(isLatestBaseState),
+        ...indexOverrides,
+      };
+      await messageStore.put(tenant(), write.message, indexes);
+      return Message.getCid(write.message);
+    }
+
+    async function putDelete(
+      recordsDelete: RecordsDelete,
+      initialWrite: RecordsWriteMessage,
+    ): Promise<string> {
+      await messageStore.put(
+        tenant(),
+        recordsDelete.message,
+        recordsDelete.constructIndexes(initialWrite)
+      );
+      return Message.getCid(recordsDelete.message);
+    }
+  });
+}
+
+function createGenericMessage(messageTimestamp: string): GenericMessage {
+  return {
+    descriptor: {
+      interface : 'Records',
+      method    : 'Write',
+      messageTimestamp,
+    },
+  };
+}
+
+function createQueryOnlyMessageStore(messages: GenericMessage[]): MessageStore {
+  return {
+    clear  : async (): Promise<void> => {},
+    close  : async (): Promise<void> => {},
+    count  : async (): Promise<number> => messages.length,
+    delete : async (): Promise<void> => {},
+    get    : async (): Promise<GenericMessage | undefined> => undefined,
+    open   : async (): Promise<void> => {},
+    put    : async (): Promise<void> => {},
+    query  : async (): Promise<{ messages: GenericMessage[] }> => ({ messages }),
+  };
+}
+
+async function firstBitPrefix(messageCid: string): Promise<boolean[]> {
+  const keyHash = await hashKey(messageCid);
+  return [getBit(keyHash, 0)];
+}
+
+async function treeValuesFromCids(
+  messageCids: string[],
+  prefix: boolean[],
+): Promise<{ rootHex: string; subtreeHex: string; leaves: string[] }> {
+  const tree = new SparseMerkleTree(new SMTStoreMemory());
+  await tree.initialize();
+
+  try {
+    for (const messageCid of messageCids) {
+      await tree.insert(messageCid);
+    }
+
+    const leaves = await tree.getLeaves(prefix);
+    return {
+      rootHex    : hashToHex(await tree.getRoot()),
+      subtreeHex : hashToHex(await tree.getSubtreeHash(prefix)),
+      leaves     : leaves.sort(lexicographicalCompare),
+    };
+  } finally {
+    await tree.close();
+  }
+}

--- a/packages/dwn-sdk-js/tests/test-suite.ts
+++ b/packages/dwn-sdk-js/tests/test-suite.ts
@@ -25,6 +25,7 @@ import { testRecordsCountHandler } from './handlers/records-count.spec.js';
 import { testRecordsDeleteHandler } from './handlers/records-delete.spec.js';
 import { testRecordsDelivery } from './features/records-delivery.spec.js';
 import { testRecordsImmutable } from './features/records-immutable.spec.js';
+import { testRecordsProjection } from './sync/records-projection.spec.js';
 import { testRecordsPrune } from './features/records-prune.spec.js';
 import { testRecordsPruneCrossProtocol } from './features/records-prune-cross-protocol.spec.js';
 import { testRecordsQueryHandler } from './handlers/records-query.spec.js';
@@ -75,6 +76,7 @@ export class TestSuite {
     testRecordsReadHandler();
     testRecordsSubscribeHandler();
     testRecordsWriteHandler();
+    testRecordsProjection();
 
     // feature tests
     testAuthorDelegatedGrant();


### PR DESCRIPTION
## Summary
- add `RecordsProjection` helpers for `records-primary-scope-root-v1` scoped primary CID roots
- support protocol, exact protocolPath, and boundary-aware contextId scope unions over latest Records primary messages
- add tests for scope normalization, exact path matching, context boundaries, delete tombstones, and SMT root/leaves

Spec companion: https://github.com/enboxorg/dwn-spec/pull/55

## Tests
- `bun run build:ci`
- `bun run --filter @enbox/dwn-sdk-js lint`
- `bun test ./packages/dwn-sdk-js/tests/store-dependent-tests.spec.ts -t RecordsProjection`
- `bun test ./packages/dwn-sdk-js/tests/store-dependent-tests.spec.ts`