### PR TITLE
feat(api): expose squash on typed records.create (#972)

### DIFF
--- a/.changeset/typed-squash-create.md
+++ b/.changeset/typed-squash-create.md
@@ -1,0 +1,9 @@
+---
+"@enbox/api": patch
+---
+
+feat(api): expose `squash` on typed `records.create`
+
+The typed `create` wrapper now forwards the `squash` directive to the underlying
+`records.write`, so `$squash`-enabled protocol paths can be compacted through the
+typed surface instead of dropping the flag.

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -172,6 +172,17 @@ export type TypedCreateRequest<
   protocolRole?: string;
 
   /**
+   * Compact the record's `$squash`-enabled path on write.
+   *
+   * When `true`, the write carries the `$squash` directive so the DWN
+   * purges older siblings per the protocol's `$squash` configuration
+   * (e.g. compacting a CRDT delta/snapshot history). No-op on paths
+   * without `$squash`. The low-level `records.write` already supports
+   * this; the typed surface forwards it.
+   */
+  squash?: true;
+
+  /**
    * The MIME type / data format for the record.
    *
    * If omitted, defaults to the first entry in the protocol type's
@@ -977,6 +988,7 @@ export class TypedEnbox<
           datePublished   : request.datePublished,
           recipient       : request.recipient,
           protocolRole    : request.protocolRole,
+          squash          : request.squash,
           tags            : request.tags,
           protocol        : this._definition.protocol,
           protocolPath    : normalizedPath,

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -176,9 +176,11 @@ export type TypedCreateRequest<
    *
    * When `true`, the write carries the `$squash` directive so the DWN
    * purges older siblings per the protocol's `$squash` configuration
-   * (e.g. compacting a CRDT delta/snapshot history). No-op on paths
-   * without `$squash`. The low-level `records.write` already supports
-   * this; the typed surface forwards it.
+   * (e.g. compacting a CRDT delta/snapshot history). The protocol path
+   * MUST declare `$squash: true` — otherwise the write is **rejected**
+   * with `ProtocolAuthorizationSquashNotEnabled` (not silently ignored).
+   * The low-level `records.write` already supports this; the typed
+   * surface forwards it.
    */
   squash?: true;
 

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -315,6 +315,54 @@ describe('TypedProtocol API', () => {
         const descriptor = record.rawRecord.rawMessage.descriptor as { squash?: true };
         expect(descriptor.squash).toBeUndefined();
       });
+
+      it('compacts older siblings end-to-end — a squash write purges prior snapshots', async () => {
+        const { record: doc } = await squashed.records.create('doc', { data: { n: 'doc' } });
+
+        // two ordinary snapshots under the document context
+        await squashed.records.create('doc/snapshot', { data: { v: 's1' }, parentContextId: doc.contextId });
+        await new Promise((r) => setTimeout(r, 5)); // guarantee a distinct, later messageTimestamp
+        await squashed.records.create('doc/snapshot', { data: { v: 's2' }, parentContextId: doc.contextId });
+        await new Promise((r) => setTimeout(r, 5));
+
+        // a squashing snapshot — must purge the two older siblings in this context
+        const { status, record: squashRec } = await squashed.records.create('doc/snapshot', {
+          data            : { v: 's3' },
+          parentContextId : doc.contextId,
+          squash          : true,
+        });
+        expect(status.code).toBe(202);
+
+        // only the squash record survives (this is the whole point of the flag reaching the write)
+        const { records } = await squashed.records.query('doc/snapshot');
+        expect(records.length).toBe(1);
+        expect(records[0].id).toBe(squashRec.id);
+      });
+
+      it('rejects squash:true on a path without $squash (error surfaced, not swallowed)', async () => {
+        // `doc` has no $squash — the squash backstop must reject the write,
+        // and the typed surface must pass that failure through (not a silent 202).
+        const { status, record } = await squashed.records.create('doc', {
+          data   : { n: 'nope' },
+          squash : true,
+        });
+
+        expect(status.code).toBe(400);
+        expect(status.detail ?? '').toContain('Squash');
+        expect(record).toBeUndefined();
+      });
+
+      it('a squashing write still stores and reads back its data', async () => {
+        const { record: doc } = await squashed.records.create('doc', { data: { n: 'doc' } });
+        const { record } = await squashed.records.create('doc/snapshot', {
+          data            : { v: 'payload' },
+          parentContextId : doc.contextId,
+          squash          : true,
+        });
+
+        const readBack = await record.data.json();
+        expect(readBack.v).toBe('payload');
+      });
     });
 
     describe('query()', () => {

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -259,6 +259,64 @@ describe('TypedProtocol API', () => {
       });
     });
 
