### PR TITLE
fix(dwn-sql-store): always use Upload for S3 streams

### DIFF
--- a/.changeset/s3-upload-streaming.md
+++ b/.changeset/s3-upload-streaming.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sql-store": patch
+---
+
+fix: always use the S3 Upload helper for streamed object writes.

--- a/packages/dwn-sql-store/src/data-store-s3.ts
+++ b/packages/dwn-sql-store/src/data-store-s3.ts
@@ -15,7 +15,8 @@ import {
 } from '@aws-sdk/client-s3';
 import { Kysely, sql } from 'kysely';
 
-const DEFAULT_PART_SIZE = 5 * 1024 * 1024;
+const MIN_PART_SIZE = 5 * 1024 * 1024;
+const DEFAULT_PART_SIZE = MIN_PART_SIZE;
 const DEFAULT_QUEUE_SIZE = 4;
 
 /**
@@ -45,8 +46,12 @@ export class DataStoreS3 implements DataStore {
     this.#partSize = config.partSize ?? DEFAULT_PART_SIZE;
     this.#queueSize = config.queueSize ?? DEFAULT_QUEUE_SIZE;
 
-    if (!Number.isFinite(this.#partSize) || this.#partSize <= 0) {
-      throw new Error('DataStoreS3: partSize must be greater than 0.');
+    if (!Number.isInteger(this.#partSize) || this.#partSize < MIN_PART_SIZE) {
+      throw new Error('DataStoreS3: partSize must be at least 5 MiB.');
+    }
+
+    if (!Number.isInteger(this.#queueSize) || this.#queueSize <= 0) {
+      throw new Error('DataStoreS3: queueSize must be a positive integer.');
     }
 
     this.#s3 = config.s3Client ?? new S3Client({
@@ -310,9 +315,9 @@ export type DataStoreS3Config = {
   /** AWS credentials. When omitted, the SDK uses the default credential chain (IAM role, env vars, etc.). */
   credentials?: { accessKeyId: string; secretAccessKey: string };
 
-  /** Multipart upload part size in bytes. Default: `5 * 1024 * 1024` (5 MB). */
+  /** Multipart upload part size in bytes. Minimum and default: `5 * 1024 * 1024` (5 MiB). */
   partSize?: number;
 
-  /** Number of concurrent multipart upload parts. Default: `4`. */
+  /** Number of concurrent multipart upload parts. Must be a positive integer. Default: `4`. */
   queueSize?: number;
 };

--- a/packages/dwn-sql-store/src/data-store-s3.ts
+++ b/packages/dwn-sql-store/src/data-store-s3.ts
@@ -11,10 +11,12 @@ import {
   DeleteObjectsCommand,
   GetObjectCommand,
   ListObjectsV2Command,
-  PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
 import { Kysely, sql } from 'kysely';
+
+const DEFAULT_PART_SIZE = 5 * 1024 * 1024;
+const DEFAULT_QUEUE_SIZE = 4;
 
 /**
  * S3-backed implementation of {@link DataStore} with SQL-based reference
@@ -25,9 +27,9 @@ import { Kysely, sql } from 'kysely';
  * reference it. A `dataRefs` SQL table tracks references; blocks are
  * garbage-collected from S3 when the last ref is deleted.
  *
- * For files over `partSize` (default 5MB), the AWS SDK Upload helper
- * automatically uses multipart upload with bounded memory
- * (`queueSize * partSize`).
+ * The AWS SDK Upload helper accepts unknown-length stream bodies, using a
+ * single PUT for small payloads and multipart upload for larger payloads with
+ * bounded memory (`queueSize * partSize`).
  */
 export class DataStoreS3 implements DataStore {
   readonly #dialect: Dialect;
@@ -40,8 +42,12 @@ export class DataStoreS3 implements DataStore {
   constructor(config: DataStoreS3Config) {
     this.#dialect = config.dialect;
     this.#bucket = config.bucket;
-    this.#partSize = config.partSize ?? 5 * 1024 * 1024; // 5 MB
-    this.#queueSize = config.queueSize ?? 4;
+    this.#partSize = config.partSize ?? DEFAULT_PART_SIZE;
+    this.#queueSize = config.queueSize ?? DEFAULT_QUEUE_SIZE;
+
+    if (!Number.isFinite(this.#partSize) || this.#partSize <= 0) {
+      throw new Error('DataStoreS3: partSize must be greater than 0.');
+    }
 
     this.#s3 = config.s3Client ?? new S3Client({
       region         : config.region ?? 'us-east-1',
@@ -247,29 +253,18 @@ export class DataStoreS3 implements DataStore {
       },
     });
 
-    // For small files, a simple PutObject suffices. For large files,
-    // Upload handles multipart automatically with bounded memory.
-    if (this.#partSize > 0) {
-      const upload = new Upload({
-        client : this.#s3,
-        params : {
-          Bucket : this.#bucket,
-          Key    : dataCid,
-          Body   : nodeStream,
-        },
-        queueSize : this.#queueSize,
-        partSize  : this.#partSize,
-      });
-
-      await upload.done();
-    } else {
-      // Single-part upload still streams from the caller; it does not buffer the body in-process.
-      await this.#s3.send(new PutObjectCommand({
+    const upload = new Upload({
+      client : this.#s3,
+      params : {
         Bucket : this.#bucket,
         Key    : dataCid,
         Body   : nodeStream,
-      }));
-    }
+      },
+      queueSize : this.#queueSize,
+      partSize  : this.#partSize,
+    });
+
+    await upload.done();
 
     return dataSize;
   }

