### PR TITLE
fix(sync): retry pushes with missing parents

### DIFF
--- a/.changeset/missing-parent-push-retry.md
+++ b/.changeset/missing-parent-push-retry.md
@@ -1,0 +1,6 @@
+---
+"@enbox/agent": patch
+"@enbox/dwn-sdk-js": patch
+---
+
+Retry sync pushes when a child record reaches a remote before its parent, while keeping malformed protocol-path failures permanent.

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -3,7 +3,7 @@ import type { GenericMessage, MessagesReadReply, MessagesSyncDiffEntry, UnionMes
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermanentPushFailure, PushResult } from './types/sync.js';
 
-import { DwnInterfaceName, DwnMethodName, Encoder, Message } from '@enbox/dwn-sdk-js';
+import { DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, Message } from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from './types/dwn.js';
 import { isRecordsWrite } from './utils.js';
@@ -74,13 +74,15 @@ export function syncMessageReplyIsSuccessful(reply: UnionMessageReply, pushedMes
 }
 
 /**
- * 400 detail substrings that indicate a protocol dependency hasn't
- * arrived on the remote yet. These resolve on retry once the
- * dependency is pushed, so they must NOT be treated as permanent.
+ * 400 error codes that indicate a dependency has not arrived on the remote yet.
+ * These resolve on retry once the missing dependency is pushed, so they must not
+ * be treated as permanent.
  */