+    describe('create() with $squash (#972)', () => {
+      // Self-contained protocol with a $squash path, so the shared Todo fixture is untouched.
+      const SquashDefinition = {
+        protocol  : 'https://example.com/protocols/squash-test',
+        published : true,
+        types     : {
+          doc      : { schema: 'https://example.com/schemas/doc', dataFormats: ['application/json'] },
+          snapshot : { schema: 'https://example.com/schemas/snapshot', dataFormats: ['application/json'] },
+        },
+        structure: {
+          doc: {
+            $actions : [{ who: 'anyone', can: ['create', 'read'] }],
+            snapshot : {
+              $immutable : true,
+              $squash    : true,
+              $actions   : [{ who: 'anyone', can: ['create', 'read'] }],
+            },
+          },
+        },
+      } as const satisfies ProtocolDefinition;
+
+      type SquashSchemaMap = { doc: { n?: string }; snapshot: { v?: string } };
+      const SquashProtocol = defineProtocol(SquashDefinition, {} as SquashSchemaMap);
+
+      let squashed: TypedEnbox<typeof SquashDefinition, SquashSchemaMap>;
+      beforeEach(async () => {
+        squashed = new TypedEnbox(dwnAlice, SquashProtocol);
+        await squashed.configure();
+      });
+
+      it('forwards squash:true to the underlying write message descriptor', async () => {
+        const { record: doc } = await squashed.records.create('doc', { data: { n: 'd' } });
+        expect(doc).toBeDefined();
+
+        const { status, record } = await squashed.records.create('doc/snapshot', {
+          data            : { v: 's1' },
+          parentContextId : doc.contextId,
+          squash          : true,
+        });
+
+        // If `squash` were dropped by the typed wrapper, this would be an ordinary
+        // (non-squashing) write — the descriptor would lack the directive.
+        expect(status.code).toBe(202);
+        const descriptor = record.rawRecord.rawMessage.descriptor as { squash?: true };
+        expect(descriptor.squash).toBe(true);
+      });
+
+      it('omits squash when not requested (no false-y field)', async () => {
+        const { record: doc } = await squashed.records.create('doc', { data: { n: 'd2' } });
+        const { record } = await squashed.records.create('doc/snapshot', {
+          data            : { v: 's2' },
+          parentContextId : doc.contextId,
+        });
+        const descriptor = record.rawRecord.rawMessage.descriptor as { squash?: true };
+        expect(descriptor.squash).toBeUndefined();
+      });
+    });
+
     describe('query()', () => {
       it('should query records and return TypedRecord instances', async () => {
         // Write two lists

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -284,6 +284,7 @@ describe('TypedProtocol API', () => {
       const SquashProtocol = defineProtocol(SquashDefinition, {} as SquashSchemaMap);
 
       let squashed: TypedEnbox<typeof SquashDefinition, SquashSchemaMap>;
+
       beforeEach(async () => {
         squashed = new TypedEnbox(dwnAlice, SquashProtocol);
         await squashed.configure();

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -334,8 +334,12 @@ describe('TypedProtocol API', () => {
         });
         expect(status.code).toBe(202);
 
-        // only the squash record survives (this is the whole point of the flag reaching the write)
-        const { records } = await squashed.records.query('doc/snapshot');
+        // Only the squash record survives (this is the whole point of the flag reaching the write).
+        // Queries on a nested protocol path must be scoped by the parent context
+        // (dwn-sdk-js requires the parent contextId for nested-path queries — see #1043).
+        const { records } = await squashed.records.query('doc/snapshot', {
+          filter: { contextId: doc.contextId },
+        });
         expect(records.length).toBe(1);
         expect(records[0].id).toBe(squashRec.id);
       });

--- a/packages/api/tests/typed-squash.spec.ts
+++ b/packages/api/tests/typed-squash.spec.ts
@@ -1,0 +1,120 @@
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+import type { DwnApi, RecordsWriteRequest } from '../src/dwn-api.js';
+
+import { beforeEach, describe, expect, it } from 'bun:test';
+
+import { defineProtocol } from '../src/define-protocol.js';
+import { TypedEnbox } from '../src/typed-enbox.js';
+
+// ---------------------------------------------------------------------------
+// Offline unit coverage for #972 — the typed `create` MUST forward `squash`
+// to the low-level `records.write`. These tests don't touch a DWN, agent, or
+// network: they capture the request handed to `_dwn.records.write` via a fake
+// DwnApi, so they verify the forwarding contract directly and deterministically.
+// (End-to-end squash *behavior* — compaction, backstop — is covered against a
+// real DWN in typed-protocol.spec.ts and exhaustively in dwn-sdk-js's
+// records-squash.spec.ts.)
+// ---------------------------------------------------------------------------
+
+const SquashDefinition = {
+  protocol  : 'https://example.com/protocols/squash-unit',
+  published : true,
+  types     : {
+    doc      : { schema: 'https://example.com/schemas/doc', dataFormats: ['application/json'] },
+    snapshot : { schema: 'https://example.com/schemas/snapshot', dataFormats: ['application/json'] },
+  },
+  structure: {
+    doc: {
+      $actions : [{ who: 'anyone', can: ['create', 'read'] }],
+      snapshot : {
+        $immutable : true,
+        $squash    : true,
+        $actions   : [{ who: 'anyone', can: ['create', 'read'] }],
+      },
+    },
+  },
+} as const satisfies ProtocolDefinition;
+
+type SquashSchemaMap = { doc: { n?: string }; snapshot: { v?: string } };
+
+const SquashProtocol = defineProtocol(SquashDefinition, {} as SquashSchemaMap);
+
+/** A fake DwnApi that records every `records.write` request and returns 202. */
+function makeCapturingDwn(): { dwn: DwnApi; writes: RecordsWriteRequest[] } {
+  const writes: RecordsWriteRequest[] = [];
+  const dwn = {
+    records: {
+      write: async (request: RecordsWriteRequest) => {
+        writes.push(request);
+        return { status: { code: 202, detail: 'Accepted' }, record: undefined };
+      },
+    },
+  } as unknown as DwnApi;
+  return { dwn, writes };
+}
+
+describe('TypedEnbox create() — squash forwarding (#972)', () => {
+  let dwn: DwnApi;
+  let writes: RecordsWriteRequest[];
+  let typed: TypedEnbox<typeof SquashDefinition, SquashSchemaMap>;
+
+  beforeEach(() => {
+    ({ dwn, writes } = makeCapturingDwn());
+    typed = new TypedEnbox(dwn, SquashProtocol);
+    // Skip auto-configure: _ensureReady() then only validates the path against
+    // the in-memory definition (no agent/DWN calls).
+    (typed as unknown as { _configured: boolean })._configured = true;
+  });
+
+  it('forwards squash: true to the low-level records.write', async () => {
+    const { status } = await typed.records.create('doc/snapshot', {
+      data   : { v: 's1' },
+      squash : true,
+    });
+
+    expect(status.code).toBe(202);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].squash).toBe(true);
+  });
+
+  it('passes squash as undefined (never a falsy false) when not requested', async () => {
+    await typed.records.create('doc/snapshot', { data: { v: 's1' } });
+
+    expect(writes[0].squash).toBeUndefined();
+    // explicitly NOT `false` — parity with omitting the field entirely
+    expect(writes[0].squash).not.toBe(false);
+  });
+
+  it('forwards squash alongside every other create field (none dropped)', async () => {
+    await typed.records.create('doc/snapshot', {
+      data            : { v: 's1' },
+      squash          : true,
+      parentContextId : 'parent-ctx',
+      recipient       : 'did:example:bob',
+      protocolRole    : 'collaborator',
+      tags            : { kind: 'snapshot' },
+      published       : true,
+      dataFormat      : 'application/json',
+    });
+
+    const req = writes[0];
+    expect(req.squash).toBe(true);
+    expect(req.parentContextId).toBe('parent-ctx');
+    expect(req.recipient).toBe('did:example:bob');
+    expect(req.protocolRole).toBe('collaborator');
+    expect(req.tags).toEqual({ kind: 'snapshot' });
+    expect(req.published).toBe(true);
+    expect(req.dataFormat).toBe('application/json');
+    // protocol + path are auto-injected from the definition
+    expect(req.protocol).toBe(SquashDefinition.protocol);
+    expect(req.protocolPath).toBe('doc/snapshot');
+  });
+
+  it('scopes squash per-call — only the create that sets it carries it', async () => {
+    await typed.records.create('doc', { data: { n: 'd' } });                 // no squash
+    await typed.records.create('doc/snapshot', { data: { v: 's' }, squash: true });
+    await typed.records.create('doc/snapshot', { data: { v: 's2' } });        // no squash
+
+    expect(writes.map((w) => w.squash)).toEqual([undefined, true, undefined]);
+  });
+});

--- a/packages/api/tests/typed-squash.spec.ts
+++ b/packages/api/tests/typed-squash.spec.ts
@@ -111,9 +111,9 @@ describe('TypedEnbox create() — squash forwarding (#972)', () => {
   });
 
   it('scopes squash per-call — only the create that sets it carries it', async () => {
-    await typed.records.create('doc', { data: { n: 'd' } });                 // no squash
+    await typed.records.create('doc', { data: { n: 'd' } }); // no squash
     await typed.records.create('doc/snapshot', { data: { v: 's' }, squash: true });
-    await typed.records.create('doc/snapshot', { data: { v: 's2' } });        // no squash
+    await typed.records.create('doc/snapshot', { data: { v: 's2' } }); // no squash
 
     expect(writes.map((w) => w.squash)).toEqual([undefined, true, undefined]);
   });


### PR DESCRIPTION
## Summary

Exposes `squash` on the **typed** `records.create`. Today the typed wrapper silently drops it: `TypedCreateRequest` doesn't declare `squash`, and typed `create` forwards an explicit enumerated field list that omits it — so `proto.records.create(path, { …, squash: true })` no-ops the flag. The low-level `records.write` already accepts it (it rides the `Partial<DwnMessageParams[RecordsWrite]>`), so this is a pure forwarding fix.

Closes #972.

## Changes

- `packages/api/src/typed-enbox.ts` — add `squash?: true` to `TypedCreateRequest`; forward `squash: request.squash` in the typed `create` write call (mirrors how `recipient`/`tags`/`protocolRole` are forwarded).
- `packages/api/tests/typed-protocol.spec.ts` — a self-contained `$squash` protocol fixture; asserts the directive reaches the write message descriptor when set and is absent when not.

## Why

Consumers (notesd's CRDT collaboration) write `$squash`-compacting snapshot records to bound delta-history growth. They currently use a low-level raw-API workaround behind a seam (`src/store/delta-repo.ts` `writeDelta`); this lets them use the typed path instead.

## Testing

- `bun run build` (full workspace `tsc`) is green — the change type-checks.
- The new spec exercises the forward path. Note: the `typed-protocol` spec's harness `beforeAll` publishes a `did:dht` to a Pkarr gateway, which is rejected against `localhost` in a bare local env — so the spec runs in CI, not bare-local. (This affects the whole spec equally, not this change.)

## Post-deploy monitoring

No additional operational monitoring required — additive optional field on a client API wrapper; no server/agent/protocol change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
