### PR TITLE
feat(agent): target remote DWNs for sync

### DIFF
--- a/.changeset/remote-sync-targets.md
+++ b/.changeset/remote-sync-targets.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Use remote DID-document DWN endpoints for sync targets and rotate sync projection IDs for the durable message-feed engine.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1742,7 +1742,7 @@ export class SyncEngineLevel implements SyncEngine {
 
   /** Hot-add a single identity to the active live sync session. */
   private async addIdentityToLiveSync(did: string, options: SyncIdentityOptions): Promise<Set<string>> {
-    const dwnEndpointUrls = await this.agent.dwn.getDwnEndpointUrlsForTarget(did);
+    const dwnEndpointUrls = await this.agent.dwn.getRemoteDwnEndpointUrls(did);
     if (dwnEndpointUrls.length === 0) { return new Set(); }
 
     const targets: SyncTarget[] = [];
@@ -4111,7 +4111,7 @@ export class SyncEngineLevel implements SyncEngine {
         continue;
       }
 
-      const dwnEndpointUrls = await this.agent.dwn.getDwnEndpointUrlsForTarget(did);
+      const dwnEndpointUrls = await this.agent.dwn.getRemoteDwnEndpointUrls(did);
       if (dwnEndpointUrls.length === 0) {
         anyTargetUnavailable = true;
         continue;

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -45,9 +45,9 @@ export type SyncMode = 'poll' | 'live';
 // ---------------------------------------------------------------------------
 
 /**
- * Root algorithm used by StateIndex full/protocol sync scopes.
+ * Root algorithm used by durable message-feed full/protocol sync scopes.
  */
-export const SYNC_PROJECTION_ROOT_VERSION = 'state-index-full-protocol-root-v1';
+export const SYNC_PROJECTION_ROOT_VERSION = 'replication-log-feed-v1';
 
 /**
  * Authorization-epoch algorithm used by delegated Messages.Read sync links.

--- a/packages/agent/tests/sync-engine-identity.spec.ts
+++ b/packages/agent/tests/sync-engine-identity.spec.ts
@@ -211,7 +211,7 @@ describe('SyncEngineLevel — identity management', () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn1.example.com', 'https://dwn2.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn1.example.com', 'https://dwn2.example.com']),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
@@ -230,7 +230,7 @@ describe('SyncEngineLevel — identity management', () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
@@ -253,7 +253,7 @@ describe('SyncEngineLevel — identity management', () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
@@ -275,7 +275,7 @@ describe('SyncEngineLevel — identity management', () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
@@ -304,7 +304,7 @@ describe('SyncEngineLevel — identity management', () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = new SyncEngineLevel({ db, agent: mockAgent });
@@ -722,7 +722,7 @@ describe('SyncEngineLevel — identity management', () => {
     it('addIdentityToLiveSync should be a no-op when identity has no DWN endpoints', async () => {
       const engine = new SyncEngineLevel({ db });
       const mockAgent = {
-        dwn: { getDwnEndpointUrlsForTarget: sinon.stub().resolves([]) },
+        dwn: { getRemoteDwnEndpointUrls: sinon.stub().resolves([]) },
       };
       (engine as any)._agent = mockAgent;
 
@@ -738,7 +738,7 @@ describe('SyncEngineLevel — identity management', () => {
     it('addIdentityToLiveSync should create one protocol-set target when protocols are specified', async () => {
       const engine = new SyncEngineLevel({ db });
       const mockAgent = {
-        dwn: { getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']) },
+        dwn: { getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']) },
       };
       (engine as any)._agent = mockAgent;
 
@@ -777,7 +777,7 @@ describe('SyncEngineLevel — identity management', () => {
     it('addIdentityToLiveSync should create a full-tenant link when protocols is all', async () => {
       const engine = new SyncEngineLevel({ db });
       const mockAgent = {
-        dwn: { getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']) },
+        dwn: { getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']) },
       };
       (engine as any)._agent = mockAgent;
 
@@ -810,7 +810,7 @@ describe('SyncEngineLevel — identity management', () => {
     it('addIdentityToLiveSync should close pull subscription if push subscription fails', async () => {
       const engine = new SyncEngineLevel({ db });
       const mockAgent = {
-        dwn: { getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']) },
+        dwn: { getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']) },
       };
       (engine as any)._agent = mockAgent;
 

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -469,7 +469,7 @@ describe('SyncEngineLevel — private methods', () => {
     it('should return empty array when no identities registered', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
-        dwn      : { getDwnEndpointUrlsForTarget: sinon.stub() },
+        dwn      : { getRemoteDwnEndpointUrls: sinon.stub() },
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
 
@@ -481,7 +481,7 @@ describe('SyncEngineLevel — private methods', () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves([]),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves([]),
         },
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
@@ -495,7 +495,7 @@ describe('SyncEngineLevel — private methods', () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
@@ -508,11 +508,32 @@ describe('SyncEngineLevel — private methods', () => {
       expect(targets[0].protocol).toBeUndefined();
     });
 
+    it('should resolve sync targets from remote DID-document endpoints only', async () => {
+      const remoteEndpointLookupStub = sinon.stub().resolves(['https://remote.example.com']);
+      const localAwareEndpointLookupStub = sinon.stub().resolves(['http://127.0.0.1:3000']);
+      const mockAgent = {
+        agentDid : 'did:example:agent',
+        dwn      : {
+          getDwnEndpointUrlsForTarget : localAwareEndpointLookupStub,
+          getRemoteDwnEndpointUrls    : remoteEndpointLookupStub,
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent });
+      await engine.registerIdentity({ did: 'did:example:remote-only', options: { protocols: 'all' } });
+
+      const targets = await (engine as any).getSyncTargets();
+      expect(remoteEndpointLookupStub.callCount).toBe(1);
+      expect(remoteEndpointLookupStub.firstCall.args).toEqual(['did:example:remote-only']);
+      expect(localAwareEndpointLookupStub.callCount).toBe(0);
+      expect(targets).toHaveLength(1);
+      expect(targets[0].dwnUrl).toBe('https://remote.example.com');
+    });
+
     it('should produce one protocol-set target per DWN URL', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
@@ -530,11 +551,47 @@ describe('SyncEngineLevel — private methods', () => {
       expect(targets[0].authorization).toEqual({ kind: 'owner' });
     });
 
+    it('should hot-add live identities from remote DID-document endpoints only', async () => {
+      const remoteEndpointLookupStub = sinon.stub().resolves(['https://remote-live.example.com']);
+      const localAwareEndpointLookupStub = sinon.stub().resolves(['http://127.0.0.1:3000']);
+      const engine = createEngine({
+        db,
+        agent: {
+          agentDid : 'did:example:agent',
+          dwn      : {
+            getDwnEndpointUrlsForTarget : localAwareEndpointLookupStub,
+            getRemoteDwnEndpointUrls    : remoteEndpointLookupStub,
+          },
+        } as any,
+      });
+      const buildTargetStub = sinon.stub(engine as any, 'buildSyncTargetsForEndpoint').resolves([
+        syncTarget('did:example:live-remote-only', 'https://remote-live.example.com'),
+      ]);
+      sinon.stub(engine as any, 'initializeLinkTargetWithRetry').resolves({
+        durableLinkIdentityKey : 'did:example:live-remote-only^projection^authorization',
+        status                 : 'active',
+      });
+
+      const keys = await (engine as any).addIdentityToLiveSync(
+        'did:example:live-remote-only',
+        { protocols: 'all' },
+      );
+
+      expect(remoteEndpointLookupStub.callCount).toBe(1);
+      expect(remoteEndpointLookupStub.firstCall.args).toEqual(['did:example:live-remote-only']);
+      expect(localAwareEndpointLookupStub.callCount).toBe(0);
+      expect(buildTargetStub.firstCall.args.slice(0, 2)).toEqual([
+        'did:example:live-remote-only',
+        'https://remote-live.example.com',
+      ]);
+      expect(keys).toEqual(new Set(['did:example:live-remote-only^projection^authorization']));
+    });
+
     it('should include delegateDid from identity options', async () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
@@ -562,7 +619,7 @@ describe('SyncEngineLevel — private methods', () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
@@ -619,7 +676,7 @@ describe('SyncEngineLevel — private methods', () => {
       const mockAgent = {
         agentDid : 'did:example:agent',
         dwn      : {
-          getDwnEndpointUrlsForTarget: sinon.stub().resolves(['https://dwn.example.com']),
+          getRemoteDwnEndpointUrls: sinon.stub().resolves(['https://dwn.example.com']),
         },
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
@@ -4930,7 +4987,7 @@ describe('SyncEngineLevel — private methods', () => {
         db,
         agent: {
           agentDid : 'did:example:agent',
-          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+          dwn      : { getRemoteDwnEndpointUrls: endpointLookupStub },
         } as any,
       });
       const ledger = (engine as any).ledger;
@@ -4965,7 +5022,7 @@ describe('SyncEngineLevel — private methods', () => {
         db,
         agent: {
           agentDid : 'did:example:agent',
-          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+          dwn      : { getRemoteDwnEndpointUrls: endpointLookupStub },
         } as any,
       });
       const ledger = (engine as any).ledger;
@@ -5009,7 +5066,7 @@ describe('SyncEngineLevel — private methods', () => {
         db,
         agent: {
           agentDid : 'did:example:agent',
-          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+          dwn      : { getRemoteDwnEndpointUrls: endpointLookupStub },
         } as any,
       });
       const grantE1 = messagesGrantEntry('grant-e1', { interface: 'Messages', method: 'Read', protocol }, {
@@ -5067,7 +5124,7 @@ describe('SyncEngineLevel — private methods', () => {
         db,
         agent: {
           agentDid : 'did:example:agent',
-          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+          dwn      : { getRemoteDwnEndpointUrls: endpointLookupStub },
         } as any,
       });
       const ledger = (engine as any).ledger;
@@ -5107,7 +5164,7 @@ describe('SyncEngineLevel — private methods', () => {
         db,
         agent: {
           agentDid : 'did:example:agent',
-          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+          dwn      : { getRemoteDwnEndpointUrls: endpointLookupStub },
         } as any,
       });
       const ledger = (engine as any).ledger;
@@ -5662,7 +5719,7 @@ describe('SyncEngineLevel — private methods', () => {
         db,
         agent: {
           agentDid : 'did:example:agent',
-          dwn      : { getDwnEndpointUrlsForTarget: endpointLookupStub },
+          dwn      : { getRemoteDwnEndpointUrls: endpointLookupStub },
         } as any,
       });
       const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });

--- a/packages/agent/tests/sync-scope.spec.ts
+++ b/packages/agent/tests/sync-scope.spec.ts
@@ -6,6 +6,7 @@ import {
   normalizeSyncProtocols,
   protocolsForSyncScope,
   singleProtocolForSyncScope,
+  SYNC_PROJECTION_ROOT_VERSION,
   syncScopeFromProtocols,
 } from '../src/types/sync.js';
 
@@ -23,6 +24,11 @@ describe('sync scope identity', () => {
 
   it('rejects empty protocol sets', () => {
     expect(() => normalizeSyncProtocols([])).toThrow('protocol-set scope requires at least one protocol');
+  });
+
+  it('uses the durable message-feed projection root version', () => {
+    expect(SYNC_PROJECTION_ROOT_VERSION).toBe('replication-log-feed-v1');
+    expect(SYNC_PROJECTION_ROOT_VERSION).not.toContain('state-index');
   });
 
   it('derives full and protocol-set scopes from identity options', () => {


### PR DESCRIPTION
## Summary
- Sync target discovery now uses only remote DWN endpoints from the DID document, so local discovery/self endpoints are not used as replication targets.
- Sync projection IDs are rotated to the durable message-feed engine version, dropping the old state-index root name.
- Added coverage for both normal target enumeration and live hot-add to pin the remote-only behavior.

## Test plan
- [x] Workspace build
- [x] Agent build
- [x] Repo lint
- [x] Focused sync scope and sync-engine tests
- [ ] Full agent suite attempted locally; remaining failures require the local DWN server on `http://localhost:3000` to be running.