### PR TITLE
feat(agent): add message feed query helpers

### DIFF
--- a/.changeset/agent-message-feed-helpers.md
+++ b/.changeset/agent-message-feed-helpers.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Add internal MessagesQuery feed helpers for the agent sync engine.

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -1,7 +1,11 @@
 import type {
   DependencyRef,
   GenericMessage,
+  MessagesFilter,
+  MessagesQueryOptions,
+  MessagesQueryReply,
   MessagesReadReply,
+  ProgressToken,
   ProtocolsConfigureMessage,
   ProtocolsQueryReply,
   RecordsQueryReply,
@@ -39,6 +43,19 @@ export type SyncMessageEntry = {
   /** Buffered data bytes for retry — avoids re-fetching from remote when stream is consumed. */
   bufferedData?: Uint8Array;
 };
+
+export type MessageFeedQuery = {
+  did: string;
+  delegateDid?: string;
+  permissionGrantIds?: string[];
+  filters?: MessagesFilter[];
+  cursor?: ProgressToken;
+  limit?: number;
+  cidsOnly?: boolean;
+  agent: EnboxPlatformAgent;
+};
+
+type MessageFeedParams = Omit<MessageFeedQuery, 'did' | 'delegateDid' | 'agent'>;
 
 type FetchLocalMessageResult =
   | { kind: 'found'; entry: SyncMessageEntry }
@@ -171,6 +188,76 @@ function shouldBufferDataStream(entry: SyncMessageEntry): boolean {
 
   const dataSize = (entry.message.descriptor as { dataSize?: unknown }).dataSize;
   return typeof dataSize === 'number' && dataSize <= MAX_BUFFER_SIZE;
+}
+
+function buildMessageFeedParams({
+  filters,
+  cursor,
+  limit,
+  cidsOnly,
+  permissionGrantIds,
+}: MessageFeedParams): Omit<MessagesQueryOptions, 'signer'> {
+  return {
+    filters,
+    cursor,
+    limit,
+    cidsOnly,
+    permissionGrantIds: toMessagesPermissionGrantIds(permissionGrantIds)
+  };
+}
+
+/**
+ * Queries a remote DWN's durable message feed using MessagesQuery.
+ */
+export async function queryRemoteMessageFeed({
+  did,
+  dwnUrl,
+  delegateDid,
+  permissionGrantIds,
+  filters,
+  cursor,
+  limit,
+  cidsOnly,
+  agent,
+}: MessageFeedQuery & { dwnUrl: string }): Promise<MessagesQueryReply> {
+  const messagesQuery = await agent.processDwnRequest({
+    store         : false,
+    author        : did,
+    target        : did,
+    messageType   : DwnInterface.MessagesQuery,
+    granteeDid    : delegateDid,
+    messageParams : buildMessageFeedParams({ filters, cursor, limit, cidsOnly, permissionGrantIds })
+  });
+
+  return await agent.rpc.sendDwnRequest({
+    dwnUrl,
+    targetDid : did,
+    message   : messagesQuery.message,
+  }) as MessagesQueryReply;
+}
+
+/**
+ * Queries the local DWN's durable message feed using MessagesQuery.
+ */
+export async function queryLocalMessageFeed({
+  did,
+  delegateDid,
+  permissionGrantIds,
+  filters,
+  cursor,
+  limit,
+  cidsOnly,
+  agent,
+}: MessageFeedQuery): Promise<MessagesQueryReply> {
+  const { reply } = await agent.dwn.processRequest({
+    author        : did,
+    target        : did,
+    messageType   : DwnInterface.MessagesQuery,
+    granteeDid    : delegateDid,
+    messageParams : buildMessageFeedParams({ filters, cursor, limit, cidsOnly, permissionGrantIds })
+  });
+
+  return reply;
 }
 
 /**

--- a/packages/agent/src/types/dwn.ts
+++ b/packages/agent/src/types/dwn.ts
@@ -125,7 +125,7 @@ export interface DwnMessageDescriptor {
 }
 
 export interface DwnMessageParams {
-  [DwnInterface.MessagesQuery] : MessagesQueryOptions;
+  [DwnInterface.MessagesQuery] : Omit<MessagesQueryOptions, 'signer'>;
   [DwnInterface.MessagesRead] : RequireOnly<MessagesReadOptions, 'messageCid'>;
   [DwnInterface.MessagesSubscribe] : Partial<MessagesSubscribeOptions>;
   [DwnInterface.MessagesSync] : RequireOnly<MessagesSyncOptions, 'action'>;

--- a/packages/agent/tests/sync-live-handler-path.spec.ts
+++ b/packages/agent/tests/sync-live-handler-path.spec.ts
@@ -14,6 +14,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { createLocalDwnRpc } from './utils/local-dwn-rpc-shim.js';
 import { DwnInterface } from '../src/types/dwn.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
+import { queryRemoteMessageFeed } from '../src/sync-messages.js';
 import { TestAgent } from './utils/test-agent.js';
 
 /**
@@ -79,6 +80,46 @@ describe('sync live handler path — real subscriptions via LocalDwnRpcShim', ()
   afterAll(async () => {
     await testHarness.clearStorage();
     await testHarness.closeStorage();
+  });
+
+  it('should query the durable feed through the local RPC shim', async () => {
+    const { reply: protoReply } = await testHarness.agent.dwn.processRequest({
+      author        : tenant,
+      target        : tenant,
+      messageType   : DwnInterface.ProtocolsConfigure,
+      messageParams : { definition: testProtocol },
+    });
+    expect(protoReply.status.code).toBe(202);
+
+    const { messageCid: writeMessageCid, reply: writeReply } = await testHarness.agent.dwn.processRequest({
+      author        : tenant,
+      target        : tenant,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : testProtocol.protocol,
+        protocolPath : 'note',
+        dataFormat   : 'text/plain',
+        schema       : 'https://schemas.example.com/note',
+      },
+      dataStream: new Blob([new TextEncoder().encode('feed query through shim')]),
+    });
+    expect(writeReply.status.code).toBe(202);
+
+    const reply = await queryRemoteMessageFeed({
+      did      : tenant,
+      dwnUrl   : 'http://localhost:9999',
+      filters  : [{ protocol: testProtocol.protocol }],
+      limit    : 10,
+      cidsOnly : true,
+      agent    : testHarness.agent,
+    });
+
+    expect(reply.status.code).toBe(200);
+    expect(reply.entries?.some(entry => entry.messageCid === writeMessageCid)).toBe(true);
+    expect(reply.entries?.every(entry => entry.message === undefined)).toBe(true);
+    expect(reply.cursor?.position).toBeDefined();
+    expect(reply.drained).toBe(true);
+    expect(reply.fingerprint).toBeDefined();
   });
 
   it('should advance pull checkpoint after processing a live event through the real handler', async () => {

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -12,6 +12,8 @@ import {
   getLocalMessage,
   getMessageCid,
   pushMessages,
+  queryLocalMessageFeed,
+  queryRemoteMessageFeed,
 } from '../src/sync-messages.js';
 
 type LocalAgentFixture = {
@@ -159,6 +161,110 @@ describe('sync-messages', () => {
   // ---------------------------------------------------------------------------
   // fetchRemoteMessages
   // ---------------------------------------------------------------------------
+
+  describe('queryRemoteMessageFeed', () => {
+    it('should construct a MessagesQuery and send it to the requested remote endpoint', async () => {
+      const messagesQuery = { descriptor: { interface: 'Messages', method: 'Query' } };
+      const reply = {
+        status  : { code: 200 },
+        entries : [],
+        drained : true,
+      };
+      const processDwnRequest = sinon.stub().resolves({ message: messagesQuery });
+      const sendDwnRequest = sinon.stub().resolves(reply);
+      const cursor = {
+        streamId : 'stream-1',
+        epoch    : 'epoch-1',
+        position : '7',
+      };
+      const filters = [{ protocol: 'https://example.com/protocol' }];
+      const agent = {
+        processDwnRequest,
+        rpc: { sendDwnRequest },
+      } as any;
+
+      const result = await queryRemoteMessageFeed({
+        did                : 'did:example:alice',
+        dwnUrl             : 'https://dwn.example.com',
+        delegateDid        : 'did:example:device',
+        permissionGrantIds : ['grant-b', 'grant-a', 'grant-b'],
+        filters,
+        cursor,
+        limit              : 10,
+        cidsOnly           : true,
+        agent,
+      });
+
+      expect(result).toBe(reply);
+      expect(processDwnRequest.calledOnce).toBe(true);
+      expect(processDwnRequest.firstCall.args[0]).toEqual({
+        store         : false,
+        author        : 'did:example:alice',
+        target        : 'did:example:alice',
+        messageType   : DwnInterface.MessagesQuery,
+        granteeDid    : 'did:example:device',
+        messageParams : {
+          filters,
+          cursor,
+          limit              : 10,
+          cidsOnly           : true,
+          permissionGrantIds : ['grant-a', 'grant-b'],
+        },
+      });
+      expect(sendDwnRequest.calledOnce).toBe(true);
+      expect(sendDwnRequest.firstCall.args[0]).toEqual({
+        dwnUrl    : 'https://dwn.example.com',
+        targetDid : 'did:example:alice',
+        message   : messagesQuery,
+      });
+    });
+  });
+
+  describe('queryLocalMessageFeed', () => {
+    it('should query the local DWN with normalized Messages.Read grant IDs', async () => {
+      const reply = {
+        status  : { code: 200 },
+        entries : [{ seq: '1', messageCid: 'cid-1', isLatestBaseState: true }],
+        drained : false,
+      };
+      const processRequest = sinon.stub().resolves({ reply });
+      const cursor = {
+        streamId : 'stream-1',
+        epoch    : 'epoch-1',
+        position : '0',
+      };
+      const agent = {
+        dwn: { processRequest },
+      } as any;
+
+      const result = await queryLocalMessageFeed({
+        did                : 'did:example:alice',
+        delegateDid        : 'did:example:device',
+        permissionGrantIds : ['grant-b', 'grant-a', 'grant-b'],
+        filters            : [{ protocol: 'https://example.com/protocol' }],
+        cursor,
+        limit              : 1,
+        cidsOnly           : true,
+        agent,
+      });
+
+      expect(result).toBe(reply);
+      expect(processRequest.calledOnce).toBe(true);
+      expect(processRequest.firstCall.args[0]).toEqual({
+        author        : 'did:example:alice',
+        target        : 'did:example:alice',
+        messageType   : DwnInterface.MessagesQuery,
+        granteeDid    : 'did:example:device',
+        messageParams : {
+          filters            : [{ protocol: 'https://example.com/protocol' }],
+          cursor,
+          limit              : 1,
+          cidsOnly           : true,
+          permissionGrantIds : ['grant-a', 'grant-b'],
+        },
+      });
+    });
+  });
 
   describe('fetchRemoteMessages', () => {
     it('should fetch messages by CID from remote DWN', async () => {


### PR DESCRIPTION
Summary
- Add reusable local and remote MessagesQuery feed helpers for the agent sync path.
- Normalize delegated Messages.Read grant IDs consistently for feed queries.
- Cover the helper behavior and the local RPC shim path with focused tests.

Test plan
- [x] Lint passes.
- [x] Agent dependency build passes.
- [x] Focused sync message and local RPC shim tests pass.
- [ ] Full agent suite needs the local DWN server on :3000; without it, server-dependent sync/e2e tests fail with connection refused.