### PR TITLE
fix(dwn-sdk-js): emit all missing ancestor refs in one Incomplete

### DIFF
--- a/.changeset/layer-batched-ancestor-refs.md
+++ b/.changeset/layer-batched-ancestor-refs.md
@@ -1,0 +1,7 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+fix: emit all missing ancestor refs in one Incomplete
+
+`applyReplicatedMessage` now layer-batches missing-ancestor dependencies: the incoming message's `contextId` is split into its recordId segments, each segment above the failure-named ancestor is presence-checked against the message store, and a single `Incomplete` names every locally-absent ancestor — for both the immediate-parent referential failure and record-chain construction failure — instead of surfacing one ancestry level per retry pass. Deep record chains now resolve in a bounded number of passes regardless of depth. Refs remain recordId selectors and the wire shape is unchanged.

--- a/packages/dwn-sdk-js/src/core/replication-apply.ts
+++ b/packages/dwn-sdk-js/src/core/replication-apply.ts
@@ -1,8 +1,10 @@
 import type { GenericMessage } from '../types/message-types.js';
+import type { MessageStore } from '../types/message-store.js';
 import type { ProtocolDefinition } from '../types/protocols-types.js';
 
 import { DwnErrorCode } from './dwn-error.js';
 import { Encoder } from '../utils/encoder.js';
+import { fetchInitialWrite } from './record-chain.js';
 import { Message } from './message.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 import { isCrossProtocolRef, parseCrossProtocolRef } from '../utils/protocols.js';
@@ -21,6 +23,15 @@ export type ReplicationApplyResult =
 
 export type ReplicationApplyResultContext = {
   protocolDefinition?: ProtocolDefinition;
+
+  /**
+   * Complete set of locally-missing ancestor recordIds for a missing-ancestor failure
+   * (immediate parent or record-chain construction), ordered root-first with the failure-named
+   * ancestor last, as computed by `missingAncestorRecordIdsFromReply()`. When present, the
+   * resulting `Incomplete` carries one ref per entry so the entire ancestry resolves in a
+   * single fetch pass instead of one ancestry level per retry.
+   */
+  missingAncestorRecordIds?: string[];
 };
 
 export type DependencyRef =
@@ -63,9 +74,9 @@ export function replicationApplyResultFromReply(
     return { kind: 'Deferred', reason: 'resolver-unavailable' };
   }
 