--- a/packages/dwn-sql-store/tests/store-guards.spec.ts
+++ b/packages/dwn-sql-store/tests/store-guards.spec.ts
@@ -186,27 +186,34 @@ describe('Store guards — db not open', () => {
   // ─── DataStoreS3 ──────────────────────────────────────────────────────
 
   describe('DataStoreS3', () => {
-    // Construct with a stub S3Client — the guard fires before any S3 call.
-    const store = new DataStoreS3({
+    const createStore = (config: { partSize?: number; queueSize?: number } = {}): DataStoreS3 => new DataStoreS3({
       dialect  : dialect,
       bucket   : 'test-bucket',
       s3Client : {} as any,
+      ...config,
     });
 
-    it('should reject non-positive partSize values', () => {
-      expect(() => new DataStoreS3({
-        dialect  : dialect,
-        bucket   : 'test-bucket',
-        partSize : 0,
-        s3Client : {} as any,
-      })).toThrow('DataStoreS3: partSize must be greater than 0.');
+    // Construct with a stub S3Client — the guard fires before any S3 call.
+    const store = createStore();
 
-      expect(() => new DataStoreS3({
-        dialect  : dialect,
-        bucket   : 'test-bucket',
-        partSize : -1,
-        s3Client : {} as any,
-      })).toThrow('DataStoreS3: partSize must be greater than 0.');
+    it('should reject partSize values below the multipart minimum', () => {
+      const invalidPartSizes = [0, -1, 1, 5 * 1024 * 1024 - 1, 5 * 1024 * 1024 + 0.5];
+
+      for (const partSize of invalidPartSizes) {
+        expect(() => createStore({ partSize })).toThrow('DataStoreS3: partSize must be at least 5 MiB.');
+      }
+
+      expect(() => createStore({ partSize: 5 * 1024 * 1024 })).not.toThrow();
+    });
+
+    it('should reject invalid queueSize values', () => {
+      const invalidQueueSizes = [0, -1, 1.5, Number.NaN];
+
+      for (const queueSize of invalidQueueSizes) {
+        expect(() => createStore({ queueSize })).toThrow('DataStoreS3: queueSize must be a positive integer.');
+      }
+
+      expect(() => createStore({ queueSize: 1 })).not.toThrow();
     });
 
     it('should throw on get() without open()', async () => {

--- a/packages/dwn-sql-store/tests/store-guards.spec.ts
+++ b/packages/dwn-sql-store/tests/store-guards.spec.ts
@@ -193,6 +193,22 @@ describe('Store guards — db not open', () => {
       s3Client : {} as any,
     });
 
+    it('should reject non-positive partSize values', () => {
+      expect(() => new DataStoreS3({
+        dialect  : dialect,
+        bucket   : 'test-bucket',
+        partSize : 0,
+        s3Client : {} as any,
+      })).toThrow('DataStoreS3: partSize must be greater than 0.');
+
+      expect(() => new DataStoreS3({
+        dialect  : dialect,
+        bucket   : 'test-bucket',
+        partSize : -1,
+        s3Client : {} as any,
+      })).toThrow('DataStoreS3: partSize must be greater than 0.');
+    });
+
     it('should throw on get() without open()', async () => {
       await expect(store.get('tenant', 'record-1', 'cid-1')).rejects.toThrow(
         'Connection to database not open'


### PR DESCRIPTION
## Summary
- remove the invalid unknown-length stream path through `PutObjectCommand`
- always write S3 data through `@aws-sdk/lib-storage` `Upload` so small bodies can still single-PUT and larger bodies stay bounded by `queueSize * partSize`
- reject non-positive `partSize` values and add guard coverage

## Test plan
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run lint:fix`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run lint`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run build`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bunx changeset status`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run --filter @enbox/dwn-sql-store test`
- [x] `PATH=/tmp/bun-1.3.14/bun-linux-x64:$PATH bun run --filter @enbox/agent build`
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 DWN_BASE_URL=http://localhost:3000 bun run test:node` from `packages/agent` with local dwn-server on `:3000`