### PR TITLE
docs(plans): realtime-collab durable core (#972/#973) + NOSTR primitives (#983)

### DIFF
--- a/docs/plans/2026-06-08-001-feat-realtime-collab-fast-follows-plan.md
+++ b/docs/plans/2026-06-08-001-feat-realtime-collab-fast-follows-plan.md
@@ -1,0 +1,201 @@
+---
+title: "feat: cross-tenant durable fast-follows (#972, #973)"
+type: feat
+status: active
+date: 2026-06-08
+worktree: .claude/worktrees/realtime-fast-follows
+branch: feat/realtime-fast-follows
+---
+
+# feat: cross-tenant durable fast-follows (#972, #973)
+
+> **Scope change (2026-06-09):** the ephemeral realtime channel (formerly Phase 3 / #977) has been **removed from this plan**. That problem is now solved by **NOSTR** as the ephemeral broadcast layer — see **#983** (#977 closed as superseded). This plan now covers only the **core durable** Enbox changes: #972 and #973. They stand on their own and were always independent of the ephemeral layer.
+
+## Overview
+
+Two enbox monorepo changes extend the **durable** record substrate that any collaborative dapp needs. They are independent and shippable separately, ordered by size:
+
+- **Phase 1 — #972 typed `squash` exposure** (~2 LOC + test): let the typed `records.create` carry `squash: true` so a consumer can write a compacting snapshot through the typed API instead of the low-level escape hatch.
+- **Phase 2 — #973 cross-tenant writes** (client-only): let a connected client author a record **into another tenant's DWN** over `from:` + `protocolRole` (or a delegated grant), mirroring the read side. This unlocks durable collaborator authorship — a shared-page collaborator publishing their own signed deltas to the owner's DWN. **Verification confirmed this needs NO server or agent changes** — the relay already authorizes role-invoked non-owner writes and the agent already supports remote dispatch + grant resolution; only the API-layer `records.write`/typed `create` wrappers omit `from` and force local dispatch.
+
+Both phases touch adjacent code in `packages/api` and should sequence 1→2 to avoid conflicts. The realtime/ephemeral plane (live cursors, presence, keystroke ops) is **not** here — it is the NOSTR broadcast layer in #983.
+
+## Requirements Trace
+
+- **R1 — Typed squash.** `proto.records.create(path, { data, squash: true })` reaches the write message with `squash: true` (today it is silently dropped). *(Phase 1.)*
+- **R2 — Cross-tenant authored writes.** A client holding a role grant (or delegated grant) can write a record into another tenant's DWN via `from:` + `protocolRole`; the write is remotely dispatched, signed by the connected (grantee) DID, and accepted by the owner's relay under the existing authorization. *(Phase 2.)*
+- **R3 — Cross-tenant create surface.** Both the low-level `records.write` and the typed `records.create` expose `from` + `protocolRole`, and the returned record carries `remoteOrigin` so a follow-up **read** (`.data`) targets the owner tenant; a follow-up **update** targets the owner tenant only when the caller passes an explicit `from` (Unit 3b — cross-tenant update is opt-in, it does **not** inherit `remoteOrigin` for routing). *(Cross-tenant **delete** is `Record.delete()` — a third local-only method; it is **out of scope** for v1 (no consumer needs collaborator cross-tenant delete) and is a trivial same-pattern follow-on if one arises — explicitly not promised here.)* *(Phase 2, Units 2–3.)*
+- **R3b — Cross-tenant update.** Typed `update` is a **separate code path** (`Record.update()` → `record.ts`, today local-only — it has no `from` and always targets/processes the connected DID). Cross-tenant update (the collaborator co-updating the owner's derived `document`/`meta` singletons) is delivered as its own unit, not folded into R3. **Cross-tenant update requires an explicit `from` on the call and does NOT silently inherit the record's `_remoteOrigin` for routing — this preserves existing local-update behavior with zero regression.** *(Phase 2, Unit 3b.)*
+
+## Scope Boundaries
+
+- **No new protocol types; no dwn-sdk-js authorization changes.** Both phases reuse the existing role/grant authz untouched. The entire change is additive optional fields on the API-layer write/create/update wrappers.
+- **#973 Tier 2 (foreign-tenant scoped sync)** — replicating a shared subtree into the grantee's *local* DWN for offline editing — is **out**. Phase 2 is online-only cross-tenant authoring. (Tracked separately on #973.)
+- **Ephemeral realtime plane is out of this plan** — live cursors/presence/keystroke ops are the NOSTR broadcast layer (#983), not a DWN/relay change here.
+- **No notesd client integration in this plan** — the squash/cross-tenant consumer swaps live in the notesd repo. This plan delivers the enbox primitives those consume; consumer follow-ups are noted per phase.
+
+## Context & Research
+
+All claims below were source-verified in the enbox monorepo during planning (file paths are relative to the repo root).
+
+### Relevant code and patterns
+
+- `packages/api/src/dwn-api.ts` — the low-level `records.{write,read,query,delete,subscribe}` implementations. Read/query/delete already accept `from` and branch `if (from) sendDwnRequest else processDwnRequest`; **write does not** (hardcodes `target: this.connectedDid`, dispatches `processDwnRequest` unconditionally). `RecordsWriteRequest` type omits `from`. The low-level write already forwards `squash` (it survives the `Partial<DwnMessageParams[RecordsWrite]>`).
+- `packages/api/src/typed-enbox.ts` — `TypedCreateRequest` (~lines 114–175) and the typed `create` (~lines 955–985), which forwards an **explicit enumerated field list** to `this._dwn.records.write`. `protocolRole` is **already** in `TypedCreateRequest` and the forward list (~lines 172, 979) — so the only typed-create gaps are `squash` (Unit 1) and `from` (Unit 3); the list omits both.
+- `packages/api/src/record.ts` — `Record.update()` (~line 581) builds params with no `from`, always targets/processes the connected DID locally, and mutates `this` in place returning a new record (~line 605). `_remoteOrigin` is `private readonly`.
+- `packages/agent/src/dwn-api.ts` (`AgentDwnApi`) — `processRequest` vs `sendRequest`/`sendDwnRpcRequest` routing (`this._dwn ? processMessage : sendDwnRpcRequest`); `constructDwnMessage` already handles `granteeDid` + delegated-grant resolution and signs with the grantee's key (`request.granteeDid ? getSigner(granteeDid) : getSigner(author)`); `sendDwnRpcRequest` already streams record data over RPC. **No agent change needed.**
+- `packages/dwn-sdk-js/src/interfaces/records-write.ts` — `RecordsWriteOptions` already has `protocolRole?` and `delegatedGrant?`.
+- `packages/dwn-sdk-js/src/handlers/records-write.ts` (`authorizeRecordsWrite`) — acceptance paths: owner-delegate, `author === tenant`, permission-grant, and protocol role-invocation (`ProtocolAuthorization.authorizeWrite` → `verifyInvokedRole`). A non-owner author with a valid invoked role or delegated grant **is already accepted**. No server change needed.
+
+### Institutional learnings / prior art
+
+- The notesd v3 plan's KTD-6 originally concluded cross-tenant writes were "blocked" pending a remote-dispatch write path plus grant/role invocation. Source verification corrected this (KTD-1 below): it is client-only.
+- The realtime/ephemeral exploration that lived here (and on #977) was superseded by the PDS/Broadcast-layer split — NOSTR for the ephemeral plane (#983). #972/#973 were always the independent durable core.
+
+## Key Technical Decisions
+
+### KTD-1 — Phase 2 is client-only (corrects the earlier "blocked" framing)
+The notesd v3 plan's KTD-6 concluded cross-tenant writes needed "a remote-dispatch write path PLUS grant/role invocation, not merely a `target` field." Verification shows that was pessimistic: the agent **already** remote-dispatches and resolves grants, `RecordsWrite` **already** carries `protocolRole`, and the relay **already** authorizes role-invoked non-owner writes. The block is *only* that `packages/api/src/dwn-api.ts`'s `records.write` wrapper omits `from` and forces local dispatch. Phase 2 mirrors the read side in that one wrapper (+ the typed `create`). No agent, no server, no protocol changes.
+
+### KTD-2 — Authoring mechanism: support both role-invocation and delegated-grant, lead with role
+Both are server-accepted. **Role-invocation** (`protocolRole` + an existing role record with `recipient = grantee`) is the right primary mechanism for "a collaborator writes into a page they were shared on" — it's symmetric, protocol-defined, and is exactly what the notesd `collaborator` `$role` already grants. **Delegated-grant** (`granteeDid` + `delegatedGrant`/`permissionGrantId`) is the asymmetric alternative the agent already resolves; Phase 2 must not *break* it (it flows through the same `from` dispatch). The API change is mechanism-agnostic: expose `from` + `protocolRole`; `granteeDid`/grant params continue to flow through `messageParams` as today.
+
+### KTD-3 — Cross-tenant `update` is explicit-`from`, not `_remoteOrigin`-defaulted
+Cross-tenant routing on `Record.update()` fires **only** when the caller passes an explicit `from` differing from the connected DID; `_remoteOrigin` stays `private readonly` and a read-remote-then-update caller stays **local** unless it passes `from`. Defaulting `from` to `_remoteOrigin` would silently re-route any existing read-remote-then-update caller for zero v1 benefit (there is no cross-tenant-update caller today). The only persisted effect is the **returned** record carrying `remoteOrigin: from ?? this._remoteOrigin` so its own `.data` re-reads target the owner tenant.
+
+## Open Questions
+
+### Resolved during planning (via source verification)
+- *Is #973 client-only or client+server?* → **Client-only** (KTD-1). Server + agent already support it.
+- *Role-invocation or delegated-grant for cross-tenant authoring?* → **Both accepted; lead with role-invocation** (KTD-2).
+- *Does cross-tenant `update` inherit `_remoteOrigin` for routing?* → **No — explicit `from` only** (KTD-3).
+
+## Implementation Units
+
+Units are dependency-ordered; each is a single landable commit.
+
+### Phase 1 — #972 typed squash
+
+- [ ] **Unit 1: Expose `squash` on the typed create path**
+
+**Goal:** `proto.records.create(path, { data, squash: true })` reaches the write message with `squash: true`.
+
+**Requirements:** R1.
+
+**Dependencies:** none.
+
+**Files:**
+- Modify: `packages/api/src/typed-enbox.ts` — add `squash?: true` to `TypedCreateRequest`; add `squash: request.squash` to the enumerated field list forwarded to `this._dwn.records.write` (~line 985).
+- Test: the api package's existing typed-create test suite (locate `typed-enbox`/`records.create` specs under `packages/api/tests/`).
+
+**Approach:** Two-line change. The low-level `records.write` already forwards `squash` (it survives the `Partial`), so nothing else is needed. Mirror how an adjacent optional field (e.g. `recipient`, `tags`) is both typed and forwarded.
+
+**Test scenarios:**
+- Happy: `create(path, { data, squash: true })` produces a write message whose descriptor carries `squash: true` (assert via a mocked/agent-captured message).
+- Edge: omitting `squash` produces no `squash` field (not `false`) — parity with today.
+- Edge (optional, integration): against an in-memory dwn with a `$squash: true` path, a `create({squash:true})` purges older siblings (reuses the dwn-sdk-js squash test harness).
+
+**Verification:** A typed `create` with `squash: true` is observably a squashing write; existing typed-create tests still pass.
+
+**Consumer follow-up (notesd):** swap `src/store/delta-repo.ts` `writeDelta({snapshot})`'s raw-API branch to the typed path (one-line internal change behind the existing seam).
+
+### Phase 2 — #973 cross-tenant writes (client-only)
+
+- [ ] **Unit 2: Low-level `records.write` — `from` + remote dispatch + `protocolRole`**
+
+**Goal:** `records.write` can target another tenant (`from`), routes remotely when `from` is set, signs as the connected (grantee) DID, threads `protocolRole`, **and stamps the returned record with `remoteOrigin: from`** so a follow-up **data read** (`.data`) on it targets the owner tenant. *(Precise per KTD-3: `remoteOrigin` drives **reads**, not routing for **update** — cross-tenant `update` requires an explicit `from` (Unit 3b); cross-tenant `delete` is out of scope.)*
+
+**Requirements:** R2, R3.
+
+**Dependencies:** Unit 1 (adjacent edits in the same files; sequence to avoid conflict).
+
+**Files:**
+- Modify: `packages/api/src/dwn-api.ts` — add `from?: string` (and ensure `protocolRole?` flows) to `RecordsWriteRequest`; in `write()`: `target = from ?? this.connectedDid` (author stays `this.connectedDid` — grantee signs as self); dispatch `if (from) sendDwnRequest else processDwnRequest`, mirroring `records.read`/`query`/`delete`; **construct the returned `Record` with `remoteOrigin: from`** (read/query already do this at the cited lines — the write path currently omits it).
+- Test: `packages/api/tests/` records-write specs (+ a new cross-tenant write spec).
+
+**Approach:** Mirror the read path exactly — copy its `from`/dispatch selection **and its `remoteOrigin` stamping** into `write`. `protocolRole` is already a valid `RecordsWriteOptions` field; ensure the wrapper passes it through `messageParams` (it may already; confirm). Do **not** touch the agent or server. Preserve the existing `granteeDid`/delegated-grant flow (it rides the same dispatch).
+
+**Execution note:** Add a failing integration test first (a write with `from` set must hit `sendDwnRequest`, not `processDwnRequest`, and the returned record must carry `remoteOrigin`).
+
+**Test scenarios:**
+- Happy: `write({ from: ownerDid, protocolRole, data, protocol, protocolPath, parentContextId })` dispatches via `sendDwnRequest` with `target = ownerDid`, `author = connectedDid` (assert the agent request shape).
+- Happy: no `from` → unchanged local `processDwnRequest` path, no `remoteOrigin` (regression guard).
+- Happy (remoteOrigin): the returned record has `remoteOrigin === ownerDid`; a follow-up `record.data.bytes()` on it targets the owner tenant (not the local one) — assert the dispatch target. *(Follow-up `update` is covered by Unit 3b; `delete` is out of scope — do not assert remote delete.)*
+- Integration (in-memory two-tenant or mocked agent): a role-authorized cross-tenant create is **accepted** (the owner tenant has a matching `$role` record with `recipient = grantee`); a non-role, non-grant cross-tenant write is **rejected** (401/403 surfaces, not swallowed).
+- Edge: a write carrying record **data** routes remotely with the payload intact — the agent's `sendDwnRequest` requires the data as a `Blob` (traced: `dwn-api.ts` throws "DataStream must be provided as a Blob"), which the write path already produces via `dataToBlob`; assert the data survives `sendDwnRequest`.
+- Note (traced): the returned record sets `remoteOrigin: from` but keeps `connectedDid = this.connectedDid` (the connected/grantee DID is always the author) — matching the read path's record construction.
+- Edge: delegated-grant write (`granteeDid` + grant) with `from` still works (no regression to the grant path).
+
+**Verification:** A grantee client writes a record into an owner tenant's DWN over `from` + `protocolRole`, the owner's relay stores it, and the returned record correctly remembers its remote origin; non-authorized writes fail visibly.
+
+- [ ] **Unit 3: Typed `create` — expose `from`**
+
+**Goal:** The typed `proto.records.create` exposes `from` so consumers author cross-tenant **creates** (the collaborator-delta case — deltas are create-only) without dropping to the low-level API. *(`protocolRole` is already supported on typed create — verified; update is a separate path — Unit 3b.)*
+
+**Requirements:** R3.
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `packages/api/src/typed-enbox.ts` — add `from?: string` to `TypedCreateRequest` and forward it in the enumerated field list (same site as Unit 1's `squash`). **`protocolRole` is already present (~lines 172, 979) — do not re-add it.**
+- Test: `packages/api/tests/` typed-create specs (+ cross-tenant typed-create assertions).
+
+**Approach:** Same enumerated-forward pattern as Unit 1 — add only `from` (the typed wrapper already forwards `protocolRole`; it strips only `squash` and `from`). **Do not** touch the typed update path here — typed `update` delegates to `Record.update()` (`record.ts`), a separate local-only path handled in Unit 3b; claiming create+update parity in one change is the over-promise the review caught.
+
+**Test scenarios:**
+- Happy: typed `create({ from, protocolRole, data })` forwards both `from` and the already-supported `protocolRole` to `records.write` (assert via captured low-level request).
+- Edge: typed `create` without `from` is unchanged (regression).
+- Integration: a typed cross-tenant create against a role-granting owner tenant is accepted (reuses Unit 2's harness through the typed layer), and the returned typed record carries `remoteOrigin`.
+
+**Verification:** A consumer authors cross-tenant **creates** through `enbox.using(Protocol).records.create({ from, protocolRole, ... })`.
+
+- [ ] **Unit 3b: Cross-tenant `Record.update` — `from`/remote-origin dispatch**
+
+**Goal:** `record.update()` can target another tenant so a collaborator can **co-update** the owner's derived `document`/`meta` singletons (the co-update action the owner's protocol already authorizes).
+
+**Requirements:** R3b.
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `packages/api/src/record.ts` — `update()` currently builds params with no `from`, always targets/processes `this._connectedDid` locally (~line 581), and **mutates `this` in place**, returning a new record that keeps the existing `_remoteOrigin` (~line 605). Add an **explicit** `from?: string` + thread `protocolRole`; when `from` is set and differs from the connected DID, dispatch remotely (`sendDwnRequest`) and sign as the connected (grantee) DID; otherwise the path is **unchanged** (local dispatch). **Do NOT default `from` to `_remoteOrigin`** — a record that was merely *read* from a remote tenant still updates **locally** unless the caller passes `from`, preserving today's documented behavior. Stamp the **returned** record with `remoteOrigin: from ?? this._remoteOrigin` (via its constructor) so a subsequent `.data` re-read hits the owner tenant; `_remoteOrigin` can stay `private readonly` (no `readonly` drop needed — the routing decision is the explicit `from`, not the stored origin).
+- Modify: `packages/api/src/typed-record.ts` (~line 295) — expose `from`/`protocolRole` on the typed update request and forward to `Record.update()`.
+- Test: `packages/api/tests/` record-update + typed-record specs (+ cross-tenant update).
+
+**Approach:** Mirror Unit 2's write changes in the update method, but as a **strictly opt-in** cross-tenant path: cross-tenant routing happens **only** when the caller passes an explicit `from` that differs from the connected DID; sign as the connected (grantee) DID. **No `from ?? _remoteOrigin` default.** This deliberately *keeps* today's behavior in which the read/query path sets a remote-fetched record's `connectedDid` to the *local* DID so `record.update()` runs locally even for remote-origin records (`_remoteOrigin` is used only for large-data re-reads) — so **no existing caller changes behavior**. The only persisted effect is that the **returned** record carries `remoteOrigin: from ?? this._remoteOrigin` so its own subsequent `.data` re-reads target the owner tenant. **Consumer audit (do before relying on it):** grep notesd/web-wallet for `.update()` on records obtained via a `from` read and confirm none expect implicit cross-tenant routing (none should — the surface is new).
+
+**Test scenarios:**
+- **Regression (the reason for the explicit-`from` choice):** a record with `_remoteOrigin = ownerDid` updated with **no** `from` dispatches **locally** (unchanged from today), **not** to `ownerDid` — assert no silent cross-tenant routing.
+- Happy: explicit `from = ownerDid` dispatches remotely (`sendDwnRequest`, `target = ownerDid`, `author = connectedDid`); `protocolRole` threads through; the returned record carries `remoteOrigin = ownerDid` so its next `.data.bytes()` targets `ownerDid`.
+- Integration: a collaborator co-updates an owner-authored singleton (`document`/`meta`) via explicit `from` under a `co-update` role rule → accepted; a non-`co-update` role → rejected.
+- Edge: a purely-local record (no `from`) updates locally and stays local (regression).
+
+**Verification:** A collaborator updates a record on the owner's tenant via role-authorized `co-update`; local updates are unchanged.
+
+**Consumer follow-up (notesd):** route `src/sharing/remote-page.ts` `publishDelta` (the `NotSupportedYet` seam) through the new `from` create for **deltas** (Unit 3), and the cross-tenant `Record.update` (passing an explicit `from: ownerDid`) for **derived `document`/`meta` co-updates** (Unit 3b); enable the dormant collaborator write actions (delta create/squash, derived co-update). Per the #973 sequencing note: collaborator *snapshot* writes must carry `squash` (via #972's typed path or the raw seam) so collaborator snapshots actually compact. If Unit 3b is deferred, the consumer still gets durable collaborator **deltas** (creates), and the owner's derived records simply refresh whenever any updater flushes — a documented v1 staleness, not data loss.
+
+## System-Wide Impact
+
+- **Interaction graph.** Both phases touch only the API wrappers — the agent and server are unchanged, so the blast radius is the typed/low-level request shapes (additive optional fields).
+- **Error propagation.** Cross-tenant write rejections must surface as thrown errors / explicit rejections, never silent empties — the consuming dapp distinguishes "unauthorized/revoked" from "transient."
+- **API surface parity.** Keep the low-level and typed surfaces consistent (`from` + `protocolRole` on both).
+- **Integration coverage.** The load-bearing cross-layer test: a role-authorized cross-tenant write traverses api→agent→relay→store and is accepted, while an unauthorized one is rejected. This proves what mocks cannot.
+
+## Risks & Dependencies
+
+- **Cross-tenant write data-over-RPC.** Writes carry data; the read-side `sendDwnRequest` is proven, but a write with a large payload over RPC is a newer path for this wrapper. Mitigation: explicit data-payload integration test (Unit 2).
+- **Consumer sequencing.** notesd's #973 follow-up must land collaborator snapshot writes through a `squash`-carrying path (#972) — noted on #973; the enbox side here is independent, but the consumer integration depends on both phases.
+- **Greenfield-but-shipped surfaces.** The API wrappers serve real tenants; changes are additive optional fields, gated by the `packages/api` + `packages/dwn-sdk-js` CI suites.
+
+## Documentation / Operational Notes
+
+- Each phase ships as its own PR referencing its issue (#972 / #973). Both are small and unblock notesd immediately.
+- The ephemeral realtime plane is tracked separately in **#983** (NOSTR broadcast layer); it is not part of this plan or these PRs.
+
+## Sources & References
+
+- **Issues:** [enboxorg/enbox#972](https://github.com/enboxorg/enbox/issues/972) (typed squash), [#973](https://github.com/enboxorg/enbox/issues/973) (cross-tenant writes). Ephemeral plane: [#983](https://github.com/enboxorg/enbox/issues/983) (NOSTR; supersedes the closed #977).
+- **API:** `packages/api/src/{dwn-api,typed-enbox,record,typed-record}.ts`.
+- **Agent:** `packages/agent/src/dwn-api.ts` (`processRequest`/`sendRequest`/`constructDwnMessage`).
+- **dwn-sdk-js:** `src/handlers/records-write.ts`, `src/interfaces/records-write.ts`, `src/core/protocol-authorization-action.ts`.
+- **Consumer plan:** notesd `docs/plans/2026-06-05-002-feat-crdt-collab-foundation-plan.md` (KTD-1/KTD-6 corrected by this plan's KTD-1).

--- a/docs/plans/2026-06-09-001-feat-nostr-live-primitives-plan.md
+++ b/docs/plans/2026-06-09-001-feat-nostr-live-primitives-plan.md
@@ -1,0 +1,86 @@
+---
+title: "feat: NOSTR ephemeral-broadcast primitives (#983 implementation)"
+type: feat
+status: active
+date: 2026-06-09
+worktree: .claude/worktrees/realtime-fast-follows
+related: implements #983; depends on #972/#973 (durable core); consumed by notesd live-edit (notesd docs/plans/2026-06-09-001)
+---
+
+# feat: NOSTR ephemeral-broadcast primitives (#983 implementation)
+
+Enbox-side primitives for the **NOSTR ephemeral data plane**. The DWN is the control plane (authz'd `liveSession` records signal/attest/negotiate); NOSTR is the dumb, fast data plane. These primitives are **generic and CRDT-agnostic** — notesd (live-edit) is the first consumer, but nothing here is notesd- or Yjs-specific. Each phase lands as its own **PR** (the review/merge/publish gate).
+
+See the consumer plan (notesd `docs/plans/2026-06-09-001-feat-live-edit-nostr-plan.md`) for the end-to-end architecture and the execution loop.
+
+## Scope
+
+- **In:** ephemeral `secp256k1`/Schnorr identity under the agent; NIP-44 crypto; a NOSTR relay client; the `enbox.live` facade (DWN↔NOSTR bridge); a relay-advertisement convention. Authenticated (plaintext) first; group-key **encryption** as a later, gated phase.
+- **Out (separate):** #972/#973 (durable core — their own plan); self-hosted relay / NIP-42 allowlist / gift-wrap (ops, P5); the dapp's protocol records + editor wiring (notesd).
+- **Dependency:** the collaborator (cross-tenant) `liveSession` write needs **#973**; the **own-tenant** (single-identity multi-device) path works without it, so the facade is buildable/testable before #973 lands.
+
+## Key Technical Decisions
+
+- **KTD-A — DWN bootstraps trust; NOSTR transports.** Acceptance of a NOSTR event is gated by the **roster**: the event's pubkey must appear in a current `liveSession` record authored by a DID the page protocol authorizes. The relay stays dumb (public relays usable for test). Confidentiality is a separate, later layer (encryption).
+- **KTD-B — Ephemeral DID-attested key.** A fresh `secp256k1` key per session, Schnorr-signs events; the DID key never does Schnorr — it *attests* via the `liveSession` `RecordsWrite`. Un-attested keys (future privacy mode) ride the same code for pseudonymous broadcast.
+- **KTD-C — CRDT-agnostic opaque payloads.** The facade carries opaque bytes + a generic `kind` (`content | presence`). No Yjs/notesd concept crosses the API.
+- **KTD-D — Authenticated first, encrypted later.** v1 = signed + roster-verified (plaintext) so we can test on public relays immediately; group-key encryption (NIP-44) is a gated follow-on for private-page confidentiality and cryptographic revocation. Owner is the v1 key authority.
+- **KTD-E — Wrap, don't reinvent.** Use `nostr-tools` / `@noble/{curves,ciphers}` for BIP-340 Schnorr, NIP-01 events, and NIP-44 — with known-answer + official interop vectors in CI. No bespoke crypto.
+
+## Implementation Units
+
+### Phase NL-1 — Crypto + ephemeral identity (PR 1)
+
+- [ ] **Unit NL-1: Schnorr + NIP-44 crypto primitives**
+  - **Files:** `@enbox/crypto` (or a new `@enbox/nostr` crypto submodule) — add BIP-340 Schnorr sign/verify over `secp256k1` and NIP-44 v2 (ChaCha20 + HKDF + HMAC) encrypt/decrypt, sourced from `@noble/curves`/`@noble/ciphers` or `nostr-tools`. Tests alongside.
+  - **Tests:** BIP-340 reference test vectors; NIP-44 official test vectors (round-trip + cross-impl); tamper/negative cases.
+  - **Verification:** vectors pass; the curve set is documented as additive (does not touch the DID `Ed25519|secp256k1|P-256` signing registry).
+- [ ] **Unit NL-2: Ephemeral broadcast-identity service (agent)**
+  - **Files:** `@enbox/agent` — a service to **mint / import / rotate** a session-scoped `secp256k1` keypair; expose its x-only pubkey; `sign(bytes)` via Schnorr (NL-1); TTL lifecycle; in-memory (not a DID verification method, not persisted as a DID key).
+  - **Tests:** mint→sign→verify; rotate invalidates prior; import an existing nsec; TTL expiry.
+  - **Verification:** an ephemeral pubkey + Schnorr signer usable by the facade; never co-mingled with DID keys.
+
+### Phase NL-2 — NOSTR relay client (PR 2)
+
+- [ ] **Unit NL-3: NOSTR client module**
+  - **Files:** new `@enbox/nostr` (or `@enbox/api` submodule) — relay WebSocket client (NIP-01 `EVENT`/`REQ`/`EOSE`/`CLOSE`/`OK`), event build/sign(NL-2)/verify, ephemeral kinds (20000–29999), filter by topic tag + author set, NIP-44 (NL-1) encrypt/decrypt, **optional** NIP-42 AUTH. Thin wrapper over `nostr-tools`.
+  - **Tests:** against a **local ephemeral relay** (test fixture) — publish/subscribe round-trip; reject bad signature; ephemeral kinds not stored; reconnect/backoff. (Public relays = manual smoke only, not CI.)
+  - **Verification:** publish a signed ephemeral event to a relay and receive it on a second subscription, verified.
+
+### Phase NL-3 — `enbox.live` facade + relay convention (PR 3)
+
+- [ ] **Unit NL-4: Relay-advertisement convention**
+  - **Files:** `@enbox/api` (+ DID-doc helper) — read/write a `NostrRelay` service endpoint in the DID document and a `relays` field on the `liveSession` record shape; a resolver that unions them.
+  - **Tests:** advertise + resolve; default/fallback relay; precedence (liveSession over DID-doc default).
+- [ ] **Unit NL-5: `enbox.live.session(...)` facade**
+  - **Files:** `@enbox/api` — `enbox.live.session({ target, protocol, contextId, contentPath, relays?, encrypt:false }) → { publish(bytes, { kind }), on(kind, handler), peers(), leave() }`. Responsibilities: mint ephemeral key (NL-2); write own `liveSession` (own-tenant now; cross-tenant via #973 when `target ≠ self`); read + **subscribe** peers' `liveSession` to maintain the trusted-pubkey **roster**; resolve relays (NL-4); connect (NL-3); publish signed **plaintext** ephemeral events (topic = `hash(contextId)`); verify inbound against the roster; dispatch by `kind`; `leave`/expiry.
+  - **Tests:** roster built from `liveSession`; inbound from an attested pubkey delivered; inbound from an **unattested** pubkey dropped; own-tenant two-instance exchange.
+  - **Verification:** two sessions (same identity, two instances) exchange `content`+`presence` on a local relay; trust is roster-gated.
+- [ ] **Unit NL-6: Integration + the consumer surface**
+  - **Files:** integration tests; export `enbox.live` on the `Enbox` class + barrel.
+  - **Tests:** two clients on a local relay converge; unattested rejected; a simulated durable-drop is healed by a re-publish (proves the degrade-to-durable contract at the seam).
+  - **Verification:** the facade is consumable by notesd; CRDT-agnostic (opaque payload test with non-Yjs bytes).
+
+### Phase NL-4 — Group-key encryption (GATED — PR 4, after the encryption go/no-go)
+
+- [ ] **Unit NL-7: Group key + encrypted payloads**
+  - **Files:** `@enbox/api` — owner mints a per-epoch group key `Gk`; delivers it to each attested peer over **NIP-44 pairwise** (NL-1) bootstrapped by the roster pubkeys (Gk never touches the DWN); symmetric-encrypt/decrypt payloads with `Gk`; `rotateKey()`.
+  - **Tests:** key delivery to a new attested peer; encrypted round-trip; a peer without `Gk` cannot read; rotation excludes a revoked peer.
+- [ ] **Unit NL-8: Revocation-by-rotation**
+  - **Files:** wire roster-change (peer left / role revoked) → `rotateKey()` → redistribute to remaining.
+  - **Tests:** revoked peer's post-rotation traffic is undecryptable; remaining peers continue seamlessly.
+  - **Verification:** confidentiality holds on a public relay (relay sees only ciphertext); revocation is cryptographic.
+
+## Risks & dependencies
+
+- **Crypto correctness** — mitigated by wrapping audited libs + official vectors (KTD-E); PR gate includes crypto review (G2).
+- **#973 dependency** — collaborator `liveSession`/durable writes are cross-tenant; own-tenant path unblocks early build/test.
+- **Public-relay reliability/metadata** — CI uses a local relay; public relays are manual smoke; metadata privacy is Phase 5 (out of scope here).
+- **Group-key management** — start simple (per-epoch, owner authority); MLS/Marmot reserved (KTD-D).
+- **SDK publish ordering** — notesd consumes a published `@enbox` bump; each PR merge + publish is the gate before the dapp loop proceeds.
+
+## Sources
+
+- Issue: #983 (NOSTR ephemeral layer). Durable core: #972/#973 + `docs/plans/2026-06-08-001`.
+- NIPs: NIP-01, NIP-44 (Cure53-audited), NIP-42, ephemeral kinds 20000–29999. Libs: `nostr-tools`, `@noble/curves`, `@noble/ciphers`.
+- Consumer + architecture + execution loop: notesd `docs/plans/2026-06-09-001-feat-live-edit-nostr-plan.md`.


### PR DESCRIPTION
## Summary

Planning docs for the realtime-collaboration work, for review (no code).

- **`2026-06-08-001`** — slim plan for the **durable core**: enboxorg/enbox#972 (typed squash) + enboxorg/enbox#973 (cross-tenant writes). The source-of-truth `$squash` CRDT.
- **`2026-06-09-001`** — **#983** implementation plan: NOSTR ephemeral-broadcast primitives (`enbox.live` facade, ephemeral DID-attested keys, relay convention; gated group-key encryption).

Context: the ephemeral realtime plane is now **NOSTR (#983)**; the prior bespoke-channel design (#977) is **closed/superseded**. The companion consumer plan (the notesd live-edit feature + the end-to-end execution loop) lives in the notesd repo.

Code lands separately — enboxorg/enbox#972 is PR enboxorg/enbox#985; enboxorg/enbox#973 follows.

## Post-deploy monitoring

No operational impact — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
