### PR TITLE
feat(agent): add MessagesQuery request support

### DIFF
--- a/.changeset/curly-maps-reply.md
+++ b/.changeset/curly-maps-reply.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Add MessagesQuery to the agent DWN request surface and treat Messages.Read grants as covering message feed queries.

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -719,11 +719,9 @@ export class AgentDwnApi {
       // Owner-authored multi-party root records get context-key delivery below
       // (participant, delegate, and cross-device paths). The externally-authored
       // multi-party root record is the open gap: it lands ProtocolPath-encrypted to
-      // the owner only, so other context-key holders cannot decrypt it. The owner
-      // cannot retrofit a ProtocolContext recipient here — that was the removed
-      // reactive-upgrade path, which mutated the stored message in place. Closing
-      // this needs a normal authored DWN write (a signed message cannot be rewritten
-      // by the owner); the mechanism is still open.
+      // the owner only, so other context-key holders cannot decrypt it. Closing this
+      // needs a normal authored DWN write because a signed message cannot be rewritten
+      // by the owner; the mechanism is still open.
       // Open issue https://github.com/enboxorg/enbox/issues/923: resolve externally-authored
       // multi-party root-record context-key access.
       const newParticipants = detectNewParticipantsFn({

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -401,8 +401,8 @@ export class AgentPermissionsApi implements PermissionsApi {
     delegated: boolean = false
   ): Promise<PermissionGrantEntry | undefined> {
     // Two-pass matching: prefer exact scope matches over unified Messages.Read fallback.
-    // This ensures that if both a Messages.Sync grant and a Messages.Read grant exist,
-    // the specific Messages.Sync grant is returned for MessagesSync lookups.
+    // Messages.Read is the only valid Messages scope, but the exact-match path
+    // preserves normal behavior for non-Messages grants and MessagesRead itself.
     let unifiedFallback: PermissionGrantEntry | undefined;
 
     for (const entry of grants) {
@@ -445,12 +445,13 @@ export class AgentPermissionsApi implements PermissionsApi {
     const scope = grant.scope;
     const scopeMessageType = scope.interface + scope.method;
 
-    // Messages.Read is the only valid Messages scope and covers Read, Sync, and Subscribe operations.
+    // Messages.Read is the only valid Messages scope and covers Query, Read, Sync, and Subscribe operations.
     // Defensively require method === Read so malformed/legacy grants with method Sync/Subscribe
     // are rejected rather than treated as valid scopes.
     const isMessagesScopeMatch = scope.interface === 'Messages'
       ? scope.method === 'Read'
-        && (messageType === DwnInterface.MessagesRead
+        && (messageType === DwnInterface.MessagesQuery
+          || messageType === DwnInterface.MessagesRead
           || messageType === DwnInterface.MessagesSync
           || messageType === DwnInterface.MessagesSubscribe)
       : scopeMessageType === messageType;

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -28,7 +28,7 @@ import { topologicalSort } from './sync-topological-sort.js';
 import { computeAuthorizationEpoch, computeProjectionId, isTenantInactivePushFailure, isTerminalPushFailure, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { fetchRemoteMessages, getMessageCid, pushMessages, SyncPullAbortedError } from './sync-messages.js';
 import { partitionRemoteEntries, SyncLinkReconciler } from './sync-link-reconciler.js';
-import { permissionGrantIdsFromEntries, resolveMessagesSyncScopes, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
+import { permissionGrantIdsFromEntries, resolveMessagesScopes, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
 export type SyncEngineLevelParams = {
   agent?: EnboxPlatformAgent;
@@ -381,7 +381,7 @@ export class SyncEngineLevel implements SyncEngine {
       }];
     }
 
-    const resolvedScopes = await resolveMessagesSyncScopes({
+    const resolvedScopes = await resolveMessagesScopes({
       did,
       delegateDid,
       requestedScope,

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -7,7 +7,7 @@ import { Jws, Message } from '@enbox/dwn-sdk-js';
 
 import { lexicographicalCompare } from './types/sync.js';
 
-export type MessagesSyncScopeResolution = {
+export type MessagesScopeResolution = {
   scope: SyncScope;
   permissionGrants: PermissionGrantEntry[];
 };
@@ -23,11 +23,11 @@ export function toMessagesPermissionGrantIds(permissionGrantIds: string[] | unde
 /**
  * Gets the active permission grant IDs that authorize a Messages operation.
  *
- * Owner-authored sync does not invoke grants. Delegate full sync requires at
- * least one active unscoped Messages.Read grant. Delegate protocol-set sync
- * requires each requested protocol root to be covered by an active
- * Messages.Read grant, then invokes every active grant that participates in
- * that root set. This keeps the authorization epoch tied to grant churn
+ * Owner-authored Messages feed access does not invoke grants. Delegate full
+ * scope requires at least one active unscoped Messages.Read grant. Delegate
+ * protocol-set scope requires each requested protocol root to be covered by an
+ * active Messages.Read grant, then invokes every active grant that participates
+ * in that root set. This keeps the authorization epoch tied to grant churn
  * without widening the CID set being compared.
  */
 export async function getMessagesPermissionGrantsForScope({
@@ -46,7 +46,7 @@ export async function getMessagesPermissionGrantsForScope({
   const requestedScope: SyncScope = protocols === undefined
     ? { kind: 'full' }
     : { kind: 'protocolSet', protocols };
-  const resolutions = await resolveMessagesSyncScopes({
+  const resolutions = await resolveMessagesScopes({
     did,
     delegateDid,
     requestedScope,
@@ -59,13 +59,12 @@ export async function getMessagesPermissionGrantsForScope({
 }
 
 /**
- * Resolves active Messages.Read grants into one or more sync targets.
+ * Resolves active Messages.Read grants into one or more Messages feed scopes.
  *
- * Full/protocol sync only compares StateIndex roots. Exact protocolPath and
- * contextId grants do not authorize those roots because they cover a strict
- * subset that this sync mechanism no longer tries to project.
+ * Exact protocolPath and contextId grants do not authorize root log scopes
+ * because they cover a strict subset of the messages in those scopes.
  */
-export async function resolveMessagesSyncScopes({
+export async function resolveMessagesScopes({
   did,
   delegateDid,
   requestedScope,
@@ -77,7 +76,7 @@ export async function resolveMessagesSyncScopes({
   requestedScope: SyncScope;
   messageType: DwnInterface;
   permissionsApi: PermissionsApi;
-}): Promise<MessagesSyncScopeResolution[]> {
+}): Promise<MessagesScopeResolution[]> {
   if (!delegateDid) {
     return [{ scope: requestedScope, permissionGrants: [] }];
   }
@@ -101,7 +100,7 @@ function resolveFullScope(
   permissionGrants: PermissionGrantEntry[],
   requestedScope: Extract<SyncScope, { kind: 'full' }>,
   messageType: DwnInterface,
-): MessagesSyncScopeResolution {
+): MessagesScopeResolution {
   const grants = permissionGrants
     .filter(grantMatchesFullRoot)
     .sort((a, b) => lexicographicalCompare(a.grant.id, b.grant.id));
@@ -116,7 +115,7 @@ function resolveProtocolSetScope(
   permissionGrants: PermissionGrantEntry[],
   requestedScope: Extract<SyncScope, { kind: 'protocolSet' }>,
   messageType: DwnInterface,
-): MessagesSyncScopeResolution {
+): MessagesScopeResolution {
   for (const protocol of requestedScope.protocols) {
     if (permissionGrants.some(entry => grantMatchesProtocolRoot(entry, protocol))) {
       continue;

--- a/packages/agent/src/types/dwn.ts
+++ b/packages/agent/src/types/dwn.ts
@@ -3,6 +3,9 @@ import type { RequireOnly } from '@enbox/common';
 
 import type {
   GenericMessageReply,
+  MessagesQueryMessage,
+  MessagesQueryOptions,
+  MessagesQueryReply,
   MessagesReadMessage,
   MessagesReadOptions,
   MessagesReadReply,
@@ -37,6 +40,7 @@ import type { MessagesSyncOptions } from '@enbox/dwn-sdk-js';
 import {
   DwnInterfaceName,
   DwnMethodName,
+  MessagesQuery,
   MessagesRead,
   MessagesSubscribe,
   MessagesSync,
@@ -75,6 +79,7 @@ import {
 export interface DwnDidService extends DidService {}
 
 export enum DwnInterface {
+  MessagesQuery = DwnInterfaceName.Messages + DwnMethodName.Query,
   MessagesRead = DwnInterfaceName.Messages + DwnMethodName.Read,
   MessagesSubscribe = DwnInterfaceName.Messages + DwnMethodName.Subscribe,
   MessagesSync = DwnInterfaceName.Messages + DwnMethodName.Sync,
@@ -92,6 +97,7 @@ export type DwnRecordsInterfaces =
   | DwnInterface.RecordsSubscribe | DwnInterface.RecordsWrite;
 
 export interface DwnMessage {
+  [DwnInterface.MessagesQuery] : MessagesQueryMessage;
   [DwnInterface.MessagesRead] : MessagesReadMessage;
   [DwnInterface.MessagesSubscribe] : MessagesSubscribeMessage;
   [DwnInterface.MessagesSync] : MessagesSyncMessage;
@@ -105,6 +111,7 @@ export interface DwnMessage {
 }
 
 export interface DwnMessageDescriptor {
+  [DwnInterface.MessagesQuery] : MessagesQueryMessage['descriptor'];
   [DwnInterface.MessagesRead] : MessagesReadMessage['descriptor'];
   [DwnInterface.MessagesSubscribe] : MessagesSubscribeMessage['descriptor'];
   [DwnInterface.MessagesSync] : MessagesSyncMessage['descriptor'];
@@ -118,6 +125,7 @@ export interface DwnMessageDescriptor {
 }
 
 export interface DwnMessageParams {
+  [DwnInterface.MessagesQuery] : MessagesQueryOptions;
   [DwnInterface.MessagesRead] : RequireOnly<MessagesReadOptions, 'messageCid'>;
   [DwnInterface.MessagesSubscribe] : Partial<MessagesSubscribeOptions>;
   [DwnInterface.MessagesSync] : RequireOnly<MessagesSyncOptions, 'action'>;
@@ -131,6 +139,7 @@ export interface DwnMessageParams {
 }
 
 export interface DwnMessageReply {
+  [DwnInterface.MessagesQuery] : MessagesQueryReply;
   [DwnInterface.MessagesRead] : MessagesReadReply;
   [DwnInterface.MessagesSubscribe] : MessagesSubscribeReply;
   [DwnInterface.MessagesSync] : MessagesSyncReply;
@@ -148,6 +157,7 @@ export interface MessageHandler {
   [DwnInterface.RecordsSubscribe] : SubscriptionListener;
 
   // define all of them individually as undefined
+  [DwnInterface.MessagesQuery] : undefined;
   [DwnInterface.MessagesRead] : undefined;
   [DwnInterface.MessagesSync] : undefined;
   [DwnInterface.ProtocolsConfigure] : undefined;
@@ -218,6 +228,7 @@ export interface DwnMessageConstructor<T extends DwnInterface> {
 }
 
 export const dwnMessageConstructors: { [T in DwnInterface]: DwnMessageConstructor<T> } = {
+  [DwnInterface.MessagesQuery]      : MessagesQuery,
   [DwnInterface.MessagesRead]       : MessagesRead,
   [DwnInterface.MessagesSubscribe]  : MessagesSubscribe,
   [DwnInterface.MessagesSync]       : MessagesSync,
@@ -231,6 +242,7 @@ export const dwnMessageConstructors: { [T in DwnInterface]: DwnMessageConstructo
 };
 
 export interface DwnMessageInstance {
+  [DwnInterface.MessagesQuery] : MessagesQuery;
   [DwnInterface.MessagesRead] : MessagesRead;
   [DwnInterface.MessagesSubscribe] : MessagesSubscribe;
   [DwnInterface.MessagesSync] : MessagesSync;

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -603,6 +603,35 @@ describe('AgentDwnApi', () => {
       await testHarness.clearStorage();
     });
 
+    it('handles MessagesQuery through the generic request path', async () => {
+      const dataBytes = Convert.string('MessagesQuery write').toUint8Array();
+      const { messageCid: writeMessageCid, reply: { status: writeStatus } } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          dataFormat   : 'text/plain',
+          protocol     : freeForAllProtocolDefinition.protocol,
+          protocolPath : 'post'
+        },
+        dataStream: new Blob([dataBytes as BlobPart])
+      });
+      expect(writeStatus.code).toBe(202);
+
+      const { reply } = await testHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.MessagesQuery,
+        messageParams : { cidsOnly: true },
+      });
+
+      expect(reply.status.code).toBe(200);
+      expect(reply.entries?.some(entry => entry.messageCid === writeMessageCid)).toBe(true);
+      expect(reply.entries?.every(entry => entry.message === undefined)).toBe(true);
+      expect(reply.cursor?.position).toBeDefined();
+      expect(reply.drained).toBe(true);
+    });
+
     it('handles MessageSubscription', async () => {
       const receivedMessages: string[] = [];
       const subscriptionHandler = async (msg): Promise<void> => {

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -1205,7 +1205,7 @@ describe('AgentPermissionsApi', () => {
       });
 
       // Messages.Read is the only valid Messages scope — one grant covers
-      // Read, Sync, and Subscribe operations.
+      // Query, Read, Sync, and Subscribe operations.
       const grant = await testHarness.agent.permissions.createGrant({
         author      : aliceDid.uri,
         grantedTo   : aliceDeviceX.did.uri,
@@ -1216,8 +1216,13 @@ describe('AgentPermissionsApi', () => {
 
       const grants = [ grant ];
 
-      // All three Messages operations match the same Read grant.
-      for (const messageType of [DwnInterface.MessagesRead, DwnInterface.MessagesSync, DwnInterface.MessagesSubscribe]) {
+      // All Messages feed operations match the same Read grant.
+      for (const messageType of [
+        DwnInterface.MessagesQuery,
+        DwnInterface.MessagesRead,
+        DwnInterface.MessagesSync,
+        DwnInterface.MessagesSubscribe,
+      ]) {
         const matched = await AgentPermissionsApi.matchGrantFromArray(aliceDid.uri, aliceDeviceX.did.uri, {
           messageType,
         }, grants);
@@ -1232,7 +1237,7 @@ describe('AgentPermissionsApi', () => {
       expect(invalidGrant).toBeUndefined();
     });
 
-    it('Messages.Read unified scope covers Sync and Subscribe', async () => {
+    it('Messages.Read unified scope covers Query, Sync, and Subscribe', async () => {
       const aliceDeviceX = await testHarness.agent.identity.create({
         store     : true,
         metadata  : { name: 'Alice Device X' },
@@ -1258,6 +1263,12 @@ describe('AgentPermissionsApi', () => {
         messageType: DwnInterface.MessagesRead,
       }, readOnlyGrants);
       expect(matchedRead?.message.recordId).toBe(readGrant.message.recordId);
+
+      // Messages.Read also matches a MessagesQuery lookup
+      const matchedQuery = await AgentPermissionsApi.matchGrantFromArray(aliceDid.uri, aliceDeviceX.did.uri, {
+        messageType: DwnInterface.MessagesQuery,
+      }, readOnlyGrants);
+      expect(matchedQuery?.message.recordId).toBe(readGrant.message.recordId);
 
       // Messages.Read also matches a MessagesSync lookup
       const matchedSync = await AgentPermissionsApi.matchGrantFromArray(aliceDid.uri, aliceDeviceX.did.uri, {
@@ -1306,7 +1317,12 @@ describe('AgentPermissionsApi', () => {
       };
 
       // The tampered grant should NOT match any Messages operation.
-      for (const messageType of [DwnInterface.MessagesRead, DwnInterface.MessagesSync, DwnInterface.MessagesSubscribe]) {
+      for (const messageType of [
+        DwnInterface.MessagesQuery,
+        DwnInterface.MessagesRead,
+        DwnInterface.MessagesSync,
+        DwnInterface.MessagesSubscribe,
+      ]) {
         const matched = await AgentPermissionsApi.matchGrantFromArray(aliceDid.uri, aliceDeviceX.did.uri, {
           messageType,
         }, [tamperedEntry as any]);
@@ -1325,7 +1341,7 @@ describe('AgentPermissionsApi', () => {
       const otherProtocol = 'http://example.com/other-protocol';
 
       // Messages.Read is the only valid Messages scope — one grant per protocol
-      // covers Read, Sync, and Subscribe operations.
+      // covers Query, Read, Sync, and Subscribe operations.
       const protoGrant = await testHarness.agent.permissions.createGrant({
         author      : aliceDid.uri,
         grantedTo   : aliceDeviceX.did.uri,
@@ -1344,8 +1360,13 @@ describe('AgentPermissionsApi', () => {
 
       const deviceXMessageGrants = [ protoGrant, otherProtoGrant ];
 
-      // All three Messages operations match the same Read grant for the given protocol.
-      for (const messageType of [DwnInterface.MessagesRead, DwnInterface.MessagesSync, DwnInterface.MessagesSubscribe]) {
+      // All Messages feed operations match the same Read grant for the given protocol.
+      for (const messageType of [
+        DwnInterface.MessagesQuery,
+        DwnInterface.MessagesRead,
+        DwnInterface.MessagesSync,
+        DwnInterface.MessagesSubscribe,
+      ]) {
         const matched = await AgentPermissionsApi.matchGrantFromArray(aliceDid.uri, aliceDeviceX.did.uri, {
           messageType,
           protocol,
@@ -1370,7 +1391,7 @@ describe('AgentPermissionsApi', () => {
       expect(otherMatch?.message.recordId).toBe(otherProtoGrant.message.recordId);
     });
 
-    it('Messages.Read unified scope covers Sync and Subscribe with protocol', async () => {
+    it('Messages.Read unified scope covers Query, Sync, and Subscribe with protocol', async () => {
       const aliceDeviceX = await testHarness.agent.identity.create({
         store     : true,
         metadata  : { name: 'Alice Device X' },
@@ -1393,6 +1414,13 @@ describe('AgentPermissionsApi', () => {
       });
 
       const readOnlyGrants = [ readGrant ];
+
+      // Matches MessagesQuery for the same protocol
+      const matchedQuery = await AgentPermissionsApi.matchGrantFromArray(aliceDid.uri, aliceDeviceX.did.uri, {
+        messageType: DwnInterface.MessagesQuery,
+        protocol
+      }, readOnlyGrants);
+      expect(matchedQuery?.message.recordId).toBe(readGrant.message.recordId);
 
       // Matches MessagesSync for the same protocol
       const matchedSync = await AgentPermissionsApi.matchGrantFromArray(aliceDid.uri, aliceDeviceX.did.uri, {
@@ -1459,6 +1487,13 @@ describe('AgentPermissionsApi', () => {
         protocolPath : 'post'
       }, grants);
       expect(pathMatch?.message.recordId).toBe(pathGrant.message.recordId);
+
+      const queryPathMatch = await AgentPermissionsApi.matchGrantFromArray(aliceDid.uri, aliceDeviceX.did.uri, {
+        messageType  : DwnInterface.MessagesQuery,
+        protocol,
+        protocolPath : 'post'
+      }, grants);
+      expect(queryPathMatch?.message.recordId).toBe(pathGrant.message.recordId);
 
       const childPathMatch = await AgentPermissionsApi.matchGrantFromArray(aliceDid.uri, aliceDeviceX.did.uri, {
         messageType  : DwnInterface.MessagesRead,

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -9,7 +9,7 @@ import { DwnInterface } from '../src/types/dwn.js';
 import { ReplicationLedger } from '../src/sync-replication-ledger.js';
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 import { SyncPullAbortedError } from '../src/sync-messages.js';
-import { getMessagesPermissionGrantsForScope, resolveMessagesSyncScopes } from '../src/sync-permission-grants.js';
+import { getMessagesPermissionGrantsForScope, resolveMessagesScopes } from '../src/sync-permission-grants.js';
 
 describe('SyncEngineLevel — private methods', () => {
   let db: Level<string, string>;
@@ -381,7 +381,7 @@ describe('SyncEngineLevel — private methods', () => {
         ]),
       };
 
-      await expect(resolveMessagesSyncScopes({
+      await expect(resolveMessagesScopes({
         did            : 'did:example:alice',
         delegateDid    : 'did:example:delegate',
         requestedScope : { kind: 'protocolSet', protocols: ['https://example.com/profile'] },
@@ -402,7 +402,7 @@ describe('SyncEngineLevel — private methods', () => {
         ]),
       };
 
-      await expect(resolveMessagesSyncScopes({
+      await expect(resolveMessagesScopes({
         did            : 'did:example:alice',
         delegateDid    : 'did:example:delegate',
         requestedScope : { kind: 'protocolSet', protocols: ['https://example.com/profile'] },
@@ -428,7 +428,7 @@ describe('SyncEngineLevel — private methods', () => {
         ]),
       };
 
-      await expect(resolveMessagesSyncScopes({
+      await expect(resolveMessagesScopes({
         did            : 'did:example:alice',
         delegateDid    : 'did:example:delegate',
         requestedScope : {

--- a/packages/auth/src/wallet-connect-client.ts
+++ b/packages/auth/src/wallet-connect-client.ts
@@ -227,8 +227,8 @@ function createPermissionRequestForProtocol({ definition, permissions }: Protoco
     method    : DwnMethodName.Query,
   });
 
-  // A Messages.Read grant is a unified scope that covers MessagesRead, MessagesSync, and MessagesSubscribe.
-  // This single grant enables sync and real-time subscriptions for the protocol.
+  // A Messages.Read grant is a unified scope for protocol message feeds and
+  // real-time subscriptions.
   requests.push({
     protocol  : definition.protocol,
     interface : DwnInterfaceName.Messages,


### PR DESCRIPTION
## Summary

- Add `MessagesQuery` to the agent DWN request types and constructor map so generic request handling can create and process query messages.
- Treat `Messages.Read` grants as covering message feed queries alongside the existing Messages operations.
- Rename the reusable Messages grant scope resolver away from the old `MessagesSync`-specific name and remove stale reactive-upgrade wording.

## Test plan

- [x] Repo lint
- [x] Agent build
- [x] Auth lint/build
- [x] Focused agent permission, `MessagesQuery`, and sync private tests
- [ ] Full agent suite with local server: attempted, but the shared local test database has pre-substrate rows and the new server correctly refuses to open it; CI should run this with fresh test services
