### PR TITLE
Fix RecordsWrite duplicate replay handling

### DIFF
--- a/.changeset/quiet-windows-replay.md
+++ b/.changeset/quiet-windows-replay.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Treat exact RecordsWrite replays as idempotent before mutable protocol-state validation.

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -37,18 +37,8 @@ export class RecordsWriteHandler implements MethodHandler {
     let recordsWrite: RecordsWrite;
     try {
       recordsWrite = await RecordsWrite.parse(message);
-
-      await ProtocolAuthorization.validateReferentialIntegrity(tenant, recordsWrite, this.deps.messageStore, this.deps.coreProtocols);
     } catch (e) {
       return messageReplyFromError(e, 400);
-    }
-
-    // authentication & authorization
-    try {
-      await authenticate(message.authorization, this.deps.didResolver, message.attestation);
-      await this.authorizeRecordsWrite(tenant, recordsWrite, this.deps.messageStore);
-    } catch (e) {
-      return messageReplyFromError(e, 401);
     }
 
     // get existing messages matching the `recordId`
@@ -58,9 +48,10 @@ export class RecordsWriteHandler implements MethodHandler {
     };
     const { messages: existingMessages } = await this.deps.messageStore.query(tenant, [ query ]);
 
-    // If the exact same message already exists, return 409 immediately.
-    // This prevents duplicate delivery races from re-processing large data
-    // streams and hitting unique constraints in SQL-backed data stores.
+    // If the exact same message already exists, return 409 before re-running
+    // mutable validation. An already-stored message has already passed
+    // admission; replay should not be reinterpreted against current protocol,
+    // parent, role, grant, or record-limit state.
     //
     // Exception: an initial write may have been stored earlier without data
     // (204). A later delivery of the same message with data must be allowed
@@ -81,6 +72,20 @@ export class RecordsWriteHandler implements MethodHandler {
       if (!canCompleteMissingData) {
         return { status: { code: 409, detail: 'Conflict' } };
       }
+    }
+
+    try {
+      await ProtocolAuthorization.validateReferentialIntegrity(tenant, recordsWrite, this.deps.messageStore, this.deps.coreProtocols);
+    } catch (e) {
+      return messageReplyFromError(e, 400);
+    }
+
+    // authentication & authorization
+    try {
+      await authenticate(message.authorization, this.deps.didResolver, message.attestation);
+      await this.authorizeRecordsWrite(tenant, recordsWrite, this.deps.messageStore);
+    } catch (e) {
+      return messageReplyFromError(e, 401);
     }
 
     // if the incoming write is not the initial write, then it must not modify any immutable properties defined by the initial write

--- a/packages/dwn-sdk-js/tests/features/records-record-limit.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-record-limit.spec.ts
@@ -4,6 +4,7 @@ import type { DataStore, MessageStore, ProtocolDefinition, ResumableTaskStore, S
 
 import sinon from 'sinon';
 
+import { DataStream } from '../../src/utils/data-stream.js';
 import { DidKey } from '@enbox/dids';
 import { Dwn } from '../../src/dwn.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
@@ -371,6 +372,13 @@ export function testRecordsRecordLimit(): void {
         const reply1 = await dwn.processMessage(alice.did, record1.message, { dataStream: record1.dataStream });
         expect(reply1.status.code).toBe(202);
 
+        // exact duplicate delivery is idempotent and should not count the
+        // same recordId against its own singleton limit
+        const duplicateReply = await dwn.processMessage(alice.did, record1.message, {
+          dataStream: DataStream.fromBytes(record1.dataBytes!),
+        });
+        expect(duplicateReply.status.code).toBe(409);
+
         // second record should be rejected
         const record2 = await TestDataGenerator.generateRecordsWrite({
           author       : alice,
@@ -542,6 +550,7 @@ export function testRecordsRecordLimit(): void {
         expect(room2Reply.status.code).toBe(202);
 
         // write 2 messages in room1 — both should succeed
+        let firstRoom1Message: Awaited<ReturnType<typeof TestDataGenerator.generateRecordsWrite>> | undefined;
         for (let i = 0; i < 2; i++) {
           const msg = await TestDataGenerator.generateRecordsWrite({
             author          : alice,
@@ -552,7 +561,14 @@ export function testRecordsRecordLimit(): void {
           });
           const msgReply = await dwn.processMessage(alice.did, msg.message, { dataStream: msg.dataStream });
           expect(msgReply.status.code).toBe(202);
+          firstRoom1Message ??= msg;
         }
+
+        // exact duplicate nested delivery is idempotent within the parent context
+        const duplicateNestedReply = await dwn.processMessage(alice.did, firstRoom1Message!.message, {
+          dataStream: DataStream.fromBytes(firstRoom1Message!.dataBytes!),
+        });
+        expect(duplicateNestedReply.status.code).toBe(409);
 
         // 3rd message in room1 should be rejected
         const msg3 = await TestDataGenerator.generateRecordsWrite({

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -206,6 +206,51 @@ export function testRecordsWriteHandler(): void {
         expect(duplicateReply.status.code).toBe(409);
       });
 
+      it('should return 409 for an exact duplicate RecordsWrite before mutable parent validation', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition = nestedProtocol as ProtocolDefinition;
+        const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition
+        });
+        const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
+        expect(protocolsConfigureReply.status.code).toBe(202);
+
+        const parentWrite = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'foo',
+          schema       : protocolDefinition.types.foo.schema,
+          dataFormat   : protocolDefinition.types.foo.dataFormats![0],
+        });
+        const parentWriteReply = await dwn.processMessage(alice.did, parentWrite.message, { dataStream: parentWrite.dataStream });
+        expect(parentWriteReply.status.code).toBe(202);
+
+        const childWrite = await TestDataGenerator.generateRecordsWrite({
+          author          : alice,
+          protocol        : protocolDefinition.protocol,
+          protocolPath    : 'foo/bar',
+          schema          : protocolDefinition.types.bar.schema,
+          dataFormat      : protocolDefinition.types.bar.dataFormats![0],
+          parentContextId : parentWrite.message.contextId,
+        });
+        const childWriteReply = await dwn.processMessage(alice.did, childWrite.message, { dataStream: childWrite.dataStream });
+        expect(childWriteReply.status.code).toBe(202);
+
+        const parentDelete = await RecordsDelete.create({
+          recordId : parentWrite.message.recordId,
+          signer   : Jws.createSigner(alice),
+        });
+        const parentDeleteReply = await dwn.processMessage(alice.did, parentDelete.message);
+        expect(parentDeleteReply.status.code).toBe(202);
+
+        const duplicateChildReply = await dwn.processMessage(alice.did, childWrite.message, {
+          dataStream: DataStream.fromBytes(childWrite.dataBytes!),
+        });
+        expect(duplicateChildReply.status.code).toBe(409);
+      });
+
       it('should only be able to overwrite existing record if new message CID is larger when `messageTimestamp` value is the same', async () => {
       // start by writing an originating message
         const author = await TestDataGenerator.generatePersona();
@@ -4508,6 +4553,7 @@ export function testRecordsWriteHandler(): void {
         const mismatchingPersona = await TestDataGenerator.generatePersona({ did: author.did, keyId: author.keyId });
         const didResolver = TestStubGenerator.createDidResolverStub(mismatchingPersona);
         const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
+        messageStoreStub.query.resolves({ messages: [] });
         const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
 
         // stub protocol validation so the handler reaches authentication/authorization
@@ -4528,6 +4574,7 @@ export function testRecordsWriteHandler(): void {
         // setting up a stub DID resolver & message store
         const didResolver = TestStubGenerator.createDidResolverStub(author);
         const messageStoreStub = sinon.createStubInstance(MessageStoreLevel);
+        messageStoreStub.query.resolves({ messages: [] });
         const dataStoreStub = sinon.createStubInstance(DataStoreLevel);
 
         // stub protocol validation so the handler reaches authentication/authorization


### PR DESCRIPTION
## Summary
- return 409 for exact RecordsWrite replays before re-running mutable protocol-state validation
- preserve the missing-data completion path for initial writes stored without data
- add regression coverage for singleton record-limit echo and replay after parent deletion

## Why
Live sync can legitimately redeliver a record the local DWN already accepted. Replaying the exact same message should be idempotent; it should not be reinterpreted against current protocol, parent, role, grant, or record-limit state. This keeps profile/avatar/hero singleton echoes from degrading sync while also covering broader exact-replay cases.

## Verification
- `bunx turbo run build --filter=@enbox/dwn-sdk-js...`
- `bun run test:node`
- `bun run lint`
- `git diff --check origin/main...HEAD`