-  const missing = dependencyRefFromStatus(message, code, detail, context);
-  if (missing !== undefined) {
-    return { kind: 'Incomplete', missing: [missing] };
+  const missing = dependencyRefsFromStatus(message, code, detail, context);
+  if (missing.length > 0) {
+    return { kind: 'Incomplete', missing };
   }
 
   if (code >= 500) {
@@ -75,40 +86,107 @@ export function replicationApplyResultFromReply(
   return { kind: 'Invalid', reason: detail || `replicated message rejected with status ${code}` };
 }
 
-function dependencyRefFromStatus(
+/**
+ * Computes the complete set of locally-missing ancestor recordIds for a replicated message that
+ * failed on a missing ancestor — either the immediate parent referential check
+ * (`ProtocolAuthorizationParentRecordNotFound`) or record-chain construction
+ * (`ProtocolAuthorizationParentNotFoundConstructingRecordChain`).
+ *
+ * Both failures name a single ancestor, but the message's `contextId` names the full ancestor
+ * recordId chain, so every segment the failed check could not reach is presence-checked here and
+ * all absent segments are returned in one batch (ordered root-first, named ancestor last).
+ * Feeding the result to `replicationApplyResultFromReply()` via `ReplicationApplyResultContext`
+ * lets sync fetch the entire ancestry in a single pass instead of one level per retry.
+ *
+ * @returns the missing ancestor recordIds, or `undefined` when the reply is not a
+ *          missing-ancestor failure or the chain cannot be determined from the message (callers
+ *          then fall back to emitting the single ancestor named by the failure).
+ */
+export async function missingAncestorRecordIdsFromReply(
+  tenant: string,
+  message: GenericMessage,
+  reply: { status: { detail?: string } },
+  messageStore: MessageStore,
+): Promise<string[] | undefined> {
+  const detail = reply.status.detail ?? '';
+  const errorCode = getDwnErrorCode(detail);
+
+  let namedRecordId: string | undefined;
+  if (errorCode === DwnErrorCode.ProtocolAuthorizationParentRecordNotFound) {
+    namedRecordId = parentRecordIdFromMessage(message, detail);
+  } else if (errorCode === DwnErrorCode.ProtocolAuthorizationParentNotFoundConstructingRecordChain) {
+    namedRecordId = ancestorRecordIdFromDetail(detail);
+  } else {
+    return undefined;
+  }
+
+  const contextId = (message as { contextId?: unknown }).contextId;
+  if (namedRecordId === undefined || typeof contextId !== 'string') {
+    return undefined;
+  }
+
+  // `contextId` is the ancestor recordId chain ending with the record's own recordId. The failed
+  // check stopped at `namedRecordId`, so every segment below it is locally present; only the
+  // segments above it (closer to the root) still need a presence check. Presence means an initial
+  // write exists — exactly what record-chain construction reads for the segments above the
+  // immediate parent.
+  const ancestorRecordIds = contextId.split('/').slice(0, -1);
+  const namedIndex = ancestorRecordIds.indexOf(namedRecordId);
+  if (namedIndex === -1) {
+    return undefined;
+  }
+
+  const missingRecordIds: string[] = [];
+  for (const ancestorRecordId of ancestorRecordIds.slice(0, namedIndex)) {
+    const initialWrite = await fetchInitialWrite(tenant, ancestorRecordId, messageStore);
+    if (initialWrite === undefined) {
+      missingRecordIds.push(ancestorRecordId);
+    }
+  }
+  missingRecordIds.push(namedRecordId);
+
+  return missingRecordIds;
+}
+
+function dependencyRefsFromStatus(
   message: GenericMessage,
   code: number,
   detail: string,
   context: ReplicationApplyResultContext,
-): DependencyRef | undefined {
+): DependencyRef[] {
   const errorCode = getDwnErrorCode(detail);
   switch (errorCode) {
   case DwnErrorCode.ProtocolAuthorizationProtocolNotFound:
   case DwnErrorCode.ProtocolsConfigureComposedProtocolNotInstalled:
-    return protocolDependencyFromMessage(message, detail);
+    return toRefList(protocolDependencyFromMessage(message, detail));
   case DwnErrorCode.ProtocolAuthorizationParentRecordNotFound:
+    return parentDependenciesFromMessage(message, detail, context);
   case DwnErrorCode.ProtocolAuthorizationCrossProtocolParentNotFound:
-    return parentDependencyFromMessage(message, detail);
+    return toRefList(parentDependencyFromMessage(message, detail));
   case DwnErrorCode.ProtocolAuthorizationParentNotFoundConstructingRecordChain:
-    return ancestorDependencyFromMessage(message, detail);
+    return ancestorDependenciesFromMessage(message, detail, context);
   case DwnErrorCode.RecordsWriteGetInitialWriteNotFound:
-    return initialWriteDependencyFromMessage(message);
+    return toRefList(initialWriteDependencyFromMessage(message));
   case DwnErrorCode.GrantAuthorizationGrantMissing:
-    return grantDependencyFromMessage(message);
+    return toRefList(grantDependencyFromMessage(message));
   case DwnErrorCode.ProtocolAuthorizationMatchingRoleRecordNotFound:
-    return roleDependencyFromMessage(message, context);
+    return toRefList(roleDependencyFromMessage(message, context));
   case DwnErrorCode.RecordsWriteMissingDataInPrevious:
   case DwnErrorCode.RecordsWriteMissingEncodedDataInPrevious:
-    return recordDataDependencyFromMessage(message);
+    return toRefList(recordDataDependencyFromMessage(message));
   default:
     break;
   }
 
   if (code === 404 && isRecordsDelete(message)) {
-    return { type: 'InitialWrite', recordId: getRecordsDeleteRecordId(message) };
+    return [{ type: 'InitialWrite', recordId: getRecordsDeleteRecordId(message) }];
   }
 
-  return undefined;
+  return [];
+}
+
+function toRefList(ref: DependencyRef | undefined): DependencyRef[] {
+  return ref === undefined ? [] : [ref];
 }
 
 function getDwnErrorCode(detail: string): string | undefined {
@@ -130,32 +208,84 @@ function protocolDependencyFromMessage(message: GenericMessage, detail: string):
   return typeof protocol === 'string' ? { type: 'Protocol', protocol } : undefined;
 }
 
-function parentDependencyFromMessage(message: GenericMessage, detail: string): DependencyRef | undefined {
+/**
+ * Emits the refs for an immediate-parent referential failure. The missing parent keeps its
+ * existing `Parent` ref; when the apply context carries the layer-batched missing-ancestor set
+ * (see `missingAncestorRecordIdsFromReply()`), an `Ancestor` ref is additionally emitted for
+ * every locally-absent segment above the parent, so the entire ancestry resolves in a single
+ * fetch pass instead of one level per retry.
+ */
+function parentDependenciesFromMessage(
+  message: GenericMessage,
+  detail: string,
+  context: ReplicationApplyResultContext,
+): DependencyRef[] {
+  const parentRef = parentDependencyFromMessage(message, detail);
+  if (parentRef === undefined) {
+    return [];
+  }
+
+  const protocol = (message.descriptor as Record<string, unknown>).protocol;
+  const protocolProperty = typeof protocol === 'string' ? { protocol } : {};
+  const ancestorRefs = (context.missingAncestorRecordIds ?? [])
+    .filter((recordId): boolean => recordId !== parentRef.recordId)
+    .map((recordId): DependencyRef => ({ type: 'Ancestor', recordId, ...protocolProperty }));
+
+  return [...ancestorRefs, parentRef];
+}
+
+function parentDependencyFromMessage(
+  message: GenericMessage,
+  detail: string,
+): Extract<DependencyRef, { type: 'Parent' }> | undefined {
   const descriptor = message.descriptor as Record<string, unknown>;
-  const parentId = typeof descriptor.parentId === 'string'
-    ? descriptor.parentId
-    : /parent record '([^']+)'/.exec(detail)?.[1];
+  const parentId = parentRecordIdFromMessage(message, detail);
   const protocol = /in protocol '([^']+)'/.exec(detail)?.[1] ?? descriptor.protocol;
 
-  if (typeof parentId !== 'string' || typeof protocol !== 'string') {
+  if (parentId === undefined || typeof protocol !== 'string') {
     return undefined;
   }
 
   return { type: 'Parent', recordId: parentId, protocol };
 }
 
-function ancestorDependencyFromMessage(message: GenericMessage, detail: string): DependencyRef | undefined {
-  const recordId = /ID ([^ ]+)/.exec(detail)?.[1];
-  if (recordId === undefined) {
-    return undefined;
+function parentRecordIdFromMessage(message: GenericMessage, detail: string): string | undefined {
+  const descriptor = message.descriptor as Record<string, unknown>;
+  return typeof descriptor.parentId === 'string'
+    ? descriptor.parentId
+    : /parent record '([^']+)'/.exec(detail)?.[1];
+}
+
+/**
+ * Emits `Ancestor` refs for a record-chain construction failure. When the apply context carries
+ * the layer-batched missing-ancestor set (see `missingAncestorRecordIdsFromReply()`), one ref is
+ * emitted per missing segment so the entire ancestry resolves in a single fetch pass; otherwise
+ * falls back to the single ancestor named by the failure detail (e.g. for messages that carry no
+ * `contextId` chain).
+ */
+function ancestorDependenciesFromMessage(
+  message: GenericMessage,
+  detail: string,
+  context: ReplicationApplyResultContext,
+): DependencyRef[] {
+  const protocol = (message.descriptor as Record<string, unknown>).protocol;
+  const protocolProperty = typeof protocol === 'string' ? { protocol } : {};
+
+  const batchedRecordIds = context.missingAncestorRecordIds;
+  if (batchedRecordIds !== undefined && batchedRecordIds.length > 0) {
+    return batchedRecordIds.map((recordId): DependencyRef => ({ type: 'Ancestor', recordId, ...protocolProperty }));
   }
 
-  const protocol = (message.descriptor as Record<string, unknown>).protocol;
-  return {
-    type: 'Ancestor',
-    recordId,
-    ...(typeof protocol === 'string' ? { protocol } : {}),
-  };
+  const namedRecordId = ancestorRecordIdFromDetail(detail);
+  if (namedRecordId === undefined) {
+    return [];
+  }
+
+  return [{ type: 'Ancestor', recordId: namedRecordId, ...protocolProperty }];
+}
+
+function ancestorRecordIdFromDetail(detail: string): string | undefined {
+  return /ID ([^ ]+)/.exec(detail)?.[1];
 }
 
 function initialWriteDependencyFromMessage(message: GenericMessage): DependencyRef | undefined {

--- a/packages/dwn-sdk-js/src/dwn.ts
+++ b/packages/dwn-sdk-js/src/dwn.ts
@@ -35,11 +35,11 @@ import { RecordsReadHandler } from './handlers/records-read.js';
 import { RecordsSubscribeHandler } from './handlers/records-subscribe.js';
 import { RecordsWrite } from './interfaces/records-write.js';
 import { RecordsWriteHandler } from './handlers/records-write.js';
-import { replicationApplyResultFromReply } from './core/replication-apply.js';
 import { ResumableTaskManager } from './core/resumable-task-manager.js';
 import { StorageController } from './store/storage-controller.js';
 import { DidDht, DidJwk, DidKey, DidResolverCacheMemory, DidWeb, UniversalResolver } from '@enbox/dids';
 import { DwnInterfaceName, DwnMethodName } from './enums/dwn-interface-method.js';
+import { missingAncestorRecordIdsFromReply, replicationApplyResultFromReply } from './core/replication-apply.js';
 
 /**
  * Structural shape for `DidResolver` implementations that expose
@@ -265,7 +265,26 @@ export class Dwn {
 
     const reply = await this.processMessage(tenant, rawMessage, options);
     const protocolDefinition = await this.getReplicationApplyProtocolDefinition(tenant, rawMessage, reply);
-    return replicationApplyResultFromReply(rawMessage, reply, { protocolDefinition });
+    const missingAncestorRecordIds = await this.getReplicationApplyMissingAncestors(tenant, rawMessage, reply);
+    return replicationApplyResultFromReply(rawMessage, reply, { protocolDefinition, missingAncestorRecordIds });
+  }
+
+  /**
+   * Computes the layer-batched missing-ancestor set for a replicated message that failed on a
+   * missing ancestor (immediate parent or record-chain construction), so the resulting
+   * `Incomplete` names every locally-absent ancestor at once. Returns `undefined`
+   * (single-ancestor emission) when the set cannot be computed.
+   */
+  private async getReplicationApplyMissingAncestors(
+    tenant: string,
+    message: GenericMessage,
+    reply: { status: { detail?: string } },
+  ): Promise<string[] | undefined> {
+    try {
+      return await missingAncestorRecordIdsFromReply(tenant, message, reply, this.messageStore);
+    } catch {
+      return undefined;
+    }
   }
 
   private async getReplicationApplyProtocolDefinition(

--- a/packages/dwn-sdk-js/tests/core/replication-apply.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/replication-apply.spec.ts
@@ -87,6 +87,59 @@ describe('replicationApplyResultFromReply', () => {
     });
   });
 
+  it('emits Ancestor refs above a batched missing parent in a single Incomplete', async () => {
+    const protocol = 'https://example.com/protocol';
+    const { message } = await TestDataGenerator.generateRecordsWrite({ protocol });
+
+    expect(replicationApplyResultFromReply(message, {
+      status: {
+        code   : 400,
+        detail : `${DwnErrorCode.ProtocolAuthorizationParentRecordNotFound}: Could not find parent record 'baz-record'.`,
+      },
+    }, { missingAncestorRecordIds: ['foo-record', 'bar-record', 'baz-record'] })).toEqual({
+      kind    : 'Incomplete',
+      missing : [
+        { type: 'Ancestor', recordId: 'foo-record', protocol },
+        { type: 'Ancestor', recordId: 'bar-record', protocol },
+        { type: 'Parent', recordId: 'baz-record', protocol },
+      ],
+    });
+  });
+
+  it('emits one Ancestor ref per batched missing ancestor in a single Incomplete', async () => {
+    const protocol = 'https://example.com/protocol';
+    const { message } = await TestDataGenerator.generateRecordsWrite({ protocol });
+
+    expect(replicationApplyResultFromReply(message, {
+      status: {
+        code   : 401,
+        detail : `${DwnErrorCode.ProtocolAuthorizationParentNotFoundConstructingRecordChain}: parent with ID baz-record was not found`,
+      },
+    }, { missingAncestorRecordIds: ['foo-record', 'bar-record', 'baz-record'] })).toEqual({
+      kind    : 'Incomplete',
+      missing : [
+        { type: 'Ancestor', recordId: 'foo-record', protocol },
+        { type: 'Ancestor', recordId: 'bar-record', protocol },
+        { type: 'Ancestor', recordId: 'baz-record', protocol },
+      ],
+    });
+  });
+
+  it('falls back to the failure-named ancestor when the batched missing-ancestor set is empty', async () => {
+    const protocol = 'https://example.com/protocol';
+    const { message } = await TestDataGenerator.generateRecordsWrite({ protocol });
+
+    expect(replicationApplyResultFromReply(message, {
+      status: {
+        code   : 401,
+        detail : `${DwnErrorCode.ProtocolAuthorizationParentNotFoundConstructingRecordChain}: parent with ID parent-record was not found`,
+      },
+    }, { missingAncestorRecordIds: [] })).toEqual({
+      kind    : 'Incomplete',
+      missing : [{ type: 'Ancestor', recordId: 'parent-record', protocol }],
+    });
+  });
+
   it('classifies grant, record data, and delete initial-write dependencies', async () => {
     const protocol = 'https://example.com/protocol';
     const permissionGrantId = 'grant-1';

--- a/packages/dwn-sdk-js/tests/dwn.spec.ts
+++ b/packages/dwn-sdk-js/tests/dwn.spec.ts
@@ -1,8 +1,9 @@
 import type { DidResolver } from '@enbox/dids';
 import type { EventLog } from '../src/types/subscriptions.js';
-import type { ProtocolDefinition } from '../src/index.js';
+import type { Persona } from './utils/test-data-generator.js';
 import type { ActiveTenantCheckResult, TenantGate } from '../src/index.js';
 import type { DataStore, MessageStore, ResumableTaskStore, StateIndex } from '../src/index.js';
+import type { ProtocolDefinition, ReplicationApplyResult } from '../src/index.js';
 
 import sinon from 'sinon';
 
@@ -657,6 +658,150 @@ export function testDwnClass(): void {
         } finally {
           await dwnB.close();
         }
+      });
+
+      const deepNestedProtocol: ProtocolDefinition = {
+        protocol  : 'https://example.com/deep-nested',
+        published : false,
+        types     : {
+          foo : {},
+          bar : {},
+          baz : {},
+          qux : {},
+        },
+        structure: {
+          foo: {
+            bar: {
+              baz: {
+                qux: {},
+              },
+            },
+          },
+        },
+      };
+
+      type GeneratedWrite = Awaited<ReturnType<typeof TestDataGenerator.generateRecordsWrite>>;
+
+      // Installs `deepNestedProtocol` on the local DWN and builds a foo -> bar -> baz -> qux
+      // record chain under it. None of the generated records are stored; each test applies the
+      // subset it needs to shape local ancestor presence.
+      async function generateDeepNestedChain(
+        alice: Persona,
+      ): Promise<{ foo: GeneratedWrite; bar: GeneratedWrite; baz: GeneratedWrite; qux: GeneratedWrite }> {
+        const protocolsConfigure = await TestDataGenerator.generateProtocolsConfigure({
+          author             : alice,
+          protocolDefinition : deepNestedProtocol,
+        });
+        expect((await dwn.processMessage(alice.did, protocolsConfigure.message)).status.code).toBe(202);
+
+        const foo = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          protocol     : deepNestedProtocol.protocol,
+          protocolPath : 'foo',
+        });
+        const bar = await TestDataGenerator.generateRecordsWrite({
+          author          : alice,
+          protocol        : deepNestedProtocol.protocol,
+          protocolPath    : 'foo/bar',
+          parentContextId : foo.message.contextId,
+        });
+        const baz = await TestDataGenerator.generateRecordsWrite({
+          author          : alice,
+          protocol        : deepNestedProtocol.protocol,
+          protocolPath    : 'foo/bar/baz',
+          parentContextId : bar.message.contextId,
+        });
+        const qux = await TestDataGenerator.generateRecordsWrite({
+          author          : alice,
+          protocol        : deepNestedProtocol.protocol,
+          protocolPath    : 'foo/bar/baz/qux',
+          parentContextId : baz.message.contextId,
+        });
+
+        return { foo, bar, baz, qux };
+      }
+
+      it('emits one ref per missing contextId segment in a single Incomplete', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const { foo, bar, baz, qux } = await generateDeepNestedChain(alice);
+
+        // no ancestors are present locally: a single apply names every missing segment,
+        // root-first, with the immediate parent keeping its existing Parent ref shape
+        const result = await dwn.applyReplicatedMessage(
+          alice.did, qux.message, { dataStream: DataStream.fromBytes(qux.dataBytes!) },
+        );
+
+        expect(result).toEqual({
+          kind    : 'Incomplete',
+          missing : [
+            { type: 'Ancestor', recordId: foo.message.recordId, protocol: deepNestedProtocol.protocol },
+            { type: 'Ancestor', recordId: bar.message.recordId, protocol: deepNestedProtocol.protocol },
+            { type: 'Parent', recordId: baz.message.recordId, protocol: deepNestedProtocol.protocol },
+          ],
+        });
+      });
+
+      it('lists only the locally-missing ancestor segments when part of the chain is present', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const { foo, bar, baz, qux } = await generateDeepNestedChain(alice);
+
+        // the root of the chain is already present locally
+        expect(await dwn.applyReplicatedMessage(
+          alice.did, foo.message, { dataStream: DataStream.fromBytes(foo.dataBytes!) },
+        )).toEqual({ kind: 'Applied' });
+
+        const result = await dwn.applyReplicatedMessage(
+          alice.did, qux.message, { dataStream: DataStream.fromBytes(qux.dataBytes!) },
+        );
+
+        expect(result).toEqual({
+          kind    : 'Incomplete',
+          missing : [
+            { type: 'Ancestor', recordId: bar.message.recordId, protocol: deepNestedProtocol.protocol },
+            { type: 'Parent', recordId: baz.message.recordId, protocol: deepNestedProtocol.protocol },
+          ],
+        });
+      });
+
+      it('resolves a deep ancestor chain in a bounded number of fetch-and-retry passes', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const { foo, bar, baz, qux } = await generateDeepNestedChain(alice);
+
+        const chainWritesByRecordId = new Map([
+          [foo.message.recordId, foo],
+          [bar.message.recordId, bar],
+          [baz.message.recordId, baz],
+        ]);
+
+        // engine loop: apply the deepest record, fetch whatever the Incomplete names, retry
+        let applyAttempts = 0;
+        let result: ReplicationApplyResult;
+        do {
+          applyAttempts += 1;
+          result = await dwn.applyReplicatedMessage(
+            alice.did, qux.message, { dataStream: DataStream.fromBytes(qux.dataBytes!) },
+          );
+
+          if (result.kind === 'Incomplete') {
+            for (const ref of result.missing) {
+              if (ref.type !== 'Ancestor' && ref.type !== 'Parent') {
+                throw new Error(`Incomplete named an unexpected dependency ref type: ${ref.type}`);
+              }
+              const ancestor = chainWritesByRecordId.get(ref.recordId);
+              if (ancestor === undefined) {
+                throw new Error(`Incomplete named an unexpected ancestor: ${ref.recordId}`);
+              }
+              expect(await dwn.applyReplicatedMessage(
+                alice.did, ancestor.message, { dataStream: DataStream.fromBytes(ancestor.dataBytes!) },
+              )).toEqual({ kind: 'Applied' });
+            }
+          }
+        } while (result.kind === 'Incomplete' && applyAttempts < 4);
+
+        // the full 4-level chain resolves in two passes — one Incomplete naming all three
+        // ancestors, then a clean apply — never one round trip per ancestry level
+        expect(result).toEqual({ kind: 'Applied' });
+        expect(applyAttempts).toBe(2);
       });
     });
   });


