### PR TITLE
Add projected sync delete dependency hints

### DIFF
--- a/.changeset/projected-sync-delete-hints.md
+++ b/.changeset/projected-sync-delete-hints.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+---
+
+Include and verify payload-free initial-write dependency hints for projected sync delete tombstones.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -134,6 +134,11 @@ type VerifiedProtocolConfigCandidate = {
   dependency: AuthenticatedProtocolConfigDependency;
 };
 type AuthenticatedProtocolConfigDependency = SyncDependencyEntryWithMessage & { message: ProtocolsConfigureMessage };
+type VerifiedRecordsInitialWriteCandidate = {
+  rootMessageCid: string;
+  dependency: AuthenticatedRecordsInitialWriteDependency;
+};
+type AuthenticatedRecordsInitialWriteDependency = SyncDependencyEntryWithMessage & { message: RecordsWriteMessage };
 
 type ProjectionReconcileTarget = {
   did: string;
@@ -2952,8 +2957,16 @@ export class SyncEngineLevel implements SyncEngine {
   ): Promise<boolean> {
     const primaryEntries = SyncEngineLevel.dedupeRemoteEntries(onlyRemote);
     try {
+      let verifiedInitialWrites: RecordsWriteMessage[] = [];
       if (scope.kind === 'recordsProjection') {
-        await this.pullProjectedDependencyHints(target, scope, primaryEntries, dependencies, permissionGrantIds, shouldContinue);
+        verifiedInitialWrites = await this.pullProjectedDependencyHints(
+          target,
+          scope,
+          primaryEntries,
+          dependencies,
+          permissionGrantIds,
+          shouldContinue,
+        );
       }
 
       const { prefetched, needsFetchCids } = partitionRemoteEntries(primaryEntries);
@@ -2965,6 +2978,7 @@ export class SyncEngineLevel implements SyncEngine {
         permissionGrantIds,
         messageCids : needsFetchCids,
         prefetched,
+        verifiedInitialWrites,
         shouldContinue,
       });
     } catch (error) {
@@ -2983,22 +2997,50 @@ export class SyncEngineLevel implements SyncEngine {
     dependencies: MessagesSyncDependencyEntry[],
     permissionGrantIds: NonEmptyStringArray | undefined,
     shouldContinue?: () => boolean,
-  ): Promise<void> {
-    const verified = await this.verifyProjectedProtocolConfigDependencies(target.did, scope, primaryEntries, dependencies);
+  ): Promise<RecordsWriteMessage[]> {
+    const verified = await this.verifyProjectedDependencies(target.did, scope, primaryEntries, dependencies);
     if (verified.length === 0) {
-      return;
+      return [];
     }
 
     await this.pullMessages({
       did         : target.did,
       dwnUrl      : target.dwnUrl,
       delegateDid : target.delegateDid,
-      scope       : SyncEngineLevel.protocolSetScopeForProtocolConfigDependencies(verified),
+      scope       : SyncEngineLevel.protocolSetScopeForProjectedDependencies(verified),
       permissionGrantIds,
       messageCids : [],
       prefetched  : verified,
       shouldContinue,
     });
+
+    return SyncEngineLevel.recordsInitialWritesFromVerifiedDependencies(verified);
+  }
+
+  private async verifyProjectedDependencies(
+    tenantDid: string,
+    scope: RecordsProjectionSyncScope,
+    primaryEntries: MessagesSyncDiffEntry[],
+    dependencies: MessagesSyncDependencyEntry[],
+  ): Promise<MessagesSyncDependencyEntry[]> {
+    const primaryByCid = SyncEngineLevel.indexEntriesWithMessage(primaryEntries);
+    const initialWritesByRoot = await this.collectProjectedRecordsInitialWriteDependencies(
+      scope,
+      primaryByCid,
+      dependencies,
+    );
+    const protocolConfigs = await this.verifyProjectedProtocolConfigDependencies(
+      tenantDid,
+      scope,
+      primaryEntries,
+      dependencies,
+      initialWritesByRoot,
+    );
+
+    return SyncEngineLevel.dedupeDependencyEntries([
+      ...protocolConfigs,
+      ...initialWritesByRoot.values(),
+    ]);
   }
 
   private async verifyProjectedProtocolConfigDependencies(
@@ -3006,25 +3048,33 @@ export class SyncEngineLevel implements SyncEngine {
     scope: RecordsProjectionSyncScope,
     primaryEntries: MessagesSyncDiffEntry[],
     dependencies: MessagesSyncDependencyEntry[],
+    initialWritesByRoot: Map<string, AuthenticatedRecordsInitialWriteDependency> = new Map(),
   ): Promise<MessagesSyncDependencyEntry[]> {
     // Projected sync dependency entries are untrusted server hints. Before any
     // config is applied, bind it to an accepted primary record by CID,
     // tenant authorship, signature, timestamp, scope, and protocol closure;
     // malformed or unrelated hints are ignored.
     const primaryByCid = SyncEngineLevel.indexEntriesWithMessage(primaryEntries);
-    const candidatesByRoot = await this.collectProjectedProtocolConfigCandidates(tenantDid, scope, primaryByCid, dependencies);
+    const candidatesByRoot = await this.collectProjectedProtocolConfigCandidates(
+      tenantDid,
+      scope,
+      primaryByCid,
+      dependencies,
+      initialWritesByRoot,
+    );
     const verified = new Map<string, MessagesSyncDependencyEntry>();
 
     for (const [rootMessageCid, rootCandidates] of candidatesByRoot) {
       const primary = primaryByCid.get(rootMessageCid);
-      const primaryProtocol = primary === undefined
+      const rootRecordsWrite = primary === undefined
         ? undefined
-        : SyncEngineLevel.recordsWriteProtocol(primary.message);
-      if (primaryProtocol === undefined) {
+        : SyncEngineLevel.protocolConfigRootRecordsWrite(primary.message, initialWritesByRoot.get(rootMessageCid)?.message);
+      const rootProtocol = SyncEngineLevel.recordsWriteProtocol(rootRecordsWrite);
+      if (rootProtocol === undefined) {
         continue;
       }
 
-      for (const dependency of SyncEngineLevel.filterProtocolConfigClosure(primaryProtocol, rootCandidates)) {
+      for (const dependency of SyncEngineLevel.filterProtocolConfigClosure(rootProtocol, rootCandidates)) {
         verified.set(dependency.messageCid, dependency);
       }
     }
@@ -3044,15 +3094,96 @@ export class SyncEngineLevel implements SyncEngine {
     return entriesByCid;
   }
 
+  private static recordsInitialWritesFromVerifiedDependencies(
+    entries: MessagesSyncDependencyEntry[],
+  ): RecordsWriteMessage[] {
+    const initialWrites: RecordsWriteMessage[] = [];
+    for (const entry of entries) {
+      if (SyncEngineLevel.hasMessage(entry) && SyncEngineLevel.isRecordsWriteMessage(entry.message)) {
+        initialWrites.push(entry.message);
+      }
+    }
+    return initialWrites;
+  }
+
+  private async collectProjectedRecordsInitialWriteDependencies(
+    scope: RecordsProjectionSyncScope,
+    primaryByCid: Map<string, SyncDiffEntryWithMessage>,
+    dependencies: MessagesSyncDependencyEntry[],
+  ): Promise<Map<string, AuthenticatedRecordsInitialWriteDependency>> {
+    const dependenciesByRoot = new Map<string, AuthenticatedRecordsInitialWriteDependency>();
+    for (const dependency of dependencies) {
+      const verified = await this.verifyRecordsInitialWriteCandidate(scope, primaryByCid, dependency);
+      if (verified === undefined) {
+        continue;
+      }
+
+      dependenciesByRoot.set(verified.rootMessageCid, verified.dependency);
+    }
+    return dependenciesByRoot;
+  }
+
+  private async verifyRecordsInitialWriteCandidate(
+    scope: RecordsProjectionSyncScope,
+    primaryByCid: Map<string, SyncDiffEntryWithMessage>,
+    dependency: MessagesSyncDependencyEntry,
+  ): Promise<VerifiedRecordsInitialWriteCandidate | undefined> {
+    if (dependency.dependencyClass !== 'recordsInitialWrite' ||
+      !SyncEngineLevel.hasMessage(dependency) ||
+      SyncEngineLevel.hasDependencyPayloadBytes(dependency)) {
+      return undefined;
+    }
+
+    const primary = primaryByCid.get(dependency.rootMessageCid);
+    if (primary === undefined ||
+      !SyncEngineLevel.isRecordsDeleteMessage(primary.message) ||
+      !await SyncEngineLevel.projectedDependencyCidsMatch({
+        dependencyCid     : dependency.messageCid,
+        dependencyMessage : dependency.message,
+        primaryCid        : primary.messageCid,
+        primaryMessage    : primary.message,
+      })) {
+      return undefined;
+    }
+
+    const initialWrite = await this.toAuthenticatedRecordsInitialWriteDependency(dependency);
+    if (initialWrite === undefined ||
+      initialWrite.message.recordId !== SyncEngineLevel.recordsDeleteRecordId(primary.message) ||
+      classifySyncMessageScope({ message: primary.message, initialWrite: initialWrite.message, scope }) !== 'in-scope') {
+      return undefined;
+    }
+
+    return { dependency: initialWrite, rootMessageCid: dependency.rootMessageCid };
+  }
+
+  private async toAuthenticatedRecordsInitialWriteDependency(
+    dependency: SyncDependencyEntryWithMessage,
+  ): Promise<AuthenticatedRecordsInitialWriteDependency | undefined> {
+    if (!SyncEngineLevel.isRecordsWriteMessage(dependency.message)) {
+      return undefined;
+    }
+
+    try {
+      const recordsWrite = await RecordsWrite.parse(dependency.message);
+      await authenticate(recordsWrite.message.authorization, this.agent.did, recordsWrite.message.attestation);
+      return await recordsWrite.isInitialWrite()
+        ? { ...dependency, message: recordsWrite.message }
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   private async collectProjectedProtocolConfigCandidates(
     tenantDid: string,
     scope: RecordsProjectionSyncScope,
     primaryByCid: Map<string, SyncDiffEntryWithMessage>,
     dependencies: MessagesSyncDependencyEntry[],
+    initialWritesByRoot: Map<string, AuthenticatedRecordsInitialWriteDependency>,
   ): Promise<Map<string, AuthenticatedProtocolConfigDependency[]>> {
     const candidatesByRoot = new Map<string, AuthenticatedProtocolConfigDependency[]>();
     for (const dependency of dependencies) {
-      const verified = await this.verifyProtocolConfigCandidate(tenantDid, scope, primaryByCid, dependency);
+      const verified = await this.verifyProtocolConfigCandidate(tenantDid, scope, primaryByCid, dependency, initialWritesByRoot);
       if (verified === undefined) {
         continue;
       }
@@ -3069,6 +3200,7 @@ export class SyncEngineLevel implements SyncEngine {
     scope: RecordsProjectionSyncScope,
     primaryByCid: Map<string, SyncDiffEntryWithMessage>,
     dependency: MessagesSyncDependencyEntry,
+    initialWritesByRoot: Map<string, AuthenticatedRecordsInitialWriteDependency>,
   ): Promise<VerifiedProtocolConfigCandidate | undefined> {
     if (dependency.dependencyClass !== 'protocolsConfigure' || !SyncEngineLevel.hasMessage(dependency)) {
       return undefined;
@@ -3079,7 +3211,13 @@ export class SyncEngineLevel implements SyncEngine {
       return undefined;
     }
 
-    const verifiedDependency = await this.verifyProtocolConfigCandidateMessage(tenantDid, scope, primary, dependency);
+    const verifiedDependency = await this.verifyProtocolConfigCandidateMessage(
+      tenantDid,
+      scope,
+      primary,
+      dependency,
+      initialWritesByRoot.get(dependency.rootMessageCid)?.message,
+    );
     return verifiedDependency === undefined
       ? undefined
       : { dependency: verifiedDependency, rootMessageCid: dependency.rootMessageCid };
@@ -3090,6 +3228,7 @@ export class SyncEngineLevel implements SyncEngine {
     scope: RecordsProjectionSyncScope,
     primary: SyncDiffEntryWithMessage,
     dependency: SyncDependencyEntryWithMessage,
+    initialWrite: RecordsWriteMessage | undefined,
   ): Promise<AuthenticatedProtocolConfigDependency | undefined> {
     // Protocol authorization is temporal: a record is governed by the protocol
     // definition active at its creation timestamp. Future configs may add
@@ -3109,10 +3248,11 @@ export class SyncEngineLevel implements SyncEngine {
       return undefined;
     }
 
-    const primaryIsInScope = SyncEngineLevel.recordsWriteProtocol(primary.message) !== undefined &&
-      classifySyncMessageScope({ message: primary.message, scope }) === 'in-scope';
+    const rootRecordsWrite = SyncEngineLevel.protocolConfigRootRecordsWrite(primary.message, initialWrite);
+    const primaryIsInScope = rootRecordsWrite !== undefined &&
+      classifySyncMessageScope({ message: primary.message, initialWrite, scope }) === 'in-scope';
     if (!primaryIsInScope ||
-      !SyncEngineLevel.protocolsConfigureIsNotNewerThanRecordsWrite(authenticatedDependency.message, primary.message)) {
+      !SyncEngineLevel.protocolsConfigureIsNotNewerThanRecordsWrite(authenticatedDependency.message, rootRecordsWrite)) {
       return undefined;
     }
 
@@ -3154,13 +3294,33 @@ export class SyncEngineLevel implements SyncEngine {
       await Message.getCid(dependencyMessage) === dependencyCid;
   }
 
-  private static recordsWriteProtocol(message: GenericMessage): string | undefined {
+  private static recordsWriteProtocol(message: GenericMessage | undefined): string | undefined {
     if (!SyncEngineLevel.isRecordsWriteProtocolMessage(message)) {
       return undefined;
     }
 
     const { protocol } = message.descriptor;
     return typeof protocol === 'string' ? protocol : undefined;
+  }
+
+  private static recordsDeleteRecordId(message: GenericMessage): string | undefined {
+    if (!SyncEngineLevel.isRecordsDeleteMessage(message)) {
+      return undefined;
+    }
+
+    const recordId = (message.descriptor as Record<string, unknown>).recordId;
+    return typeof recordId === 'string' ? recordId : undefined;
+  }
+
+  private static protocolConfigRootRecordsWrite(
+    primary: GenericMessage,
+    initialWrite: RecordsWriteMessage | undefined,
+  ): RecordsWriteMessage | undefined {
+    if (SyncEngineLevel.isRecordsWriteMessage(primary)) {
+      return primary;
+    }
+
+    return SyncEngineLevel.isRecordsDeleteMessage(primary) ? initialWrite : undefined;
   }
 
   private static protocolsConfigureProtocol(message: ProtocolsConfigureMessage): string {
@@ -3195,9 +3355,22 @@ export class SyncEngineLevel implements SyncEngine {
     return entry?.message !== undefined;
   }
 
-  private static isRecordsWriteProtocolMessage(message: GenericMessage): message is RecordsWriteProtocolMessage {
-    return message.descriptor.interface === DwnInterfaceName.Records &&
+  private static isRecordsWriteProtocolMessage(message: GenericMessage | undefined): message is RecordsWriteProtocolMessage {
+    return message?.descriptor.interface === DwnInterfaceName.Records &&
       message.descriptor.method === DwnMethodName.Write;
+  }
+
+  private static isRecordsWriteMessage(message: GenericMessage | undefined): message is RecordsWriteMessage {
+    return SyncEngineLevel.isRecordsWriteProtocolMessage(message) &&
+      'recordId' in message &&
+      typeof message.recordId === 'string' &&
+      'contextId' in message &&
+      typeof message.contextId === 'string';
+  }
+
+  private static isRecordsDeleteMessage(message: GenericMessage): boolean {
+    return message.descriptor.interface === DwnInterfaceName.Records &&
+      message.descriptor.method === DwnMethodName.Delete;
   }
 
   private static isProtocolsConfigureDefinitionMessage(message: GenericMessage): message is ProtocolsConfigureMessage {
@@ -3333,7 +3506,7 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
-  private static protocolSetScopeForProtocolConfigDependencies(
+  private static protocolSetScopeForProjectedDependencies(
     dependencies: MessagesSyncDependencyEntry[],
   ): Extract<SyncScope, { kind: 'protocolSet' }> {
     // Verification above is the security boundary. This protocolSet scope only
@@ -3342,19 +3515,46 @@ export class SyncEngineLevel implements SyncEngine {
     // the supplied sync scope before it reaches processRawMessage().
     const protocols = SyncEngineLevel.dedupeStrings(
       dependencies
-        .map(dependency => dependency.message === undefined
-          ? undefined
-          : SyncEngineLevel.protocolsConfigureProtocolFromGenericMessage(dependency.message))
-        .filter((protocol): protocol is string => protocol !== undefined)
+        .flatMap(dependency => SyncEngineLevel.projectedDependencyProtocols(dependency))
     ).sort(lexicographicalCompare);
     if (protocols.length === 0) {
-      throw new Error('SyncEngineLevel: projected protocol-config dependency hints contained no protocols.');
+      throw new Error('SyncEngineLevel: projected dependency hints contained no protocols.');
     }
 
     return {
       kind      : 'protocolSet',
       protocols : protocols as NonEmptyStringArray,
     };
+  }
+
+  private static projectedDependencyProtocols(dependency: MessagesSyncDependencyEntry): string[] {
+    if (dependency.message === undefined) {
+      return [];
+    }
+
+    const protocol = dependency.dependencyClass === 'protocolsConfigure'
+      ? SyncEngineLevel.protocolsConfigureProtocolFromGenericMessage(dependency.message)
+      : SyncEngineLevel.recordsWriteProtocol(dependency.message);
+    return protocol === undefined ? [] : [protocol];
+  }
+
+  private static hasDependencyPayloadBytes(dependency: MessagesSyncDependencyEntry): boolean {
+    if (dependency.encodedData !== undefined) {
+      return true;
+    }
+
+    const message = dependency.message as Record<string, unknown> | undefined;
+    return message !== undefined && 'encodedData' in message;
+  }
+
+  private static dedupeDependencyEntries(
+    dependencies: Iterable<MessagesSyncDependencyEntry>,
+  ): MessagesSyncDependencyEntry[] {
+    const deduped = new Map<string, MessagesSyncDependencyEntry>();
+    for (const dependency of dependencies) {
+      deduped.set(dependency.messageCid, dependency);
+    }
+    return [...deduped.values()];
   }
 
   private async pushLocalDiffEntries(
@@ -4151,7 +4351,18 @@ export class SyncEngineLevel implements SyncEngine {
    * they are processed directly without additional HTTP round-trips.
    * Only `messageCids` that were NOT prefetched are fetched individually.
    */
-  private async pullMessages({ did, dwnUrl, delegateDid, protocol, scope, permissionGrantIds, messageCids, prefetched, shouldContinue }: {
+  private async pullMessages({
+    did,
+    dwnUrl,
+    delegateDid,
+    protocol,
+    scope,
+    permissionGrantIds,
+    messageCids,
+    prefetched,
+    verifiedInitialWrites,
+    shouldContinue,
+  }: {
     did: string;
     dwnUrl: string;
     delegateDid?: string;
@@ -4160,6 +4371,7 @@ export class SyncEngineLevel implements SyncEngine {
     permissionGrantIds?: string[];
     messageCids: string[];
     prefetched?: MessagesSyncDiffEntry[];
+    verifiedInitialWrites?: RecordsWriteMessage[];
     shouldContinue?: () => boolean;
   }): Promise<void> {
     const acceptanceScope: SyncScope = scope ?? (protocol === undefined
@@ -4176,7 +4388,7 @@ export class SyncEngineLevel implements SyncEngine {
       shouldContinue,
       agent       : this.agent,
       acceptEntry : async (entry, entries) => {
-        const result = await this.acceptPulledSyncEntry(did, acceptanceScope, entry, entries);
+        const result = await this.acceptPulledSyncEntry(did, acceptanceScope, entry, entries, verifiedInitialWrites);
         if (!result.accepted) {
           rejectedPullEntries.set(await getMessageCid(entry.message), result);
         }
@@ -4206,12 +4418,13 @@ export class SyncEngineLevel implements SyncEngine {
     scope: SyncScope,
     entry: SyncMessageEntry,
     entries: SyncMessageEntry[],
+    verifiedInitialWrites: RecordsWriteMessage[] = [],
   ): Promise<PullAcceptanceResult> {
     if (scope.kind === 'full') {
       return { accepted: true };
     }
 
-    const initialWrite = await this.resolvePulledDeleteInitialWrite(did, entry.message, entries);
+    const initialWrite = await this.resolvePulledDeleteInitialWrite(did, entry.message, entries, verifiedInitialWrites);
     const classification = classifySyncMessageScope({
       message: entry.message,
       initialWrite,
@@ -4231,6 +4444,7 @@ export class SyncEngineLevel implements SyncEngine {
     did: string,
     message: GenericMessage,
     entries: SyncMessageEntry[],
+    verifiedInitialWrites: RecordsWriteMessage[] = [],
   ): Promise<RecordsWriteMessage | undefined> {
     const descriptor = message.descriptor as Record<string, unknown>;
     if (
@@ -4252,11 +4466,25 @@ export class SyncEngineLevel implements SyncEngine {
       }
     }
 
+    const verifiedInitialWrite = SyncEngineLevel.findInitialWriteByRecordId(descriptor.recordId, verifiedInitialWrites);
+    if (verifiedInitialWrite !== undefined) {
+      return verifiedInitialWrite;
+    }
+
     // Batch entries are only used when the initial write has not been applied
-    // locally yet. RecordsWrite.isInitialWrite binds the candidate's CID to
-    // recordId, and processRawMessage still authenticates the delete before
-    // any local mutation occurs.
+    // locally yet. Verified dependency hints cover the projected remote-mode
+    // path where the initial write was applied in the previous pull batch and
+    // no embedded local message store is available. Batch entries are still
+    // parsed as initial RecordsWrite messages, and processRawMessage
+    // authenticates the delete before any local mutation occurs.
     return this.findInitialWriteInPullBatch(descriptor.recordId, entries);
+  }
+
+  private static findInitialWriteByRecordId(
+    recordId: string,
+    initialWrites: RecordsWriteMessage[],
+  ): RecordsWriteMessage | undefined {
+    return initialWrites.find(initialWrite => initialWrite.recordId === recordId);
   }
 
   private async findInitialWriteInPullBatch(

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -1,6 +1,7 @@
-import type { GenericMessage } from '@enbox/dwn-sdk-js';
-import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+import type { BearerIdentity } from '../src/bearer-identity.js';
 import type { SyncIdentityOptions } from '../src/index.js';
+import type { SyncScope } from '../src/types/sync.js';
+import type { GenericMessage, MessagesSyncDependencyEntry, ProtocolDefinition } from '@enbox/dwn-sdk-js';
 
 import sinon from 'sinon';
 
@@ -8,9 +9,7 @@ import { AbstractLevel } from 'abstract-level';
 import { Convert } from '@enbox/common';
 import { CryptoUtils } from '@enbox/crypto';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { DwnConstant, DwnInterfaceName, DwnMethodName, Jws, Message, PermissionsProtocol, Time } from '@enbox/dwn-sdk-js';
-
-import type { BearerIdentity } from '../src/bearer-identity.js';
+import { DwnConstant, DwnInterfaceName, DwnMethodName, Jws, Message, PermissionsProtocol, RecordsProjection, Time } from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from '../src/types/dwn.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
@@ -1407,6 +1406,104 @@ describe('SyncEngineLevel', () => {
         });
         expect(queryResponse.reply.status.code).toBe(200);
         expect(queryResponse.reply.entries).toHaveLength(0);
+      });
+
+      it('applies projected delete dependency hints through the real local DWN', async () => {
+        const protocolDefinition: ProtocolDefinition = {
+          ...freeForAllProtocolDefinition,
+          protocol: `https://protocol.xyz/projected-delete-apply/${CryptoUtils.randomUuid()}`,
+        };
+        const protocolResponse = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.ProtocolsConfigure,
+          messageParams : { definition: protocolDefinition },
+        });
+        expect(protocolResponse.reply.status.code).toBe(202);
+
+        const writeResponse = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsWrite,
+          messageParams : {
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'post',
+            dataFormat   : 'text/plain',
+          },
+          dataStream: new Blob(['Record to delete through projected sync'])
+        });
+        expect(writeResponse.reply.status.code).toBe(202);
+
+        const deleteResponse = await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsDelete,
+          messageParams : { recordId: writeResponse.message!.recordId }
+        });
+        expect(deleteResponse.reply.status.code).toBe(202);
+
+        const protocolMessage = protocolResponse.message!;
+        const initialWriteMessage = writeResponse.message!;
+        const deleteMessage = deleteResponse.message!;
+        const protocolCid = await Message.getCid(protocolMessage);
+        const initialWriteCid = await Message.getCid(initialWriteMessage);
+        const deleteCid = await Message.getCid(deleteMessage);
+        const dependencies: MessagesSyncDependencyEntry[] = [
+          {
+            dependencyClass : 'protocolsConfigure',
+            messageCid      : protocolCid,
+            message         : protocolMessage,
+            rootMessageCid  : deleteCid,
+          },
+          {
+            dependencyClass : 'recordsInitialWrite',
+            messageCid      : initialWriteCid,
+            message         : initialWriteMessage,
+            rootMessageCid  : deleteCid,
+          },
+        ];
+
+        const projectedScope = {
+          kind   : 'recordsProjection',
+          scopes : RecordsProjection.normalizeScopes([{ protocol: protocolDefinition.protocol, protocolPath: 'post' }]),
+        } satisfies Extract<SyncScope, { kind: 'recordsProjection' }>;
+        const projectedTarget = {
+          did           : alice.did.uri,
+          dwnUrl        : testDwnUrl,
+          scope         : projectedScope,
+          authorization : { kind: 'owner' },
+        } satisfies Parameters<typeof syncEngine['pullProjectedRemoteDiff']>[0];
+
+        const aborted = await syncEngine['pullProjectedRemoteDiff'](
+          projectedTarget,
+          projectedScope,
+          {
+            dependencies,
+            onlyLocal  : [],
+            onlyRemote : [{ messageCid: deleteCid, message: deleteMessage }],
+          },
+          undefined,
+        );
+
+        expect(aborted).toBe(false);
+
+        const deleteRead = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.MessagesRead,
+          messageParams : { messageCid: deleteCid },
+        });
+        expect(deleteRead.reply.status.code).toBe(200);
+        expect(deleteRead.reply.entry?.message.descriptor.method).toBe(DwnMethodName.Delete);
+
+        const localQuery = await testHarness.agent.dwn.processRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsQuery,
+          messageParams : { filter: { recordId: initialWriteMessage.recordId } }
+        });
+        expect(localQuery.reply.status.code).toBe(200);
+        expect(localQuery.reply.entries).toHaveLength(0);
       });
 
       it('syncs RecordsDelete messages from local to remote', async () => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -2938,6 +2938,16 @@ describe('SyncEngineLevel — private methods', () => {
       rootMessageCid,
     });
 
+    const initialWriteDependencyEntry = async (
+      message: GenericMessage,
+      rootMessageCid: string,
+    ): Promise<MessagesSyncDependencyEntry> => ({
+      dependencyClass : 'recordsInitialWrite',
+      messageCid      : await Message.getCid(message),
+      message,
+      rootMessageCid,
+    });
+
     it('reconcileRecordsProjectionTarget should diff and verify convergence for projected roots', async () => {
       const engine = createEngine({ db, agent: { agentDid: 'did:example:agent' } as any });
       sinon.stub(engine as any, 'getLocalProjectedRoot')
@@ -3070,6 +3080,101 @@ describe('SyncEngineLevel — private methods', () => {
       });
     });
 
+    it('pullProjectedRemoteDiff should apply verified initial-write dependencies before delete primaries', async () => {
+      const author = await TestDataGenerator.generatePersona();
+      const processRawMessage = sinon.stub().resolves({ status: { code: 202 } });
+      const agent = {
+        ...createResolvingAgent(author),
+        dwn: {
+          isRemoteMode : false,
+          node         : { storage: { messageStore: {} } },
+          processRawMessage,
+        },
+      };
+      const engine = createEngine({ db, agent: agent as any });
+      const tenantTarget = { ...target, did: author.did };
+      const protocolConfig = await protocolsConfigureMessage({ author });
+      const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+        author,
+        protocol     : projectedProtocol,
+        protocolPath : 'profile/avatar',
+      });
+      const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+        author   : recordsWrite.author,
+        recordId : recordsWrite.message.recordId,
+      });
+      const deleteCid = await Message.getCid(recordsDelete.message);
+      const fetchInitialStub = sinon.stub(RecordsWrite, 'fetchInitialRecordsWriteMessage').resolves(recordsWrite.message);
+
+      const aborted = await (engine as any).pullProjectedRemoteDiff(
+        tenantTarget,
+        projectedScope,
+        {
+          dependencies: [
+            await initialWriteDependencyEntry(recordsWrite.message, deleteCid),
+            await dependencyEntry(protocolConfig, deleteCid),
+          ],
+          onlyLocal  : [],
+          onlyRemote : [{ messageCid: deleteCid, message: recordsDelete.message }],
+        },
+        ['grant-1'],
+      );
+
+      expect(aborted).toBe(false);
+      expect(fetchInitialStub.calledOnce).toBe(true);
+      expect(processRawMessage.callCount).toBe(3);
+      expect(await Message.getCid(processRawMessage.firstCall.args[1])).toBe(await Message.getCid(protocolConfig));
+      expect(await Message.getCid(processRawMessage.secondCall.args[1])).toBe(await Message.getCid(recordsWrite.message));
+      expect(await Message.getCid(processRawMessage.thirdCall.args[1])).toBe(await Message.getCid(recordsDelete.message));
+    });
+
+    it('pullProjectedRemoteDiff should use verified initial-write dependencies for remote-mode delete classification', async () => {
+      const author = await TestDataGenerator.generatePersona();
+      const processRawMessage = sinon.stub().resolves({ status: { code: 202 } });
+      const agent = {
+        ...createResolvingAgent(author),
+        dwn: {
+          isRemoteMode: true,
+          processRawMessage,
+        },
+      };
+      const engine = createEngine({ db, agent: agent as any });
+      const tenantTarget = { ...target, did: author.did };
+      const protocolConfig = await protocolsConfigureMessage({ author });
+      const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+        author,
+        protocol     : projectedProtocol,
+        protocolPath : 'profile/avatar',
+      });
+      const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+        author   : recordsWrite.author,
+        recordId : recordsWrite.message.recordId,
+      });
+      const deleteCid = await Message.getCid(recordsDelete.message);
+      const fetchInitialStub = sinon.stub(RecordsWrite, 'fetchInitialRecordsWriteMessage');
+
+      const aborted = await (engine as any).pullProjectedRemoteDiff(
+        tenantTarget,
+        projectedScope,
+        {
+          dependencies: [
+            await initialWriteDependencyEntry(recordsWrite.message, deleteCid),
+            await dependencyEntry(protocolConfig, deleteCid),
+          ],
+          onlyLocal  : [],
+          onlyRemote : [{ messageCid: deleteCid, message: recordsDelete.message }],
+        },
+        ['grant-1'],
+      );
+
+      expect(aborted).toBe(false);
+      expect(fetchInitialStub.called).toBe(false);
+      expect(processRawMessage.callCount).toBe(3);
+      expect(await Message.getCid(processRawMessage.firstCall.args[1])).toBe(await Message.getCid(protocolConfig));
+      expect(await Message.getCid(processRawMessage.secondCall.args[1])).toBe(await Message.getCid(recordsWrite.message));
+      expect(await Message.getCid(processRawMessage.thirdCall.args[1])).toBe(await Message.getCid(recordsDelete.message));
+    });
+
     it('verifyProjectedProtocolConfigDependencies should reject malformed or out-of-scope hints', async () => {
       const author = await TestDataGenerator.generatePersona();
       const engine = createEngine({ db, agent: createResolvingAgent(author) as any });
@@ -3125,6 +3230,76 @@ describe('SyncEngineLevel — private methods', () => {
             message         : futureProtocolConfig,
             rootMessageCid  : primaryCid,
           },
+        ],
+      );
+
+      expect(verified).toEqual([]);
+    });
+
+    it('verifyProjectedDependencies should reject malformed or out-of-scope initial-write hints', async () => {
+      const author = await TestDataGenerator.generatePersona();
+      const engine = createEngine({ db, agent: createResolvingAgent(author) as any });
+      const inScopeWrite = await TestDataGenerator.generateRecordsWrite({
+        author,
+        protocol     : projectedProtocol,
+        protocolPath : 'profile/avatar',
+      });
+      const inScopeDelete = await TestDataGenerator.generateRecordsDelete({
+        author   : inScopeWrite.author,
+        recordId : inScopeWrite.message.recordId,
+      });
+      const protocolConfig = await protocolsConfigureMessage({ author });
+      const outOfScopeWrite = await TestDataGenerator.generateRecordsWrite({
+        author,
+        protocol     : projectedProtocol,
+        protocolPath : 'profile/banner',
+      });
+      const outOfScopeDelete = await TestDataGenerator.generateRecordsDelete({
+        author   : outOfScopeWrite.author,
+        recordId : outOfScopeWrite.message.recordId,
+      });
+      const otherInScopeWrite = await TestDataGenerator.generateRecordsWrite({
+        author,
+        protocol     : projectedProtocol,
+        protocolPath : 'profile/avatar',
+      });
+      const nonInitialWrite = await TestDataGenerator.generateFromRecordsWrite({
+        author,
+        existingWrite: inScopeWrite.recordsWrite,
+      });
+      const inScopeDeleteCid = await Message.getCid(inScopeDelete.message);
+      const outOfScopeDeleteCid = await Message.getCid(outOfScopeDelete.message);
+      const inScopeWriteCid = await Message.getCid(inScopeWrite.message);
+      const validInitialWriteDependency = await initialWriteDependencyEntry(inScopeWrite.message, inScopeDeleteCid);
+      const outOfScopeInitialWriteDependency = await initialWriteDependencyEntry(outOfScopeWrite.message, outOfScopeDeleteCid);
+      const encodedInitialWriteMessage: GenericMessage & { encodedData: string } = {
+        ...validInitialWriteDependency.message!,
+        encodedData: 'eyJub3QiOiJhbGxvd2VkIn0',
+      };
+      const { authorization: _authorization, ...unauthenticatedInitialWriteMessage } = inScopeWrite.message;
+
+      const verified = await (engine as any).verifyProjectedDependencies(
+        author.did,
+        projectedScope,
+        [
+          { messageCid: inScopeDeleteCid, message: inScopeDelete.message },
+          { messageCid: outOfScopeDeleteCid, message: outOfScopeDelete.message },
+          { messageCid: inScopeWriteCid, message: inScopeWrite.message },
+        ],
+        [
+          { ...validInitialWriteDependency, messageCid: 'wrong-cid' },
+          { ...validInitialWriteDependency, encodedData: 'eyJub3QiOiJhbGxvd2VkIn0' },
+          {
+            ...validInitialWriteDependency,
+            message: encodedInitialWriteMessage,
+          },
+          await initialWriteDependencyEntry(otherInScopeWrite.message, inScopeDeleteCid),
+          await initialWriteDependencyEntry(nonInitialWrite.message, inScopeDeleteCid),
+          await initialWriteDependencyEntry(unauthenticatedInitialWriteMessage, inScopeDeleteCid),
+          await initialWriteDependencyEntry(inScopeWrite.message, inScopeWriteCid),
+          await dependencyEntry(protocolConfig, inScopeDeleteCid),
+          await initialWriteDependencyEntry(outOfScopeWrite.message, inScopeDeleteCid),
+          outOfScopeInitialWriteDependency,
         ],
       );
 

--- a/packages/dwn-sdk-js/src/handlers/messages-sync.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-sync.ts
@@ -15,6 +15,7 @@ import { MessagesGrantAuthorization } from '../core/messages-grant-authorization
 import { MessagesSync } from '../interfaces/messages-sync.js';
 import { Records } from '../utils/records.js';
 import { RecordsProjection } from '../sync/records-projection.js';
+import { RecordsWrite } from '../interfaces/records-write.js';
 import { SortDirection } from '../types/query-types.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
@@ -29,6 +30,10 @@ import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.j
 const DEFAULT_MAX_INLINE_DATA_SIZE = DwnConstant.maxDataSizeAllowedToBeEncoded;
 
 type StoredMessageWithEncodedData = GenericMessage & { encodedData?: string };
+type StoredMessageWithInternalFields = GenericMessage & {
+  encodedData?: unknown;
+  initialWrite?: unknown;
+};
 type RecordsWriteProtocolDescriptor = GenericMessage['descriptor'] & { protocol?: unknown };
 type RecordsWriteProtocolMetadata = { protocol: string; messageTimestamp: string };
 type ProtocolsConfigureDefinitionDescriptor = GenericMessage['descriptor'] & {
@@ -482,14 +487,38 @@ export class MessagesSyncHandler implements MethodHandler {
 
     for (const primaryEntry of primaryEntries) {
       const protocolMetadata = MessagesSyncHandler.recordsWriteProtocolMetadata(primaryEntry.message);
-      if (protocolMetadata === undefined) {
+      if (protocolMetadata !== undefined) {
+        await this.addProtocolConfigClosureDependencies(
+          tenant,
+          protocolMetadata.protocol,
+          protocolMetadata.messageTimestamp,
+          primaryEntry.messageCid,
+          configsByProtocol,
+          dependenciesByCid,
+        );
+        continue;
+      }
+
+      const initialWrite = await this.readRecordsDeleteInitialWrite(tenant, primaryEntry.message);
+      if (initialWrite === undefined) {
+        continue;
+      }
+
+      await MessagesSyncHandler.addRecordsInitialWriteDependency(
+        primaryEntry.messageCid,
+        initialWrite,
+        dependenciesByCid,
+      );
+
+      const initialWriteMetadata = MessagesSyncHandler.recordsWriteProtocolMetadata(initialWrite);
+      if (initialWriteMetadata === undefined) {
         continue;
       }
 
       await this.addProtocolConfigClosureDependencies(
         tenant,
-        protocolMetadata.protocol,
-        protocolMetadata.messageTimestamp,
+        initialWriteMetadata.protocol,
+        initialWriteMetadata.messageTimestamp,
         primaryEntry.messageCid,
         configsByProtocol,
         dependenciesByCid,
@@ -497,6 +526,42 @@ export class MessagesSyncHandler implements MethodHandler {
     }
 
     return [...dependenciesByCid.values()];
+  }
+
+  private async readRecordsDeleteInitialWrite(
+    tenant: string,
+    message: GenericMessage | undefined,
+  ): Promise<GenericMessage | undefined> {
+    const recordId = MessagesSyncHandler.recordsDeleteRecordId(message);
+    if (recordId === undefined) {
+      return undefined;
+    }
+
+    const { messages } = await this.deps.messageStore.query(tenant, [{
+      interface : DwnInterfaceName.Records,
+      method    : DwnMethodName.Write,
+      recordId,
+    }]);
+    const initialWrite = await RecordsWrite.getInitialWrite(messages);
+    return initialWrite === undefined ? undefined : MessagesSyncHandler.toWireMessage(initialWrite);
+  }
+
+  private static async addRecordsInitialWriteDependency(
+    rootMessageCid: string,
+    dependency: GenericMessage,
+    dependenciesByCid: Map<string, MessagesSyncDependencyEntry>,
+  ): Promise<void> {
+    const dependencyCid = await Message.getCid(dependency);
+    if (dependenciesByCid.has(dependencyCid)) {
+      return;
+    }
+
+    dependenciesByCid.set(dependencyCid, {
+      dependencyClass : 'recordsInitialWrite',
+      messageCid      : dependencyCid,
+      message         : dependency,
+      rootMessageCid,
+    });
   }
 
   private async addProtocolConfigClosureDependencies(
@@ -666,6 +731,23 @@ export class MessagesSyncHandler implements MethodHandler {
     return typeof protocol === 'string'
       ? { protocol, messageTimestamp: message.descriptor.messageTimestamp }
       : undefined;
+  }
+
+  private static recordsDeleteRecordId(message: GenericMessage | undefined): string | undefined {
+    if (
+      message?.descriptor.interface !== DwnInterfaceName.Records ||
+      message.descriptor.method !== DwnMethodName.Delete
+    ) {
+      return undefined;
+    }
+
+    const recordId = (message.descriptor as Record<string, unknown>).recordId;
+    return typeof recordId === 'string' ? recordId : undefined;
+  }
+
+  private static toWireMessage(message: GenericMessage): GenericMessage {
+    const { encodedData: _encodedData, initialWrite: _initialWrite, ...wireMessage } = message as StoredMessageWithInternalFields;
+    return wireMessage;
   }
 
   /**

--- a/packages/dwn-sdk-js/src/types/messages-types.ts
+++ b/packages/dwn-sdk-js/src/types/messages-types.ts
@@ -91,7 +91,7 @@ export type MessagesSyncDiffEntry = {
   encodedData? : string;
 };
 
-export type MessagesSyncDependencyClass = 'protocolsConfigure';
+export type MessagesSyncDependencyClass = 'protocolsConfigure' | 'recordsInitialWrite';
 
 /**
  * Advisory dependency hint returned with projected diff responses. Dependency

--- a/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-sync.spec.ts
@@ -1074,6 +1074,88 @@ export function testMessagesSyncHandler(): void {
           ]);
         });
 
+        it('returns initial write and protocol config dependencies for projected delete tombstones', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+          const protocolDefinition: ProtocolDefinition = { ...freeForAll, protocol: 'http://projected-sync-delete-hints', published: true };
+          const unrelatedDefinition: ProtocolDefinition = { ...freeForAll, protocol: 'http://projected-sync-delete-hints-unrelated', published: true };
+          const protocol = protocolDefinition.protocol;
+
+          const { message: protocolMessage } = await TestDataGenerator.generateProtocolsConfigure({
+            author: alice,
+            protocolDefinition,
+          });
+          expect((await dwn.processMessage(alice.did, protocolMessage)).status.code).toBe(202);
+
+          const { message: unrelatedProtocolMessage } = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : unrelatedDefinition,
+          });
+          expect((await dwn.processMessage(alice.did, unrelatedProtocolMessage)).status.code).toBe(202);
+
+          const { message: postMessage, dataStream: postDataStream } = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol,
+            protocolPath : 'post',
+            schema       : protocolDefinition.types.post.schema,
+          });
+          expect((await dwn.processMessage(alice.did, postMessage, { dataStream: postDataStream })).status.code).toBe(202);
+
+          const { message: deleteMessage } = await TestDataGenerator.generateRecordsDelete({
+            author   : alice,
+            recordId : postMessage.recordId,
+          });
+          expect((await dwn.processMessage(alice.did, deleteMessage)).status.code).toBe(202);
+
+          const { message: grantMessage, dataStream: grantDataStream } = await TestDataGenerator.generateGrantCreate({
+            author    : alice,
+            grantedTo : bob,
+            scope     : {
+              interface    : DwnInterfaceName.Messages,
+              method       : DwnMethodName.Read,
+              protocol,
+              protocolPath : 'post',
+            },
+          });
+          expect((await dwn.processMessage(alice.did, grantMessage, { dataStream: grantDataStream })).status.code).toBe(202);
+
+          const { message: diffMsg } = await MessagesSync.create({
+            signer                : Jws.createSigner(bob),
+            action                : 'diff',
+            hashes                : {},
+            depth                 : 2,
+            projectionRootVersion : RECORDS_PROJECTION_ROOT_VERSION,
+            projectionScopes      : [{ protocol, protocolPath: 'post' }],
+            permissionGrantIds    : [grantMessage.recordId],
+          });
+
+          const reply = await dwn.processMessage(alice.did, diffMsg);
+          expect(reply.status.code).toBe(200);
+
+          const deleteCid = await Message.getCid(deleteMessage);
+          const postCid = await Message.getCid(postMessage);
+          const protocolCid = await Message.getCid(protocolMessage);
+          expect(reply.onlyRemote!.map(entry => entry.messageCid)).toEqual([deleteCid]);
+          expect(reply.dependencies!.map(entry => entry.messageCid)).not.toContain(await Message.getCid(unrelatedProtocolMessage));
+          expect(reply.dependencies).toEqual([
+            {
+              dependencyClass : 'recordsInitialWrite',
+              messageCid      : postCid,
+              message         : postMessage,
+              rootMessageCid  : deleteCid,
+            },
+            {
+              dependencyClass : 'protocolsConfigure',
+              messageCid      : protocolCid,
+              message         : protocolMessage,
+              rootMessageCid  : deleteCid,
+            },
+          ]);
+          const initialWriteDependency = reply.dependencies!.find(entry => entry.dependencyClass === 'recordsInitialWrite')!;
+          expect(initialWriteDependency.encodedData).toBeUndefined();
+          expect('encodedData' in initialWriteDependency.message!).toBe(false);
+        });
+
         it('returns composed protocol config dependencies for projected sync', async () => {
           const alice = await TestDataGenerator.generateDidKeyPersona();
           const bob = await TestDataGenerator.generateDidKeyPersona();


### PR DESCRIPTION
## Summary
- return payload-free initial-write dependency hints for projected delete tombstones
- verify delete dependencies before applying them in the agent
- derive delete protocol-config hints from the verified initial write

Companion spec PR: enboxorg/dwn-spec#59

## Verification
- bunx turbo run lint --filter=@enbox/dwn-sdk-js --filter=@enbox/agent
- bunx turbo run build --filter=@enbox/dwn-sdk-js... --filter=@enbox/agent...
- bun test --timeout 20000 tests/sync-engine-private.spec.ts
- bun ./build/compile-validators.js && bun test tests/store-dependent-tests.spec.ts -t "MessagesSyncHandler.handle"