### PR TITLE
fix(dwn-clients): stream Bun HTTP payloads

### DIFF
--- a/.changeset/streaming-fetch-bun.md
+++ b/.changeset/streaming-fetch-bun.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-clients": patch
+"@enbox/dwn-server": patch
+---
+
+Remove Bun fetch stream buffering workarounds and pass HTTP data streams through directly.

--- a/.changeset/streaming-fetch-bun.md
+++ b/.changeset/streaming-fetch-bun.md
@@ -1,6 +1,9 @@
 ---
+"@enbox/agent": patch
+"@enbox/api": patch
 "@enbox/dwn-clients": patch
 "@enbox/dwn-server": patch
+"@enbox/dwn-sql-store": patch
 ---
 
-Remove Bun fetch stream buffering workarounds and pass HTTP data streams through directly.
+Remove Bun fetch stream buffering workarounds and pass data streams through HTTP and storage paths directly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4
@@ -266,7 +266,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4
@@ -306,7 +306,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4
@@ -365,7 +365,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4
@@ -434,7 +434,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4
@@ -570,7 +570,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4
@@ -688,7 +688,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4
@@ -757,7 +757,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4
@@ -832,7 +832,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4
@@ -1251,7 +1251,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/e2e-identity-lifecycle.yml
+++ b/.github/workflows/e2e-identity-lifecycle.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Restore bun cache
         uses: actions/cache@v4

--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
         "@typescript-eslint/parser": "8.32.1",
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-istanbul": "4.0.18",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "eslint": "9.7.0",
         "sinon": "18.0.0",
         "typescript": "5.9.3",
@@ -99,7 +99,7 @@
         "@typescript-eslint/parser": "8.32.1",
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-istanbul": "4.0.18",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "eslint": "9.7.0",
         "sinon": "18.0.0",
         "typescript": "5.9.3",
@@ -121,7 +121,7 @@
       "devDependencies": {
         "@types/node": "22.19.15",
         "@types/sinon": "17.0.3",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "sinon": "18.0.0",
         "typescript": "5.9.3",
       },
@@ -209,7 +209,7 @@
         "@typescript-eslint/parser": "8.32.1",
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-istanbul": "4.0.18",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "eslint": "9.7.0",
         "typescript": "5.9.3",
         "vitest": "4.0.18",
@@ -230,7 +230,7 @@
         "@types/sinon": "17.0.3",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "eslint": "9.7.0",
         "sinon": "18.0.0",
         "typescript": "5.9.3",
@@ -274,7 +274,7 @@
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-istanbul": "4.0.18",
         "blockstore-core": "4.2.0",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "dependency-cruiser": "16.3.7",
         "eslint": "9.7.0",
         "eslint-plugin-todo-plz": "1.3.0",
@@ -319,14 +319,14 @@
         "ws": "8.18.0",
       },
       "devDependencies": {
-        "@types/bun": "1.3.10",
+        "@types/bun": "1.3.14",
         "@types/bytes": "3.1.1",
         "@types/node": "22.19.15",
         "@types/sinon": "17.0.3",
         "@types/ws": "8.5.10",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "eslint": "9.7.0",
         "eslint-plugin-todo-plz": "1.3.0",
         "multiformats": "11.0.2",
@@ -365,7 +365,7 @@
         "multiformats": "11.0.2",
       },
       "devDependencies": {
-        "@types/bun": "1.3.10",
+        "@types/bun": "1.3.14",
         "@types/express": "4.17.17",
         "@types/node": "22.19.15",
         "@types/pg": "8.10.2",
@@ -373,7 +373,7 @@
         "@types/supertest": "2.0.12",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "esbuild": "0.23.0",
         "eslint": "9.7.0",
         "mysql2": "3.9.8",
@@ -404,7 +404,7 @@
         "syntax-highlight-element": "1.2.0",
       },
       "devDependencies": {
-        "@types/bun": "1.3.10",
+        "@types/bun": "1.3.14",
       },
     },
     "packages/protocol-codegen": {
@@ -422,7 +422,7 @@
         "@types/yargs": "17.0.35",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "eslint": "9.7.0",
         "typescript": "5.9.3",
       },
@@ -437,7 +437,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
-        "bun-types": "1.3.10",
+        "bun-types": "1.3.14",
         "eslint": "9.7.0",
         "typescript": "5.9.3",
       },
@@ -1220,7 +1220,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/bytes": ["@types/bytes@3.1.1", "", {}, "sha512-lOGyCnw+2JVPKU3wIV0srU0NyALwTBJlVSx5DfMQOFuuohA8y9S8orImpuIQikZ0uIQ8gehrRjxgQC1rLRi11w=="],
 
@@ -1436,7 +1436,7 @@
 
     "buffer-writer": ["buffer-writer@2.0.0", "", {}, "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -3068,6 +3068,8 @@
 
     "ed25519-keygen/@noble/hashes": ["@noble/hashes@1.3.3", "", {}, "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="],
 
+    "electrobun/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
     "esast-util-from-js/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "eslint/@eslint/js": ["@eslint/js@9.7.0", "", {}, "sha512-ChuWDQenef8OSFnvuxv0TCVxEwmu3+hPNKvM9B34qpM0rDRbjL8t5QkQeHHeAfsKQjuH9wS82WeCi1J/owatng=="],
@@ -3240,6 +3242,8 @@
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "electrobun/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
     "eslint-plugin-mocha/globals/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
 
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
@@ -3376,8 +3380,12 @@
 
     "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "electrobun/@types/bun/bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
     "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "electrobun/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "turbo": "2.8.13",
     "typescript": "5.9.3"
   },