### PR DESCRIPTION
## Summary

Implements the **layer-batched ancestor refs** stream of the sync replication-log plan (SDK item 7).

A replicated message applying ahead of its ancestors previously surfaced one missing-dependency ref per `applyReplicatedMessage` pass — one fetch round trip per ancestry level. Since a record's `contextId` is the full ancestor recordId chain (`interfaces/records-write.ts` — `parentContextId + '/' + recordId`), `applyReplicatedMessage` now:

- splits the incoming message's `contextId` into its recordId segments,
- presence-checks every segment above the failure-named ancestor against the message store (segments below it are present by construction — the failed check walked through them),
- emits **one `Incomplete` naming every locally-absent ancestor**, ordered root-first.

Resolution of a deep chain is now ~3 layers regardless of depth: ancestors → their grants/roles (IDs embedded in the fetched messages) → apply.

Refs stay **selectors** (recordId-based, never resolved CIDs — a recorded CID can dangle after supersession). The `DependencyRef` wire shape is unchanged; only the adapter-internal `ReplicationApplyResultContext` gains an optional `missingAncestorRecordIds` field, computed in `Dwn.applyReplicatedMessage` following the existing `protocolDefinition` context-enrichment pattern.

### Deviation from the spec text, and why

The plan bullet names only the record-chain construction error (`ProtocolAuthorizationParentNotFoundConstructingRecordChain`, `replication-apply.ts:147-155`). Verified against the actual handler flow, that error alone cannot deliver the stated outcome: `validateReferentialIntegrity` (immediate-parent latest check, `handlers/records-write.ts:78`) runs **before** record-chain construction (`:86`), so a deep record arriving with no local ancestors fails with `ProtocolAuthorizationParentRecordNotFound` — and would have kept resolving one level per pass. The batch therefore covers **both** missing-ancestor failures:

