### PR TITLE
fix(auth): remove implicit full identity sync

### DIFF
--- a/.changeset/remove-implicit-full-sync.md
+++ b/.changeset/remove-implicit-full-sync.md
@@ -1,0 +1,5 @@
+---
+"@enbox/auth": patch
+---
+
+Stop registering local and recovered identities for full-DWN sync unless an explicit identity sync protocol scope is provided.

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -1193,6 +1193,15 @@ export class AuthManager {
     }
   }
 
+  private async _unregisterSyncIdentityIfRegistered(connectedDid: string): Promise<void> {
+    try {
+      await this._userAgent.sync.unregisterIdentity(connectedDid);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : '';
+      if (!msg.includes('is not registered')) { throw error; }
+    }
+  }
+
   /**
    * Repair the sync registration for a connected DID based on derived protocols.
    * - `'all'` or non-empty list → register or update
@@ -1204,28 +1213,24 @@ export class AuthManager {
     delegateDid: string | undefined,
     derivedProtocols: 'all' | string[] | undefined,
   ): Promise<void> {
-    if (delegateDid && derivedProtocols !== undefined) {
-      const narrowed = toSyncIdentityProtocols(derivedProtocols);
-      if (narrowed === undefined) {
-        try {
-          await this._userAgent.sync.unregisterIdentity(connectedDid);
-        } catch (error: unknown) {
-          const msg = error instanceof Error ? error.message : '';
-          if (!msg.includes('is not registered')) { throw error; }
-        }
-        return;
+    if (delegateDid === undefined) {
+      if (this._defaultIdentitySyncProtocols !== undefined) {
+        await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, this._defaultIdentitySyncProtocols);
       }
-      await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, narrowed);
       return;
     }
 
-    if (!delegateDid && this._defaultIdentitySyncProtocols !== undefined) {
-      await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, this._defaultIdentitySyncProtocols);
+    if (derivedProtocols === undefined) {
       return;
     }
 
-    // Local identity sync is app-owned unless the caller configured an
-    // explicit default scope for auth to manage.
+    const narrowed = toSyncIdentityProtocols(derivedProtocols);
+    if (narrowed === undefined) {
+      await this._unregisterSyncIdentityIfRegistered(connectedDid);
+      return;
+    }
+
+    await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, narrowed);
   }
 
   private _setState(state: AuthState): void {

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -29,6 +29,7 @@ import type {
   DisconnectOptions,
   HandlerConnectOptions,
   HeadlessConnectOptions,
+  IdentitySyncProtocols,
   ImportFromPortableOptions,
   RegistrationOptions,
   RestoreFromPhraseOptions,
@@ -102,6 +103,7 @@ export class AuthManager {
   private readonly _defaultPassword?: string;
   private readonly _passwordProvider?: PasswordProvider;
   private readonly _defaultSync?: SyncOption;
+  private readonly _defaultIdentitySyncProtocols?: IdentitySyncProtocols;
   private readonly _defaultDwnEndpoints?: string[];
   private readonly _registration?: RegistrationOptions;
   private readonly _connectHandler?: ConnectHandler;
@@ -121,6 +123,7 @@ export class AuthManager {
     defaultPassword?: string;
     passwordProvider?: PasswordProvider;
     defaultSync?: SyncOption;
+    defaultIdentitySyncProtocols?: IdentitySyncProtocols;
     defaultDwnEndpoints?: string[];
     registration?: RegistrationOptions;
     localDwnEndpoint?: string;
@@ -132,6 +135,7 @@ export class AuthManager {
     this._defaultPassword = params.defaultPassword;
     this._passwordProvider = params.passwordProvider;
     this._defaultSync = params.defaultSync;
+    this._defaultIdentitySyncProtocols = params.defaultIdentitySyncProtocols;
     this._defaultDwnEndpoints = params.defaultDwnEndpoints;
     this._registration = params.registration;
     this._localDwnEndpoint = params.localDwnEndpoint;
@@ -179,13 +183,14 @@ export class AuthManager {
       userAgent,
       emitter,
       storage,
-      defaultPassword     : options.password,
-      passwordProvider    : options.passwordProvider,
-      defaultSync         : options.sync,
-      defaultDwnEndpoints : options.dwnEndpoints,
-      registration        : options.registration,
+      defaultPassword              : options.password,
+      passwordProvider             : options.passwordProvider,
+      defaultSync                  : options.sync,
+      defaultIdentitySyncProtocols : options.identitySyncProtocols,
+      defaultDwnEndpoints          : options.dwnEndpoints,
+      registration                 : options.registration,
       localDwnEndpoint,
-      connectHandler      : options.connectHandler,
+      connectHandler               : options.connectHandler,
     });
 
     // Determine initial state.
@@ -1097,14 +1102,15 @@ export class AuthManager {
    */
   private _flowContext(): FlowContext {
     return {
-      userAgent           : this._userAgent,
-      emitter             : this._emitter,
-      storage             : this._storage,
-      defaultPassword     : this._defaultPassword,
-      passwordProvider    : this._passwordProvider,
-      defaultSync         : this._defaultSync,
-      defaultDwnEndpoints : this._defaultDwnEndpoints,
-      registration        : this._registration,
+      userAgent                    : this._userAgent,
+      emitter                      : this._emitter,
+      storage                      : this._storage,
+      defaultPassword              : this._defaultPassword,
+      passwordProvider             : this._passwordProvider,
+      defaultSync                  : this._defaultSync,
+      defaultIdentitySyncProtocols : this._defaultIdentitySyncProtocols,
+      defaultDwnEndpoints          : this._defaultDwnEndpoints,
+      registration                 : this._registration,
     };
   }
 
