### PR TITLE
fix(agent): emit checkpoints without message CIDs

### DIFF
--- a/.changeset/optional-checkpoint-message-cid.md
+++ b/.changeset/optional-checkpoint-message-cid.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Emit sync checkpoint events for high-water cursors that do not carry a message CID.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -2301,7 +2301,7 @@ export class SyncEngineLevel implements SyncEngine {
 
   private emitPullCheckpointAdvance(link: ReplicationLinkState): void {
     const token = link.pull.contiguousAppliedToken;
-    if (token?.messageCid === undefined) {
+    if (token === undefined) {
       return;
     }
 
@@ -2312,7 +2312,7 @@ export class SyncEngineLevel implements SyncEngine {
       remoteEndpoint : link.remoteEndpoint,
       ...syncEventScope(link.scope),
       position       : token.position,
-      messageCid     : token.messageCid,
+      ...(token.messageCid !== undefined ? { messageCid: token.messageCid } : {}),
     });
   }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -2305,15 +2305,21 @@ export class SyncEngineLevel implements SyncEngine {
       return;
     }
 
-    // Emit after durable save — "advanced" means persisted.
-    this.emitEvent({
+    const event: SyncEvent = {
       type           : 'checkpoint:pull-advance',
       tenantDid      : link.tenantDid,
       remoteEndpoint : link.remoteEndpoint,
       ...syncEventScope(link.scope),
       position       : token.position,
-      ...(token.messageCid !== undefined ? { messageCid: token.messageCid } : {}),
-    });
+    };
+
+    // Emit after durable save — "advanced" means persisted.
+    if (token.messageCid === undefined) {
+      this.emitEvent(event);
+      return;
+    }
+
+    this.emitEvent({ ...event, messageCid: token.messageCid });
   }
 
   private async handleLivePullProcessingError(

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -402,7 +402,7 @@ type SyncEventBase = {
 export type SyncEvent =
   | SyncEventBase & { type: 'link:status-change'; from: LinkStatus; to: LinkStatus }
   | SyncEventBase & { type: 'link:connectivity-change'; from: SyncConnectivityState; to: SyncConnectivityState }
-  | SyncEventBase & { type: 'checkpoint:pull-advance'; position: string; messageCid: string }
+  | SyncEventBase & { type: 'checkpoint:pull-advance'; position: string; messageCid?: string }
   /** Emitted when set reconciliation admits remote messages outside the live pull checkpoint stream. */
   | SyncEventBase & { type: 'reconcile:applied'; messageCids: string[] }
   | SyncEventBase & { type: 'reconcile:needed'; reason: string }

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -4729,6 +4729,27 @@ describe('SyncEngineLevel — private methods', () => {
       expect(pullEvent).toBeUndefined();
     });
 
+    it('should emit checkpoint:pull-advance for high-water tokens without messageCid', () => {
+      const engine = createEngine({ db });
+      const events: any[] = [];
+      engine.on((event) => { events.push(event); });
+
+      const link = {
+        tenantDid      : 'did:example:alice',
+        remoteEndpoint : 'https://dwn.example.com',
+        pull           : {
+          contiguousAppliedToken: { streamId: 's', epoch: 'e', position: '42' },
+        },
+      } as any;
+
+      (engine as any).emitPullCheckpointAdvance(link);
+
+      const pullEvent = events.find(e => e.type === 'checkpoint:pull-advance');
+      expect(pullEvent).toBeDefined();
+      expect(pullEvent.position).toBe('42');
+      expect(pullEvent.messageCid).toBeUndefined();
+    });
+
     it('should return an unsubscribe function from on()', () => {
       const engine = createEngine({ db });
       const events: any[] = [];


### PR DESCRIPTION
## Summary
- Make pull checkpoint event `messageCid` optional to match durable high-water cursors.
- Emit checkpoint advance events even when the persisted progress token has no message CID.
- Add focused coverage for messageCid-less checkpoint events.

## Test plan
- [x] Workspace build
- [x] Agent build
- [x] Repo lint
- [x] Focused checkpoint event tests
- [ ] Full local agent suite (blocked by stale shared SQL test store; CI runs this on clean infrastructure)