- `ProtocolAuthorizationParentRecordNotFound`: the named parent keeps its existing `Parent` ref (byte-identical to today's emission, satisfies the stricter wire validator that requires `protocol` on `Parent` refs); locally-absent upper segments are added as `Ancestor` refs. With no batch available the emission is exactly today's single `Parent` ref.
- `ProtocolAuthorizationParentNotFoundConstructingRecordChain`: all missing segments emit as `Ancestor` refs; messages without a `contextId` (e.g. deletes) fall back to today's single failure-named ref.

Consumers are unaffected: the agent dispatch handles `Parent`/`Ancestor`/`InitialWrite` through the same recordId fetch, and `fetchMissingDependencies` already iterates every ref in one `Incomplete`.

## Test plan

- [x] Adapter unit tests (`tests/core/replication-apply.spec.ts`): batched `Ancestor` emission for the chain error; `Ancestor`-above-`Parent` emission for the parent error; empty-batch and no-context fallbacks preserve existing single-ref behavior (13 pass)
- [x] Integration (`tests/dwn.spec.ts`, 4-level foo→bar→baz→qux chain): deepest record applied with **no** ancestors present → single `Incomplete` listing one selector per missing segment (all of them); with the root present → only the missing segments listed; simulated engine loop (fetch named refs, retry) resolves the chain in exactly 2 apply passes (bound ≤ 3 asserted via loop guard)
- [x] `bun run lint` clean (15/15 packages)
- [x] `bun run --filter @enbox/dwn-sdk-js build` and `bun run --filter @enbox/agent build` green
- [x] Full `bun run test:node` in `packages/dwn-sdk-js`: 1464 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
