### PR TITLE
Repair scoped sync protocol metadata gaps

### DIFF
--- a/.changeset/sync-protocol-metadata-repair.md
+++ b/.changeset/sync-protocol-metadata-repair.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Repair scoped live sync closure when protocol metadata arrives after records by fetching and applying tenant-signed protocol configs from the remote DWN.

--- a/packages/agent/src/sync-closure-types.ts
+++ b/packages/agent/src/sync-closure-types.ts
@@ -206,6 +206,8 @@ export function invalidateClosureCache(
       : undefined;
     if (protocol) {
       context.protocolCache.delete(protocol);
+      deleteProtocolDependencyCacheEntries(context.satisfiedDeps, protocol);
+      deleteProtocolDependencyCacheEntries(context.missingDeps, protocol);
     }
   }
 
@@ -316,6 +318,20 @@ export function invalidateClosureCache(
 function deleteDependencyCacheEntries(cache: Set<string>, dependencyKeySuffix: string): void {
   for (const key of cache) {
     if (key.endsWith(dependencyKeySuffix)) {
+      cache.delete(key);
+    }
+  }
+}
+
+function deleteProtocolDependencyCacheEntries(cache: Set<string>, protocol: string): void {
+  const marker = ':protocol:';
+  for (const key of cache) {
+    const markerIndex = key.lastIndexOf(marker);
+    if (markerIndex === -1) {
+      continue;
+    }
+    const protocolIdentifier = key.substring(markerIndex + marker.length);
+    if (protocolIdentifier === protocol) {
       cache.delete(key);
     }
   }

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1,7 +1,7 @@
 import type { AbstractLevel } from 'abstract-level';
 
 import type { DwnSubscriptionHandler, ResubscribeFactory } from '@enbox/dwn-clients';
-import type { GenericMessage, MessageEvent, MessagesSubscribeReply, MessagesSyncDependencyEntry, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, ProtocolsConfigureMessage, RecordsProjectionScope, RecordsWriteMessage, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, MessageEvent, MessagesSubscribeReply, MessagesSyncDependencyEntry, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, ProtocolsConfigureMessage, ProtocolsQueryReply, RecordsProjectionScope, RecordsWriteMessage, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
 import ms from 'ms';
 
@@ -9,15 +9,15 @@ import { Level } from 'level';
 import { sleep } from '@enbox/common';
 import { authenticate, DwnInterfaceName, DwnMethodName, Encoder, hashToHex, initDefaultHashes, Message, ProtocolsConfigure, RECORDS_PROJECTION_ROOT_VERSION, RecordsProjection, RecordsWrite } from '@enbox/dwn-sdk-js';
 
-import type { ClosureEvaluationContext } from './sync-closure-types.js';
+import type { DwnMessageParams } from './types/dwn.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
 import type { SyncMessageEntry } from './sync-messages.js';
 import type { SyncScopeClassification } from './sync-scope-acceptance.js';
+import type { ClosureEvaluationContext, ClosureResult } from './sync-closure-types.js';
 import type { DeadLetterCategory, DeadLetterEntry, NonEmptyStringArray, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
-import type { DwnMessageParams } from './types/dwn.js';
 
 import { buildLinkId } from './sync-link-id.js';
 import { DwnInterface } from './types/dwn.js';
@@ -26,8 +26,8 @@ import { isRecordsWrite } from './utils.js';
 import { ReplicationLedger } from './sync-replication-ledger.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { classifySyncEventScope, classifySyncMessageScope } from './sync-scope-acceptance.js';
+import { ClosureFailureCode, createClosureContext, invalidateClosureCache, isTerminalClosureFailureCode } from './sync-closure-types.js';
 import { computeAuthorizationEpoch, computeProjectionId, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
-import { createClosureContext, invalidateClosureCache, isTerminalClosureFailureCode } from './sync-closure-types.js';
 import { fetchRemoteMessages, getMessageCid, pullMessages, pushMessages, SyncPullAbortedError } from './sync-messages.js';
 import { partitionRemoteEntries, SyncLinkReconciler } from './sync-link-reconciler.js';
 import { permissionGrantIdsFromEntries, resolveMessagesSyncScopes, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
@@ -242,6 +242,13 @@ type PullDelivery = {
   ordinal: number;
 };
 
+type LivePullDataStreamFactory = () => Promise<ReadableStream<Uint8Array> | undefined>;
+
+type ApplyStatus = {
+  code: number;
+  detail?: string;
+};
+
 function syncEventScope(scope: SyncScope | undefined): SyncEventScope {
   if (scope === undefined) {
     return {};
@@ -352,6 +359,9 @@ export class SyncEngineLevel implements SyncEngine {
    * tenant. Keyed by tenantDid to prevent cross-tenant cache pollution.
    */
   private readonly _closureContexts: Map<string, ClosureEvaluationContext> = new Map();
+
+  /** Deduplicates concurrent live-sync repairs for the same tenant/protocol. */
+  private readonly _protocolMetadataRepairs: Map<string, Promise<boolean>> = new Map();
 
   /** Maximum entries in the echo-loop suppression cache. */
   private static readonly ECHO_SUPPRESS_MAX_ENTRIES = 10_000;
@@ -1533,6 +1543,7 @@ export class SyncEngineLevel implements SyncEngine {
 
     // Clear closure evaluation contexts.
     this._closureContexts.clear();
+    this._protocolMetadataRepairs.clear();
     this._recentlyPulledCids.clear();
 
     // Clear the in-memory link and runtime state.
@@ -2163,13 +2174,28 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private async processLivePullEvent(context: LivePullContext, event: MessageEvent): Promise<string | undefined> {
-    const dataStream = await this.getLivePullDataStream(context, event);
-    await this.agent.dwn.processRawMessage(context.did, event.message, { dataStream });
+    const dataStreamFactory = await this.createLivePullDataStreamFactory(context, event);
+    let applyStatus = await this.applyLivePullEvent(context, event, dataStreamFactory);
     if (context.isStale()) { return undefined; }
 
-    this.invalidateClosureCacheForMessage(context.did, event.message);
+    let applied = SyncEngineLevel.isApplySuccess(applyStatus.code);
+    if (applied) {
+      this.invalidateClosureCacheForMessage(context.did, event.message);
+    }
+
     if (!await this.ensureClosureComplete(context, event)) {
       return undefined;
+    }
+
+    if (!applied) {
+      applyStatus = await this.applyLivePullEvent(context, event, dataStreamFactory);
+      if (context.isStale()) { return undefined; }
+
+      applied = SyncEngineLevel.isApplySuccess(applyStatus.code);
+      if (!applied) {
+        throw await this.createLivePullApplyError(event, applyStatus);
+      }
+      this.invalidateClosureCacheForMessage(context.did, event.message);
     }
 
     // Squash convergence: processRawMessage triggers the DWN's built-in
@@ -2178,27 +2204,102 @@ export class SyncEngineLevel implements SyncEngine {
     return Message.getCid(event.message);
   }
 
-  private async getLivePullDataStream(
-    { did, dwnUrl, delegateDid, permissionGrantIds }: LivePullContext,
+  private async applyLivePullEvent(
+    context: LivePullContext,
     event: MessageEvent,
-  ): Promise<ReadableStream<Uint8Array> | undefined> {
-    const inlineData = this.extractDataStream(event);
-    if (inlineData || !isRecordsWrite(event) || !(event.message.descriptor as any).dataCid) {
-      return inlineData;
+    dataStreamFactory: LivePullDataStreamFactory,
+  ): Promise<ApplyStatus> {
+    const dataStream = await dataStreamFactory();
+    const reply = await this.agent.dwn.processRawMessage(context.did, event.message, { dataStream });
+    return reply.status;
+  }
+
+  private async createLivePullDataStreamFactory(
+    context: LivePullContext,
+    event: MessageEvent,
+  ): Promise<LivePullDataStreamFactory> {
+    if (!isRecordsWrite(event)) {
+      return async () => undefined;
+    }
+
+    const encodedData = (event.message as any).encodedData as string | undefined;
+    if (encodedData) {
+      delete (event.message as any).encodedData;
+      const bytes = Encoder.base64UrlToBytes(encodedData);
+      return async () => SyncEngineLevel.dataStreamFromBytes(bytes);
+    }
+
+    const eventData = (event as any).data as ReadableStream<Uint8Array> | undefined;
+    if (eventData) {
+      const bytes = await SyncEngineLevel.readStreamBytes(eventData);
+      return async () => SyncEngineLevel.dataStreamFromBytes(bytes);
+    }
+
+    if (!(event.message.descriptor as any).dataCid) {
+      return async () => undefined;
     }
 
     // For large RecordsWrite messages (no inline data), fetch the data from
-    // the remote DWN via MessagesRead before storing locally.
+    // the remote DWN via MessagesRead before each store attempt. ReadableStream
+    // instances are single-use, so a repair-triggered retry needs a fresh fetch.
+    const { did, dwnUrl, delegateDid, permissionGrantIds } = context;
     const messageCid = await Message.getCid(event.message);
-    const fetched = await fetchRemoteMessages({
-      did,
-      dwnUrl,
-      delegateDid,
-      permissionGrantIds,
-      messageCids : [messageCid],
-      agent       : this.agent,
+    return async () => {
+      const fetched = await fetchRemoteMessages({
+        did,
+        dwnUrl,
+        delegateDid,
+        permissionGrantIds,
+        messageCids : [messageCid],
+        agent       : this.agent,
+      });
+      return fetched[0]?.dataStream;
+    };
+  }
+
+  private async createLivePullApplyError(event: MessageEvent, status: ApplyStatus): Promise<Error> {
+    const cid = await Message.getCid(event.message);
+    return new Error(
+      `SyncEngineLevel: live pull apply failed for ${cid}: ${status.code} ${status.detail ?? ''}`.trim()
+    );
+  }
+
+  private static dataStreamFromBytes(bytes: Uint8Array): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+      start(controller): void {
+        controller.enqueue(bytes);
+        controller.close();
+      }
     });
-    return fetched[0]?.dataStream;
+  }
+
+  private static async readStreamBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalSize = 0;
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) { break; }
+        chunks.push(value);
+        totalSize += value.byteLength;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const bytes = new Uint8Array(totalSize);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return bytes;
+  }
+
+  private static isApplySuccess(code: number): boolean {
+    return (code >= 200 && code < 300) || code === 409;
   }
 
   private invalidateClosureCacheForMessage(did: string, message: GenericMessage): void {
@@ -2225,12 +2326,277 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     const messageStore = this.agent.dwn.node.storage.messageStore;
-    const closureResult = await evaluateClosure(event.message, messageStore, link.scope, closureCtx);
+    let closureResult = await evaluateClosure(event.message, messageStore, link.scope, closureCtx);
     if (isStale()) { return false; }
     if (closureResult.complete) { return true; }
 
+    if (await this.tryRepairMissingProtocolMetadata(context, closureCtx, closureResult)) {
+      if (isStale()) { return false; }
+
+      closureResult = await evaluateClosure(event.message, messageStore, link.scope, closureCtx);
+      if (isStale()) { return false; }
+      if (closureResult.complete) { return true; }
+    }
+
     await this.recordClosureFailure(context, event, closureResult.failure!.code, closureResult.failure!.detail);
     return false;
+  }
+
+  private async tryRepairMissingProtocolMetadata(
+    context: LivePullContext,
+    closureCtx: ClosureEvaluationContext,
+    closureResult: ClosureResult,
+  ): Promise<boolean> {
+    const failure = closureResult.failure;
+    if (!SyncEngineLevel.isRepairableProtocolMetadataFailure(failure)) {
+      return false;
+    }
+
+    const { did } = context;
+    const repairKey = `${did}|${failure.edge.identifier}`;
+    const activeRepair = this._protocolMetadataRepairs.get(repairKey);
+    if (activeRepair) {
+      return activeRepair;
+    }
+
+    const repair = this.repairMissingProtocolMetadata(context, closureCtx, failure.edge.identifier);
+    this._protocolMetadataRepairs.set(repairKey, repair);
+    repair.finally(() => {
+      if (this._protocolMetadataRepairs.get(repairKey) === repair) {
+        this._protocolMetadataRepairs.delete(repairKey);
+      }
+    }).catch(() => { /* caller handles the repair result */ });
+    return repair;
+  }
+
+  private async repairMissingProtocolMetadata(
+    { did, dwnUrl, delegateDid, isStale }: LivePullContext,
+    closureCtx: ClosureEvaluationContext,
+    protocol: string,
+  ): Promise<boolean> {
+    if (isStale()) {
+      return false;
+    }
+
+    const configs = await this.fetchRemoteProtocolConfigClosure({
+      authorDid : delegateDid ?? did,
+      delegateDid,
+      dwnUrl,
+      protocol,
+      tenantDid : did,
+    });
+    if (isStale() || configs.length === 0) {
+      return false;
+    }
+
+    // Live subscriptions can deliver scoped records before the local replica
+    // has the tenant's protocol metadata. Reuse the DWN ProtocolsQuery path and
+    // only install configs that are signed by the tenant, including composed
+    // protocol dependencies needed to authorize the record.
+    let repaired = false;
+    for (const config of configs) {
+      if (isStale()) {
+        return repaired;
+      }
+      const reply = await this.agent.dwn.processRawMessage(did, config);
+      if (isStale()) {
+        return repaired;
+      }
+      if (!SyncEngineLevel.protocolConfigApplySucceeded(reply.status.code)) {
+        return repaired;
+      }
+
+      invalidateClosureCache(closureCtx, config);
+      repaired = true;
+    }
+
+    return repaired;
+  }
+
+  private async fetchRemoteProtocolConfigClosure({
+    authorDid,
+    delegateDid,
+    dwnUrl,
+    protocol,
+    tenantDid,
+  }: {
+    authorDid: string;
+    delegateDid?: string;
+    dwnUrl: string;
+    protocol: string;
+    tenantDid: string;
+  }): Promise<ProtocolsConfigureMessage[]> {
+    const configsByProtocol = new Map<string, ProtocolsConfigureMessage>();
+    const visiting = new Set<string>();
+
+    const visit = async (protocolUri: string): Promise<boolean> => {
+      if (configsByProtocol.has(protocolUri)) {
+        return true;
+      }
+      if (visiting.has(protocolUri)) {
+        return true;
+      }
+      visiting.add(protocolUri);
+
+      const config = await this.fetchRemoteProtocolConfig({
+        authorDid,
+        delegateDid,
+        dwnUrl,
+        protocol: protocolUri,
+        tenantDid,
+      });
+      if (config === undefined) {
+        visiting.delete(protocolUri);
+        return false;
+      }
+
+      for (const usedProtocol of SyncEngineLevel.protocolsConfigureUses(config)) {
+        if (!await visit(usedProtocol)) {
+          visiting.delete(protocolUri);
+          return false;
+        }
+      }
+
+      configsByProtocol.set(protocolUri, config);
+      visiting.delete(protocolUri);
+      return true;
+    };
+
+    return await visit(protocol) ? [...configsByProtocol.values()] : [];
+  }
+
+  private async fetchRemoteProtocolConfig({
+    authorDid,
+    delegateDid,
+    dwnUrl,
+    protocol,
+    tenantDid,
+  }: {
+    authorDid: string;
+    delegateDid?: string;
+    dwnUrl: string;
+    protocol: string;
+    tenantDid: string;
+  }): Promise<ProtocolsConfigureMessage | undefined> {
+    try {
+      const permissionGrantId = await this.getProtocolsQueryPermissionGrantId({
+        delegateDid,
+        protocol,
+        tenantDid,
+      });
+      const { message } = await this.agent.processDwnRequest({
+        author        : authorDid,
+        messageParams : {
+          filter: { protocol },
+          ...(permissionGrantId === undefined ? {} : { permissionGrantId }),
+        },
+        messageType : DwnInterface.ProtocolsQuery,
+        store       : false,
+        target      : tenantDid,
+      });
+
+      const reply = await this.agent.rpc.sendDwnRequest({
+        dwnUrl,
+        message,
+        targetDid: tenantDid,
+      }) as ProtocolsQueryReply;
+      if (reply.status.code !== 200 || reply.entries === undefined) {
+        return undefined;
+      }
+
+      const candidates: ProtocolsConfigureMessage[] = [];
+      for (const entry of reply.entries) {
+        const config = await this.toAuthenticatedTenantProtocolConfig(tenantDid, entry);
+        if (config?.descriptor.definition.protocol === protocol) {
+          candidates.push(config);
+        }
+      }
+
+      return SyncEngineLevel.newestProtocolConfig(candidates);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async getProtocolsQueryPermissionGrantId({
+    delegateDid,
+    protocol,
+    tenantDid,
+  }: {
+    delegateDid?: string;
+    protocol: string;
+    tenantDid: string;
+  }): Promise<string | undefined> {
+    if (delegateDid === undefined) {
+      return undefined;
+    }
+
+    try {
+      const { grant } = await this._permissionsApi.getPermissionForRequest({
+        connectedDid : tenantDid,
+        delegateDid,
+        protocol,
+        cached       : true,
+        messageType  : DwnInterface.ProtocolsQuery,
+      });
+      return grant.id;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async toAuthenticatedTenantProtocolConfig(
+    tenantDid: string,
+    message: GenericMessage,
+  ): Promise<ProtocolsConfigureMessage | undefined> {
+    if (!SyncEngineLevel.isProtocolsConfigureDefinitionMessage(message)) {
+      return undefined;
+    }
+
+    try {
+      await ProtocolsConfigure.parse(message);
+      if (Message.getAuthor(message) !== tenantDid) {
+        return undefined;
+      }
+      await authenticate(message.authorization, this.agent.did);
+      return message;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private static newestProtocolConfig(
+    configs: ProtocolsConfigureMessage[],
+  ): ProtocolsConfigureMessage | undefined {
+    let newest: ProtocolsConfigureMessage | undefined;
+    for (const config of configs) {
+      if (newest === undefined || SyncEngineLevel.isProtocolConfigNewer(config, newest)) {
+        newest = config;
+      }
+    }
+    return newest;
+  }
+
+  private static isProtocolConfigNewer(
+    candidate: ProtocolsConfigureMessage,
+    current: ProtocolsConfigureMessage,
+  ): boolean {
+    return candidate.descriptor.messageTimestamp > current.descriptor.messageTimestamp;
+  }
+
+  private static protocolConfigApplySucceeded(code: number): boolean {
+    return (code >= 200 && code < 300) || code === 409;
+  }
+
+  private static isRepairableProtocolMetadataFailure(
+    failure: ClosureResult['failure'] | undefined,
+  ): failure is NonNullable<ClosureResult['failure']> {
+    return failure?.edge.identifierType === 'protocol' &&
+      (
+        failure.code === ClosureFailureCode.ProtocolMetadataMissing ||
+        failure.code === ClosureFailureCode.CrossProtocolReferenceMissing ||
+        failure.code === ClosureFailureCode.EncryptionDependencyMissing
+      );
   }
 
   private async recordClosureFailure(
@@ -3263,20 +3629,12 @@ export class SyncEngineLevel implements SyncEngine {
     tenantDid: string,
     dependency: SyncDependencyEntryWithMessage,
   ): Promise<AuthenticatedProtocolConfigDependency | undefined> {
-    if (!SyncEngineLevel.isProtocolsConfigureDefinitionMessage(dependency.message)) {
+    const config = await this.toAuthenticatedTenantProtocolConfig(tenantDid, dependency.message);
+    if (config === undefined) {
       return undefined;
     }
 
-    try {
-      await ProtocolsConfigure.parse(dependency.message);
-      if (Message.getAuthor(dependency.message) !== tenantDid) {
-        return undefined;
-      }
-      await authenticate(dependency.message.authorization, this.agent.did);
-      return { ...dependency, message: dependency.message };
-    } catch {
-      return undefined;
-    }
+    return { ...dependency, message: config };
   }
 
   private static async projectedDependencyCidsMatch({
@@ -3773,43 +4131,6 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private buildLinkKey(did: string, dwnUrl: string, projectionId: string, authorizationEpoch: string): string {
     return buildLinkId(did, dwnUrl, projectionId, authorizationEpoch);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Utility helpers
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Extracts a ReadableStream from a MessageEvent if it contains a
-   * RecordsWrite with data — either as an inline `encodedData` field
-   * (for records <= 30 KB) or as a pre-existing data stream.
-   */
-  private extractDataStream(event: MessageEvent): ReadableStream<Uint8Array> | undefined {
-    if (!isRecordsWrite(event)) {
-      return undefined;
-    }
-
-    // Check for inline base64url-encoded data (small records from EventLog).
-    // Delete the transport-level field so the DWN schema validator does not
-    // reject the message for having unevaluated properties.
-    const encodedData = (event.message as any).encodedData as string | undefined;
-    if (encodedData) {
-      delete (event.message as any).encodedData;
-      const bytes = Encoder.base64UrlToBytes(encodedData);
-      return new ReadableStream<Uint8Array>({
-        start(controller): void {
-          controller.enqueue(bytes);
-          controller.close();
-        }
-      });
-    }
-
-    // Check for a pre-existing data stream (e.g. from a direct message read).
-    if ((event as any).data) {
-      return (event as any).data;
-    }
-
-    return undefined;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/tests/sync-closure-resolver.spec.ts
+++ b/packages/agent/tests/sync-closure-resolver.spec.ts
@@ -1768,17 +1768,33 @@ describe('evaluateClosure', () => {
   describe('invalidateClosureCache', () => {
     it('should invalidate protocolCache when a ProtocolsConfigure is processed', () => {
       const ctx = createClosureContext('did:example:alice');
-      ctx.protocolCache.set('https://example.com/proto', { some: 'cached-definition' });
+      const protocol = 'https://example.com/proto';
+      const protocolDepKeys = [
+        'protocolsConfigure',
+        'encryptionKeyMaterial',
+        'keyDeliveryProtocol',
+        'crossProtocolConfig',
+        'crossProtocolRoleConfig',
+      ].map(label => protocolSetDependencyKey(protocol, `${label}:protocol:${protocol}`));
+      ctx.protocolCache.set(protocol, { some: 'cached-definition' });
+      for (const key of protocolDepKeys) {
+        ctx.satisfiedDeps.add(key);
+        ctx.missingDeps.add(key);
+      }
 
       const protocolMsg = mockMessage({
         interface  : 'Protocols',
         method     : 'Configure',
-        definition : { protocol: 'https://example.com/proto' },
+        definition : { protocol },
       });
 
       invalidateClosureCache(ctx, protocolMsg);
 
-      expect(ctx.protocolCache.has('https://example.com/proto')).toBe(false);
+      expect(ctx.protocolCache.has(protocol)).toBe(false);
+      for (const key of protocolDepKeys) {
+        expect(ctx.satisfiedDeps.has(key)).toBe(false);
+        expect(ctx.missingDeps.has(key)).toBe(false);
+      }
     });
 
     it('should invalidate grantCache when a grant write is processed', () => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -6,12 +6,12 @@ import { Level } from 'level';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { DwnInterfaceName, DwnMethodName, Message, RECORDS_PROJECTION_ROOT_VERSION, RecordsProjection, RecordsWrite, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
-import { ClosureFailureCode } from '../src/sync-closure-types.js';
 import { computeAuthorizationEpoch } from '../src/types/sync.js';
 import { DwnInterface } from '../src/types/dwn.js';
 import { ReplicationLedger } from '../src/sync-replication-ledger.js';
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 import { SyncPullAbortedError } from '../src/sync-messages.js';
+import { ClosureFailureCode, createClosureContext } from '../src/sync-closure-types.js';
 import { getMessagesPermissionGrantsForScope, resolveMessagesSyncScopes } from '../src/sync-permission-grants.js';
 
 describe('SyncEngineLevel — private methods', () => {
@@ -135,27 +135,64 @@ describe('SyncEngineLevel — private methods', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // extractDataStream
+  // createLivePullDataStreamFactory
   // ---------------------------------------------------------------------------
 
-  describe('extractDataStream', () => {
-    it('should return undefined for non-RecordsWrite events', () => {
-      const event = { message: { descriptor: { interface: 'Protocols', method: 'Configure' } } };
-      expect((syncEngine as any).extractDataStream(event)).toBeUndefined();
+  describe('createLivePullDataStreamFactory', () => {
+    const livePullContext = {
+      did        : 'did:example:alice',
+      dwnUrl     : 'https://dwn.example',
+      eventScope : {},
+      linkKey    : 'link-key',
+      isStale    : (): boolean => false,
+    };
+
+    const textStream = (text: string): ReadableStream<Uint8Array> => new ReadableStream<Uint8Array>({
+      start(controller): void {
+        controller.enqueue(new TextEncoder().encode(text));
+        controller.close();
+      }
     });
 
-    it('should return data stream for RecordsWrite with data', () => {
-      const mockStream = new ReadableStream();
+    const readStreamText = async (stream: ReadableStream<Uint8Array> | undefined): Promise<string | undefined> => {
+      if (!stream) {
+        return undefined;
+      }
+
+      const reader = stream.getReader();
+      const chunks: Uint8Array[] = [];
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) { break; }
+          chunks.push(value);
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      return new TextDecoder().decode(Buffer.concat(chunks));
+    };
+
+    it('should return undefined for non-RecordsWrite events', async () => {
+      const event = { message: { descriptor: { interface: 'Protocols', method: 'Configure' } } };
+      const factory = await (syncEngine as any).createLivePullDataStreamFactory(livePullContext, event);
+      expect(await factory()).toBeUndefined();
+    });
+
+    it('should return data stream for RecordsWrite with data', async () => {
       const event = {
         message : { descriptor: { interface: 'Records', method: 'Write' } },
-        data    : mockStream,
+        data    : textStream('hello from event'),
       };
-      expect((syncEngine as any).extractDataStream(event)).toBe(mockStream);
+      const factory = await (syncEngine as any).createLivePullDataStreamFactory(livePullContext, event);
+      expect(await readStreamText(await factory())).toBe('hello from event');
     });
 
-    it('should return undefined for RecordsWrite without data', () => {
+    it('should return undefined for RecordsWrite without data', async () => {
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } };
-      expect((syncEngine as any).extractDataStream(event)).toBeUndefined();
+      const factory = await (syncEngine as any).createLivePullDataStreamFactory(livePullContext, event);
+      expect(await factory()).toBeUndefined();
     });
 
     it('should decode inline encodedData and delete it from the message', async () => {
@@ -172,7 +209,8 @@ describe('SyncEngineLevel — private methods', () => {
         },
       };
 
-      const stream = (syncEngine as any).extractDataStream(event);
+      const factory = await (syncEngine as any).createLivePullDataStreamFactory(livePullContext, event);
+      const stream = await factory();
       expect(stream).toBeInstanceOf(ReadableStream);
 
       // encodedData must be deleted so the DWN schema validator does not
@@ -180,9 +218,7 @@ describe('SyncEngineLevel — private methods', () => {
       expect((event.message as any).encodedData).toBeUndefined();
 
       // Verify the stream yields the original data.
-      const reader = stream.getReader();
-      const { value } = await reader.read();
-      expect(new TextDecoder().decode(value)).toBe(originalData);
+      expect(await readStreamText(stream)).toBe(originalData);
     });
   });
 
@@ -3525,6 +3561,401 @@ describe('SyncEngineLevel — private methods', () => {
       );
 
       expect(verified).toEqual([await dependencyEntry(governingConfig, primaryCid)]);
+    });
+
+    it('tryRepairMissingProtocolMetadata should fetch and apply composed protocol configs before retrying closure', async () => {
+      const tenant = await TestDataGenerator.generatePersona();
+      const usedProtocol = 'https://identity.foundation/protocols/social-graph';
+      const profileConfig = await protocolsConfigureMessage({
+        author   : tenant,
+        protocol : projectedProtocol,
+        uses     : { social: usedProtocol },
+      });
+      const socialConfig = await protocolsConfigureMessage({
+        author   : tenant,
+        protocol : usedProtocol,
+      });
+      const processRawMessage = sinon.stub().resolves({ status: { code: 202, detail: 'Accepted' } });
+      const processDwnRequest = sinon.stub().callsFake(async (request: any) => ({
+        message: {
+          descriptor: {
+            filter: request.messageParams.filter,
+          },
+        },
+      }));
+      const sendDwnRequest = sinon.stub().callsFake(async ({ message }: { message: any }) => {
+        const protocol = message.descriptor.filter.protocol;
+        return {
+          status  : { code: 200, detail: 'OK' },
+          entries : protocol === projectedProtocol
+            ? [profileConfig]
+            : protocol === usedProtocol
+              ? [socialConfig]
+              : [],
+        };
+      });
+      const agent = {
+        ...createResolvingAgent(tenant),
+        dwn : { processRawMessage },
+        processDwnRequest,
+        rpc : { sendDwnRequest },
+      };
+      const engine = createEngine({ db, agent: agent as any });
+      const closureCtx = createClosureContext(tenant.did);
+      closureCtx.missingDeps.add(
+        `protocolSet:${projectedProtocol}:protocolsConfigure:protocol:${projectedProtocol}`,
+      );
+
+      const repaired = await (engine as any).tryRepairMissingProtocolMetadata(
+        {
+          did        : tenant.did,
+          dwnUrl     : 'https://dwn.example',
+          eventScope : { protocols: [projectedProtocol] },
+          linkKey    : 'link-key',
+          isStale    : (): boolean => false,
+        },
+        closureCtx,
+        {
+          complete       : false,
+          rootMessageCid : 'root-cid',
+          edges          : [],
+          depth          : 0,
+          failure        : {
+            code   : ClosureFailureCode.ProtocolMetadataMissing,
+            detail : `dependency 'protocolsConfigure' (${projectedProtocol}) not found locally`,
+            edge   : {
+              dependencyClass : 1,
+              identifier      : projectedProtocol,
+              identifierType  : 'protocol',
+              label           : 'protocolsConfigure',
+            },
+          },
+        },
+      );
+
+      expect(repaired).toBe(true);
+      expect(processDwnRequest.getCalls().map(call => call.args[0])).toEqual([
+        {
+          author        : tenant.did,
+          messageParams : { filter: { protocol: projectedProtocol } },
+          messageType   : DwnInterface.ProtocolsQuery,
+          store         : false,
+          target        : tenant.did,
+        },
+        {
+          author        : tenant.did,
+          messageParams : { filter: { protocol: usedProtocol } },
+          messageType   : DwnInterface.ProtocolsQuery,
+          store         : false,
+          target        : tenant.did,
+        },
+      ]);
+      expect(sendDwnRequest.getCalls().map(call => call.args[0].dwnUrl)).toEqual([
+        'https://dwn.example',
+        'https://dwn.example',
+      ]);
+      expect(processRawMessage.getCalls().map(call => call.args[1])).toEqual([
+        socialConfig,
+        profileConfig,
+      ]);
+      expect(closureCtx.missingDeps.has(
+        `protocolSet:${projectedProtocol}:protocolsConfigure:protocol:${projectedProtocol}`,
+      )).toBe(false);
+    });
+
+    for (const repairCase of [
+      {
+        dependencyClass : 5,
+        failureCode     : ClosureFailureCode.EncryptionDependencyMissing,
+        label           : 'keyDeliveryProtocol',
+      },
+      {
+        dependencyClass : 6,
+        failureCode     : ClosureFailureCode.CrossProtocolReferenceMissing,
+        label           : 'crossProtocolConfig',
+      },
+    ]) {
+      it(`tryRepairMissingProtocolMetadata should repair ${repairCase.failureCode} protocol misses`, async () => {
+        const tenant = await TestDataGenerator.generatePersona();
+        const dependencyProtocol = `https://example.com/${repairCase.label}`;
+        const dependencyConfig = await protocolsConfigureMessage({
+          author   : tenant,
+          protocol : dependencyProtocol,
+        });
+        const processRawMessage = sinon.stub().resolves({ status: { code: 202, detail: 'Accepted' } });
+        const processDwnRequest = sinon.stub().callsFake(async (request: any) => ({
+          message: {
+            descriptor: {
+              filter: request.messageParams.filter,
+            },
+          },
+        }));
+        const sendDwnRequest = sinon.stub().callsFake(async ({ message }: { message: any }) => ({
+          status  : { code: 200, detail: 'OK' },
+          entries : message.descriptor.filter.protocol === dependencyProtocol ? [dependencyConfig] : [],
+        }));
+        const agent = {
+          ...createResolvingAgent(tenant),
+          dwn : { processRawMessage },
+          processDwnRequest,
+          rpc : { sendDwnRequest },
+        };
+        const engine = createEngine({ db, agent: agent as any });
+        const closureCtx = createClosureContext(tenant.did);
+        const depKey = `protocolSet:${projectedProtocol}:${repairCase.label}:protocol:${dependencyProtocol}`;
+        closureCtx.missingDeps.add(depKey);
+
+        const repaired = await (engine as any).tryRepairMissingProtocolMetadata(
+          {
+            did        : tenant.did,
+            dwnUrl     : 'https://dwn.example',
+            eventScope : { protocols: [projectedProtocol] },
+            linkKey    : 'link-key',
+            isStale    : (): boolean => false,
+          },
+          closureCtx,
+          {
+            complete       : false,
+            rootMessageCid : 'root-cid',
+            edges          : [],
+            depth          : 0,
+            failure        : {
+              code   : repairCase.failureCode,
+              detail : `dependency '${repairCase.label}' (${dependencyProtocol}) not found locally`,
+              edge   : {
+                dependencyClass : repairCase.dependencyClass,
+                identifier      : dependencyProtocol,
+                identifierType  : 'protocol',
+                label           : repairCase.label,
+              },
+            },
+          },
+        );
+
+        expect(repaired).toBe(true);
+        expect(processDwnRequest.firstCall.args[0].messageParams).toEqual({
+          filter: { protocol: dependencyProtocol },
+        });
+        expect(processRawMessage.getCalls().map(call => call.args[1])).toEqual([
+          dependencyConfig,
+        ]);
+        expect(closureCtx.missingDeps.has(depKey)).toBe(false);
+      });
+    }
+
+    it('tryRepairMissingProtocolMetadata should reject non-tenant-authored protocol configs', async () => {
+      const tenant = await TestDataGenerator.generatePersona();
+      const attacker = await TestDataGenerator.generatePersona();
+      const forgedConfig = await protocolsConfigureMessage({
+        author   : attacker,
+        protocol : projectedProtocol,
+      });
+      const processRawMessage = sinon.stub().resolves({ status: { code: 202, detail: 'Accepted' } });
+      const processDwnRequest = sinon.stub().callsFake(async (request: any) => ({
+        message: {
+          descriptor: {
+            filter: request.messageParams.filter,
+          },
+        },
+      }));
+      const sendDwnRequest = sinon.stub().resolves({
+        status  : { code: 200, detail: 'OK' },
+        entries : [forgedConfig],
+      });
+      const agent = {
+        ...createResolvingAgent(tenant, attacker),
+        dwn : { processRawMessage },
+        processDwnRequest,
+        rpc : { sendDwnRequest },
+      };
+      const engine = createEngine({ db, agent: agent as any });
+
+      const repaired = await (engine as any).tryRepairMissingProtocolMetadata(
+        {
+          did        : tenant.did,
+          dwnUrl     : 'https://dwn.example',
+          eventScope : { protocols: [projectedProtocol] },
+          linkKey    : 'link-key',
+          isStale    : (): boolean => false,
+        },
+        createClosureContext(tenant.did),
+        {
+          complete       : false,
+          rootMessageCid : 'root-cid',
+          edges          : [],
+          depth          : 0,
+          failure        : {
+            code   : ClosureFailureCode.ProtocolMetadataMissing,
+            detail : `dependency 'protocolsConfigure' (${projectedProtocol}) not found locally`,
+            edge   : {
+              dependencyClass : 1,
+              identifier      : projectedProtocol,
+              identifierType  : 'protocol',
+              label           : 'protocolsConfigure',
+            },
+          },
+        },
+      );
+
+      expect(repaired).toBe(false);
+      expect(processRawMessage.called).toBe(false);
+      expect(processDwnRequest.callCount).toBe(1);
+      expect(sendDwnRequest.callCount).toBe(1);
+    });
+
+    it('tryRepairMissingProtocolMetadata should attach delegated ProtocolsQuery grants when available', async () => {
+      const tenant = await TestDataGenerator.generatePersona();
+      const delegate = await TestDataGenerator.generatePersona();
+      const profileConfig = await protocolsConfigureMessage({
+        author   : tenant,
+        protocol : projectedProtocol,
+      });
+      const processRawMessage = sinon.stub().resolves({ status: { code: 202, detail: 'Accepted' } });
+      const processDwnRequest = sinon.stub().callsFake(async (request: any) => ({
+        message: {
+          descriptor: {
+            filter            : request.messageParams.filter,
+            permissionGrantId : request.messageParams.permissionGrantId,
+          },
+        },
+      }));
+      const sendDwnRequest = sinon.stub().resolves({
+        status  : { code: 200, detail: 'OK' },
+        entries : [profileConfig],
+      });
+      const getPermissionForRequest = sinon.stub().resolves({ grant: { id: 'protocol-query-grant' } });
+      const agent = {
+        ...createResolvingAgent(tenant, delegate),
+        dwn : { processRawMessage },
+        processDwnRequest,
+        rpc : { sendDwnRequest },
+      };
+      const engine = createEngine({ db, agent: agent as any });
+      (engine as any)._permissionsApi = {
+        clear: sinon.stub().resolves(),
+        getPermissionForRequest,
+      };
+
+      const repaired = await (engine as any).tryRepairMissingProtocolMetadata(
+        {
+          delegateDid : delegate.did,
+          did         : tenant.did,
+          dwnUrl      : 'https://dwn.example',
+          eventScope  : { protocols: [projectedProtocol] },
+          linkKey     : 'link-key',
+          isStale     : (): boolean => false,
+        },
+        createClosureContext(tenant.did),
+        {
+          complete       : false,
+          rootMessageCid : 'root-cid',
+          edges          : [],
+          depth          : 0,
+          failure        : {
+            code   : ClosureFailureCode.ProtocolMetadataMissing,
+            detail : `dependency 'protocolsConfigure' (${projectedProtocol}) not found locally`,
+            edge   : {
+              dependencyClass : 1,
+              identifier      : projectedProtocol,
+              identifierType  : 'protocol',
+              label           : 'protocolsConfigure',
+            },
+          },
+        },
+      );
+
+      expect(repaired).toBe(true);
+      expect(getPermissionForRequest.firstCall.args[0]).toEqual({
+        connectedDid : tenant.did,
+        delegateDid  : delegate.did,
+        protocol     : projectedProtocol,
+        cached       : true,
+        messageType  : DwnInterface.ProtocolsQuery,
+      });
+      expect(processDwnRequest.firstCall.args[0].author).toBe(delegate.did);
+      expect(processDwnRequest.firstCall.args[0].messageParams).toEqual({
+        filter            : { protocol: projectedProtocol },
+        permissionGrantId : 'protocol-query-grant',
+      });
+    });
+
+    it('processLivePullEvent should re-apply a record after repairing missing protocol metadata', async () => {
+      const tenant = await TestDataGenerator.generatePersona();
+      const record = projectedRecordMessage('profile/avatar', projectedProtocol);
+      const recordCid = await Message.getCid(record);
+      const profileConfig = await protocolsConfigureMessage({
+        author   : tenant,
+        protocol : projectedProtocol,
+      });
+      let installedConfig: ProtocolsConfigureMessage | undefined;
+      const messageStore = {
+        query: sinon.stub().callsFake(async (_tenant: string, filters: any[]) => {
+          const filter = filters[0];
+          if (
+            filter.interface === DwnInterfaceName.Protocols &&
+            filter.method === DwnMethodName.Configure &&
+            filter.protocol === projectedProtocol &&
+            installedConfig !== undefined
+          ) {
+            return { messages: [installedConfig] };
+          }
+          return { messages: [] };
+        }),
+      };
+      const recordStatuses = [
+        { code: 401, detail: 'ProtocolAuthorizationProtocolNotFound' },
+        { code: 202, detail: 'Accepted' },
+      ];
+      const processRawMessage = sinon.stub().callsFake(async (_did: string, message: GenericMessage) => {
+        if (message.descriptor.interface === DwnInterfaceName.Protocols) {
+          installedConfig = message as ProtocolsConfigureMessage;
+          return { status: { code: 202, detail: 'Accepted' } };
+        }
+        return { status: recordStatuses.shift() };
+      });
+      const processDwnRequest = sinon.stub().callsFake(async (request: any) => ({
+        message: {
+          descriptor: {
+            filter: request.messageParams.filter,
+          },
+        },
+      }));
+      const sendDwnRequest = sinon.stub().resolves({
+        status  : { code: 200, detail: 'OK' },
+        entries : [profileConfig],
+      });
+      const agent = {
+        ...createResolvingAgent(tenant),
+        dwn: {
+          node: {
+            storage: { messageStore },
+          },
+          processRawMessage,
+        },
+        processDwnRequest,
+        rpc: { sendDwnRequest },
+      };
+      const engine = createEngine({ db, agent: agent as any });
+
+      const cid = await (engine as any).processLivePullEvent(
+        {
+          did        : tenant.did,
+          dwnUrl     : 'https://dwn.example',
+          eventScope : { protocols: [projectedProtocol] },
+          link       : { scope: { kind: 'protocolSet', protocols: [projectedProtocol] } },
+          linkKey    : 'link-key',
+          isStale    : (): boolean => false,
+        },
+        { message: record },
+      );
+
+      expect(cid).toBe(recordCid);
+      expect(processRawMessage.getCalls().map(call => call.args[1])).toEqual([
+        record,
+        profileConfig,
+        record,
+      ]);
+      expect(recordStatuses).toEqual([]);
     });
 
     it('pullProjectedRemoteDiff should apply only verified dependency hints through the pull path', async () => {


### PR DESCRIPTION
## Summary
- repairs live scoped sync protocol metadata gaps without checkpointing failed records: live pulls retry the record after metadata repair and only commit on a 2xx/409 apply result
- fetches tenant-signed ProtocolsConfigure closures from the same remote DWN, including composed, cross-protocol, and encryption protocol dependencies
- uses delegated ProtocolsQuery grants when needed and deduplicates concurrent per-tenant/protocol repairs
- clears all protocol dependency cache entries when ProtocolsConfigure messages are processed

## Verification
- bun run --filter @enbox/agent lint
- bun run --filter @enbox/agent build
- bun test tests/sync-closure-resolver.spec.ts tests/sync-engine-private.spec.ts --timeout 30000
- bun run --filter @enbox/agent test:node (fails locally: 1016 pass, 6 skip, 336 fail; failures are existing local DID-DHT localhost gateway validation and dependent DWN key/encryption/connect tests)