### PR TITLE
feat(dwn-sql-store): add durable replication log

### DIFF
--- a/.changeset/sql-replication-log.md
+++ b/.changeset/sql-replication-log.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sql-store": patch
+---
+
+feat: add SQL-backed durable replication log state

--- a/packages/dwn-server/tests/dwn-apply-replicated-message.test.ts
+++ b/packages/dwn-server/tests/dwn-apply-replicated-message.test.ts
@@ -1,12 +1,13 @@
+import type { ReplicationApplyResult } from '@enbox/dwn-sdk-js';
 import type { RequestContext } from '../src/lib/json-rpc-router.js';
 
-import { createRecordsWriteMessage } from './utils.js';
 import { DwnServerErrorCode } from '../src/dwn-error.js';
 import { getTestDwn } from './test-dwn.js';
 import { handleDwnApplyReplicatedMessage } from '../src/json-rpc-handlers/dwn/apply-replicated-message.js';
 import { RateLimiter } from '../src/rate-limiter.js';
 import { v4 as uuidv4 } from 'uuid';
 import { createJsonRpcRequest, JsonRpcErrorCodes } from '@enbox/dwn-clients';
+import { createRecordsWriteMessage, expectAppliedResultWithPosition } from './utils.js';
 import { DataStream, Encoder, TestDataGenerator } from '@enbox/dwn-sdk-js';
 import { describe, expect, it, spyOn } from 'bun:test';
 
@@ -30,7 +31,7 @@ describe('handleDwnApplyReplicatedMessage', () => {
     );
 
     expect(jsonRpcResponse.error).toBeUndefined();
-    expect(jsonRpcResponse.result.result).toEqual({ kind: 'Applied' });
+    await expectAppliedResultWithPosition(jsonRpcResponse.result.result as ReplicationApplyResult, alice.did, recordsWrite.toJSON());
     await dwn.close();
   });
 

--- a/packages/dwn-server/tests/utils.ts
+++ b/packages/dwn-server/tests/utils.ts
@@ -1,15 +1,16 @@
 import type { Dialect } from '@enbox/dwn-sql-store';
 import type { JsonRpcResponse } from '@enbox/dwn-clients';
-import type { GenericMessage, Persona, UnionMessageReply } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, Persona, ReplicationApplyResult, UnionMessageReply } from '@enbox/dwn-sdk-js';
 
 import { createJsonRpcRequest } from '@enbox/dwn-clients';
+import { expect } from 'bun:test';
 import { fileURLToPath } from 'url';
 import fs from 'node:fs';
 import { Kysely } from 'kysely';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { WebSocket } from 'ws';
-import { Cid, DataStream, RecordsWrite } from '@enbox/dwn-sdk-js';
+import { Cid, DataStream, Message, RecordsWrite, Replication } from '@enbox/dwn-sdk-js';
 import { createBunSqliteDatabase, SqliteDialect } from '@enbox/dwn-sql-store';
 
 import { getDialectFromUrl } from '../src/storage.js';
@@ -69,6 +70,24 @@ export async function createRecordsWriteMessage(
     recordsWrite,
     dataStream,
   };