-  "packageManager": "bun@1.3.10",
+  "packageManager": "bun@1.3.14",
   "engines": {
     "bun": ">=1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "packageManager": "bun@1.3.14",
   "engines": {
-    "bun": ">=1.0.0"
+    "bun": ">=1.3.14"
   },
   "repository": {
     "type": "git",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -92,7 +92,7 @@
     "@typescript-eslint/parser": "8.32.1",
     "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-istanbul": "4.0.18",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "eslint": "9.7.0",
     "sinon": "18.0.0",
     "typescript": "5.9.3",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -68,7 +68,7 @@
     "access": "public"
   },
   "engines": {
-    "bun": ">=1.0.0"
+    "bun": ">=1.3.14"
   },
   "dependencies": {
     "@scure/bip39": "1.2.2",

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -100,9 +100,11 @@ import {
   getProtocolDefinition as getProtocolDefinitionFn,
 } from './dwn-protocol-cache.js';
 
-type DwnMessageWithBlob<T extends DwnInterface> = {
+type DwnRpcData = Blob | ReadableStream<Uint8Array>;
+
+type DwnMessageWithRpcData<T extends DwnInterface> = {
   message: DwnMessage[T];
-  data?: Blob;
+  data?: DwnRpcData;
 };
 
 type DwnApiParams = {
@@ -529,20 +531,11 @@ export class AgentDwnApi {
       );
     } else {
       // Remote mode: route through RPC to the local DWN server.
-      // TODO(#713): This buffers the entire stream into memory before
-      // re-streaming it over HTTP. The RPC transport should accept a
-      // ReadableStream directly to avoid the extra copy.
-      let data: Blob | undefined;
-      if (dataStream) {
-        const bytes = await DataStream.toBytes(dataStream);
-        data = new Blob([bytes as BlobPart]);
-      }
-
       reply = await this.sendDwnRpcRequest({
         targetDid       : request.target,
         dwnEndpointUrls : [this._localDwnEndpoint!],
         message,
-        data,
+        data            : dataStream,
         subscriptionHandler,
       });
     }
@@ -585,20 +578,11 @@ export class AgentDwnApi {
       return this._dwn.processMessage(tenant, message, { dataStream: options?.dataStream });
     }
 
-    // TODO(#713): This buffers the entire stream into memory before
-    // re-streaming it over HTTP. The RPC transport should accept a
-    // ReadableStream directly to avoid the extra copy.
-    let data: Blob | undefined;
-    if (options?.dataStream) {
-      const bytes = await DataStream.toBytes(options.dataStream);
-      data = new Blob([bytes as BlobPart]);
-    }
-
     return this.sendDwnRpcRequest({
       targetDid       : tenant,
       dwnEndpointUrls : [this._localDwnEndpoint!],
       message         : message as DwnMessage[DwnInterface],
-      data,
+      data            : options?.dataStream,
     });
   }
 
@@ -618,17 +602,11 @@ export class AgentDwnApi {
       return this._dwn.applyReplicatedMessage(tenant, message, options);
     }
 
-    let data: Blob | undefined;
-    if (options?.dataStream) {
-      const bytes = await DataStream.toBytes(options.dataStream);
-      data = new Blob([bytes as BlobPart]);
-    }
-
     return this.agent.rpc.applyReplicatedMessage({
       targetDid : tenant,
       dwnUrl    : this._localDwnEndpoint!,
       message,
-      data,
+      data      : options?.dataStream,
     });
   }
 
@@ -643,7 +621,7 @@ export class AgentDwnApi {
 
     let messageCid: string | undefined;
     let message: DwnMessage[T];
-    let data: Blob | undefined;
+    let data: DwnRpcData | undefined;
     let subscriptionHandler: MessageHandler[T] | undefined;
 
     // If `messageCid` is given, retrieve message and data, if any.
@@ -657,11 +635,7 @@ export class AgentDwnApi {
 
     } else {
       // Otherwise, construct a new message.
-      ({ message } = await this.constructDwnMessage({ request }));
-      if (request.dataStream && !(request.dataStream instanceof Blob)) {
-        throw new Error('AgentDwnApi: DataStream must be provided as a Blob');
-      }
-      data = request.dataStream;
+      ({ message, dataStream: data } = await this.constructDwnMessage({ request }));
       subscriptionHandler = request.subscriptionHandler;
     }
 
@@ -893,7 +867,7 @@ export class AgentDwnApi {
       targetDid: string;
       dwnEndpointUrls: string[];
       message: DwnMessage[T];
-      data?: Blob;
+      data?: DwnRpcData;
       subscriptionHandler?: MessageHandler[T];
       resubscribeFactory?: ResubscribeFactory;
     }
@@ -959,7 +933,6 @@ export class AgentDwnApi {
 
     const rawMessage = request.rawMessage;
     let readableStream: ReadableStream<Uint8Array> | undefined;
-    // TODO: Consider refactoring to move data transformations imposed by fetch() limitations to the HTTP transport-related methods.
     // if the request is a RecordsWrite message, we need to handle the data stream and update the messageParams accordingly
     if (isDwnRequest(request, DwnInterface.RecordsWrite)) {
       const messageParams = request.messageParams;
@@ -1575,7 +1548,7 @@ export class AgentDwnApi {
     author: string;
     messageType: T;
     messageCid: string;
-  }): Promise<DwnMessageWithBlob<T>> {
+  }): Promise<DwnMessageWithRpcData<T>> {
     const signer = await this.getSigner(author);
 
     // Construct a MessagesRead message to fetch the message.
@@ -1605,7 +1578,7 @@ export class AgentDwnApi {
     const messageEntry = result.entry!;
     const message = messageEntry.message as DwnMessage[T];
 
-    const dwnMessageWithBlob: DwnMessageWithBlob<T> = { message };
+    const dwnMessageWithData: DwnMessageWithRpcData<T> = { message };
     // If the message is a RecordsWrite, data will be present in the form of a stream
 
     if (isRecordsWrite(messageEntry)) {
@@ -1615,12 +1588,11 @@ export class AgentDwnApi {
       // `Record<string, unknown>` (which loses the value type entirely).
       const entryData = (messageEntry as { data?: ReadableStream<Uint8Array> }).data;
       if (entryData) {
-        const dataBytes = await DataStream.toBytes(entryData);
-        dwnMessageWithBlob.data = new Blob([ dataBytes as BlobPart ], { type: messageEntry.message.descriptor.dataFormat });
+        dwnMessageWithData.data = entryData;
       }
     }
 
-    return dwnMessageWithBlob;
+    return dwnMessageWithData;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/src/dwn-key-delivery.ts
+++ b/packages/agent/src/dwn-key-delivery.ts
@@ -25,6 +25,8 @@ import { KeyDeliveryProtocolDefinition } from './store-data-protocols.js';
 
 import { buildEncryptionInput, encryptAndComputeCid, getEncryptionKeyDeriver, ivLength } from './dwn-encryption.js';
 
+type DwnRpcData = Blob | ReadableStream<Uint8Array>;
+
 /**
  * Parameters for writeContextKeyRecord.
  */
@@ -229,8 +231,8 @@ export async function eagerSendContextKeyRecord(
   agent: EnboxPlatformAgent,
   tenantDid: string,
   contextKeyMessage: DwnMessage[DwnInterface.RecordsWrite],
-  getDwnMessage: (params: { author: string; messageType: DwnInterface; messageCid: string }) => Promise<{ message: any; data?: Blob }>,
-  sendDwnRpcRequest: (params: { targetDid: string; dwnEndpointUrls: string[]; message: any; data?: Blob }) => Promise<any>,
+  getDwnMessage: (params: { author: string; messageType: DwnInterface; messageCid: string }) => Promise<{ message: any; data?: DwnRpcData }>,
+  sendDwnRpcRequest: (params: { targetDid: string; dwnEndpointUrls: string[]; message: any; data?: DwnRpcData }) => Promise<any>,
   getDwnEndpointUrlsForTarget: (targetDid: string) => Promise<string[]>,
 ): Promise<void> {
   let dwnEndpointUrls: string[];
@@ -245,7 +247,7 @@ export async function eagerSendContextKeyRecord(
     return;
   }
 
-  // Read the full message (including data blob) from the local DWN
+  // Read the full message (including data) from the local DWN.
   const { data } = await getDwnMessage({
     author      : tenantDid,
     messageType : DwnInterface.RecordsWrite,

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -234,7 +234,6 @@ type LivePullProcessResult = {
 type LivePullDataStreamFactory = () => Promise<ReadableStream<Uint8Array> | undefined>;
 
 type LivePullRecordsWriteEvent = MessageEvent & {
-  data?: ReadableStream<Uint8Array>;
   message: GenericMessage & {
     descriptor: GenericMessage['descriptor'] & { dataCid?: string };
   };
@@ -2237,12 +2236,6 @@ export class SyncEngineLevel implements SyncEngine {
       return async () => SyncEngineLevel.dataStreamFromBytes(bytes);
     }
 
-    const eventData = recordsWriteEvent.data;
-    if (eventData) {
-      const bytes = await SyncEngineLevel.readStreamBytes(eventData);
-      return async () => SyncEngineLevel.dataStreamFromBytes(bytes);
-    }
-
     if (recordsWriteEvent.message.descriptor.dataCid === undefined) {
       return async () => undefined;
     }
@@ -2272,31 +2265,6 @@ export class SyncEngineLevel implements SyncEngine {
         controller.close();
       }
     });
-  }
-
-  private static async readStreamBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
-    const reader = stream.getReader();
-    const chunks: Uint8Array[] = [];
-    let totalSize = 0;
-
-    try {
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) { break; }
-        chunks.push(value);
-        totalSize += value.byteLength;
-      }
-    } finally {
-      reader.releaseLock();
-    }
-
-    const bytes = new Uint8Array(totalSize);
-    let offset = 0;
-    for (const chunk of chunks) {
-      bytes.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    return bytes;
   }
 
   private trackRecentlyPulledMessage(messageCid: string, dwnUrl: string): void {

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -214,7 +214,7 @@ describe('AgentDwnApi', () => {
       expect(rpcSendStub.firstCall.args[0].dwnUrl).toBe('http://127.0.0.1:55557');
     });
 
-    it('processRawMessage converts data stream to Blob for RPC', async () => {
+    it('processRawMessage streams data through RPC in remote mode', async () => {
       const rpcSendStub = sinon.stub().resolves({
         status: { code: 202, detail: 'Accepted' },
       });
@@ -249,9 +249,8 @@ describe('AgentDwnApi', () => {
       );
 
       expect(result.status.code).toBe(202);
-      // Verify data was converted to Blob for RPC
       const rpcCall = rpcSendStub.firstCall.args[0];
-      expect(rpcCall.data).toBeInstanceOf(Blob);
+      expect(rpcCall.data).toBe(dataStream);
     });
 
     it('routes replicated apply through RPC in remote mode', async () => {
@@ -292,7 +291,90 @@ describe('AgentDwnApi', () => {
         message   : fakeMessage,
         targetDid : 'did:dht:testtenant',
       });
-      expect(rpcApplyStub.firstCall.args[0].data).toBeInstanceOf(Blob);
+      expect(rpcApplyStub.firstCall.args[0].data).toBe(dataStream);
+      expect(mockAgent.rpc.sendDwnRequest.called).toBe(false);
+    });
+
+    it('sendRequest streams constructed data through RPC in remote mode', async () => {
+      const mockAgent: any = {
+        rpc: {
+          getServerInfo  : sinon.stub().resolves({ server: '@enbox/dwn-server', webSocketSupport: false }),
+          sendDwnRequest : sinon.stub(),
+        },
+      };
+
+      const dwnApi = new AgentDwnApi({
+        agent            : mockAgent,
+        localDwnEndpoint : 'http://127.0.0.1:55557',
+      });
+      const dataStream = new ReadableStream<Uint8Array>({
+        start(controller): void {
+          controller.enqueue(new TextEncoder().encode('external write'));
+          controller.close();
+        },
+      });
+      const fakeMessage = {
+        descriptor: { interface: 'Records', method: 'Write' },
+      } as any;
+      const sendDwnRpcRequestStub = sinon.stub(dwnApi as any, 'sendDwnRpcRequest').resolves({
+        status: { code: 202, detail: 'Accepted' },
+      });
+      sinon.stub(dwnApi as any, 'constructDwnMessage').resolves({ message: fakeMessage, dataStream });
+      sinon.stub(dwnApi as any, 'getDwnEndpointUrlsForTarget').resolves(['https://dwn.example']);
+      sinon.stub(Message, 'getCid').resolves('bafytestmessagecid');
+
+      const result = await dwnApi.sendRequest({
+        author        : 'did:dht:testagent',
+        target        : 'did:dht:testtenant',
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {},
+        dataStream,
+      } as any);
+
+      expect(result.messageCid).toBe('bafytestmessagecid');
+      expect(sendDwnRpcRequestStub.calledOnce).toBe(true);
+      expect(sendDwnRpcRequestStub.firstCall.args[0].data).toBe(dataStream);
+      expect(mockAgent.rpc.sendDwnRequest.called).toBe(false);
+    });
+
+    it('sendRequest streams existing message data through RPC when using messageCid', async () => {
+      const mockAgent: any = {
+        rpc: {
+          getServerInfo  : sinon.stub().resolves({ server: '@enbox/dwn-server', webSocketSupport: false }),
+          sendDwnRequest : sinon.stub(),
+        },
+      };
+
+      const dwnApi = new AgentDwnApi({
+        agent            : mockAgent,
+        localDwnEndpoint : 'http://127.0.0.1:55557',
+      });
+      const dataStream = new ReadableStream<Uint8Array>({
+        start(controller): void {
+          controller.enqueue(new TextEncoder().encode('existing write'));
+          controller.close();
+        },
+      });
+      const fakeMessage = {
+        descriptor: { interface: 'Records', method: 'Write' },
+      } as any;
+      const sendDwnRpcRequestStub = sinon.stub(dwnApi as any, 'sendDwnRpcRequest').resolves({
+        status: { code: 202, detail: 'Accepted' },
+      });
+      sinon.stub(dwnApi as any, 'getDwnMessage').resolves({ message: fakeMessage, data: dataStream });
+      sinon.stub(dwnApi as any, 'getDwnEndpointUrlsForTarget').resolves(['https://dwn.example']);
+      sinon.stub(Message, 'getCid').resolves('bafytestmessagecid');
+
+      const result = await dwnApi.sendRequest({
+        author      : 'did:dht:testagent',
+        target      : 'did:dht:testtenant',
+        messageType : DwnInterface.RecordsWrite,
+        messageCid  : 'bafyexistingmessagecid',
+      } as any);
+
+      expect(result.messageCid).toBe('bafyexistingmessagecid');
+      expect(sendDwnRpcRequestStub.calledOnce).toBe(true);
+      expect(sendDwnRpcRequestStub.firstCall.args[0].data).toBe(dataStream);
       expect(mockAgent.rpc.sendDwnRequest.called).toBe(false);
     });
 
@@ -3951,8 +4033,8 @@ describe('Key Delivery Protocol Infrastructure (PR A)', () => {
       expect(rpcCallArgs.targetDid).toBe(alice.did.uri);
       expect(rpcCallArgs.dwnUrl).toBe('https://dwn.example.com');
       expect(rpcCallArgs.message).toHaveProperty('recordId', recordId);
-      // Verify data blob is included (the encrypted contextKey payload)
-      expect(rpcCallArgs.data).toBeInstanceOf(Blob);
+      // Verify data stream is included (the encrypted contextKey payload).
+      expect(rpcCallArgs.data).toBeInstanceOf(ReadableStream);
     }, 10000);
 
     it('should not fail when eager send encounters an error', async () => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -177,13 +177,13 @@ describe('SyncEngineLevel — private methods', () => {
       expect(await factory()).toBeUndefined();
     });
 
-    it('should return data stream for RecordsWrite with data', async () => {
+    it('should ignore non-contract RecordsWrite event data', async () => {
       const event = {
         message : { descriptor: { interface: 'Records', method: 'Write' } },
         data    : textStream('hello from event'),
       };
       const factory = await (syncEngine as any).createLivePullDataStreamFactory(livePullContext, event);
-      expect(await readStreamText(await factory())).toBe('hello from event');
+      expect(await factory()).toBeUndefined();
     });
 
     it('should return undefined for RecordsWrite without data', async () => {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/parser": "8.32.1",
     "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-istanbul": "4.0.18",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "eslint": "9.7.0",
     "sinon": "18.0.0",
     "typescript": "5.9.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -78,7 +78,7 @@
     "access": "public"
   },
   "engines": {
-    "bun": ">=1.0.0"
+    "bun": ">=1.3.14"
   },
   "dependencies": {
     "@enbox/agent": "workspace:*",

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -433,7 +433,7 @@ export class Record implements RecordModel {
         messageType : DwnInterface.RecordsWrite,
         author      : this._connectedDid,
         target      : target,
-        dataStream  : this._encodedData ?? await this.data.blob(),
+        dataStream  : this._encodedData ?? await this.data.stream(),
         rawMessage  : { ...this.rawMessage }
       };
     }
@@ -784,7 +784,7 @@ export class Record implements RecordModel {
         rawMessage  : this.rawMessage,
         author      : this._connectedDid,
         target      : this._connectedDid,
-        dataStream  : await this.data.blob(),
+        dataStream  : this._encodedData ?? await this.data.stream(),
         signAsOwner : signAsOwnerValue,
         signAsOwnerDelegate,
         store,

--- a/packages/api/tests/record-coverage.spec.ts
+++ b/packages/api/tests/record-coverage.spec.ts
@@ -80,6 +80,15 @@ function createDeleteDescriptor(recordId: string): any {
   };
 }
 
+function createDataStream(bytes: Uint8Array = new Uint8Array([1, 2, 3])): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller): void {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -189,6 +198,23 @@ describe('Record — coverage gaps (stubbed)', () => {
       const call = agentStub.sendDwnRequest.firstCall;
       expect(call.args[0].target).toBe('did:example:myDid');
     });
+
+    it('should pass record data as a stream when encoded data is not already available', async () => {
+      const dataStream = createDataStream();
+      const options = createRecordOptions({ encodedData: undefined, data: dataStream });
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
+
+      agentStub.sendDwnRequest.resolves({
+        messageCid : 'cid-1',
+        message    : {},
+        reply      : { status: { code: 202, detail: 'Accepted' } },
+      } as any);
+
+      await record.send();
+
+      const call = agentStub.sendDwnRequest.firstCall;
+      expect(call.args[0].dataStream).toBe(dataStream);
+    });
   });
 
   describe('processRecord() — signAsOwner updates authorization', () => {
@@ -208,6 +234,24 @@ describe('Record — coverage gaps (stubbed)', () => {
 
       // The authorization should have been updated to the response message's authorization.
       expect(record.authorization).toEqual(newAuth);
+    });
+
+    it('should pass record data as a stream when storing without encoded data', async () => {
+      const dataStream = createDataStream();
+      const options = createRecordOptions({ encodedData: undefined, data: dataStream });
+      const record = new Record(agentStub as unknown as EnboxAgent, options);
+
+      agentStub.processDwnRequest.resolves({
+        messageCid : 'cid-1',
+        message    : {},
+        reply      : { status: { code: 202, detail: 'Accepted' } },
+      } as any);
+
+      const result = await record.store();
+      expect(result.status.code).toBe(202);
+
+      const call = agentStub.processDwnRequest.firstCall;
+      expect(call.args[0].dataStream).toBe(dataStream);
     });
   });
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@types/node": "22.19.15",
     "@types/sinon": "17.0.3",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "sinon": "18.0.0",
     "typescript": "5.9.3"
   }

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/parser": "8.32.1",
     "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-istanbul": "4.0.18",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "eslint": "9.7.0",
     "typescript": "5.9.3",
     "vitest": "4.0.18"

--- a/packages/dwn-clients/package.json
+++ b/packages/dwn-clients/package.json
@@ -57,7 +57,7 @@
     "@types/sinon": "17.0.3",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "eslint": "9.7.0",
     "sinon": "18.0.0",
     "typescript": "5.9.3"

--- a/packages/dwn-clients/package.json
+++ b/packages/dwn-clients/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "engines": {
-    "bun": ">=1.0.0"
+    "bun": ">=1.3.14"
   },
   "dependencies": {
     "@enbox/common": "workspace:*",

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -4,7 +4,6 @@ import type { DwnReplicationApplyRequest, DwnRpc, DwnRpcRequest, DwnRpcResponse 
 import type { DwnServerInfoCache, ServerInfo } from './server-info-types.js';
 
 import { CryptoUtils } from '@enbox/crypto';
-import { DataStream } from '@enbox/dwn-sdk-js';
 import { DwnRpcError } from './dwn-rpc-error.js';
 import { DwnServerInfoCacheMemory } from './dwn-server-info-cache-memory.js';
 import { parseReplicationApplyResult } from './replication-apply-result.js';
@@ -99,6 +98,61 @@ function parseRetryAfterMs(response: Response): number | undefined {
   return undefined;
 }
 
+function attachDataRequestBody(fetchOpts: RequestInit, requestHeaders: Record<string, string>, requestBody: BodyInit): boolean {
+  requestHeaders['content-type'] = 'application/octet-stream';
+  fetchOpts.body = requestBody;
+
+  if (requestBody instanceof ReadableStream) {
+    // Required by the Fetch standard for streaming request bodies. The stream is one-shot,
+    // so transport-level retries must not replay the same body after a failed attempt.
+    (fetchOpts as RequestInit & { duplex: 'half' }).duplex = 'half';
+    return false;
+  }
+
+  return true;
+}
+
+type ReadableStreamReader = {
+  cancel?: (reason?: unknown) => Promise<void>;
+  read(): Promise<{ done: boolean; value?: Uint8Array }>;
+  releaseLock?: () => void;
+};
+
+function normalizeReadableStream(readableStream: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  const reader = readableStream.getReader() as ReadableStreamReader;
+  let readerReleased = false;
+
+  const releaseReader = (): void => {
+    if (readerReleased) {
+      return;
+    }
+
+    reader.releaseLock?.();
+    readerReleased = true;
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller): Promise<void> {
+      const { done, value } = await reader.read();
+      if (done) {
+        releaseReader();
+        controller.close();
+        return;
+      }
+
+      controller.enqueue(value!);
+    },
+
+    async cancel(reason): Promise<void> {
+      try {
+        await reader.cancel?.(reason);
+      } finally {
+        releaseReader();
+      }
+    },
+  });
+}
+
 /**
  * HTTP client that can be used to communicate with Dwn Servers.
  *
@@ -147,29 +201,15 @@ export class HttpDwnRpcClient implements DwnRpc {
       ...(request.signal ? { signal: request.signal } : {}),
     };
 
-    if (request.data) {
-      requestHeaders['content-type'] = 'application/octet-stream';
-      let requestBody = request.data;
-
-      if (requestBody instanceof ReadableStream) {
-        // Bun's fetch currently fails on some ReadableStream uploads in the sync push path.
-        // Buffer to a Blob in Bun to avoid the broken path. In browsers, keep the stream
-        // and set `duplex: 'half'` which the Fetch spec requires for streaming request bodies.
-        // See: https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests
-        if (HttpDwnRpcClient.isBunRuntime()) {
-          const bodyBytes = await DataStream.toBytes(requestBody as ReadableStream<Uint8Array>);
-          requestBody = new Blob([bodyBytes as BlobPart], { type: 'application/octet-stream' });
-        } else {
-          // Browsers require `duplex: 'half'` when the fetch body is a ReadableStream.
-          // TypeScript's built-in RequestInit does not include `duplex` yet.
-          (fetchOpts as Record<string, unknown>).duplex = 'half';
-        }
-      }
-
-      fetchOpts.body = requestBody;
+    let isRequestBodyReplayable = true;
+    if (request.data !== undefined) {
+      isRequestBodyReplayable = attachDataRequestBody(fetchOpts, requestHeaders, request.data as BodyInit);
     }
 
-    const resp = await this.fetchWithRetry(request.dwnUrl, fetchOpts, { requestTimeoutMs: request.timeoutMs });
+    const resp = await this.fetchWithRetry(request.dwnUrl, fetchOpts, {
+      requestTimeoutMs     : request.timeoutMs,
+      retryableRequestBody : isRequestBodyReplayable,
+    });
 
     // After retries are exhausted, a 429 means we're still rate-limited.
     // Per-IP 429s return plain JSON (not a JSON-RPC envelope), so we must
@@ -214,20 +254,16 @@ export class HttpDwnRpcClient implements DwnRpc {
       throw new DwnRpcError(code, message, dwnRpcResponse.error.data);
     }
 
-    // Materialise the response body before attaching to the reply.
-    // Bun has a bug where ReadableStream from fetch resp.body crashes in
-    // DataStream.toBytes() (reader.releaseLock() is undefined) when the
-    // stream is later consumed by the local DWN node (e.g. during sync).
-    // Buffering via arrayBuffer() avoids the broken getReader() path.
-    // TODO: https://github.com/enboxorg/enbox/issues/90 — remove once Bun ships fix
     const { reply } = dwnRpcResponse.result;
     if (hasDataStream) {
-      const bodyBytes = new Uint8Array(await resp.arrayBuffer());
-      const dataStream = DataStream.fromBytes(bodyBytes);
+      const dataStream = resp.body;
+      if (dataStream === null) {
+        throw new Error(`missing data stream in json rpc response. dwn url: ${request.dwnUrl}`);
+      }
       if (reply.record) {
-        reply.record.data = dataStream;
+        reply.record.data = normalizeReadableStream(dataStream);
       } else if (reply.entry) {
-        reply.entry.data = dataStream;
+        reply.entry.data = normalizeReadableStream(dataStream);
       }
     }
 
@@ -251,24 +287,14 @@ export class HttpDwnRpcClient implements DwnRpc {
       ...(request.signal ? { signal: request.signal } : {}),
     };
 
-    if (request.data) {
-      requestHeaders['content-type'] = 'application/octet-stream';
-      let requestBody = request.data;
-
-      if (requestBody instanceof ReadableStream) {
-        if (HttpDwnRpcClient.isBunRuntime()) {
-          const bodyBytes = await DataStream.toBytes(requestBody as ReadableStream<Uint8Array>);
-          requestBody = new Blob([bodyBytes as BlobPart], { type: 'application/octet-stream' });
-        } else {
-          (fetchOpts as Record<string, unknown>).duplex = 'half';
-        }
-      }
-
-      fetchOpts.body = requestBody;
+    let isRequestBodyReplayable = true;
+    if (request.data !== undefined) {
+      isRequestBodyReplayable = attachDataRequestBody(fetchOpts, requestHeaders, request.data as BodyInit);
     }
 
     const resp = await this.fetchWithRetry(request.dwnUrl, fetchOpts, {
-      requestTimeoutMs: request.timeoutMs ?? defaultReplicationApplyTimeoutMs(request.message),
+      requestTimeoutMs     : request.timeoutMs ?? defaultReplicationApplyTimeoutMs(request.message),
+      retryableRequestBody : isRequestBodyReplayable,
     });
     if (resp.status === 429) {
       const retryAfter = Number.parseInt(resp.headers.get('retry-after') ?? '1', 10);
@@ -344,14 +370,19 @@ export class HttpDwnRpcClient implements DwnRpc {
    * retryable HTTP status codes with exponential backoff and jitter.
    * Honours the `Retry-After` response header when present.
    */
-  private async fetchWithRetry(url: string, init?: RequestInit, options: { requestTimeoutMs?: number } = {}): Promise<Response> {
+  private async fetchWithRetry(
+    url: string,
+    init?: RequestInit,
+    options: { requestTimeoutMs?: number; retryableRequestBody?: boolean } = {},
+  ): Promise<Response> {
     const { maxRetries, baseDelayMs, maxDelayMs } = this._retryOptions;
     const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    const maxRetriesForRequest = options.retryableRequestBody === false ? 0 : maxRetries;
 
     let lastError: unknown;
     let lastResponse: Response | undefined;
 
-    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    for (let attempt = 0; attempt <= maxRetriesForRequest; attempt++) {
       try {
         // Apply a per-attempt timeout to prevent hung connections / SSRF.
         // If the caller already supplied a signal, combine it with the timeout
@@ -366,14 +397,14 @@ export class HttpDwnRpcClient implements DwnRpc {
 
         const response = await fetch(url, attemptInit);
 
-        if (!RETRYABLE_STATUS_CODES.has(response.status) || attempt === maxRetries) {
+        if (!RETRYABLE_STATUS_CODES.has(response.status) || attempt === maxRetriesForRequest) {
           return response;
         }
 
         // Retryable status — back off and try again.
         lastResponse = response;
       } catch (error: unknown) {
-        if (!isRetryable(error) || attempt === maxRetries) {
+        if (!isRetryable(error) || attempt === maxRetriesForRequest) {
           throw error;
         }
         lastError = error;

--- a/packages/dwn-clients/src/http-dwn-rpc-client.ts
+++ b/packages/dwn-clients/src/http-dwn-rpc-client.ts
@@ -6,6 +6,7 @@ import type { DwnServerInfoCache, ServerInfo } from './server-info-types.js';
 import { CryptoUtils } from '@enbox/crypto';
 import { DwnRpcError } from './dwn-rpc-error.js';
 import { DwnServerInfoCacheMemory } from './dwn-server-info-cache-memory.js';
+import { normalizeReadableStream } from './readable-stream.js';
 import { parseReplicationApplyResult } from './replication-apply-result.js';
 import { RateLimitError } from './rate-limit-error.js';
 import { sleep } from '@enbox/common';
@@ -98,6 +99,34 @@ function parseRetryAfterMs(response: Response): number | undefined {
   return undefined;
 }
 
+function createAttemptInit(init: RequestInit | undefined, requestTimeoutMs: number): RequestInit {
+  const timeoutSignal = AbortSignal.timeout(requestTimeoutMs);
+  if (init?.signal === undefined || init.signal === null) {
+    return { ...init, signal: timeoutSignal };
+  }
+
+  return { ...init, signal: AbortSignal.any([init.signal, timeoutSignal]) };
+}
+
+function shouldReturnResponse(response: Response, attempt: number, maxRetriesForRequest: number): boolean {
+  return !RETRYABLE_STATUS_CODES.has(response.status) || attempt === maxRetriesForRequest;
+}
+
+function shouldRethrowFetchError(error: unknown, attempt: number, maxRetriesForRequest: number): boolean {
+  return !isRetryable(error) || attempt === maxRetriesForRequest;
+}
+
+function getRetryDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number, lastResponse?: Response): number {
+  const retryAfterMs = lastResponse !== undefined ? parseRetryAfterMs(lastResponse) : undefined;
+  const backoffMs = computeBackoffDelay(attempt, baseDelayMs, maxDelayMs);
+
+  return retryAfterMs === undefined ? backoffMs : Math.max(retryAfterMs, backoffMs);
+}
+
+/**
+ * Mutates the request options and headers with an octet-stream body.
+ * Returns whether the body is replayable for transport-level retries.
+ */
 function attachDataRequestBody(fetchOpts: RequestInit, requestHeaders: Record<string, string>, requestBody: BodyInit): boolean {
   requestHeaders['content-type'] = 'application/octet-stream';
   fetchOpts.body = requestBody;
@@ -110,47 +139,6 @@ function attachDataRequestBody(fetchOpts: RequestInit, requestHeaders: Record<st
   }
 
   return true;
-}
-
-type ReadableStreamReader = {
-  cancel?: (reason?: unknown) => Promise<void>;
-  read(): Promise<{ done: boolean; value?: Uint8Array }>;
-  releaseLock?: () => void;
-};
-
-function normalizeReadableStream(readableStream: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
-  const reader = readableStream.getReader() as ReadableStreamReader;
-  let readerReleased = false;
-
-  const releaseReader = (): void => {
-    if (readerReleased) {
-      return;
-    }
-
-    reader.releaseLock?.();
-    readerReleased = true;
-  };
-
-  return new ReadableStream<Uint8Array>({
-    async pull(controller): Promise<void> {
-      const { done, value } = await reader.read();
-      if (done) {
-        releaseReader();
-        controller.close();
-        return;
-      }
-
-      controller.enqueue(value!);
-    },
-
-    async cancel(reason): Promise<void> {
-      try {
-        await reader.cancel?.(reason);
-      } finally {
-        releaseReader();
-      }
-    },
-  });
 }
 
 /**
@@ -171,11 +159,6 @@ export class HttpDwnRpcClient implements DwnRpc {
       baseDelayMs : retryOptions?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
       maxDelayMs  : retryOptions?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
     };
-  }
-
-  /** Detects whether the current runtime is Bun (vs a browser). */
-  static isBunRuntime(): boolean {
-    return typeof (globalThis as Record<string, unknown>).Bun !== 'undefined';
   }
 
   get transportProtocols(): string[] { return ['http:', 'https:']; }
@@ -387,35 +370,22 @@ export class HttpDwnRpcClient implements DwnRpc {
         // Apply a per-attempt timeout to prevent hung connections / SSRF.
         // If the caller already supplied a signal, combine it with the timeout
         // via AbortSignal.any(); otherwise create a fresh timeout signal.
-        const timeoutSignal = AbortSignal.timeout(requestTimeoutMs);
-        const attemptInit: RequestInit = {
-          ...init,
-          signal: init?.signal
-            ? AbortSignal.any([init.signal, timeoutSignal])
-            : timeoutSignal,
-        };
-
-        const response = await fetch(url, attemptInit);
-
-        if (!RETRYABLE_STATUS_CODES.has(response.status) || attempt === maxRetriesForRequest) {
+        const response = await fetch(url, createAttemptInit(init, requestTimeoutMs));
+        if (shouldReturnResponse(response, attempt, maxRetriesForRequest)) {
           return response;
         }
 
         // Retryable status — back off and try again.
         lastResponse = response;
       } catch (error: unknown) {
-        if (!isRetryable(error) || attempt === maxRetriesForRequest) {
+        if (shouldRethrowFetchError(error, attempt, maxRetriesForRequest)) {
           throw error;
         }
         lastError = error;
       }
 
       // Compute the delay, preferring Retry-After when available.
-      const retryAfterMs = lastResponse ? parseRetryAfterMs(lastResponse) : undefined;
-      const backoffMs = computeBackoffDelay(attempt, baseDelayMs, maxDelayMs);
-      const delayMs = retryAfterMs === undefined ? backoffMs : Math.max(retryAfterMs, backoffMs);
-
-      await sleep(delayMs);
+      await sleep(getRetryDelayMs(attempt, baseDelayMs, maxDelayMs, lastResponse));
     }
 
     // Should not reach here, but satisfy the compiler.

--- a/packages/dwn-clients/src/index.ts
+++ b/packages/dwn-clients/src/index.ts
@@ -7,6 +7,7 @@ export * from './json-rpc.js';
 export * from './json-rpc-socket.js';
 export * from './provider-directory-types.js';
 export * from './rate-limit-error.js';
+export * from './readable-stream.js';
 export * from './registration-types.js';
 export * from './rpc-client.js';
 export * from './server-info-types.js';

--- a/packages/dwn-clients/src/readable-stream.ts
+++ b/packages/dwn-clients/src/readable-stream.ts
@@ -1,0 +1,59 @@
+type ReadableStreamReader = {
+  cancel?: (reason?: unknown) => Promise<void>;
+  read(): Promise<{ done: boolean; value?: Uint8Array }>;
+  releaseLock?: () => void;
+};
+
+/**
+ * Wraps runtime-provided streams in a standard `ReadableStream` so downstream
+ * consumers see consistent reader behavior across Bun and browsers.
+ */
+export function normalizeReadableStream(readableStream: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  const reader = readableStream.getReader() as ReadableStreamReader;
+  let readerReleased = false;
+
+  const releaseReader = (): void => {
+    if (readerReleased) {
+      return;
+    }
+
+    reader.releaseLock?.();
+    readerReleased = true;
+  };
+
+  const cancelReader = async (reason?: unknown): Promise<void> => {
+    try {
+      await reader.cancel?.(reason);
+    } finally {
+      releaseReader();
+    }
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller): Promise<void> {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          releaseReader();
+          controller.close();
+          return;
+        }
+
+        controller.enqueue(value!);
+      } catch (error: unknown) {
+        try {
+          await reader.cancel?.(error);
+        } catch {
+          // Preserve the original read error.
+        } finally {
+          releaseReader();
+        }
+        throw error;
+      }
+    },
+
+    async cancel(reason): Promise<void> {
+      await cancelReader(reason);
+    },
+  });
+}

--- a/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
+++ b/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
@@ -3,7 +3,7 @@ import type { Persona, ProtocolDefinition } from '@enbox/dwn-sdk-js';
 import sinon from 'sinon';
 
 import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
-import { Jws, ProtocolsConfigure, RecordsRead, TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { DataStream, Jws, ProtocolsConfigure, RecordsRead, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
 import { DwnRpcError } from '../src/dwn-rpc-error.js';
 import { DwnServerInfoCacheMemory } from '../src/dwn-server-info-cache-memory.js';
@@ -115,9 +115,7 @@ describe('HttpDwnRpcClient', () => {
       expect(readResponse.entry?.recordsWrite?.recordId).toBe(writeMessage.recordId);
     });
 
-    it('should buffer ReadableStream to Blob in Bun (no duplex)', async () => {
-      // In Bun, ReadableStream bodies are buffered to a Blob because Bun's
-      // fetch can fail on stream uploads. The Blob path does not need `duplex`.
+    it('should stream ReadableStream request bodies with duplex half', async () => {
       const streamBytes = new TextEncoder().encode('streamed-payload');
       const dataStream = new ReadableStream<Uint8Array>({
         start(controller): void {
@@ -155,70 +153,47 @@ describe('HttpDwnRpcClient', () => {
       const fetchCallArgs = fetchStub.firstCall.args;
       const fetchOpts = fetchCallArgs[1] as Record<string, unknown>;
 
-      // In Bun, body should have been buffered to a Blob.
-      expect(fetchOpts.body instanceof ReadableStream).toBe(false);
-      expect(fetchOpts.body instanceof Blob).toBe(true);
+      expect(fetchOpts.body instanceof ReadableStream).toBe(true);
+      expect(fetchOpts.duplex).toBe('half');
 
-      // `duplex` must NOT be set since the body is a Blob, not a stream.
-      expect(fetchOpts.duplex).toBeUndefined();
-
-      // Verify the Blob contains the original stream bytes.
-      const sentBlob = fetchOpts.body as Blob;
-      const sentBytes = new Uint8Array(await sentBlob.arrayBuffer());
+      const sentBytes = await DataStream.toBytes(fetchOpts.body as ReadableStream<Uint8Array>);
       expect(sentBytes).toEqual(streamBytes);
     });
 
-    it('should set duplex half on ReadableStream body in non-Bun environments', async () => {
-      // Browsers require `duplex: 'half'` when a fetch body is a ReadableStream.
-      // Simulate a non-Bun (browser) environment by stubbing isBunRuntime.
-      const bunStub = sinon.stub(HttpDwnRpcClient, 'isBunRuntime').returns(false);
+    it('should not set duplex half on replayable request bodies', async () => {
+      const streamBytes = new TextEncoder().encode('blob-payload');
+      const dataBlob = new Blob([streamBytes as BlobPart]);
+      const jsonRpcResponse = {
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { reply: { status: { code: 202, detail: 'Accepted' } } },
+      };
 
-      try {
-        const streamBytes = new TextEncoder().encode('browser-payload');
-        const dataStream = new ReadableStream<Uint8Array>({
-          start(controller): void {
-            controller.enqueue(streamBytes);
-            controller.close();
-          },
-        });
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves({
+        status  : 200,
+        headers : new Headers(),
+        text    : async (): Promise<string> => JSON.stringify(jsonRpcResponse),
+      } as any);
 
-        const jsonRpcResponse = {
-          id      : 'test',
-          jsonrpc : '2.0',
-          result  : { reply: { status: { code: 202, detail: 'Accepted' } } },
-        };
+      const { message: writeMessage } = await TestDataGenerator.generateRecordsWrite({
+        author : alice,
+        schema : 'foo/bar',
+      });
 
-        const fetchStub = sinon.stub(globalThis, 'fetch').resolves({
-          status  : 200,
-          headers : new Headers(),
-          text    : async (): Promise<string> => JSON.stringify(jsonRpcResponse),
-        } as any);
+      await client.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message   : writeMessage,
+        data      : dataBlob,
+      });
 
-        const { message: writeMessage } = await TestDataGenerator.generateRecordsWrite({
-          author : alice,
-          schema : 'foo/bar',
-        });
+      expect(fetchStub.calledOnce).toBe(true);
 
-        await client.sendDwnRequest({
-          dwnUrl    : testDwnUrl,
-          targetDid : alice.did,
-          message   : writeMessage,
-          data      : dataStream,
-        });
+      const fetchCallArgs = fetchStub.firstCall.args;
+      const fetchOpts = fetchCallArgs[1] as Record<string, unknown>;
 
-        expect(fetchStub.calledOnce).toBe(true);
-
-        const fetchCallArgs = fetchStub.firstCall.args;
-        const fetchOpts = fetchCallArgs[1] as Record<string, unknown>;
-
-        // In browsers, body stays as a ReadableStream.
-        expect(fetchOpts.body instanceof ReadableStream).toBe(true);
-
-        // `duplex: 'half'` must be set for streaming request bodies.
-        expect(fetchOpts.duplex).toBe('half');
-      } finally {
-        bunStub.restore();
-      }
+      expect(fetchOpts.body).toBe(dataBlob);
+      expect(fetchOpts.duplex).toBeUndefined();
     });
 
     it('sends replicated apply requests to the replication JSON-RPC method', async () => {
@@ -288,10 +263,10 @@ describe('HttpDwnRpcClient', () => {
       const fetchOpts = fetchStub.firstCall.args[1] as RequestInit;
       const headers = fetchOpts.headers as Record<string, string>;
       expect(headers['content-type']).toBe('application/octet-stream');
-      expect(fetchOpts.body instanceof Blob).toBe(true);
+      expect(fetchOpts.body instanceof ReadableStream).toBe(true);
+      expect((fetchOpts as Record<string, unknown>).duplex).toBe('half');
 
-      const sentBlob = fetchOpts.body as Blob;
-      const sentBytes = new Uint8Array(await sentBlob.arrayBuffer());
+      const sentBytes = await DataStream.toBytes(fetchOpts.body as ReadableStream<Uint8Array>);
       expect(sentBytes).toEqual(payload);
     });
 
@@ -396,11 +371,25 @@ describe('HttpDwnRpcClient', () => {
         'dwn-response': JSON.stringify(entryReply),
       });
 
+      let bodyOffset = 0;
+      const responseStream = {
+        getReader(): { read(): Promise<{ done: boolean; value?: Uint8Array }> } {
+          return {
+            async read(): Promise<{ done: boolean; value?: Uint8Array }> {
+              if (bodyOffset >= bodyBytes.byteLength) {
+                return { done: true };
+              }
+
+              const value = bodyBytes.subarray(bodyOffset, bodyBytes.byteLength);
+              bodyOffset = bodyBytes.byteLength;
+              return { done: false, value };
+            },
+          };
+        },
+      } as unknown as ReadableStream<Uint8Array>;
       sinon.stub(globalThis, 'fetch').resolves({
+        body: responseStream,
         headers,
-        arrayBuffer: async (): Promise<ArrayBuffer> => bodyBytes.buffer.slice(
-          bodyBytes.byteOffset, bodyBytes.byteOffset + bodyBytes.byteLength
-        ),
       } as any);
 
       const { message } = await TestDataGenerator.generateRecordsQuery({
@@ -418,6 +407,8 @@ describe('HttpDwnRpcClient', () => {
       expect(response.status.code).toBe(200);
       expect(response.entry).toBeDefined();
       expect(response.entry!.data).toBeDefined();
+      expect(response.entry!.data).not.toBe(responseStream);
+      expect(await DataStream.toBytes(response.entry!.data as ReadableStream<Uint8Array>)).toEqual(bodyBytes);
     });
 
     it('throws error if response body is not valid JSON', async () => {
@@ -545,6 +536,34 @@ describe('HttpDwnRpcClient', () => {
 
       expect(response.status.code).toBe(200);
       expect(fetchStub.callCount).toBe(2);
+    });
+
+    it('should not retry when the request body is a one-shot ReadableStream', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+      const jsonRpcResponse = {
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { reply: { status: { code: 503, detail: 'Service Unavailable' }, entries: [] } },
+      };
+      fetchStub.resolves({
+        status  : 503,
+        headers : new Headers(),
+        text    : async (): Promise<string> => JSON.stringify(jsonRpcResponse),
+      } as any);
+
+      const retryClient = new HttpDwnRpcClient(undefined, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 });
+      const { message } = await TestDataGenerator.generateRecordsWrite({ author: alice });
+      const dataStream = DataStream.fromBytes(new TextEncoder().encode('one-shot-body'));
+
+      const response = await retryClient.sendDwnRequest({
+        dwnUrl    : testDwnUrl,
+        targetDid : alice.did,
+        message,
+        data      : dataStream,
+      });
+
+      expect(response.status.code).toBe(503);
+      expect(fetchStub.callCount).toBe(1);
     });
 
     it('should retry on network TypeError and succeed', async () => {

--- a/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
+++ b/packages/dwn-clients/tests/http-dwn-rpc-client.spec.ts
@@ -9,6 +9,7 @@ import { DwnRpcError } from '../src/dwn-rpc-error.js';
 import { DwnServerInfoCacheMemory } from '../src/dwn-server-info-cache-memory.js';
 import { HttpDwnRpcClient } from '../src/http-dwn-rpc-client.js';
 import { JsonRpcErrorCodes } from '../src/json-rpc.js';
+import { normalizeReadableStream } from '../src/readable-stream.js';
 
 /**
  * Matches the defaults used by `TestDataGenerator.generateRecordsWrite()`.
@@ -409,6 +410,26 @@ describe('HttpDwnRpcClient', () => {
       expect(response.entry!.data).toBeDefined();
       expect(response.entry!.data).not.toBe(responseStream);
       expect(await DataStream.toBytes(response.entry!.data as ReadableStream<Uint8Array>)).toEqual(bodyBytes);
+    });
+
+    it('cancels and releases the source reader when a normalized stream read rejects', async () => {
+      const readError = new Error('network stream failed');
+      const cancelSpy = sinon.spy(async (): Promise<void> => {});
+      const releaseLockSpy = sinon.spy();
+      const sourceReader = {
+        cancel      : cancelSpy,
+        read        : async (): Promise<{ done: boolean; value?: Uint8Array }> => { throw readError; },
+        releaseLock : releaseLockSpy,
+      };
+      const sourceStream = {
+        getReader(): typeof sourceReader {
+          return sourceReader;
+        },
+      } as unknown as ReadableStream<Uint8Array>;
+
+      await expect(DataStream.toBytes(normalizeReadableStream(sourceStream))).rejects.toThrow('network stream failed');
+      expect(cancelSpy.calledOnceWith(readError)).toBe(true);
+      expect(releaseLockSpy.calledOnce).toBe(true);
     });
 
     it('throws error if response body is not valid JSON', async () => {

--- a/packages/dwn-sdk-js/package.json
+++ b/packages/dwn-sdk-js/package.json
@@ -98,7 +98,7 @@
     "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-istanbul": "4.0.18",
     "blockstore-core": "4.2.0",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "dependency-cruiser": "16.3.7",
     "eslint": "9.7.0",
     "eslint-plugin-todo-plz": "1.3.0",

--- a/packages/dwn-server/package.json
+++ b/packages/dwn-server/package.json
@@ -55,14 +55,14 @@
     "@enbox/dwn-server-admin-ui": "workspace:*"
   },
   "devDependencies": {
-    "@types/bun": "1.3.10",
+    "@types/bun": "1.3.14",
     "@types/bytes": "3.1.1",
     "@types/node": "22.19.15",
     "@types/sinon": "17.0.3",
     "@types/ws": "8.5.10",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "eslint": "9.7.0",
     "eslint-plugin-todo-plz": "1.3.0",
     "multiformats": "11.0.2",

--- a/packages/dwn-server/package.json
+++ b/packages/dwn-server/package.json
@@ -29,6 +29,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "bun": ">=1.3.14"
+  },
   "dependencies": {
     "@enbox/common": "workspace:*",
     "@enbox/crypto": "workspace:*",

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -25,7 +25,7 @@ import { Convert } from '@enbox/common';
 import { register } from 'prom-client';
 import { v4 as uuidv4 } from 'uuid';
 import { createJsonRpcErrorResponse, JsonRpcErrorCodes, maxWsJsonRpcPayloadBytes } from '@enbox/dwn-clients';
-import { DataStream, DateSort, type Dwn, ProtocolsQuery, RecordsQuery, RecordsRead } from '@enbox/dwn-sdk-js';
+import { DateSort, type Dwn, ProtocolsQuery, RecordsQuery, RecordsRead } from '@enbox/dwn-sdk-js';
 import { existsSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
 
@@ -38,6 +38,47 @@ import { requestCounter, responseHistogram } from './metrics.js';
 
 /** Property names that must never be used as keys when building objects from user input. */
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+type ReadableStreamReader = {
+  cancel?: (reason?: unknown) => Promise<void>;
+  read(): Promise<{ done: boolean; value?: Uint8Array }>;
+  releaseLock?: () => void;
+};
+
+function normalizeReadableStream(readableStream: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  const reader = readableStream.getReader() as ReadableStreamReader;
+  let readerReleased = false;
+
+  const releaseReader = (): void => {
+    if (readerReleased) {
+      return;
+    }
+
+    reader.releaseLock?.();
+    readerReleased = true;
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller): Promise<void> {
+      const { done, value } = await reader.read();
+      if (done) {
+        releaseReader();
+        controller.close();
+        return;
+      }
+
+      controller.enqueue(value!);
+    },
+
+    async cancel(reason): Promise<void> {
+      try {
+        await reader.cancel?.(reason);
+      } finally {
+        releaseReader();
+      }
+    },
+  });
+}
 
 // Resolve admin UI dist path at module load time. Gracefully handle the case
 // where the admin UI package is not installed.
@@ -574,19 +615,14 @@ export class HttpApi {
       return Response.json(reply, { status: 400 });
     }
 
-    // Materialise the request body before passing to DWN.
-    // Bun's Bun.serve() returns a ReadableStream for req.body that is
-    // incompatible with the ReadableStream consumer code in dwn-sdk-js,
-    // causing DataStream.toBytes() to crash with "undefined is not a
-    // function" at reader.releaseLock().  Buffering via arrayBuffer()
-    // converts it into a well-behaved stream that dwn-sdk-js can consume.
-    // TODO: https://github.com/enboxorg/enbox/issues/90 — remove once Bun ships fix
     const contentLength = req.headers.get('content-length');
     const transferEncoding = req.headers.get('transfer-encoding');
     let requestDataStream: ReadableStream<Uint8Array> | undefined;
     if (parseInt(contentLength ?? '0') > 0 || transferEncoding !== null) {
-      const bodyBytes = new Uint8Array(await req.arrayBuffer());
-      requestDataStream = DataStream.fromBytes(bodyBytes);
+      if (req.body === null) {
+        throw new Error('HTTP request advertised a body but no request body stream was available.');
+      }
+      requestDataStream = normalizeReadableStream(req.body);
     }
 
     const requestContext: RequestContext = {

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -24,7 +24,12 @@ import log from 'loglevel';
 import { Convert } from '@enbox/common';
 import { register } from 'prom-client';
 import { v4 as uuidv4 } from 'uuid';
-import { createJsonRpcErrorResponse, JsonRpcErrorCodes, maxWsJsonRpcPayloadBytes } from '@enbox/dwn-clients';
+import {
+  createJsonRpcErrorResponse,
+  JsonRpcErrorCodes,
+  maxWsJsonRpcPayloadBytes,
+  normalizeReadableStream,
+} from '@enbox/dwn-clients';
 import { DateSort, type Dwn, ProtocolsQuery, RecordsQuery, RecordsRead } from '@enbox/dwn-sdk-js';
 import { existsSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
@@ -38,47 +43,6 @@ import { requestCounter, responseHistogram } from './metrics.js';
 
 /** Property names that must never be used as keys when building objects from user input. */
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-type ReadableStreamReader = {
-  cancel?: (reason?: unknown) => Promise<void>;
-  read(): Promise<{ done: boolean; value?: Uint8Array }>;
-  releaseLock?: () => void;
-};
-
-function normalizeReadableStream(readableStream: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
-  const reader = readableStream.getReader() as ReadableStreamReader;
-  let readerReleased = false;
-
-  const releaseReader = (): void => {
-    if (readerReleased) {
-      return;
-    }
-
-    reader.releaseLock?.();
-    readerReleased = true;
-  };
-
-  return new ReadableStream<Uint8Array>({
-    async pull(controller): Promise<void> {
-      const { done, value } = await reader.read();
-      if (done) {
-        releaseReader();
-        controller.close();
-        return;
-      }
-
-      controller.enqueue(value!);
-    },
-
-    async cancel(reason): Promise<void> {
-      try {
-        await reader.cancel?.(reason);
-      } finally {
-        releaseReader();
-      }
-    },
-  });
-}
 
 // Resolve admin UI dist path at module load time. Gracefully handle the case
 // where the admin UI package is not installed.
@@ -620,7 +584,10 @@ export class HttpApi {
     let requestDataStream: ReadableStream<Uint8Array> | undefined;
     if (parseInt(contentLength ?? '0') > 0 || transferEncoding !== null) {
       if (req.body === null) {
-        throw new Error('HTTP request advertised a body but no request body stream was available.');
+        const reply = createJsonRpcErrorResponse(
+          dwnRpcRequest.id, JsonRpcErrorCodes.BadRequest, 'request advertised a body but none was provided.'
+        );
+        return Response.json(reply, { status: 400 });
       }
       requestDataStream = normalizeReadableStream(req.body);
     }

--- a/packages/dwn-server/tests/http-api.test.ts
+++ b/packages/dwn-server/tests/http-api.test.ts
@@ -205,6 +205,39 @@ describe('http api', function () {
   });
 
   describe('RecordsWrite', function () {
+    it('streams RecordsWrite request bodies into the DWN', async function () {
+      const dataBytes = new Uint8Array(1_048_577);
+      dataBytes.fill(7);
+      dataBytes[0] = 1;
+      dataBytes[dataBytes.length - 1] = 255;
+
+      const { recordsWrite, dataStream } = await createRecordsWriteMessage(alice, { data: dataBytes });
+
+      const requestId = uuidv4();
+      const dwnRequest = createJsonRpcRequest(requestId, 'dwn.processMessage', {
+        message : recordsWrite.toJSON(),
+        target  : alice.did,
+      });
+
+      const response = await fetch(baseUrl, {
+        method  : 'POST',
+        headers : {
+          'dwn-request': JSON.stringify(dwnRequest),
+        },
+        body   : dataStream,
+        duplex : 'half',
+      } as RequestInit & { duplex: 'half' });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as JsonRpcResponse;
+      expect(body.error).toBeUndefined();
+      expect(body.id).toBe(requestId);
+
+      const { reply } = body.result;
+      expect(reply.status.code).toBe(202);
+    });
+
     it('handles RecordsWrite overwrite that does not mutate data', async function () {
       // First RecordsWrite that creates the record.
       const { recordsWrite: initialWrite, dataStream } =

--- a/packages/dwn-sql-store/package.json
+++ b/packages/dwn-sql-store/package.json
@@ -35,7 +35,7 @@
     "multiformats": "11.0.2"
   },
   "devDependencies": {
-    "@types/bun": "1.3.10",
+    "@types/bun": "1.3.14",
     "@types/express": "4.17.17",
     "@types/node": "22.19.15",
     "@types/pg": "8.10.2",
@@ -43,7 +43,7 @@
     "@types/supertest": "2.0.12",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "esbuild": "0.23.0",
     "eslint": "9.7.0",
     "mysql2": "3.9.8",

--- a/packages/dwn-sql-store/src/data-store-s3.ts
+++ b/packages/dwn-sql-store/src/data-store-s3.ts
@@ -3,7 +3,7 @@ import type { DwnDatabaseType } from './types.js';
 import type { DataStore, DataStoreGetResult, DataStorePutResult } from '@enbox/dwn-sdk-js';
 
 import * as DataRefs from './utils/data-refs.js';
-import { DataStream } from '@enbox/dwn-sdk-js';
+import { drainReadableStream } from './utils/stream.js';
 import { Readable } from 'stream';
 import { Upload } from '@aws-sdk/lib-storage';
 import {
@@ -106,7 +106,7 @@ export class DataStoreS3 implements DataStore {
 
     const existingDataSize = await DataRefs.getDataRefSize(db, { tenant, recordId, dataCid });
     if (existingDataSize !== undefined) {
-      await DataStream.toBytes(dataStream);
+      await drainReadableStream(dataStream);
       return { dataSize: existingDataSize };
     }
 
@@ -120,7 +120,7 @@ export class DataStoreS3 implements DataStore {
       dataSize = await this.#uploadToS3(dataCid, dataStream);
     } else {
       // S3 object already exists — skip upload.
-      await DataStream.toBytes(dataStream);
+      await drainReadableStream(dataStream);
       dataSize = otherDataSize;
     }
 
@@ -196,15 +196,54 @@ export class DataStoreS3 implements DataStore {
 
     // Create a Node Readable from the web ReadableStream, counting bytes.
     const reader = dataStream.getReader();
+    let readerReleased = false;
+    const releaseReader = (): void => {
+      if (!readerReleased) {
+        reader.releaseLock();
+        readerReleased = true;
+      }
+    };
+    const cancelReader = async (reason?: unknown): Promise<void> => {
+      if (readerReleased) {
+        return;
+      }
+
+      try {
+        await reader.cancel(reason);
+      } finally {
+        releaseReader();
+      }
+    };
+
     const nodeStream = new Readable({
       async read(): Promise<void> {
-        const { done, value } = await reader.read();
-        if (done) {
-          this.push(null);
-        } else {
-          dataSize += value.byteLength;
-          this.push(Buffer.from(value));
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            releaseReader();
+            this.push(null);
+          } else {
+            dataSize += value.byteLength;
+            this.push(Buffer.from(value));
+          }
+        } catch (error: unknown) {
+          try {
+            await cancelReader(error);
+          } catch {
+            // Preserve the original stream read error.
+          }
+          this.destroy(error as Error);
         }
+      },
+      destroy(error: Error | null, callback: (error?: Error | null) => void): void {
+        void (async (): Promise<void> => {
+          try {
+            await cancelReader(error ?? undefined);
+            callback(error);
+          } catch (cancelError: unknown) {
+            callback((error ?? cancelError) as Error);
+          }
+        })();
       },
     });
 
@@ -224,19 +263,11 @@ export class DataStoreS3 implements DataStore {
 
       await upload.done();
     } else {
-      // Fallback: buffer entire stream (only for tiny test payloads).
-      const chunks: Uint8Array[] = [];
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) { break; }
-        dataSize += value.byteLength;
-        chunks.push(value);
-      }
-      const body = Buffer.concat(chunks);
+      // Single-part upload still streams from the caller; it does not buffer the body in-process.
       await this.#s3.send(new PutObjectCommand({
         Bucket : this.#bucket,
         Key    : dataCid,
-        Body   : body,
+        Body   : nodeStream,
       }));
     }
 

--- a/packages/dwn-sql-store/src/data-store-sql.ts
+++ b/packages/dwn-sql-store/src/data-store-sql.ts
@@ -7,6 +7,7 @@ import * as DataRefs from './utils/data-refs.js';
 import { BlockstoreSql } from './blockstore-sql.js';
 import { CID } from 'multiformats';
 import { DataStream } from '@enbox/dwn-sdk-js';
+import { drainReadableStream } from './utils/stream.js';
 import { exporter } from 'ipfs-unixfs-exporter';
 import { importer } from 'ipfs-unixfs-importer';
 import { Kysely, sql } from 'kysely';
@@ -93,7 +94,7 @@ export class DataStoreSql implements DataStore {
     const existingDataSize = await DataRefs.getDataRefSize(db, { tenant, recordId, dataCid });
     if (existingDataSize !== undefined) {
       // Drain the stream — caller expects it to be consumed.
-      await DataStream.toBytes(dataStream);
+      await drainReadableStream(dataStream);
       return { dataSize: existingDataSize };
     }
 
@@ -115,7 +116,7 @@ export class DataStoreSql implements DataStore {
       } else {
         dataSize = otherDataSize;
         // Drain the stream — caller expects it to be consumed.
-        await DataStream.toBytes(dataStream);
+        await drainReadableStream(dataStream);
       }
     } else {
       // New data — clean up any partial blocks from interrupted imports,
@@ -201,13 +202,19 @@ export class DataStoreSql implements DataStore {
   static async #countStreamBytes(stream: ReadableStream<Uint8Array>): Promise<number> {
     const reader = stream.getReader();
     let size = 0;
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        size += value.byteLength;
       }
-      size += value.byteLength;
+    } finally {
+      reader.releaseLock();
     }
+
     return size;
   }
 }

--- a/packages/dwn-sql-store/src/utils/stream.ts
+++ b/packages/dwn-sql-store/src/utils/stream.ts
@@ -1,0 +1,15 @@
+/** Consumes a stream to completion without retaining its chunks. */
+export async function drainReadableStream(stream: ReadableStream<Uint8Array>): Promise<void> {
+  const reader = stream.getReader();
+
+  try {
+    for (;;) {
+      const { done } = await reader.read();
+      if (done) {
+        return;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/electrobun-dwn/electrobun.config.ts
+++ b/packages/electrobun-dwn/electrobun.config.ts
@@ -43,7 +43,8 @@ export default {
     exitOnLastWindowClosed: false,
   },
   build: {
-    views: {
+    bunVersion : '1.3.14',
+    views      : {
       mainview: {
         entrypoint : 'src/mainview/index.ts',
         conditions : ['browser'],

--- a/packages/electrobun-dwn/package.json
+++ b/packages/electrobun-dwn/package.json
@@ -14,6 +14,9 @@
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix --max-warnings 0"
   },
+  "engines": {
+    "bun": ">=1.3.14"
+  },
   "dependencies": {
     "@digitalbazaar/did-io": "2.1.0",
     "@enbox/agent": "workspace:*",

--- a/packages/electrobun-dwn/package.json
+++ b/packages/electrobun-dwn/package.json
@@ -33,6 +33,6 @@
     "syntax-highlight-element": "1.2.0"
   },
   "devDependencies": {
-    "@types/bun": "1.3.10"
+    "@types/bun": "1.3.14"
   }
 }

--- a/packages/electrobun-dwn/src/mainview/identity-runtime.ts
+++ b/packages/electrobun-dwn/src/mainview/identity-runtime.ts
@@ -1104,10 +1104,9 @@ class IdentityRuntimeController implements IdentityRuntime {
       return;
     }
 
-    const normalizedFile = await this._materializeBlob(file);
-    const dataFormat = normalizedFile.type || existingRecord?.dataFormat || undefined;
+    const dataFormat = file.type || existingRecord?.dataFormat || undefined;
     if (existingRecord) {
-      const updateResult = await existingRecord.update({ data: normalizedFile, dataFormat });
+      const updateResult = await existingRecord.update({ data: file, dataFormat });
       if (updateResult.status.code >= 300) {
         throw new Error(updateResult.status.detail || `Failed to update ${path} image (${updateResult.status.code}).`);
       }
@@ -1115,18 +1114,13 @@ class IdentityRuntimeController implements IdentityRuntime {
     }
 
     const createResult = await typed.records.create(path, {
-      data: normalizedFile,
+      data: file,
       parentContextId,
       dataFormat,
     });
     if (createResult.status.code >= 300) {
       throw new Error(createResult.status.detail || `Failed to create ${path} image (${createResult.status.code}).`);
     }
-  }
-
-  private async _materializeBlob(blob: Blob): Promise<Blob> {
-    const bytes = await blob.arrayBuffer();
-    return new Blob([bytes], { type: blob.type });
   }
 
   private async _ensureConnected(password?: string): Promise<void> {

--- a/packages/protocol-codegen/package.json
+++ b/packages/protocol-codegen/package.json
@@ -58,7 +58,7 @@
     "@types/yargs": "17.0.35",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "eslint": "9.7.0",
     "typescript": "5.9.3"
   }

--- a/packages/protocols/package.json
+++ b/packages/protocols/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "bun-types": "1.3.10",
+    "bun-types": "1.3.14",
     "eslint": "9.7.0",
     "typescript": "5.9.3"
   }


### PR DESCRIPTION
Summary
- Require Bun >=1.3.14 for the stream-safe fetch behavior this change now depends on, and pin Electrobun's embedded Bun runtime to 1.3.14.
- Remove the Bun fetch buffering fork entirely: request bodies now use built-in streaming with `duplex: 'half'`, responses/server request bodies are normalized through one shared helper, and one-shot streams are not retried after consumption.
- Address the reviewer fixes: delete the dead Bun runtime probe, return a structured 400 JSON-RPC error for advertised-but-missing request bodies, share the stream normalizer, and release/cancel source readers on read failure.
- Extend the streaming audit beyond dwn-clients: agent/API remote send paths pass `ReadableStream`s instead of `Blob` copies, SQL/S3 dedup paths drain without retaining chunks, S3 single-part uploads stream to `PutObject`, Electrobun image uploads keep the original `File`/`Blob`, and a dead live-pull event-data buffering branch is removed.

Audit notes
- Remaining full materialization is intentional and bounded to the 30 KB inline threshold, explicit caller APIs such as `.bytes()`/`.blob()`/`.text()`/`.json()`, small control records, or WebSocket JSON-RPC's non-streaming base64 transport.
- Agent encryption still materializes plaintext/ciphertext today; true streaming encryption/CID/JWE handling is a larger follow-up outside this transport/storage fix.

Closes #90

Test plan
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run lint:fix`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run lint`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run build`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run --filter @enbox/electrobun-dwn build`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bunx changeset status`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun test tests/http-api.test.ts` from `packages/dwn-server`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/http-dwn-rpc-client.spec.ts` from `packages/dwn-clients`, with a local dwn-server on `:3000`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run test` from `packages/dwn-sql-store`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun test tests/record-coverage.spec.ts` from `packages/api`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test --timeout 10000 $(find tests -name '*.spec.ts' ! -name 'protocols-integration.spec.ts')` from `packages/api`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node` from `packages/agent`