@@ -1191,16 +1197,13 @@ export class AuthManager {
    * Repair the sync registration for a connected DID based on derived protocols.
    * - `'all'` or non-empty list → register or update
    * - Empty list (zero grants) for a delegate → unregister stale registration
-   * - Non-delegate with no derived protocols → register with `'all'`
+   * - Non-delegate with no explicit local sync scope → leave app-owned registration unchanged
    */
   private async _repairSyncRegistration(
     connectedDid: string,
     delegateDid: string | undefined,
     derivedProtocols: 'all' | string[] | undefined,
   ): Promise<void> {
-    // Only delegates with an explicit zero-grant derivation should be
-    // unregistered. A non-delegate identity defaults to `'all'` when no
-    // derivation was performed.
     if (delegateDid && derivedProtocols !== undefined) {
       const narrowed = toSyncIdentityProtocols(derivedProtocols);
       if (narrowed === undefined) {
@@ -1216,8 +1219,13 @@ export class AuthManager {
       return;
     }
 
-    // Non-delegate identity: register with `'all'` (full-replica sync).
-    await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, 'all');
+    if (!delegateDid && this._defaultIdentitySyncProtocols !== undefined) {
+      await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, this._defaultIdentitySyncProtocols);
+      return;
+    }
+
+    // Local identity sync is app-owned unless the caller configured an
+    // explicit default scope for auth to manage.
   }
 
   private _setState(state: AuthState): void {

--- a/packages/auth/src/connect/import.ts
+++ b/packages/auth/src/connect/import.ts
@@ -25,6 +25,7 @@ export async function importFromPortable(
 ): Promise<AuthSession> {
   const { userAgent, emitter, storage } = ctx;
   const sync = options.sync ?? ctx.defaultSync;
+  const identitySyncProtocols = options.identitySyncProtocols ?? ctx.defaultIdentitySyncProtocols;
 
   const identity = await userAgent.identity.import({
     portableIdentity: options.portableIdentity,
@@ -53,7 +54,7 @@ export async function importFromPortable(
   if (delegateDid) {
     await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
   } else if (sync !== 'off') {
-    await registerSyncScopeForIdentity({ userAgent, connectedDid });
+    await registerSyncScopeForIdentity({ userAgent, connectedDid, identitySyncProtocols });
   }
 
   await startSyncIfEnabled(userAgent, sync);

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -19,7 +19,7 @@ import type { AgentSessionIdentity, BearerIdentity, DelegateContextKey, Delegate
 
 import type { AuthEventEmitter } from '../events.js';
 import type { PasswordProvider } from '../password-provider.js';
-import type { RegistrationOptions, StorageAdapter, SyncOption } from '../types.js';
+import type { IdentitySyncProtocols, RegistrationOptions, StorageAdapter, SyncOption } from '../types.js';
 
 import { Convert } from '@enbox/common';
 import type { GenericMessage } from '@enbox/dwn-sdk-js';
@@ -50,6 +50,7 @@ export interface FlowContext {
   defaultPassword?: string;
   passwordProvider?: PasswordProvider;
   defaultSync?: SyncOption;
+  defaultIdentitySyncProtocols?: IdentitySyncProtocols;
   defaultDwnEndpoints?: string[];
   registration?: RegistrationOptions;
 }
@@ -409,9 +410,9 @@ export function toSyncIdentityProtocols(
  *   "is not registered" error from unregister is silently tolerated;
  *   `"already registered"` from register falls back to `updateIdentityOptions`.
  *
- * - For a **local session** (no `delegateDid`): registers with
- *   `protocols: 'all'` (a local identity is a full replica of its own DWN).
- *   The `"already registered"` error falls back to `updateIdentityOptions`.
+ * - For a **local session** (no `delegateDid`): registers only when the
+ *   caller supplied an explicit protocol scope. If no scope is supplied, auth
+ *   leaves local identity sync registration to the application.
  *
  * @internal
  */
@@ -419,8 +420,9 @@ export async function registerSyncScopeForIdentity(params: {
   userAgent: EnboxUserAgent;
   connectedDid: string;
   delegateDid?: string;
+  identitySyncProtocols?: IdentitySyncProtocols;
 }): Promise<void> {
-  const { userAgent, connectedDid, delegateDid } = params;
+  const { userAgent, connectedDid, delegateDid, identitySyncProtocols } = params;
 
   if (delegateDid !== undefined) {
     const scope = await deriveActiveSyncScope(userAgent, delegateDid);
@@ -449,8 +451,11 @@ export async function registerSyncScopeForIdentity(params: {
     return;
   }
 
-  // Local session — register with full-replica scope.
-  const options = { protocols: 'all' as const };
+  if (identitySyncProtocols === undefined) {
+    return;
+  }
+
+  const options = { protocols: identitySyncProtocols };
   try {
     await userAgent.sync.registerIdentity({ did: connectedDid, options });
   } catch (error: unknown) {

--- a/packages/auth/src/connect/recovery.ts
+++ b/packages/auth/src/connect/recovery.ts
@@ -10,12 +10,10 @@
  * @internal
  */
 
-import type { IdentitySyncProtocols } from '../types.js';
 import type { BearerIdentity, EnboxUserAgent } from '@enbox/agent';
+import type { IdentitySyncProtocols, RegistrationOptions, StorageAdapter } from '../types.js';
 
 import { IdentityProtocolDefinition, JwkProtocolDefinition } from '@enbox/agent';
-
-import type { RegistrationOptions, StorageAdapter } from '../types.js';
 
 import { registerWithDwnEndpoints } from '../registration.js';
 

--- a/packages/auth/src/connect/recovery.ts
+++ b/packages/auth/src/connect/recovery.ts
@@ -10,6 +10,7 @@
  * @internal
  */
 
+import type { IdentitySyncProtocols } from '../types.js';
 import type { BearerIdentity, EnboxUserAgent } from '@enbox/agent';
 
 import { IdentityProtocolDefinition, JwkProtocolDefinition } from '@enbox/agent';
@@ -56,8 +57,9 @@ export async function registerAgentDidForSync(userAgent: EnboxUserAgent): Promis
  *   agent DID's DWN.
  *
  * Phase 2 — register each recovered identity DID as a tenant and for
- *   sync, then pull their profile data, protocol configurations, and
- *   records.
+ *   explicitly scoped sync, then pull the requested protocol data. If no
+ *   `identitySyncProtocols` is provided, auth recovers identity metadata only
+ *   and leaves product-scoped record sync to the application.
  *
  * Returns the recovered identities, or an empty array if the remote
  * had nothing (e.g. first-ever setup with a pre-generated phrase).
@@ -65,10 +67,11 @@ export async function registerAgentDidForSync(userAgent: EnboxUserAgent): Promis
 export async function recoverIdentitiesFromRemote(params: {
   userAgent: EnboxUserAgent;
   dwnEndpoints: string[];
+  identitySyncProtocols?: IdentitySyncProtocols;
   registration?: RegistrationOptions;
   storage: StorageAdapter;
 }): Promise<BearerIdentity[]> {
-  const { userAgent, dwnEndpoints, registration, storage } = params;
+  const { userAgent, dwnEndpoints, identitySyncProtocols, registration, storage } = params;
   const agentDid = userAgent.agentDid.uri;
 
   // Install the KeyDeliveryProtocol for the agent DID before pulling.
@@ -86,9 +89,11 @@ export async function recoverIdentitiesFromRemote(params: {
     return [];
   }
 
-  // Register each recovered identity DID as a DWN tenant, then for sync.
+  // Register each recovered identity DID as a DWN tenant. Register for sync
+  // only when the application supplied an explicit identity protocol scope.
   // Tenant registration must come first — sync('pull') issues
   // MessagesSync which requires the DID to be a recognised tenant.
+  let registeredIdentityForSync = false;
   for (const identity of identities) {
     const did = identity.metadata.connectedDid ?? identity.did.uri;
 
@@ -104,15 +109,20 @@ export async function recoverIdentitiesFromRemote(params: {
       }
     }
 
-    try {
-      await userAgent.sync.registerIdentity({ did, options: { protocols: 'all' } });
-    } catch {
-      // Already registered from a previous session.
+    if (identitySyncProtocols !== undefined) {
+      try {
+        await userAgent.sync.registerIdentity({ did, options: { protocols: identitySyncProtocols } });
+      } catch {
+        // Already registered from a previous session.
+      }
+      registeredIdentityForSync = true;
     }
   }
 
-  // Phase 2: pull profile data, protocol configurations, and records.
-  await userAgent.sync.sync('pull');
+  if (registeredIdentityForSync) {
+    // Phase 2: pull explicitly scoped protocol configurations and records.
+    await userAgent.sync.sync('pull');
+  }
 
   return userAgent.identity.list();
 }

--- a/packages/auth/src/connect/restore.ts
+++ b/packages/auth/src/connect/restore.ts
@@ -221,25 +221,32 @@ export async function restoreSession(
     identity, storedDelegateDid ?? undefined,
   );
 
-  // Ensure the sync registration is protocol-scoped for delegate sessions.
+  // Ensure the sync registration is scoped explicitly. Delegate sessions derive
+  // scope from grants; local sessions are updated only when the caller provides
+  // an explicit identity sync scope.
   // Previous versions registered delegates with protocols: [] (global sync),
   // which causes the sync engine to attempt syncing the permissions protocol
   // and fail with "No permissions found for MessagesSync".
-  // Derive the correct protocol list from stored grants and update.
   // Always repair regardless of sync state — a stale registration persists
   // on disk and would take effect if sync is later enabled.
   let syncRepairFailed = false;
-  if (delegateDid) {
-    try {
+  try {
+    if (delegateDid) {
       await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
-    } catch {
-      // Grant query or registration repair failed — don't block restore,
-      // but don't let a stale registration remain usable.
-      syncRepairFailed = true;
-      // Best-effort: remove any existing registration so a later manual
-      // startSync() cannot use stale scope for this connected DID.
-      try { await userAgent.sync.unregisterIdentity(connectedDid); } catch { /* already gone or store error */ }
+    } else {
+      await registerSyncScopeForIdentity({
+        userAgent,
+        connectedDid,
+        identitySyncProtocols: ctx.defaultIdentitySyncProtocols,
+      });
     }
+  } catch {
+    // Grant query or registration repair failed — don't block restore,
+    // but don't let a stale registration remain usable.
+    syncRepairFailed = true;
+    // Best-effort: remove any existing registration so a later manual
+    // startSync() cannot use stale scope for this connected DID.
+    try { await userAgent.sync.unregisterIdentity(connectedDid); } catch { /* already gone or store error */ }
   }
 
   // Restore delegate decryption/context keys BEFORE starting sync so that
@@ -581,4 +588,3 @@ export async function retryOrphanedRevocations(
  * permissions protocol itself (permission records are already included
  * in each protocol's sync stream via `constructAdditionalMessageFilter`).
  */
-

--- a/packages/auth/src/connect/vault.ts
+++ b/packages/auth/src/connect/vault.ts
@@ -44,6 +44,7 @@ export async function vaultConnect(
   const password = await resolvePassword(ctx, options.password, isFirstLaunch);
 
   const sync = options.sync ?? ctx.defaultSync;
+  const identitySyncProtocols = options.identitySyncProtocols ?? ctx.defaultIdentitySyncProtocols;
   const dwnEndpoints = options.dwnEndpoints ?? ctx.defaultDwnEndpoints ?? DEFAULT_DWN_ENDPOINTS;
   const shouldCreateIdentity = options.createIdentity === true;
 
@@ -92,7 +93,7 @@ export async function vaultConnect(
   // pull them from the remote DWN before deciding whether to create a new identity.
   if (!identity && options.recoveryPhrase && sync !== 'off') {
     try {
-      identities = await recoverIdentitiesFromRemote({ userAgent, dwnEndpoints, registration: ctx.registration, storage });
+      identities = await recoverIdentitiesFromRemote({ userAgent, dwnEndpoints, identitySyncProtocols, registration: ctx.registration, storage });
       identity = identities[0];
     } catch (err) {
       console.warn('[@enbox/auth] Seed phrase recovery failed:', err);
@@ -130,11 +131,13 @@ export async function vaultConnect(
     );
   }
   if (isNewIdentity && sync !== 'off') {
-    await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
+    await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid, identitySyncProtocols });
   } else if (!isNewIdentity && delegateDid) {
     // Persisted delegate identities need their sync scope refreshed from
     // current grants so revoked protocols do not keep syncing after restore.
     await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
+  } else if (!isNewIdentity && sync !== 'off') {
+    await registerSyncScopeForIdentity({ userAgent, connectedDid, identitySyncProtocols });
   }
 
   // Start sync.

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -26,6 +26,15 @@ export type { EnboxUserAgent } from '@enbox/agent';
  */
 export type SyncOption = 'off' | `${number}${'s' | 'm' | 'h'}`;
 
+/**
+ * Protocol scope used when auth registers a local identity for sync.
+ *
+ * Auth never chooses `'all'` implicitly. Applications that truly want a
+ * full-DWN replica must pass `'all'` explicitly; product-scoped apps should
+ * pass the protocol URI list they own.
+ */
+export type IdentitySyncProtocols = 'all' | [string, ...string[]];
+
 // ─── Auth State Machine ─────────────────────────────────────────
 
 /**
@@ -371,6 +380,14 @@ export interface AuthManagerOptions {
    */
   sync?: SyncOption;
 
+  /**
+   * Protocol scope to register for local identity sync.
+   *
+   * Omit this to leave local identities unregistered by auth. Use `'all'`
+   * only for applications that explicitly mirror the entire identity DWN.
+   */
+  identitySyncProtocols?: IdentitySyncProtocols;
+
   /** Default DWN endpoints for new identities. */
   dwnEndpoints?: string[];
 
@@ -408,6 +425,9 @@ export interface VaultConnectOptions {
 
   /** Override manager default sync interval. */
   sync?: SyncOption;
+
+  /** Override manager default local identity sync scope. */
+  identitySyncProtocols?: IdentitySyncProtocols;
 
   /** Override manager default DWN endpoints. */
   dwnEndpoints?: string[];
@@ -572,6 +592,9 @@ export interface ImportFromPortableOptions {
 
   /** Override manager default sync interval. */
   sync?: SyncOption;
+
+  /** Override manager default local identity sync scope. */
+  identitySyncProtocols?: IdentitySyncProtocols;
 }
 
 /** Options for {@link AuthManager.restoreSession}. */

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -36,6 +36,7 @@ function createTestManager(
     password?: string;
     passwordProvider?: PasswordProvider;
     sync?: any;
+    identitySyncProtocols?: 'all' | [string, ...string[]];
     dwnEndpoints?: string[];
     initialState?: string;
   } = {},
@@ -55,6 +56,7 @@ function createTestManager(
   manager._defaultPassword = overrides.password;
   manager._passwordProvider = overrides.passwordProvider;
   manager._defaultSync = overrides.sync;
+  manager._defaultIdentitySyncProtocols = overrides.identitySyncProtocols;
   manager._defaultDwnEndpoints = overrides.dwnEndpoints;
 
   return manager as AuthManager;
@@ -1387,7 +1389,7 @@ describe('AuthManager', () => {
   });
 
   describe('switchIdentity() — sync registration', () => {
-    test('calls sync.registerIdentity for the target identity', async () => {
+    test('calls sync.registerIdentity with explicit local identity scope for the target identity', async () => {
       const registerCalls: any[] = [];
       const identity = createMockIdentity();
       const agent = createMockAgent({
@@ -1395,13 +1397,34 @@ describe('AuthManager', () => {
         syncRegisterIdentity : async (params) => { registerCalls.push(params); },
         syncStartSync        : async () => {},
       });
-      const manager = createTestManager(agent, { sync: '10s' });
+      const manager = createTestManager(agent, {
+        sync                  : '10s',
+        identitySyncProtocols : ['https://proto.example/profile'],
+      });
 
       await manager.switchIdentity('did:dht:testuser123');
 
       expect(registerCalls).toHaveLength(1);
       expect(registerCalls[0].did).toBe('did:dht:testuser123');
-      expect(registerCalls[0].options.protocols).toBe('all');
+      expect(registerCalls[0].options.protocols).toEqual(['https://proto.example/profile']);
+    });
+
+    test('leaves local identity sync registration to the application when no explicit scope is configured', async () => {
+      const registerCalls: any[] = [];
+      const unregisterCalls: string[] = [];
+      const identity = createMockIdentity();
+      const agent = createMockAgent({
+        identityGet            : async () => identity,
+        syncRegisterIdentity   : async (params) => { registerCalls.push(params); },
+        syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
+        syncStartSync          : async () => {},
+      });
+      const manager = createTestManager(agent, { sync: '10s' });
+
+      await manager.switchIdentity('did:dht:testuser123');
+
+      expect(registerCalls).toHaveLength(0);
+      expect(unregisterCalls).toHaveLength(0);
     });
 
     test('unregisters sync for delegate with zero grants', async () => {
@@ -1417,7 +1440,10 @@ describe('AuthManager', () => {
         syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
         syncStartSync          : async () => {},
       });
-      const manager = createTestManager(agent, { sync: '10s' });
+      const manager = createTestManager(agent, {
+        sync                  : '10s',
+        identitySyncProtocols : ['https://proto.example/profile'],
+      });
 
       await manager.switchIdentity('did:delegate');
 
@@ -1474,7 +1500,10 @@ describe('AuthManager', () => {
           return { reply: { status: { code: 202, detail: 'Accepted' } } };
         },
       });
-      const manager = createTestManager(agent, { sync: '10s' });
+      const manager = createTestManager(agent, {
+        sync                  : '10s',
+        identitySyncProtocols : ['https://proto.example/profile'],
+      });
 
       await manager.switchIdentity('did:delegate');
 
@@ -1506,7 +1535,10 @@ describe('AuthManager', () => {
         syncUpdateIdentityOptions : async (params) => { updateCalls.push(params); },
         syncStartSync             : async () => {},
       });
-      const manager = createTestManager(agent, { sync: '10s' });
+      const manager = createTestManager(agent, {
+        sync                  : '10s',
+        identitySyncProtocols : ['https://proto.example/profile'],
+      });
 
       // Should not throw — falls back to updateIdentityOptions.
       const session = await manager.switchIdentity('did:dht:testuser123');
@@ -1524,7 +1556,10 @@ describe('AuthManager', () => {
         syncRegisterIdentity : async (params) => { registerCalls.push(params); },
         syncStartSync        : async (params) => { syncStartCalls.push(params); },
       });
-      const manager = createTestManager(agent, { sync: 'off' });
+      const manager = createTestManager(agent, {
+        sync                  : 'off',
+        identitySyncProtocols : ['https://proto.example/profile'],
+      });
 
       await manager.switchIdentity('did:dht:testuser123');
 

--- a/packages/auth/tests/import-identity.spec.ts
+++ b/packages/auth/tests/import-identity.spec.ts
@@ -48,7 +48,7 @@ describe('importFromPortable', () => {
     expect(session.delegateDid).toBe('did:dht:delegate');
   });
 
-  test('registers and starts sync when enabled', async () => {
+  test('registers explicit local identity sync scope and starts sync when enabled', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
     const syncRegCalls: any[] = [];
@@ -61,14 +61,41 @@ describe('importFromPortable', () => {
     });
 
     await importFromPortable(
-      { userAgent: agent, emitter, storage, defaultSync: '30s' },
+      {
+        userAgent                    : agent,
+        emitter,
+        storage,
+        defaultSync                  : '30s',
+        defaultIdentitySyncProtocols : ['https://proto.example/profile'],
+      },
       { portableIdentity: {} as any },
     );
 
     expect(syncRegCalls).toHaveLength(1);
-    expect(syncRegCalls[0].options.protocols).toBe('all');
+    expect(syncRegCalls[0].options.protocols).toEqual(['https://proto.example/profile']);
     expect(syncStartCalls).toHaveLength(1);
     expect(syncStartCalls[0].mode).toBe('poll');
+  });
+
+  test('leaves local sync registration to the application when no identity scope is provided', async () => {
+    const emitter = new AuthEventEmitter();
+    const storage = new MemoryStorage();
+    const unregisterCalls: string[] = [];
+    const syncStartCalls: any[] = [];
+
+    const agent = createMockAgent({
+      identityImport         : async () => createMockIdentity(),
+      syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
+      syncStartSync          : async (params) => { syncStartCalls.push(params); },
+    });
+
+    await importFromPortable(
+      { userAgent: agent, emitter, storage, defaultSync: '30s' },
+      { portableIdentity: {} as any },
+    );
+
+    expect(unregisterCalls).toHaveLength(0);
+    expect(syncStartCalls).toHaveLength(1);
   });
 
   test('skips sync when disabled', async () => {

--- a/packages/auth/tests/lifecycle.spec.ts
+++ b/packages/auth/tests/lifecycle.spec.ts
@@ -930,10 +930,31 @@ describe('registerSyncScopeForIdentity', () => {
     ).rejects.toThrow('database unavailable');
   });
 
-  test('local (no delegateDid): calls registerIdentity with protocols: all', async () => {
+  test('local with explicit protocols: calls registerIdentity with that scope', async () => {
     const syncCalls: any[] = [];
     const agent = createMockAgent({
       syncRegisterIdentity: async (params) => { syncCalls.push(params); },
+    });
+
+    await registerSyncScopeForIdentity({
+      userAgent             : agent,
+      connectedDid          : 'did:dht:connected1',
+      identitySyncProtocols : ['https://proto.example/profile'],
+    });
+
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].did).toBe('did:dht:connected1');
+    expect(syncCalls[0].options.protocols).toEqual(['https://proto.example/profile']);
+    // Local session — delegateDid should not be present in the options payload.
+    expect(syncCalls[0].options.delegateDid).toBeUndefined();
+  });
+
+  test('local without explicit protocols: leaves sync registration to the application', async () => {
+    const registerCalls: any[] = [];
+    const unregisterCalls: string[] = [];
+    const agent = createMockAgent({
+      syncRegisterIdentity   : async (params) => { registerCalls.push(params); },
+      syncUnregisterIdentity : async (did) => { unregisterCalls.push(did); },
     });
 
     await registerSyncScopeForIdentity({
@@ -941,11 +962,8 @@ describe('registerSyncScopeForIdentity', () => {
       connectedDid : 'did:dht:connected1',
     });
 
-    expect(syncCalls).toHaveLength(1);
-    expect(syncCalls[0].did).toBe('did:dht:connected1');
-    expect(syncCalls[0].options.protocols).toBe('all');
-    // Local session — delegateDid should not be present in the options payload.
-    expect(syncCalls[0].options.delegateDid).toBeUndefined();
+    expect(registerCalls).toHaveLength(0);
+    expect(unregisterCalls).toHaveLength(0);
   });
 
   test('local already-registered: falls back to updateIdentityOptions', async () => {
@@ -956,13 +974,14 @@ describe('registerSyncScopeForIdentity', () => {
     });
 
     await registerSyncScopeForIdentity({
-      userAgent    : agent,
-      connectedDid : 'did:dht:connected1',
+      userAgent             : agent,
+      connectedDid          : 'did:dht:connected1',
+      identitySyncProtocols : ['https://proto.example/profile'],
     });
 
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0].did).toBe('did:dht:connected1');
-    expect(updateCalls[0].options.protocols).toBe('all');
+    expect(updateCalls[0].options.protocols).toEqual(['https://proto.example/profile']);
   });
 
   test('local: rethrows non-"already registered" errors from registerIdentity', async () => {
@@ -972,8 +991,9 @@ describe('registerSyncScopeForIdentity', () => {
 
     await expect(
       registerSyncScopeForIdentity({
-        userAgent    : agent,
-        connectedDid : 'did:dht:connected1',
+        userAgent             : agent,
+        connectedDid          : 'did:dht:connected1',
+        identitySyncProtocols : ['https://proto.example/profile'],
       })
     ).rejects.toThrow('database unavailable');
   });

--- a/packages/auth/tests/recovery.spec.ts
+++ b/packages/auth/tests/recovery.spec.ts
@@ -37,7 +37,7 @@ describe('registerAgentDidForSync', () => {
 });
 
 describe('recoverIdentitiesFromRemote', () => {
-  test('returns recovered identities after two-phase pull', async () => {
+  test('returns recovered identities after explicitly scoped two-phase pull', async () => {
     const identity = createMockIdentity();
     let pullCount = 0;
     const syncCalls: any[] = [];
@@ -52,9 +52,10 @@ describe('recoverIdentitiesFromRemote', () => {
     });
 
     const result = await recoverIdentitiesFromRemote({
-      userAgent    : agent,
-      dwnEndpoints : ['https://dwn.example.com'],
-      storage      : new MemoryStorage(),
+      userAgent             : agent,
+      dwnEndpoints          : ['https://dwn.example.com'],
+      identitySyncProtocols : ['https://proto.example/profile'],
+      storage               : new MemoryStorage(),
     });
 
     expect(result).toHaveLength(1);
@@ -62,7 +63,31 @@ describe('recoverIdentitiesFromRemote', () => {
     expect(pullCount).toBe(2);
     expect(syncCalls).toHaveLength(1);
     expect(syncCalls[0].did).toBe('did:dht:testuser123');
-    expect(syncCalls[0].options.protocols).toBe('all');
+    expect(syncCalls[0].options.protocols).toEqual(['https://proto.example/profile']);
+  });
+
+  test('without explicit identity scope recovers identity metadata only', async () => {
+    const identity = createMockIdentity();
+    let pullCount = 0;
+    const syncCalls: any[] = [];
+
+    const agent = createMockAgent({
+      identityList: async () => {
+        return pullCount > 0 ? [identity] : [];
+      },
+      syncSync             : async () => { pullCount++; },
+      syncRegisterIdentity : async (params) => { syncCalls.push(params); },
+    });
+
+    const result = await recoverIdentitiesFromRemote({
+      userAgent    : agent,
+      dwnEndpoints : ['https://dwn.example.com'],
+      storage      : new MemoryStorage(),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(pullCount).toBe(1);
+    expect(syncCalls).toHaveLength(0);
   });
 
   test('returns empty array when remote has no identities', async () => {
@@ -97,9 +122,10 @@ describe('recoverIdentitiesFromRemote', () => {
     });
 
     await recoverIdentitiesFromRemote({
-      userAgent    : agent,
-      dwnEndpoints : ['https://dwn.example.com'],
-      registration : {
+      userAgent             : agent,
+      dwnEndpoints          : ['https://dwn.example.com'],
+      identitySyncProtocols : ['https://proto.example/profile'],
+      registration          : {
         onSuccess : () => { registrationSucceeded = true; },
         onFailure : () => {},
       },
@@ -122,9 +148,10 @@ describe('recoverIdentitiesFromRemote', () => {
     });
 
     const result = await recoverIdentitiesFromRemote({
-      userAgent    : agent,
-      dwnEndpoints : ['https://dwn.example.com'],
-      registration : {
+      userAgent             : agent,
+      dwnEndpoints          : ['https://dwn.example.com'],
+      identitySyncProtocols : ['https://proto.example/profile'],
+      registration          : {
         onSuccess : () => {},
         onFailure : () => {},
       },
@@ -150,9 +177,10 @@ describe('recoverIdentitiesFromRemote', () => {
     });
 
     await recoverIdentitiesFromRemote({
-      userAgent    : agent,
-      dwnEndpoints : ['https://dwn.example.com'],
-      storage      : new MemoryStorage(),
+      userAgent             : agent,
+      dwnEndpoints          : ['https://dwn.example.com'],
+      identitySyncProtocols : ['https://proto.example/profile'],
+      storage               : new MemoryStorage(),
     });
 
     expect(syncCalls[0].did).toBe('did:dht:external');
@@ -169,9 +197,10 @@ describe('recoverIdentitiesFromRemote', () => {
     });
 
     const result = await recoverIdentitiesFromRemote({
-      userAgent    : agent,
-      dwnEndpoints : ['https://dwn.example.com'],
-      storage      : new MemoryStorage(),
+      userAgent             : agent,
+      dwnEndpoints          : ['https://dwn.example.com'],
+      identitySyncProtocols : ['https://proto.example/profile'],
+      storage               : new MemoryStorage(),
     });
 
     expect(result).toHaveLength(1);

--- a/packages/auth/tests/vault-connect.spec.ts
+++ b/packages/auth/tests/vault-connect.spec.ts
@@ -124,7 +124,7 @@ describe('vaultConnect', () => {
     expect(events).toEqual(['vault-unlocked', 'identity-added', 'session-start']);
   });
 
-  test('registers sync for new identities and agent DID when sync is not off', async () => {
+  test('registers explicit identity sync scope for new identities and agent DID when sync is not off', async () => {
     const emitter = new AuthEventEmitter();
     const storage = new MemoryStorage();
     const syncCalls: any[] = [];
@@ -137,7 +137,13 @@ describe('vaultConnect', () => {
     });
 
     await vaultConnect(
-      { userAgent: agent, emitter, storage, defaultSync: '15s' },
+      {
+        userAgent                    : agent,
+        emitter,
+        storage,
+        defaultSync                  : '15s',
+        defaultIdentitySyncProtocols : ['https://proto.example/profile'],
+      },
       { createIdentity: true },
     );
 
@@ -149,7 +155,7 @@ describe('vaultConnect', () => {
       'https://identity.foundation/protocols/web5/jwk-store',
     ]);
     expect(syncCalls[1].did).toBe('did:dht:testuser123');
-    expect(syncCalls[1].options.protocols).toBe('all');
+    expect(syncCalls[1].options.protocols).toEqual(['https://proto.example/profile']);
   });
 
   test('registers agent DID for sync even without identity creation', async () => {


### PR DESCRIPTION
Summary
- Stop auth local-session and seed-phrase recovery flows from registering identity sync with `protocols: all` unless the app provides `identitySyncProtocols`.
- Keep full-DWN sync available as an explicit caller choice and keep delegate unrestricted-grant behavior unchanged.
- Add auth tests for explicit scoped registration and metadata-only recovery when no identity scope is provided.

Test plan
- [x] bun run build
- [x] bun run lint:fix
- [x] bun run lint
- [x] bun run --filter @enbox/auth build
- [x] bun run --filter @enbox/auth test:node

Rollout
- Apps that want auth-managed local identity sync must pass `identitySyncProtocols`. Product-scoped apps should pass their owned protocol URI list; `all` remains only for explicit full-DWN replicas.