### PR TITLE
feat(dwn-sdk-js): mark permission records immutable

### DIFF
--- a/.changeset/permissions-immutable.md
+++ b/.changeset/permissions-immutable.md
@@ -1,0 +1,7 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+feat: mark permission records immutable
+
+The permissions protocol now sets `$immutable: true` on the `request`, `grant`, and `grant/revocation` paths. Permission records are write-once by design — a grant is never amended, it is revoked and re-issued — and immutability locks each record's initial-write facts (notably the `protocol` tag), which replication fingerprint domains and protocol-scoped shadow filters are computed from. Updates to existing permission records (including tags-only mutations) are now rejected with `ProtocolAuthorizationImmutableRecord` in both `processMessage` and `applyReplicatedMessage`; creating permission records and revoking grants are unaffected.

--- a/packages/dwn-sdk-js/src/protocols/permissions.ts
+++ b/packages/dwn-sdk-js/src/protocols/permissions.ts
@@ -131,8 +131,15 @@ export class PermissionsProtocol implements CoreProtocol {
       }
     },
     structure: {
+      // All permission record paths are `$immutable`: requests, grants, and revocations are
+      // write-once by design (a grant is never amended — it is revoked and re-issued).
+      // Immutability locks each record's initial-write facts (notably the `protocol` tag),
+      // which replication fingerprint domains and protocol-scoped shadow filters depend on —
+      // a tag-mutated permission record would otherwise drift between the shadow-filter
+      // stream (current tags) and its fingerprint domain (initial tags).
       request: {
-        $size: {
+        $immutable : true,
+        $size      : {
           max: 10000
         },
         $actions: [
@@ -143,7 +150,8 @@ export class PermissionsProtocol implements CoreProtocol {
         ]
       },
       grant: {
-        $size: {
+        $immutable : true,
+        $size      : {
           max: 10000
         },
         $actions: [
@@ -154,7 +162,8 @@ export class PermissionsProtocol implements CoreProtocol {
           }
         ],
         revocation: {
-          $size: {
+          $immutable : true,
+          $size      : {
             max: 10000
           },
           $actions: [

--- a/packages/dwn-sdk-js/tests/features/permissions.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/permissions.spec.ts
@@ -1458,5 +1458,239 @@ export function testPermissions(): void {
         expect(queryAfterReply.entries![0].recordId).toBe(write1.recordsWrite.message.recordId);
       });
     });
+
+    describe('permission record immutability', () => {
+      // Permission records (requests, grants, and revocations) are `$immutable`: a grant is
+      // never amended — it is revoked and re-issued. Immutability also locks each record's
+      // initial-write facts (notably the `protocol` tag), which replication fingerprint
+      // domains and protocol-scoped shadow filters are computed from.
+
+      it('should reject an update to an existing permission grant record', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        // Alice creates a permission grant for Bob — the initial write is allowed.
+        const grantWrite = await PermissionsProtocol.createGrant({
+          signer      : Jws.createSigner(alice),
+          dateExpires : Time.createOffsetTimestamp({ seconds: 100 }),
+          description : 'Allow Bob to write',
+          grantedTo   : bob.did,
+          scope       : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Write,
+            protocol  : 'https://example.com/protocol/test'
+          }
+        });
+
+        const grantWriteReply = await dwn.processMessage(
+          alice.did,
+          grantWrite.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(grantWrite.permissionGrantBytes) }
+        );
+        expect(grantWriteReply.status.code).toBe(202);
+
+        // A non-initial RecordsWrite to the same grant record is rejected by `$immutable`.
+        const grantUpdate = await RecordsWrite.createFrom({
+          recordsWriteMessage : grantWrite.recordsWrite.message,
+          data                : grantWrite.permissionGrantBytes,
+          signer              : Jws.createSigner(alice),
+        });
+
+        const grantUpdateReply = await dwn.processMessage(
+          alice.did,
+          grantUpdate.message,
+          { dataStream: DataStream.fromBytes(grantWrite.permissionGrantBytes) }
+        );
+        expect(grantUpdateReply.status.code).toBe(400);
+        expect(grantUpdateReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationImmutableRecord);
+      });
+
+      it('should reject a tags-only mutation of an existing permission grant record', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        // Alice creates a protocol-scoped grant; the scoped protocol is carried in `tags.protocol`.
+        const grantWrite = await PermissionsProtocol.createGrant({
+          signer      : Jws.createSigner(alice),
+          dateExpires : Time.createOffsetTimestamp({ seconds: 100 }),
+          description : 'Allow Bob to write',
+          grantedTo   : bob.did,
+          scope       : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Write,
+            protocol  : 'https://example.com/protocol/test'
+          }
+        });
+
+        const grantWriteReply = await dwn.processMessage(
+          alice.did,
+          grantWrite.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(grantWrite.permissionGrantBytes) }
+        );
+        expect(grantWriteReply.status.code).toBe(202);
+
+        // A tags-only mutation (no data change) is still a non-initial RecordsWrite and must be
+        // rejected — a retagged grant would drift between the protocol shadow-filter stream
+        // (current tags) and its replication fingerprint domain (initial-write tags).
+        const grantUpdate = await RecordsWrite.createFrom({
+          recordsWriteMessage : grantWrite.recordsWrite.message,
+          tags                : { protocol: 'https://example.com/protocol/other' },
+          signer              : Jws.createSigner(alice),
+        });
+
+        const grantUpdateReply = await dwn.processMessage(alice.did, grantUpdate.message);
+        expect(grantUpdateReply.status.code).toBe(400);
+        expect(grantUpdateReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationImmutableRecord);
+      });
+
+      it('should reject an update to an existing permission request record', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        // Bob creates a permission request in Alice's DWN — the initial write is allowed.
+        const requestWrite = await PermissionsProtocol.createRequest({
+          signer      : Jws.createSigner(bob),
+          description : 'Requesting to write',
+          delegated   : false,
+          scope       : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Write,
+            protocol  : 'https://example.com/protocol/test'
+          }
+        });
+
+        const requestWriteReply = await dwn.processMessage(
+          alice.did,
+          requestWrite.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(requestWrite.permissionRequestBytes) }
+        );
+        expect(requestWriteReply.status.code).toBe(202);
+
+        // Even the original author cannot update the request record.
+        const requestUpdate = await RecordsWrite.createFrom({
+          recordsWriteMessage : requestWrite.recordsWrite.message,
+          data                : requestWrite.permissionRequestBytes,
+          signer              : Jws.createSigner(bob),
+        });
+
+        const requestUpdateReply = await dwn.processMessage(
+          alice.did,
+          requestUpdate.message,
+          { dataStream: DataStream.fromBytes(requestWrite.permissionRequestBytes) }
+        );
+        expect(requestUpdateReply.status.code).toBe(400);
+        expect(requestUpdateReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationImmutableRecord);
+      });
+
+      it('should still allow revoking a grant but reject updates to the revocation record', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        // Alice creates a permission grant for Bob.
+        const grantWrite = await PermissionsProtocol.createGrant({
+          signer      : Jws.createSigner(alice),
+          dateExpires : Time.createOffsetTimestamp({ seconds: 100 }),
+          description : 'Allow Bob to write',
+          grantedTo   : bob.did,
+          scope       : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Write,
+            protocol  : 'https://example.com/protocol/test'
+          }
+        });
+
+        const grantWriteReply = await dwn.processMessage(
+          alice.did,
+          grantWrite.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(grantWrite.permissionGrantBytes) }
+        );
+        expect(grantWriteReply.status.code).toBe(202);
+
+        // Revoking the grant still works: the revocation is a new record (an initial write
+        // under the grant), so `$immutable` on the grant path does not block it.
+        const revocationWrite = await PermissionsProtocol.createRevocation({
+          signer : Jws.createSigner(alice),
+          grant  : PermissionGrant.parse(grantWrite.dataEncodedMessage),
+        });
+
+        const revocationWriteReply = await dwn.processMessage(
+          alice.did,
+          revocationWrite.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(revocationWrite.permissionRevocationBytes) }
+        );
+        expect(revocationWriteReply.status.code).toBe(202);
+
+        // The revocation record itself is immutable as well.
+        const revocationUpdate = await RecordsWrite.createFrom({
+          recordsWriteMessage : revocationWrite.recordsWrite.message,
+          data                : revocationWrite.permissionRevocationBytes,
+          signer              : Jws.createSigner(alice),
+        });
+
+        const revocationUpdateReply = await dwn.processMessage(
+          alice.did,
+          revocationUpdate.message,
+          { dataStream: DataStream.fromBytes(revocationWrite.permissionRevocationBytes) }
+        );
+        expect(revocationUpdateReply.status.code).toBe(400);
+        expect(revocationUpdateReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationImmutableRecord);
+      });
+
+      it('should reject replicated updates to permission records in applyReplicatedMessage', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        // A replicated initial grant write is admitted.
+        const grantWrite = await PermissionsProtocol.createGrant({
+          signer      : Jws.createSigner(alice),
+          dateExpires : Time.createOffsetTimestamp({ seconds: 100 }),
+          description : 'Allow Bob to write',
+          grantedTo   : bob.did,
+          scope       : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Write,
+            protocol  : 'https://example.com/protocol/test'
+          }
+        });
+
+        const applyInitialResult = await dwn.applyReplicatedMessage(
+          alice.did,
+          grantWrite.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(grantWrite.permissionGrantBytes) }
+        );
+        expect(applyInitialResult).toEqual({ kind: 'Applied' });
+
+        // A replicated non-initial write to the same grant record is terminally invalid,
+        // not a missing-dependency retry.
+        const grantUpdate = await RecordsWrite.createFrom({
+          recordsWriteMessage : grantWrite.recordsWrite.message,
+          data                : grantWrite.permissionGrantBytes,
+          signer              : Jws.createSigner(alice),
+        });
+
+        const applyUpdateResult = await dwn.applyReplicatedMessage(
+          alice.did,
+          grantUpdate.message,
+          { dataStream: DataStream.fromBytes(grantWrite.permissionGrantBytes) }
+        );
+        expect(applyUpdateResult.kind).toBe('Invalid');
+        if (applyUpdateResult.kind === 'Invalid') {
+          expect(applyUpdateResult.reason).toContain(DwnErrorCode.ProtocolAuthorizationImmutableRecord);
+        }
+
+        // A replicated tags-only mutation is rejected the same way.
+        const grantTagsUpdate = await RecordsWrite.createFrom({
+          recordsWriteMessage : grantWrite.recordsWrite.message,
+          tags                : { protocol: 'https://example.com/protocol/other' },
+          signer              : Jws.createSigner(alice),
+        });
+
+        const applyTagsUpdateResult = await dwn.applyReplicatedMessage(alice.did, grantTagsUpdate.message);
+        expect(applyTagsUpdateResult.kind).toBe('Invalid');
+        if (applyTagsUpdateResult.kind === 'Invalid') {
+          expect(applyTagsUpdateResult.reason).toContain(DwnErrorCode.ProtocolAuthorizationImmutableRecord);
+        }
+      });
+    });
   });
 }