+}
+
+export async function expectAppliedResultWithPosition(
+  result: ReplicationApplyResult,
+  tenant: string,
+  message: GenericMessage,
+): Promise<void> {
+  expect(result.kind).toBe('Applied');
+  if (result.kind !== 'Applied') {
+    throw new Error(`expected Applied replication result, received ${result.kind}`);
+  }
+
+  expect(result.position).toBeDefined();
+  expect(result.position!.streamId).toBe(await Replication.deriveStreamId(tenant));
+  expect(result.position!.position).toBe('2');
+  expect(result.position!.messageCid).toBe(await Message.getCid(message));
+  expect(typeof result.position!.epoch).toBe('string');
+  expect(result.position!.epoch.length).toBeGreaterThan(0);
 }
 
 export function randomBytes(length: number): Uint8Array {

--- a/packages/dwn-server/tests/ws-api.test.ts
+++ b/packages/dwn-server/tests/ws-api.test.ts
@@ -14,8 +14,7 @@ import { getTestDwn } from './test-dwn.js';
 import { HttpApi } from '../src/http-api.js';
 import { WsApi } from '../src/ws-api.js';
 import { createJsonRpcAck, createJsonRpcRequest, createJsonRpcSubscriptionRequest, HttpDwnRpcClient, JsonRpcErrorCodes, JsonRpcSocket, WebSocketDwnRpcClient } from '@enbox/dwn-clients';
-import { createRecordsWriteMessage, sendHttpMessage, sendWsMessage, waitUntil } from './utils.js';
-
+import { createRecordsWriteMessage, expectAppliedResultWithPosition, sendHttpMessage, sendWsMessage, waitUntil } from './utils.js';
 
 describe('websocket api', function () {
   let httpApi: HttpApi;
@@ -120,7 +119,7 @@ describe('websocket api', function () {
       data      : dataStream,
     });
 
-    expect(result).toEqual({ kind: 'Applied' });
+    await expectAppliedResultWithPosition(result, alice.did, recordsWrite.toJSON());
 
     const recordsRead = await RecordsRead.create({
       signer : alice.signer,
@@ -151,7 +150,7 @@ describe('websocket api', function () {
       data      : dataStream,
     });
 
-    expect(result).toEqual({ kind: 'Applied' });
+    await expectAppliedResultWithPosition(result, alice.did, recordsWrite.toJSON());
 
     const recordsRead = await RecordsRead.create({
       signer : alice.signer,

--- a/packages/dwn-sql-store/src/dialect/bun-sqlite-adapter.ts
+++ b/packages/dwn-sql-store/src/dialect/bun-sqlite-adapter.ts
@@ -34,6 +34,7 @@ const READER_PREFIXES = /^\s*(SELECT|PRAGMA|EXPLAIN|WITH)\b/i;
  * These produce rows like a SELECT, so the statement must use `all()` not `run()`.
  */
 const HAS_RETURNING = /\bRETURNING\b/i;
+const SQLITE_BUSY_TIMEOUT_MS = 5_000;
 
 /**
  * Creates a Kysely-compatible SQLite database backed by `bun:sqlite`.
@@ -49,6 +50,11 @@ export function createBunSqliteDatabase(
   options?: { readonly?: boolean; create?: boolean },
 ): KyselySqliteDatabase {
   const db = new BunDatabase(path, options);
+  db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+
+  if (options?.readonly !== true && path !== ':memory:') {
+    db.exec('PRAGMA journal_mode = WAL');
+  }
 
   return {
     close(): void {

--- a/packages/dwn-sql-store/src/dialect/dialect.ts
+++ b/packages/dwn-sql-store/src/dialect/dialect.ts
@@ -6,6 +6,7 @@ import type {
   InsertQueryBuilder,
   Kysely,
   Dialect as KyselyDialect,
+  RawBuilder,
   SelectExpression,
   Selection,
   Transaction,
@@ -73,4 +74,22 @@ export interface Dialect extends KyselyDialect {
     values: InsertObject<DB, TB & string>,
     returning: SE & `${string} as insertId`,
   ): InsertQueryBuilder<DB, TB & string, Selection<DB, TB & string, SE & `${string} as insertId`>>;
+
+  /**
+   * Ensures a replication counter row exists and takes the dialect-specific write lock for that
+   * tenant on the transaction connection. Call before reading or mutating tenant log/fingerprint
+   * state so same-tenant mutations are serialized in commit order.
+   */
+  lockReplicationCounter<DB>(tx: Transaction<DB>, tenant: string): Promise<void>;
+
+  /**
+   * Advances the locked tenant replication counter by one and returns the assigned position.
+   */
+  incrementReplicationCounter<DB>(tx: Transaction<DB>, tenant: string): Promise<bigint>;
+
+  /**
+   * Casts a bigint/integer column to text so database drivers cannot narrow
+   * replication positions to JavaScript numbers when reading rows.
+   */
+  bigIntColumnAsText(columnReference: string): RawBuilder<string | null>;
 }

--- a/packages/dwn-sql-store/src/dialect/mysql-dialect.ts
+++ b/packages/dwn-sql-store/src/dialect/mysql-dialect.ts
@@ -7,12 +7,14 @@ import type {
   InsertObject,
   InsertQueryBuilder,
   Kysely,
+  RawBuilder,
   SelectExpression,
   Selection,
   Transaction } from 'kysely';
 
 import {
-  MysqlDialect as KyselyMysqlDialect
+  MysqlDialect as KyselyMysqlDialect,
+  sql,
 } from 'kysely';
 
 export class MysqlDialect extends KyselyMysqlDialect implements Dialect {
@@ -84,5 +86,31 @@ export class MysqlDialect extends KyselyMysqlDialect implements Dialect {
     _returning: SE & `${string} as insertId`,
   ): InsertQueryBuilder<DB, TB & string, Selection<DB, TB & string, SE & `${string} as insertId`>> {
     return db.insertInto(table).values(values);
+  }
+
+  async lockReplicationCounter<DB>(tx: Transaction<DB>, tenant: string): Promise<void> {
+    await sql`
+      INSERT INTO ${sql.table('replicationCounters')} (tenant, seq)
+      VALUES (${tenant}, 0)
+      ON DUPLICATE KEY UPDATE seq = seq
+    `.execute(tx);
+  }
+
+  async incrementReplicationCounter<DB>(tx: Transaction<DB>, tenant: string): Promise<bigint> {
+    await sql`
+      UPDATE ${sql.table('replicationCounters')}
+      SET seq = LAST_INSERT_ID(seq + 1)
+      WHERE tenant = ${tenant}
+    `.execute(tx);
+
+    const result = await sql<{ seq: string }>`
+      SELECT CAST(LAST_INSERT_ID() AS CHAR) AS seq
+    `.execute(tx);
+
+    return BigInt(String(result.rows[0].seq));
+  }
+
+  bigIntColumnAsText(columnReference: string): RawBuilder<string | null> {
+    return sql<string | null>`CAST(${sql.ref(columnReference)} AS CHAR)`;
   }
 }

--- a/packages/dwn-sql-store/src/dialect/postgres-dialect.ts
+++ b/packages/dwn-sql-store/src/dialect/postgres-dialect.ts
@@ -6,12 +6,14 @@ import type {
   InsertObject,
   InsertQueryBuilder,
   Kysely,
+  RawBuilder,
   SelectExpression,
   Selection,
   Transaction } from 'kysely';
 
 import {
-  PostgresDialect as KyselyPostgresDialect
+  PostgresDialect as KyselyPostgresDialect,
+  sql,
 } from 'kysely';
 
 export class PostgresDialect extends KyselyPostgresDialect implements Dialect {
@@ -66,6 +68,29 @@ export class PostgresDialect extends KyselyPostgresDialect implements Dialect {
     returning: SE & `${string} as insertId`,
   ): InsertQueryBuilder<DB, TB & string, Selection<DB, TB & string, SE & `${string} as insertId`>> {
     return db.insertInto(table).values(values).returning(returning);
+  }
+
+  async lockReplicationCounter<DB>(tx: Transaction<DB>, tenant: string): Promise<void> {
+    await sql`
+      INSERT INTO ${sql.table('replicationCounters')} (tenant, seq)
+      VALUES (${tenant}, 0)
+      ON CONFLICT (tenant) DO UPDATE SET seq = ${sql.ref('replicationCounters.seq')}
+    `.execute(tx);
+  }
+
+  async incrementReplicationCounter<DB>(tx: Transaction<DB>, tenant: string): Promise<bigint> {
+    const result = await sql<{ seq: string }>`
+      UPDATE ${sql.table('replicationCounters')}
+      SET seq = seq + 1
+      WHERE tenant = ${tenant}
+      RETURNING CAST(seq AS TEXT) AS seq
+    `.execute(tx);
+
+    return BigInt(String(result.rows[0].seq));
+  }
+
+  bigIntColumnAsText(columnReference: string): RawBuilder<string | null> {
+    return sql<string | null>`CAST(${sql.ref(columnReference)} AS TEXT)`;
   }
 
 }

--- a/packages/dwn-sql-store/src/dialect/sqlite-dialect.ts
+++ b/packages/dwn-sql-store/src/dialect/sqlite-dialect.ts
@@ -6,12 +6,14 @@ import type {
   InsertObject,
   InsertQueryBuilder,
   Kysely,
+  RawBuilder,
   SelectExpression,
   Selection,
   Transaction } from 'kysely';
 
 import {
-  SqliteDialect as KyselySqliteDialect
+  SqliteDialect as KyselySqliteDialect,
+  sql,
 } from 'kysely';
 
 export class SqliteDialect extends KyselySqliteDialect implements Dialect {
@@ -73,5 +75,28 @@ export class SqliteDialect extends KyselySqliteDialect implements Dialect {
     returning: SE & `${string} as insertId`,
   ): InsertQueryBuilder<DB, TB & string, Selection<DB, TB & string, SE & `${string} as insertId`>> {
     return db.insertInto(table).values(values).returning(returning);
+  }
+
+  async lockReplicationCounter<DB>(tx: Transaction<DB>, tenant: string): Promise<void> {
+    await sql`
+      INSERT INTO ${sql.table('replicationCounters')} (tenant, seq)
+      VALUES (${tenant}, 0)
+      ON CONFLICT (tenant) DO UPDATE SET seq = seq
+    `.execute(tx);
+  }
+
+  async incrementReplicationCounter<DB>(tx: Transaction<DB>, tenant: string): Promise<bigint> {
+    const result = await sql<{ seq: string }>`
+      UPDATE ${sql.table('replicationCounters')}
+      SET seq = seq + 1
+      WHERE tenant = ${tenant}
+      RETURNING CAST(seq AS TEXT) AS seq
+    `.execute(tx);
+
+    return BigInt(String(result.rows[0].seq));
+  }
+
+  bigIntColumnAsText(columnReference: string): RawBuilder<string | null> {
+    return sql<string | null>`CAST(${sql.ref(columnReference)} AS TEXT)`;
   }
 }

--- a/packages/dwn-sql-store/src/message-store-sql.ts
+++ b/packages/dwn-sql-store/src/message-store-sql.ts
@@ -1,6 +1,9 @@
 import type { Dialect } from './dialect/dialect.js';
 import type { DwnDatabaseType, KeyValues } from './types.js';
 import type {
+  EventLogEntry,
+  EventLogReadOptions,
+  EventLogReadResult,
   Filter,
   GenericMessage,
   MessageSort,
@@ -10,15 +13,20 @@ import type {
   MessageStorePutResult,
   Pagination,
   PaginationCursor,
+  ProgressGapInfo,
+  ProgressGapReason,
+  ProgressToken,
+  ReplicationFeedReader,
+  WakePublisher,
 } from '@enbox/dwn-sdk-js';
-import type { Transaction, UpdateObject } from 'kysely';
+import type { InsertObject, Kysely, Selectable, Transaction, UpdateObject } from 'kysely';
 
 import * as block from 'multiformats/block';
 import * as cbor from '@ipld/dag-cbor';
+
 import { executeWithTransaction } from './utils/transaction.js';
 import { extractTagsAndSanitizeIndexes } from './utils/sanitize.js';
 import { filterSelectQuery } from './utils/filter.js';
-import { isDuplicateKeyError } from './utils/duplicate-key-error.js';
 import { sha256 } from 'multiformats/hashes/sha2';
 import { TagTables } from './utils/tags.js';
 import {
@@ -28,12 +36,32 @@ import {
   DwnMethodName,
   executeUnlessAborted,
   Message,
-  SortDirection
+  Replication,
+  SortDirection,
 } from '@enbox/dwn-sdk-js';
-import { Kysely, sql } from 'kysely';
+import { isDuplicateKeyError, isMessageCidDuplicateKeyError } from './utils/duplicate-key-error.js';
+import { Kysely as KyselyDatabase, sql } from 'kysely';
 
-type MessageStoreSystemColumn = 'id' | 'tenant' | 'messageCid' | 'encodedMessageBytes' | 'encodedData';
+type MessageStoreSystemColumn =
+  'id' |
+  'tenant' |
+  'messageCid' |
+  'encodedMessageBytes' |
+  'encodedData' |
+  'seq' |
+  'redeliverSeq' |
+  'fingerprintScopes';
 type MessageStoreIndexColumn = Exclude<keyof DwnDatabaseType['messageStoreMessages'], MessageStoreSystemColumn>;
+type MessageStoreRow = Selectable<DwnDatabaseType['messageStoreMessages']>;
+type MessageStoreExecutor = Kysely<DwnDatabaseType> | Transaction<DwnDatabaseType>;
+type PositionColumn = 'seq' | 'redeliverSeq';
+type PositionTextColumns = {
+  seqText: string | null;
+  redeliverSeqText: string | null;
+};
+type LogRow = MessageStoreRow & PositionTextColumns;
+
+const EPOCH_KEY = 'epoch';
 
 const MESSAGE_STORE_INDEX_COLUMN_COVERAGE = {
   interface         : true,
@@ -67,347 +95,144 @@ const NULLED_INDEX_COLUMNS = Object.fromEntries(
   MESSAGE_STORE_INDEX_COLUMNS.map((column) => [column, null])
 ) as Record<MessageStoreIndexColumn, null>;
 
-export class MessageStoreSql implements MessageStore {
+const BOOLEAN_INDEX_COLUMNS = new Set<MessageStoreIndexColumn>([
+  'isLatestBaseState',
+  'published',
+  'prune',
+  'squash',
+]);
+
+/**
+ * SQL-backed MessageStore with the durable replication feed embedded in the message table.
+ *
+ * Every mutating operation that can affect replay state takes the tenant counter lock before it
+ * reads or writes row/fingerprint state. This keeps tenant positions gap-free and serializes the
+ * fingerprint folds without requiring backend-specific advisory locks.
+ */
+export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
   readonly #dialect: Dialect;
   readonly #tags: TagTables;
   #db: Kysely<DwnDatabaseType> | null = null;
+  #epochPromise?: Promise<string>;
+  readonly #streamIdPromises = new Map<string, Promise<string>>();
+  #wakePublisher?: WakePublisher;
 
-  constructor(dialect: Dialect) {
+  public constructor(dialect: Dialect, wakePublisher?: WakePublisher) {
     this.#dialect = dialect;
     this.#tags = new TagTables(dialect);
+    this.#wakePublisher = wakePublisher;
   }
 
-  async open(): Promise<void> {
+  public setWakePublisher(wakePublisher: WakePublisher | undefined): void {
+    this.#wakePublisher = wakePublisher;
+  }
+
+  public async open(): Promise<void> {
     if (this.#db) {
       return;
     }
 
-    this.#db = new Kysely<DwnDatabaseType>({ dialect: this.#dialect });
+    this.#db = new KyselyDatabase<DwnDatabaseType>({ dialect: this.#dialect });
 
-    // Fail fast if migrations have not been run — tables must already exist.
-    await this.#assertTablesExist();
+    await this.assertTablesExist();
+    await this.assertNoPreSubstrateRows();
+    await this.epoch();
   }
 
-  /**
-   * Verifies that the required tables exist by executing a zero-row SELECT.
-   * Throws a clear error directing the caller to run migrations first.
-   */
-  async #assertTablesExist(): Promise<void> {
-    const tables = ['messageStoreMessages', 'messageStoreRecordsTags'] as const;
-    for (const table of tables) {
-      try {
-        await sql`SELECT 1 FROM ${sql.table(table)} LIMIT 0`.execute(this.#db!);
-      } catch {
-        throw new Error(
-          `MessageStoreSql: table '${table}' does not exist. Run DWN store migrations before opening stores.`
-        );
-      }
-    }
-  }
-
-  async close(): Promise<void> {
+  public async close(): Promise<void> {
     await this.#db?.destroy();
     this.#db = null;
+    this.#epochPromise = undefined;
+    this.#streamIdPromises.clear();
   }
 
-  async put(
+  public async put(
     tenant: string,
     message: GenericMessage,
     indexes: KeyValues,
     options?: MessageStoreOptions
   ): Promise<MessageStorePutResult> {
-    if (!this.#db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before using `put`.'
-      );
-    }
-
+    const db = this.requireDb('put');
     options?.signal?.throwIfAborted();
 
-    // gets the encoded data and removes it from the message
-    // we remove it from the message as it would cause the `encodedMessageBytes` to be greater than the
-    // maximum bytes allowed by SQL
-    const getEncodedData = (message: GenericMessage): { message: GenericMessage, encodedData: string|null} => {
-      const messageToProcess = { ...message };
-      let encodedData: string|null = null;
-      if (messageToProcess.descriptor.interface === DwnInterfaceName.Records && messageToProcess.descriptor.method === DwnMethodName.Write) {
-        const data = messageToProcess.encodedData;
-        if (data) {
-          delete messageToProcess.encodedData;
-          encodedData = data;
-        }
-      }
-      return { message: messageToProcess, encodedData };
-    };
-
-    const { message: messageToProcess, encodedData } = getEncodedData(message);
-
+    const { messageToStore, encodedData } = MessageStoreSql.detachInlineData(message);
     const encodedMessageBlock = await executeUnlessAborted(
-      block.encode({ value: messageToProcess, codec: cbor, hasher: sha256 }),
+      block.encode({ value: messageToStore, codec: cbor, hasher: sha256 }),
       options?.signal
     );
 
     const messageCid = encodedMessageBlock.cid.toString();
     const encodedMessageBytes = Buffer.from(encodedMessageBlock.bytes);
 
-    // we execute the insert in a transaction as we are making multiple inserts into multiple tables.
-    // if any of these inserts would throw, the whole transaction would be rolled back.
-    // otherwise it is committed.
-    const putMessageOperation = this.constructPutMessageOperation({ tenant, messageCid, encodedMessageBytes, encodedData, indexes });
     try {
-      await executeWithTransaction(this.#db, putMessageOperation);
+      const position = await executeWithTransaction(db, async (tx) => {
+        await this.#dialect.lockReplicationCounter(tx, tenant);
+
+        const existing = await tx
+          .selectFrom('messageStoreMessages')
+          .select('id')
+          .where('tenant', '=', tenant)
+          .where('messageCid', '=', messageCid)
+          .executeTakeFirst();
+
+        if (existing !== undefined) {
+          return undefined;
+        }
+
+        const seq = await this.#dialect.incrementReplicationCounter(tx, tenant);
+        const fingerprintScopes = Replication.computeFingerprintScopes(message, indexes);
+        const { indexes: putIndexes, tags } = extractTagsAndSanitizeIndexes(indexes);
+
+        const messageIndexValues: InsertObject<DwnDatabaseType, 'messageStoreMessages'> = {
+          tenant,
+          messageCid,
+          encodedMessageBytes,
+          encodedData,
+          seq               : seq.toString(),
+          redeliverSeq      : null,
+          fingerprintScopes : JSON.stringify(fingerprintScopes),
+          ...putIndexes,
+        };
+
+        const result = await this.#dialect
+          .insertThenReturnId(tx, 'messageStoreMessages', messageIndexValues, 'id as insertId')
+          .executeTakeFirstOrThrow();
+
+        if (Object.keys(tags).length > 0) {
+          await this.#tags.executeTagsInsert(result.insertId, tags, tx);
+        }
+
+        await this.foldFingerprints(tx, tenant, messageCid, fingerprintScopes);
+        return seq;
+      });
+
+      if (position === undefined) {
+        return { status: 'duplicate' };
+      }
+
+      this.publishWake(tenant, position);
+      return {
+        status   : 'inserted',
+        position : await this.buildToken(tenant, position, messageCid),
+      };
     } catch (error: unknown) {
-      if (isDuplicateKeyError(error)) {
-        // Idempotent write — the exact same message already exists.
-        // This is expected when sync or protocol.send() re-delivers a
-        // message the DWN already has.  A race between the handler's
-        // duplicate-CID check and the actual insert makes this
-        // unavoidable in concurrent environments.
-        // NOTE: `position` is omitted until the SQL replication log lands (no seq column yet).
+      if (isMessageCidDuplicateKeyError(error) && await this.hasMessage(tenant, messageCid)) {
         return { status: 'duplicate' };
       }
       throw error;
     }
-
-    return { status: 'inserted' };
   }
 
-  /**
-   * Replaces the indexes of an existing message in place — a row UPDATE that also syncs the tag
-   * tables (tags are indexed only while `isLatestBaseState` is true, so an index flip must add or
-   * remove tag rows in the same transaction). The row — and its `encodedData` — is never deleted.
-   */
-  async updateIndexes(
-    tenant: string,
-    messageCid: string,
-    indexes: KeyValues,
-    options?: MessageStoreOptions
-  ): Promise<void> {
-    if (!this.#db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before using `updateIndexes`.'
-      );
-    }
-
-    options?.signal?.throwIfAborted();
-
-    await this.replaceRowIndexes({
-      tenant,
-      messageCid,
-      indexes,
-      notFoundErrorCode: DwnErrorCode.MessageStoreUpdateIndexesMessageNotFound,
-    });
-  }
-
-  /**
-   * Replaces the same-CID row payload and indexes in place. This is used when an inline-data
-   * RecordsWrite is retained only for lineage/reconstruction and must no longer expose data.
-   */
-  async updateMessageAndIndexes(
-    tenant: string,
-    messageCid: string,
-    message: GenericMessage,
-    indexes: KeyValues,
-    options?: MessageStoreOptions
-  ): Promise<void> {
-    if (!this.#db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before using `updateMessageAndIndexes`.'
-      );
-    }
-
-    options?.signal?.throwIfAborted();
-
-    const computedMessageCid = await Message.getCid(message);
-    if (computedMessageCid !== messageCid) {
-      throw new DwnError(
-        DwnErrorCode.MessageStoreUpdateMessageAndIndexesCidMismatch,
-        `replacement message CID ${computedMessageCid} does not match target CID ${messageCid}`
-      );
-    }
-
-    let encodedData: string | null = null;
-    const messageToProcess = { ...message };
-    if (messageToProcess.descriptor.interface === DwnInterfaceName.Records && messageToProcess.descriptor.method === DwnMethodName.Write) {
-      if (messageToProcess.encodedData !== undefined) {
-        encodedData = messageToProcess.encodedData;
-        delete messageToProcess.encodedData;
-      }
-    }
-
-    const encodedMessageBlock = await executeUnlessAborted(
-      block.encode({ value: messageToProcess, codec: cbor, hasher: sha256 }),
-      options?.signal
-    );
-
-    await this.replaceRowIndexes({
-      tenant,
-      messageCid,
-      indexes,
-      encodedMessageBytes : Buffer.from(encodedMessageBlock.bytes),
-      encodedData,
-      notFoundErrorCode   : DwnErrorCode.MessageStoreUpdateMessageAndIndexesMessageNotFound,
-    });
-  }
-
-  /**
-   * Completes a previously dataless row with its data: same CID, same row. Attaches the inline
-   * `encodedData` column when given and flips the row's indexes (syncing the tag tables).
-   *
-   * NOTE: redelivery stamping (`redeliverSeq` from the tenant counter) and the post-commit wake
-   * land with the SQL replication log; until then this store returns no `position`.
-   */
-  async completeData(
-    tenant: string,
-    messageCid: string,
-    indexes: KeyValues,
-    encodedData?: string,
-    options?: MessageStoreOptions
-  ): Promise<MessageStoreCompleteDataResult> {
-    if (!this.#db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before using `completeData`.'
-      );
-    }
-
-    options?.signal?.throwIfAborted();
-
-    await this.replaceRowIndexes({
-      tenant,
-      messageCid,
-      indexes,
-      encodedData,
-      notFoundErrorCode    : DwnErrorCode.MessageStoreCompleteDataMessageNotFound,
-      rejectAlreadyStamped : true,
-    });
-
-    return {};
-  }
-
-  /**
-   * Shared row-UPDATE implementation for `updateIndexes` and `completeData`: nulls every index
-   * column, overlays the sanitized replacement indexes, optionally attaches `encodedData`, and
-   * rebuilds the row's tag table entries — all in one transaction.
-   */
-  private async replaceRowIndexes(input: {
-    tenant: string;
-    messageCid: string;
-    indexes: KeyValues;
-    encodedMessageBytes?: Buffer;
-    encodedData?: string | null;
-    notFoundErrorCode: DwnErrorCode;
-    rejectAlreadyStamped?: boolean;
-  }): Promise<void> {
-    const { tenant, messageCid, indexes, encodedMessageBytes, encodedData, notFoundErrorCode, rejectAlreadyStamped } = input;
-    const db = this.#db;
-    if (!db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before replacing row indexes.'
-      );
-    }
-
-    // we extract the tag indexes into their own object to be inserted separately.
-    // we also sanitize the indexes to convert any `boolean` values to `number` representations.
-    const { indexes: replacementIndexes, tags } = extractTagsAndSanitizeIndexes(indexes);
-
-    await executeWithTransaction(db, async (tx) => {
-      const existingRow = await tx
-        .selectFrom('messageStoreMessages')
-        .select(['id', 'encodedData', 'isLatestBaseState'])
-        .where('tenant', '=', tenant)
-        .where('messageCid', '=', messageCid)
-        .executeTakeFirst();
-
-      if (existingRow === undefined) {
-        throw new DwnError(notFoundErrorCode, `no message found for tenant ${tenant} with CID ${messageCid}`);
-      }
-
-      if (rejectAlreadyStamped === true && (existingRow.encodedData !== null || Number(existingRow.isLatestBaseState) === 1)) {
-        throw new DwnError(
-          DwnErrorCode.MessageStoreCompleteDataAlreadyStamped,
-          `message ${messageCid} is already completed; the dataless-to-data transition cannot repeat`
-        );
-      }
-
-      const replacementColumns = {
-        ...NULLED_INDEX_COLUMNS,
-        ...replacementIndexes,
-        ...(encodedMessageBytes !== undefined && { encodedMessageBytes }),
-        ...(encodedData !== undefined && { encodedData }),
-      };
-
-      await tx
-        .updateTable('messageStoreMessages')
-        .set(replacementColumns as UpdateObject<DwnDatabaseType, 'messageStoreMessages'>)
-        .where('id', '=', existingRow.id)
-        .execute();
-
-      // rebuild the tag rows to mirror the replacement indexes
-      await tx
-        .deleteFrom('messageStoreRecordsTags')
-        .where('messageInsertId', '=', existingRow.id)
-        .execute();
-
-      if (Object.keys(tags).length > 0) {
-        await this.#tags.executeTagsInsert(existingRow.id, tags, tx);
-      }
-    });
-  }
-
-  /**
-   * Constructs the transactional operation to insert the given message into the database.
-   */
-  private constructPutMessageOperation(queryOptions: {
-    tenant: string;
-    messageCid: string;
-    encodedMessageBytes: Buffer;
-    encodedData: string | null;
-    indexes: KeyValues;
-  }): (tx: Transaction<DwnDatabaseType>) => Promise<void> {
-    const { tenant, messageCid, encodedMessageBytes, encodedData, indexes } = queryOptions;
-
-    // we extract the tag indexes into their own object to be inserted separately.
-    // we also sanitize the indexes to convert any `boolean` values to `text` representations.
-    const { indexes: putIndexes, tags } = extractTagsAndSanitizeIndexes(indexes);
-
-    return async (tx) => {
-
-      const messageIndexValues = {
-        tenant,
-        messageCid,
-        encodedMessageBytes,
-        encodedData,
-        ...putIndexes
-      };
-
-      // we use the dialect-specific `insertThenReturnId` in order to be able to extract the `insertId`
-      const result = await this.#dialect
-        .insertThenReturnId(tx, 'messageStoreMessages', messageIndexValues, 'id as insertId')
-        .executeTakeFirstOrThrow();
-
-      // if tags exist, we execute those within the transaction associating them with the `insertId`.
-      if (Object.keys(tags).length > 0) {
-        await this.#tags.executeTagsInsert(result.insertId, tags, tx);
-      }
-
-    };
-  }
-
-  async get(
+  public async get(
     tenant: string,
     cid: string,
     options?: MessageStoreOptions
   ): Promise<GenericMessage | undefined> {
-    if (!this.#db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before using `get`.'
-      );
-    }
-
+    const db = this.requireDb('get');
     options?.signal?.throwIfAborted();
 
     const result = await executeUnlessAborted(
-      this.#db
+      db
         .selectFrom('messageStoreMessages')
         .selectAll()
         .where('tenant', '=', tenant)
@@ -423,27 +248,22 @@ export class MessageStoreSql implements MessageStore {
     return this.parseEncodedMessage(result.encodedMessageBytes, result.encodedData, options);
   }
 
-  async query(
+  public async query(
     tenant: string,
     filters: Filter[],
     messageSort?: MessageSort,
     pagination?: Pagination,
     options?: MessageStoreOptions
-  ): Promise<{ messages: GenericMessage[], cursor?: PaginationCursor}> {
-    if (!this.#db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before using `query`.'
-      );
-    }
-
+  ): Promise<{ messages: GenericMessage[], cursor?: PaginationCursor }> {
+    const db = this.requireDb('query');
     options?.signal?.throwIfAborted();
 
-    // extract sort property and direction from the supplied messageSort
     const { property: sortProperty, direction: sortDirection } = this.extractSortProperties(messageSort);
+    const filtersIncludeTags = MessageStoreSql.filtersIncludeTags(filters);
 
-    let query = this.#db
+    let query = db
       .selectFrom('messageStoreMessages')
-      .leftJoin('messageStoreRecordsTags', 'messageStoreRecordsTags.messageInsertId', 'messageStoreMessages.id')
+      .$if(filtersIncludeTags, (qb) => qb.leftJoin('messageStoreRecordsTags', 'messageStoreRecordsTags.messageInsertId', 'messageStoreMessages.id'))
       .select('messageCid')
       .distinct()
       .select([
@@ -453,30 +273,24 @@ export class MessageStoreSql implements MessageStore {
       ])
       .where('tenant', '=', tenant);
 
-    // filter sanitization takes place within `filterSelectQuery`
     query = filterSelectQuery(filters, query);
 
     if (pagination?.cursor !== undefined) {
-      // currently the sort property is explicitly either `dateCreated` | `messageTimestamp` | `datePublished` which are all strings
-      // TODO: https://github.com/enboxorg/enbox/issues/664 to handle the edge case
       const cursorValue = pagination.cursor.value as string;
       const cursorMessageId = pagination.cursor.messageCid;
 
       query = query.where(({ eb, refTuple, tuple }) => {
         const direction = sortDirection === SortDirection.Ascending ? '>' : '<';
-        // https://kysely-org.github.io/kysely-apidoc/interfaces/ExpressionBuilder.html#refTuple
         return eb(refTuple(sortProperty, 'messageCid'), direction, tuple(cursorValue, cursorMessageId));
       });
     }
 
     const orderDirection = sortDirection === SortDirection.Ascending ? 'asc' : 'desc';
-    // sorting by the provided sort property, the tiebreak is always in ascending order regardless of sort
     query = query
       .orderBy(sortProperty, orderDirection)
       .orderBy('messageCid', orderDirection);
 
     if (pagination?.limit !== undefined && pagination?.limit > 0) {
-      // we query for one additional record to decide if we return a pagination cursor or not.
       query = query.limit(pagination.limit + 1);
     }
 
@@ -485,28 +299,22 @@ export class MessageStoreSql implements MessageStore {
       options?.signal
     );
 
-    // prunes the additional requested message, if it exists, and adds a cursor to the results.
-    // also parses the encoded message for each of the returned results.
     return this.processPaginationResults(results, sortProperty, pagination?.limit, options);
   }
 
-  async count(
+  public async count(
     tenant: string,
     filters: Filter[],
     messageSort?: MessageSort,
     options?: MessageStoreOptions
   ): Promise<number> {
-    if (!this.#db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before using `count`.'
-      );
-    }
-
+    const db = this.requireDb('count');
     options?.signal?.throwIfAborted();
+    const filtersIncludeTags = MessageStoreSql.filtersIncludeTags(filters);
 
-    let query = this.#db
+    let query = db
       .selectFrom('messageStoreMessages')
-      .leftJoin('messageStoreRecordsTags', 'messageStoreRecordsTags.messageInsertId', 'messageStoreMessages.id')
+      .$if(filtersIncludeTags, (qb) => qb.leftJoin('messageStoreRecordsTags', 'messageStoreRecordsTags.messageInsertId', 'messageStoreMessages.id'))
       .select(sql<number>`count(distinct ${sql.ref('messageStoreMessages.messageCid')})`.as('count'))
       .where('tenant', '=', tenant);
 
@@ -517,39 +325,598 @@ export class MessageStoreSql implements MessageStore {
     return Number(result.count);
   }
 
-  async delete(
+  public async updateIndexes(
+    tenant: string,
+    messageCid: string,
+    indexes: KeyValues,
+    options?: MessageStoreOptions
+  ): Promise<void> {
+    this.requireDb('updateIndexes');
+    options?.signal?.throwIfAborted();
+
+    await this.replaceRowIndexes({
+      tenant,
+      messageCid,
+      indexes,
+      notFoundErrorCode: DwnErrorCode.MessageStoreUpdateIndexesMessageNotFound,
+    });
+  }
+
+  public async updateMessageAndIndexes(
+    tenant: string,
+    messageCid: string,
+    message: GenericMessage,
+    indexes: KeyValues,
+    options?: MessageStoreOptions
+  ): Promise<void> {
+    this.requireDb('updateMessageAndIndexes');
+    options?.signal?.throwIfAborted();
+
+    const computedMessageCid = await Message.getCid(message);
+    if (computedMessageCid !== messageCid) {
+      throw new DwnError(
+        DwnErrorCode.MessageStoreUpdateMessageAndIndexesCidMismatch,
+        `replacement message CID ${computedMessageCid} does not match target CID ${messageCid}`
+      );
+    }
+
+    const { messageToStore, encodedData } = MessageStoreSql.detachInlineData(message);
+    const encodedMessageBlock = await executeUnlessAborted(
+      block.encode({ value: messageToStore, codec: cbor, hasher: sha256 }),
+      options?.signal
+    );
+
+    await this.replaceRowIndexes({
+      tenant,
+      messageCid,
+      indexes,
+      messageForScopeCheck : message,
+      encodedMessageBytes  : Buffer.from(encodedMessageBlock.bytes),
+      encodedData,
+      notFoundErrorCode    : DwnErrorCode.MessageStoreUpdateMessageAndIndexesMessageNotFound,
+    });
+  }
+
+  public async completeData(
+    tenant: string,
+    messageCid: string,
+    indexes: KeyValues,
+    encodedData?: string,
+    options?: MessageStoreOptions
+  ): Promise<MessageStoreCompleteDataResult> {
+    this.requireDb('completeData');
+    options?.signal?.throwIfAborted();
+
+    const redeliverSeq = await this.replaceRowIndexes({
+      tenant,
+      messageCid,
+      indexes,
+      encodedData,
+      notFoundErrorCode : DwnErrorCode.MessageStoreCompleteDataMessageNotFound,
+      stampRedelivery   : true,
+    });
+
+    if (redeliverSeq === undefined) {
+      return {};
+    }
+
+    this.publishWake(tenant, redeliverSeq);
+    return { position: await this.buildToken(tenant, redeliverSeq, messageCid) };
+  }
+
+  public async delete(
     tenant: string,
     cid: string,
     options?: MessageStoreOptions
   ): Promise<void> {
-    if (!this.#db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before using `delete`.'
-      );
+    const db = this.requireDb('delete');
+    options?.signal?.throwIfAborted();
+    if (options?.signal?.aborted === true) {
+      throw options.signal.reason;
     }
 
-    options?.signal?.throwIfAborted();
-
     await executeUnlessAborted(
-      this.#db
-        .deleteFrom('messageStoreMessages')
-        .where('tenant', '=', tenant)
-        .where('messageCid', '=', cid)
-        .execute(),
+      executeWithTransaction(db, async (tx) => {
+        await this.#dialect.lockReplicationCounter(tx, tenant);
+
+        const row = await tx
+          .selectFrom('messageStoreMessages')
+          .select(['id', 'messageCid', 'fingerprintScopes'])
+          .where('tenant', '=', tenant)
+          .where('messageCid', '=', cid)
+          .executeTakeFirst();
+
+        if (row === undefined) {
+          return;
+        }
+
+        await tx
+          .deleteFrom('messageStoreMessages')
+          .where('id', '=', row.id)
+          .execute();
+
+        await this.foldFingerprints(tx, tenant, row.messageCid, MessageStoreSql.parseFingerprintScopes(row.fingerprintScopes, row.messageCid));
+      }),
       options?.signal
     );
   }
 
-  async clear(): Promise<void> {
-    if (!this.#db) {
-      throw new Error(
-        'Connection to database not open. Call `open` before using `clear`.'
-      );
+  /**
+   * Deletes all message-store rows and rotates the replication epoch. This invalidates all cursors
+   * issued before the reset.
+   */
+  public async clear(): Promise<void> {
+    const db = this.requireDb('clear');
+
+    await executeWithTransaction(db, async (tx) => {
+      await tx
+        .deleteFrom('messageStoreRecordsTags')
+        .execute();
+
+      await tx
+        .deleteFrom('messageStoreMessages')
+        .execute();
+
+      await tx
+        .deleteFrom('replicationCounters')
+        .execute();
+
+      await tx
+        .deleteFrom('replicationFingerprints')
+        .execute();
+
+      await tx
+        .deleteFrom('replicationMeta')
+        .execute();
+    });
+
+    this.#epochPromise = undefined;
+    await this.epoch();
+  }
+
+  public async logRead(tenant: string, options: EventLogReadOptions = {}): Promise<EventLogReadResult> {
+    const db = this.requireDb('logRead');
+    const { cursor, limit, filters } = options;
+
+    const head = await this.getHead(db, tenant);
+    if (cursor !== undefined) {
+      await this.validateCursor(tenant, cursor, head);
     }
 
-    await this.#db
-      .deleteFrom('messageStoreMessages')
+    const startPosition = cursor === undefined ? 0n : BigInt(cursor.position);
+
+    if (head === 0n) {
+      return { events: [], cursor, drained: true };
+    }
+
+    const maxResults = limit ?? Number.MAX_SAFE_INTEGER;
+    if (maxResults <= 0) {
+      return { events: [], cursor, drained: startPosition >= head };
+    }
+
+    if (startPosition >= head) {
+      return { events: [], cursor, drained: true };
+    }
+
+    const [originalRows, redeliveryRows] = await Promise.all([
+      this.selectLogRows(db, tenant, 'seq', startPosition, head, filters, maxResults),
+      this.selectLogRows(db, tenant, 'redeliverSeq', startPosition, head, filters, maxResults),
+    ]);
+
+    const mergedRows = MessageStoreSql.mergeRowsByPosition(originalRows, redeliveryRows)
+      .slice(0, maxResults);
+
+    const events = await this.buildEventEntries(db, mergedRows);
+    const lastDelivered = events.at(-1);
+    const lastDeliveredPosition = lastDelivered === undefined ? undefined : BigInt(lastDelivered.position ?? lastDelivered.seq);
+    const lastScannedPosition = mergedRows.at(-1)?.position ?? startPosition;
+    const drained = events.length < maxResults || lastScannedPosition >= head;
+    const cursorPosition = drained ? head : lastScannedPosition;
+    const cursorMessageCid = lastDeliveredPosition === cursorPosition ? lastDelivered?.messageCid : undefined;
+
+    return {
+      events,
+      cursor: await this.buildToken(tenant, cursorPosition, cursorMessageCid),
+      drained,
+    };
+  }
+
+  public async logBounds(tenant: string): Promise<{ oldest: ProgressToken; latest: ProgressToken } | undefined> {
+    const db = this.requireDb('logBounds');
+    const head = await this.getHead(db, tenant);
+    if (head === 0n) {
+      return undefined;
+    }
+
+    const oldest = await this.buildToken(tenant, 0n);
+    const latest = await this.buildToken(tenant, head, await this.getMessageCidAtPosition(tenant, head));
+
+    return { oldest, latest };
+  }
+
+  public async fingerprint(tenant: string, scopes: string[]): Promise<string> {
+    const db = this.requireDb('fingerprint');
+
+    let composed = Replication.emptyFingerprint();
+    for (const scope of scopes) {
+      const row = await db
+        .selectFrom('replicationFingerprints')
+        .select('fingerprint')
+        .where('tenant', '=', tenant)
+        .where('scope', '=', scope)
+        .executeTakeFirst();
+
+      if (row !== undefined) {
+        composed = Replication.xorFingerprint(composed, Replication.hexToFingerprint(row.fingerprint));
+      }
+    }
+
+    return Replication.fingerprintToHex(composed);
+  }
+
+  public async epoch(): Promise<string> {
+    const db = this.requireDb('epoch');
+    this.#epochPromise ??= this.initializeEpoch(db).catch((error) => {
+      this.#epochPromise = undefined;
+      throw error;
+    });
+    return this.#epochPromise;
+  }
+
+  private async replaceRowIndexes(input: {
+    tenant: string;
+    messageCid: string;
+    indexes: KeyValues;
+    encodedMessageBytes?: Buffer;
+    encodedData?: string | null;
+    messageForScopeCheck?: GenericMessage;
+    notFoundErrorCode: DwnErrorCode;
+    stampRedelivery?: boolean;
+  }): Promise<bigint | undefined> {
+    const { tenant, messageCid, indexes, encodedMessageBytes, encodedData, messageForScopeCheck, notFoundErrorCode, stampRedelivery } = input;
+    const db = this.requireDb('replaceRowIndexes');
+    const { indexes: replacementIndexes, tags } = extractTagsAndSanitizeIndexes(indexes);
+
+    return executeWithTransaction(db, async (tx) => {
+      await this.#dialect.lockReplicationCounter(tx, tenant);
+
+      const existingRow = await tx
+        .selectFrom('messageStoreMessages')
+        .selectAll()
+        .where('tenant', '=', tenant)
+        .where('messageCid', '=', messageCid)
+        .executeTakeFirst();
+
+      if (existingRow === undefined) {
+        throw new DwnError(notFoundErrorCode, `no message found for tenant ${tenant} with CID ${messageCid}`);
+      }
+
+      if (stampRedelivery === true && existingRow.redeliverSeq !== null) {
+        throw new DwnError(
+          DwnErrorCode.MessageStoreCompleteDataAlreadyStamped,
+          `message ${messageCid} is already stamped at position ${existingRow.redeliverSeq}; the dataless-to-data transition cannot repeat`
+        );
+      }
+
+      const message = messageForScopeCheck ?? await this.parseEncodedMessage(existingRow.encodedMessageBytes, existingRow.encodedData);
+      Replication.assertFingerprintScopesUntouched(
+        MessageStoreSql.parseFingerprintScopes(existingRow.fingerprintScopes, messageCid),
+        message,
+        messageCid,
+        indexes
+      );
+
+      const redeliverSeq = stampRedelivery === true ? await this.#dialect.incrementReplicationCounter(tx, tenant) : undefined;
+      const replacementColumns = {
+        ...NULLED_INDEX_COLUMNS,
+        ...replacementIndexes,
+        ...(encodedMessageBytes !== undefined && { encodedMessageBytes }),
+        ...(encodedData !== undefined && { encodedData }),
+        ...(redeliverSeq !== undefined && { redeliverSeq: redeliverSeq.toString() }),
+      };
+
+      await tx
+        .updateTable('messageStoreMessages')
+        .set(replacementColumns as UpdateObject<DwnDatabaseType, 'messageStoreMessages'>)
+        .where('id', '=', existingRow.id)
+        .execute();
+
+      await tx
+        .deleteFrom('messageStoreRecordsTags')
+        .where('messageInsertId', '=', existingRow.id)
+        .execute();
+
+      if (Object.keys(tags).length > 0) {
+        await this.#tags.executeTagsInsert(existingRow.id, tags, tx);
+      }
+
+      return redeliverSeq;
+    });
+  }
+
+  private async selectLogRows(
+    executor: MessageStoreExecutor,
+    tenant: string,
+    positionColumn: PositionColumn,
+    startPosition: bigint,
+    head: bigint,
+    filters: Filter[] | undefined,
+    maxResults: number,
+  ): Promise<Array<{ row: LogRow; position: bigint }>> {
+    let query = executor
+      .selectFrom('messageStoreMessages')
+      .leftJoin('messageStoreRecordsTags', 'messageStoreRecordsTags.messageInsertId', 'messageStoreMessages.id')
+      .selectAll('messageStoreMessages')
+      .select([
+        this.#dialect.bigIntColumnAsText('messageStoreMessages.seq').as('seqText'),
+        this.#dialect.bigIntColumnAsText('messageStoreMessages.redeliverSeq').as('redeliverSeqText'),
+      ])
+      .distinct()
+      .where('tenant', '=', tenant)
+      .where(positionColumn, '>', startPosition.toString())
+      .where(positionColumn, '<=', head.toString())
+      .orderBy(positionColumn, 'asc');
+
+    if (filters !== undefined && filters.length > 0) {
+      query = filterSelectQuery(filters, query);
+    }
+
+    if (maxResults < Number.MAX_SAFE_INTEGER) {
+      query = query.limit(maxResults);
+    }
+
+    const rows = await query.execute() as LogRow[];
+    return rows.map((row) => ({
+      row,
+      position: MessageStoreSql.requirePosition(row, positionColumn),
+    }));
+  }
+
+  private async buildEventEntries(
+    executor: MessageStoreExecutor,
+    positionedRows: Array<{ row: LogRow; position: bigint }>,
+  ): Promise<EventLogEntry[]> {
+    const tagMap = await this.fetchTagsByMessageIds(positionedRows.map(({ row }) => row.id), executor);
+    const entries: EventLogEntry[] = [];
+
+    for (const { row, position } of positionedRows) {
+      const message = await this.parseEncodedMessage(row.encodedMessageBytes, row.encodedData);
+      entries.push({
+        seq        : MessageStoreSql.requirePosition(row, 'seq').toString(),
+        position   : position.toString(),
+        event      : { message },
+        indexes    : MessageStoreSql.rowToIndexes(row, tagMap.get(row.id)),
+        messageCid : row.messageCid,
+      });
+    }
+
+    return entries;
+  }
+
+  private async fetchTagsByMessageIds(
+    messageInsertIds: number[],
+    executor: MessageStoreExecutor,
+  ): Promise<Map<number, KeyValues>> {
+    const tagsByMessageId = new Map<number, KeyValues>();
+    if (messageInsertIds.length === 0) {
+      return tagsByMessageId;
+    }
+
+    const rows = await executor
+      .selectFrom('messageStoreRecordsTags')
+      .select(['messageInsertId', 'tag', 'valueNumber', 'valueString'])
+      .where('messageInsertId', 'in', messageInsertIds)
       .execute();
+
+    for (const row of rows) {
+      const tags = tagsByMessageId.get(row.messageInsertId) ?? {};
+      const tagValue = row.valueString === null ? Number(row.valueNumber) : row.valueString;
+      const existing = tags[row.tag];
+      if (existing === undefined) {
+        tags[row.tag] = tagValue;
+      } else {
+        tags[row.tag] = MessageStoreSql.appendTagValue(existing, tagValue);
+      }
+      tagsByMessageId.set(row.messageInsertId, tags);
+    }
+
+    return tagsByMessageId;
+  }
+
+  private async foldFingerprints(
+    tx: Transaction<DwnDatabaseType>,
+    tenant: string,
+    messageCid: string,
+    scopes: string[],
+  ): Promise<void> {
+    const contribution = await Replication.hashMessageCid(messageCid);
+
+    for (const scope of scopes) {
+      const existing = await tx
+        .selectFrom('replicationFingerprints')
+        .select('fingerprint')
+        .where('tenant', '=', tenant)
+        .where('scope', '=', scope)
+        .executeTakeFirst();
+
+      const current = existing === undefined ? Replication.emptyFingerprint() : Replication.hexToFingerprint(existing.fingerprint);
+      const folded = Replication.fingerprintToHex(Replication.xorFingerprint(current, contribution));
+
+      if (existing === undefined) {
+        await tx
+          .insertInto('replicationFingerprints')
+          .values({ tenant, scope, fingerprint: folded })
+          .execute();
+      } else {
+        await tx
+          .updateTable('replicationFingerprints')
+          .set({ fingerprint: folded })
+          .where('tenant', '=', tenant)
+          .where('scope', '=', scope)
+          .execute();
+      }
+    }
+  }
+
+  private async validateCursor(tenant: string, cursor: ProgressToken, head: bigint): Promise<void> {
+    const expectedStreamId = await Replication.deriveStreamId(tenant);
+    const reason = await this.validateCursorPosition(tenant, cursor, head, expectedStreamId);
+    if (reason === undefined) {
+      return;
+    }
+
+    const bounds = await this.logBounds(tenant);
+    const gapInfo: ProgressGapInfo = {
+      requested       : cursor,
+      oldestAvailable : bounds?.oldest ?? cursor,
+      latestAvailable : bounds?.latest ?? cursor,
+      reason,
+    };
+
+    const error = Object.assign(new DwnError(
+      DwnErrorCode.EventLogProgressGap,
+      `progress token gap: ${reason}`
+    ), { gapInfo });
+    throw error;
+  }
+
+  private async validateCursorPosition(
+    tenant: string,
+    cursor: ProgressToken,
+    head: bigint,
+    expectedStreamId: string,
+  ): Promise<ProgressGapReason | undefined> {
+    if (cursor.streamId !== expectedStreamId) {
+      return 'stream_mismatch';
+    }
+
+    if (cursor.epoch !== await this.epoch()) {
+      return 'epoch_mismatch';
+    }
+
+    const cursorPosition = BigInt(cursor.position);
+    if (cursorPosition > head) {
+      return 'token_too_new';
+    }
+
+    if (cursor.messageCid === undefined) {
+      return undefined;
+    }
+
+    const positionMessageCid = await this.getMessageCidAtPosition(tenant, cursorPosition);
+    if (positionMessageCid !== undefined && positionMessageCid !== cursor.messageCid) {
+      return 'message_mismatch';
+    }
+
+    return undefined;
+  }
+
+  private async getMessageCidAtPosition(tenant: string, position: bigint): Promise<string | undefined> {
+    if (position <= 0n) {
+      return undefined;
+    }
+
+    const db = this.requireDb('getMessageCidAtPosition');
+    const positionString = position.toString();
+    const row = await db
+      .selectFrom('messageStoreMessages')
+      .select('messageCid')
+      .where('tenant', '=', tenant)
+      .where(({ eb, or }) => or([
+        eb('seq', '=', positionString),
+        eb('redeliverSeq', '=', positionString),
+      ]))
+      .executeTakeFirst();
+
+    return row?.messageCid;
+  }
+
+  private async getHead(executor: MessageStoreExecutor, tenant: string): Promise<bigint> {
+    const row = await executor
+      .selectFrom('replicationCounters')
+      .select(this.#dialect.bigIntColumnAsText('replicationCounters.seq').as('seq'))
+      .where('tenant', '=', tenant)
+      .executeTakeFirst();
+
+    return row?.seq === undefined || row.seq === null ? 0n : BigInt(row.seq);
+  }
+
+  private async hasMessage(tenant: string, messageCid: string): Promise<boolean> {
+    const db = this.requireDb('hasMessage');
+    const existing = await db
+      .selectFrom('messageStoreMessages')
+      .select('id')
+      .where('tenant', '=', tenant)
+      .where('messageCid', '=', messageCid)
+      .executeTakeFirst();
+
+    return existing !== undefined;
+  }
+
+  private async initializeEpoch(db: Kysely<DwnDatabaseType>): Promise<string> {
+    const existing = await db
+      .selectFrom('replicationMeta')
+      .select('value')
+      .where('key', '=', EPOCH_KEY)
+      .executeTakeFirst();
+
+    if (existing !== undefined) {
+      return existing.value;
+    }
+
+    const epoch = crypto.randomUUID();
+    try {
+      await db
+        .insertInto('replicationMeta')
+        .values({ key: EPOCH_KEY, value: epoch })
+        .execute();
+      return epoch;
+    } catch (error: unknown) {
+      if (!isDuplicateKeyError(error)) {
+        throw error;
+      }
+
+      const row = await db
+        .selectFrom('replicationMeta')
+        .select('value')
+        .where('key', '=', EPOCH_KEY)
+        .executeTakeFirstOrThrow();
+
+      return row.value;
+    }
+  }
+
+  private async buildToken(tenant: string, position: bigint, messageCid?: string): Promise<ProgressToken> {
+    const token: ProgressToken = {
+      streamId : await this.getStreamId(tenant),
+      epoch    : await this.epoch(),
+      position : position.toString(),
+    };
+
+    if (messageCid !== undefined) {
+      token.messageCid = messageCid;
+    }
+
+    return token;
+  }
+
+  private getStreamId(tenant: string): Promise<string> {
+    let streamIdPromise = this.#streamIdPromises.get(tenant);
+    if (streamIdPromise !== undefined) {
+      return streamIdPromise;
+    }
+
+    streamIdPromise = Replication.deriveStreamId(tenant);
+    this.#streamIdPromises.set(tenant, streamIdPromise);
+    return streamIdPromise;
+  }
+
+  private publishWake(tenant: string, position: bigint): void {
+    try {
+      this.#wakePublisher?.publish({ tenant, seq: position.toString() });
+    } catch {
+      // A lost wake only delays delivery; consumers' idle re-drain bounds the latency.
+    }
   }
 
   private async parseEncodedMessage(
@@ -562,38 +929,22 @@ export class MessageStoreSql implements MessageStore {
     const decodedBlock = await block.decode({
       bytes  : encodedMessageBytes,
       codec  : cbor,
-      hasher : sha256
+      hasher : sha256,
     });
 
     const message = decodedBlock.value as GenericMessage;
-    // If encodedData is stored within the MessageStore we include it in the response.
-    // We store encodedData when the data is below a certain threshold.
-    // https://github.com/enboxorg/enbox/pull/456
     if (message !== undefined && encodedData !== undefined && encodedData !== null) {
       message.encodedData = encodedData;
     }
     return message;
   }
 
-  /**
-   * Processes the paginated query results.
-   * Builds a pagination cursor if there are additional messages to paginate.
-   * Accepts more messages than the limit, as we query for additional records to check if we should paginate.
-   *
-   * @param messages a list of messages, potentially larger than the provided limit.
-   * @param limit the maximum number of messages to be returned
-   *
-   * @returns the pruned message results and an optional pagination cursor
-   */
   private async processPaginationResults(
     results: any[],
     sortProperty: string,
     limit?: number,
     options?: MessageStoreOptions,
-  ): Promise<{ messages: GenericMessage[], cursor?: PaginationCursor}> {
-    // we queried for one additional message to determine if there are any additional messages beyond the limit
-    // we now check if the returned results are greater than the limit, if so we pluck the last item out of the result set
-    // the cursor is always the last item in the *returned* result so we use the last item in the remaining result set to build a cursor
+  ): Promise<{ messages: GenericMessage[], cursor?: PaginationCursor }> {
     let cursor: PaginationCursor | undefined;
     if (limit !== undefined && results.length > limit) {
       results = results.slice(0, limit);
@@ -602,17 +953,15 @@ export class MessageStoreSql implements MessageStore {
       cursor = { messageCid: lastMessage.messageCid, value: cursorValue };
     }
 
-    // extracts the full encoded message from the stored blob for each result item.
-    const messages: Promise<GenericMessage>[] = results.map(r => this.parseEncodedMessage(r.encodedMessageBytes, r.encodedData, options));
+    const messages: Promise<GenericMessage>[] = results.map(
+      (result): Promise<GenericMessage> => this.parseEncodedMessage(result.encodedMessageBytes, result.encodedData, options)
+    );
     return { messages: await Promise.all(messages), cursor };
   }
 
-  /**
-   * Extracts the appropriate sort property and direction given a MessageSort object.
-   */
   private extractSortProperties(
     messageSort?: MessageSort
-  ):{ property: 'dateCreated' | 'datePublished' | 'messageTimestamp', direction: SortDirection } {
+  ): { property: 'dateCreated' | 'datePublished' | 'messageTimestamp', direction: SortDirection } {
     if (messageSort?.dateCreated !== undefined) {
       return { property: 'dateCreated', direction: messageSort.dateCreated };
     } else if (messageSort?.datePublished !== undefined) {
@@ -623,6 +972,164 @@ export class MessageStoreSql implements MessageStore {
       return { property: 'messageTimestamp', direction: messageSort.messageTimestamp };
     }
   }
+
+  private async assertTablesExist(): Promise<void> {
+    const tables = [
+      'messageStoreMessages',
+      'messageStoreRecordsTags',
+      'replicationCounters',
+      'replicationFingerprints',
+      'replicationMeta',
+    ] as const;
+
+    for (const table of tables) {
+      try {
+        await sql`SELECT 1 FROM ${sql.table(table)} LIMIT 0`.execute(this.#db!);
+      } catch {
+        throw new Error(
+          `MessageStoreSql: table '${table}' does not exist. Run DWN store migrations before opening stores.`
+        );
+      }
+    }
+  }
+
+  private async assertNoPreSubstrateRows(): Promise<void> {
+    const row = await this.#db!
+      .selectFrom('messageStoreMessages')
+      .select('messageCid')
+      .where(({ eb, or }) => or([
+        eb('seq', 'is', null),
+        eb('fingerprintScopes', 'is', null),
+      ]))
+      .executeTakeFirst();
+
+    if (row !== undefined) {
+      throw new DwnError(
+        DwnErrorCode.MessageStorePreSubstrateLayout,
+        'messageStoreMessages contains rows without replication log metadata; reset the SQL store before opening it'
+      );
+    }
+  }
+
+  private requireDb(operation: string): Kysely<DwnDatabaseType> {
+    if (!this.#db) {
+      throw new Error(
+        `Connection to database not open. Call \`open\` before using \`${operation}\`.`
+      );
+    }
+
+    return this.#db;
+  }
+
+  private static detachInlineData(message: GenericMessage): {
+    messageToStore: GenericMessage;
+    encodedData: string | null;
+  } {
+    const messageToStore = { ...message };
+    let encodedData: string | null = null;
+
+    if (messageToStore.descriptor.interface === DwnInterfaceName.Records && messageToStore.descriptor.method === DwnMethodName.Write) {
+      const data = messageToStore.encodedData;
+      if (data !== undefined) {
+        delete messageToStore.encodedData;
+        encodedData = data;
+      }
+    }
+
+    return { messageToStore, encodedData };
+  }
+
+  private static mergeRowsByPosition<TRow extends MessageStoreRow>(
+    originalRows: Array<{ row: TRow; position: bigint }>,
+    redeliveryRows: Array<{ row: TRow; position: bigint }>,
+  ): Array<{ row: TRow; position: bigint }> {
+    const rows = [...originalRows, ...redeliveryRows];
+    rows.sort((left, right) => {
+      if (left.position === right.position) {
+        return 0;
+      }
+      return left.position < right.position ? -1 : 1;
+    });
+    return rows;
+  }
+
+  private static rowToIndexes(row: MessageStoreRow, tags: KeyValues = {}): KeyValues {
+    const indexes: KeyValues = {};
+
+    for (const column of MESSAGE_STORE_INDEX_COLUMNS) {
+      const value = row[column];
+      if (value === null || value === undefined) {
+        continue;
+      }
+
+      indexes[column] = BOOLEAN_INDEX_COLUMNS.has(column) ? MessageStoreSql.toBooleanIndex(value) : value as string | number;
+    }
+
+    for (const [tag, value] of Object.entries(tags)) {
+      indexes[`tag.${tag}`] = value;
+    }
+
+    return indexes;
+  }
+
+  private static toBooleanIndex(value: unknown): boolean {
+    return value === true || value === 1 || value === '1';
+  }
+
+  private static appendTagValue(
+    existing: string | number | boolean | string[] | number[],
+    tagValue: string | number,
+  ): string[] | number[] {
+    if (Array.isArray(existing)) {
+      if (existing.every((value) => typeof value === 'number') && typeof tagValue === 'number') {
+        return [...existing, tagValue] as number[];
+      }
+
+      return [...existing.map(String), String(tagValue)];
+    }
+
+    if (typeof existing === 'number' && typeof tagValue === 'number') {
+      return [existing, tagValue];
+    }
+
+    return [String(existing), String(tagValue)];
+  }
+
+  private static filtersIncludeTags(filters: Filter[]): boolean {
+    return filters.some((filter) => Object.keys(filter).some((key) => key.startsWith('tag.')));
+  }
+
+  private static requirePosition(row: MessageStoreRow & Partial<PositionTextColumns>, positionColumn: PositionColumn): bigint {
+    const textValue = positionColumn === 'seq' ? row.seqText : row.redeliverSeqText;
+    const value = textValue ?? row[positionColumn];
+    if (value === null || value === undefined) {
+      throw new DwnError(
+        DwnErrorCode.MessageStorePreSubstrateLayout,
+        `message ${row.messageCid} is missing replication position ${positionColumn}`
+      );
+    }
+
+    return BigInt(String(value));
+  }
+
+  private static parseFingerprintScopes(scopes: string | null, messageCid: string): string[] {
+    if (scopes === null) {
+      throw new DwnError(
+        DwnErrorCode.MessageStorePreSubstrateLayout,
+        `message ${messageCid} is missing persisted fingerprint scopes`
+      );
+    }
+
+    const parsed = JSON.parse(scopes);
+    if (!Array.isArray(parsed) || parsed.some((scope) => typeof scope !== 'string')) {
+      throw new DwnError(
+        DwnErrorCode.MessageStoreFingerprintScopeMutation,
+        `message ${messageCid} has invalid persisted fingerprint scopes`
+      );
+    }
+
+    return parsed;
+  }
 }
 
-export { isDuplicateKeyError } from './utils/duplicate-key-error.js';
+export { isDuplicateKeyError, isMessageCidDuplicateKeyError } from './utils/duplicate-key-error.js';

--- a/packages/dwn-sql-store/src/message-store-sql.ts
+++ b/packages/dwn-sql-store/src/message-store-sql.ts
@@ -55,6 +55,9 @@ type MessageStoreIndexColumn = Exclude<keyof DwnDatabaseType['messageStoreMessag
 type MessageStoreRow = Selectable<DwnDatabaseType['messageStoreMessages']>;
 type MessageStoreExecutor = Kysely<DwnDatabaseType> | Transaction<DwnDatabaseType>;
 type PositionColumn = 'seq' | 'redeliverSeq';
+// Replication positions (`seq`/`redeliverSeq`) must be read through these text columns, populated by
+// `Dialect.bigIntColumnAsText` (`CAST(... AS CHAR/TEXT)`). Reading the raw bigint columns instead lets
+// the MySQL/SQLite drivers narrow them to a JS `number`, truncating positions above 2^53.
 type PositionTextColumns = {
   seqText: string | null;
   redeliverSeqText: string | null;
@@ -1100,6 +1103,9 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
   }
 
   private static requirePosition(row: MessageStoreRow & Partial<PositionTextColumns>, positionColumn: PositionColumn): bigint {
+    // Prefer the cast text column (BigInt-exact). The raw-column fallback is NOT safe above 2^53 —
+    // every position-bearing read (logRead/getHead/increment) selects the `*Text` columns, so the
+    // fallback should never carry a real position; it exists only for rows fetched without them.
     const textValue = positionColumn === 'seq' ? row.seqText : row.redeliverSeqText;
     const value = textValue ?? row[positionColumn];
     if (value === null || value === undefined) {

--- a/packages/dwn-sql-store/src/migrations/004-replication-log.ts
+++ b/packages/dwn-sql-store/src/migrations/004-replication-log.ts
@@ -1,0 +1,81 @@
+import type { Dialect } from '../dialect/dialect.js';
+import type { DwnMigrationFactory } from '../migration-provider.js';
+import type { Kysely, Migration } from 'kysely';
+
+/**
+ * Migration 004: durable replication log substrate for SQL stores.
+ *
+ * The log is represented by `messageStoreMessages` itself: each live row gets an original `seq`,
+ * optional completion `redeliverSeq`, and persisted fingerprint-domain membership. Fresh stores
+ * fill these columns for every write; existing pre-substrate rows are intentionally not backfilled.
+ */
+export const migration004ReplicationLog: DwnMigrationFactory = (dialect: Dialect): Migration => ({
+
+  async up(db: Kysely<any>): Promise<void> {
+    await db.schema
+      .alterTable('messageStoreMessages')
+      .addColumn('seq', 'bigint')
+      .execute();
+
+    await db.schema
+      .alterTable('messageStoreMessages')
+      .addColumn('redeliverSeq', 'bigint')
+      .execute();
+
+    await db.schema
+      .alterTable('messageStoreMessages')
+      .addColumn('fingerprintScopes', 'text')
+      .execute();
+
+    await db.schema.createIndex('index_messageStoreMessages_tenant_seq')
+      .on('messageStoreMessages')
+      .columns(['tenant', 'seq'])
+      .unique()
+      .execute();
+
+    await db.schema.createIndex('index_messageStoreMessages_tenant_redeliverSeq')
+      .on('messageStoreMessages')
+      .columns(['tenant', 'redeliverSeq'])
+      .unique()
+      .execute();
+
+    await db.schema.createIndex('index_messageStoreMessages_tenant_protocol_seq')
+      .on('messageStoreMessages')
+      .columns(['tenant', 'protocol', 'seq'])
+      .execute();
+
+    if (!(await dialect.hasTable(db, 'replicationCounters'))) {
+      await db.schema
+        .createTable('replicationCounters')
+        .ifNotExists()
+        .addColumn('tenant', 'varchar(255)', (col) => col.primaryKey())
+        .addColumn('seq', 'bigint', (col) => col.notNull())
+        .execute();
+    }
+
+    if (!(await dialect.hasTable(db, 'replicationFingerprints'))) {
+      await db.schema
+        .createTable('replicationFingerprints')
+        .ifNotExists()
+        .addColumn('tenant', 'varchar(255)', (col) => col.notNull())
+        .addColumn('scope', 'varchar(512)', (col) => col.notNull())
+        .addColumn('fingerprint', 'varchar(64)', (col) => col.notNull())
+        .execute();
+
+      await db.schema.createIndex('index_replicationFingerprints_tenant_scope')
+        .on('replicationFingerprints')
+        .columns(['tenant', 'scope'])
+        .unique()
+        .execute();
+    }
+
+    if (!(await dialect.hasTable(db, 'replicationMeta'))) {
+      await db.schema
+        .createTable('replicationMeta')
+        .ifNotExists()
+        .addColumn('key', 'varchar(100)', (col) => col.primaryKey())
+        .addColumn('value', 'text', (col) => col.notNull())
+        .execute();
+    }
+  },
+});

--- a/packages/dwn-sql-store/src/migrations/index.ts
+++ b/packages/dwn-sql-store/src/migrations/index.ts
@@ -3,6 +3,7 @@ import type { DwnMigrationFactory } from '../migration-provider.js';
 import { migration001InitialSchema } from './001-initial-schema.js';
 import { migration002ContentAddressedDatastore } from './002-content-addressed-datastore.js';
 import { migration003AddSquashColumn } from './003-add-squash-column.js';
+import { migration004ReplicationLog } from './004-replication-log.js';
 
 /**
  * All DWN store migrations in sequential order.
@@ -20,4 +21,5 @@ export const allDwnMigrations: ReadonlyArray<readonly [name: string, factory: Dw
   ['001-initial-schema', migration001InitialSchema],
   ['002-content-addressed-datastore', migration002ContentAddressedDatastore],
   ['003-add-squash-column', migration003AddSquashColumn],
+  ['004-replication-log', migration004ReplicationLog],
 ];

--- a/packages/dwn-sql-store/src/smt-store-sql.ts
+++ b/packages/dwn-sql-store/src/smt-store-sql.ts
@@ -11,7 +11,7 @@
  */
 
 import type { DwnDatabaseType } from './types.js';
-import type { Kysely } from 'kysely';
+import type { Kysely, Transaction } from 'kysely';
 
 import type { Hash, SMTInternalNode, SMTLeafNode, SMTNode, SMTNodeStore } from '@enbox/dwn-sdk-js';
 
@@ -19,7 +19,7 @@ import { hashToHex, hexToHash } from '@enbox/dwn-sdk-js';
 
 export type SMTStoreSqlParams = {
   /** The shared Kysely database instance. */
-  db: Kysely<DwnDatabaseType>;
+  db: Kysely<DwnDatabaseType> | Transaction<DwnDatabaseType>;
   /** The tenant DID that owns this tree. */
   tenant: string;
   /** The scope key for this tree (e.g. '' for global, protocol URI for protocol-scoped). */
@@ -27,7 +27,7 @@ export type SMTStoreSqlParams = {
 };
 
 export class SMTStoreSql implements SMTNodeStore {
-  readonly #db: Kysely<DwnDatabaseType>;
+  readonly #db: Kysely<DwnDatabaseType> | Transaction<DwnDatabaseType>;
   readonly #tenant: string;
   readonly #scope: string;
 

--- a/packages/dwn-sql-store/src/state-index-sql.ts
+++ b/packages/dwn-sql-store/src/state-index-sql.ts
@@ -14,11 +14,15 @@ import type { DwnDatabaseType } from './types.js';
 import type { Hash } from '@enbox/dwn-sdk-js';
 import type { KeyValues } from '@enbox/dwn-sdk-js';
 import type { StateIndex } from '@enbox/dwn-sdk-js';
+import type { Kysely, Transaction } from 'kysely';
 
+import { executeWithTransaction } from './utils/transaction.js';
 import { initDefaultHashes } from '@enbox/dwn-sdk-js';
 import { SMTStoreSql } from './smt-store-sql.js';
 import { SparseMerkleTree } from '@enbox/dwn-sdk-js';
-import { Kysely, sql } from 'kysely';
+import { Kysely as KyselyDatabase, sql } from 'kysely';
+
+type StateIndexExecutor = Kysely<DwnDatabaseType> | Transaction<DwnDatabaseType>;
 
 export class StateIndexSql implements StateIndex {
   readonly #dialect: Dialect;
@@ -46,7 +50,7 @@ export class StateIndexSql implements StateIndex {
       return;
     }
 
-    this.#db = new Kysely<DwnDatabaseType>({ dialect: this.#dialect });
+    this.#db = new KyselyDatabase<DwnDatabaseType>({ dialect: this.#dialect });
 
     // Ensure default hashes are initialized for the SMT
     await initDefaultHashes();
@@ -60,10 +64,11 @@ export class StateIndexSql implements StateIndex {
    * Throws a clear error directing the caller to run migrations first.
    */
   async #assertTablesExist(): Promise<void> {
+    const db = this.requireDb('open');
     const tables = ['stateIndexNodes', 'stateIndexRoots', 'stateIndexMeta'] as const;
     for (const table of tables) {
       try {
-        await sql`SELECT 1 FROM ${sql.table(table)} LIMIT 0`.execute(this.#db!);
+        await sql`SELECT 1 FROM ${sql.table(table)} LIMIT 0`.execute(db);
       } catch {
         throw new Error(
           `StateIndexSql: table '${table}' does not exist. Run DWN store migrations before opening stores.`
@@ -93,31 +98,29 @@ export class StateIndexSql implements StateIndex {
   }
 
   async insert(tenant: string, messageCid: string, indexes: KeyValues): Promise<void> {
-    if (!this.#db) {
-      throw new Error('Connection to database not open. Call `open` before using `insert`.');
-    }
-
-    // Insert into the global tree
-    const globalSmt = await this.getGlobalTree(tenant);
-    await globalSmt.insert(messageCid);
-
-    // Insert into the protocol-scoped tree if the message has a protocol (e.g. RecordsWrite).
-    // Non-record messages like ProtocolsConfigure do not have a protocol.
+    const db = this.requireDb('insert');
     const protocol = indexes.protocol as string | undefined;
-    if (protocol !== undefined) {
-      const protoSmt = await this.getProtocolTree(tenant, protocol);
-      await protoSmt.insert(messageCid);
-    }
+    await executeWithTransaction(db, async (tx) => {
+      const globalSmt = await this.createTree(tenant, '', tx);
+      await globalSmt.insert(messageCid);
 
-    // Store reverse lookup metadata for deletion
-    await this.#db
-      .insertInto('stateIndexMeta')
-      .values({
-        tenant,
-        messageCid,
-        protocol: protocol ?? null,
-      })
-      .execute();
+      // Insert into the protocol-scoped tree if the message has a protocol (e.g. RecordsWrite).
+      // Non-record messages like ProtocolsConfigure do not have a protocol.
+      if (protocol !== undefined) {
+        const protoSmt = await this.createTree(tenant, protocol, tx);
+        await protoSmt.insert(messageCid);
+      }
+
+      // Store reverse lookup metadata for deletion
+      await tx
+        .insertInto('stateIndexMeta')
+        .values({
+          tenant,
+          messageCid,
+          protocol: protocol ?? null,
+        })
+        .execute();
+    });
   }
 
   async delete(tenant: string, messageCids: string[]): Promise<void> {
@@ -224,9 +227,14 @@ export class StateIndexSql implements StateIndex {
   /**
    * Create and initialize a new SparseMerkleTree backed by SQL via SMTStoreSql.
    */
-  private async createTree(tenant: string, scope: string): Promise<SparseMerkleTree> {
+  private async createTree(
+    tenant: string,
+    scope: string,
+    executor?: StateIndexExecutor,
+  ): Promise<SparseMerkleTree> {
+    const db = executor ?? this.requireDb('createTree');
     const store = new SMTStoreSql({
-      db: this.#db!,
+      db,
       tenant,
       scope,
     });
@@ -235,6 +243,14 @@ export class StateIndexSql implements StateIndex {
     return smt;
   }
 
+  private requireDb(operation: string): Kysely<DwnDatabaseType> {
+    if (!this.#db) {
+      throw new Error(
+        `Connection to database not open. Call \`open\` before using \`${operation}\`.`
+      );
+    }
+
+    return this.#db;
+  }
+
 }
-
-

--- a/packages/dwn-sql-store/src/types.ts
+++ b/packages/dwn-sql-store/src/types.ts
@@ -9,6 +9,9 @@ type MessageStoreTable = {
   messageCid: string;
   encodedMessageBytes: Uint8Array;
   encodedData: string | null;
+  seq: string | null;
+  redeliverSeq: string | null;
+  fingerprintScopes: string | null;
   // "indexes" start
   interface: string | null;
   method: string | null;
@@ -111,6 +114,22 @@ type ResumableTaskTable = {
   retryCount: number;
 };
 
+type ReplicationCounterTable = {
+  tenant: string;
+  seq: string;
+};
+
+type ReplicationFingerprintTable = {
+  tenant: string;
+  scope: string;
+  fingerprint: string;
+};
+
+type ReplicationMetaTable = {
+  key: string;
+  value: string;
+};
+
 export type DwnDatabaseType = {
   messageStoreMessages: MessageStoreTable;
   messageStoreRecordsTags: MessageStoreRecordsTagsTable;
@@ -121,4 +140,7 @@ export type DwnDatabaseType = {
   stateIndexNodes: StateIndexNodeTable;
   stateIndexRoots: StateIndexRootTable;
   stateIndexMeta: StateIndexMetaTable;
+  replicationCounters: ReplicationCounterTable;
+  replicationFingerprints: ReplicationFingerprintTable;
+  replicationMeta: ReplicationMetaTable;
 };

--- a/packages/dwn-sql-store/src/utils/duplicate-key-error.ts
+++ b/packages/dwn-sql-store/src/utils/duplicate-key-error.ts
@@ -40,3 +40,24 @@ export function isDuplicateKeyError(error: unknown): boolean {
 
   return false;
 }
+
+/**
+ * Detects the specific message-store uniqueness constraint used to make put()
+ * idempotent. Other unique violations must surface because they indicate index
+ * or replication-position corruption rather than a duplicate message write.
+ */
+export function isMessageCidDuplicateKeyError(error: unknown): boolean {
+  if (!isDuplicateKeyError(error)) {
+    return false;
+  }
+
+  const err = error as Record<string, unknown>;
+  const constraint = typeof err.constraint === 'string' ? err.constraint : '';
+  const message = typeof err.message === 'string' ? err.message : '';
+  const normalizedConstraint = constraint.toLowerCase();
+  const normalizedMessage = message.toLowerCase();
+
+  return normalizedConstraint === 'index_tenant_messagecid' ||
+    normalizedMessage.includes('index_tenant_messagecid') ||
+    normalizedMessage.includes('messagestoremessages.tenant, messagestoremessages.messagecid');
+}

--- a/packages/dwn-sql-store/src/utils/transaction.ts
+++ b/packages/dwn-sql-store/src/utils/transaction.ts
@@ -1,12 +1,74 @@
 import type { DwnDatabaseType } from '../types.js';
 import type { Kysely, Transaction } from 'kysely';
 
+import { randomInt } from 'node:crypto';
+
+export type TransactionOptions = {
+  maxAttempts?: number;
+};
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const BASE_RETRY_DELAY_MS = 5;
+const MAX_RETRY_DELAY_MS = 50;
+const RETRYABLE_ERROR_CODES = new Set<unknown>([
+  '1205',
+  '1213',
+  '40001',
+  '40P01',
+  'ER_LOCK_DEADLOCK',
+  'ER_LOCK_WAIT_TIMEOUT',
+  'SQLITE_BUSY',
+  'SQLITE_LOCKED',
+]);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * Executes the provided operation atomically within a database transaction.
  */
-export async function executeWithTransaction(
+export async function executeWithTransaction<T>(
   database: Kysely<DwnDatabaseType>,
-  operation: (transaction: Transaction<DwnDatabaseType>) => Promise<void>
-): Promise<void> {
-  await database.transaction().execute(operation);
+  operation: (transaction: Transaction<DwnDatabaseType>) => Promise<T>,
+  options: TransactionOptions = {},
+): Promise<T> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await database.transaction().execute(operation);
+    } catch (error: unknown) {
+      if (attempt >= maxAttempts || !isRetryableTransactionError(error)) {
+        throw error;
+      }
+
+      await sleep(retryDelayMs(attempt));
+    }
+  }
+}
+
+export function retryDelayMs(attempt: number): number {
+  const delay = Math.min(MAX_RETRY_DELAY_MS, BASE_RETRY_DELAY_MS * (2 ** Math.max(0, attempt - 1)));
+  return delay + randomInt(delay + 1);
+}
+
+/**
+ * Detects transient database transaction failures that are safe to retry by
+ * re-running the entire transaction body on a fresh transaction.
+ */
+export function isRetryableTransactionError(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') {
+    return false;
+  }
+
+  const err = error as Record<string, unknown>;
+  if (RETRYABLE_ERROR_CODES.has(err.code) || RETRYABLE_ERROR_CODES.has(err.errno) || RETRYABLE_ERROR_CODES.has(err.sqlState)) {
+    return true;
+  }
+
+  const message = typeof err.message === 'string' ? err.message : '';
+  return message.includes('Deadlock found') ||
+    message.includes('Lock wait timeout exceeded') ||
+    message.includes('database is locked');
 }

--- a/packages/dwn-sql-store/tests/dialect.spec.ts
+++ b/packages/dwn-sql-store/tests/dialect.spec.ts
@@ -1,10 +1,21 @@
 import type { DwnDatabaseType } from '../src/types.js';
+import type { Transaction } from 'kysely';
 
-import { executeWithTransaction } from '../src/utils/transaction.js';
+import { createBunSqliteDatabase } from '../src/dialect/bun-sqlite-adapter.js';
+import { join } from 'node:path';
 import { Kysely } from 'kysely';
 import { TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'bun:test';
+import { executeWithTransaction, isRetryableTransactionError, retryDelayMs } from '../src/utils/transaction.js';
+import { existsSync, unlinkSync } from 'node:fs';
 import { testMysqlDialect, testPostgresDialect, testSqliteDialect } from './test-dialects.js';
+
+function unlinkIfExists(path: string): void {
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+}
 
 describe('Dialect tests', () => {
   const databaseDialects = [testMysqlDialect, testPostgresDialect, testSqliteDialect];
@@ -42,4 +53,85 @@ describe('Dialect tests', () => {
         await expect(executePromise).rejects.toThrow('Some error');
       });
   }
+
+  it('executeWithTransaction() should retry transient transaction errors', async () => {
+    let attempts = 0;
+    const deadlock = new Error('Deadlock found when trying to get lock');
+    (deadlock as any).errno = 1213;
+
+    const database = {
+      transaction: (): { execute<T>(operation: (transaction: Transaction<DwnDatabaseType>) => Promise<T>): Promise<T> } => ({
+        execute: async <T>(operation: (transaction: Transaction<DwnDatabaseType>) => Promise<T>): Promise<T> => {
+          attempts++;
+          if (attempts < 3) {
+            throw deadlock;
+          }
+          return operation({} as Transaction<DwnDatabaseType>);
+        },
+      }),
+    } as Kysely<DwnDatabaseType>;
+
+    await expect(executeWithTransaction(database, async (): Promise<string> => 'ok')).resolves.toBe('ok');
+    expect(attempts).toBe(3);
+  });
+
+  it('retryDelayMs() should apply bounded jittered backoff', () => {
+    const cases = [
+      { attempt: 1, min: 5, max: 10 },
+      { attempt: 2, min: 10, max: 20 },
+      { attempt: 10, min: 50, max: 100 },
+    ];
+
+    for (const testCase of cases) {
+      for (let i = 0; i < 20; i++) {
+        const delay = retryDelayMs(testCase.attempt);
+        expect(delay).toBeGreaterThanOrEqual(testCase.min);
+        expect(delay).toBeLessThanOrEqual(testCase.max);
+      }
+    }
+  });
+
+  it('executeWithTransaction() should stop retrying after maxAttempts', async () => {
+    let attempts = 0;
+    const deadlock = new Error('Deadlock found when trying to get lock');
+    (deadlock as any).errno = 1213;
+
+    const database = {
+      transaction: (): { execute<T>(operation: (transaction: Transaction<DwnDatabaseType>) => Promise<T>): Promise<T> } => ({
+        execute: async <T>(): Promise<T> => {
+          attempts++;
+          throw deadlock;
+        },
+      }),
+    } as Kysely<DwnDatabaseType>;
+
+    await expect(executeWithTransaction(database, async (): Promise<string> => 'ok', { maxAttempts: 2 }))
+      .rejects.toThrow('Deadlock found');
+    expect(attempts).toBe(2);
+  });
+
+  it('isRetryableTransactionError() should not match unique constraint errors', () => {
+    const duplicate = new Error('duplicate key value violates unique constraint "index_tenant_messageCid"');
+    (duplicate as any).code = '23505';
+
+    expect(isRetryableTransactionError(duplicate)).toBe(false);
+  });
+
+  it('createBunSqliteDatabase() should configure file-backed write databases for contention', () => {
+    const path = join(tmpdir(), `enbox-sqlite-${TestDataGenerator.randomString(10)}.db`);
+    const database = createBunSqliteDatabase(path);
+
+    try {
+      const timeout = database.prepare('PRAGMA busy_timeout').all([])[0] as { timeout: number };
+      const journalMode = database.prepare('PRAGMA journal_mode').all([])[0] as { journal_mode: string };
+
+      expect(timeout.timeout).toBe(5_000);
+      expect(journalMode.journal_mode).toBe('wal');
+    } finally {
+      database.close();
+      unlinkIfExists(path);
+      unlinkIfExists(`${path}-shm`);
+      unlinkIfExists(`${path}-wal`);
+    }
+  });
 });

--- a/packages/dwn-sql-store/tests/message-store-duplicate.spec.ts
+++ b/packages/dwn-sql-store/tests/message-store-duplicate.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { isDuplicateKeyError } from '../src/message-store-sql.js';
+import { isDuplicateKeyError, isMessageCidDuplicateKeyError } from '../src/message-store-sql.js';
 
 // ---------------------------------------------------------------------------
 // isDuplicateKeyError — unit tests for all dialect error shapes
@@ -63,6 +63,36 @@ describe('isDuplicateKeyError', () => {
     const err = new Error('NOT NULL constraint failed: table.column');
     (err as any).code = 'SQLITE_CONSTRAINT';
     expect(isDuplicateKeyError(err)).toBe(false);
+  });
+});
+
+describe('isMessageCidDuplicateKeyError', () => {
+  it('detects the message-store message CID unique index', () => {
+    const err = new Error('duplicate key value violates unique constraint "index_tenant_messageCid"');
+    (err as any).code = '23505';
+    (err as any).constraint = 'index_tenant_messageCid';
+
+    expect(isMessageCidDuplicateKeyError(err)).toBe(true);
+  });
+
+  it('detects PostgreSQL message CID unique indexes with unquoted lowercase names', () => {
+    const err = new Error('duplicate key value violates unique constraint "index_tenant_messagecid"');
+    (err as any).code = '23505';
+    (err as any).constraint = 'index_tenant_messagecid';
+
+    expect(isMessageCidDuplicateKeyError(err)).toBe(true);
+  });
+
+  it('does not match replication position unique indexes', () => {
+    const postgresSeqError = new Error('duplicate key value violates unique constraint "index_messageStoreMessages_tenant_seq"');
+    (postgresSeqError as any).code = '23505';
+    (postgresSeqError as any).constraint = 'index_messageStoreMessages_tenant_seq';
+
+    const sqliteRedeliveryError = new Error('UNIQUE constraint failed: messageStoreMessages.tenant, messageStoreMessages.redeliverSeq');
+    (sqliteRedeliveryError as any).code = 'SQLITE_CONSTRAINT_UNIQUE';
+
+    expect(isMessageCidDuplicateKeyError(postgresSeqError)).toBe(false);
+    expect(isMessageCidDuplicateKeyError(sqliteRedeliveryError)).toBe(false);
   });
 });
 

--- a/packages/dwn-sql-store/tests/message-store-replication-log.spec.ts
+++ b/packages/dwn-sql-store/tests/message-store-replication-log.spec.ts
@@ -1,0 +1,538 @@
+import type { Dialect } from '../src/dialect/dialect.js';
+import type { DwnDatabaseType, KeyValues } from '../src/types.js';
+import type { Wake, WakePublisher } from '@enbox/dwn-sdk-js';
+
+import { createBunSqliteDatabase } from '../src/dialect/bun-sqlite-adapter.js';
+import { Kysely } from 'kysely';
+import { MessageStoreSql } from '../src/message-store-sql.js';
+import { runDwnStoreMigrations } from '../src/migration-runner.js';
+import { SqliteDialect } from '../src/dialect/sqlite-dialect.js';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { DwnErrorCode, Message, PermissionsProtocol, Replication, TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { testMysqlDialect, testPostgresDialect, testSqliteDialect } from './test-dialects.js';
+
+const ZERO_FINGERPRINT = '0'.repeat(64);
+
+class RecordingWakePublisher implements WakePublisher {
+  public readonly wakes: Wake[] = [];
+
+  public publish(wake: Wake): void {
+    this.wakes.push(wake);
+  }
+
+  public clear(): void {
+    this.wakes.length = 0;
+  }
+}
+
+async function cidFingerprint(messageCid: string): Promise<string> {
+  return Replication.fingerprintToHex(await Replication.hashMessageCid(messageCid));
+}
+
+function xorHex(a: string, b: string): string {
+  return Replication.fingerprintToHex(
+    Replication.xorFingerprint(Replication.hexToFingerprint(a), Replication.hexToFingerprint(b))
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function generateStoredMessage(overrides: {
+  protocol?: string;
+  tags?: Record<string, string>;
+} = {}): Promise<{ message: any, messageCid: string, indexes: KeyValues }> {
+  const { message } = await TestDataGenerator.generateRecordsWrite({
+    ...(overrides.protocol !== undefined && { protocol: overrides.protocol, protocolPath: 'post' }),
+    ...(overrides.tags !== undefined && { tags: overrides.tags }),
+  });
+
+  const messageCid = await Message.getCid(message);
+  const indexes: KeyValues = {
+    interface         : 'Records',
+    method            : 'Write',
+    messageTimestamp  : message.descriptor.messageTimestamp,
+    isLatestBaseState : true,
+    recordId          : message.recordId,
+  };
+
+  if (message.descriptor.protocol !== undefined) {
+    indexes.protocol = message.descriptor.protocol;
+    indexes.protocolPath = message.descriptor.protocolPath;
+  }
+
+  if (message.descriptor.tags !== undefined) {
+    for (const [key, value] of Object.entries(message.descriptor.tags)) {
+      indexes[`tag.${key}`] = value as string;
+    }
+  }
+
+  return { message, messageCid, indexes };
+}
+
+function constructProtocolConfigureIndexes(message: any, author: string, isLatestBaseState: boolean): KeyValues {
+  return {
+    interface        : message.descriptor.interface,
+    method           : message.descriptor.method,
+    messageTimestamp : message.descriptor.messageTimestamp,
+    author,
+    protocol         : message.descriptor.definition.protocol,
+    published        : message.descriptor.definition.published,
+    isLatestBaseState,
+  };
+}
+
+function runReplicationLogTests(dialect: Dialect): void {
+  describe(`${dialect.name} replication feed`, () => {
+    let db: Kysely<DwnDatabaseType>;
+    let messageStore: MessageStoreSql;
+    let wakePublisher: RecordingWakePublisher;
+
+    beforeAll(async () => {
+      db = new Kysely<DwnDatabaseType>({ dialect });
+      await runDwnStoreMigrations(db, dialect);
+      wakePublisher = new RecordingWakePublisher();
+      messageStore = new MessageStoreSql(dialect, wakePublisher);
+      await messageStore.open();
+    });
+
+    beforeEach(async () => {
+      await messageStore.clear();
+      wakePublisher.clear();
+    });
+
+    afterAll(async () => {
+      await messageStore.close();
+      await db?.destroy();
+    });
+
+    it('should append puts in commit order, return positions, and publish wakes', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const storedCids: string[] = [];
+
+      for (let i = 0; i < 3; i++) {
+        const { message, messageCid, indexes } = await generateStoredMessage();
+        const result = await messageStore.put(alice.did, message, indexes);
+
+        expect(result.status).toBe('inserted');
+        expect(result.position!.position).toBe(String(i + 1));
+        expect(result.position!.messageCid).toBe(messageCid);
+        storedCids.push(messageCid);
+      }
+
+      expect(wakePublisher.wakes.map((wake) => wake.seq)).toEqual(['1', '2', '3']);
+
+      const { events, cursor, drained } = await messageStore.logRead(alice.did);
+      expect(events.map((entry) => entry.seq)).toEqual(['1', '2', '3']);
+      expect(events.map((entry) => entry.messageCid)).toEqual(storedCids);
+      expect(cursor!.position).toBe('3');
+      expect(drained).toBe(true);
+    });
+
+    it('should assign gap-free monotonic positions for concurrent puts', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const writes = await Promise.all(
+        Array.from({ length: 12 }, async () => generateStoredMessage())
+      );
+
+      const results = await Promise.all(
+        writes.map(async ({ message, indexes }) => messageStore.put(alice.did, message, indexes))
+      );
+      const positions = results
+        .map((result) => Number(result.position!.position))
+        .sort((a, b) => a - b);
+
+      expect(positions).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+      const { events, cursor, drained } = await messageStore.logRead(alice.did);
+      expect(events).toHaveLength(12);
+      expect(cursor!.position).toBe('12');
+      expect(drained).toBe(true);
+    });
+
+    it('should let a second store read a gap-free stream while writes are in flight', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const readerStore = new MessageStoreSql(dialect);
+      await readerStore.open();
+
+      try {
+        const writes = await Promise.all(
+          Array.from({ length: 12 }, async () => generateStoredMessage())
+        );
+        let writesSettled = false;
+        let cursor: Awaited<ReturnType<MessageStoreSql['logRead']>>['cursor'];
+        const observedPositions: string[] = [];
+        let drained = false;
+
+        const writerPromise = Promise.all(
+          writes.map(async ({ message, indexes }, index) => {
+            await delay(index % 4);
+            return messageStore.put(alice.did, message, indexes);
+          })
+        ).finally(() => {
+          writesSettled = true;
+        });
+
+        const readNextPage = async (): Promise<void> => {
+          const page = await readerStore.logRead(alice.did, { cursor, limit: 3 });
+          observedPositions.push(...page.events.map((entry) => entry.position ?? entry.seq));
+          cursor = page.cursor;
+          drained = page.drained;
+        };
+
+        for (let attempt = 0; attempt < 200 && !writesSettled; attempt++) {
+          await readNextPage();
+          await delay(1);
+        }
+
+        const results = await writerPromise;
+        const expectedPositions = results
+          .map((result) => result.position!.position)
+          .sort((a, b) => (BigInt(a) < BigInt(b) ? -1 : 1));
+        const finalPosition = expectedPositions.at(-1)!;
+
+        for (let attempt = 0; attempt < 200; attempt++) {
+          await readNextPage();
+          if (drained && cursor!.position === finalPosition) {
+            break;
+          }
+          await delay(1);
+        }
+
+        expect(results.map((result) => result.status)).toEqual(Array(12).fill('inserted'));
+        expect(observedPositions).toEqual(expectedPositions);
+        expect(cursor!.position).toBe(finalPosition);
+        expect(drained).toBe(true);
+      } finally {
+        await readerStore.close();
+      }
+    });
+
+    it('should treat duplicate puts as non-mutating', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const { message, indexes } = await generateStoredMessage();
+
+      const first = await messageStore.put(alice.did, message, indexes);
+      const second = await messageStore.put(alice.did, message, indexes);
+
+      expect(first.status).toBe('inserted');
+      expect(second.status).toBe('duplicate');
+      expect(second.position).toBeUndefined();
+      expect(wakePublisher.wakes.map((wake) => wake.seq)).toEqual(['1']);
+
+      const third = await generateStoredMessage();
+      const thirdPut = await messageStore.put(alice.did, third.message, third.indexes);
+      expect(thirdPut.position!.position).toBe('2');
+    });
+
+    it('should surface replication position collisions instead of treating them as duplicate puts', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const first = await generateStoredMessage();
+      const second = await generateStoredMessage();
+
+      await messageStore.put(alice.did, first.message, first.indexes);
+      await db
+        .updateTable('replicationCounters')
+        .set({ seq: '0' })
+        .where('tenant', '=', alice.did)
+        .execute();
+
+      await expect(messageStore.put(alice.did, second.message, second.indexes)).rejects.toThrow();
+
+      const rows = await db
+        .selectFrom('messageStoreMessages')
+        .select(['messageCid', 'seq'])
+        .where('tenant', '=', alice.did)
+        .execute();
+
+      expect(rows.map((row) => ({ messageCid: row.messageCid, seq: String(row.seq) })))
+        .toEqual([{ messageCid: first.messageCid, seq: '1' }]);
+    });
+
+    it('should preserve replication positions beyond Number.MAX_SAFE_INTEGER', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const highBase = 9_007_199_254_740_992n;
+      const expectedPutPosition = highBase + 1n;
+      const expectedRedeliveryPosition = highBase + 2n;
+
+      await db
+        .insertInto('replicationCounters')
+        .values({ tenant: alice.did, seq: highBase.toString() })
+        .execute();
+
+      const stored = await generateStoredMessage();
+      const put = await messageStore.put(alice.did, stored.message, stored.indexes);
+      expect(put.position!.position).toBe(expectedPutPosition.toString());
+
+      const redelivery = await messageStore.completeData(alice.did, stored.messageCid, stored.indexes, 'aGVsbG8');
+      expect(redelivery.position!.position).toBe(expectedRedeliveryPosition.toString());
+
+      const { events, cursor, drained } = await messageStore.logRead(alice.did);
+      expect(events.map((entry) => entry.position)).toEqual([
+        expectedPutPosition.toString(),
+        expectedRedeliveryPosition.toString(),
+      ]);
+      expect(events.map((entry) => entry.seq)).toEqual([
+        expectedPutPosition.toString(),
+        expectedPutPosition.toString(),
+      ]);
+      expect(cursor!.position).toBe(expectedRedeliveryPosition.toString());
+      expect(drained).toBe(true);
+    });
+
+    it('should page with high-water cursors and preserve zero-limit cursor semantics', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const protocol = 'https://example.com/photos';
+
+      const matching = await generateStoredMessage({ protocol });
+      const matchingPut = await messageStore.put(alice.did, matching.message, matching.indexes);
+      const other = await generateStoredMessage();
+      const otherPut = await messageStore.put(alice.did, other.message, other.indexes);
+      const tail = await generateStoredMessage();
+      await messageStore.put(alice.did, tail.message, tail.indexes);
+
+      const filtered = await messageStore.logRead(alice.did, { filters: [{ protocol }] });
+      expect(filtered.events.map((entry) => entry.messageCid)).toEqual([matching.messageCid]);
+      expect(filtered.drained).toBe(true);
+      expect(filtered.cursor!.position).toBe('3');
+      expect(filtered.cursor!.messageCid).toBeUndefined();
+
+      const firstPage = await messageStore.logRead(alice.did, { limit: 2 });
+      expect(firstPage.drained).toBe(false);
+      expect(firstPage.cursor!.position).toBe('2');
+
+      const secondPage = await messageStore.logRead(alice.did, { cursor: firstPage.cursor });
+      expect(secondPage.events.map((entry) => entry.messageCid)).toEqual([tail.messageCid]);
+      expect(secondPage.drained).toBe(true);
+      expect(secondPage.cursor!.position).toBe('3');
+
+      expect((await messageStore.logRead(alice.did, { limit: 0 })).drained).toBe(false);
+      expect(await messageStore.logRead(alice.did, { cursor: matchingPut.position, limit: 0 }))
+        .toMatchObject({ events: [], cursor: matchingPut.position, drained: false });
+      expect(await messageStore.logRead(alice.did, { cursor: otherPut.position, limit: 0 }))
+        .toMatchObject({ events: [], cursor: otherPut.position, drained: false });
+    });
+
+    it('should reject invalid cursors and resume from deleted cursor positions', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const first = await generateStoredMessage();
+      const second = await generateStoredMessage();
+      const firstPut = await messageStore.put(alice.did, first.message, first.indexes);
+      await messageStore.put(alice.did, second.message, second.indexes);
+
+      await expect(messageStore.logRead(alice.did, { cursor: { ...firstPut.position!, streamId: 'wrong-stream' } }))
+        .rejects.toThrow('stream_mismatch');
+      await expect(messageStore.logRead(alice.did, { cursor: { ...firstPut.position!, position: '3' } }))
+        .rejects.toThrow('token_too_new');
+      await expect(messageStore.logRead(alice.did, { cursor: { ...firstPut.position!, messageCid: 'bafy-wrong-message' } }))
+        .rejects.toThrow('message_mismatch');
+
+      await messageStore.delete(alice.did, first.messageCid);
+      const resumed = await messageStore.logRead(alice.did, { cursor: firstPut.position });
+      expect(resumed.events.map((entry) => entry.messageCid)).toEqual([second.messageCid]);
+      expect(resumed.drained).toBe(true);
+
+      const staleCursor = firstPut.position!;
+      await messageStore.clear();
+      await expect(messageStore.logRead(alice.did, { cursor: staleCursor }))
+        .rejects.toThrow('epoch_mismatch');
+    });
+
+    it('should replace indexes in place without moving rows or mutating fingerprint scopes', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const protocol = 'https://example.com/photos';
+      const first = await generateStoredMessage({ protocol });
+      const second = await generateStoredMessage();
+
+      await messageStore.put(alice.did, { ...first.message, encodedData: 'c29tZSBkYXRh' }, first.indexes);
+      await messageStore.put(alice.did, second.message, second.indexes);
+      const wakeCountBefore = wakePublisher.wakes.length;
+
+      await messageStore.updateIndexes(alice.did, first.messageCid, { ...first.indexes, isLatestBaseState: false });
+
+      const { events } = await messageStore.logRead(alice.did);
+      expect(events.map((entry) => entry.seq)).toEqual(['1', '2']);
+      expect(events[0].indexes.isLatestBaseState).toBe(false);
+      expect((await messageStore.get(alice.did, first.messageCid))!.encodedData).toBe('c29tZSBkYXRh');
+      expect(wakePublisher.wakes.length).toBe(wakeCountBefore);
+      expect((await messageStore.logBounds(alice.did))!.latest.position).toBe('2');
+
+      await expect(messageStore.updateIndexes(alice.did, first.messageCid, { ...first.indexes, protocol: 'https://example.com/other' }))
+        .rejects.toThrow(DwnErrorCode.MessageStoreFingerprintScopeMutation);
+    });
+
+    it('should stamp completeData redelivery once and preserve permission fingerprint scopes', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const stub = await generateStoredMessage();
+      const other = await generateStoredMessage();
+
+      await messageStore.put(alice.did, stub.message, { ...stub.indexes, isLatestBaseState: false });
+      await messageStore.put(alice.did, other.message, other.indexes);
+
+      const result = await messageStore.completeData(alice.did, stub.messageCid, stub.indexes, 'aGVsbG8');
+      expect(result.position!.position).toBe('3');
+      expect(result.position!.messageCid).toBe(stub.messageCid);
+      expect(wakePublisher.wakes.map((wake) => wake.seq)).toEqual(['1', '2', '3']);
+
+      const storedMessage = await messageStore.get(alice.did, stub.messageCid);
+      expect(storedMessage!.encodedData).toBe('aGVsbG8');
+
+      const { events, cursor, drained } = await messageStore.logRead(alice.did);
+      expect(events.map((entry) => entry.messageCid)).toEqual([stub.messageCid, other.messageCid, stub.messageCid]);
+      expect(events.filter((entry) => entry.messageCid === stub.messageCid).map((entry) => entry.seq)).toEqual(['1', '1']);
+      expect(cursor!.position).toBe('3');
+      expect(drained).toBe(true);
+
+      const boundsBeforeRetry = await messageStore.logBounds(alice.did);
+      const wakeCountBeforeRetry = wakePublisher.wakes.length;
+      await expect(messageStore.completeData(alice.did, stub.messageCid, stub.indexes, 'aGVsbG8'))
+        .rejects.toThrow(DwnErrorCode.MessageStoreCompleteDataAlreadyStamped);
+      expect(wakePublisher.wakes).toHaveLength(wakeCountBeforeRetry);
+      expect((await messageStore.logBounds(alice.did))!.latest).toEqual(boundsBeforeRetry!.latest);
+
+      await messageStore.clear();
+      const scopedProtocol = 'https://example.com/permission-photos';
+      const grant = await generateStoredMessage({
+        protocol : PermissionsProtocol.uri,
+        tags     : { protocol: scopedProtocol },
+      });
+      const grantFingerprint = await cidFingerprint(grant.messageCid);
+      const { 'tag.protocol': _tagProtocol, ...datalessGrantIndexes } = grant.indexes;
+
+      await messageStore.put(alice.did, grant.message, { ...datalessGrantIndexes, isLatestBaseState: false });
+      expect(await messageStore.fingerprint(alice.did, [Replication.permissionDomain(scopedProtocol)])).toBe(grantFingerprint);
+      expect((await messageStore.logRead(alice.did, { filters: [{ 'tag.protocol': scopedProtocol }] })).events).toHaveLength(0);
+
+      const completion = await messageStore.completeData(alice.did, grant.messageCid, grant.indexes, 'aGVsbG8');
+      expect(completion.position!.position).toBe('2');
+      expect(await messageStore.fingerprint(alice.did, [Replication.permissionDomain(scopedProtocol)])).toBe(grantFingerprint);
+      expect((await messageStore.logRead(alice.did)).events.map((entry) => entry.indexes['tag.protocol']))
+        .toEqual([scopedProtocol, scopedProtocol]);
+    });
+
+    it('should page redeliveries by redelivery position on partial pages', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const first = await generateStoredMessage();
+      const second = await generateStoredMessage();
+      const third = await generateStoredMessage();
+
+      await messageStore.put(alice.did, first.message, first.indexes);
+      await messageStore.put(alice.did, second.message, second.indexes);
+      await messageStore.put(alice.did, third.message, third.indexes);
+      await messageStore.completeData(alice.did, first.messageCid, first.indexes, 'aGVsbG8');
+
+      const firstPage = await messageStore.logRead(alice.did, { limit: 2 });
+      expect(firstPage.events.map((entry) => entry.position)).toEqual(['1', '2']);
+      expect(firstPage.events.map((entry) => entry.messageCid)).toEqual([first.messageCid, second.messageCid]);
+      expect(firstPage.cursor!.position).toBe('2');
+      expect(firstPage.drained).toBe(false);
+
+      const secondPage = await messageStore.logRead(alice.did, { cursor: firstPage.cursor, limit: 2 });
+      expect(secondPage.events.map((entry) => entry.position)).toEqual(['3', '4']);
+      expect(secondPage.events.map((entry) => entry.seq)).toEqual(['3', '1']);
+      expect(secondPage.events.map((entry) => entry.messageCid)).toEqual([third.messageCid, first.messageCid]);
+      expect(secondPage.cursor!.position).toBe('4');
+      expect(secondPage.cursor!.messageCid).toBe(first.messageCid);
+      expect(secondPage.drained).toBe(true);
+
+      const drained = await messageStore.logRead(alice.did, { cursor: secondPage.cursor, limit: 2 });
+      expect(drained.events).toHaveLength(0);
+      expect(drained.cursor).toEqual(secondPage.cursor);
+      expect(drained.drained).toBe(true);
+    });
+
+    it('should fold protocol configs and tombstones into protocol fingerprints and persist across reopen', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const photosProtocol = 'https://example.com/photos-fingerprint';
+      const protocolDefinition = {
+        protocol  : photosProtocol,
+        published : false,
+        types     : { post: { schema: 'post', dataFormats: ['text/plain'] } },
+        structure : { post: {} },
+      };
+      const initialEpoch = await messageStore.epoch();
+
+      const config = await TestDataGenerator.generateProtocolsConfigure({
+        author: alice,
+        protocolDefinition,
+      });
+      const configIndexes = constructProtocolConfigureIndexes(config.message, alice.did, true);
+      await messageStore.put(alice.did, config.message, configIndexes);
+      const configFingerprint = await cidFingerprint(await Message.getCid(config.message));
+
+      expect(await messageStore.fingerprint(alice.did, [Replication.protocolDomain(photosProtocol)])).toBe(configFingerprint);
+
+      const photo = await generateStoredMessage({ protocol: photosProtocol });
+      await messageStore.put(alice.did, photo.message, photo.indexes);
+      const photoFingerprint = await cidFingerprint(photo.messageCid);
+
+      const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+        author   : alice,
+        recordId : photo.message.recordId,
+      });
+      const deleteIndexes = recordsDelete.recordsDelete.constructIndexes(photo.message, photo.message);
+      await messageStore.put(alice.did, recordsDelete.message, deleteIndexes);
+      const recordsDeleteCid = await Message.getCid(recordsDelete.message);
+      const deleteFingerprint = await cidFingerprint(recordsDeleteCid);
+
+      const expectedProtocolFingerprint = xorHex(xorHex(configFingerprint, photoFingerprint), deleteFingerprint);
+      expect(await messageStore.fingerprint(alice.did, [Replication.protocolDomain(photosProtocol)]))
+        .toBe(expectedProtocolFingerprint);
+
+      const boundsBefore = await messageStore.logBounds(alice.did);
+      const logBefore = await messageStore.logRead(alice.did);
+      const globalFingerprintBefore = await messageStore.fingerprint(alice.did, [Replication.globalDomain]);
+
+      await messageStore.close();
+      await messageStore.open();
+
+      expect(await messageStore.epoch()).toBe(initialEpoch);
+      expect(await messageStore.logBounds(alice.did)).toEqual(boundsBefore);
+      expect((await messageStore.logRead(alice.did)).events.map((entry) => entry.messageCid))
+        .toEqual(logBefore.events.map((entry) => entry.messageCid));
+      expect(await messageStore.fingerprint(alice.did, [Replication.globalDomain])).toBe(globalFingerprintBefore);
+      expect(await messageStore.fingerprint(alice.did, [Replication.protocolDomain(photosProtocol)]))
+        .toBe(expectedProtocolFingerprint);
+
+      await messageStore.delete(alice.did, recordsDeleteCid);
+      expect(await messageStore.fingerprint(alice.did, [Replication.protocolDomain(photosProtocol)]))
+        .toBe(xorHex(configFingerprint, photoFingerprint));
+      await messageStore.clear();
+      expect(await messageStore.epoch()).not.toBe(initialEpoch);
+      expect(await messageStore.fingerprint(alice.did, [Replication.globalDomain])).toBe(ZERO_FINGERPRINT);
+    });
+  });
+}
+
+describe('MessageStoreSql replication log', () => {
+  for (const dialect of [testMysqlDialect, testPostgresDialect, testSqliteDialect]) {
+    runReplicationLogTests(dialect);
+  }
+
+  it('should fail fast when pre-substrate rows exist without replication metadata', async () => {
+    const sharedDb = createBunSqliteDatabase(':memory:', { create: true });
+    const dialect = new SqliteDialect({
+      database: async (): Promise<ReturnType<typeof createBunSqliteDatabase>> => sharedDb,
+    });
+    const db = new Kysely<DwnDatabaseType>({ dialect });
+    await runDwnStoreMigrations(db, dialect);
+
+    const { message } = await generateStoredMessage();
+    const encodedMessageBlock = new TextEncoder().encode(JSON.stringify(message));
+    await db
+      .insertInto('messageStoreMessages')
+      .values({
+        tenant              : 'did:example:alice',
+        messageCid          : await Message.getCid(message),
+        encodedMessageBytes : encodedMessageBlock,
+      })
+      .execute();
+
+    const messageStore = new MessageStoreSql(dialect);
+    await expect(messageStore.open()).rejects.toThrow(DwnErrorCode.MessageStorePreSubstrateLayout);
+
+    await db.destroy();
+    sharedDb.close();
+  });
+});

--- a/packages/dwn-sql-store/tests/message-store-replication-log.spec.ts
+++ b/packages/dwn-sql-store/tests/message-store-replication-log.spec.ts
@@ -279,6 +279,11 @@ function runReplicationLogTests(dialect: Dialect): void {
       ]);
       expect(cursor!.position).toBe(expectedRedeliveryPosition.toString());
       expect(drained).toBe(true);
+
+      // logBounds reads the head via the cast getHead path — assert it also round-trips beyond 2^53.
+      const bounds = await messageStore.logBounds(alice.did);
+      expect(bounds!.oldest.position).toBe('0');
+      expect(bounds!.latest.position).toBe(expectedRedeliveryPosition.toString());
     });
 
     it('should page with high-water cursors and preserve zero-limit cursor semantics', async () => {

--- a/packages/dwn-sql-store/tests/migration-runner.spec.ts
+++ b/packages/dwn-sql-store/tests/migration-runner.spec.ts
@@ -30,6 +30,9 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
           'stateIndexNodes',
           'stateIndexRoots',
           'stateIndexMeta',
+          'replicationCounters',
+          'replicationFingerprints',
+          'replicationMeta',
           'kysely_migration',
           'kysely_migration_lock',
         ];
@@ -54,6 +57,9 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
           'stateIndexNodes',
           'stateIndexRoots',
           'stateIndexMeta',
+          'replicationCounters',
+          'replicationFingerprints',
+          'replicationMeta',
           'kysely_migration',
           'kysely_migration_lock',
         ];
@@ -90,6 +96,7 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
           '001-initial-schema',
           '002-content-addressed-datastore',
           '003-add-squash-column',
+          '004-replication-log',
         ]);
 
         // Verify tables created by migration 001
@@ -99,6 +106,9 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
         expect(await dialect.hasTable(db, 'stateIndexNodes')).toBe(true);
         expect(await dialect.hasTable(db, 'stateIndexRoots')).toBe(true);
         expect(await dialect.hasTable(db, 'stateIndexMeta')).toBe(true);
+        expect(await dialect.hasTable(db, 'replicationCounters')).toBe(true);
+        expect(await dialect.hasTable(db, 'replicationFingerprints')).toBe(true);
+        expect(await dialect.hasTable(db, 'replicationMeta')).toBe(true);
 
         // Verify migration 002 created new tables and dropped old one
         expect(await dialect.hasTable(db, 'dataRefs')).toBe(true);
@@ -115,10 +125,11 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
           .orderBy('name', 'asc')
           .execute();
 
-        expect(rows.length).toBe(3);
+        expect(rows.length).toBe(4);
         expect((rows[0] as any).name).toBe('001-initial-schema');
         expect((rows[1] as any).name).toBe('002-content-addressed-datastore');
         expect((rows[2] as any).name).toBe('003-add-squash-column');
+        expect((rows[3] as any).name).toBe('004-replication-log');
         // Kysely uses `timestamp` column for when migration was applied
         expect((rows[0] as any).timestamp).toBeDefined();
       });
@@ -127,7 +138,7 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
 
       it('should be idempotent — second run returns no new migrations', async () => {
         const firstRun = await runDwnStoreMigrations(db, dialect);
-        expect(firstRun.length).toBe(3);
+        expect(firstRun.length).toBe(4);
 
         const secondRun = await runDwnStoreMigrations(db, dialect);
         expect(secondRun.length).toBe(0);
@@ -140,7 +151,7 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
 
         // Now run with all migrations — only 002 and 003 should be applied
         const secondRun = await runDwnStoreMigrations(db, dialect);
-        expect(secondRun).toEqual(['002-content-addressed-datastore', '003-add-squash-column']);
+        expect(secondRun).toEqual(['002-content-addressed-datastore', '003-add-squash-column', '004-replication-log']);
       });
 
       // ─── Data migration tests ───────────────────────────────────────
@@ -175,7 +186,7 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
 
         // Step 3: Apply remaining migrations which should migrate data
         const applied = await runDwnStoreMigrations(db, dialect);
-        expect(applied).toEqual(['002-content-addressed-datastore', '003-add-squash-column']);
+        expect(applied).toEqual(['002-content-addressed-datastore', '003-add-squash-column', '004-replication-log']);
 
         // Step 4: Verify data was migrated to dataRefs
         const refs = await db
@@ -269,7 +280,7 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
 
         // Apply remaining migrations — should not fail on empty table
         const applied = await runDwnStoreMigrations(db, dialect);
-        expect(applied).toEqual(['002-content-addressed-datastore', '003-add-squash-column']);
+        expect(applied).toEqual(['002-content-addressed-datastore', '003-add-squash-column', '004-replication-log']);
 
         // New tables exist, old one gone
         expect(await dialect.hasTable(db, 'dataRefs')).toBe(true);
@@ -303,7 +314,7 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
           .selectAll()
           .execute();
 
-        expect(rows.length).toBe(3); // only the 3 real migrations
+        expect(rows.length).toBe(4); // only the 4 real migrations
         const names = rows.map((r: any) => r.name);
         expect(names).not.toContain('999-failing-migration');
       });
@@ -330,6 +341,7 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
           '001-initial-schema',
           '002-content-addressed-datastore',
           '003-add-squash-column',
+          '004-replication-log',
         ]);
 
         // All should now be recorded
@@ -338,7 +350,7 @@ describe('runDwnStoreMigrations (Kysely Migrator)', () => {
           .selectAll()
           .execute();
 
-        expect(rows.length).toBe(3);
+        expect(rows.length).toBe(4);
       });
 
       // ─── Empty migrations list test ─────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds SQL schema support for tenant-scoped replication positions, redelivery stamps, stream epoch, and scoped fingerprints.
- Implements `ReplicationFeedReader` on `MessageStoreSql`, including cursor validation, gap-free positions, fingerprint folding, data-completion redelivery, and wake publication.
- Hardens dialect handling with transient transaction retries, bigint-safe replication position reads, and narrow duplicate-message detection.
- Keeps SQL state-index inserts atomic so SQLite remains fast and crash-safe under the shared test suite.
- Adds cross-dialect coverage for feed ordering, duplicate puts, reader/writer concurrency, cursor gaps, redelivery, fingerprint scopes, high positions, persistence, and pre-substrate fail-fast behavior.

## Test plan
- [x] SQL store lint
- [x] Dependent package build
- [x] Focused SQL replication-log and transaction tests
- [x] Full SQL store test suite

## Migration note
Existing SQL message stores that already contain rows without replication metadata now fail fast on open and should be reset for this greenfield sync substrate.