### PR TITLE
Add agent projected sync targets

### DIFF
--- a/.changeset/agent-projected-sync-targets.md
+++ b/.changeset/agent-projected-sync-targets.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Resolve delegated path and context `Messages.Read` grants into Records-primary projected `MessagesSync` targets.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,6 +12,7 @@ export {
   normalizeSyncProtocols,
   protocolsForSyncScope,
   singleProtocolForSyncScope,
+  syncScopeFromRecordsProjectionScopes,
   syncScopeFromProtocols,
 } from './types/sync.js';
 export { ReplicationLedger } from './sync-replication-ledger.js';

--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -9,6 +9,7 @@ import type { GenericMessage, MessageStore, ProtocolDefinition, ProtocolRuleSet 
 import { classifySyncMessageScope } from './sync-scope-acceptance.js';
 import { getInvokedPermissionGrantIds } from './sync-permission-grants.js';
 import { isMultiPartyContext } from './protocol-utils.js';
+import { protocolsForSyncScope } from './types/sync.js';
 import { ClosureFailureCode, createClosureContext } from './sync-closure-types.js';
 import { Message, PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
@@ -847,9 +848,15 @@ function dependencyCacheKey(edge: ClosureDependencyEdge, scope: SyncScope): stri
 }
 
 function scopeCacheKey(scope: SyncScope): string {
-  return scope.kind === 'full'
-    ? 'full'
-    : `protocolSet:${scope.protocols.join('\u001f')}`;
+  if (scope.kind === 'full') {
+    return 'full';
+  }
+
+  if (scope.kind === 'protocolSet') {
+    return `protocolSet:${scope.protocols.join('\u001f')}`;
+  }
+
+  return `recordsProjection:${scope.scopes.map(scopeEntry => JSON.stringify(scopeEntry)).join('\u001f')}`;
 }
 
 function isResolvedDependencyAllowed(
@@ -901,6 +908,7 @@ function isContextKeyDependencyAllowed(
   const rootContextId = edge.identifier.substring(separatorIdx + 1);
   const descriptor = message.descriptor as Record<string, unknown>;
   const tags = descriptor.tags as Record<string, unknown> | undefined;
+  const coveredProtocols = protocolsForSyncScope(scope);
 
   return descriptor.interface === 'Records' &&
     descriptor.method === 'Write' &&
@@ -908,7 +916,7 @@ function isContextKeyDependencyAllowed(
     descriptor.protocolPath === 'contextKey' &&
     tags?.protocol === sourceProtocol &&
     tags?.contextId === rootContextId &&
-    scope.protocols.includes(sourceProtocol);
+    coveredProtocols?.includes(sourceProtocol) === true;
 }
 
 /**

--- a/packages/agent/src/sync-closure-resolver.ts
+++ b/packages/agent/src/sync-closure-resolver.ts
@@ -11,7 +11,7 @@ import { getInvokedPermissionGrantIds } from './sync-permission-grants.js';
 import { isMultiPartyContext } from './protocol-utils.js';
 import { protocolsForSyncScope } from './types/sync.js';
 import { ClosureFailureCode, createClosureContext } from './sync-closure-types.js';
-import { Message, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+import { Message, PermissionScopeMatcher, PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
 // ---------------------------------------------------------------------------
 // Dependency extraction helpers (one per dependency class)
@@ -908,15 +908,26 @@ function isContextKeyDependencyAllowed(
   const rootContextId = edge.identifier.substring(separatorIdx + 1);
   const descriptor = message.descriptor as Record<string, unknown>;
   const tags = descriptor.tags as Record<string, unknown> | undefined;
-  const coveredProtocols = protocolsForSyncScope(scope);
 
-  return descriptor.interface === 'Records' &&
+  const isContextKeyRecord = descriptor.interface === 'Records' &&
     descriptor.method === 'Write' &&
     descriptor.protocol === 'https://identity.foundation/protocols/key-delivery' &&
     descriptor.protocolPath === 'contextKey' &&
     tags?.protocol === sourceProtocol &&
-    tags?.contextId === rootContextId &&
-    coveredProtocols?.includes(sourceProtocol) === true;
+    tags?.contextId === rootContextId;
+  if (!isContextKeyRecord) {
+    return false;
+  }
+
+  if (scope.kind === 'recordsProjection') {
+    return scope.scopes.some(scopeEntry => PermissionScopeMatcher.matches(scopeEntry, {
+      protocol  : sourceProtocol,
+      contextId : rootContextId,
+    }));
+  }
+
+  const coveredProtocols = protocolsForSyncScope(scope);
+  return coveredProtocols?.includes(sourceProtocol) === true;
 }
 
 /**

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1558,6 +1558,9 @@ export class SyncEngineLevel implements SyncEngine {
     if (link.pull.contiguousAppliedToken) {
       return;
     }
+    if (target.scope.kind === 'recordsProjection') {
+      return;
+    }
 
     const legacyKey = buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
     const legacyCursor = await this.getCursor(legacyKey);
@@ -1592,6 +1595,8 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private static supportsLiveSubscriptions(scope: SyncScope): boolean {
+    // Records-primary projected links reconcile by root/diff polling until the
+    // DWN has explicit path/context live subscription semantics.
     return scope.kind !== 'recordsProjection';
   }
 
@@ -3424,6 +3429,8 @@ export class SyncEngineLevel implements SyncEngine {
     permissionGrantIds?: string[],
   ): Promise<string> {
     if (this.stateIndex) {
+      // Local projected roots use the already-derived scope directly. The
+      // remote root/diff request still re-authorizes the invoked grant set.
       return RecordsProjection.getRootHex({
         tenant       : did,
         messageStore : this.agent.dwn.node.storage.messageStore,
@@ -3938,8 +3945,9 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     // Batch entries are only used when the initial write has not been applied
-    // locally yet. The eventual processRawMessage call still authenticates the
-    // delete before any local mutation occurs.
+    // locally yet. RecordsWrite.isInitialWrite binds the candidate's CID to
+    // recordId, and processRawMessage still authenticates the delete before
+    // any local mutation occurs.
     return this.findInitialWriteInPullBatch(descriptor.recordId, entries);
   }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -17,6 +17,8 @@ import type { SyncScopeClassification } from './sync-scope-acceptance.js';
 import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
+import type { DwnMessageParams } from './types/dwn.js';
+
 import { DwnInterface } from './types/dwn.js';
 import { evaluateClosure } from './sync-closure-resolver.js';
 import { isRecordsWrite } from './utils.js';
@@ -126,6 +128,11 @@ type ProjectionReconcileOptions = {
 type ProjectionReconcileResult = {
   aborted?: boolean;
   converged?: boolean;
+};
+
+type ProjectionDiffResult = {
+  onlyRemote: MessagesSyncDiffEntry[];
+  onlyLocal: string[];
 };
 
 type ProtocolSetScope = Extract<SyncScope, { kind: 'protocolSet' }>;
@@ -933,16 +940,7 @@ export class SyncEngineLevel implements SyncEngine {
       return;
     }
 
-    const prevStatus = link.status;
-    const prevConnectivity = link.connectivity;
-    link.connectivity = 'offline';
-    await this.ledger.setStatus(link, 'repairing');
-
-    const eventScope = syncEventScope(link.scope);
-    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevStatus, to: 'repairing' });
-    if (prevConnectivity !== 'offline') {
-      this.emitEvent({ type: 'link:connectivity-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevConnectivity, to: 'offline' });
-    }
+    await this.setLinkOfflineStatus(link, 'repairing');
 
     if (options?.resumeToken) {
       this._repairContext.set(linkKey, { resumeToken: options.resumeToken });
@@ -950,11 +948,7 @@ export class SyncEngineLevel implements SyncEngine {
 
     // Clear runtime ordinals immediately — stale state must not linger
     // across repair attempts.
-    const rt = this._linkRuntimes.get(linkKey);
-    if (rt) {
-      rt.inflight.clear();
-      rt.nextCommitOrdinal = rt.nextDeliveryOrdinal;
-    }
+    this.clearLinkRuntimeInflight(linkKey);
 
     // Kick off repair with retry scheduling on failure.
     void this.repairLink(linkKey).catch(() => {
@@ -970,24 +964,11 @@ export class SyncEngineLevel implements SyncEngine {
       return;
     }
 
-    const prevStatus = link.status;
-    const prevConnectivity = link.connectivity;
-    link.connectivity = 'offline';
-    await this.ledger.setStatus(link, 'terminal_incomplete');
-
-    const eventScope = syncEventScope(link.scope);
-    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevStatus, to: 'terminal_incomplete' });
-    if (prevConnectivity !== 'offline') {
-      this.emitEvent({ type: 'link:connectivity-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevConnectivity, to: 'offline' });
-    }
+    await this.setLinkOfflineStatus(link, 'terminal_incomplete');
 
     await this.closeLinkSubscriptions(link);
 
-    const rt = this._linkRuntimes.get(linkKey);
-    if (rt) {
-      rt.inflight.clear();
-      rt.nextCommitOrdinal = rt.nextDeliveryOrdinal;
-    }
+    this.clearLinkRuntimeInflight(linkKey);
 
     const retryTimer = this._repairRetryTimers.get(linkKey);
     if (retryTimer) {
@@ -1012,6 +993,29 @@ export class SyncEngineLevel implements SyncEngine {
 
     this._repairAttempts.delete(linkKey);
     this._repairContext.delete(linkKey);
+  }
+
+  private async setLinkOfflineStatus(link: ReplicationLinkState, status: ReplicationLinkState['status']): Promise<void> {
+    const prevStatus = link.status;
+    const prevConnectivity = link.connectivity;
+    link.connectivity = 'offline';
+    await this.ledger.setStatus(link, status);
+
+    const eventScope = syncEventScope(link.scope);
+    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevStatus, to: status });
+    if (prevConnectivity !== 'offline') {
+      this.emitEvent({ type: 'link:connectivity-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevConnectivity, to: 'offline' });
+    }
+  }
+
+  private clearLinkRuntimeInflight(linkKey: string): void {
+    const rt = this._linkRuntimes.get(linkKey);
+    if (!rt) {
+      return;
+    }
+
+    rt.inflight.clear();
+    rt.nextCommitOrdinal = rt.nextDeliveryOrdinal;
   }
 
   /**
@@ -2898,25 +2902,7 @@ export class SyncEngineLevel implements SyncEngine {
     // order composed protocol configs before records that use them. Any future
     // chunking for large protocol sets must preserve this global dependency
     // order instead of reverting to independent per-protocol chunks.
-    const { prefetched, needsFetchCids } = partitionRemoteEntries(SyncEngineLevel.dedupeRemoteEntries(onlyRemote));
-    try {
-      await this.pullMessages({
-        did                : target.did,
-        dwnUrl             : target.dwnUrl,
-        delegateDid        : target.delegateDid,
-        scope              : scope,
-        permissionGrantIds : permissionGrantIds,
-        messageCids        : needsFetchCids,
-        prefetched         : prefetched,
-        shouldContinue     : shouldContinue,
-      });
-    } catch (error) {
-      if (error instanceof SyncPullAbortedError) {
-        return true;
-      }
-      throw error;
-    }
-    return shouldContinue?.() === false;
+    return this.pullRemoteDiffEntries(target, scope, onlyRemote, permissionGrantIds, shouldContinue);
   }
 
   private async applyProjectedDiff(
@@ -2946,25 +2932,7 @@ export class SyncEngineLevel implements SyncEngine {
       return false;
     }
 
-    const { prefetched, needsFetchCids } = partitionRemoteEntries(SyncEngineLevel.dedupeRemoteEntries(onlyRemote));
-    try {
-      await this.pullMessages({
-        did                : target.did,
-        dwnUrl             : target.dwnUrl,
-        delegateDid        : target.delegateDid,
-        scope              : scope,
-        permissionGrantIds : permissionGrantIds,
-        messageCids        : needsFetchCids,
-        prefetched         : prefetched,
-        shouldContinue     : shouldContinue,
-      });
-    } catch (error) {
-      if (error instanceof SyncPullAbortedError) {
-        return true;
-      }
-      throw error;
-    }
-    return shouldContinue?.() === false;
+    return this.pullRemoteDiffEntries(target, scope, onlyRemote, permissionGrantIds, shouldContinue);
   }
 
   private async pushProjectedLocalDiff(
@@ -2978,14 +2946,7 @@ export class SyncEngineLevel implements SyncEngine {
       return false;
     }
 
-    await this.pushMessages({
-      did         : target.did,
-      dwnUrl      : target.dwnUrl,
-      delegateDid : target.delegateDid,
-      permissionGrantIds,
-      messageCids : SyncEngineLevel.dedupeStrings(onlyLocal),
-    });
-    return shouldContinue?.() === false;
+    return this.pushLocalDiffEntries(target, onlyLocal, permissionGrantIds, shouldContinue);
   }
 
   private async pushProtocolSetLocalDiff(
@@ -2999,6 +2960,43 @@ export class SyncEngineLevel implements SyncEngine {
       return false;
     }
 
+    return this.pushLocalDiffEntries(target, onlyLocal, permissionGrantIds, shouldContinue);
+  }
+
+  private async pullRemoteDiffEntries(
+    target: ProjectionReconcileTarget,
+    scope: SyncScope,
+    onlyRemote: MessagesSyncDiffEntry[],
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    shouldContinue?: () => boolean,
+  ): Promise<boolean> {
+    const { prefetched, needsFetchCids } = partitionRemoteEntries(SyncEngineLevel.dedupeRemoteEntries(onlyRemote));
+    try {
+      await this.pullMessages({
+        did         : target.did,
+        dwnUrl      : target.dwnUrl,
+        delegateDid : target.delegateDid,
+        scope,
+        permissionGrantIds,
+        messageCids : needsFetchCids,
+        prefetched,
+        shouldContinue,
+      });
+    } catch (error) {
+      if (error instanceof SyncPullAbortedError) {
+        return true;
+      }
+      throw error;
+    }
+    return shouldContinue?.() === false;
+  }
+
+  private async pushLocalDiffEntries(
+    target: ProjectionReconcileTarget,
+    onlyLocal: string[],
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    shouldContinue?: () => boolean,
+  ): Promise<boolean> {
     await this.pushMessages({
       did         : target.did,
       dwnUrl      : target.dwnUrl,
@@ -3508,48 +3506,27 @@ export class SyncEngineLevel implements SyncEngine {
     delegateDid?: string;
     protocol?: string;
     permissionGrantIds?: string[];
-  }): Promise<{ onlyRemote: MessagesSyncDiffEntry[]; onlyLocal: string[] }> {
+  }): Promise<ProjectionDiffResult> {
     // Step 1: Collect local subtree hashes at BATCHED_DIFF_DEPTH directly from StateIndex.
     const localHashes = await this.collectLocalSubtreeHashes(did, protocol, BATCHED_DIFF_DEPTH, permissionGrantIds);
 
     // Step 2: Send a single 'diff' request to the remote with our hashes.
-    const syncMessage = await this.agent.dwn.processRequest({
-      store         : false,
-      author        : did,
-      target        : did,
-      messageType   : DwnInterface.MessagesSync,
-      granteeDid    : delegateDid,
-      messageParams : {
-        action             : 'diff',
-        protocol,
-        hashes             : localHashes,
-        depth              : BATCHED_DIFF_DEPTH,
-        permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantIds),
-      }
-    });
-
-    const reply = await this.agent.rpc.sendDwnRequest({
-      dwnUrl,
-      targetDid : did,
-      message   : syncMessage.message,
-    }) as MessagesSyncReply;
-
-    if (reply.status.code !== 200) {
-      throw new Error(`SyncEngineLevel: diff failed with ${reply.status.code}: ${reply.status.detail}`);
-    }
+    const messageParams: DwnMessageParams[DwnInterface.MessagesSync] = {
+      action             : 'diff',
+      protocol,
+      hashes             : localHashes,
+      depth              : BATCHED_DIFF_DEPTH,
+      permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantIds),
+    };
 
     // Step 3: Enumerate local leaves for prefixes the remote reported as onlyLocal.
     // Reuse the same grant set from step 2.
-    const onlyLocalCids: string[] = [];
-    for (const prefix of reply.onlyLocal ?? []) {
-      const leaves = await this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantIds);
-      onlyLocalCids.push(...leaves);
-    }
-
-    return {
-      onlyRemote : reply.onlyRemote ?? [],
-      onlyLocal  : onlyLocalCids,
-    };
+    return this.diffRemoteMessages(
+      { did, dwnUrl, delegateDid },
+      messageParams,
+      prefix => this.getLocalLeaves(did, prefix, delegateDid, protocol, permissionGrantIds),
+      'diff',
+    );
   }
 
   private async diffProjectedWithRemote({ did, dwnUrl, delegateDid, scopes, permissionGrantIds }: {
@@ -3558,7 +3535,7 @@ export class SyncEngineLevel implements SyncEngine {
     delegateDid?: string;
     scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]];
     permissionGrantIds?: string[];
-  }): Promise<{ onlyRemote: MessagesSyncDiffEntry[]; onlyLocal: string[] }> {
+  }): Promise<ProjectionDiffResult> {
     const localHashes = await this.collectLocalProjectedSubtreeHashes(
       did,
       scopes,
@@ -3567,35 +3544,51 @@ export class SyncEngineLevel implements SyncEngine {
       permissionGrantIds,
     );
 
+    const messageParams: DwnMessageParams[DwnInterface.MessagesSync] = {
+      action                : 'diff',
+      projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+      projectionScopes      : [...scopes],
+      hashes                : localHashes,
+      depth                 : BATCHED_DIFF_DEPTH,
+      permissionGrantIds    : toMessagesPermissionGrantIds(permissionGrantIds),
+    };
+
+    return this.diffRemoteMessages(
+      { did, dwnUrl, delegateDid },
+      messageParams,
+      prefix => this.getLocalProjectedLeaves(did, prefix, delegateDid, scopes, permissionGrantIds),
+      'projected diff',
+    );
+  }
+
+  private async diffRemoteMessages(
+    target: Pick<ProjectionReconcileTarget, 'did' | 'dwnUrl' | 'delegateDid'>,
+    messageParams: DwnMessageParams[DwnInterface.MessagesSync],
+    getLocalLeavesForPrefix: (prefix: string) => Promise<string[]>,
+    operationName: string,
+  ): Promise<ProjectionDiffResult> {
     const syncMessage = await this.agent.dwn.processRequest({
-      store         : false,
-      author        : did,
-      target        : did,
-      messageType   : DwnInterface.MessagesSync,
-      granteeDid    : delegateDid,
-      messageParams : {
-        action                : 'diff',
-        projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
-        projectionScopes      : [...scopes],
-        hashes                : localHashes,
-        depth                 : BATCHED_DIFF_DEPTH,
-        permissionGrantIds    : toMessagesPermissionGrantIds(permissionGrantIds),
-      }
+      store       : false,
+      author      : target.did,
+      target      : target.did,
+      messageType : DwnInterface.MessagesSync,
+      granteeDid  : target.delegateDid,
+      messageParams,
     });
 
     const reply = await this.agent.rpc.sendDwnRequest({
-      dwnUrl,
-      targetDid : did,
+      dwnUrl    : target.dwnUrl,
+      targetDid : target.did,
       message   : syncMessage.message,
     }) as MessagesSyncReply;
 
     if (reply.status.code !== 200) {
-      throw new Error(`SyncEngineLevel: projected diff failed with ${reply.status.code}: ${reply.status.detail}`);
+      throw new Error(`SyncEngineLevel: ${operationName} failed with ${reply.status.code}: ${reply.status.detail}`);
     }
 
     const onlyLocalCids: string[] = [];
     for (const prefix of reply.onlyLocal ?? []) {
-      const leaves = await this.getLocalProjectedLeaves(did, prefix, delegateDid, scopes, permissionGrantIds);
+      const leaves = await getLocalLeavesForPrefix(prefix);
       onlyLocalCids.push(...leaves);
     }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1,13 +1,13 @@
 import type { AbstractLevel } from 'abstract-level';
 
 import type { DwnSubscriptionHandler, ResubscribeFactory } from '@enbox/dwn-clients';
-import type { GenericMessage, MessageEvent, MessagesSubscribeReply, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, RecordsWriteMessage, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, MessageEvent, MessagesSubscribeReply, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, RecordsProjectionScope, RecordsWriteMessage, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
 import ms from 'ms';
 
 import { Level } from 'level';
 import { sleep } from '@enbox/common';
-import { DwnInterfaceName, DwnMethodName, Encoder, hashToHex, initDefaultHashes, Message, RecordsWrite } from '@enbox/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName, Encoder, hashToHex, initDefaultHashes, Message, RECORDS_PROJECTION_ROOT_VERSION, RecordsProjection, RecordsWrite } from '@enbox/dwn-sdk-js';
 
 import type { ClosureEvaluationContext } from './sync-closure-types.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
@@ -27,8 +27,8 @@ import { classifySyncEventScope, classifySyncMessageScope } from './sync-scope-a
 import { computeAuthorizationEpoch, computeProjectionId, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { createClosureContext, invalidateClosureCache, isTerminalClosureFailureCode } from './sync-closure-types.js';
 import { fetchRemoteMessages, getMessageCid, pullMessages, pushMessages, SyncPullAbortedError } from './sync-messages.js';
-import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 import { partitionRemoteEntries, SyncLinkReconciler } from './sync-link-reconciler.js';
+import { permissionGrantIdsFromEntries, resolveMessagesSyncScopes, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
 export type SyncEngineLevelParams = {
   agent?: EnboxPlatformAgent;
@@ -87,12 +87,13 @@ type SyncTarget = {
   permissionGrantIds?: NonEmptyStringArray;
 };
 
-type SyncTargetAuthorization = Pick<SyncTarget, 'authorization' | 'authorizationEpoch' | 'delegateDid' | 'permissionGrantIds'>;
+type SyncTargetResolution = Pick<SyncTarget, 'authorization' | 'authorizationEpoch' | 'delegateDid' | 'permissionGrantIds' | 'scope'>;
 
 type LinkSyncTarget = SyncTarget & { linkKey: string };
 
 enum LinkSubscriptionOpenResult {
   ReadyForLive = 'readyForLive',
+  Polling = 'polling',
   Repairing = 'repairing',
 }
 
@@ -128,6 +129,7 @@ type ProjectionReconcileResult = {
 };
 
 type ProtocolSetScope = Extract<SyncScope, { kind: 'protocolSet' }>;
+type RecordsProjectionSyncScope = Extract<SyncScope, { kind: 'recordsProjection' }>;
 
 type ProtocolSetDiffPlan = {
   changedProtocols: string[];
@@ -205,11 +207,16 @@ type PullDelivery = {
 };
 
 function syncEventScope(scope: SyncScope | undefined): SyncEventScope {
-  if (scope === undefined || scope.kind === 'full') {
+  if (scope === undefined) {
     return {};
   }
 
-  const protocols = [...scope.protocols] as NonEmptyStringArray;
+  const coveredProtocols = protocolsForSyncScope(scope);
+  if (coveredProtocols === undefined) {
+    return {};
+  }
+
+  const protocols = [...coveredProtocols] as NonEmptyStringArray;
   return protocols.length === 1
     ? { protocol: protocols[0], protocols }
     : { protocols };
@@ -326,55 +333,58 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
-  private async buildSyncTarget(did: string, dwnUrl: string, options: SyncIdentityOptions): Promise<SyncTarget> {
-    const scope = syncScopeFromProtocols(options.protocols);
-    const authorization = await this.buildSyncTargetAuthorization(did, scope, options);
+  private async buildSyncTargetsForEndpoint(did: string, dwnUrl: string, options: SyncIdentityOptions): Promise<SyncTarget[]> {
+    const requestedScope = syncScopeFromProtocols(options.protocols);
+    const resolutions = await this.buildSyncTargetResolutions(did, requestedScope, options);
 
-    return {
+    return resolutions.map(resolution => ({
       did,
       dwnUrl,
-      scope,
-      ...authorization,
-    };
+      ...resolution,
+    }));
   }
 
-  private async buildSyncTargetAuthorization(did: string, scope: SyncScope, options: SyncIdentityOptions): Promise<SyncTargetAuthorization> {
-    const protocols = protocolsForSyncScope(scope);
+  private async buildSyncTargetResolutions(did: string, requestedScope: SyncScope, options: SyncIdentityOptions): Promise<SyncTargetResolution[]> {
     const { delegateDid } = options;
 
     if (delegateDid === undefined) {
-      return {
+      return [{
+        scope              : requestedScope,
         authorization      : { kind: 'owner' },
         authorizationEpoch : await computeAuthorizationEpoch({ kind: 'owner' }),
-      };
+      }];
     }
 
-    const permissionGrants = await getMessagesPermissionGrantsForScope({
+    const resolvedScopes = await resolveMessagesSyncScopes({
       did,
       delegateDid,
-      protocols,
+      requestedScope,
       messageType    : DwnInterface.MessagesSync,
       permissionsApi : this._permissionsApi,
     });
-    const permissionGrantIds = permissionGrantIdsFromEntries(permissionGrants);
-    if (permissionGrantIds === undefined) {
-      throw new Error(`SyncEngineLevel: delegate ${delegateDid} has no active sync grants for ${did}.`);
-    }
 
-    return {
-      delegateDid,
-      authorization: {
-        kind: 'delegate',
+    return Promise.all(resolvedScopes.map(async ({ scope, permissionGrants }) => {
+      const permissionGrantIds = permissionGrantIdsFromEntries(permissionGrants);
+      if (permissionGrantIds === undefined) {
+        throw new Error(`SyncEngineLevel: delegate ${delegateDid} has no active sync grants for ${did}.`);
+      }
+
+      return {
+        scope,
         delegateDid,
+        authorization: {
+          kind: 'delegate' as const,
+          delegateDid,
+          permissionGrantIds,
+        },
+        authorizationEpoch: await computeAuthorizationEpoch({
+          kind   : 'delegate' as const,
+          delegateDid,
+          grants : toSyncAuthorizationGrants(permissionGrants),
+        }),
         permissionGrantIds,
-      },
-      authorizationEpoch: await computeAuthorizationEpoch({
-        kind   : 'delegate',
-        delegateDid,
-        grants : toSyncAuthorizationGrants(permissionGrants),
-      }),
-      permissionGrantIds,
-    };
+      };
+    }));
   }
 
   /**
@@ -1520,6 +1530,8 @@ export class SyncEngineLevel implements SyncEngine {
       const subscriptionResult = await this.openLinkSubscriptions({ ...target, linkKey });
       if (subscriptionResult === LinkSubscriptionOpenResult.ReadyForLive) {
         await this.markLinkLive(target, link, linkKey);
+      } else if (subscriptionResult === LinkSubscriptionOpenResult.Polling) {
+        await this.markLinkPolling(target, link);
       }
       return this.createActiveLinkInitializationResult(link);
     } catch (error: any) {
@@ -1559,6 +1571,10 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private async openLinkSubscriptions(target: LinkSyncTarget): Promise<LinkSubscriptionOpenResult> {
+    if (!SyncEngineLevel.supportsLiveSubscriptions(target.scope)) {
+      return LinkSubscriptionOpenResult.Polling;
+    }
+
     await this.openLivePullSubscription(target);
     const link = this._activeLinks.get(target.linkKey);
     if (link?.status === 'repairing') {
@@ -1575,6 +1591,10 @@ export class SyncEngineLevel implements SyncEngine {
     return LinkSubscriptionOpenResult.ReadyForLive;
   }
 
+  private static supportsLiveSubscriptions(scope: SyncScope): boolean {
+    return scope.kind !== 'recordsProjection';
+  }
+
   private async markLinkLive(target: SyncTarget, link: ReplicationLinkState, linkKey: string): Promise<void> {
     this.emitEvent({
       type           : 'link:status-change',
@@ -1589,6 +1609,18 @@ export class SyncEngineLevel implements SyncEngine {
     if (link.needsReconcile) {
       this.scheduleReconcile(linkKey, 1000);
     }
+  }
+
+  private async markLinkPolling(target: SyncTarget, link: ReplicationLinkState): Promise<void> {
+    this.emitEvent({
+      type           : 'link:status-change',
+      tenantDid      : target.did,
+      remoteEndpoint : target.dwnUrl,
+      ...syncEventScope(target.scope),
+      from           : 'initializing',
+      to             : 'polling'
+    });
+    await this.ledger.setStatus(link, 'polling');
   }
 
   private async handleInitializeLinkTargetError(
@@ -1696,7 +1728,7 @@ export class SyncEngineLevel implements SyncEngine {
 
     const targets: SyncTarget[] = [];
     for (const dwnUrl of dwnEndpointUrls) {
-      targets.push(await this.buildSyncTarget(did, dwnUrl, options));
+      targets.push(...await this.buildSyncTargetsForEndpoint(did, dwnUrl, options));
     }
 
     const results = await Promise.allSettled(targets.map(t => this.initializeLinkTargetWithRetry(t)));
@@ -1766,9 +1798,13 @@ export class SyncEngineLevel implements SyncEngine {
 
   private async getDurableLinkIdentityKeysForRegisteredIdentity(did: string, options: SyncIdentityOptions): Promise<Set<string>> {
     const scope = syncScopeFromProtocols(options.protocols);
-    const projectionId = await computeProjectionId(did, scope);
-    const { authorizationEpoch } = await this.buildSyncTargetAuthorization(did, scope, options);
-    return new Set([SyncEngineLevel.durableLinkIdentityKey(did, projectionId, authorizationEpoch)]);
+    const resolutions = await this.buildSyncTargetResolutions(did, scope, options);
+    const keys = new Set<string>();
+    for (const resolution of resolutions) {
+      const projectionId = await computeProjectionId(did, resolution.scope);
+      keys.add(SyncEngineLevel.durableLinkIdentityKey(did, projectionId, resolution.authorizationEpoch));
+    }
+    return keys;
   }
 
   private async pruneSupersededDurableLinksForIdentity(did: string, currentIdentityKeys: Set<string>): Promise<void> {
@@ -2161,7 +2197,7 @@ export class SyncEngineLevel implements SyncEngine {
 
   private async ensureClosureComplete(context: LivePullContext, event: MessageEvent): Promise<boolean> {
     const { did, delegateDid, link, isStale } = context;
-    if (link?.scope.kind !== 'protocolSet') {
+    if (!link || link.scope.kind === 'full') {
       return true;
     }
 
@@ -2663,7 +2699,7 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private getReconcileProtocols(scope: SyncScope): (string | undefined)[] {
-    return scope.kind === 'full' ? [undefined] : scope.protocols;
+    return protocolsForSyncScope(scope) ?? [undefined];
   }
 
   private getAuthorizationGrantIds(authorization: SyncAuthorization): NonEmptyStringArray | undefined {
@@ -2675,6 +2711,10 @@ export class SyncEngineLevel implements SyncEngine {
     options?: ProjectionReconcileOptions,
     shouldContinue?: () => boolean,
   ): Promise<ProjectionReconcileResult> {
+    if (target.scope.kind === 'recordsProjection') {
+      return this.reconcileRecordsProjectionTarget(target, target.scope, options, shouldContinue);
+    }
+
     if (target.scope.kind === 'protocolSet' && target.scope.protocols.length > 1) {
       return this.reconcileProtocolSetProjectionTarget(target, options, shouldContinue);
     }
@@ -2700,6 +2740,46 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     return options?.verifyConvergence === true ? { converged } : {};
+  }
+
+  private async reconcileRecordsProjectionTarget(
+    target: ProjectionReconcileTarget,
+    scope: RecordsProjectionSyncScope,
+    options?: ProjectionReconcileOptions,
+    shouldContinue?: () => boolean,
+  ): Promise<ProjectionReconcileResult> {
+    const permissionGrantIds = this.getAuthorizationGrantIds(target.authorization);
+    const localRoot = await this.getLocalProjectedRoot(target.did, target.delegateDid, scope.scopes, permissionGrantIds);
+    if (shouldContinue?.() === false) { return { aborted: true }; }
+
+    const remoteRoot = await this.getRemoteProjectedRoot(target.did, target.dwnUrl, target.delegateDid, scope.scopes, permissionGrantIds);
+    if (shouldContinue?.() === false) { return { aborted: true }; }
+
+    if (localRoot !== remoteRoot) {
+      const diff = await this.diffProjectedWithRemote({
+        did         : target.did,
+        dwnUrl      : target.dwnUrl,
+        delegateDid : target.delegateDid,
+        scopes      : scope.scopes,
+        permissionGrantIds,
+      });
+      if (shouldContinue?.() === false) { return { aborted: true }; }
+
+      const aborted = await this.applyProjectedDiff(target, scope, diff, permissionGrantIds, options, shouldContinue);
+      if (aborted) { return { aborted: true }; }
+    }
+
+    if (options?.verifyConvergence !== true) {
+      return {};
+    }
+
+    const postLocalRoot = await this.getLocalProjectedRoot(target.did, target.delegateDid, scope.scopes, permissionGrantIds);
+    if (shouldContinue?.() === false) { return { aborted: true }; }
+
+    const postRemoteRoot = await this.getRemoteProjectedRoot(target.did, target.dwnUrl, target.delegateDid, scope.scopes, permissionGrantIds);
+    if (shouldContinue?.() === false) { return { aborted: true }; }
+
+    return { converged: postLocalRoot === postRemoteRoot };
   }
 
   private async reconcileProtocolSetProjectionTarget(
@@ -2834,6 +2914,75 @@ export class SyncEngineLevel implements SyncEngine {
     return shouldContinue?.() === false;
   }
 
+  private async applyProjectedDiff(
+    target: ProjectionReconcileTarget,
+    scope: RecordsProjectionSyncScope,
+    diff: { onlyRemote: MessagesSyncDiffEntry[]; onlyLocal: string[] },
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    options?: ProjectionReconcileOptions,
+    shouldContinue?: () => boolean,
+  ): Promise<boolean> {
+    if (await this.pullProjectedRemoteDiff(target, scope, diff.onlyRemote, permissionGrantIds, options, shouldContinue)) {
+      return true;
+    }
+
+    return this.pushProjectedLocalDiff(target, diff.onlyLocal, permissionGrantIds, options, shouldContinue);
+  }
+
+  private async pullProjectedRemoteDiff(
+    target: ProjectionReconcileTarget,
+    scope: RecordsProjectionSyncScope,
+    onlyRemote: MessagesSyncDiffEntry[],
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    options?: ProjectionReconcileOptions,
+    shouldContinue?: () => boolean,
+  ): Promise<boolean> {
+    if (options?.direction === 'push' || onlyRemote.length === 0) {
+      return false;
+    }
+
+    const { prefetched, needsFetchCids } = partitionRemoteEntries(SyncEngineLevel.dedupeRemoteEntries(onlyRemote));
+    try {
+      await this.pullMessages({
+        did                : target.did,
+        dwnUrl             : target.dwnUrl,
+        delegateDid        : target.delegateDid,
+        scope              : scope,
+        permissionGrantIds : permissionGrantIds,
+        messageCids        : needsFetchCids,
+        prefetched         : prefetched,
+        shouldContinue     : shouldContinue,
+      });
+    } catch (error) {
+      if (error instanceof SyncPullAbortedError) {
+        return true;
+      }
+      throw error;
+    }
+    return shouldContinue?.() === false;
+  }
+
+  private async pushProjectedLocalDiff(
+    target: ProjectionReconcileTarget,
+    onlyLocal: string[],
+    permissionGrantIds: NonEmptyStringArray | undefined,
+    options?: ProjectionReconcileOptions,
+    shouldContinue?: () => boolean,
+  ): Promise<boolean> {
+    if (options?.direction === 'pull' || onlyLocal.length === 0) {
+      return false;
+    }
+
+    await this.pushMessages({
+      did         : target.did,
+      dwnUrl      : target.dwnUrl,
+      delegateDid : target.delegateDid,
+      permissionGrantIds,
+      messageCids : SyncEngineLevel.dedupeStrings(onlyLocal),
+    });
+    return shouldContinue?.() === false;
+  }
+
   private async pushProtocolSetLocalDiff(
     target: ProjectionReconcileTarget,
     onlyLocal: string[],
@@ -2895,9 +3044,10 @@ export class SyncEngineLevel implements SyncEngine {
     remoteEndpoint: string,
     scope: SyncScope,
   ): Promise<void> {
-    if (scope.kind === 'protocolSet' && scope.protocols.length > 1) {
-      // Batched multi-protocol pulls pass the full scope to pullMessages, so
-      // pull dead letters can be recorded without a single protocol key.
+    if (scope.kind === 'recordsProjection' || (scope.kind === 'protocolSet' && scope.protocols.length > 1)) {
+      // Batched multi-protocol and projected pulls pass the full scope to
+      // pullMessages, so pull dead letters can be recorded without a single
+      // legacy protocol key.
       await this.clearRootConvergenceDeadLetters(tenantDid, remoteEndpoint);
     }
 
@@ -3267,6 +3417,66 @@ export class SyncEngineLevel implements SyncEngine {
     return reply.root ?? '';
   }
 
+  private async getLocalProjectedRoot(
+    did: string,
+    delegateDid: string | undefined,
+    scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]],
+    permissionGrantIds?: string[],
+  ): Promise<string> {
+    if (this.stateIndex) {
+      return RecordsProjection.getRootHex({
+        tenant       : did,
+        messageStore : this.agent.dwn.node.storage.messageStore,
+        scopes,
+      });
+    }
+
+    const response = await this.agent.dwn.processRequest({
+      author        : did,
+      target        : did,
+      messageType   : DwnInterface.MessagesSync,
+      granteeDid    : delegateDid,
+      messageParams : {
+        action                : 'root',
+        projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+        projectionScopes      : [...scopes],
+        permissionGrantIds    : toMessagesPermissionGrantIds(permissionGrantIds),
+      }
+    });
+    const reply = response.reply as MessagesSyncReply;
+    return reply.root ?? '';
+  }
+
+  private async getRemoteProjectedRoot(
+    did: string,
+    dwnUrl: string,
+    delegateDid: string | undefined,
+    scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]],
+    permissionGrantIds?: string[],
+  ): Promise<string> {
+    const syncMessage = await this.agent.dwn.processRequest({
+      store         : false,
+      author        : did,
+      target        : did,
+      messageType   : DwnInterface.MessagesSync,
+      granteeDid    : delegateDid,
+      messageParams : {
+        action                : 'root',
+        projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+        projectionScopes      : [...scopes],
+        permissionGrantIds    : toMessagesPermissionGrantIds(permissionGrantIds),
+      }
+    });
+
+    const reply = await this.agent.rpc.sendDwnRequest({
+      dwnUrl,
+      targetDid : did,
+      message   : syncMessage.message,
+    }) as MessagesSyncReply;
+
+    return reply.root ?? '';
+  }
+
   // ---------------------------------------------------------------------------
   // ---------------------------------------------------------------------------
   // Batched Diff — single round-trip set reconciliation
@@ -3335,6 +3545,59 @@ export class SyncEngineLevel implements SyncEngine {
     };
   }
 
+  private async diffProjectedWithRemote({ did, dwnUrl, delegateDid, scopes, permissionGrantIds }: {
+    did: string;
+    dwnUrl: string;
+    delegateDid?: string;
+    scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]];
+    permissionGrantIds?: string[];
+  }): Promise<{ onlyRemote: MessagesSyncDiffEntry[]; onlyLocal: string[] }> {
+    const localHashes = await this.collectLocalProjectedSubtreeHashes(
+      did,
+      scopes,
+      BATCHED_DIFF_DEPTH,
+      delegateDid,
+      permissionGrantIds,
+    );
+
+    const syncMessage = await this.agent.dwn.processRequest({
+      store         : false,
+      author        : did,
+      target        : did,
+      messageType   : DwnInterface.MessagesSync,
+      granteeDid    : delegateDid,
+      messageParams : {
+        action                : 'diff',
+        projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+        projectionScopes      : [...scopes],
+        hashes                : localHashes,
+        depth                 : BATCHED_DIFF_DEPTH,
+        permissionGrantIds    : toMessagesPermissionGrantIds(permissionGrantIds),
+      }
+    });
+
+    const reply = await this.agent.rpc.sendDwnRequest({
+      dwnUrl,
+      targetDid : did,
+      message   : syncMessage.message,
+    }) as MessagesSyncReply;
+
+    if (reply.status.code !== 200) {
+      throw new Error(`SyncEngineLevel: projected diff failed with ${reply.status.code}: ${reply.status.detail}`);
+    }
+
+    const onlyLocalCids: string[] = [];
+    for (const prefix of reply.onlyLocal ?? []) {
+      const leaves = await this.getLocalProjectedLeaves(did, prefix, delegateDid, scopes, permissionGrantIds);
+      onlyLocalCids.push(...leaves);
+    }
+
+    return {
+      onlyRemote : reply.onlyRemote ?? [],
+      onlyLocal  : onlyLocalCids,
+    };
+  }
+
   /**
    * Walk the local SMT to a given depth and collect non-empty subtree hashes.
    * Returns a `{ prefix: hexHash }` map. Empty subtrees (matching the default
@@ -3389,6 +3652,52 @@ export class SyncEngineLevel implements SyncEngine {
     return result;
   }
 
+  private async collectLocalProjectedSubtreeHashes(
+    did: string,
+    scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]],
+    depth: number,
+    delegateDid?: string,
+    permissionGrantIds?: string[],
+  ): Promise<Record<string, string>> {
+    const result: Record<string, string> = {};
+    const snapshot = this.stateIndex
+      ? await RecordsProjection.createSnapshot({
+        tenant       : did,
+        messageStore : this.agent.dwn.node.storage.messageStore,
+        scopes,
+      })
+      : undefined;
+
+    try {
+      const walk = async (prefix: string, currentDepth: number): Promise<void> => {
+        const bitPath = SyncEngineLevel.parseBitPrefix(prefix);
+        const hexHash = snapshot
+          ? hashToHex(await snapshot.getSubtreeHash(bitPath))
+          : await this.getLocalProjectedSubtreeHash(did, prefix, delegateDid, scopes, permissionGrantIds);
+        const defaultHash = await this.getDefaultHashHex(currentDepth);
+
+        if (hexHash === defaultHash) {
+          return;
+        }
+
+        if (currentDepth >= depth) {
+          result[prefix] = hexHash;
+          return;
+        }
+
+        await Promise.all([
+          walk(prefix + '0', currentDepth + 1),
+          walk(prefix + '1', currentDepth + 1),
+        ]);
+      };
+
+      await walk('', 0);
+      return result;
+    } finally {
+      await snapshot?.close();
+    }
+  }
+
   /**
    * Get the subtree hash at a given bit prefix from the local DWN.
    *
@@ -3424,6 +3733,30 @@ export class SyncEngineLevel implements SyncEngine {
     return reply.hash ?? '';
   }
 
+  private async getLocalProjectedSubtreeHash(
+    did: string,
+    prefix: string,
+    delegateDid: string | undefined,
+    scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]],
+    permissionGrantIds?: string[],
+  ): Promise<string> {
+    const response = await this.agent.dwn.processRequest({
+      author        : did,
+      target        : did,
+      messageType   : DwnInterface.MessagesSync,
+      granteeDid    : delegateDid,
+      messageParams : {
+        action                : 'subtree',
+        prefix,
+        projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+        projectionScopes      : [...scopes],
+        permissionGrantIds    : toMessagesPermissionGrantIds(permissionGrantIds)
+      }
+    });
+    const reply = response.reply as MessagesSyncReply;
+    return reply.hash ?? '';
+  }
+
   /**
    * Get all leaf messageCids under a given prefix from the local DWN.
    *
@@ -3452,6 +3785,39 @@ export class SyncEngineLevel implements SyncEngine {
         prefix,
         protocol,
         permissionGrantIds : toMessagesPermissionGrantIds(permissionGrantIds)
+      }
+    });
+    const reply = response.reply as MessagesSyncReply;
+    return reply.entries ?? [];
+  }
+
+  private async getLocalProjectedLeaves(
+    did: string,
+    prefix: string,
+    delegateDid: string | undefined,
+    scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]],
+    permissionGrantIds?: string[],
+  ): Promise<string[]> {
+    if (this.stateIndex) {
+      return RecordsProjection.getLeaves({
+        tenant       : did,
+        messageStore : this.agent.dwn.node.storage.messageStore,
+        scopes,
+        prefix       : SyncEngineLevel.parseBitPrefix(prefix),
+      });
+    }
+
+    const response = await this.agent.dwn.processRequest({
+      author        : did,
+      target        : did,
+      messageType   : DwnInterface.MessagesSync,
+      granteeDid    : delegateDid,
+      messageParams : {
+        action                : 'leaves',
+        prefix,
+        projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+        projectionScopes      : [...scopes],
+        permissionGrantIds    : toMessagesPermissionGrantIds(permissionGrantIds)
       }
     });
     const reply = response.reply as MessagesSyncReply;
@@ -3865,9 +4231,11 @@ export class SyncEngineLevel implements SyncEngine {
         }
 
         const scope = syncScopeFromProtocols(parsed.protocols);
-        const projectionId = await computeProjectionId(did, scope);
-        const { authorizationEpoch } = await this.buildSyncTargetAuthorization(did, scope, parsed);
-        identityKeys.add(SyncEngineLevel.durableLinkIdentityKey(did, projectionId, authorizationEpoch));
+        const resolutions = await this.buildSyncTargetResolutions(did, scope, parsed);
+        for (const resolution of resolutions) {
+          const projectionId = await computeProjectionId(did, resolution.scope);
+          identityKeys.add(SyncEngineLevel.durableLinkIdentityKey(did, projectionId, resolution.authorizationEpoch));
+        }
       }
       return identityKeys;
     } catch (error: unknown) {
@@ -3932,7 +4300,7 @@ export class SyncEngineLevel implements SyncEngine {
       }
 
       for (const dwnUrl of dwnEndpointUrls) {
-        targets.push(await this.buildSyncTarget(did, dwnUrl, parsed));
+        targets.push(...await this.buildSyncTargetsForEndpoint(did, dwnUrl, parsed));
       }
     }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -19,12 +19,12 @@ import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResu
 import { AgentPermissionsApi } from './permissions-api.js';
 import type { DwnMessageParams } from './types/dwn.js';
 
+import { buildLinkId } from './sync-link-id.js';
 import { DwnInterface } from './types/dwn.js';
 import { evaluateClosure } from './sync-closure-resolver.js';
 import { isRecordsWrite } from './utils.js';
 import { ReplicationLedger } from './sync-replication-ledger.js';
 import { topologicalSort } from './sync-topological-sort.js';
-import { buildLegacyCursorKey, buildLinkId } from './sync-link-id.js';
 import { classifySyncEventScope, classifySyncMessageScope } from './sync-scope-acceptance.js';
 import { computeAuthorizationEpoch, computeProjectionId, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { createClosureContext, invalidateClosureCache, isTerminalClosureFailureCode } from './sync-closure-types.js';
@@ -39,7 +39,7 @@ export type SyncEngineLevelParams = {
 };
 
 /**
- * Maximum bit prefix depth for the per-node tree walk (legacy fallback).
+ * Maximum bit prefix depth for the per-node tree walk fallback.
  * At depth 16, each subtree covers ~1/65536 of the key space.
  */
 const MAX_DIFF_DEPTH = 16;
@@ -761,7 +761,7 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   // ---------------------------------------------------------------------------
-  // Poll-mode sync (legacy)
+  // Poll-mode sync
   // ---------------------------------------------------------------------------
 
   private async startPollSync(intervalMilliseconds: number): Promise<void> {
@@ -1517,15 +1517,13 @@ export class SyncEngineLevel implements SyncEngine {
 
   /**
    * Initialize a single replication link target: create or resume the durable
-   * link, migrate legacy cursors, open pull + push subscriptions, and
-   * transition the link to `'live'`.
+   * link, open pull + push subscriptions, and transition the link to `'live'`.
    */
   private async initializeLinkTarget(target: SyncTarget): Promise<LinkInitializationResult> {
     let link: ReplicationLinkState | undefined;
     try {
       link = await this.getOrCreateReplicationLink(target);
       const linkKey = this.getReplicationLinkKey(target, link);
-      await this.migrateLegacyCursorIfNeeded(target, link);
       this._activeLinks.set(linkKey, link);
       if (link.status === 'terminal_incomplete') {
         return this.createActiveLinkInitializationResult(link);
@@ -1556,25 +1554,6 @@ export class SyncEngineLevel implements SyncEngine {
 
   private getReplicationLinkKey(target: SyncTarget, link: ReplicationLinkState): string {
     return this.buildLinkKey(target.did, target.dwnUrl, link.projectionId, link.authorizationEpoch);
-  }
-
-  private async migrateLegacyCursorIfNeeded(target: SyncTarget, link: ReplicationLinkState): Promise<void> {
-    if (link.pull.contiguousAppliedToken) {
-      return;
-    }
-    if (target.scope.kind === 'recordsProjection') {
-      return;
-    }
-
-    const legacyKey = buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
-    const legacyCursor = await this.getCursor(legacyKey);
-    if (!legacyCursor) {
-      return;
-    }
-
-    ReplicationLedger.resetCheckpoint(link.pull, legacyCursor);
-    await this.ledger.saveLink(link);
-    await this.deleteLegacyCursor(legacyKey);
   }
 
   private async openLinkSubscriptions(target: LinkSyncTarget): Promise<LinkSubscriptionOpenResult> {
@@ -1637,11 +1616,8 @@ export class SyncEngineLevel implements SyncEngine {
     link: ReplicationLinkState | undefined,
     error: any,
   ): Promise<LinkInitializationResult> {
-    const linkKey = link
-      ? this.getReplicationLinkKey(target, link)
-      : buildLegacyCursorKey(target.did, target.dwnUrl, singleProtocolForSyncScope(target.scope));
-
     if (error.isProgressGap && link) {
+      const linkKey = this.getReplicationLinkKey(target, link);
       console.warn(`SyncEngineLevel: ProgressGap detected for ${target.did} -> ${target.dwnUrl}, initiating repair`);
       this.emitEvent({
         type           : 'gap:detected',
@@ -1657,7 +1633,9 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     console.error(`SyncEngineLevel: Failed to open live subscription for ${target.did} -> ${target.dwnUrl}`, error);
-    this.cleanupFailedLinkInitialization(linkKey);
+    if (link) {
+      this.cleanupFailedLinkInitialization(this.getReplicationLinkKey(target, link));
+    }
     if (this.isDidResolutionFailure(error)) {
       throw error;
     }
@@ -1959,8 +1937,7 @@ export class SyncEngineLevel implements SyncEngine {
     dwnUrl: string;
     link?: ReplicationLinkState;
   }): Promise<ProgressToken | undefined> {
-    // Resolve the cursor from the link's durable pull checkpoint. Legacy
-    // syncCursors migration happens during link initialization.
+    // Resolve the cursor from the link's durable pull checkpoint.
     if (!link) {
       return undefined;
     }
@@ -2443,10 +2420,9 @@ export class SyncEngineLevel implements SyncEngine {
       throw new Error(`SyncEngineLevel: Local MessagesSubscribe failed for ${did}: ${reply.status.code} ${reply.status.detail}`);
     }
 
-    const linkKey = target.linkKey ?? buildLegacyCursorKey(did, dwnUrl, protocol);
     const close = async (): Promise<void> => { await reply.subscription!.close(); };
     this._localSubscriptions.push({
-      linkKey,
+      linkKey: target.linkKey,
       did,
       dwnUrl,
       delegateDid,
@@ -3029,7 +3005,7 @@ export class SyncEngineLevel implements SyncEngine {
     if (scope.kind === 'recordsProjection' || (scope.kind === 'protocolSet' && scope.protocols.length > 1)) {
       // Batched multi-protocol and projected pulls pass the full scope to
       // pullMessages, so pull dead letters can be recorded without a single
-      // legacy protocol key.
+      // protocol bucket.
       await this.clearRootConvergenceDeadLetters(tenantDid, remoteEndpoint);
     }
 
@@ -3186,58 +3162,6 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private buildLinkKey(did: string, dwnUrl: string, projectionId: string, authorizationEpoch: string): string {
     return buildLinkId(did, dwnUrl, projectionId, authorizationEpoch);
-  }
-
-  /**
-   * @deprecated Used by poll-mode sync and one-time migration only. Live mode
-   * uses ReplicationLedger checkpoints. Handles migration from old string cursors:
-   * if the stored value is a bare string (pre-ProgressToken format), it is treated
-   * as absent — the sync engine will do a full SMT reconciliation on first startup
-   * after upgrade, which is correct and safe.
-   */
-  private async getCursor(key: string): Promise<ProgressToken | undefined> {
-    const cursors = this._db.sublevel('syncCursors');
-    try {
-      const raw = await cursors.get(key);
-      try {
-        const parsed = JSON.parse(raw);
-        if (parsed && typeof parsed === 'object' &&
-            typeof parsed.streamId === 'string' && parsed.streamId.length > 0 &&
-            typeof parsed.epoch === 'string' && parsed.epoch.length > 0 &&
-            typeof parsed.position === 'string' && parsed.position.length > 0 &&
-            typeof parsed.messageCid === 'string' && parsed.messageCid.length > 0) {
-          return parsed as ProgressToken;
-        }
-      } catch {
-        // Not valid JSON (old string cursor) — fall through to delete.
-      }
-      // Entry exists but is unparseable or has invalid/empty fields. Delete it
-      // so subsequent startups don't re-check it on every launch.
-      await this.deleteLegacyCursor(key);
-      return undefined;
-    } catch (error) {
-      const e = error as { code: string };
-      if (e.code === 'LEVEL_NOT_FOUND') {
-        return undefined;
-      }
-      throw error;
-    }
-  }
-
-
-  /**
-   * Delete a legacy cursor from the old syncCursors sublevel.
-   * Called as part of one-time migration to ReplicationLedger.
-   */
-  private async deleteLegacyCursor(key: string): Promise<void> {
-    const cursors = this._db.sublevel('syncCursors');
-    try {
-      await cursors.del(key);
-    } catch {
-      // Best-effort — ignore LEVEL_NOT_FOUND and transient I/O errors alike.
-      // A failed delete leaves the bad entry for one more re-check on the
-      // next startup, which is harmless.
-    }
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -2879,30 +2879,23 @@ export class SyncEngineLevel implements SyncEngine {
     options?: ProjectionReconcileOptions,
     shouldContinue?: () => boolean,
   ): Promise<boolean> {
-    if (await this.pullProtocolSetRemoteDiff(target, scope, diffPlan.onlyRemote, permissionGrantIds, options, shouldContinue)) {
-      return true;
-    }
-
-    return this.pushProtocolSetLocalDiff(target, diffPlan.onlyLocal, permissionGrantIds, options, shouldContinue);
-  }
-
-  private async pullProtocolSetRemoteDiff(
-    target: ProjectionReconcileTarget,
-    scope: ProtocolSetScope,
-    onlyRemote: MessagesSyncDiffEntry[],
-    permissionGrantIds: NonEmptyStringArray | undefined,
-    options?: ProjectionReconcileOptions,
-    shouldContinue?: () => boolean,
-  ): Promise<boolean> {
-    if (options?.direction === 'push' || onlyRemote.length === 0) {
-      return false;
-    }
-
     // Keep the remote diff combined across protocols so topologicalSort can
     // order composed protocol configs before records that use them. Any future
     // chunking for large protocol sets must preserve this global dependency
     // order instead of reverting to independent per-protocol chunks.
-    return this.pullRemoteDiffEntries(target, scope, onlyRemote, permissionGrantIds, shouldContinue);
+    if (
+      options?.direction !== 'push' &&
+      diffPlan.onlyRemote.length > 0 &&
+      await this.pullRemoteDiffEntries(target, scope, diffPlan.onlyRemote, permissionGrantIds, shouldContinue)
+    ) {
+      return true;
+    }
+
+    if (options?.direction === 'pull' || diffPlan.onlyLocal.length === 0) {
+      return false;
+    }
+
+    return this.pushLocalDiffEntries(target, diffPlan.onlyLocal, permissionGrantIds, shouldContinue);
   }
 
   private async applyProjectedDiff(
@@ -2936,20 +2929,6 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private async pushProjectedLocalDiff(
-    target: ProjectionReconcileTarget,
-    onlyLocal: string[],
-    permissionGrantIds: NonEmptyStringArray | undefined,
-    options?: ProjectionReconcileOptions,
-    shouldContinue?: () => boolean,
-  ): Promise<boolean> {
-    if (options?.direction === 'pull' || onlyLocal.length === 0) {
-      return false;
-    }
-
-    return this.pushLocalDiffEntries(target, onlyLocal, permissionGrantIds, shouldContinue);
-  }
-
-  private async pushProtocolSetLocalDiff(
     target: ProjectionReconcileTarget,
     onlyLocal: string[],
     permissionGrantIds: NonEmptyStringArray | undefined,

--- a/packages/agent/src/sync-link-id.ts
+++ b/packages/agent/src/sync-link-id.ts
@@ -1,4 +1,4 @@
-/** Separator used in compound runtime/legacy cursor keys. */
+/** Separator used in compound replication link identifiers. */
 export const LINK_ID_SEPARATOR = '^';
 
 /** Opaque runtime identifier for a replication link. */
@@ -16,14 +16,4 @@ export function buildLinkId(
   authorizationEpoch: string,
 ): LinkId {
   return `${tenantDid}${LINK_ID_SEPARATOR}${remoteEndpoint}${LINK_ID_SEPARATOR}${projectionId}${LINK_ID_SEPARATOR}${authorizationEpoch}`;
-}
-
-/**
- * Build the legacy cursor key used by the deprecated `syncCursors` sublevel.
- *
- * This remains only for one-time migration from the legacy cursor-key format.
- */
-export function buildLegacyCursorKey(tenantDid: string, remoteEndpoint: string, protocol?: string): string {
-  const base = `${tenantDid}${LINK_ID_SEPARATOR}${remoteEndpoint}`;
-  return protocol ? `${base}${LINK_ID_SEPARATOR}${protocol}` : base;
 }

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -1,11 +1,17 @@
 import type { DwnInterface } from './types/dwn.js';
-import type { GenericMessage, GenericSignaturePayload } from '@enbox/dwn-sdk-js';
-import type { NonEmptyStringArray, SyncAuthorizationGrant } from './types/sync.js';
+import type { GenericMessage, GenericSignaturePayload, MessagesPermissionScope, RecordsProjectionScope } from '@enbox/dwn-sdk-js';
+import type { NonEmptyStringArray, SyncAuthorizationGrant, SyncScope } from './types/sync.js';
 import type { PermissionGrantEntry, PermissionsApi } from './types/permissions.js';
 
 import { Jws, Message, PermissionScopeMatcher } from '@enbox/dwn-sdk-js';
 
-import { lexicographicalCompare } from './types/sync.js';
+import { lexicographicalCompare, syncScopeFromRecordsProjectionScopes } from './types/sync.js';
+
+export type MessagesSyncScopeResolution = {
+  scope: SyncScope;
+  permissionGrants: PermissionGrantEntry[];
+};
+
 /** Returns a sorted, duplicate-free grant ID set, or `undefined` for owner requests. */
 export function toMessagesPermissionGrantIds(permissionGrantIds: string[] | undefined): NonEmptyStringArray | undefined {
   if (permissionGrantIds === undefined || permissionGrantIds.length === 0) {
@@ -34,11 +40,46 @@ export async function getMessagesPermissionGrantsForScope({
   did: string;
   delegateDid?: string;
   protocols?: NonEmptyStringArray;
-  messageType: DwnInterface.MessagesRead | DwnInterface.MessagesSubscribe | DwnInterface.MessagesSync;
+  messageType: DwnInterface;
   permissionsApi: PermissionsApi;
 }): Promise<PermissionGrantEntry[]> {
+  const requestedScope: SyncScope = protocols === undefined
+    ? { kind: 'full' }
+    : { kind: 'protocolSet', protocols };
+  const resolutions = await resolveMessagesSyncScopes({
+    did,
+    delegateDid,
+    requestedScope,
+    messageType,
+    permissionsApi,
+  });
+  return resolutions
+    .flatMap(resolution => resolution.permissionGrants)
+    .sort((a, b) => lexicographicalCompare(a.grant.id, b.grant.id));
+}
+
+/**
+ * Resolves active Messages.Read grants into one or more sync targets.
+ *
+ * Broad protocol coverage remains on legacy full/protocol roots. Exact
+ * protocolPath and contextId grants are grouped into a Records-primary
+ * projection target so a narrow grant never authorizes a broad protocol root.
+ */
+export async function resolveMessagesSyncScopes({
+  did,
+  delegateDid,
+  requestedScope,
+  messageType,
+  permissionsApi,
+}: {
+  did: string;
+  delegateDid?: string;
+  requestedScope: SyncScope;
+  messageType: DwnInterface;
+  permissionsApi: PermissionsApi;
+}): Promise<MessagesSyncScopeResolution[]> {
   if (!delegateDid) {
-    return [];
+    return [{ scope: requestedScope, permissionGrants: [] }];
   }
 
   const now = new Date().toISOString();
@@ -49,16 +90,139 @@ export async function getMessagesPermissionGrantsForScope({
     grantee : delegateDid,
   })).filter(entry => isActiveMessagesGrant(entry, did, delegateDid, now));
 
-  const requestedProtocols = protocols ?? [undefined];
-  for (const protocol of requestedProtocols) {
-    if (!permissionGrants.some(entry => grantMatchesProtocol(entry, protocol))) {
-      throw new Error(`SyncPermissions: No active Messages.Read permission found for ${messageType}: ${protocol ?? 'all protocols'}`);
-    }
+  if (requestedScope.kind === 'full') {
+    return [resolveFullScope(permissionGrants, requestedScope, messageType)];
   }
 
-  return permissionGrants
-    .filter(entry => grantParticipatesInProjection(entry, protocols))
+  if (requestedScope.kind === 'protocolSet') {
+    return resolveProtocolSetScope(permissionGrants, requestedScope, messageType);
+  }
+
+  return [resolveRecordsProjectionScope(permissionGrants, requestedScope, messageType)];
+}
+
+function resolveFullScope(
+  permissionGrants: PermissionGrantEntry[],
+  requestedScope: Extract<SyncScope, { kind: 'full' }>,
+  messageType: DwnInterface,
+): MessagesSyncScopeResolution {
+  const grants = permissionGrants
+    .filter(entry => grantMatchesProtocol(entry, undefined))
     .sort((a, b) => lexicographicalCompare(a.grant.id, b.grant.id));
+  if (grants.length === 0) {
+    throw new Error(`SyncPermissions: No active Messages.Read permission found for ${messageType}: all protocols`);
+  }
+
+  return { scope: requestedScope, permissionGrants: grants };
+}
+
+function resolveProtocolSetScope(
+  permissionGrants: PermissionGrantEntry[],
+  requestedScope: Extract<SyncScope, { kind: 'protocolSet' }>,
+  messageType: DwnInterface,
+): MessagesSyncScopeResolution[] {
+  const broadProtocols: string[] = [];
+  const narrowScopes: RecordsProjectionScope[] = [];
+
+  for (const protocol of requestedScope.protocols) {
+    if (permissionGrants.some(entry => grantMatchesProtocol(entry, protocol))) {
+      broadProtocols.push(protocol);
+      continue;
+    }
+
+    const protocolNarrowScopes = permissionGrants
+      .map(entry => grantProjectionScopeForProtocol(entry, protocol))
+      .filter((scope): scope is RecordsProjectionScope => scope !== undefined);
+    if (protocolNarrowScopes.length === 0) {
+      throw new Error(`SyncPermissions: No active Messages.Read permission found for ${messageType}: ${protocol}`);
+    }
+    narrowScopes.push(...protocolNarrowScopes);
+  }
+
+  return [
+    ...broadProtocolResolution(permissionGrants, broadProtocols),
+    ...recordsProjectionResolution(permissionGrants, narrowScopes, messageType),
+  ];
+}
+
+function resolveRecordsProjectionScope(
+  permissionGrants: PermissionGrantEntry[],
+  requestedScope: Extract<SyncScope, { kind: 'recordsProjection' }>,
+  messageType: DwnInterface,
+): MessagesSyncScopeResolution {
+  const grants = permissionGrants
+    .filter(entry => requestedScope.scopes.some(scope => PermissionScopeMatcher.matches(entry.grant.scope, scope)))
+    .sort((a, b) => lexicographicalCompare(a.grant.id, b.grant.id));
+
+  if (grants.length === 0) {
+    throw new Error(`SyncPermissions: No active Messages.Read permission found for ${messageType}: projected Records scope`);
+  }
+
+  return { scope: requestedScope, permissionGrants: grants };
+}
+
+function broadProtocolResolution(
+  permissionGrants: PermissionGrantEntry[],
+  broadProtocols: string[],
+): MessagesSyncScopeResolution[] {
+  if (broadProtocols.length === 0) {
+    return [];
+  }
+
+  const protocols = [...new Set(broadProtocols)].sort(lexicographicalCompare) as NonEmptyStringArray;
+  const grants = permissionGrants
+    .filter(entry => grantParticipatesInLegacyProtocolSet(entry, protocols))
+    .sort((a, b) => lexicographicalCompare(a.grant.id, b.grant.id));
+
+  return [{
+    scope: {
+      kind: 'protocolSet',
+      protocols,
+    },
+    permissionGrants: grants,
+  }];
+}
+
+function recordsProjectionResolution(
+  permissionGrants: PermissionGrantEntry[],
+  projectionScopes: RecordsProjectionScope[],
+  messageType: DwnInterface,
+): MessagesSyncScopeResolution[] {
+  const [firstScope, ...remainingScopes] = projectionScopes;
+  if (firstScope === undefined) {
+    return [];
+  }
+
+  const requestedScope = syncScopeFromRecordsProjectionScopes([firstScope, ...remainingScopes]);
+  return [resolveRecordsProjectionScope(permissionGrants, requestedScope, messageType)];
+}
+
+function grantProjectionScopeForProtocol(
+  entry: PermissionGrantEntry,
+  protocol: string,
+): RecordsProjectionScope | undefined {
+  const scope = entry.grant.scope;
+  if (!isMessagesReadScope(scope) || scope.protocol !== protocol) {
+    return undefined;
+  }
+  if (scope.protocolPath !== undefined) {
+    return { protocol, protocolPath: scope.protocolPath };
+  }
+  if (scope.contextId !== undefined) {
+    return { protocol, contextId: scope.contextId };
+  }
+}
+
+function isMessagesReadScope(scope: PermissionGrantEntry['grant']['scope']): scope is MessagesPermissionScope {
+  return scope.interface === 'Messages' &&
+    scope.method === 'Read';
+}
+
+function grantParticipatesInLegacyProtocolSet(
+  entry: PermissionGrantEntry,
+  protocols: NonEmptyStringArray,
+): boolean {
+  return protocols.some(protocol => grantMatchesProtocol(entry, protocol));
 }
 
 /** Converts permission grant entries into authorization epoch inputs. */
@@ -100,13 +264,6 @@ function grantMatchesProtocol(
   protocol: string | undefined,
 ): boolean {
   return PermissionScopeMatcher.matches(entry.grant.scope, { protocol });
-}
-
-function grantParticipatesInProjection(
-  entry: PermissionGrantEntry,
-  protocols: NonEmptyStringArray | undefined,
-): boolean {
-  return (protocols ?? [undefined]).some(protocol => grantMatchesProtocol(entry, protocol));
 }
 
 /** Returns sorted grant IDs from permission grant entries. */

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -150,15 +150,22 @@ function resolveRecordsProjectionScope(
   requestedScope: Extract<SyncScope, { kind: 'recordsProjection' }>,
   messageType: DwnInterface,
 ): MessagesSyncScopeResolution {
+  if (!requestedScope.scopes.every(scope => isProjectionScopeCovered(permissionGrants, scope))) {
+    throw new Error(`SyncPermissions: No active Messages.Read permission found for ${messageType}: projected Records scope`);
+  }
+
   const grants = permissionGrants
     .filter(entry => requestedScope.scopes.some(scope => PermissionScopeMatcher.matches(entry.grant.scope, scope)))
     .sort((a, b) => lexicographicalCompare(a.grant.id, b.grant.id));
 
-  if (grants.length === 0) {
-    throw new Error(`SyncPermissions: No active Messages.Read permission found for ${messageType}: projected Records scope`);
-  }
-
   return { scope: requestedScope, permissionGrants: grants };
+}
+
+function isProjectionScopeCovered(
+  permissionGrants: PermissionGrantEntry[],
+  scope: RecordsProjectionScope,
+): boolean {
+  return permissionGrants.some(entry => PermissionScopeMatcher.matches(entry.grant.scope, scope));
 }
 
 function broadProtocolResolution(

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -61,7 +61,7 @@ export async function getMessagesPermissionGrantsForScope({
 /**
  * Resolves active Messages.Read grants into one or more sync targets.
  *
- * Broad protocol coverage remains on legacy full/protocol roots. Exact
+ * Broad protocol coverage remains on StateIndex full/protocol roots. Exact
  * protocolPath and contextId grants are grouped into a Records-primary
  * projection target so a narrow grant never authorizes a broad protocol root.
  */
@@ -178,7 +178,7 @@ function broadProtocolResolution(
 
   const protocols = [...new Set(broadProtocols)].sort(lexicographicalCompare) as NonEmptyStringArray;
   const grants = permissionGrants
-    .filter(entry => grantParticipatesInLegacyProtocolSet(entry, protocols))
+    .filter(entry => grantParticipatesInProtocolSet(entry, protocols))
     .sort((a, b) => lexicographicalCompare(a.grant.id, b.grant.id));
 
   return [{
@@ -225,7 +225,7 @@ function isMessagesReadScope(scope: PermissionGrantEntry['grant']['scope']): sco
     scope.method === 'Read';
 }
 
-function grantParticipatesInLegacyProtocolSet(
+function grantParticipatesInProtocolSet(
   entry: PermissionGrantEntry,
   protocols: NonEmptyStringArray,
 ): boolean {

--- a/packages/agent/src/sync-replication-ledger.ts
+++ b/packages/agent/src/sync-replication-ledger.ts
@@ -75,7 +75,6 @@ export class ReplicationLedger {
     try {
       const raw = await this.sublevel.get(key);
       const link = JSON.parse(raw) as ReplicationLinkState;
-      delete (link as any).push; // strip legacy push field from old persisted links
       // connectivity is runtime state — always reset to 'unknown' on load
       // so stale 'online' from a previous session doesn't give false positives.
       link.connectivity = 'unknown';

--- a/packages/agent/src/sync-scope-acceptance.ts
+++ b/packages/agent/src/sync-scope-acceptance.ts
@@ -1,6 +1,6 @@
-import type { GenericMessage, MessageEvent, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, MessageEvent, ProtocolScope, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 
-import { DwnInterfaceName, DwnMethodName, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName, PermissionScopeMatcher, PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
 import type { SyncScope } from './types/sync.js';
 
@@ -42,6 +42,9 @@ export function classifySyncMessageScope({
   scope,
 }: SyncMessageScopeClassificationParams): SyncScopeClassification {
   if (scope.kind === 'full') { return 'in-scope'; }
+  if (scope.kind === 'recordsProjection') {
+    return classifyRecordsProjectionScope(message, initialWrite, scope);
+  }
 
   const descriptor = message.descriptor as Record<string, unknown>;
   const scopedDescriptor = getScopedMessageDescriptor(message, initialWrite);
@@ -90,6 +93,60 @@ function getScopedMessageDescriptor(
   return descriptor;
 }
 
+function classifyRecordsProjectionScope(
+  message: GenericMessage,
+  initialWrite: RecordsWriteMessage | undefined,
+  scope: Extract<SyncScope, { kind: 'recordsProjection' }>,
+): SyncScopeClassification {
+  const target = getRecordsProjectionTarget(message, initialWrite);
+  if (target === undefined) {
+    return isRecordsDelete(message) ? 'unknown' : 'out-of-scope';
+  }
+
+  return scope.scopes.some(projectionScope => PermissionScopeMatcher.matches(projectionScope, target))
+    ? 'in-scope'
+    : 'out-of-scope';
+}
+
+function getRecordsProjectionTarget(
+  message: GenericMessage,
+  initialWrite: RecordsWriteMessage | undefined,
+): ProtocolScope | undefined {
+  const descriptor = message.descriptor as Record<string, unknown>;
+  if (descriptor.interface !== DwnInterfaceName.Records) {
+    return undefined;
+  }
+
+  if (descriptor.method === DwnMethodName.Write) {
+    return {
+      protocol     : stringField(descriptor.protocol),
+      protocolPath : stringField(descriptor.protocolPath),
+      contextId    : (message as RecordsWriteMessage).contextId,
+    };
+  }
+
+  if (descriptor.method === DwnMethodName.Delete) {
+    if (initialWrite === undefined) {
+      return undefined;
+    }
+    return {
+      protocol     : initialWrite.descriptor.protocol,
+      protocolPath : initialWrite.descriptor.protocolPath,
+      contextId    : initialWrite.contextId,
+    };
+  }
+}
+
+function isRecordsDelete(message: GenericMessage): boolean {
+  const descriptor = message.descriptor as Record<string, unknown>;
+  return descriptor.interface === DwnInterfaceName.Records &&
+    descriptor.method === DwnMethodName.Delete;
+}
+
 function isRecordObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
 }

--- a/packages/agent/src/sync-scope-acceptance.ts
+++ b/packages/agent/src/sync-scope-acceptance.ts
@@ -13,6 +13,9 @@ type SyncMessageScopeClassificationParams = {
   scope: SyncScope;
 };
 
+type ProtocolSetSyncScope = Extract<SyncScope, { kind: 'protocolSet' }>;
+type RecordsProjectionSyncScope = Extract<SyncScope, { kind: 'recordsProjection' }>;
+
 /**
  * Classifies whether a live event belongs to the link's current sync scope.
  *
@@ -46,31 +49,62 @@ export function classifySyncMessageScope({
     return classifyRecordsProjectionScope(message, initialWrite, scope);
   }
 
+  return classifyProtocolSetScope(message, initialWrite, scope);
+}
+
+function classifyProtocolSetScope(
+  message: GenericMessage,
+  initialWrite: RecordsWriteMessage | undefined,
+  scope: ProtocolSetSyncScope,
+): SyncScopeClassification {
   const descriptor = message.descriptor as Record<string, unknown>;
   const scopedDescriptor = getScopedMessageDescriptor(message, initialWrite);
   if (scopedDescriptor === undefined) {
     return 'unknown';
   }
 
-  const protocol = scopedDescriptor.protocol;
-  if (protocol === PermissionsProtocol.uri && isRecordObject(scopedDescriptor.tags)) {
-    const taggedProtocol = scopedDescriptor.tags.protocol;
-    return typeof taggedProtocol === 'string' && scope.protocols.includes(taggedProtocol)
-      ? 'in-scope'
-      : 'out-of-scope';
+  const permissionRecordClassification = classifyTaggedPermissionRecord(scopedDescriptor, scope.protocols);
+  if (permissionRecordClassification !== undefined) { return permissionRecordClassification; }
+
+  const protocolClassification = classifyProtocolField(scopedDescriptor.protocol, scope.protocols);
+  if (protocolClassification !== undefined) { return protocolClassification; }
+
+  return classifyProtocolsConfigureDescriptor(descriptor, scope.protocols);
+}
+
+function classifyTaggedPermissionRecord(
+  descriptor: Record<string, unknown>,
+  protocols: readonly string[],
+): SyncScopeClassification | undefined {
+  if (descriptor.protocol !== PermissionsProtocol.uri || !isRecordObject(descriptor.tags)) {
+    return undefined;
   }
 
-  if (typeof protocol === 'string') {
-    return scope.protocols.includes(protocol) ? 'in-scope' : 'out-of-scope';
+  const taggedProtocol = descriptor.tags.protocol;
+  return typeof taggedProtocol === 'string' && protocols.includes(taggedProtocol)
+    ? 'in-scope'
+    : 'out-of-scope';
+}
+
+function classifyProtocolField(protocol: unknown, protocols: readonly string[]): SyncScopeClassification | undefined {
+  if (typeof protocol !== 'string') {
+    return undefined;
   }
 
+  return protocols.includes(protocol) ? 'in-scope' : 'out-of-scope';
+}
+
+function classifyProtocolsConfigureDescriptor(
+  descriptor: Record<string, unknown>,
+  protocols: readonly string[],
+): SyncScopeClassification {
   if (
     descriptor.interface === DwnInterfaceName.Protocols &&
     descriptor.method === DwnMethodName.Configure &&
     isRecordObject(descriptor.definition)
   ) {
     const definitionProtocol = descriptor.definition.protocol;
-    return typeof definitionProtocol === 'string' && scope.protocols.includes(definitionProtocol)
+    return typeof definitionProtocol === 'string' && protocols.includes(definitionProtocol)
       ? 'in-scope'
       : 'out-of-scope';
   }
@@ -96,7 +130,7 @@ function getScopedMessageDescriptor(
 function classifyRecordsProjectionScope(
   message: GenericMessage,
   initialWrite: RecordsWriteMessage | undefined,
-  scope: Extract<SyncScope, { kind: 'recordsProjection' }>,
+  scope: RecordsProjectionSyncScope,
 ): SyncScopeClassification {
   const target = getRecordsProjectionTarget(message, initialWrite);
   if (target === undefined) {

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -47,7 +47,7 @@ export type SyncMode = 'poll' | 'live';
 // ---------------------------------------------------------------------------
 
 /**
- * Projection-root algorithm used by the legacy full/protocol sync scopes.
+ * Projection-root algorithm used by StateIndex full/protocol sync scopes.
  *
  * Sync compares either the existing full-tenant StateIndex root or existing
  * per-protocol StateIndex roots. Records-primary projection scopes use the
@@ -153,7 +153,7 @@ export function protocolsForSyncScope(scope: SyncScope): NonEmptyStringArray | u
   return normalizeSyncProtocols(scope.scopes.map(scope => scope.protocol));
 }
 
-/** Returns the single legacy protocol root covered by a scope, if any. */
+/** Returns the single protocol root covered by a protocol-set scope, if any. */
 export function singleProtocolForSyncScope(scope: SyncScope): string | undefined {
   return scope.kind === 'protocolSet' && scope.protocols.length === 1 ? scope.protocols[0] : undefined;
 }
@@ -382,7 +382,7 @@ export type StartSyncParams = {
    *   push. Falls back to SMT reconciliation on cold start or long disconnect.
    *   An infrequent SMT integrity check still runs at `interval`.
    *
-   * - `'poll'`: Legacy mode. Performs a full SMT set-reconciliation sync on a
+   * - `'poll'`: Performs a full SMT set-reconciliation sync on a
    *   fixed interval. No WebSocket subscriptions are used.
    */
   mode?: SyncMode;

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -1,6 +1,8 @@
-import type { ProgressToken } from '@enbox/dwn-sdk-js';
+import type { NormalizedRecordsProjectionScope, ProgressToken, RecordsProjectionScope } from '@enbox/dwn-sdk-js';
 
 import type { EnboxPlatformAgent } from './agent.js';
+
+import { RECORDS_PROJECTION_ROOT_VERSION, RecordsProjection } from '@enbox/dwn-sdk-js';
 
 /** Deterministic bytewise string comparator for hash inputs and canonical IDs. */
 export function lexicographicalCompare(a: string, b: string): number {
@@ -45,12 +47,11 @@ export type SyncMode = 'poll' | 'live';
 // ---------------------------------------------------------------------------
 
 /**
- * Projection-root algorithm used by the current full/protocol sync scopes.
+ * Projection-root algorithm used by the legacy full/protocol sync scopes.
  *
  * Sync compares either the existing full-tenant StateIndex root or existing
- * per-protocol StateIndex roots. ProtocolPath/contextId projection roots are
- * intentionally not represented here; add a projection-root builder before
- * enabling those scopes.
+ * per-protocol StateIndex roots. Records-primary projection scopes use the
+ * DWN SDK's `RECORDS_PROJECTION_ROOT_VERSION` instead.
  */
 export const SYNC_PROJECTION_ROOT_VERSION = 'state-index-full-protocol-root-v1';
 
@@ -66,15 +67,18 @@ export const SYNC_AUTHORIZATION_EPOCH_VERSION = 'messages-read-grants-v1';
 /** A non-empty, sorted, duplicate-free string list. */
 export type NonEmptyStringArray = [string, ...string[]];
 
+/** A non-empty, sorted, duplicate-free, subsumption-reduced Records projection scope union. */
+export type NonEmptyRecordsProjectionScopes = [NormalizedRecordsProjectionScope, ...NormalizedRecordsProjectionScope[]];
+
 /**
  * Describes the primary CID set a replication link syncs.
  *
- * Sync currently supports full-tenant sync and protocol-set sync. A protocol-set link owns
- * one durable subscription/cursor for the whole set; reconciliation still walks
- * the existing per-protocol roots until dedicated path/context projection roots
- * are implemented. For composed protocols, the scope must include the composed
- * protocol and any `uses` targets required for local protocol installation and
- * closure evaluation.
+ * Full and protocol-set sync use the existing StateIndex roots. Records
+ * projections use the `records-primary-scope-root-v1` root over latest Records
+ * primary messages selected by protocol, exact protocolPath, or context
+ * subtree. For composed protocols, the scope must include the composed protocol
+ * and any `uses` targets required for local protocol installation and closure
+ * evaluation.
  */
 export type SyncScope = {
   /** Full-tenant projection. Valid only for owner sync or unscoped delegated grants. */
@@ -83,6 +87,10 @@ export type SyncScope = {
   /** Protocol-set projection over one or more protocol roots. */
   kind: 'protocolSet';
   protocols: NonEmptyStringArray;
+} | {
+  /** Records-primary projected root over protocol/path/context scope entries. */
+  kind: 'recordsProjection';
+  scopes: NonEmptyRecordsProjectionScopes;
 };
 
 /**
@@ -122,12 +130,30 @@ export function syncScopeFromProtocols(protocols: SyncIdentityOptions['protocols
     : { kind: 'protocolSet', protocols: normalizeSyncProtocols(protocols) };
 }
 
-/** Returns the protocol list covered by a scope, or `undefined` for full scope. */
-export function protocolsForSyncScope(scope: SyncScope): NonEmptyStringArray | undefined {
-  return scope.kind === 'protocolSet' ? scope.protocols : undefined;
+/** Converts Records projection scopes into the canonical sync scope shape. */
+export function syncScopeFromRecordsProjectionScopes(
+  scopes: readonly [RecordsProjectionScope, ...RecordsProjectionScope[]],
+): Extract<SyncScope, { kind: 'recordsProjection' }> {
+  return {
+    kind   : 'recordsProjection',
+    scopes : RecordsProjection.normalizeScopes(scopes),
+  };
 }
 
-/** Returns the single covered protocol, or `undefined` for full/multi-protocol scopes. */
+/** Returns the protocol list covered by a scope, or `undefined` for full scope. */
+export function protocolsForSyncScope(scope: SyncScope): NonEmptyStringArray | undefined {
+  if (scope.kind === 'full') {
+    return undefined;
+  }
+
+  if (scope.kind === 'protocolSet') {
+    return scope.protocols;
+  }
+
+  return normalizeSyncProtocols(scope.scopes.map(scope => scope.protocol));
+}
+
+/** Returns the single legacy protocol root covered by a scope, if any. */
 export function singleProtocolForSyncScope(scope: SyncScope): string | undefined {
   return scope.kind === 'protocolSet' && scope.protocols.length === 1 ? scope.protocols[0] : undefined;
 }
@@ -151,9 +177,18 @@ async function hashCanonicalObject(value: Record<string, unknown>): Promise<stri
 
 /** Returns a canonical JSON-ready representation of a sync scope. */
 export function canonicalizeSyncScope(scope: SyncScope): SyncScope {
-  return scope.kind === 'full'
-    ? { kind: 'full' }
-    : { kind: 'protocolSet', protocols: normalizeSyncProtocols(scope.protocols) };
+  if (scope.kind === 'full') {
+    return { kind: 'full' };
+  }
+
+  if (scope.kind === 'protocolSet') {
+    return { kind: 'protocolSet', protocols: normalizeSyncProtocols(scope.protocols) };
+  }
+
+  return {
+    kind   : 'recordsProjection',
+    scopes : RecordsProjection.normalizeScopes(scope.scopes),
+  };
 }
 
 /**
@@ -165,10 +200,14 @@ export function canonicalizeSyncScope(scope: SyncScope): SyncScope {
  */
 export async function computeProjectionId(tenantDid: string, scope: SyncScope): Promise<string> {
   const canonicalScope = canonicalizeSyncScope(scope);
+  const version = canonicalScope.kind === 'recordsProjection'
+    ? RECORDS_PROJECTION_ROOT_VERSION
+    : SYNC_PROJECTION_ROOT_VERSION;
+
   return hashCanonicalObject({
-    scope   : canonicalScope,
+    scope: canonicalScope,
     tenantDid,
-    version : SYNC_PROJECTION_ROOT_VERSION,
+    version,
   });
 }
 
@@ -251,12 +290,13 @@ export type DirectionCheckpoint = {
  *
  * - `initializing` — link created, no subscriptions open yet.
  * - `live` — actively receiving events via subscription.
+ * - `polling` — current link is reconciled by periodic SMT sync; live subscription is not supported for its scope.
  * - `repairing` — gap detected or pending overflow; running SMT reconciliation.
  * - `degraded_poll` — subscription failed; polling at reduced frequency.
  * - `terminal_incomplete` — closure failed with a terminal dependency error; requires a new scope/authorization epoch.
  * - `paused` — explicitly paused by the application.
  */
-export type LinkStatus = 'initializing' | 'live' | 'repairing' | 'degraded_poll' | 'terminal_incomplete' | 'paused';
+export type LinkStatus = 'initializing' | 'live' | 'polling' | 'repairing' | 'degraded_poll' | 'terminal_incomplete' | 'paused';
 
 /**
  * Durable state of a single replication link. Persisted to LevelDB and

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -1129,6 +1129,89 @@ describe('evaluateClosure', () => {
       expect(result.failure!.code).toBe(ClosureFailureCode.DependencyForbidden);
       expect(result.failure!.edge.label).toBe('contextKeyRecord');
     });
+
+    it('should gate contextKey records by projected context scope, not bare protocol', async () => {
+      const protocolDef = {
+        protocol  : 'https://example.com/chat',
+        published : true,
+        types     : {
+          thread  : {},
+          message : { encryptionRequired: true },
+        },
+        structure: {
+          thread: {
+            participant: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['read'] }],
+            },
+            message: {
+              $encryption : { rootKeyId: 'key-1', publicKeyJwk: {} },
+              $actions    : [{ role: 'thread/participant', can: ['create', 'read'] }],
+            },
+          },
+        },
+      };
+      const protocolConfig = {
+        descriptor: { interface: 'Protocols', method: 'Configure', definition: protocolDef },
+      } as any;
+      const keyDeliveryConfig = mockMessage({ interface: 'Protocols', method: 'Configure' });
+      const contextKeyRecord = mockMessage({
+        interface    : 'Records',
+        method       : 'Write',
+        protocol     : 'https://identity.foundation/protocols/key-delivery',
+        protocolPath : 'contextKey',
+        tags         : {
+          protocol  : 'https://example.com/chat',
+          contextId : 'thread-1',
+        },
+      });
+      const msg = mockMessage({
+        protocol     : 'https://example.com/chat',
+        protocolPath : 'thread/message',
+        dateCreated  : '2025-01-01T00:00:00.000000Z',
+      });
+      (msg as any).recordId = 'thread-1';
+      (msg as any).contextId = 'thread-1';
+
+      const store = mockMessageStore();
+      (store.query as any).callsFake(async (_tenant: string, filters: any[]): Promise<{ messages: GenericMessage[] }> => {
+        const filter = filters[0] ?? {};
+        if (filter.interface === 'Protocols' && filter.protocol === 'https://example.com/chat') {
+          return { messages: [protocolConfig] };
+        }
+        if (filter.interface === 'Protocols' && filter.protocol === 'https://identity.foundation/protocols/key-delivery') {
+          return { messages: [keyDeliveryConfig] };
+        }
+        if (filter['tag.protocol'] && filter['tag.contextId']) {
+          return { messages: [contextKeyRecord] };
+        }
+        return { messages: [] };
+      });
+
+      const contextScopedResult = await evaluateClosure(
+        msg,
+        store,
+        {
+          kind   : 'recordsProjection',
+          scopes : [{ protocol: 'https://example.com/chat', contextId: 'thread-1' }],
+        },
+        createClosureContext('did:example:alice'),
+      );
+      expect(contextScopedResult.complete).toBe(true);
+
+      const pathScopedResult = await evaluateClosure(
+        msg,
+        store,
+        {
+          kind   : 'recordsProjection',
+          scopes : [{ protocol: 'https://example.com/chat', protocolPath: 'thread/message' }],
+        },
+        createClosureContext('did:example:alice'),
+      );
+      expect(pathScopedResult.complete).toBe(false);
+      expect(pathScopedResult.failure!.code).toBe(ClosureFailureCode.DependencyForbidden);
+      expect(pathScopedResult.failure!.edge.label).toBe('contextKeyRecord');
+    });
   });
 
   describe('Class 5 — delegate session encryption closure', () => {

--- a/packages/agent/tests/sync-engine-identity.spec.ts
+++ b/packages/agent/tests/sync-engine-identity.spec.ts
@@ -775,7 +775,6 @@ describe('SyncEngineLevel — identity management', () => {
       }));
       sinon.stub(engine as any, 'openLivePullSubscription').resolves();
       sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       await (engine as any).addIdentityToLiveSync('did:example:proto', {
         protocols: ['https://proto1.example', 'https://proto2.example'],
@@ -815,7 +814,6 @@ describe('SyncEngineLevel — identity management', () => {
       }));
       sinon.stub(engine as any, 'openLivePullSubscription').resolves();
       sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       await (engine as any).addIdentityToLiveSync('did:example:full', { protocols: 'all' });
 
@@ -846,7 +844,6 @@ describe('SyncEngineLevel — identity management', () => {
         saveLink  : sinon.stub().resolves(),
         setStatus : sinon.stub().resolves(),
       }));
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       const pullCloseSpy = sinon.stub().resolves();
       sinon.stub(engine as any, 'openLivePullSubscription').callsFake(async (target: any) => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -133,86 +133,6 @@ describe('SyncEngineLevel — private methods', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // getCursor (legacy migration helper)
-  // ---------------------------------------------------------------------------
-
-  describe('cursor persistence', () => {
-    it('should return undefined when cursor does not exist', async () => {
-      const cursor = await (syncEngine as any).getCursor('nonexistent-key');
-      expect(cursor).toBeUndefined();
-    });
-
-    it('should return undefined and delete legacy string cursors', async () => {
-      // Simulate an old-format string cursor stored before the ProgressToken migration.
-      const cursors = db.sublevel('syncCursors');
-      await cursors.put('legacy-key', 'old-string-cursor-42');
-      const cursor = await (syncEngine as any).getCursor('legacy-key');
-      expect(cursor).toBeUndefined();
-      // The invalid entry should have been deleted so it is not re-checked on
-      // every subsequent startup.
-      await expect(cursors.get('legacy-key')).rejects.toMatchObject({ code: 'LEVEL_NOT_FOUND' });
-    });
-
-    it('should return undefined and delete tokens with empty messageCid', async () => {
-      // A corrupted token with empty messageCid should be discarded and deleted —
-      // it would fail MessagesSubscribe JSON schema validation (minLength: 1).
-      const cursors = db.sublevel('syncCursors');
-      await cursors.put('bad-cid-key', JSON.stringify({
-        streamId: 's1', epoch: 'e1', position: '5', messageCid: '',
-      }));
-      const cursor = await (syncEngine as any).getCursor('bad-cid-key');
-      expect(cursor).toBeUndefined();
-      await expect(cursors.get('bad-cid-key')).rejects.toMatchObject({ code: 'LEVEL_NOT_FOUND' });
-    });
-
-    it('should return undefined and delete tokens with empty streamId', async () => {
-      const cursors = db.sublevel('syncCursors');
-      await cursors.put('bad-stream-key', JSON.stringify({
-        streamId: '', epoch: 'e1', position: '5', messageCid: 'cid-5',
-      }));
-      const cursor = await (syncEngine as any).getCursor('bad-stream-key');
-      expect(cursor).toBeUndefined();
-      await expect(cursors.get('bad-stream-key')).rejects.toMatchObject({ code: 'LEVEL_NOT_FOUND' });
-    });
-
-    it('should rethrow non-LEVEL_NOT_FOUND errors from getCursor', async () => {
-      const ioError = new Error('IO error') as Error & { code: string };
-      ioError.code = 'LEVEL_IO_ERROR';
-      const cursors = db.sublevel('syncCursors');
-      sinon.stub(cursors, 'get').rejects(ioError);
-      sinon.stub(db, 'sublevel').returns(cursors as any);
-
-      await expect((syncEngine as any).getCursor('key')).rejects.toThrow();
-    });
-
-    it('should not migrate legacy cursors into projected links', async () => {
-      const engine = createEngine({ db });
-      const getCursorStub = sinon.stub(engine as any, 'getCursor').resolves({
-        streamId   : 'stream',
-        epoch      : 'epoch',
-        position   : '1',
-        messageCid : 'cid',
-      });
-      const link = {
-        pull: {},
-      };
-
-      await (engine as any).migrateLegacyCursorIfNeeded(syncTarget('did:example:alice', 'https://dwn.example.com', {
-        scope: {
-          kind   : 'recordsProjection',
-          scopes : [{
-            protocol     : 'https://example.com/profile',
-            protocolPath : 'profile/avatar',
-          }],
-        },
-      }), link);
-
-      expect(getCursorStub.called).toBe(false);
-      expect(link.pull).toEqual({});
-    });
-  });
-
-  // ---------------------------------------------------------------------------
   // extractDataStream
   // ---------------------------------------------------------------------------
 
@@ -801,8 +721,8 @@ describe('SyncEngineLevel — private methods', () => {
       sinon.stub(engine as any, 'getSyncTargets').resolves([
         syncTarget('did:example:1', 'https://dwn.example.com', { scope: projectedScope }),
       ]);
-      const legacyLocalRoot = sinon.stub(engine as any, 'getLocalRoot').resolves('legacy-local');
-      const legacyRemoteRoot = sinon.stub(engine as any, 'getRemoteRoot').resolves('legacy-remote');
+      const stateIndexLocalRoot = sinon.stub(engine as any, 'getLocalRoot').resolves('state-index-local');
+      const stateIndexRemoteRoot = sinon.stub(engine as any, 'getRemoteRoot').resolves('state-index-remote');
       sinon.stub(engine as any, 'getLocalProjectedRoot').resolves('aabbcc');
       sinon.stub(engine as any, 'getRemoteProjectedRoot').resolves('ddeeff');
       sinon.stub(engine as any, 'diffProjectedWithRemote').resolves({
@@ -814,8 +734,8 @@ describe('SyncEngineLevel — private methods', () => {
 
       await engine.sync();
 
-      expect(legacyLocalRoot.called).toBe(false);
-      expect(legacyRemoteRoot.called).toBe(false);
+      expect(stateIndexLocalRoot.called).toBe(false);
+      expect(stateIndexRemoteRoot.called).toBe(false);
       expect(pullStub.firstCall.args[0].scope).toEqual(projectedScope);
       expect(pushStub.firstCall.args[0].messageCids).toEqual(['cid-local-1']);
     });
@@ -1241,7 +1161,6 @@ describe('SyncEngineLevel — private methods', () => {
 
       sinon.stub(engine as any, 'getOrCreateReplicationLink').resolves(link);
       sinon.stub(engine as any, 'getReplicationLinkKey').returns(linkKey);
-      sinon.stub(engine as any, 'migrateLegacyCursorIfNeeded').resolves();
       sinon.stub(engine as any, 'openLivePullSubscription').callsFake(async (): Promise<void> => {
         (engine as any)._liveSubscriptions.push({ linkKey, did: link.tenantDid, dwnUrl: link.remoteEndpoint, close: closePull });
         link.status = 'repairing';
@@ -1283,7 +1202,6 @@ describe('SyncEngineLevel — private methods', () => {
 
       sinon.stub(engine as any, 'getOrCreateReplicationLink').resolves(link);
       sinon.stub(engine as any, 'getReplicationLinkKey').returns(linkKey);
-      sinon.stub(engine as any, 'migrateLegacyCursorIfNeeded').resolves();
       const openLivePullStub = sinon.stub(engine as any, 'openLivePullSubscription').rejects(new Error('unexpected live pull'));
       const openLocalPushStub = sinon.stub(engine as any, 'openLocalPushSubscription').rejects(new Error('unexpected local push'));
 
@@ -1371,7 +1289,6 @@ describe('SyncEngineLevel — private methods', () => {
     it('should open a subscription and add it to _liveSubscriptions', async () => {
       const { agent, rpcStub } = createPullMockAgent();
       const engine = createEngine({ db, agent });
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       await (engine as any).openLivePullSubscription(fullPullTarget());
 
@@ -1387,7 +1304,6 @@ describe('SyncEngineLevel — private methods', () => {
         subscription : undefined,
       });
       const engine = createEngine({ db, agent });
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       await expect(
         (engine as any).openLivePullSubscription(fullPullTarget())
@@ -1399,7 +1315,6 @@ describe('SyncEngineLevel — private methods', () => {
     it('should include one subscription filter per protocol in a protocol-set scope', async () => {
       const { agent, processRequestStub } = createPullMockAgent();
       const engine = createEngine({ db, agent });
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       await (engine as any).openLivePullSubscription(fullPullTarget({
         scope: {
@@ -1419,7 +1334,6 @@ describe('SyncEngineLevel — private methods', () => {
     it('should include delegate grant IDs when provided by the sync target', async () => {
       const { agent, processRequestStub } = createPullMockAgent();
       const engine = createEngine({ db, agent });
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       await (engine as any).openLivePullSubscription(fullPullTarget({
         delegateDid   : 'did:example:delegate',
@@ -1442,7 +1356,7 @@ describe('SyncEngineLevel — private methods', () => {
       const engine = createEngine({ db, agent });
       const savedCursor = { streamId: 's1', epoch: 'e1', position: '42', messageCid: 'cid-42' };
 
-      // Set cursor on the link's pull checkpoint (not legacy getCursor).
+      // Set cursor on the link's durable pull checkpoint.
       const linkKey = 'did:example:alice^https://dwn.example.com^projection-test^authorization-test';
       const link = {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
@@ -3752,7 +3666,6 @@ describe('SyncEngineLevel — private methods', () => {
         rpc      : { sendDwnRequest: rpcStub },
       } as any;
       const engine = createEngine({ db, agent });
-      sinon.stub(engine as any, 'getCursor').resolves(undefined);
 
       try {
         await (engine as any).openLivePullSubscription(syncTarget('did:example:alice', 'https://dwn.example.com', {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import { Level } from 'level';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
-import { Message, RecordsWrite, TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { Message, RECORDS_PROJECTION_ROOT_VERSION, RecordsProjection, RecordsWrite, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
 import { ClosureFailureCode } from '../src/sync-closure-types.js';
 import { computeAuthorizationEpoch } from '../src/types/sync.js';
@@ -443,6 +443,37 @@ describe('SyncEngineLevel — private methods', () => {
         }],
       });
       expect(result[0].permissionGrants.map(entry => entry.grant.id)).toEqual(['grant-profile-path']);
+    });
+
+    it('should resolve contextId grants to a Records projection scope', async () => {
+      const permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          grantEntry('grant-profile-context', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : 'https://example.com/profile',
+            contextId : 'bafyroot/bafyprofile',
+          }),
+        ]),
+      };
+
+      const result = await resolveMessagesSyncScopes({
+        did            : 'did:example:alice',
+        delegateDid    : 'did:example:delegate',
+        requestedScope : { kind: 'protocolSet', protocols: ['https://example.com/profile'] },
+        messageType    : DwnInterface.MessagesSync,
+        permissionsApi : permissionsApi as any,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].scope).toEqual({
+        kind   : 'recordsProjection',
+        scopes : [{
+          protocol  : 'https://example.com/profile',
+          contextId : 'bafyroot/bafyprofile',
+        }],
+      });
+      expect(result[0].permissionGrants.map(entry => entry.grant.id)).toEqual(['grant-profile-context']);
     });
 
     it('should reject projected scope unions when any member lacks grant coverage', async () => {
@@ -1760,6 +1791,101 @@ describe('SyncEngineLevel — private methods', () => {
       const root = await (engine as any).getRemoteRoot('did:example:alice', 'https://dwn.example.com');
       expect(root).toBe('remotehash');
     });
+
+    it('getLocalProjectedRoot should request a local projected root when StateIndex is unavailable', async () => {
+      const scopes = [{ protocol: 'https://example.com/profile', protocolPath: 'profile/avatar' }];
+      const processRequest = sinon.stub().resolves({
+        reply: { status: { code: 200 }, root: 'local-projected-root' },
+      });
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : { isRemoteMode: true, processRequest },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+
+      const root = await (engine as any).getLocalProjectedRoot(
+        'did:example:alice',
+        'did:example:delegate',
+        scopes,
+        ['grant-1'],
+      );
+
+      expect(root).toBe('local-projected-root');
+      expect(processRequest.firstCall.args[0]).toMatchObject({
+        author        : 'did:example:alice',
+        target        : 'did:example:alice',
+        granteeDid    : 'did:example:delegate',
+        messageParams : {
+          action                : 'root',
+          projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+          projectionScopes      : scopes,
+          permissionGrantIds    : ['grant-1'],
+        },
+      });
+    });
+
+    it('getLocalProjectedRoot should use RecordsProjection directly when StateIndex is available', async () => {
+      const scopes = [{ protocol: 'https://example.com/profile', contextId: 'bafyroot' }];
+      const messageStore = {};
+      const getRootStub = sinon.stub(RecordsProjection, 'getRootHex').resolves('indexed-projected-root');
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : { node: { storage: { messageStore, stateIndex: {} } } },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+
+      const root = await (engine as any).getLocalProjectedRoot(
+        'did:example:alice',
+        undefined,
+        scopes,
+      );
+
+      expect(root).toBe('indexed-projected-root');
+      expect(getRootStub.firstCall.args[0]).toEqual({
+        tenant: 'did:example:alice',
+        messageStore,
+        scopes,
+      });
+    });
+
+    it('getRemoteProjectedRoot should send a projected root request to the remote DWN', async () => {
+      const scopes = [{ protocol: 'https://example.com/profile', protocolPath: 'profile/avatar' }];
+      const syncMessage = { descriptor: { action: 'root' } };
+      const processRequest = sinon.stub().resolves({ message: syncMessage });
+      const sendDwnRequest = sinon.stub().resolves({ status: { code: 200 }, root: 'remote-projected-root' });
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : { processRequest },
+        rpc      : { sendDwnRequest },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+
+      const root = await (engine as any).getRemoteProjectedRoot(
+        'did:example:alice',
+        'https://dwn.example.com',
+        'did:example:delegate',
+        scopes,
+        ['grant-1'],
+      );
+
+      expect(root).toBe('remote-projected-root');
+      expect(processRequest.firstCall.args[0]).toMatchObject({
+        store         : false,
+        author        : 'did:example:alice',
+        target        : 'did:example:alice',
+        messageParams : {
+          action                : 'root',
+          projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+          projectionScopes      : scopes,
+          permissionGrantIds    : ['grant-1'],
+        },
+      });
+      expect(sendDwnRequest.firstCall.args[0]).toEqual({
+        dwnUrl    : 'https://dwn.example.com',
+        targetDid : 'did:example:alice',
+        message   : syncMessage,
+      });
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -1832,6 +1958,157 @@ describe('SyncEngineLevel — private methods', () => {
 
       const leaves = await (engine as any).getLocalLeaves('did:example:alice', '01');
       expect(leaves).toEqual([]);
+    });
+
+    it('getLocalProjectedSubtreeHash should request a local projected subtree hash', async () => {
+      const scopes = [{ protocol: 'https://example.com/profile', protocolPath: 'profile/avatar' }];
+      const processRequest = sinon.stub().resolves({
+        reply: { status: { code: 200 }, hash: 'projected-subtree-hash' },
+      });
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : { isRemoteMode: true, processRequest },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+
+      const hash = await (engine as any).getLocalProjectedSubtreeHash(
+        'did:example:alice',
+        '01',
+        'did:example:delegate',
+        scopes,
+        ['grant-1'],
+      );
+
+      expect(hash).toBe('projected-subtree-hash');
+      expect(processRequest.firstCall.args[0]).toMatchObject({
+        author        : 'did:example:alice',
+        target        : 'did:example:alice',
+        granteeDid    : 'did:example:delegate',
+        messageParams : {
+          action                : 'subtree',
+          prefix                : '01',
+          projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+          projectionScopes      : scopes,
+          permissionGrantIds    : ['grant-1'],
+        },
+      });
+    });
+
+    it('getLocalProjectedLeaves should request local projected leaves when StateIndex is unavailable', async () => {
+      const scopes = [{ protocol: 'https://example.com/profile', protocolPath: 'profile/avatar' }];
+      const processRequest = sinon.stub().resolves({
+        reply: { status: { code: 200 }, entries: ['cid-a', 'cid-b'] },
+      });
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : { isRemoteMode: true, processRequest },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+
+      const leaves = await (engine as any).getLocalProjectedLeaves(
+        'did:example:alice',
+        '01',
+        'did:example:delegate',
+        scopes,
+        ['grant-1'],
+      );
+
+      expect(leaves).toEqual(['cid-a', 'cid-b']);
+      expect(processRequest.firstCall.args[0]).toMatchObject({
+        messageParams: {
+          action                : 'leaves',
+          prefix                : '01',
+          projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+          projectionScopes      : scopes,
+          permissionGrantIds    : ['grant-1'],
+        },
+      });
+    });
+
+    it('getLocalProjectedLeaves should use RecordsProjection directly when StateIndex is available', async () => {
+      const scopes = [{ protocol: 'https://example.com/profile', contextId: 'bafyroot' }];
+      const messageStore = {};
+      const getLeavesStub = sinon.stub(RecordsProjection, 'getLeaves').resolves(['cid-projected']);
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : { node: { storage: { messageStore, stateIndex: {} } } },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+
+      const leaves = await (engine as any).getLocalProjectedLeaves(
+        'did:example:alice',
+        '01',
+        undefined,
+        scopes,
+      );
+
+      expect(leaves).toEqual(['cid-projected']);
+      expect(getLeavesStub.firstCall.args[0]).toEqual({
+        tenant : 'did:example:alice',
+        messageStore,
+        scopes,
+        prefix : [false, true],
+      });
+    });
+
+    it('collectLocalProjectedSubtreeHashes should prune empty projected subtrees by current depth', async () => {
+      const scopes = [{ protocol: 'https://example.com/profile', protocolPath: 'profile/avatar' }];
+      const engine = createEngine({ db, agent: { agentDid: 'did:example:agent', dwn: { isRemoteMode: true } } as any });
+      const getSubtreeHashStub = sinon.stub(engine as any, 'getLocalProjectedSubtreeHash')
+        .callsFake(async (_did: string, prefix: string): Promise<string> => {
+          if (prefix === '') { return 'root-hash'; }
+          if (prefix === '0') { return 'left-hash'; }
+          return 'default-depth-1';
+        });
+      sinon.stub(engine as any, 'getDefaultHashHex')
+        .callsFake(async (depth: number): Promise<string> => `default-depth-${depth}`);
+
+      const hashes = await (engine as any).collectLocalProjectedSubtreeHashes(
+        'did:example:alice',
+        scopes,
+        1,
+        'did:example:delegate',
+        ['grant-1'],
+      );
+
+      expect(hashes).toEqual({ '0': 'left-hash' });
+      expect(getSubtreeHashStub.getCalls().map(call => call.args[1]).sort()).toEqual(['', '0', '1']);
+    });
+
+    it('collectLocalProjectedSubtreeHashes should close StateIndex projection snapshots', async () => {
+      const scopes = [{ protocol: 'https://example.com/profile', protocolPath: 'profile/avatar' }];
+      const messageStore = {};
+      const nonEmptyHash = new Uint8Array(32);
+      nonEmptyHash[0] = 0x01;
+      const emptyHash = new Uint8Array(32);
+      const snapshot = {
+        close          : sinon.stub().resolves(),
+        getSubtreeHash : sinon.stub().callsFake(async (prefix: boolean[]): Promise<Uint8Array> => {
+          return prefix.length === 1 && prefix[0] === true ? emptyHash : nonEmptyHash;
+        }),
+      };
+      const createSnapshotStub = sinon.stub(RecordsProjection, 'createSnapshot').resolves(snapshot as any);
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : { node: { storage: { messageStore, stateIndex: {} } } },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      sinon.stub(engine as any, 'getDefaultHashHex')
+        .callsFake(async (depth: number): Promise<string> => depth === 1 ? '00'.repeat(32) : 'default-root');
+
+      const hashes = await (engine as any).collectLocalProjectedSubtreeHashes(
+        'did:example:alice',
+        scopes,
+        1,
+      );
+
+      expect(hashes).toEqual({ '0': `01${'00'.repeat(31)}` });
+      expect(createSnapshotStub.firstCall.args[0]).toEqual({
+        tenant: 'did:example:alice',
+        messageStore,
+        scopes,
+      });
+      expect(snapshot.close.calledOnce).toBe(true);
     });
 
   });
@@ -2647,6 +2924,223 @@ describe('SyncEngineLevel — private methods', () => {
   // ---------------------------------------------------------------------------
   // pullMessages / pushMessages delegate wrappers
   // ---------------------------------------------------------------------------
+
+  describe('projected reconciliation', () => {
+    const projectedScope = {
+      kind   : 'recordsProjection',
+      scopes : [{
+        protocol     : 'https://example.com/profile',
+        protocolPath : 'profile/avatar',
+      }],
+    };
+    const target = {
+      did           : 'did:example:alice',
+      dwnUrl        : 'https://dwn.example.com',
+      delegateDid   : 'did:example:delegate',
+      scope         : projectedScope,
+      authorization : {
+        kind               : 'delegate',
+        delegateDid        : 'did:example:delegate',
+        permissionGrantIds : ['grant-1'],
+      },
+    };
+
+    it('reconcileRecordsProjectionTarget should diff and verify convergence for projected roots', async () => {
+      const engine = createEngine({ db, agent: { agentDid: 'did:example:agent' } as any });
+      sinon.stub(engine as any, 'getLocalProjectedRoot')
+        .onFirstCall().resolves('local-before')
+        .onSecondCall().resolves('converged-root');
+      sinon.stub(engine as any, 'getRemoteProjectedRoot')
+        .onFirstCall().resolves('remote-before')
+        .onSecondCall().resolves('converged-root');
+      const diffStub = sinon.stub(engine as any, 'diffProjectedWithRemote').resolves({
+        onlyLocal  : ['cid-local'],
+        onlyRemote : [{ messageCid: 'cid-remote' }],
+      });
+      const applyStub = sinon.stub(engine as any, 'applyProjectedDiff').resolves(false);
+
+      const result = await (engine as any).reconcileRecordsProjectionTarget(
+        target,
+        projectedScope,
+        { verifyConvergence: true },
+      );
+
+      expect(result).toEqual({ converged: true });
+      expect(diffStub.firstCall.args[0]).toMatchObject({
+        did                : 'did:example:alice',
+        dwnUrl             : 'https://dwn.example.com',
+        delegateDid        : 'did:example:delegate',
+        permissionGrantIds : ['grant-1'],
+      });
+      expect(diffStub.firstCall.args[0].scopes).toEqual(projectedScope.scopes);
+      expect(applyStub.firstCall.args[2]).toEqual({
+        onlyLocal  : ['cid-local'],
+        onlyRemote : [{ messageCid: 'cid-remote' }],
+      });
+    });
+
+    it('reconcileRecordsProjectionTarget should abort after projected root reads', async () => {
+      const engine = createEngine({ db, agent: { agentDid: 'did:example:agent' } as any });
+      sinon.stub(engine as any, 'getLocalProjectedRoot').resolves('local-root');
+      const remoteRootStub = sinon.stub(engine as any, 'getRemoteProjectedRoot').resolves('remote-root');
+      const diffStub = sinon.stub(engine as any, 'diffProjectedWithRemote').resolves({ onlyLocal: [], onlyRemote: [] });
+
+      const result = await (engine as any).reconcileRecordsProjectionTarget(
+        target,
+        projectedScope,
+        undefined,
+        () => false,
+      );
+
+      expect(result).toEqual({ aborted: true });
+      expect(remoteRootStub.called).toBe(false);
+      expect(diffStub.called).toBe(false);
+    });
+
+    it('applyProjectedDiff should pull remote entries before pushing local projected CIDs', async () => {
+      const engine = createEngine({ db, agent: { agentDid: 'did:example:agent' } as any });
+      const pullStub = sinon.stub(engine as any, 'pullMessages').resolves();
+      const pushStub = sinon.stub(engine as any, 'pushMessages').resolves();
+      const diff = {
+        onlyRemote: [
+          { messageCid: 'cid-prefetched', message: { descriptor: { interface: 'Records', method: 'Write' } } },
+          { messageCid: 'cid-fetch' },
+          { messageCid: 'cid-fetch' },
+        ],
+        onlyLocal: ['cid-local', 'cid-local'],
+      };
+
+      const aborted = await (engine as any).applyProjectedDiff(
+        target,
+        projectedScope,
+        diff,
+        ['grant-1'],
+      );
+
+      expect(aborted).toBe(false);
+      expect(pullStub.firstCall.args[0]).toMatchObject({
+        did                : 'did:example:alice',
+        dwnUrl             : 'https://dwn.example.com',
+        delegateDid        : 'did:example:delegate',
+        scope              : projectedScope,
+        permissionGrantIds : ['grant-1'],
+        messageCids        : ['cid-fetch'],
+      });
+      expect(pullStub.firstCall.args[0].prefetched).toEqual([
+        { messageCid: 'cid-prefetched', message: { descriptor: { interface: 'Records', method: 'Write' } } },
+      ]);
+      expect(pushStub.firstCall.args[0].messageCids).toEqual(['cid-local']);
+    });
+
+    it('pullProjectedRemoteDiff should report aborted pulls without pushing', async () => {
+      const engine = createEngine({ db, agent: { agentDid: 'did:example:agent' } as any });
+      sinon.stub(engine as any, 'pullMessages').rejects(new SyncPullAbortedError());
+
+      const aborted = await (engine as any).pullProjectedRemoteDiff(
+        target,
+        projectedScope,
+        [{ messageCid: 'cid-remote' }],
+        ['grant-1'],
+      );
+
+      expect(aborted).toBe(true);
+    });
+
+    it('projected pull and push helpers should respect one-way sync direction gates', async () => {
+      const engine = createEngine({ db, agent: { agentDid: 'did:example:agent' } as any });
+      const pullStub = sinon.stub(engine as any, 'pullMessages').resolves();
+      const pushStub = sinon.stub(engine as any, 'pushMessages').resolves();
+
+      const pullAborted = await (engine as any).pullProjectedRemoteDiff(
+        target,
+        projectedScope,
+        [{ messageCid: 'cid-remote' }],
+        ['grant-1'],
+        { direction: 'push' },
+      );
+      const pushAborted = await (engine as any).pushProjectedLocalDiff(
+        target,
+        ['cid-local'],
+        ['grant-1'],
+        { direction: 'pull' },
+      );
+
+      expect(pullAborted).toBe(false);
+      expect(pushAborted).toBe(false);
+      expect(pullStub.called).toBe(false);
+      expect(pushStub.called).toBe(false);
+    });
+
+    it('diffProjectedWithRemote should request remote diff and expand local projected leaves', async () => {
+      const scopes = projectedScope.scopes;
+      const syncMessage = { descriptor: { action: 'diff' } };
+      const processRequest = sinon.stub().resolves({ message: syncMessage });
+      const sendDwnRequest = sinon.stub().resolves({
+        status     : { code: 200 },
+        onlyRemote : [{ messageCid: 'cid-remote' }],
+        onlyLocal  : ['00', '11'],
+      });
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : { processRequest },
+        rpc      : { sendDwnRequest },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      sinon.stub(engine as any, 'collectLocalProjectedSubtreeHashes').resolves({ '0': 'hash-0' });
+      sinon.stub(engine as any, 'getLocalProjectedLeaves')
+        .callsFake(async (_did: string, prefix: string): Promise<string[]> => [`cid-local-${prefix}`]);
+
+      const result = await (engine as any).diffProjectedWithRemote({
+        did                : 'did:example:alice',
+        dwnUrl             : 'https://dwn.example.com',
+        delegateDid        : 'did:example:delegate',
+        scopes,
+        permissionGrantIds : ['grant-1'],
+      });
+
+      expect(result).toEqual({
+        onlyRemote : [{ messageCid: 'cid-remote' }],
+        onlyLocal  : ['cid-local-00', 'cid-local-11'],
+      });
+      expect(processRequest.firstCall.args[0]).toMatchObject({
+        store         : false,
+        author        : 'did:example:alice',
+        target        : 'did:example:alice',
+        messageParams : {
+          action                : 'diff',
+          projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+          projectionScopes      : scopes,
+          hashes                : { '0': 'hash-0' },
+          permissionGrantIds    : ['grant-1'],
+        },
+      });
+      expect(sendDwnRequest.firstCall.args[0]).toEqual({
+        dwnUrl    : 'https://dwn.example.com',
+        targetDid : 'did:example:alice',
+        message   : syncMessage,
+      });
+    });
+
+    it('diffProjectedWithRemote should reject failed remote diff replies', async () => {
+      const processRequest = sinon.stub().resolves({ message: { descriptor: { action: 'diff' } } });
+      const sendDwnRequest = sinon.stub().resolves({
+        status: { code: 401, detail: 'Unauthorized' },
+      });
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : { processRequest },
+        rpc      : { sendDwnRequest },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      sinon.stub(engine as any, 'collectLocalProjectedSubtreeHashes').resolves({});
+
+      await expect((engine as any).diffProjectedWithRemote({
+        did    : 'did:example:alice',
+        dwnUrl : 'https://dwn.example.com',
+        scopes : projectedScope.scopes,
+      })).rejects.toThrow('SyncEngineLevel: projected diff failed with 401: Unauthorized');
+    });
+  });
 
   describe('protocol-set reconciliation', () => {
     it('batches changed protocol diffs before pulling and pushing messages', async () => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -7,10 +7,10 @@ import { Message, RecordsWrite, TestDataGenerator } from '@enbox/dwn-sdk-js';
 import { ClosureFailureCode } from '../src/sync-closure-types.js';
 import { computeAuthorizationEpoch } from '../src/types/sync.js';
 import { DwnInterface } from '../src/types/dwn.js';
-import { getMessagesPermissionGrantsForScope } from '../src/sync-permission-grants.js';
 import { ReplicationLedger } from '../src/sync-replication-ledger.js';
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 import { SyncPullAbortedError } from '../src/sync-messages.js';
+import { getMessagesPermissionGrantsForScope, resolveMessagesSyncScopes } from '../src/sync-permission-grants.js';
 
 describe('SyncEngineLevel — private methods', () => {
   let db: Level<string, string>;
@@ -388,7 +388,7 @@ describe('SyncEngineLevel — private methods', () => {
       expect(result.map(entry => entry.grant.id)).toEqual(['grant-a', 'grant-b', 'grant-c']);
     });
 
-    it('should reject protocol-set sync when a requested protocol has only subtree grant coverage', async () => {
+    it('should resolve protocolPath grants to a Records projection scope', async () => {
       const permissionsApi = {
         fetchGrants: sinon.stub().resolves([
           grantEntry('grant-profile-path', {
@@ -400,13 +400,67 @@ describe('SyncEngineLevel — private methods', () => {
         ]),
       };
 
-      await expect(getMessagesPermissionGrantsForScope({
+      const result = await resolveMessagesSyncScopes({
         did            : 'did:example:alice',
         delegateDid    : 'did:example:delegate',
+        requestedScope : { kind: 'protocolSet', protocols: ['https://example.com/profile'] },
         messageType    : DwnInterface.MessagesSync,
-        protocols      : ['https://example.com/profile'],
         permissionsApi : permissionsApi as any,
-      })).rejects.toThrow('No active Messages.Read permission found');
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].scope).toEqual({
+        kind   : 'recordsProjection',
+        scopes : [{
+          protocol     : 'https://example.com/profile',
+          protocolPath : 'profile',
+        }],
+      });
+      expect(result[0].permissionGrants.map(entry => entry.grant.id)).toEqual(['grant-profile-path']);
+    });
+
+    it('should split broad protocol grants from narrow projected grants', async () => {
+      const permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          grantEntry('grant-social', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : 'https://example.com/social',
+          }),
+          grantEntry('grant-profile-path', {
+            interface    : 'Messages',
+            method       : 'Read',
+            protocol     : 'https://example.com/profile',
+            protocolPath : 'profile/avatar',
+          }),
+        ]),
+      };
+
+      const result = await resolveMessagesSyncScopes({
+        did            : 'did:example:alice',
+        delegateDid    : 'did:example:delegate',
+        requestedScope : {
+          kind      : 'protocolSet',
+          protocols : ['https://example.com/profile', 'https://example.com/social'],
+        },
+        messageType    : DwnInterface.MessagesSync,
+        permissionsApi : permissionsApi as any,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].scope).toEqual({
+        kind      : 'protocolSet',
+        protocols : ['https://example.com/social'],
+      });
+      expect(result[0].permissionGrants.map(entry => entry.grant.id)).toEqual(['grant-social']);
+      expect(result[1].scope).toEqual({
+        kind   : 'recordsProjection',
+        scopes : [{
+          protocol     : 'https://example.com/profile',
+          protocolPath : 'profile/avatar',
+        }],
+      });
+      expect(result[1].permissionGrants.map(entry => entry.grant.id)).toEqual(['grant-profile-path']);
     });
 
     it('should reject protocol-set sync when any requested protocol lacks coverage', async () => {
@@ -527,6 +581,60 @@ describe('SyncEngineLevel — private methods', () => {
       });
     });
 
+    it('should split delegated sync targets by broad and projected grant coverage', async () => {
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : {
+          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      (engine as any)._permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          messagesGrantEntry('grant-social', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : 'https://example.com/social',
+          }),
+          messagesGrantEntry('grant-profile-avatar', {
+            interface    : 'Messages',
+            method       : 'Read',
+            protocol     : 'https://example.com/profile',
+            protocolPath : 'profile/avatar',
+          }),
+        ]),
+      };
+
+      await engine.registerIdentity({
+        did     : 'did:example:carol',
+        options : {
+          protocols   : ['https://example.com/profile', 'https://example.com/social'],
+          delegateDid : 'did:example:delegate',
+        },
+      });
+
+      const targets = await (engine as any).getSyncTargets();
+
+      expect(targets).toHaveLength(2);
+      expect(targets.map((target: any) => target.scope)).toEqual([
+        {
+          kind      : 'protocolSet',
+          protocols : ['https://example.com/social'],
+        },
+        {
+          kind   : 'recordsProjection',
+          scopes : [{
+            protocol     : 'https://example.com/profile',
+            protocolPath : 'profile/avatar',
+          }],
+        },
+      ]);
+      expect(targets.map((target: any) => target.permissionGrantIds)).toEqual([
+        ['grant-social'],
+        ['grant-profile-avatar'],
+      ]);
+    });
+
     it('should handle invalid JSON in identity options gracefully', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
@@ -587,6 +695,39 @@ describe('SyncEngineLevel — private methods', () => {
 
       expect(pullStub.calledOnce).toBe(true);
       expect(pushStub.calledOnce).toBe(true);
+    });
+
+    it('should reconcile Records projection targets through projected roots', async () => {
+      const mockAgent = { agentDid: 'did:example:agent', did: { dereference: sinon.stub() } } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      const projectedScope = {
+        kind   : 'recordsProjection',
+        scopes : [{
+          protocol     : 'https://example.com/profile',
+          protocolPath : 'profile/avatar',
+        }],
+      };
+
+      sinon.stub(engine as any, 'getSyncTargets').resolves([
+        syncTarget('did:example:1', 'https://dwn.example.com', { scope: projectedScope }),
+      ]);
+      const legacyLocalRoot = sinon.stub(engine as any, 'getLocalRoot').resolves('legacy-local');
+      const legacyRemoteRoot = sinon.stub(engine as any, 'getRemoteRoot').resolves('legacy-remote');
+      sinon.stub(engine as any, 'getLocalProjectedRoot').resolves('aabbcc');
+      sinon.stub(engine as any, 'getRemoteProjectedRoot').resolves('ddeeff');
+      sinon.stub(engine as any, 'diffProjectedWithRemote').resolves({
+        onlyLocal  : ['cid-local-1'],
+        onlyRemote : [{ messageCid: 'cid-remote-1' }],
+      });
+      const pullStub = sinon.stub(engine as any, 'pullMessages').resolves();
+      const pushStub = sinon.stub(engine as any, 'pushMessages').resolves();
+
+      await engine.sync();
+
+      expect(legacyLocalRoot.called).toBe(false);
+      expect(legacyRemoteRoot.called).toBe(false);
+      expect(pullStub.firstCall.args[0].scope).toEqual(projectedScope);
+      expect(pushStub.firstCall.args[0].messageCids).toEqual(['cid-local-1']);
     });
 
     it('should only pull when direction is "pull"', async () => {
@@ -1025,6 +1166,46 @@ describe('SyncEngineLevel — private methods', () => {
       expect(closePull.calledOnce).toBe(true);
       expect((engine as any)._activeLinks.get(linkKey)).toBe(link);
       expect(link.status).toBe('repairing');
+    });
+
+    it('should mark projected links polling without opening live subscriptions', async () => {
+      const engine = createEngine({ db });
+      const projectedScope = {
+        kind   : 'recordsProjection',
+        scopes : [{
+          protocol     : 'https://example.com/profile',
+          protocolPath : 'profile/avatar',
+        }],
+      };
+      const linkKey = 'did:example:alice^https://dwn.example.com^projection-test^authorization-test';
+      const link = {
+        tenantDid          : 'did:example:alice',
+        remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test',
+        authorizationEpoch : 'authorization-test',
+        authorization      : { kind: 'owner' },
+        scope              : projectedScope,
+        status             : 'initializing',
+        pull               : {},
+        connectivity       : 'unknown',
+        needsReconcile     : false,
+      } as any;
+
+      sinon.stub(engine as any, 'getOrCreateReplicationLink').resolves(link);
+      sinon.stub(engine as any, 'getReplicationLinkKey').returns(linkKey);
+      sinon.stub(engine as any, 'migrateLegacyCursorIfNeeded').resolves();
+      const openLivePullStub = sinon.stub(engine as any, 'openLivePullSubscription').rejects(new Error('unexpected live pull'));
+      const openLocalPushStub = sinon.stub(engine as any, 'openLocalPushSubscription').rejects(new Error('unexpected local push'));
+
+      const result = await (engine as any).initializeLinkTarget(syncTarget('did:example:alice', 'https://dwn.example.com', {
+        scope: projectedScope,
+      }));
+
+      expect(result.status).toBe('active');
+      expect(openLivePullStub.called).toBe(false);
+      expect(openLocalPushStub.called).toBe(false);
+      expect((engine as any)._activeLinks.get(linkKey)).toBe(link);
+      expect(link.status).toBe('polling');
     });
   });
 

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -184,6 +184,32 @@ describe('SyncEngineLevel — private methods', () => {
 
       await expect((syncEngine as any).getCursor('key')).rejects.toThrow();
     });
+
+    it('should not migrate legacy cursors into projected links', async () => {
+      const engine = createEngine({ db });
+      const getCursorStub = sinon.stub(engine as any, 'getCursor').resolves({
+        streamId   : 'stream',
+        epoch      : 'epoch',
+        position   : '1',
+        messageCid : 'cid',
+      });
+      const link = {
+        pull: {},
+      };
+
+      await (engine as any).migrateLegacyCursorIfNeeded(syncTarget('did:example:alice', 'https://dwn.example.com', {
+        scope: {
+          kind   : 'recordsProjection',
+          scopes : [{
+            protocol     : 'https://example.com/profile',
+            protocolPath : 'profile/avatar',
+          }],
+        },
+      }), link);
+
+      expect(getCursorStub.called).toBe(false);
+      expect(link.pull).toEqual({});
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -417,6 +443,39 @@ describe('SyncEngineLevel — private methods', () => {
         }],
       });
       expect(result[0].permissionGrants.map(entry => entry.grant.id)).toEqual(['grant-profile-path']);
+    });
+
+    it('should reject projected scope unions when any member lacks grant coverage', async () => {
+      const permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          grantEntry('grant-profile-path', {
+            interface    : 'Messages',
+            method       : 'Read',
+            protocol     : 'https://example.com/profile',
+            protocolPath : 'profile/avatar',
+          }),
+        ]),
+      };
+
+      await expect(resolveMessagesSyncScopes({
+        did            : 'did:example:alice',
+        delegateDid    : 'did:example:delegate',
+        requestedScope : {
+          kind   : 'recordsProjection',
+          scopes : [
+            {
+              protocol     : 'https://example.com/profile',
+              protocolPath : 'profile/avatar',
+            },
+            {
+              protocol     : 'https://example.com/profile',
+              protocolPath : 'profile/banner',
+            },
+          ],
+        },
+        messageType    : DwnInterface.MessagesSync,
+        permissionsApi : permissionsApi as any,
+      })).rejects.toThrow('No active Messages.Read permission found for MessagesSync: projected Records scope');
     });
 
     it('should split broad protocol grants from narrow projected grants', async () => {

--- a/packages/agent/tests/sync-scope-acceptance.spec.ts
+++ b/packages/agent/tests/sync-scope-acceptance.spec.ts
@@ -11,6 +11,13 @@ describe('sync-scope-acceptance', () => {
   const profileProtocol = 'https://identity.foundation/protocols/profile';
   const socialProtocol = 'https://identity.foundation/protocols/social-graph';
   const profileScope: SyncScope = { kind: 'protocolSet', protocols: [profileProtocol] };
+  const profileAvatarProjectionScope: SyncScope = {
+    kind   : 'recordsProjection',
+    scopes : [{
+      protocol     : profileProtocol,
+      protocolPath : 'profile/avatar',
+    }],
+  };
 
   it('accepts RecordsWrite messages for a covered protocol', async () => {
     const { message } = await TestDataGenerator.generateRecordsWrite({ protocol: profileProtocol });
@@ -115,6 +122,82 @@ describe('sync-scope-acceptance', () => {
     } as unknown as GenericMessage;
 
     const classification = classifySyncMessageScope({ message, scope: profileScope });
+
+    expect(classification).toBe('out-of-scope');
+  });
+
+  it('accepts RecordsWrite messages matching a projected protocolPath scope', async () => {
+    const { message } = await TestDataGenerator.generateRecordsWrite({
+      protocol     : profileProtocol,
+      protocolPath : 'profile/avatar',
+    });
+
+    const classification = classifySyncMessageScope({
+      message,
+      scope: profileAvatarProjectionScope,
+    });
+
+    expect(classification).toBe('in-scope');
+  });
+
+  it('rejects RecordsWrite messages outside a projected protocolPath scope', async () => {
+    const { message } = await TestDataGenerator.generateRecordsWrite({
+      protocol     : profileProtocol,
+      protocolPath : 'profile/banner',
+    });
+
+    const classification = classifySyncMessageScope({
+      message,
+      scope: profileAvatarProjectionScope,
+    });
+
+    expect(classification).toBe('out-of-scope');
+  });
+
+  it('accepts RecordsDelete messages when the initial write matches a projected scope', async () => {
+    const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+      protocol     : profileProtocol,
+      protocolPath : 'profile/avatar',
+    });
+    const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+      author   : recordsWrite.author,
+      recordId : recordsWrite.message.recordId,
+    });
+
+    const classification = classifySyncMessageScope({
+      message      : recordsDelete.message,
+      initialWrite : recordsWrite.message,
+      scope        : profileAvatarProjectionScope,
+    });
+
+    expect(classification).toBe('in-scope');
+  });
+
+  it('returns unknown for projected RecordsDelete without initial write metadata', async () => {
+    const { message } = await TestDataGenerator.generateRecordsDelete();
+
+    const classification = classifySyncMessageScope({
+      message,
+      scope: profileAvatarProjectionScope,
+    });
+
+    expect(classification).toBe('unknown');
+  });
+
+  it('rejects ProtocolsConfigure as Records-primary projected data', async () => {
+    const { message } = await TestDataGenerator.generateProtocolsConfigure({
+      protocolDefinition: {
+        protocol  : profileProtocol,
+        published : true,
+        types     : {},
+        structure : {},
+      },
+    });
+
+    const classification = classifySyncMessageScope({
+      message,
+      scope: profileAvatarProjectionScope,
+    });
 
     expect(classification).toBe('out-of-scope');
   });

--- a/packages/agent/tests/sync-scope.spec.ts
+++ b/packages/agent/tests/sync-scope.spec.ts
@@ -7,6 +7,7 @@ import {
   protocolsForSyncScope,
   singleProtocolForSyncScope,
   syncScopeFromProtocols,
+  syncScopeFromRecordsProjectionScopes,
 } from '../src/types/sync.js';
 
 describe('sync scope identity', () => {
@@ -43,6 +44,41 @@ describe('sync scope identity', () => {
   it('returns a single protocol label only for one-protocol scopes', () => {
     const scope = syncScopeFromProtocols(['https://example.com/profile']);
     expect(singleProtocolForSyncScope(scope)).toBe('https://example.com/profile');
+  });
+
+  it('normalizes Records projection scopes and exposes their covered protocols', () => {
+    const scope = syncScopeFromRecordsProjectionScopes([
+      {
+        protocol  : 'https://example.com/profile',
+        contextId : 'root/child',
+      },
+      {
+        protocol  : 'https://example.com/social',
+        contextId : 'thread',
+      },
+      {
+        protocol  : 'https://example.com/profile',
+        contextId : 'root',
+      },
+      {
+        protocol     : 'https://example.com/profile',
+        protocolPath : 'profile/avatar',
+      },
+    ]);
+
+    expect(scope).toEqual({
+      kind   : 'recordsProjection',
+      scopes : [
+        { protocol: 'https://example.com/profile', protocolPath: 'profile/avatar' },
+        { protocol: 'https://example.com/profile', contextId: 'root' },
+        { protocol: 'https://example.com/social', contextId: 'thread' },
+      ],
+    });
+    expect(protocolsForSyncScope(scope)).toEqual([
+      'https://example.com/profile',
+      'https://example.com/social',
+    ]);
+    expect(singleProtocolForSyncScope(scope)).toBeUndefined();
   });
 
   it('computes projection IDs from tenant and normalized scope', async () => {
@@ -131,5 +167,16 @@ describe('sync scope identity', () => {
 
     expect(projectionId).toBe(sameProjectionId);
     expect(oldEpoch).not.toBe(newEpoch);
+  });
+
+  it('uses distinct projection IDs for legacy protocol roots and Records-primary projection roots', async () => {
+    const tenantDid = 'did:example:alice';
+    const protocolScope = syncScopeFromProtocols(['https://example.com/profile']);
+    const projectedScope = syncScopeFromRecordsProjectionScopes([
+      { protocol: 'https://example.com/profile' },
+    ]);
+
+    await expect(computeProjectionId(tenantDid, protocolScope))
+      .resolves.not.toBe(await computeProjectionId(tenantDid, projectedScope));
   });
 });

--- a/packages/agent/tests/sync-scope.spec.ts
+++ b/packages/agent/tests/sync-scope.spec.ts
@@ -169,7 +169,7 @@ describe('sync scope identity', () => {
     expect(oldEpoch).not.toBe(newEpoch);
   });
 
-  it('uses distinct projection IDs for legacy protocol roots and Records-primary projection roots', async () => {
+  it('uses distinct projection IDs for StateIndex protocol roots and Records-primary projection roots', async () => {
     const tenantDid = 'did:example:alice';
     const protocolScope = syncScopeFromProtocols(['https://example.com/profile']);
     const projectedScope = syncScopeFromRecordsProjectionScopes([

--- a/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
@@ -1441,7 +1441,7 @@ export function testMessagesSyncHandler(): void {
         }
       });
 
-      it('returns 400 when projected sync also specifies a legacy protocol root', async () => {
+      it('returns 400 when projected sync also specifies a protocol root', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
         const { message } = await MessagesSync.create({


### PR DESCRIPTION
## Summary
- resolve delegated protocol-set sync into StateIndex protocol roots plus Records-primary projected roots for protocolPath/contextId grants
- reconcile projected roots through MessagesSync root/diff/leaves and gate pulled records against the projected scope
- remove old sync cursor migration/compatibility paths so replication state uses durable link checkpoints only
- keep projected live-mode links polling-only until explicit path/context live subscription semantics are added

## Tests
- bun run --filter @enbox/agent lint
- bun run build --filter=@enbox/dwn-sdk-js --filter=@enbox/agent
- bun test --timeout 10000 packages/agent/tests/sync-engine-identity.spec.ts packages/agent/tests/sync-engine-private.spec.ts packages/agent/tests/sync-replication-ledger.spec.ts packages/agent/tests/sync-scope.spec.ts packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
- bun test --timeout 10000 packages/agent/tests/sync-engine-private.spec.ts packages/agent/tests/sync-closure-resolver.spec.ts packages/agent/tests/sync-scope.spec.ts packages/agent/tests/sync-scope-acceptance.spec.ts with focused LCOV diff coverage: 86.1% changed-line coverage

## Notes
- Updated /home/liran/src/enboxorg/scoped-dependency-aware-sync-plan.md with this slice and remaining dependency-read/live-projection follow-ups.