-const TRANSIENT_DEPENDENCY_PATTERNS = [
-  'ComposedProtocolNotInstalled',
-  'ProtocolNotFound',
+const TRANSIENT_DEPENDENCY_ERROR_CODES = [
+  DwnErrorCode.ProtocolsConfigureComposedProtocolNotInstalled,
+  DwnErrorCode.ProtocolAuthorizationCrossProtocolParentNotFound,
+  DwnErrorCode.ProtocolAuthorizationParentRecordNotFound,
+  DwnErrorCode.ProtocolAuthorizationProtocolNotFound,
 ];
 
 /**
@@ -97,7 +99,7 @@ export function isPermanentPushFailure(reply: UnionMessageReply): boolean {
   if (code === 401 || code === 403) { return true; }
 
   if (code === 400) {
-    return !TRANSIENT_DEPENDENCY_PATTERNS.some(pattern => detail?.includes(pattern));
+    return !TRANSIENT_DEPENDENCY_ERROR_CODES.some(errorCode => detail?.startsWith(`${errorCode}:`));
   }
 
   return false;

--- a/packages/agent/tests/sync-push-resilience.spec.ts
+++ b/packages/agent/tests/sync-push-resilience.spec.ts
@@ -36,6 +36,46 @@ describe('isPermanentPushFailure', () => {
     expect(isPermanentPushFailure(reply)).toBe(false);
   });
 
+  test('400 with missing parent record is transient', () => {
+    const reply = {
+      status: {
+        code   : 400,
+        detail : 'ProtocolAuthorizationParentRecordNotFound: Could not find parent record \'bafy-parent\' to verify declared protocol path \'profile/avatar\'.',
+      },
+    } as UnionMessageReply;
+    expect(isPermanentPushFailure(reply)).toBe(false);
+  });
+
+  test('400 with missing cross-protocol parent record is transient', () => {
+    const reply = {
+      status: {
+        code   : 400,
+        detail : 'ProtocolAuthorizationCrossProtocolParentNotFound: Could not find parent record \'bafy-parent\' in protocol \'https://example.com/parent\'',
+      },
+    } as UnionMessageReply;
+    expect(isPermanentPushFailure(reply)).toBe(false);
+  });
+
+  test('400 with parentless nested protocol path is permanent', () => {
+    const reply = {
+      status: {
+        code   : 400,
+        detail : 'ProtocolAuthorizationParentlessIncorrectProtocolPath: Declared protocol path \'profile/avatar\' is not valid for records with no parent.',
+      },
+    } as UnionMessageReply;
+    expect(isPermanentPushFailure(reply)).toBe(true);
+  });
+
+  test('400 with incorrect protocol path is permanent', () => {
+    const reply = {
+      status: {
+        code   : 400,
+        detail : 'ProtocolAuthorizationIncorrectProtocolPath: Could not find matching parent record to verify declared protocol path \'profile/avatar\'.',
+      },
+    } as UnionMessageReply;
+    expect(isPermanentPushFailure(reply)).toBe(true);
+  });
+
   test('500 is transient (not permanent)', () => {
     expect(isPermanentPushFailure({ status: { code: 500, detail: 'Internal Server Error' } } as UnionMessageReply)).toBe(false);
   });

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -111,6 +111,7 @@ export enum DwnErrorCode {
   ProtocolAuthorizationStoredInitialWriteRoleMissingRecipient = 'ProtocolAuthorizationStoredInitialWriteRoleMissingRecipient',
   ProtocolAuthorizationMissingContextId = 'ProtocolAuthorizationMissingContextId',
   ProtocolAuthorizationMissingRuleSet = 'ProtocolAuthorizationMissingRuleSet',
+  ProtocolAuthorizationParentRecordNotFound = 'ProtocolAuthorizationParentRecordNotFound',
   ProtocolAuthorizationParentlessIncorrectProtocolPath = 'ProtocolAuthorizationParentlessIncorrectProtocolPath',
   ProtocolAuthorizationNotARole = 'ProtocolAuthorizationNotARole',
   ProtocolAuthorizationParentNotFoundConstructingRecordChain = 'ProtocolAuthorizationParentNotFoundConstructingRecordChain',

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -74,8 +74,8 @@ export async function verifyProtocolPathAndContextId(
     }
 
     throw new DwnError(
-      DwnErrorCode.ProtocolAuthorizationIncorrectProtocolPath,
-      `Could not find matching parent record to verify declared protocol path '${declaredProtocolPath}'.`
+      DwnErrorCode.ProtocolAuthorizationParentRecordNotFound,
+      `Could not find parent record '${parentId}' to verify declared protocol path '${declaredProtocolPath}'.`
     );
   }
 

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -3080,7 +3080,7 @@ export function testRecordsWriteHandler(): void {
 
           reply = await dwn.processMessage(pfi.did, fulfillmentMessageData.message, { dataStream: fulfillmentMessageData.dataStream });
           expect(reply.status.code).toBe(400);
-          expect(reply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationIncorrectProtocolPath);
+          expect(reply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationParentRecordNotFound);
         });
 
         it('should 400 if expected CID of `encryption` mismatches the `encryptionCid` in `authorization`', async () => {
@@ -3654,7 +3654,7 @@ export function testRecordsWriteHandler(): void {
           const bar1 = await TestDataGenerator.generateRecordsWrite(barOptions);
           const bar1WriteResponse = await dwn.processMessage(alice.did, bar1.message, { dataStream: bar1.dataStream });
           expect(bar1WriteResponse.status.code).toBe(400);
-          expect(bar1WriteResponse.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationIncorrectProtocolPath);
+          expect(bar1WriteResponse.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationParentRecordNotFound);
         });
 
         it('should fail if a write references a mismatching parent that compared to the parent in the `contextId` ', async () => {


### PR DESCRIPTION
## Summary
- split missing same-protocol parent records into a distinct DWN error code
- classify missing parent/protocol dependency push failures as retryable using exact DWN error codes
- keep malformed protocol-path failures permanent

## Tests
- bun run build
- bun run lint (packages/agent, packages/dwn-sdk-js)
- bun test tests/sync-messages.spec.ts tests/sync-push-resilience.spec.ts (packages/agent)
- bun test --timeout 30000 tests/store-dependent-tests.spec.ts (packages/dwn-sdk-js)

Note: canonical singleton identity is deferred to #992 and is not included here.