### PR TITLE
feat(dwn-sdk-js): add durable messages query surface

### DIFF
--- a/.changeset/messages-query-feed.md
+++ b/.changeset/messages-query-feed.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Add MessagesQuery over the durable replication feed.

--- a/packages/dwn-sdk-js/build/compile-validators.js
+++ b/packages/dwn-sdk-js/build/compile-validators.js
@@ -27,6 +27,7 @@ import GeneralJws from '../json-schemas/general-jws.json' with { type: 'json' };
 import GenericSignaturePayload from '../json-schemas/signature-payloads/generic-signature-payload.json' with { type: 'json' };
 import JwkVerificationMethod from '../json-schemas/jwk-verification-method.json' with { type: 'json' };
 import MessagesFilter from '../json-schemas/interface-methods/messages-filter.json' with { type: 'json' };
+import MessagesQuery from '../json-schemas/interface-methods/messages-query.json' with { type: 'json' };
 import MessagesRead from '../json-schemas/interface-methods/messages-read.json' with { type: 'json' };
 import MessagesSubscribe from '../json-schemas/interface-methods/messages-subscribe.json' with { type: 'json' };
 import MessagesSync from '../json-schemas/interface-methods/messages-sync.json' with { type: 'json' };
@@ -71,6 +72,7 @@ const schemas = {
   GeneralJws,
   JwkVerificationMethod,
   MessagesFilter,
+  MessagesQuery,
   MessagesRead,
   MessagesSubscribe,
   MessagesSync,

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/messages-query.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/messages-query.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://identity.foundation/dwn/json-schemas/messages-query.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "authorization",
+    "descriptor"
+  ],
+  "properties": {
+    "authorization": {
+      "$ref": "https://identity.foundation/dwn/json-schemas/authorization.json"
+    },
+    "descriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "interface",
+        "method",
+        "messageTimestamp",
+        "filters"
+      ],
+      "properties": {
+        "interface": {
+          "enum": [
+            "Messages"
+          ],
+          "type": "string"
+        },
+        "method": {
+          "enum": [
+            "Query"
+          ],
+          "type": "string"
+        },
+        "messageTimestamp": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "https://identity.foundation/dwn/json-schemas/messages-filter.json"
+          }
+        },
+        "permissionGrantIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "cursor": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/progress-token.json"
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cidsOnly": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -64,6 +64,8 @@ export enum DwnErrorCode {
   MessagePermissionGrantIdsNotCanonical = 'MessagePermissionGrantIdsNotCanonical',
   MessagePermissionGrantValidateInvocationAmbiguous = 'MessagePermissionGrantValidateInvocationAmbiguous',
   MessagesReadInvalidCid = 'MessagesReadInvalidCid',
+  MessagesQueryAuthorizationFailed = 'MessagesQueryAuthorizationFailed',
+  MessagesQueryReplicationFeedUnimplemented = 'MessagesQueryReplicationFeedUnimplemented',
   MessagesReadAuthorizationFailed = 'MessagesReadAuthorizationFailed',
   MessageGetInvalidCid = 'MessageGetInvalidCid',
   MessagesReadVerifyScopeFailed = 'MessagesReadVerifyScopeFailed',

--- a/packages/dwn-sdk-js/src/core/grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/grant-authorization.ts
@@ -119,7 +119,7 @@ export class GrantAuthorization {
    * Verify that the `interface` and `method` grant scopes match the incoming message.
    *
    * For the Messages interface, a `Read` scope is treated as a unified scope that also authorizes
-   * `Subscribe` and `Sync` operations.
+   * `Query`, `Subscribe`, and `Sync` operations.
    *
    * @throws {DwnError} if the `interface` and `method` of the incoming message do not match the scope of the permission grant.
    */
@@ -136,7 +136,7 @@ export class GrantAuthorization {
       );
     }
 
