### PR TITLE
Allow scoped MessagesRead protocol config reads

### DIFF
--- a/.changeset/messages-read-protocol-config.md
+++ b/.changeset/messages-read-protocol-config.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Allow delegated MessagesRead grants scoped inside a protocol to read that protocol's configuration metadata.

--- a/packages/dwn-sdk-js/src/core/grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/grant-authorization.ts
@@ -146,7 +146,7 @@ export class GrantAuthorization {
     }
 
     // Messages.Read is the only valid Messages scope and covers Read, Subscribe, and Sync operations.
-    // Reject any Messages grant with method !== Read (malformed or legacy stored data).
+    // Reject any Messages grant with method !== Read.
     if (dwnInterface === DwnInterfaceName.Messages) {
       if (permissionGrant.scope.method !== DwnMethodName.Read) {
         throw new DwnError(

--- a/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
@@ -330,10 +330,10 @@ export class MessagesGrantAuthorization {
     protocolsConfigureMessage: ProtocolsConfigureMessage,
     incomingScope: MessagesPermissionScope
   ): boolean {
-    return PermissionScopeMatcher.matches(
-      incomingScope,
-      { protocol: protocolsConfigureMessage.descriptor.definition.protocol }
-    );
+    // A delegate with any Messages.Read grant inside a protocol needs that
+    // protocol definition to interpret and validate the records it can read.
+    return incomingScope.protocol !== undefined &&
+      incomingScope.protocol === protocolsConfigureMessage.descriptor.definition.protocol;
   }
 
   private static async getAssociatedRecordsWrite(

--- a/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
@@ -991,8 +991,17 @@ export function testMessagesReadHandler(): void {
             permissionGrantIds : [grantId],
           });
           const protocolReadReply = await dwn.processMessage(alice.did, protocolRead.message);
-          expect(protocolReadReply.status.code).toBe(401);
-          expect(protocolReadReply.status.detail).toContain(DwnErrorCode.MessagesReadVerifyScopeFailed);
+          expect(protocolReadReply.status.code).toBe(200);
+          expect(protocolReadReply.entry!.message).toEqual(protocolMessage);
+
+          const otherProtocolConfigRead = await TestDataGenerator.generateMessagesRead({
+            author             : bob,
+            messageCid         : await Message.getCid(otherProtocolMessage),
+            permissionGrantIds : [grantId],
+          });
+          const otherProtocolConfigReadReply = await dwn.processMessage(alice.did, otherProtocolConfigRead.message);
+          expect(otherProtocolConfigReadReply.status.code).toBe(401);
+          expect(otherProtocolConfigReadReply.status.detail).toContain(DwnErrorCode.MessagesReadVerifyScopeFailed);
 
           const grantRecordRead = await TestDataGenerator.generateMessagesRead({
             author             : bob,
@@ -1115,8 +1124,8 @@ export function testMessagesReadHandler(): void {
             permissionGrantIds : [grantId],
           });
           const protocolReadReply = await dwn.processMessage(alice.did, protocolRead.message);
-          expect(protocolReadReply.status.code).toBe(401);
-          expect(protocolReadReply.status.detail).toContain(DwnErrorCode.MessagesReadVerifyScopeFailed);
+          expect(protocolReadReply.status.code).toBe(200);
+          expect(protocolReadReply.entry!.message).toEqual(protocolMessage);
 
           const grantRecordRead = await TestDataGenerator.generateMessagesRead({
             author             : bob,

--- a/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
@@ -1096,7 +1096,7 @@ export function testMessagesSyncHandler(): void {
           expect(readReply.status.code).toBe(401);
           expect(readReply.status.detail).toContain(DwnErrorCode.MessagesReadVerifyScopeFailed);
 
-          const legacySyncActions = [
+          const stateIndexSyncActions = [
             { action: 'root' as const },
             { action: 'subtree' as const, prefix: '' },
             { action: 'leaves' as const, prefix: '' },
@@ -1108,7 +1108,7 @@ export function testMessagesSyncHandler(): void {
           ];
 
           for (const { protocol, grantId } of infrastructureProtocolGrants) {
-            for (const syncAction of legacySyncActions) {
+            for (const syncAction of stateIndexSyncActions) {
               const { message: syncMessage } = await MessagesSync.create({
                 signer             : Jws.createSigner(bob),
                 ...syncAction,

--- a/packages/dwn-sdk-js/tests/interfaces/messages-get.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/messages-get.spec.ts
@@ -90,10 +90,10 @@ describe('MessagesRead Message', () => {
         signer: await Jws.createSigner(author),
         messageCid,
       });
-      const messageWithLegacyGrant = structuredClone(messagesRead.message) as any;
-      messageWithLegacyGrant.descriptor.permissionGrantId = 'grant-a';
+      const messageWithSingularGrant = structuredClone(messagesRead.message) as any;
+      messageWithSingularGrant.descriptor.permissionGrantId = 'grant-a';
 
-      await expect(MessagesRead.parse(messageWithLegacyGrant)).rejects.toThrow(DwnErrorCode.SchemaValidatorAdditionalPropertyNotAllowed);
+      await expect(MessagesRead.parse(messageWithSingularGrant)).rejects.toThrow(DwnErrorCode.SchemaValidatorAdditionalPropertyNotAllowed);
     });
 
     it('does not include permissionGrantIds in the descriptor when not provided', async () => {


### PR DESCRIPTION
## Summary
- allow a delegated `Messages.Read` grant scoped inside protocol `P` to read `ProtocolsConfigure(P)`
- keep other protocol configs, permission records, key-delivery records, and out-of-scope Records data unauthorized
- remove the proposed `primaryMessageCid` dependency-read API from this PR

## Tests
- `bun --filter @enbox/dwn-sdk-js lint`
- `bun --filter @enbox/dwn-sdk-js test:node-grep -- "MessagesRead"`
- `bunx turbo run build --filter=@enbox/dwn-sdk-js...`