--- a/packages/dwn-sdk-js/tests/protocols/permissions.spec.ts
+++ b/packages/dwn-sdk-js/tests/protocols/permissions.spec.ts
@@ -1,4 +1,4 @@
-import type { MessageStore } from '../../src/index.js';
+import type { MessageStore, ProtocolRuleSet } from '../../src/index.js';
 
 import sinon from 'sinon';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
@@ -6,7 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { Jws } from '../../src/utils/jws.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestStores } from '../test-stores.js';
-import { DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, PermissionGrant, PermissionRequest, PermissionsProtocol, Time } from '../../src/index.js';
+import { DwnConstant, DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, PermissionGrant, PermissionRequest, PermissionsProtocol, ProtocolsConfigure, Time } from '../../src/index.js';
 
 describe('PermissionsProtocol', () => {
   let messageStore: MessageStore;
@@ -30,6 +30,52 @@ describe('PermissionsProtocol', () => {
 
   afterAll(async () => {
     await messageStore.close();
+  });
+
+  describe('protocol definition', () => {
+    it('should cap permission record sizes strictly below the inline-encoding threshold', () => {
+      // This relationship is load-bearing for grant replay during sync: a record whose data size
+      // is at most `DwnConstant.maxDataSizeAllowedToBeEncoded` is stored with `encodedData` inline
+      // in the message store, so a replayed permission record re-admits as latest-with-data and
+      // `PermissionGrant.parse()` (which requires `encodedData`) keeps working. If a `$size` max
+      // ever reached the threshold, permission record data could be stored out-of-line in the data
+      // store instead, and grant validation on replay would break.
+      const { structure } = PermissionsProtocol.definition;
+      const revocation = structure.grant.revocation as ProtocolRuleSet;
+
+      expect(structure.request.$size!.max!).toBeLessThan(DwnConstant.maxDataSizeAllowedToBeEncoded);
+      expect(structure.grant.$size!.max!).toBeLessThan(DwnConstant.maxDataSizeAllowedToBeEncoded);
+      expect(revocation.$size!.max!).toBeLessThan(DwnConstant.maxDataSizeAllowedToBeEncoded);
+    });
+
+    it('should mark the request, grant, and revocation paths as $immutable', () => {
+      // Permission records are write-once: immutability locks their initial-write facts
+      // (notably the `protocol` tag) which replication fingerprint domains and
+      // protocol-scoped shadow filters are computed from.
+      const { structure } = PermissionsProtocol.definition;
+      const revocation = structure.grant.revocation as ProtocolRuleSet;
+
+      expect(structure.request.$immutable).toBe(true);
+      expect(structure.grant.$immutable).toBe(true);
+      expect(revocation.$immutable).toBe(true);
+    });
+
+    it('should pass ProtocolsConfigure validation without $immutable warnings', async () => {
+      // `$immutable: true` combined with `update`/`co-update` actions triggers a `console.warn`
+      // during ProtocolsConfigure rule-set validation. No permission record path grants update
+      // actions (permission records are never updated semantically), so validating the live
+      // definition must be warning-free.
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const warnSpy = sinon.spy(console, 'warn');
+
+      const protocolsConfigure = await ProtocolsConfigure.create({
+        definition : PermissionsProtocol.definition,
+        signer     : Jws.createSigner(alice),
+      });
+
+      expect(protocolsConfigure.message).toBeDefined();
+      expect(warnSpy.called).toBe(false);
+    });
   });
 
   describe('getScopeFromPermissionRecord', () => {


### PR DESCRIPTION
## Summary

Permissions-immutability stream of the sync replication-log plan (SDK item 5, permissions clauses).

- The permissions protocol definition now sets `$immutable: true` on the `request`, `grant`, and `grant/revocation` paths. Permission records are write-once by design — a grant is never amended, it is revoked and re-issued. Immutability locks each record's initial-write facts (notably the `protocol` tag), which replication fingerprint domains and protocol-scoped shadow filters are computed from; a tag-mutated permission record would otherwise drift between the shadow-filter stream (current tags) and its fingerprint domain (initial tags).
- Updates to existing permission records — including tags-only mutations — are rejected with `ProtocolAuthorizationImmutableRecord` (400) in `processMessage`, and map to `{ kind: 'Invalid' }` in `applyReplicatedMessage`. Creation, grant revocation, and the revocation-cleanup core-protocol hooks are unaffected.
- New definition-level tests pin the existing `$size` caps (10,000) strictly below `DwnConstant.maxDataSizeAllowedToBeEncoded` (30,000): permission record data is structurally inline-and-retained, which grant replay depends on (`PermissionGrant.parse` requires `encodedData`).
- A validation pin runs `ProtocolsConfigure.create` over the live definition and asserts no `$immutable`/`$actions` warning fires: no permission path grants `update`/`co-update` actions, so the known `$immutable`-overrides-update validation warning does not apply.

No existing tests updated permission records, so no pinned semantics had to be retired.

## Test plan

- [x] `bun run lint:fix` + `bun run lint` clean (15/15 tasks)
- [x] `bun run --filter @enbox/dwn-sdk-js build` exit 0
- [x] `bun run --filter @enbox/agent build` exit 0
- [x] `cd packages/dwn-sdk-js && bun run test:node`: 1466 pass, 1 todo, 0 fail (113 files) — full permissions/grant surface including delegated grants and revocation cleanup
- [x] New: 3 definition tests (`tests/protocols/permissions.spec.ts`) + 5 enforcement tests (`tests/features/permissions.spec.ts`) covering grant/request/revocation update rejection (data and tags-only) in both `processMessage` and `applyReplicatedMessage`, creation still admitted, revocation flow intact
- [x] `bunx changeset status` valid (patch `@enbox/dwn-sdk-js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