-    // Messages.Read is the only valid Messages scope and covers Read, Subscribe, and Sync operations.
+    // Messages.Read is the only valid Messages scope and covers Read, Query, Subscribe, and Sync operations.
     // Reject any Messages grant with method !== Read.
     if (dwnInterface === DwnInterfaceName.Messages) {
       if (permissionGrant.scope.method !== DwnMethodName.Read) {
@@ -145,7 +145,7 @@ export class GrantAuthorization {
           `messages permission grant must have method 'Read', got '${permissionGrant.scope.method}' for grant ${permissionGrant.id}`
         );
       }
-      const allowedMethods = [DwnMethodName.Read, DwnMethodName.Subscribe, DwnMethodName.Sync];
+      const allowedMethods = [DwnMethodName.Read, DwnMethodName.Query, DwnMethodName.Subscribe, DwnMethodName.Sync];
       if (!allowedMethods.includes(dwnMethod as DwnMethodName)) {
         throw new DwnError(
           DwnErrorCode.GrantAuthorizationMethodMismatch,

--- a/packages/dwn-sdk-js/src/core/message-reply.ts
+++ b/packages/dwn-sdk-js/src/core/message-reply.ts
@@ -1,8 +1,9 @@
-import type { MessagesReadReplyEntry } from '../types/messages-types.js';
 import type { PaginationCursor } from '../types/query-types.js';
+import type { ProgressToken } from '../types/subscriptions.js';
 import type { ProtocolsConfigureMessage } from '../types/protocols-types.js';
 import type { RecordsReadReplyEntry } from '../types/records-types.js';
 import type { GenericMessageReply, MessageSubscription, QueryResultEntry } from '../types/message-types.js';
+import type { MessagesQueryReplyEntry, MessagesReadReplyEntry } from '../types/messages-types.js';
 
 export function messageReplyFromError(e: unknown, code: number): GenericMessageReply {
 
@@ -26,13 +27,13 @@ export type UnionMessageReply = GenericMessageReply & {
    * e.g. the resulting messages from a RecordsQuery, or array of messageCid strings for MessagesSync
    * Mutually exclusive with `record`.
    */
-  entries?: QueryResultEntry[] | ProtocolsConfigureMessage[] | string[];
+  entries?: QueryResultEntry[] | ProtocolsConfigureMessage[] | MessagesQueryReplyEntry[] | string[];
 
   /**
    * A cursor for pagination if applicable (e.g. RecordsQuery).
    * Mutually exclusive with `record`.
    */
-  cursor?: PaginationCursor;
+  cursor?: PaginationCursor | ProgressToken;
 
   /**
    * A subscription object if a subscription was requested.

--- a/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
@@ -5,7 +5,7 @@ import type { ProtocolsConfigureMessage } from '../types/protocols-types.js';
 import type { ProtocolScope } from '../utils/permission-scope.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
 import type { DataEncodedRecordsWriteMessage, RecordsDeleteMessage, RecordsWriteMessage } from '../types/records-types.js';
-import type { MessagesReadMessage, MessagesSubscribeMessage, MessagesSyncMessage } from '../types/messages-types.js';
+import type { MessagesQueryMessage, MessagesReadMessage, MessagesSubscribeMessage, MessagesSyncMessage } from '../types/messages-types.js';
 
 import { DwnInterfaceName } from '../enums/dwn-interface-method.js';
 import { GrantAuthorization } from './grant-authorization.js';
@@ -62,11 +62,11 @@ export class MessagesGrantAuthorization {
   }
 
   /**
-   * Authorizes the scope of a permission grant for MessagesSubscribe or MessagesSync.
+   * Authorizes the scope of a permission grant for MessagesQuery, MessagesSubscribe, or MessagesSync.
    * @param validationStateReader Used to check if the grant has been revoked.
    */
   public static async authorizeSubscribeOrSync(input: {
-    incomingMessage: MessagesSubscribeMessage | MessagesSyncMessage,
+    incomingMessage: MessagesQueryMessage | MessagesSubscribeMessage | MessagesSyncMessage,
     expectedGrantor: string,
     expectedGrantee: string,
     permissionGrants: PermissionGrant[],
@@ -91,7 +91,7 @@ export class MessagesGrantAuthorization {
       return;
     }
 
-    MessagesGrantAuthorization.authorizeSubscribeScope(incomingMessage as MessagesSubscribeMessage, scopes);
+    MessagesGrantAuthorization.authorizeFilterScope(incomingMessage as MessagesQueryMessage | MessagesSubscribeMessage, scopes);
   }
 
   private static authorizeSyncScope(
@@ -120,11 +120,11 @@ export class MessagesGrantAuthorization {
     }
   }
 
-  private static authorizeSubscribeScope(
-    subscribeMessage: MessagesSubscribeMessage,
+  private static authorizeFilterScope(
+    messagesMessage: MessagesQueryMessage | MessagesSubscribeMessage,
     scopes: MessagesPermissionScope[]
   ): void {
-    const { filters } = subscribeMessage.descriptor;
+    const { filters } = messagesMessage.descriptor;
 
     if (filters.length === 0 && !MessagesGrantAuthorization.hasUnscopedGrant(scopes)) {
       throw new DwnError(
@@ -198,7 +198,7 @@ export class MessagesGrantAuthorization {
    * unresolved, revoked, expired, or interface/method-mismatched grants fail the request.
    */
   private static async performBaseValidationForGrantSet(input: {
-    incomingMessage: MessagesReadMessage | MessagesSubscribeMessage | MessagesSyncMessage,
+    incomingMessage: MessagesQueryMessage | MessagesReadMessage | MessagesSubscribeMessage | MessagesSyncMessage,
     expectedGrantor: string,
     expectedGrantee: string,
     permissionGrants: PermissionGrant[],

--- a/packages/dwn-sdk-js/src/dwn.ts
+++ b/packages/dwn-sdk-js/src/dwn.ts
@@ -12,6 +12,8 @@ import type { EventLog, MessageEvent, SubscriptionListener } from './types/subsc
 import type { GenericMessage, GenericMessageReply } from './types/message-types.js';
 import type { HandlerDependencies, MethodHandler } from './types/method-handler.js';
 import type {
+  MessagesQueryMessage,
+  MessagesQueryReply,
   MessagesReadMessage,
   MessagesReadReply,
   MessagesSubscribeMessage,
@@ -45,6 +47,7 @@ import { DataStream } from './utils/data-stream.js';
 import { DwnConstant } from './core/dwn-constant.js';
 import { Message } from './core/message.js';
 import { messageReplyFromError } from './core/message-reply.js';
+import { MessagesQueryHandler } from './handlers/messages-query.js';
 import { MessagesReadHandler } from './handlers/messages-read.js';
 import { MessagesSubscribeHandler } from './handlers/messages-subscribe.js';
 import { MessagesSyncHandler } from './handlers/messages-sync.js';
@@ -152,6 +155,7 @@ export class Dwn {
 
     this.methodHandlers = {
       [DwnInterfaceName.Messages + DwnMethodName.Read]       : new MessagesReadHandler(deps),
+      [DwnInterfaceName.Messages + DwnMethodName.Query]      : new MessagesQueryHandler(deps),
       [DwnInterfaceName.Messages + DwnMethodName.Subscribe]  : new MessagesSubscribeHandler(deps),
       [DwnInterfaceName.Messages + DwnMethodName.Sync]       : new MessagesSyncHandler(deps),
       [DwnInterfaceName.Protocols + DwnMethodName.Configure] : new ProtocolsConfigureHandler(deps),
@@ -249,6 +253,7 @@ export class Dwn {
   public async processMessage(
     tenant: string, rawMessage: MessagesSubscribeMessage, options?: MessagesSubscribeMessageOptions): Promise<MessagesSubscribeReply>;
   public async processMessage(tenant: string, rawMessage: MessagesReadMessage): Promise<MessagesReadReply>;
+  public async processMessage(tenant: string, rawMessage: MessagesQueryMessage): Promise<MessagesQueryReply>;
   public async processMessage(tenant: string, rawMessage: MessagesSyncMessage): Promise<MessagesSyncReply>;
   public async processMessage(tenant: string, rawMessage: ProtocolsConfigureMessage): Promise<GenericMessageReply>;
   public async processMessage(tenant: string, rawMessage: ProtocolsQueryMessage): Promise<ProtocolsQueryReply>;

--- a/packages/dwn-sdk-js/src/event-stream/durable-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/durable-event-log.ts
@@ -278,7 +278,6 @@ export class DurableEventLog implements EventLog {
         return frozenCursor;
       }
 
-      readCursor = pageState.readCursor;
       const resultCursor = result.cursor ?? pageState.readCursor;
       if (DurableEventLog.isCatchUpComplete(pageState.reachedFrozenPosition, result, resultCursor, frozenPosition)) {
         DurableEventLog.finishCatchUp(subscription, frozenCursor);

--- a/packages/dwn-sdk-js/src/event-stream/durable-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/durable-event-log.ts
@@ -59,6 +59,11 @@ type DurableSubscription = {
   redrainRequested: boolean;
 };
 
+type CatchUpPageState = {
+  readCursor : ProgressToken;
+  reachedFrozenPosition : boolean;
+};
+
 const DEFAULT_READ_LIMIT = 100;
 const DEFAULT_IDLE_REDRAIN_INTERVAL_MS = 30_000;
 
@@ -262,50 +267,30 @@ export class DurableEventLog implements EventLog {
     let readCursor = cursor;
     subscription.cursor = cursor;
 
-    for (;;) {
-      if (subscription.closed) {
-        return frozenCursor;
-      }
-
-      if (BigInt(readCursor.position) >= frozenPosition) {
-        subscription.cursor = frozenCursor;
-        return frozenCursor;
-      }
-
+    while (!subscription.closed && BigInt(readCursor.position) < frozenPosition) {
       const result = await this.read(subscription.tenant, {
         cursor  : readCursor,
         filters : subscription.filters,
         limit   : this.readLimit,
       });
-
-      let reachedFrozenPosition = false;
-      for (const entry of result.events) {
-        const entryPosition = BigInt(DurableEventLog.getEntryPosition(entry));
-        if (entryPosition > frozenPosition) {
-          reachedFrozenPosition = true;
-          break;
-        }
-
-        const deliveredCursor = await this.deliverEntry(subscription, entry);
-        if (subscription.closed) {
-          return frozenCursor;
-        }
-
-        if (deliveredCursor !== undefined) {
-          readCursor = deliveredCursor;
-          subscription.cursor = deliveredCursor;
-        }
+      const pageState = await this.deliverCatchUpPage(subscription, result.events, readCursor, frozenPosition);
+      if (subscription.closed) {
+        return frozenCursor;
       }
 
-      const resultCursor = result.cursor ?? readCursor;
-      if (reachedFrozenPosition || result.drained || BigInt(resultCursor.position) >= frozenPosition) {
-        subscription.cursor = frozenCursor;
+      readCursor = pageState.readCursor;
+      const resultCursor = result.cursor ?? pageState.readCursor;
+      if (DurableEventLog.isCatchUpComplete(pageState.reachedFrozenPosition, result, resultCursor, frozenPosition)) {
+        DurableEventLog.finishCatchUp(subscription, frozenCursor);
         return frozenCursor;
       }
 
       readCursor = resultCursor;
       subscription.cursor = resultCursor;
     }
+
+    DurableEventLog.finishCatchUp(subscription, frozenCursor);
+    return frozenCursor;
   }
 
   private async getCatchUpHighWater(tenant: string, cursor: ProgressToken): Promise<ProgressToken> {
@@ -314,6 +299,31 @@ export class DurableEventLog implements EventLog {
 
     await this.read(tenant, { cursor, limit: 0 });
     return frozenCursor;
+  }
+
+  private async deliverCatchUpPage(
+    subscription: DurableSubscription,
+    entries: EventLogEntry[],
+    readCursor: ProgressToken,
+    frozenPosition: bigint,
+  ): Promise<CatchUpPageState> {
+    let nextCursor = readCursor;
+
+    for (const entry of entries) {
+      if (BigInt(DurableEventLog.getEntryPosition(entry)) > frozenPosition) {
+        return { readCursor: nextCursor, reachedFrozenPosition: true };
+      }
+
+      const deliveredCursor = await this.deliverEntry(subscription, entry);
+      if (subscription.closed) {
+        return { readCursor: nextCursor, reachedFrozenPosition: false };
+      }
+
+      nextCursor = deliveredCursor ?? nextCursor;
+      subscription.cursor = nextCursor;
+    }
+
+    return { readCursor: nextCursor, reachedFrozenPosition: false };
   }
 
   private async drainSubscription(subscription: DurableSubscription): Promise<void> {
@@ -462,6 +472,19 @@ export class DurableEventLog implements EventLog {
     }
 
     return gapInfo;
+  }
+
+  private static isCatchUpComplete(
+    reachedFrozenPosition: boolean,
+    result: EventLogReadResult,
+    resultCursor: ProgressToken,
+    frozenPosition: bigint,
+  ): boolean {
+    return reachedFrozenPosition || result.drained || BigInt(resultCursor.position) >= frozenPosition;
+  }
+
+  private static finishCatchUp(subscription: DurableSubscription, frozenCursor: ProgressToken): void {
+    subscription.cursor = frozenCursor;
   }
 
   private static isLatestBaseState(entry: EventLogEntry): boolean {

--- a/packages/dwn-sdk-js/src/event-stream/durable-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/durable-event-log.ts
@@ -1,0 +1,344 @@
+import type { GenericMessage } from '../types/message-types.js';
+import type { MessageStore } from '../types/message-store.js';
+import type { RecordsWriteMessage } from '../types/records-types.js';
+import type {
+  EventLog,
+  EventLogEntry,
+  EventLogReadOptions,
+  EventLogReadResult,
+  EventLogSubscribeOptions,
+  EventSubscription,
+  MessageEvent,
+  ProgressToken,
+  ReplicationFeedReader,
+  SubscriptionEvent,
+  SubscriptionListener,
+  Wake,
+  WakeSubscriber,
+} from '../types/subscriptions.js';
+import type { Filter, KeyValues } from '../types/query-types.js';
+
+import { Messages } from '../utils/messages.js';
+import { Records } from '../utils/records.js';
+import { RecordsWrite } from '../interfaces/records-write.js';
+import { Replication } from '../utils/replication.js';
+import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
+
+export type DurableEventLogStore = ReplicationFeedReader & Pick<MessageStore, 'query'>;
+
+export type DurableEventLogConfig = {
+  /**
+   * Maximum number of log rows read per drain step.
+   * Defaults to 100.
+   */
+  readLimit?: number;
+
+  /**
+   * Interval for idle re-drain. This bounds dropped-wake latency.
+   * Set to 0 to disable the interval.
+   */
+  idleRedrainIntervalMs?: number;
+
+  /**
+   * Optional handler for background subscription-drain errors.
+   */
+  errorHandler?: (error: unknown) => void;
+};
+
+type DurableSubscription = {
+  id: string;
+  tenant: string;
+  listener: SubscriptionListener;
+  filters?: Filter[];
+  cursor?: ProgressToken;
+  closed: boolean;
+  draining: boolean;
+  redrainRequested: boolean;
+};
+
+const DEFAULT_READ_LIMIT = 100;
+const DEFAULT_IDLE_REDRAIN_INTERVAL_MS = 30_000;
+
+/**
+ * EventLog implementation backed by the durable replication feed.
+ *
+ * Writes are store-owned: MessageStore commits publish wakes after the row is
+ * durable. `emit()` is therefore intentionally a no-op while legacy handlers
+ * still depend on the EventLog interface.
+ */
+export class DurableEventLog implements EventLog {
+  private readonly subscriptions: Map<string, DurableSubscription> = new Map();
+  private readonly readLimit: number;
+  private readonly idleRedrainIntervalMs: number;
+  private readonly errorHandler: (error: unknown) => void;
+  private unsubscribeWake?: () => void;
+  private idleRedrainTimer?: ReturnType<typeof setInterval>;
+  private isOpen: boolean = false;
+
+  public constructor(
+    private readonly store: DurableEventLogStore,
+    private readonly wakeSubscriber: WakeSubscriber,
+    config: DurableEventLogConfig = {},
+  ) {
+    this.readLimit = Math.max(1, config.readLimit ?? DEFAULT_READ_LIMIT);
+    this.idleRedrainIntervalMs = config.idleRedrainIntervalMs ?? DEFAULT_IDLE_REDRAIN_INTERVAL_MS;
+    this.errorHandler = config.errorHandler ?? ((error): void => { console.error('durable event log error', error); });
+  }
+
+  public async open(): Promise<void> {
+    if (this.isOpen) {
+      return;
+    }
+
+    this.unsubscribeWake = this.wakeSubscriber.subscribe((wake): void => {
+      this.handleWake(wake);
+    });
+
+    if (this.idleRedrainIntervalMs > 0) {
+      this.idleRedrainTimer = setInterval((): void => {
+        this.redrainAll();
+      }, this.idleRedrainIntervalMs);
+    }
+
+    this.isOpen = true;
+  }
+
+  public async close(): Promise<void> {
+    this.unsubscribeWake?.();
+    this.unsubscribeWake = undefined;
+
+    if (this.idleRedrainTimer !== undefined) {
+      clearInterval(this.idleRedrainTimer);
+      this.idleRedrainTimer = undefined;
+    }
+
+    for (const subscription of this.subscriptions.values()) {
+      subscription.closed = true;
+    }
+    this.subscriptions.clear();
+    this.isOpen = false;
+  }
+
+  public async emit(_tenant: string, _event: MessageEvent, _indexes: KeyValues, _messageCid: string): Promise<ProgressToken | undefined> {
+    return undefined;
+  }
+
+  public async read(tenant: string, options: EventLogReadOptions = {}): Promise<EventLogReadResult> {
+    const result = await this.store.logRead(tenant, options);
+    return {
+      ...result,
+      events: DurableEventLog.detachEntryEncodedData(await this.attachInitialWrites(tenant, result.events)),
+    };
+  }
+
+  public async subscribe(
+    tenant: string,
+    id: string,
+    listener: SubscriptionListener,
+    options: EventLogSubscribeOptions = {},
+  ): Promise<EventSubscription> {
+    const subscription: DurableSubscription = {
+      id,
+      tenant,
+      listener,
+      filters          : options.filters,
+      cursor           : await this.getInitialCursor(tenant, options.cursor),
+      closed           : false,
+      draining         : false,
+      redrainRequested : false,
+    };
+    this.subscriptions.set(id, subscription);
+
+    if (options.cursor !== undefined) {
+      try {
+        await this.drainSubscription(subscription);
+      } catch (error) {
+        subscription.closed = true;
+        this.subscriptions.delete(id);
+        throw error;
+      }
+      listener({ type: 'eose', cursor: subscription.cursor ?? options.cursor });
+    }
+
+    return {
+      id,
+      close: async (): Promise<void> => {
+        subscription.closed = true;
+        this.subscriptions.delete(id);
+      }
+    };
+  }
+
+  public async getReplayBounds(tenant: string): Promise<{ oldest: ProgressToken; latest: ProgressToken } | undefined> {
+    return this.store.logBounds(tenant);
+  }
+
+  public async trim(_tenant: string, _olderThan: number | string): Promise<void> {
+    // Durable retention is owned by the backing store.
+  }
+
+  private async getInitialCursor(tenant: string, cursor: ProgressToken | undefined): Promise<ProgressToken | undefined> {
+    if (cursor !== undefined) {
+      return cursor;
+    }
+
+    const bounds = await this.store.logBounds(tenant);
+    return bounds?.latest;
+  }
+
+  private handleWake(wake: Wake): void {
+    for (const subscription of this.subscriptions.values()) {
+      if (subscription.tenant !== wake.tenant || subscription.closed) {
+        continue;
+      }
+
+      void this.drainSubscription(subscription).catch(this.errorHandler);
+    }
+  }
+
+  private redrainAll(): void {
+    for (const subscription of this.subscriptions.values()) {
+      if (subscription.closed) {
+        continue;
+      }
+
+      void this.drainSubscription(subscription).catch(this.errorHandler);
+    }
+  }
+
+  private async drainSubscription(subscription: DurableSubscription): Promise<void> {
+    if (subscription.draining) {
+      subscription.redrainRequested = true;
+      return;
+    }
+
+    subscription.draining = true;
+    try {
+      do {
+        subscription.redrainRequested = false;
+        await this.drainOnce(subscription);
+      } while (subscription.redrainRequested && !subscription.closed);
+    } finally {
+      subscription.draining = false;
+    }
+  }
+
+  private async drainOnce(subscription: DurableSubscription): Promise<void> {
+    for (;;) {
+      if (subscription.closed) {
+        return;
+      }
+
+      const result = await this.read(subscription.tenant, {
+        cursor  : subscription.cursor,
+        filters : subscription.filters,
+        limit   : this.readLimit,
+      });
+
+      for (const entry of result.events) {
+        const cursor = await this.buildToken(subscription.tenant, entry.position ?? entry.seq, entry.messageCid);
+        const event: SubscriptionEvent = {
+          type              : 'event',
+          cursor,
+          event             : entry.event,
+          seq               : entry.seq,
+          messageCid        : entry.messageCid,
+          isLatestBaseState : DurableEventLog.isLatestBaseState(entry),
+          protocol          : DurableEventLog.getProtocol(entry),
+        };
+
+        if (entry.encodedData !== undefined) {
+          event.encodedData = entry.encodedData;
+        }
+
+        subscription.listener(event);
+      }
+
+      subscription.cursor = result.cursor ?? subscription.cursor;
+      if (result.drained) {
+        return;
+      }
+    }
+  }
+
+  private async attachInitialWrites(tenant: string, entries: EventLogEntry[]): Promise<EventLogEntry[]> {
+    const result: EventLogEntry[] = [];
+    for (const entry of entries) {
+      result.push({
+        ...entry,
+        event: await this.attachInitialWrite(tenant, entry.event),
+      });
+    }
+
+    return result;
+  }
+
+  private async attachInitialWrite(tenant: string, event: MessageEvent): Promise<MessageEvent> {
+    if (event.initialWrite !== undefined || !await DurableEventLog.needsInitialWrite(event.message)) {
+      return event;
+    }
+
+    const recordId = (event.message as { recordId?: string }).recordId;
+    if (recordId === undefined) {
+      return event;
+    }
+
+    const { messages } = await this.store.query(tenant, [{
+      interface: DwnInterfaceName.Records,
+      recordId,
+    }]);
+    const initialWrite = await RecordsWrite.getInitialWrite(messages);
+    if (initialWrite === undefined) {
+      return event;
+    }
+
+    const { message } = Messages.detachEncodedData(initialWrite);
+    return { ...event, initialWrite: message as RecordsWriteMessage };
+  }
+
+  private static async needsInitialWrite(message: GenericMessage): Promise<boolean> {
+    if (Records.isRecordsWrite(message)) {
+      return !await RecordsWrite.isInitialWrite(message);
+    }
+
+    return message.descriptor.interface === DwnInterfaceName.Records &&
+      message.descriptor.method === DwnMethodName.Delete;
+  }
+
+  private async buildToken(tenant: string, position: string, messageCid: string | undefined): Promise<ProgressToken> {
+    const token: ProgressToken = {
+      streamId : await Replication.deriveStreamId(tenant),
+      epoch    : await this.store.epoch(),
+      position,
+    };
+
+    if (messageCid !== undefined) {
+      token.messageCid = messageCid;
+    }
+
+    return token;
+  }
+
+  private static isLatestBaseState(entry: EventLogEntry): boolean {
+    return entry.indexes.isLatestBaseState === true || entry.indexes.isLatestBaseState === 'true';
+  }
+
+  private static getProtocol(entry: EventLogEntry): string | undefined {
+    const protocol = entry.indexes.protocol;
+    return typeof protocol === 'string' ? protocol : undefined;
+  }
+
+  private static detachEntryEncodedData(entries: EventLogEntry[]): EventLogEntry[] {
+    return entries.map((entry): EventLogEntry => {
+      const { message, encodedData } = Messages.detachEncodedData(entry.event.message);
+      return {
+        ...entry,
+        event: {
+          ...entry.event,
+          message,
+        },
+        encodedData,
+      };
+    });
+  }
+}

--- a/packages/dwn-sdk-js/src/event-stream/durable-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/durable-event-log.ts
@@ -9,6 +9,7 @@ import type {
   EventLogSubscribeOptions,
   EventSubscription,
   MessageEvent,
+  ProgressGapInfo,
   ProgressToken,
   ReplicationFeedReader,
   SubscriptionEvent,
@@ -22,6 +23,7 @@ import { Messages } from '../utils/messages.js';
 import { Records } from '../utils/records.js';
 import { RecordsWrite } from '../interfaces/records-write.js';
 import { Replication } from '../utils/replication.js';
+import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
 export type DurableEventLogStore = ReplicationFeedReader & Pick<MessageStore, 'query'>;
@@ -53,6 +55,7 @@ type DurableSubscription = {
   cursor?: ProgressToken;
   closed: boolean;
   draining: boolean;
+  liveReady: boolean;
   redrainRequested: boolean;
 };
 
@@ -145,19 +148,26 @@ export class DurableEventLog implements EventLog {
       cursor           : await this.getInitialCursor(tenant, options.cursor),
       closed           : false,
       draining         : false,
+      liveReady        : options.cursor === undefined,
       redrainRequested : false,
     };
     this.subscriptions.set(id, subscription);
 
     if (options.cursor !== undefined) {
       try {
-        await this.drainSubscription(subscription);
+        const eoseCursor = await this.catchUpSubscription(subscription, options.cursor);
+        if (!subscription.closed) {
+          listener({ type: 'eose', cursor: eoseCursor });
+          subscription.liveReady = true;
+          if (subscription.redrainRequested) {
+            this.scheduleDrain(subscription);
+          }
+        }
       } catch (error) {
         subscription.closed = true;
         this.subscriptions.delete(id);
         throw error;
       }
-      listener({ type: 'eose', cursor: subscription.cursor ?? options.cursor });
     }
 
     return {
@@ -192,7 +202,7 @@ export class DurableEventLog implements EventLog {
         continue;
       }
 
-      void this.drainSubscription(subscription).catch(this.errorHandler);
+      this.scheduleDrain(subscription);
     }
   }
 
@@ -202,8 +212,108 @@ export class DurableEventLog implements EventLog {
         continue;
       }
 
-      void this.drainSubscription(subscription).catch(this.errorHandler);
+      this.scheduleDrain(subscription);
     }
+  }
+
+  private scheduleDrain(subscription: DurableSubscription): void {
+    if (!subscription.liveReady) {
+      subscription.redrainRequested = true;
+      return;
+    }
+
+    void this.drainSubscription(subscription).catch((error): void => {
+      this.handleDrainError(subscription, error);
+    });
+  }
+
+  private handleDrainError(subscription: DurableSubscription, error: unknown): void {
+    if (subscription.closed) {
+      return;
+    }
+
+    if (error instanceof DwnError && error.code === DwnErrorCode.EventLogProgressGap) {
+      const gapInfo = DurableEventLog.getProgressGapInfo(error);
+      const cursor = gapInfo?.requested ?? subscription.cursor ?? gapInfo?.latestAvailable;
+      if (cursor === undefined) {
+        this.errorHandler(error);
+        return;
+      }
+
+      subscription.closed = true;
+      this.subscriptions.delete(subscription.id);
+      subscription.listener({
+        type  : 'error',
+        cursor,
+        error : {
+          code   : 'ProgressGap',
+          detail : error.message,
+        },
+      });
+      return;
+    }
+
+    this.errorHandler(error);
+  }
+
+  private async catchUpSubscription(subscription: DurableSubscription, cursor: ProgressToken): Promise<ProgressToken> {
+    const frozenCursor = await this.getCatchUpHighWater(subscription.tenant, cursor);
+    const frozenPosition = BigInt(frozenCursor.position);
+    let readCursor = cursor;
+    subscription.cursor = cursor;
+
+    for (;;) {
+      if (subscription.closed) {
+        return frozenCursor;
+      }
+
+      if (BigInt(readCursor.position) >= frozenPosition) {
+        subscription.cursor = frozenCursor;
+        return frozenCursor;
+      }
+
+      const result = await this.read(subscription.tenant, {
+        cursor  : readCursor,
+        filters : subscription.filters,
+        limit   : this.readLimit,
+      });
+
+      let reachedFrozenPosition = false;
+      for (const entry of result.events) {
+        const entryPosition = BigInt(DurableEventLog.getEntryPosition(entry));
+        if (entryPosition > frozenPosition) {
+          reachedFrozenPosition = true;
+          break;
+        }
+
+        const deliveredCursor = await this.deliverEntry(subscription, entry);
+        if (subscription.closed) {
+          return frozenCursor;
+        }
+
+        if (deliveredCursor !== undefined) {
+          readCursor = deliveredCursor;
+          subscription.cursor = deliveredCursor;
+        }
+      }
+
+      const resultCursor = result.cursor ?? readCursor;
+      if (reachedFrozenPosition || result.drained || BigInt(resultCursor.position) >= frozenPosition) {
+        subscription.cursor = frozenCursor;
+        return frozenCursor;
+      }
+
+      readCursor = resultCursor;
+      subscription.cursor = resultCursor;
+    }
+  }
+
+  private async getCatchUpHighWater(tenant: string, cursor: ProgressToken): Promise<ProgressToken> {
+    const bounds = await this.store.logBounds(tenant);
+    const frozenCursor = bounds?.latest ?? cursor;
+
+    await this.read(tenant, { cursor, limit: 0 });
+    return frozenCursor;
   }
 
   private async drainSubscription(subscription: DurableSubscription): Promise<void> {
@@ -236,22 +346,16 @@ export class DurableEventLog implements EventLog {
       });
 
       for (const entry of result.events) {
-        const cursor = await this.buildToken(subscription.tenant, entry.position ?? entry.seq, entry.messageCid);
-        const event: SubscriptionEvent = {
-          type              : 'event',
-          cursor,
-          event             : entry.event,
-          seq               : entry.seq,
-          messageCid        : entry.messageCid,
-          isLatestBaseState : DurableEventLog.isLatestBaseState(entry),
-          protocol          : DurableEventLog.getProtocol(entry),
-        };
-
-        if (entry.encodedData !== undefined) {
-          event.encodedData = entry.encodedData;
+        const cursor = await this.deliverEntry(subscription, entry);
+        if (subscription.closed) {
+          return;
         }
 
-        subscription.listener(event);
+        subscription.cursor = cursor ?? subscription.cursor;
+      }
+
+      if (subscription.closed) {
+        return;
       }
 
       subscription.cursor = result.cursor ?? subscription.cursor;
@@ -259,6 +363,34 @@ export class DurableEventLog implements EventLog {
         return;
       }
     }
+  }
+
+  private async deliverEntry(subscription: DurableSubscription, entry: EventLogEntry): Promise<ProgressToken | undefined> {
+    if (subscription.closed) {
+      return undefined;
+    }
+
+    const cursor = await this.buildToken(subscription.tenant, DurableEventLog.getEntryPosition(entry), entry.messageCid);
+    if (subscription.closed) {
+      return undefined;
+    }
+
+    const event: SubscriptionEvent = {
+      type              : 'event',
+      cursor,
+      event             : entry.event,
+      seq               : entry.seq,
+      messageCid        : entry.messageCid,
+      isLatestBaseState : DurableEventLog.isLatestBaseState(entry),
+      protocol          : DurableEventLog.getProtocol(entry),
+    };
+
+    if (entry.encodedData !== undefined) {
+      event.encodedData = entry.encodedData;
+    }
+
+    subscription.listener(event);
+    return cursor;
   }
 
   private async attachInitialWrites(tenant: string, entries: EventLogEntry[]): Promise<EventLogEntry[]> {
@@ -317,6 +449,19 @@ export class DurableEventLog implements EventLog {
     }
 
     return token;
+  }
+
+  private static getEntryPosition(entry: EventLogEntry): string {
+    return entry.position ?? entry.seq;
+  }
+
+  private static getProgressGapInfo(error: DwnError): ProgressGapInfo | undefined {
+    const gapInfo = (error as DwnError & { gapInfo?: ProgressGapInfo }).gapInfo;
+    if (gapInfo === undefined) {
+      return undefined;
+    }
+
+    return gapInfo;
   }
 
   private static isLatestBaseState(entry: EventLogEntry): boolean {

--- a/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
@@ -271,6 +271,7 @@ export class EventEmitterEventLog implements EventLog {
 
       results.push({
         seq        : String(seq),
+        position   : String(seq),
         event      : entry.event,
         indexes    : entry.indexes,
         messageCid : entry.messageCid,
@@ -367,7 +368,15 @@ export class EventEmitterEventLog implements EventLog {
       // any async yield, so eviction during read()'s buildToken() cannot lose it.
       for (const entry of readResult.events) {
         const token = await this.buildToken(tenant, EventEmitterEventLog.parsePosition(entry.seq), entry.messageCid);
-        listener({ type: 'event', cursor: token, event: entry.event });
+        listener({
+          type              : 'event',
+          cursor            : token,
+          event             : entry.event,
+          seq               : entry.seq,
+          messageCid        : entry.messageCid,
+          isLatestBaseState : entry.indexes.isLatestBaseState === true || entry.indexes.isLatestBaseState === 'true',
+          protocol          : typeof entry.indexes.protocol === 'string' ? entry.indexes.protocol : undefined,
+        });
       }
 
       // Step 3: Deliver any live events that arrived during catch-up (with seq > lastCatchUpSeq).
@@ -376,7 +385,7 @@ export class EventEmitterEventLog implements EventLog {
       for (const liveEvent of pendingLiveEvents) {
         if (liveEvent.seq > lastCatchUpSeq) {
           const token = await this.buildToken(tenant, liveEvent.seq, liveEvent.messageCid);
-          listener({ type: 'event', cursor: token, event: liveEvent.event });
+          listener({ type: 'event', cursor: token, event: liveEvent.event, seq: String(liveEvent.seq), messageCid: liveEvent.messageCid });
         }
       }
 

--- a/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
+++ b/packages/dwn-sdk-js/src/event-stream/event-emitter-event-log.ts
@@ -10,6 +10,7 @@ import type {
   ProgressGapInfo,
   ProgressGapReason,
   ProgressToken,
+  SubscriptionEvent,
   SubscriptionListener,
 } from '../types/subscriptions.js';
 
@@ -335,7 +336,7 @@ export class EventEmitterEventLog implements EventLog {
       const cursorSeq = EventEmitterEventLog.parsePosition(cursor.position);
 
       // Buffer live events that arrive during catch-up to avoid losing them.
-      type BufferedEvent = { event: MessageEvent; seq: number; messageCid: string };
+      type BufferedEvent = { event: MessageEvent; indexes: KeyValues; seq: number; messageCid: string };
       const pendingLiveEvents: BufferedEvent[] = [];
       let catchUpComplete = false;
 
@@ -346,10 +347,10 @@ export class EventEmitterEventLog implements EventLog {
         }
         if (catchUpComplete) {
           void tokenFromPayload(payload).then((token) => {
-            listener({ type: 'event', cursor: token, event: payload.event });
+            listener(EventEmitterEventLog.createSubscriptionEvent(token, payload.event, payload.indexes, payload.seq, payload.messageCid));
           });
         } else {
-          pendingLiveEvents.push({ event: payload.event, seq: payload.seq, messageCid: payload.messageCid });
+          pendingLiveEvents.push({ event: payload.event, indexes: payload.indexes, seq: payload.seq, messageCid: payload.messageCid });
         }
       };
 
@@ -368,29 +369,21 @@ export class EventEmitterEventLog implements EventLog {
       // any async yield, so eviction during read()'s buildToken() cannot lose it.
       for (const entry of readResult.events) {
         const token = await this.buildToken(tenant, EventEmitterEventLog.parsePosition(entry.seq), entry.messageCid);
-        listener({
-          type              : 'event',
-          cursor            : token,
-          event             : entry.event,
-          seq               : entry.seq,
-          messageCid        : entry.messageCid,
-          isLatestBaseState : entry.indexes.isLatestBaseState === true || entry.indexes.isLatestBaseState === 'true',
-          protocol          : typeof entry.indexes.protocol === 'string' ? entry.indexes.protocol : undefined,
-        });
+        listener(EventEmitterEventLog.createSubscriptionEvent(token, entry.event, entry.indexes, entry.seq, entry.messageCid));
       }
 
-      // Step 3: Deliver any live events that arrived during catch-up (with seq > lastCatchUpSeq).
+      // Step 3: Send EOSE marker at the catch-up high-water.
+      listener({ type: 'eose', cursor: eoseCursor });
+
+      // Step 4: Deliver any live events that arrived during catch-up (with seq > lastCatchUpSeq).
       // messageCid was captured at buffer time from the EmitterPayload.
       catchUpComplete = true;
       for (const liveEvent of pendingLiveEvents) {
         if (liveEvent.seq > lastCatchUpSeq) {
           const token = await this.buildToken(tenant, liveEvent.seq, liveEvent.messageCid);
-          listener({ type: 'event', cursor: token, event: liveEvent.event, seq: String(liveEvent.seq), messageCid: liveEvent.messageCid });
+          listener(EventEmitterEventLog.createSubscriptionEvent(token, liveEvent.event, liveEvent.indexes, liveEvent.seq, liveEvent.messageCid));
         }
       }
-
-      // Step 4: Send EOSE marker.
-      listener({ type: 'eose', cursor: eoseCursor });
 
       return {
         id,
@@ -405,7 +398,7 @@ export class EventEmitterEventLog implements EventLog {
         if (!FilterUtility.matchAnyFilter(payload.indexes, filters)) { return; }
       }
       void tokenFromPayload(payload).then((token) => {
-        listener({ type: 'event', cursor: token, event: payload.event });
+        listener(EventEmitterEventLog.createSubscriptionEvent(token, payload.event, payload.indexes, payload.seq, payload.messageCid));
       });
     };
 
@@ -459,5 +452,23 @@ export class EventEmitterEventLog implements EventLog {
         }
       }
     }
+  }
+
+  private static createSubscriptionEvent(
+    cursor: ProgressToken,
+    event: MessageEvent,
+    indexes: KeyValues,
+    seq: number | string,
+    messageCid: string | undefined,
+  ): SubscriptionEvent {
+    return {
+      type              : 'event',
+      cursor,
+      event,
+      seq               : String(seq),
+      messageCid,
+      isLatestBaseState : indexes.isLatestBaseState === true || indexes.isLatestBaseState === 'true',
+      protocol          : typeof indexes.protocol === 'string' ? indexes.protocol : undefined,
+    };
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/messages-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-query.ts
@@ -1,0 +1,203 @@
+import type { EventLogEntry, ProgressGapInfo, ReplicationFeedReader } from '../types/subscriptions.js';
+import type { Filter, KeyValues } from '../types/query-types.js';
+import type { HandlerDependencies, MethodHandler } from '../types/method-handler.js';
+import type { MessagesFilter, MessagesQueryMessage, MessagesQueryReply, MessagesQueryReplyEntry } from '../types/messages-types.js';
+
+import { authenticate } from '../core/auth.js';
+import { Message } from '../core/message.js';
+import { messageReplyFromError } from '../core/message-reply.js';
+import { Messages } from '../utils/messages.js';
+import { MessagesGrantAuthorization } from '../core/messages-grant-authorization.js';
+import { MessagesQuery } from '../interfaces/messages-query.js';
+import { PermissionsProtocol } from '../protocols/permissions.js';
+import { Replication } from '../utils/replication.js';
+import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
+
+export class MessagesQueryHandler implements MethodHandler {
+
+  constructor(private readonly deps: HandlerDependencies) { }
+
+  public async handle({ tenant, message }: { tenant: string, message: MessagesQueryMessage }): Promise<MessagesQueryReply> {
+    let messagesQuery: MessagesQuery;
+    try {
+      messagesQuery = await MessagesQuery.parse(message);
+    } catch (e) {
+      return messageReplyFromError(e, 400);
+    }
+
+    try {
+      await authenticate(message.authorization, this.deps.didResolver);
+      await this.authorizeMessagesQuery(tenant, messagesQuery);
+    } catch (e) {
+      return messageReplyFromError(e, 401);
+    }
+
+    const replicationFeedReader = MessagesQueryHandler.asReplicationFeedReader(this.deps.messageStore);
+    if (replicationFeedReader === undefined) {
+      return {
+        status: {
+          code   : 501,
+          detail : `${DwnErrorCode.MessagesQueryReplicationFeedUnimplemented}: MessagesQuery requires a replication feed reader`,
+        }
+      };
+    }
+
+    try {
+      const filters = MessagesQueryHandler.convertFilters(message.descriptor.filters, this.deps);
+      const result = await replicationFeedReader.logRead(tenant, {
+        cursor : message.descriptor.cursor,
+        filters,
+        limit  : message.descriptor.limit,
+      });
+
+      const reply: MessagesQueryReply = {
+        status  : { code: 200, detail: 'OK' },
+        entries : await MessagesQueryHandler.buildEntries(result.events, message.descriptor.cidsOnly ?? false),
+        cursor  : result.cursor,
+        drained : result.drained,
+      };
+
+      const fingerprintScopes = MessagesQueryHandler.computeFingerprintScopes(message.descriptor.filters);
+      if (fingerprintScopes !== undefined) {
+        reply.fingerprint = await replicationFeedReader.fingerprint(tenant, fingerprintScopes);
+      }
+
+      return reply;
+    } catch (e) {
+      if (e instanceof DwnError && e.code === DwnErrorCode.EventLogProgressGap) {
+        const gapInfo = MessagesQueryHandler.getProgressGapInfo(e);
+        return {
+          status : { code: 410, detail: 'Progress token gap' },
+          error  : gapInfo === undefined ? undefined : { code: 'ProgressGap', ...gapInfo },
+        };
+      }
+
+      return messageReplyFromError(e, 500);
+    }
+  }
+
+  private async authorizeMessagesQuery(
+    tenant: string,
+    messagesQuery: MessagesQuery,
+  ): Promise<void> {
+    if (messagesQuery.author === tenant) {
+      return;
+    }
+
+    const permissionGrantIds = Message.getPermissionGrantIds(messagesQuery.signaturePayload!);
+    if (messagesQuery.author !== undefined && permissionGrantIds.length > 0) {
+      const permissionGrants = await MessagesGrantAuthorization.fetchPermissionGrants(
+        tenant,
+        this.deps.validationStateReader,
+        permissionGrantIds
+      );
+      await MessagesGrantAuthorization.authorizeSubscribeOrSync({
+        incomingMessage       : messagesQuery.message,
+        expectedGrantor       : tenant,
+        expectedGrantee       : messagesQuery.author,
+        permissionGrants,
+        validationStateReader : this.deps.validationStateReader
+      });
+      return;
+    }
+
+    throw new DwnError(DwnErrorCode.MessagesQueryAuthorizationFailed, 'message failed authorization');
+  }
+
+  private static asReplicationFeedReader(candidate: unknown): ReplicationFeedReader | undefined {
+    const partial = candidate as Partial<ReplicationFeedReader>;
+    if (
+      typeof partial.logRead === 'function' &&
+      typeof partial.logBounds === 'function' &&
+      typeof partial.fingerprint === 'function' &&
+      typeof partial.epoch === 'function'
+    ) {
+      return partial as ReplicationFeedReader;
+    }
+  }
+
+  private static convertFilters(filters: MessagesFilter[], deps: HandlerDependencies): Filter[] | undefined {
+    if (filters.length === 0) {
+      return undefined;
+    }
+
+    return Messages.convertFilters(filters, deps.coreProtocols);
+  }
+
+  private static async buildEntries(
+    events: EventLogEntry[],
+    cidsOnly: boolean,
+  ): Promise<MessagesQueryReplyEntry[]> {
+    const entries: MessagesQueryReplyEntry[] = [];
+
+    for (const event of events) {
+      entries.push(await MessagesQueryHandler.buildEntry(event, cidsOnly));
+    }
+
+    return entries;
+  }
+
+  private static async buildEntry(
+    event: EventLogEntry,
+    cidsOnly: boolean,
+  ): Promise<MessagesQueryReplyEntry> {
+    const messageCid = event.messageCid ?? await Message.getCid(event.event.message);
+    const protocol = MessagesQueryHandler.getStringIndex(event.indexes, 'protocol');
+    const entry: MessagesQueryReplyEntry = {
+      seq               : event.seq,
+      messageCid,
+      isLatestBaseState : MessagesQueryHandler.isLatestBaseState(event.indexes),
+      protocol,
+    };
+
+    if (cidsOnly) {
+      return entry;
+    }
+
+    const { message, encodedData } = Messages.detachEncodedData(event.event.message);
+    entry.message = message;
+    if (encodedData !== undefined) {
+      entry.encodedData = encodedData;
+    }
+
+    return entry;
+  }
+
+  private static getStringIndex(indexes: KeyValues, key: string): string | undefined {
+    const value = indexes[key];
+    return typeof value === 'string' ? value : undefined;
+  }
+
+  private static isLatestBaseState(indexes: KeyValues): boolean {
+    return indexes.isLatestBaseState === true || indexes.isLatestBaseState === 'true';
+  }
+
+  private static computeFingerprintScopes(filters: MessagesFilter[]): string[] | undefined {
+    if (filters.length === 0) {
+      return [Replication.globalDomain];
+    }
+
+    const protocols = new Set<string>();
+    for (const filter of filters) {
+      const keys = Object.keys(filter);
+      if (keys.length !== 1 || typeof filter.protocol !== 'string') {
+        return undefined;
+      }
+
+      protocols.add(filter.protocol);
+    }
+
+    const protocolList = [...protocols];
+    const scopes = protocolList.map(protocol => Replication.protocolDomain(protocol));
+    if (!protocols.has(PermissionsProtocol.uri)) {
+      scopes.push(...protocolList.map(protocol => Replication.permissionDomain(protocol)));
+    }
+
+    return scopes;
+  }
+
+  private static getProgressGapInfo(error: DwnError): ProgressGapInfo | undefined {
+    const gapInfo = (error as DwnError & { gapInfo?: ProgressGapInfo }).gapInfo;
+    return gapInfo;
+  }
+}

--- a/packages/dwn-sdk-js/src/handlers/messages-sync.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-sync.ts
@@ -9,6 +9,7 @@ import { Encoder } from '../utils/encoder.js';
 import { hashToHex } from '../smt/smt-utils.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
+import { Messages } from '../utils/messages.js';
 import { MessagesGrantAuthorization } from '../core/messages-grant-authorization.js';
 import { MessagesSync } from '../interfaces/messages-sync.js';
 import { Records } from '../utils/records.js';
@@ -19,8 +20,6 @@ import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
  * {@link DwnConstant.maxDataSizeAllowedToBeEncoded} threshold.
  */
 const DEFAULT_MAX_INLINE_DATA_SIZE = DwnConstant.maxDataSizeAllowedToBeEncoded;
-
-type StoredMessageWithEncodedData = GenericMessage & { encodedData?: string };
 
 export class MessagesSyncHandler implements MethodHandler {
 
@@ -316,26 +315,18 @@ export class MessagesSyncHandler implements MethodHandler {
       return {};
     }
 
-    let inlineEncodedData: string | undefined;
-    if (MessagesSyncHandler.hasEncodedData(storedMessage)) {
-      inlineEncodedData = storedMessage.encodedData;
-      delete storedMessage.encodedData;
-    }
+    const { message, encodedData: inlineEncodedData } = Messages.detachEncodedData(storedMessage);
 
     let data: ReadableStream<Uint8Array> | undefined;
-    if (inlineEncodedData === undefined && Records.isRecordsWrite(storedMessage)) {
-      const { dataCid, dataSize } = storedMessage.descriptor;
+    if (inlineEncodedData === undefined && Records.isRecordsWrite(message)) {
+      const { dataCid, dataSize } = message.descriptor;
       if (dataSize <= DEFAULT_MAX_INLINE_DATA_SIZE && this.deps.dataStore) {
-        const dataResult = await this.deps.dataStore.get(tenant, storedMessage.recordId, dataCid);
+        const dataResult = await this.deps.dataStore.get(tenant, message.recordId, dataCid);
         data = dataResult?.dataStream;
       }
     }
 
-    return { message: storedMessage, encodedData: inlineEncodedData, data };
-  }
-
-  private static hasEncodedData(message: GenericMessage): message is StoredMessageWithEncodedData {
-    return 'encodedData' in message && typeof message.encodedData === 'string';
+    return { message, encodedData: inlineEncodedData, data };
   }
 
   private static async streamToBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -1,6 +1,6 @@
 // export everything that we want to be consumable
 export type { DwnConfig } from './dwn.js';
-export type { EventListener, EventLog, EventLogEntry, EventLogReadOptions, EventLogReadResult, EventLogSubscribeOptions, EventSubscription, MessageEvent, ProgressGapInfo, ProgressGapReason, ProgressToken, ReplicationFeedReader, SubscriptionEose, SubscriptionError, SubscriptionEvent, SubscriptionListener, SubscriptionMessage, SubscriptionReply, Wake, WakePublisher } from './types/subscriptions.js';
+export type { EventListener, EventLog, EventLogEntry, EventLogReadOptions, EventLogReadResult, EventLogSubscribeOptions, EventSubscription, MessageEvent, ProgressGapInfo, ProgressGapReason, ProgressToken, ReplicationFeedReader, SubscriptionEose, SubscriptionError, SubscriptionEvent, SubscriptionListener, SubscriptionMessage, SubscriptionReply, Wake, WakePublisher, WakeSubscriber } from './types/subscriptions.js';
 export type { AuthorizationModel, Descriptor, DelegatedGrantRecordsWriteMessage, GenericMessage, GenericMessageReply, GenericSignaturePayload, MessageSort, MessageSubscription, Pagination, QueryResultEntry, Status } from './types/message-types.js';
 export type { DependencyRef, ReplicationApplyOptions, ReplicationApplyResult, ReplicationApplyResultContext } from './core/replication-apply.js';
 export { replicationApplyResultFromReply } from './core/replication-apply.js';
@@ -8,7 +8,7 @@ export type { ValidationStateReader } from './types/validation-state-reader.js';
 export { StoreValidationStateReader } from './core/validation-state-reader.js';
 export type { RecordedValidationRead } from './core/recording-validation-state-reader.js';
 export { RecordingValidationStateReader } from './core/recording-validation-state-reader.js';
-export type { MessagesFilter, MessagesReadMessage, MessagesReadReply, MessagesReadReplyEntry, MessagesReadDescriptor, MessagesSubscribeDescriptor, MessagesSubscribeMessage, MessagesSubscribeReply, MessagesSubscribeMessageOptions, MessagesSyncAction, MessagesSyncDescriptor, MessagesSyncDiffEntry, MessagesSyncMessage, MessagesSyncReply } from './types/messages-types.js';
+export type { MessagesFilter, MessagesQueryDescriptor, MessagesQueryMessage, MessagesQueryReply, MessagesQueryReplyEntry, MessagesReadMessage, MessagesReadReply, MessagesReadReplyEntry, MessagesReadDescriptor, MessagesSubscribeDescriptor, MessagesSubscribeMessage, MessagesSubscribeReply, MessagesSubscribeMessageOptions, MessagesSyncAction, MessagesSyncDescriptor, MessagesSyncDiffEntry, MessagesSyncMessage, MessagesSyncReply } from './types/messages-types.js';
 export type { GT, LT, Filter, FilterValue, KeyValues, EqualFilter, OneOfFilter, RangeFilter, RangeCriterion, PaginationCursor, QueryOptions, RangeValue, StartsWithFilter } from './types/query-types.js';
 export type { ProtocolsConfigureDescriptor, ProtocolDefinition, ProtocolTypes, ProtocolRuleSet, ProtocolsQueryFilter, ProtocolsConfigureMessage, ProtocolsQueryMessage, ProtocolsQueryReply, ProtocolActionRule, ProtocolDeliveryStrategy, ProtocolPathEncryption, ProtocolsQueryDescriptor, ProtocolRecordLimitDefinition, ProtocolSizeDefinition, ProtocolTagsDefinition, ProtocolTagSchema, ProtocolType, ProtocolUses } from './types/protocols-types.js';
 export { ProtocolRecordLimitStrategy } from './types/protocols-types.js';
@@ -48,6 +48,8 @@ export type { KeyMaterial, PrivateKeyJwk, PublicKeyJwk, Jwk } from './types/jose
 export { Message } from './core/message.js';
 export { MessagesRead } from './interfaces/messages-read.js';
 export type { MessagesReadOptions } from './interfaces/messages-read.js';
+export { MessagesQuery } from './interfaces/messages-query.js';
+export type { MessagesQueryOptions } from './interfaces/messages-query.js';
 export { MessagesSync } from './interfaces/messages-sync.js';
 export type { MessagesSyncOptions } from './interfaces/messages-sync.js';
 export type { UnionMessageReply } from './core/message-reply.js';
@@ -100,6 +102,8 @@ export { ResumableTaskStoreLevel } from './store/resumable-task-store-level.js';
 export type { ResumableTaskStoreLevelConfig } from './store/resumable-task-store-level.js';
 export { EventEmitterEventLog } from './event-stream/event-emitter-event-log.js';
 export type { EventEmitterEventLogConfig } from './event-stream/event-emitter-event-log.js';
+export { DurableEventLog } from './event-stream/durable-event-log.js';
+export type { DurableEventLogConfig, DurableEventLogStore } from './event-stream/durable-event-log.js';
 
 // Sparse Merkle Tree and StateIndex
 export type { StateIndex } from './types/state-index.js';
@@ -111,6 +115,6 @@ export { SMTStoreMemory } from './smt/smt-store-memory.js';
 export type { Hash, SMTNode, SMTInternalNode, SMTLeafNode, SMTProof, SMTDiffResult, SMTNodeStore } from './types/smt-types.js';
 export { hashChildren, hashEquals, hashKey, hashLeaf, hashToHex, hexToHash, getBit, initDefaultHashes, getDefaultHashes, SMT_DEPTH, ZERO_HASH } from './smt/smt-utils.js';
 // test library exports
-export type { GenerateFromRecordsWriteInput, GenerateFromRecordsWriteOut, GenerateGrantCreateInput, GenerateGrantCreateOutput, GenerateMessagesReadInput, GenerateMessagesReadOutput, GenerateMessagesSubscribeInput, GenerateMessagesSubscribeOutput, GenerateProtocolsConfigureInput, GenerateProtocolsConfigureOutput, GenerateProtocolsQueryInput, GenerateProtocolsQueryOutput, GenerateRecordsCountInput, GenerateRecordsCountOutput, GenerateRecordsDeleteInput, GenerateRecordsDeleteOutput, GenerateRecordsQueryInput, GenerateRecordsQueryOutput, GenerateRecordsSubscribeInput, GenerateRecordsSubscribeOutput, GenerateRecordsWriteInput, GenerateRecordsWriteOutput, Persona } from '../tests/utils/test-data-generator.js';
+export type { GenerateFromRecordsWriteInput, GenerateFromRecordsWriteOut, GenerateGrantCreateInput, GenerateGrantCreateOutput, GenerateMessagesQueryInput, GenerateMessagesQueryOutput, GenerateMessagesReadInput, GenerateMessagesReadOutput, GenerateMessagesSubscribeInput, GenerateMessagesSubscribeOutput, GenerateProtocolsConfigureInput, GenerateProtocolsConfigureOutput, GenerateProtocolsQueryInput, GenerateProtocolsQueryOutput, GenerateRecordsCountInput, GenerateRecordsCountOutput, GenerateRecordsDeleteInput, GenerateRecordsDeleteOutput, GenerateRecordsQueryInput, GenerateRecordsQueryOutput, GenerateRecordsSubscribeInput, GenerateRecordsSubscribeOutput, GenerateRecordsWriteInput, GenerateRecordsWriteOutput, Persona } from '../tests/utils/test-data-generator.js';
 export { TestDataGenerator } from '../tests/utils/test-data-generator.js';
 export { Poller } from '../tests/utils/poller.js';

--- a/packages/dwn-sdk-js/src/interfaces/messages-query.ts
+++ b/packages/dwn-sdk-js/src/interfaces/messages-query.ts
@@ -1,0 +1,70 @@
+import type { MessageSigner } from '../types/signer.js';
+import type { ProgressToken } from '../types/subscriptions.js';
+import type { MessagesFilter, MessagesQueryDescriptor, MessagesQueryMessage } from '../types/messages-types.js';
+
+import { AbstractMessage } from '../core/abstract-message.js';
+import { Message } from '../core/message.js';
+import { removeUndefinedProperties } from '@enbox/common';
+import { Time } from '../utils/time.js';
+import { validateProtocolUrlNormalized } from '../utils/url.js';
+import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
+
+export type MessagesQueryOptions = {
+  signer: MessageSigner;
+  messageTimestamp?: string;
+  filters?: MessagesFilter[];
+  permissionGrantIds?: string[];
+  cursor?: ProgressToken;
+  limit?: number;
+  cidsOnly?: boolean;
+};
+
+export class MessagesQuery extends AbstractMessage<MessagesQueryMessage> {
+  public static async parse(message: MessagesQueryMessage): Promise<MessagesQuery> {
+    Message.validateJsonSchema(message);
+    await Message.validateSignatureStructure(message.authorization.signature, message.descriptor);
+
+    for (const filter of message.descriptor.filters) {
+      if ('protocol' in filter && filter.protocol !== undefined) {
+        validateProtocolUrlNormalized(filter.protocol);
+      }
+    }
+
+    Time.validateTimestamp(message.descriptor.messageTimestamp);
+    return new MessagesQuery(message);
+  }
+
+  /**
+   * Creates a MessagesQuery message.
+   *
+   * @throws {DwnError} if json schema validation fails.
+   */
+  public static async create(options: MessagesQueryOptions): Promise<MessagesQuery> {
+    const permissionGrantInvocation = Message.normalizePermissionGrantInvocation({
+      permissionGrantIds: options.permissionGrantIds
+    });
+
+    const descriptor: MessagesQueryDescriptor = {
+      interface        : DwnInterfaceName.Messages,
+      method           : DwnMethodName.Query,
+      filters          : options.filters ?? [],
+      messageTimestamp : options.messageTimestamp ?? Time.getCurrentTimestamp(),
+      cursor           : options.cursor,
+      limit            : options.limit,
+      cidsOnly         : options.cidsOnly,
+      ...permissionGrantInvocation,
+    };
+
+    removeUndefinedProperties(descriptor);
+
+    const authorization = await Message.createAuthorization({
+      descriptor,
+      signer: options.signer,
+      ...permissionGrantInvocation,
+    });
+
+    const message: MessagesQueryMessage = { descriptor, authorization };
+    Message.validateJsonSchema(message);
+    return new MessagesQuery(message);
+  }
+}

--- a/packages/dwn-sdk-js/src/store/message-store-level.ts
+++ b/packages/dwn-sdk-js/src/store/message-store-level.ts
@@ -715,7 +715,7 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
     for await (const { position, entry } of this.mergePositionStreams(logIterator, redeliveryIterator, tenantLog)) {
       lastScannedPosition = position;
 
-      const event = await this.readEventFromLogEntry(tenantBlocks, entry, filters);
+      const event = await this.readEventFromLogEntry(tenantBlocks, position, entry, filters);
       if (event === undefined) {
         continue;
       }
@@ -741,6 +741,7 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
 
   private async readEventFromLogEntry(
     tenantBlocks: LevelWrapper<Uint8Array>,
+    position: bigint,
     entry: LogEntryValue | undefined,
     filters: Filter[] | undefined,
   ): Promise<EventLogEntry | undefined> {
@@ -764,6 +765,7 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
     const message = decodedBlock.value as GenericMessage;
     return {
       seq        : entry.seq, // a redelivered entry carries the row's original seq
+      position   : position.toString(),
       event      : { message },
       indexes    : entry.indexes,
       messageCid : entry.messageCid,

--- a/packages/dwn-sdk-js/src/types/messages-types.ts
+++ b/packages/dwn-sdk-js/src/types/messages-types.ts
@@ -42,6 +42,40 @@ export type MessagesReadReply = GenericMessageReply & {
   entry?: MessagesReadReplyEntry;
 };
 
+export type MessagesQueryDescriptor = {
+  interface: DwnInterfaceName.Messages;
+  method: DwnMethodName.Query;
+  messageTimestamp: string;
+  filters: MessagesFilter[];
+  permissionGrantIds?: string[];
+  cursor?: ProgressToken;
+  limit?: number;
+  cidsOnly?: boolean;
+};
+
+export type MessagesQueryMessage = {
+  authorization: AuthorizationModel;
+  descriptor: MessagesQueryDescriptor;
+};
+
+export type MessagesQueryReplyEntry = {
+  seq: string;
+  messageCid: string;
+  isLatestBaseState: boolean;
+  protocol?: string;
+  message?: GenericMessage;
+  encodedData?: string;
+};
+
+export type MessagesQueryReply = GenericMessageReply & {
+  entries?: MessagesQueryReplyEntry[];
+  cursor?: ProgressToken;
+  drained?: boolean;
+  fingerprint?: string;
+  /** Present when status.code is 410 — structured gap metadata. */
+  error?: { code: 'ProgressGap' } & ProgressGapInfo;
+};
+
 export type MessagesSyncAction = 'root' | 'subtree' | 'leaves' | 'diff';
 
 export type MessagesSyncDescriptor = {

--- a/packages/dwn-sdk-js/src/types/subscriptions.ts
+++ b/packages/dwn-sdk-js/src/types/subscriptions.ts
@@ -95,6 +95,16 @@ export type SubscriptionEvent = {
   cursor : ProgressToken;
   /** The event payload (message + optional initialWrite). */
   event : MessageEvent;
+  /** Original row sequence for this message. Redelivery events keep the row's original sequence. */
+  seq? : string;
+  /** CID of the message that produced this event. */
+  messageCid? : string;
+  /** Whether this event's source row was latest base state at read time. */
+  isLatestBaseState? : boolean;
+  /** Protocol index value associated with the source row, when present. */
+  protocol? : string;
+  /** Base64url-encoded inline data carried beside the message payload. */
+  encodedData? : string;
 };
 
 /**
@@ -174,8 +184,17 @@ export type EventLogEntry = {
   /** Monotonic sequence number scoped to (instance, tenant), as a decimal string. */
   seq: string;
 
+  /**
+   * The actual delivered log position. This differs from `seq` for redelivery
+   * stamps, where the entry keeps the row's original `seq` but is delivered at
+   * the later redelivery position.
+   */
+  position?: string;
+
   /** The event payload. */
   event: MessageEvent;
+  /** Base64url-encoded inline data carried beside the message payload. */
+  encodedData?: string;
 
   /** Indexes associated with the event (used for filter matching). */
   indexes: KeyValues;
@@ -285,6 +304,10 @@ export type Wake = {
 
 export interface WakePublisher {
   publish(wake: Wake): void;
+}
+
+export interface WakeSubscriber {
+  subscribe(listener: (wake: Wake) => void): () => void;
 }
 
 export interface ReplicationFeedReader {

--- a/packages/dwn-sdk-js/src/utils/messages.ts
+++ b/packages/dwn-sdk-js/src/utils/messages.ts
@@ -1,10 +1,14 @@
 import type { CoreProtocolRegistry } from '../core/core-protocol.js';
 import type { Filter } from '../types/query-types.js';
+import type { GenericMessage } from '../types/message-types.js';
 import type { MessagesFilter } from '../types/messages-types.js';
 
 import { FilterUtility } from './filter.js';
 import { normalizeProtocolUrl } from './url.js';
+import { Records } from './records.js';
 import { isEmptyObject, removeUndefinedProperties } from '@enbox/common';
+
+type StoredMessageWithEncodedData = GenericMessage & { encodedData?: string };
 
 
 /**
@@ -96,6 +100,22 @@ export class Messages {
   }
 
   /**
+   * Returns a copy of a RecordsWrite message without inline encodedData, and the
+   * detached encodedData value for wire surfaces that carry data beside the message.
+   */
+  public static detachEncodedData(message: GenericMessage): { message: GenericMessage; encodedData?: string } {
+    if (!Records.isRecordsWrite(message) || !Messages.hasEncodedData(message)) {
+      return { message };
+    }
+
+    const messageWithoutEncodedData: StoredMessageWithEncodedData = { ...message };
+    const { encodedData } = messageWithoutEncodedData;
+    delete messageWithoutEncodedData.encodedData;
+
+    return { message: messageWithoutEncodedData, encodedData };
+  }
+
+  /**
    * Converts an external-facing filter model into an internal-facing filer model used by data store.
    */
   private static convertFilter(filter: MessagesFilter): Filter {
@@ -131,5 +151,9 @@ export class Messages {
     }
 
     return filterCopy;
+  }
+
+  private static hasEncodedData(message: GenericMessage): message is StoredMessageWithEncodedData {
+    return 'encodedData' in message && typeof message.encodedData === 'string';
   }
 }

--- a/packages/dwn-sdk-js/tests/durable-event-log.spec.ts
+++ b/packages/dwn-sdk-js/tests/durable-event-log.spec.ts
@@ -1,0 +1,165 @@
+import type { GenerateRecordsWriteOutput, Persona } from './utils/test-data-generator.js';
+import type { RecordsWriteMessage, SubscriptionMessage } from '../src/index.js';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+import { DurableEventLog } from '../src/event-stream/durable-event-log.js';
+import { EventEmitterWakePublisher } from '../src/event-stream/event-emitter-wake-publisher.js';
+import { Message } from '../src/core/message.js';
+import { MessageStoreLevel } from '../src/store/message-store-level.js';
+import { Poller } from './utils/poller.js';
+import { TestDataGenerator } from './utils/test-data-generator.js';
+
+type StoredRecord = GenerateRecordsWriteOutput & {
+  messageCid: string;
+  position: string;
+};
+
+describe('DurableEventLog', () => {
+  let messageStore: MessageStoreLevel;
+  let eventLog: DurableEventLog;
+  let wakePublisher: EventEmitterWakePublisher;
+
+  beforeAll(async () => {
+    wakePublisher = new EventEmitterWakePublisher();
+    messageStore = new MessageStoreLevel({
+      location: 'TEST-MESSAGESTORE-DURABLE-EVENT-LOG',
+      wakePublisher,
+    });
+    await messageStore.open();
+  });
+
+  beforeEach(async () => {
+    await eventLog?.close();
+    await messageStore.clear();
+    wakePublisher.clear();
+    eventLog = new DurableEventLog(messageStore, wakePublisher, { idleRedrainIntervalMs: 0 });
+    await eventLog.open();
+  });
+
+  afterAll(async () => {
+    await eventLog.close();
+    await messageStore.close();
+  });
+
+  it('should read durable log entries with high-water cursors', async () => {
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    const first = await storeRecord(alice);
+    const second = await storeRecord(alice);
+
+    const result = await eventLog.read(alice.did);
+
+    expect(result.events.map(entry => entry.messageCid)).toEqual([first.messageCid, second.messageCid]);
+    expect(result.events.map(entry => entry.position)).toEqual(['1', '2']);
+    expect(result.events[0].encodedData).toBe((first.message as RecordsWriteMessage & { encodedData?: string }).encodedData);
+    expect((result.events[0].event.message as RecordsWriteMessage & { encodedData?: string }).encodedData).toBeUndefined();
+    expect(result.cursor!.position).toBe('2');
+    expect(result.drained).toBe(true);
+  });
+
+  it('should replay from a cursor, send EOSE, then drain live wakes', async () => {
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    const first = await storeRecord(alice);
+    const bounds = await eventLog.getReplayBounds(alice.did);
+    const received: SubscriptionMessage[] = [];
+
+    const subscription = await eventLog.subscribe(alice.did, 'subscription-1', (message): void => {
+      received.push(message);
+    }, { cursor: bounds!.oldest });
+
+    expect(received).toHaveLength(2);
+    expect(received[0]).toEqual(expect.objectContaining({
+      type       : 'event',
+      seq        : '1',
+      messageCid : first.messageCid,
+    }));
+    expect(received[0].cursor.position).toBe('1');
+    expect(received[1]).toEqual(expect.objectContaining({ type: 'eose' }));
+    expect(received[1].cursor.position).toBe('1');
+
+    const second = await storeRecord(alice);
+    await Poller.pollUntilSuccessOrTimeout(async () => {
+      expect(received.filter(message => message.type === 'event')).toHaveLength(2);
+    });
+
+    const liveEvent = received[2];
+    expect(liveEvent).toEqual(expect.objectContaining({
+      type       : 'event',
+      seq        : '2',
+      messageCid : second.messageCid,
+    }));
+    expect(liveEvent.cursor.position).toBe('2');
+
+    await subscription.close();
+  });
+
+  it('should emit redelivery events at the redelivery cursor position', async () => {
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    const record = await TestDataGenerator.generateRecordsWrite({ author: alice });
+    const message = { ...record.message } as RecordsWriteMessage & { encodedData?: string };
+    delete message.encodedData;
+
+    const messageCid = await Message.getCid(message);
+    const indexes = await record.recordsWrite.constructIndexes(true);
+    const initialPut = await messageStore.put(alice.did, message, { ...indexes, isLatestBaseState: false });
+    const completion = await messageStore.completeData(
+      alice.did,
+      messageCid,
+      indexes,
+      (record.message as RecordsWriteMessage & { encodedData?: string }).encodedData
+    );
+    expect(completion.position!.position).toBe('2');
+
+    const received: SubscriptionMessage[] = [];
+    await eventLog.subscribe(alice.did, 'redelivery-subscription', (message): void => {
+      received.push(message);
+    }, { cursor: initialPut.position! });
+
+    expect(received[0]).toEqual(expect.objectContaining({
+      type : 'event',
+      seq  : '1',
+      messageCid,
+    }));
+    const redeliveryEvent = received[0];
+    expect(redeliveryEvent.type).toBe('event');
+    if (redeliveryEvent.type !== 'event') {
+      throw new Error('expected a redelivery event');
+    }
+    expect(redeliveryEvent.encodedData).toBe((record.message as RecordsWriteMessage & { encodedData?: string }).encodedData);
+    expect((redeliveryEvent.event.message as RecordsWriteMessage & { encodedData?: string }).encodedData).toBeUndefined();
+    expect(redeliveryEvent.cursor.position).toBe('2');
+    expect(received[1]).toEqual(expect.objectContaining({ type: 'eose' }));
+    expect(received[1].cursor.position).toBe('2');
+  });
+
+  it('should attach initial writes to non-initial RecordsWrite events', async () => {
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    const initial = await TestDataGenerator.generateRecordsWrite({ author: alice });
+    const update = await TestDataGenerator.generateFromRecordsWrite({
+      author        : alice,
+      existingWrite : initial.recordsWrite,
+    });
+
+    await messageStore.put(alice.did, initial.message, await initial.recordsWrite.constructIndexes(false));
+    const updatePut = await messageStore.put(alice.did, update.message, await update.recordsWrite.constructIndexes(true));
+
+    const result = await eventLog.read(alice.did);
+    const updateEntry = result.events.find(entry => entry.messageCid === updatePut.position!.messageCid);
+
+    expect(updateEntry).toBeDefined();
+    expect(updateEntry!.event.initialWrite).toBeDefined();
+    expect(updateEntry!.event.initialWrite!.recordId).toBe(initial.message.recordId);
+  });
+
+  async function storeRecord(author: Persona): Promise<StoredRecord> {
+    const record = await TestDataGenerator.generateRecordsWrite({ author });
+    const indexes = await record.recordsWrite.constructIndexes(true);
+    const putResult = await messageStore.put(author.did, record.message, indexes);
+
+    return {
+      ...record,
+      messageCid : await Message.getCid(record.message),
+      position   : putResult.position!.position,
+    };
+  }
+});

--- a/packages/dwn-sdk-js/tests/durable-event-log.spec.ts
+++ b/packages/dwn-sdk-js/tests/durable-event-log.spec.ts
@@ -1,3 +1,7 @@
+import type { DurableEventLogStore } from '../src/event-stream/durable-event-log.js';
+import type { Filter } from '../src/types/query-types.js';
+import type { GenericMessage } from '../src/types/message-types.js';
+import type { EventLogEntry, EventLogReadOptions, EventLogReadResult, ProgressGapInfo, ProgressToken } from '../src/types/subscriptions.js';
 import type { GenerateRecordsWriteOutput, Persona } from './utils/test-data-generator.js';
 import type { RecordsWriteMessage, SubscriptionMessage } from '../src/index.js';
 
@@ -8,12 +12,152 @@ import { EventEmitterWakePublisher } from '../src/event-stream/event-emitter-wak
 import { Message } from '../src/core/message.js';
 import { MessageStoreLevel } from '../src/store/message-store-level.js';
 import { Poller } from './utils/poller.js';
+import { Replication } from '../src/utils/replication.js';
 import { TestDataGenerator } from './utils/test-data-generator.js';
+import { DwnError, DwnErrorCode } from '../src/core/dwn-error.js';
 
 type StoredRecord = GenerateRecordsWriteOutput & {
   messageCid: string;
   position: string;
 };
+
+class ScriptedFeedStore implements DurableEventLogStore {
+  private readonly epochValue: string = crypto.randomUUID();
+  private wakeDuringNextRead?: EventLogEntry;
+  public throwGapOnNextRead: boolean = false;
+
+  public constructor(
+    private readonly tenant: string,
+    private readonly entries: EventLogEntry[],
+    private readonly wakePublisher: EventEmitterWakePublisher,
+  ) {}
+
+  public append(entry: EventLogEntry): void {
+    this.entries.push(entry);
+    this.entries.sort((left, right): number => Number(BigInt(ScriptedFeedStore.getPosition(left)) - BigInt(ScriptedFeedStore.getPosition(right))));
+  }
+
+  public publishWakeDuringNextRead(entry: EventLogEntry): void {
+    this.wakeDuringNextRead = entry;
+  }
+
+  public async epoch(): Promise<string> {
+    return this.epochValue;
+  }
+
+  public async fingerprint(_tenant: string, _scopes: string[]): Promise<string> {
+    return Replication.fingerprintToHex(Replication.emptyFingerprint());
+  }
+
+  public async query(_tenant: string, _filters: Filter[]): Promise<{ messages: GenericMessage[] }> {
+    return { messages: [] };
+  }
+
+  public async logBounds(tenant: string): Promise<{ oldest: ProgressToken; latest: ProgressToken } | undefined> {
+    this.assertTenant(tenant);
+    if (this.entries.length === 0) {
+      return undefined;
+    }
+
+    const oldestEntry = this.entries[0];
+    const latestEntry = this.entries[this.entries.length - 1];
+    return {
+      oldest : await this.createToken(ScriptedFeedStore.getPosition(oldestEntry), oldestEntry.messageCid),
+      latest : await this.createToken(ScriptedFeedStore.getPosition(latestEntry), latestEntry.messageCid),
+    };
+  }
+
+  public async logRead(tenant: string, options: EventLogReadOptions = {}): Promise<EventLogReadResult> {
+    this.assertTenant(tenant);
+    await this.validateCursor(options.cursor);
+
+    if (this.throwGapOnNextRead) {
+      this.throwGapOnNextRead = false;
+      await this.throwProgressGap(options.cursor);
+    }
+
+    const limit = options.limit ?? Number.MAX_SAFE_INTEGER;
+    const cursorPosition = options.cursor === undefined ? 0n : BigInt(options.cursor.position);
+    const headPosition = this.getHeadPosition();
+    if (limit <= 0) {
+      return { events: [], cursor: options.cursor, drained: cursorPosition >= headPosition };
+    }
+
+    if (this.wakeDuringNextRead !== undefined) {
+      const entry = this.wakeDuringNextRead;
+      this.wakeDuringNextRead = undefined;
+      this.append(entry);
+      this.wakePublisher.publish({ tenant: this.tenant, seq: ScriptedFeedStore.getPosition(entry) });
+    }
+
+    const events = this.entries
+      .filter(entry => BigInt(ScriptedFeedStore.getPosition(entry)) > cursorPosition)
+      .slice(0, limit);
+    const lastEvent = events.at(-1);
+    const resultCursor = lastEvent === undefined
+      ? options.cursor
+      : await this.createToken(ScriptedFeedStore.getPosition(lastEvent), lastEvent.messageCid);
+    const drained = BigInt(resultCursor?.position ?? options.cursor?.position ?? '0') >= this.getHeadPosition();
+
+    return { events, cursor: resultCursor, drained };
+  }
+
+  public async createToken(position: string, messageCid?: string): Promise<ProgressToken> {
+    const token: ProgressToken = {
+      streamId : await Replication.deriveStreamId(this.tenant),
+      epoch    : this.epochValue,
+      position,
+    };
+
+    if (messageCid !== undefined) {
+      token.messageCid = messageCid;
+    }
+
+    return token;
+  }
+
+  private assertTenant(tenant: string): void {
+    if (tenant !== this.tenant) {
+      throw new Error(`unexpected tenant ${tenant}`);
+    }
+  }
+
+  private async validateCursor(cursor: ProgressToken | undefined): Promise<void> {
+    if (cursor === undefined) {
+      return;
+    }
+
+    const invalidStream = cursor.streamId !== await Replication.deriveStreamId(this.tenant);
+    const invalidEpoch = cursor.epoch !== this.epochValue;
+    const invalidPosition = BigInt(cursor.position) > this.getHeadPosition();
+    if (invalidStream || invalidEpoch || invalidPosition) {
+      await this.throwProgressGap(cursor);
+    }
+  }
+
+  private async throwProgressGap(cursor: ProgressToken | undefined): Promise<never> {
+    const fallbackCursor = cursor ?? await this.createToken('0');
+    const bounds = await this.logBounds(this.tenant);
+    const gapInfo: ProgressGapInfo = {
+      requested       : fallbackCursor,
+      oldestAvailable : bounds?.oldest ?? fallbackCursor,
+      latestAvailable : bounds?.latest ?? fallbackCursor,
+      reason          : 'token_too_old',
+    };
+    const error = new DwnError(DwnErrorCode.EventLogProgressGap, 'progress token gap: token_too_old');
+    (error as DwnError & { gapInfo?: ProgressGapInfo }).gapInfo = gapInfo;
+    throw error;
+  }
+
+  private getHeadPosition(): bigint {
+    const latestEntry = this.entries.at(-1);
+    return latestEntry === undefined ? 0n : BigInt(ScriptedFeedStore.getPosition(latestEntry));
+  }
+
+  private static getPosition(entry: EventLogEntry): string {
+    return entry.position ?? entry.seq;
+  }
+}
 
 describe('DurableEventLog', () => {
   let messageStore: MessageStoreLevel;
@@ -93,6 +237,99 @@ describe('DurableEventLog', () => {
     await subscription.close();
   });
 
+  it('should gate wake-driven live delivery until after EOSE at the frozen catch-up cursor', async () => {
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    const localWakePublisher = new EventEmitterWakePublisher();
+    const firstEntry = await createLogEntry(alice, '1');
+    const secondEntry = await createLogEntry(alice, '2');
+    const scriptedStore = new ScriptedFeedStore(alice.did, [firstEntry], localWakePublisher);
+    const scriptedLog = new DurableEventLog(scriptedStore, localWakePublisher, { idleRedrainIntervalMs: 0 });
+    const received: SubscriptionMessage[] = [];
+
+    await scriptedLog.open();
+    scriptedStore.publishWakeDuringNextRead(secondEntry);
+    await scriptedLog.subscribe(alice.did, 'wake-during-catch-up', (message): void => {
+      received.push(message);
+    }, { cursor: await scriptedStore.createToken('0') });
+
+    await Poller.pollUntilSuccessOrTimeout(async () => {
+      expect(received.map(message => message.type)).toEqual(['event', 'eose', 'event']);
+    });
+
+    expect(received[0].cursor.position).toBe('1');
+    expect(received[1].cursor.position).toBe('1');
+    expect(received[2].cursor.position).toBe('2');
+    await scriptedLog.close();
+  });
+
+  it('should emit a subscription error and close after a wake-driven progress gap', async () => {
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    const localWakePublisher = new EventEmitterWakePublisher();
+    const firstEntry = await createLogEntry(alice, '1');
+    const secondEntry = await createLogEntry(alice, '2');
+    const scriptedStore = new ScriptedFeedStore(alice.did, [firstEntry], localWakePublisher);
+    const scriptedLog = new DurableEventLog(scriptedStore, localWakePublisher, { idleRedrainIntervalMs: 0 });
+    const received: SubscriptionMessage[] = [];
+
+    await scriptedLog.open();
+    await scriptedLog.subscribe(alice.did, 'gap-after-subscribe', (message): void => {
+      received.push(message);
+    });
+
+    scriptedStore.throwGapOnNextRead = true;
+    localWakePublisher.publish({ tenant: alice.did, seq: '2' });
+
+    await Poller.pollUntilSuccessOrTimeout(async () => {
+      expect(received).toHaveLength(1);
+      expect(received[0].type).toBe('error');
+    });
+
+    expect(received[0].cursor.position).toBe('1');
+    if (received[0].type !== 'error') {
+      throw new Error('expected subscription error');
+    }
+    expect(received[0].error.code).toBe('ProgressGap');
+
+    scriptedStore.append(secondEntry);
+    localWakePublisher.publish({ tenant: alice.did, seq: '2' });
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(received).toHaveLength(1);
+    await scriptedLog.close();
+  });
+
+  it('should stop delivering the current page after a subscription closes', async () => {
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    const localWakePublisher = new EventEmitterWakePublisher();
+    const firstEntry = await createLogEntry(alice, '1');
+    const secondEntry = await createLogEntry(alice, '2');
+    const thirdEntry = await createLogEntry(alice, '3');
+    const scriptedStore = new ScriptedFeedStore(alice.did, [firstEntry], localWakePublisher);
+    const scriptedLog = new DurableEventLog(scriptedStore, localWakePublisher, { idleRedrainIntervalMs: 0 });
+    const received: SubscriptionMessage[] = [];
+
+    await scriptedLog.open();
+    const subscription = await scriptedLog.subscribe(alice.did, 'close-during-drain', (message): void => {
+      if (message.type !== 'event') {
+        return;
+      }
+
+      received.push(message);
+      void subscription.close();
+    });
+
+    scriptedStore.append(secondEntry);
+    scriptedStore.append(thirdEntry);
+    localWakePublisher.publish({ tenant: alice.did, seq: '3' });
+
+    await Poller.pollUntilSuccessOrTimeout(async () => {
+      expect(received).toHaveLength(1);
+    });
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(received).toHaveLength(1);
+    expect(received[0].cursor.position).toBe('2');
+    await scriptedLog.close();
+  });
+
   it('should emit redelivery events at the redelivery cursor position', async () => {
     const alice = await TestDataGenerator.generateDidKeyPersona();
     const record = await TestDataGenerator.generateRecordsWrite({ author: alice });
@@ -160,6 +397,19 @@ describe('DurableEventLog', () => {
       ...record,
       messageCid : await Message.getCid(record.message),
       position   : putResult.position!.position,
+    };
+  }
+
+  async function createLogEntry(author: Persona, position: string): Promise<EventLogEntry> {
+    const record = await TestDataGenerator.generateRecordsWrite({ author });
+    const indexes = await record.recordsWrite.constructIndexes(true);
+
+    return {
+      seq        : position,
+      position,
+      event      : { message: record.message },
+      indexes,
+      messageCid : await Message.getCid(record.message),
     };
   }
 });

--- a/packages/dwn-sdk-js/tests/event-emitter-event-log.spec.ts
+++ b/packages/dwn-sdk-js/tests/event-emitter-event-log.spec.ts
@@ -1,4 +1,4 @@
-import type { SubscriptionMessage } from '../src/types/subscriptions.js';
+import type { EventLogReadOptions, EventLogReadResult, SubscriptionMessage } from '../src/types/subscriptions.js';
 
 import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
 
@@ -147,7 +147,7 @@ describe('EventEmitterEventLog', () => {
       const tenant = 'did:example:alice';
       const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
 
-      await eventLog.emit(tenant, event, {}, cid(1));
+      await eventLog.emit(tenant, event, { isLatestBaseState: true, protocol: 'http://protocol' }, cid(1));
       await eventLog.emit(tenant, event, {}, cid(2));
       await eventLog.emit(tenant, event, {}, cid(3));
 
@@ -188,7 +188,7 @@ describe('EventEmitterEventLog', () => {
       const received: SubscriptionMessage[] = [];
       await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); });
 
-      await eventLog.emit(tenant, event, {}, cid(1));
+      await eventLog.emit(tenant, event, { isLatestBaseState: true, protocol: 'http://protocol' }, cid(1));
       await eventLog.emit(tenant, event, {}, cid(2));
 
       // Allow async token construction to settle.
@@ -200,6 +200,10 @@ describe('EventEmitterEventLog', () => {
       if (received[0].type === 'event') {
         expect(typeof received[0].cursor).toBe('object');
         expect(received[0].cursor.streamId.length).toBeGreaterThan(0);
+        expect(received[0].seq).toBe('1');
+        expect(received[0].messageCid).toBe(cid(1));
+        expect(received[0].isLatestBaseState).toBe(true);
+        expect(received[0].protocol).toBe('http://protocol');
       }
     });
 
@@ -335,6 +339,39 @@ describe('EventEmitterEventLog', () => {
       if (received[1].type === 'event') {
         expect(typeof received[1].cursor).toBe('object');
       }
+    });
+
+    it('should deliver live events buffered during catch-up after EOSE', async () => {
+      const tenant = 'did:example:alice';
+      const event = { message: { descriptor: { interface: 'Records', method: 'Write' } } as any };
+      const cursorBefore = await eventLog.emit(tenant, event, { idx: 'before' }, cid(1));
+      await eventLog.emit(tenant, event, { idx: 'catch-up' }, cid(2));
+      const received: SubscriptionMessage[] = [];
+      const originalRead = eventLog.read.bind(eventLog);
+      let emittedDuringRead = false;
+
+      eventLog.read = async (readTenant: string, options?: EventLogReadOptions): Promise<EventLogReadResult> => {
+        const result = await originalRead(readTenant, options);
+        if (!emittedDuringRead) {
+          emittedDuringRead = true;
+          await eventLog.emit(tenant, event, { isLatestBaseState: true, protocol: 'http://protocol' }, cid(3));
+        }
+
+        return result;
+      };
+
+      await eventLog.subscribe(tenant, 'sub-1', (msg) => { received.push(msg); }, { cursor: cursorBefore! });
+
+      expect(received.map(message => message.type)).toEqual(['event', 'eose', 'event']);
+      expect(received[0].cursor.position).toBe('2');
+      expect(received[1].cursor.position).toBe('2');
+      expect(received[2].cursor.position).toBe('3');
+      if (received[2].type !== 'event') {
+        throw new Error('expected buffered live event');
+      }
+      expect(received[2].messageCid).toBe(cid(3));
+      expect(received[2].isLatestBaseState).toBe(true);
+      expect(received[2].protocol).toBe('http://protocol');
     });
 
     it('should apply filters to both catch-up and live events', async () => {

--- a/packages/dwn-sdk-js/tests/fuzz/schema-validation.fuzz.spec.ts
+++ b/packages/dwn-sdk-js/tests/fuzz/schema-validation.fuzz.spec.ts
@@ -21,6 +21,7 @@ const messageSchemaNames = [
   'RecordsSubscribe',
   'ProtocolsConfigure',
   'ProtocolsQuery',
+  'MessagesQuery',
   'MessagesRead',
   'MessagesSubscribe',
   'MessagesSync',

--- a/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
@@ -1,0 +1,298 @@
+import type { DidResolver } from '@enbox/dids';
+import type { DataStore, MessageStore, ProtocolDefinition, ReplicationFeedReader, ResumableTaskStore, StateIndex } from '../../src/index.js';
+
+import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { DidKey, UniversalResolver } from '@enbox/dids';
+
+import { Message } from '../../src/core/message.js';
+import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestStores } from '../test-stores.js';
+import { Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, Replication } from '../../src/index.js';
+
+function getFeedReader(messageStore: MessageStore): ReplicationFeedReader | undefined {
+  const candidate = messageStore as Partial<ReplicationFeedReader>;
+  if (
+    typeof candidate.logRead === 'function' &&
+    typeof candidate.logBounds === 'function' &&
+    typeof candidate.fingerprint === 'function' &&
+    typeof candidate.epoch === 'function'
+  ) {
+    return candidate as ReplicationFeedReader;
+  }
+}
+
+export function testMessagesQueryHandler(): void {
+  describe('MessagesQueryHandler.handle()', () => {
+    let didResolver: DidResolver;
+    let messageStore: MessageStore;
+    let dataStore: DataStore;
+    let resumableTaskStore: ResumableTaskStore;
+    let stateIndex: StateIndex;
+    let dwn: Dwn;
+
+    beforeAll(async () => {
+      didResolver = new UniversalResolver({ didResolvers: [DidKey] });
+
+      const stores = TestStores.get();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      resumableTaskStore = stores.resumableTaskStore;
+      stateIndex = stores.stateIndex;
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, stateIndex, resumableTaskStore });
+    });
+
+    beforeEach(async () => {
+      await messageStore.clear();
+      await dataStore.clear();
+      await resumableTaskStore.clear();
+      await stateIndex.clear();
+    });
+
+    afterAll(async () => {
+      await dwn.close();
+    });
+
+    it('returns 501 when the message store does not provide a replication feed reader', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const { message } = await TestDataGenerator.generateMessagesQuery({ author: alice });
+
+      const reply = await dwn.processMessage(alice.did, message);
+      if (getFeedReader(messageStore) !== undefined) {
+        expect(reply.status.code).toBe(200);
+        return;
+      }
+
+      expect(reply.status.code).toBe(501);
+      expect(reply.status.detail).toContain(DwnErrorCode.MessagesQueryReplicationFeedUnimplemented);
+    });
+
+    it('returns full log entries with inline RecordsWrite data detached from the message', async () => {
+      if (getFeedReader(messageStore) === undefined) {
+        return;
+      }
+
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+      const dataBytes = Encoder.stringToBytes('hello query');
+      const record = await TestDataGenerator.generateRecordsWrite({
+        author : alice,
+        data   : dataBytes,
+      });
+      const writeReply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+      expect(writeReply.status.code).toBe(202);
+
+      const { message: query } = await TestDataGenerator.generateMessagesQuery({
+        author  : alice,
+        filters : [{ interface: DwnInterfaceName.Records, method: DwnMethodName.Write }],
+      });
+      const reply = await dwn.processMessage(alice.did, query);
+
+      expect(reply.status.code).toBe(200);
+      expect(reply.entries).toHaveLength(1);
+      expect(reply.entries![0].messageCid).toBe(await Message.getCid(record.message));
+      expect(reply.entries![0].isLatestBaseState).toBe(true);
+      expect(reply.entries![0].protocol).toBe(record.message.descriptor.protocol);
+      expect(reply.entries![0].encodedData).toBe(Encoder.bytesToBase64Url(dataBytes));
+      expect(reply.entries![0].message).toBeDefined();
+      expect((reply.entries![0].message as { encodedData?: string }).encodedData).toBeUndefined();
+      expect(reply.drained).toBe(true);
+      expect(reply.cursor).toBeDefined();
+    });
+
+    it('supports cidsOnly pagination with high-water cursors', async () => {
+      if (getFeedReader(messageStore) === undefined) {
+        return;
+      }
+
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+      const expectedCids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const record = await TestDataGenerator.generateRecordsWrite({ author: alice });
+        const writeReply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+        expect(writeReply.status.code).toBe(202);
+        expectedCids.push(await Message.getCid(record.message));
+      }
+
+      const firstQuery = await TestDataGenerator.generateMessagesQuery({
+        author   : alice,
+        filters  : [{ interface: DwnInterfaceName.Records, method: DwnMethodName.Write }],
+        limit    : 2,
+        cidsOnly : true,
+      });
+      const firstReply = await dwn.processMessage(alice.did, firstQuery.message);
+      expect(firstReply.status.code).toBe(200);
+      expect(firstReply.entries!.map(entry => entry.messageCid)).toEqual(expectedCids.slice(0, 2));
+      expect(firstReply.entries!.every(entry => entry.message === undefined && entry.encodedData === undefined)).toBe(true);
+      expect(firstReply.drained).toBe(false);
+      expect(firstReply.cursor).toBeDefined();
+
+      const secondQuery = await TestDataGenerator.generateMessagesQuery({
+        author   : alice,
+        filters  : [{ interface: DwnInterfaceName.Records, method: DwnMethodName.Write }],
+        cursor   : firstReply.cursor,
+        cidsOnly : true,
+      });
+      const secondReply = await dwn.processMessage(alice.did, secondQuery.message);
+      expect(secondReply.status.code).toBe(200);
+      expect(secondReply.entries!.map(entry => entry.messageCid)).toEqual(expectedCids.slice(2));
+      expect(secondReply.drained).toBe(true);
+    });
+
+    it('includes fingerprints only for canonical sync scopes', async () => {
+      const feedReader = getFeedReader(messageStore);
+      if (feedReader === undefined) {
+        return;
+      }
+
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+      const record = await TestDataGenerator.generateRecordsWrite({ author: alice });
+      const writeReply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+      expect(writeReply.status.code).toBe(202);
+
+      const globalQuery = await TestDataGenerator.generateMessagesQuery({ author: alice });
+      const globalReply = await dwn.processMessage(alice.did, globalQuery.message);
+      expect(globalReply.status.code).toBe(200);
+      expect(globalReply.fingerprint).toBe(await feedReader.fingerprint(alice.did, [Replication.globalDomain]));
+
+      const protocol = record.message.descriptor.protocol;
+      const protocolQuery = await TestDataGenerator.generateMessagesQuery({
+        author  : alice,
+        filters : [{ protocol }],
+      });
+      const protocolReply = await dwn.processMessage(alice.did, protocolQuery.message);
+      expect(protocolReply.status.code).toBe(200);
+      expect(protocolReply.fingerprint).toBe(await feedReader.fingerprint(alice.did, [
+        Replication.protocolDomain(protocol),
+        Replication.permissionDomain(protocol),
+      ]));
+
+      const nonCanonicalQuery = await TestDataGenerator.generateMessagesQuery({
+        author  : alice,
+        filters : [{ protocol, method: DwnMethodName.Write }],
+      });
+      const nonCanonicalReply = await dwn.processMessage(alice.did, nonCanonicalQuery.message);
+      expect(nonCanonicalReply.status.code).toBe(200);
+      expect(nonCanonicalReply.fingerprint).toBeUndefined();
+    });
+
+    it('maps progress gaps to a 410 response with structured metadata', async () => {
+      if (getFeedReader(messageStore) === undefined) {
+        return;
+      }
+
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+      const { message } = await TestDataGenerator.generateMessagesQuery({
+        author : alice,
+        cursor : {
+          streamId : 'wrong-stream',
+          epoch    : 'wrong-epoch',
+          position : '0',
+        },
+      });
+      const reply = await dwn.processMessage(alice.did, message);
+
+      expect(reply.status.code).toBe(410);
+      expect(reply.error?.code).toBe('ProgressGap');
+      expect(reply.error?.reason).toBe('stream_mismatch');
+    });
+
+    it('allows delegated protocol-scoped queries and includes permission shadow records', async () => {
+      if (getFeedReader(messageStore) === undefined) {
+        return;
+      }
+
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const bob = await TestDataGenerator.generateDidKeyPersona();
+      const protocolDefinition: ProtocolDefinition = { ...freeForAll, published: false, protocol: 'http://messages-query-delegated' };
+
+      const { message: protocolConfigure } = await TestDataGenerator.generateProtocolsConfigure({
+        author: alice,
+        protocolDefinition,
+      });
+      const protocolReply = await dwn.processMessage(alice.did, protocolConfigure);
+      expect(protocolReply.status.code).toBe(202);
+
+      const grant = await TestDataGenerator.generateGrantCreate({
+        author    : alice,
+        grantedTo : bob,
+        scope     : {
+          interface : DwnInterfaceName.Messages,
+          method    : DwnMethodName.Read,
+          protocol  : protocolDefinition.protocol,
+        },
+      });
+      const grantReply = await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream });
+      expect(grantReply.status.code).toBe(202);
+
+      const record = await TestDataGenerator.generateRecordsWrite({
+        author       : alice,
+        protocol     : protocolDefinition.protocol,
+        protocolPath : 'post',
+        schema       : protocolDefinition.types.post.schema,
+      });
+      const writeReply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+      expect(writeReply.status.code).toBe(202);
+
+      const { message: query } = await TestDataGenerator.generateMessagesQuery({
+        author             : bob,
+        filters            : [{ protocol: protocolDefinition.protocol }],
+        permissionGrantIds : [grant.message.recordId],
+        cidsOnly           : true,
+      });
+      const reply = await dwn.processMessage(alice.did, query);
+
+      expect(reply.status.code).toBe(200);
+      expect(reply.entries!.map(entry => entry.messageCid).sort()).toEqual([
+        await Message.getCid(protocolConfigure),
+        await Message.getCid(grant.message),
+        await Message.getCid(record.message),
+      ].sort());
+    });
+
+    it('rejects unfiltered delegated queries with a protocol-scoped grant', async () => {
+      if (getFeedReader(messageStore) === undefined) {
+        return;
+      }
+
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const bob = await TestDataGenerator.generateDidKeyPersona();
+      const protocolDefinition: ProtocolDefinition = { ...freeForAll, published: false, protocol: 'http://messages-query-unfiltered-delegated' };
+
+      const { message: protocolConfigure } = await TestDataGenerator.generateProtocolsConfigure({
+        author: alice,
+        protocolDefinition,
+      });
+      expect((await dwn.processMessage(alice.did, protocolConfigure)).status.code).toBe(202);
+
+      const grant = await TestDataGenerator.generateGrantCreate({
+        author    : alice,
+        grantedTo : bob,
+        scope     : {
+          interface : DwnInterfaceName.Messages,
+          method    : DwnMethodName.Read,
+          protocol  : protocolDefinition.protocol,
+        },
+      });
+      expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+      const { message: query } = await TestDataGenerator.generateMessagesQuery({
+        author             : bob,
+        permissionGrantIds : [grant.message.recordId],
+      });
+      const reply = await dwn.processMessage(alice.did, query);
+
+      expect(reply.status.code).toBe(401);
+      expect(reply.status.detail).toContain(DwnErrorCode.MessagesGrantAuthorizationUnfilteredSubscribeProtocolScope);
+    });
+  });
+}

--- a/packages/dwn-sdk-js/tests/test-suite.ts
+++ b/packages/dwn-sdk-js/tests/test-suite.ts
@@ -7,6 +7,7 @@ import { testDeletedRecordScenarios } from './scenarios/deleted-record.spec.js';
 import { testDwnClass } from './dwn.spec.js';
 import { testEndToEndScenarios } from './scenarios/end-to-end-tests.spec.js';
 import { TestEventLog } from './test-event-stream.js';
+import { testMessagesQueryHandler } from './handlers/messages-query.spec.js';
 import { testMessagesReadHandler } from './handlers/messages-read.spec.js';
 import { testMessagesSubscribeHandler } from './handlers/messages-subscribe.spec.js';
 import { testMessagesSyncHandler } from './handlers/messages-sync.spec.js';
@@ -64,6 +65,7 @@ export class TestSuite {
     testMessageStore();
 
     // handler tests
+    testMessagesQueryHandler();
     testMessagesReadHandler();
     testMessagesSubscribeHandler();
     testMessagesSyncHandler();

--- a/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
+++ b/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
@@ -3,6 +3,7 @@ import type { DidResolutionResult } from '@enbox/dids';
 import type { Dwn } from '../../src/dwn.js';
 import type { GeneralJws } from '../../src/types/jws-types.js';
 import type { MessageSigner } from '../../src/types/signer.js';
+import type { MessagesQueryOptions } from '../../src/interfaces/messages-query.js';
 import type { MessagesReadOptions } from '../../src/interfaces/messages-read.js';
 import type { MessagesSubscribeOptions } from '../../src/interfaces/messages-subscribe.js';
 import type { PermissionGrantCreateOptions } from '../../src/protocols/permissions.js';
@@ -16,7 +17,7 @@ import type { RecordsSubscribeOptions } from '../../src/interfaces/records-subsc
 import type { AuthorizationModel, Pagination } from '../../src/types/message-types.js';
 import type { CreateFromOptions, EncryptionInput, KeyEncryptionInput, RecordsWriteOptions } from '../../src/interfaces/records-write.js';
 import type { DataEncodedRecordsWriteMessage, DateSort, RecordsCountMessage, RecordsDeleteMessage, RecordsFilter, RecordsQueryMessage, RecordsWriteTags } from '../../src/types/records-types.js';
-import type { MessagesFilter, MessagesReadMessage, MessagesSubscribeMessage } from '../../src/types/messages-types.js';
+import type { MessagesFilter, MessagesQueryMessage, MessagesReadMessage, MessagesSubscribeMessage } from '../../src/types/messages-types.js';
 import type { PermissionConditions, PermissionScope } from '../../src/types/permission-types.js';
 import type { PrivateKeyJwk, PublicKeyJwk } from '../../src/types/jose-types.js';
 import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage, ProtocolsQueryMessage } from '../../src/types/protocols-types.js';
@@ -29,6 +30,7 @@ import { DidKey } from '@enbox/dids';
 import { ed25519 } from '../../src/jose/algorithms/signing/ed25519.js';
 import { Encoder } from '../../src/utils/encoder.js';
 import { Jws } from '../../src/utils/jws.js';
+import { MessagesQuery } from '../../src/interfaces/messages-query.js';
 import { MessagesRead } from '../../src/interfaces/messages-read.js';
 import { MessagesSubscribe } from '../../src/interfaces/messages-subscribe.js';
 import { PermissionsProtocol } from '../../src/protocols/permissions.js';
@@ -255,6 +257,22 @@ export type GenerateMessagesSubscribeOutput = {
   author: Persona;
   messagesSubscribe: MessagesSubscribe;
   message: MessagesSubscribeMessage;
+};
+
+export type GenerateMessagesQueryInput = {
+  author: Persona;
+  filters?: MessagesFilter[];
+  messageTimestamp?: string;
+  permissionGrantIds?: string[];
+  cursor?: ProgressToken;
+  limit?: number;
+  cidsOnly?: boolean;
+};
+
+export type GenerateMessagesQueryOutput = {
+  author: Persona;
+  messagesQuery: MessagesQuery;
+  message: MessagesQueryMessage;
 };
 
 export type GenerateMessagesReadInput = {
@@ -852,6 +870,34 @@ export class TestDataGenerator {
     return {
       author,
       messagesSubscribe,
+      message
+    };
+  }
+
+  /**
+   * Generates a MessagesQuery message for testing.
+   */
+  public static async generateMessagesQuery(input?: GenerateMessagesQueryInput): Promise<GenerateMessagesQueryOutput> {
+    const author = input?.author ?? await TestDataGenerator.generatePersona();
+    const signer = Jws.createSigner(author);
+
+    const options: MessagesQueryOptions = {
+      filters            : input?.filters,
+      messageTimestamp   : input?.messageTimestamp,
+      permissionGrantIds : input?.permissionGrantIds,
+      cursor             : input?.cursor,
+      limit              : input?.limit,
+      cidsOnly           : input?.cidsOnly,
+      signer,
+    };
+    removeUndefinedProperties(options);
+
+    const messagesQuery = await MessagesQuery.create(options);
+    const message = messagesQuery.message;
+
+    return {
+      author,
+      messagesQuery,
       message
     };
   }


### PR DESCRIPTION
## Summary
- add `MessagesQuery` under the Messages interface, backed by the durable replication feed with high-water cursors, `cidsOnly` pages, progress-gap replies, and canonical-scope fingerprints
- add `DurableEventLog` over the replication feed and wake bus so subscriptions can replay from cursors, emit EOSE, drain live wakes, and carry source metadata with detached inline data
- harden event-log subscriptions by freezing the catch-up high-water before EOSE, delaying live delivery until after EOSE, surfacing post-subscribe progress gaps as subscription errors, and stopping page delivery after close
- extend Messages Read grant authorization to cover Query, share encoded-data detaching across Query/Sync/subscriptions, and add focused coverage for delegated query, permission shadow expansion, cursor gaps, redelivery positions, durable replay, and schema fuzzing
- defer the shared per-page inline-byte budget to server wiring; the current row limit and per-entry inline cap bound page size until that lands

## Test plan
- [x] DWN SDK lint, build, and node tests
- [x] repo lint
- [x] downstream dwn-clients and agent builds
