### PR TITLE
fix(agent): cap synced record data streams

### DIFF
--- a/.changeset/agent-stream-size-cap.md
+++ b/.changeset/agent-stream-size-cap.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Enforce RecordsWrite descriptor dataSize limits while syncing record data streams.

--- a/packages/agent/src/sync-admit-closure.ts
+++ b/packages/agent/src/sync-admit-closure.ts
@@ -18,8 +18,15 @@ import { classifySyncMessageScope } from './sync-scope-acceptance.js';
 import { DwnInterface } from './types/dwn.js';
 import { KeyDeliveryProtocolDefinition } from './store-data-protocols.js';
 import { topologicalSort } from './sync-topological-sort.js';
+
+import {
+  capRecordsWriteDataStream,
+  fetchRemoteMessages,
+  getMessageCid,
+  SyncDataSizeLimitExceededError,
+  SyncPullAbortedError,
+} from './sync-messages.js';
 import { DwnInterfaceName, DwnMethodName, Encoder, Message, RecordsWrite } from '@enbox/dwn-sdk-js';
-import { fetchRemoteMessages, getMessageCid, SyncPullAbortedError } from './sync-messages.js';
 
 export type AdmitOutcome =
   | { kind: 'admitted'; appliedCids: string[] }
@@ -128,7 +135,18 @@ class AdmitClosureContext {
       };
     }
 
-    return this.admissionResultFromApply(rootCid, entry, cid, await this.applyEntry(entry));
+    try {
+      return this.admissionResultFromApply(rootCid, entry, cid, await this.applyEntry(entry));
+    } catch (error: any) {
+      if (error instanceof SyncDataSizeLimitExceededError) {
+        return {
+          kind    : 'done',
+          outcome : { kind: 'failed', rootCid, reason: 'invalid', detail: error.message },
+        };
+      }
+
+      throw error;
+    }
   }
 
   private async admissionResultFromApply(
@@ -448,7 +466,7 @@ class AdmitClosureContext {
       return [];
     }
 
-    const entry = { message: recordsWrite, dataStream: reply.entry.data };
+    const entry = { message: recordsWrite, dataStream: capRecordsWriteDataStream(recordsWrite, reply.entry.data) };
     await this.rememberEntry(entry);
     return [entry];
   }

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -94,6 +94,13 @@ class LocalDataSizeMismatchError extends Error {
   }
 }
 
+export class SyncDataSizeLimitExceededError extends Error {
+  public constructor(dataSize: number) {
+    super(`SyncEngineLevel: RecordsWrite data exceeded descriptor dataSize ${dataSize}.`);
+    this.name = 'SyncDataSizeLimitExceededError';
+  }
+}
+
 function assertShouldContinue(shouldContinue: (() => boolean) | undefined): void {
   if (shouldContinue?.() === false) {
     throw new SyncPullAbortedError();
@@ -118,6 +125,40 @@ function dataStreamFromBytes(bytes: Uint8Array): ReadableStream<Uint8Array> {
       controller.close();
     }
   });
+}
+
+export function capRecordsWriteDataStream(
+  message: GenericMessage,
+  dataStream: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  if (!isRecordsWriteMessage(message)) {
+    return dataStream;
+  }
+
+  const dataSize = message.descriptor.dataSize;
+  if (typeof dataSize !== 'number') {
+    return dataStream;
+  }
+
+  return capDataStream(dataStream, dataSize);
+}
+
+function capDataStream(
+  dataStream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): ReadableStream<Uint8Array> {
+  let totalBytes = 0;
+
+  return dataStream.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller): void {
+      totalBytes += chunk.byteLength;
+      if (totalBytes > maxBytes) {
+        throw new SyncDataSizeLimitExceededError(maxBytes);
+      }
+
+      controller.enqueue(chunk);
+    },
+  }));
 }
 
 /**
@@ -312,7 +353,7 @@ export async function fetchRemoteMessages({ did, dwnUrl, delegateDid, permission
       const replyEntry = reply.entry;
       let dataStream: ReadableStream<Uint8Array> | undefined;
       if (isRecordsWrite(replyEntry) && replyEntry.data) {
-        dataStream = replyEntry.data;
+        dataStream = capRecordsWriteDataStream(replyEntry.message, replyEntry.data);
       }
 
       return { message: replyEntry.message, dataStream };
@@ -396,7 +437,7 @@ async function readLocalMessage({ author, delegateDid, permissionGrantIds, messa
   };
 
   if (isRecordsWrite(messageEntry) && messageEntry.data) {
-    result.dataStream = messageEntry.data;
+    result.dataStream = capRecordsWriteDataStream(messageEntry.message, messageEntry.data);
     result.dataStreamFactory = async (): Promise<ReadableStream<Uint8Array> | undefined> => {
       const refreshed = await readLocalMessage({ author, delegateDid, permissionGrantIds, messageCid, agent });
       return refreshed.kind === 'found' ? refreshed.entry.dataStream : undefined;
@@ -489,7 +530,7 @@ class RemoteApplyPushContext {
     } catch (error: any) {
       const detail = error.message ?? String(error);
       console.error(`SyncEngineLevel: push error for ${cid}: ${detail}`);
-      if (error instanceof LocalDataSizeMismatchError) {
+      if (error instanceof LocalDataSizeMismatchError || error instanceof SyncDataSizeLimitExceededError) {
         return {
           kind    : 'failed',
           failure : this.terminalFailure(rootCid, cid, detail, { kind: 'Invalid', reason: detail }),
@@ -509,6 +550,9 @@ class RemoteApplyPushContext {
     } catch (error: any) {
       const detail = error.message ?? String(error);
       console.error(`SyncEngineLevel: push error for ${cid}: ${detail}`);
+      if (error instanceof SyncDataSizeLimitExceededError) {
+        return { kind: 'failed', failure: this.terminalFailure(rootCid, cid, detail, { kind: 'Invalid', reason: detail }) };
+      }
       if (error instanceof DwnRpcError && error.terminal) {
         return { kind: 'failed', failure: this.terminalFailure(rootCid, cid, detail, { kind: 'Invalid', reason: detail }) };
       }
@@ -798,7 +842,7 @@ class RemoteApplyPushContext {
 
     const entry: SyncMessageEntry = {
       message           : recordsWrite,
-      dataStream        : recordsReply.entry.data,
+      dataStream        : capRecordsWriteDataStream(recordsWrite, recordsReply.entry.data),
       dataStreamFactory : async (): Promise<ReadableStream<Uint8Array> | undefined> => {
         const refreshed = await this.fetchRecordData(ref);
         return refreshed.kind === 'fetched' ? refreshed.entries[0]?.dataStream : undefined;

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -87,13 +87,6 @@ export class SyncPullAbortedError extends Error {
   }
 }
 
-class LocalDataSizeMismatchError extends Error {
-  constructor(dataSize: number) {
-    super(`SyncEngineLevel: local RecordsWrite data exceeded descriptor dataSize ${dataSize} while buffering push data.`);
-    this.name = 'LocalDataSizeMismatchError';
-  }
-}
-
 export class SyncDataSizeLimitExceededError extends Error {
   public constructor(dataSize: number) {
     super(`SyncEngineLevel: RecordsWrite data exceeded descriptor dataSize ${dataSize}.`);
@@ -198,9 +191,6 @@ async function bufferDataStream(entry: SyncMessageEntry, shouldContinue?: () => 
       assertShouldContinue(shouldContinue);
       totalSize += value.byteLength;
       if (totalSize > MAX_BUFFER_SIZE) {
-        if (isRecordsWriteMessage(entry.message)) {
-          throw new LocalDataSizeMismatchError((entry.message.descriptor as { dataSize: number }).dataSize);
-        }
         throw new Error('SyncEngineLevel: unexpected large stream while buffering push data.');
       }
       chunks.push(value);
@@ -530,7 +520,7 @@ class RemoteApplyPushContext {
     } catch (error: any) {
       const detail = error.message ?? String(error);
       console.error(`SyncEngineLevel: push error for ${cid}: ${detail}`);
-      if (error instanceof LocalDataSizeMismatchError || error instanceof SyncDataSizeLimitExceededError) {
+      if (error instanceof SyncDataSizeLimitExceededError) {
         return {
           kind    : 'failed',
           failure : this.terminalFailure(rootCid, cid, detail, { kind: 'Invalid', reason: detail }),

--- a/packages/agent/tests/sync-admit-closure.spec.ts
+++ b/packages/agent/tests/sync-admit-closure.spec.ts
@@ -31,6 +31,30 @@ describe('admitClosure', () => {
     return new Blob([bytes]).stream();
   }
 
+  async function readStreamBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalLength = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) { break; }
+        chunks.push(value);
+        totalLength += value.length;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const bytes = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return bytes;
+  }
+
   it('fetches a missing initial write and retries the root in dependency order', async () => {
     const protocol = 'https://example.com/protocol';
     const initial = await TestDataGenerator.generateRecordsWrite({ protocol });
@@ -480,6 +504,55 @@ describe('admitClosure', () => {
       },
     });
     expect(agent.dwn.applyReplicatedMessage.secondCall.args[2].dataStream).toBeDefined();
+  });
+
+  it('fails admission when a record data dependency exceeds descriptor dataSize', async () => {
+    const protocol = 'https://example.com/protocol';
+    const root = await TestDataGenerator.generateRecordsWrite({ protocol });
+    const dataRecord = await TestDataGenerator.generateRecordsWrite({
+      data: new Uint8Array([4]),
+      protocol,
+    });
+    const rootCid = await Message.getCid(root.message);
+    const dataCid = dataRecord.message.descriptor.dataCid;
+    const agent = createMockAgent();
+
+    agent.rpc.sendDwnRequest.resolves({
+      status : { code: 200 },
+      entry  : {
+        recordsWrite : dataRecord.message,
+        data         : streamFromBytes(new Uint8Array([4, 5])),
+      },
+    });
+    agent.dwn.applyReplicatedMessage
+      .onFirstCall().resolves({
+        kind    : 'Incomplete',
+        missing : [{ type: 'RecordData', recordId: dataRecord.message.recordId, dataCid, protocol }],
+      })
+      .onSecondCall().callsFake(async (
+        _tenant: string,
+        _message: unknown,
+        options: { dataStream?: ReadableStream<Uint8Array> },
+      ): Promise<{ kind: 'Applied' }> => {
+        await readStreamBytes(options.dataStream!);
+        return { kind: 'Applied' };
+      });
+
+    const outcome = await admitClosure(rootCid, {
+      did        : 'did:example:alice',
+      dwnUrl     : 'https://dwn.example.com',
+      agent,
+      prefetched : [{ message: root.message }],
+    });
+
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind !== 'failed') {
+      throw new Error('expected admission to fail');
+    }
+    expect(outcome.rootCid).toBe(rootCid);
+    expect(outcome.reason).toBe('invalid');
+    expect(outcome.detail).toContain('RecordsWrite data exceeded descriptor dataSize');
+    expect(agent.dwn.applyReplicatedMessage.callCount).toBe(2);
   });
 
   it('fetches the newest tenant protocol config', async () => {

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -14,6 +14,7 @@ import {
   pushMessages,
   queryLocalMessageFeed,
   queryRemoteMessageFeed,
+  SyncDataSizeLimitExceededError,
 } from '../src/sync-messages.js';
 
 type LocalAgentFixture = {
@@ -354,6 +355,32 @@ describe('sync-messages', () => {
       expect(result[0].dataStream).toBe(mockStream);
     });
 
+    it('should cap RecordsWrite data streams at the descriptor dataSize', async () => {
+      const write = await TestDataGenerator.generateRecordsWrite({ data: new Uint8Array([7]) });
+      const mockAgent = {
+        processDwnRequest : sinon.stub().resolves({ message: {} }),
+        rpc               : {
+          sendDwnRequest: sinon.stub().resolves({
+            status : { code: 200 },
+            entry  : {
+              message : write.message,
+              data    : streamFromBytes(new Uint8Array([7, 8])),
+            },
+          }),
+        },
+      } as any;
+
+      const result = await fetchRemoteMessages({
+        did         : write.author.did,
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : ['cid-1'],
+        agent       : mockAgent,
+      });
+
+      expect(result).toHaveLength(1);
+      await expect(readStreamBytes(result[0].dataStream!)).rejects.toThrow(SyncDataSizeLimitExceededError);
+    });
+
     it('should not include dataStream for non-RecordsWrite messages', async () => {
       const mockAgent = {
         processDwnRequest : sinon.stub().resolves({ message: {} }),
@@ -602,8 +629,8 @@ describe('sync-messages', () => {
       expect(processRequestStub.withArgs(sinon.match({ messageType: DwnInterface.MessagesRead })).callCount).toBe(1);
     });
 
-    it('should convert deterministic local data size mismatches into terminal failures', async () => {
-      const payload = new Uint8Array(1_048_577);
+    it('should convert local RecordsWrite data overruns into terminal failures', async () => {
+      const payload = new Uint8Array([1, 2]);
       const write = await TestDataGenerator.generateRecordsWrite({ data: new Uint8Array([1]) });
       const messageCid = await Message.getCid(write.message);
       const { agent, applyStub } = createLocalAgentFixture({
@@ -624,7 +651,7 @@ describe('sync-messages', () => {
       expect(result.failed[0].cid).toBe(messageCid);
       expect(result.failed[0].kind).toBe('Invalid');
       expect(result.failed[0].terminal).toBe(true);
-      expect(result.failed[0].detail).toContain('local RecordsWrite data exceeded descriptor dataSize');
+      expect(result.failed[0].detail).toContain('RecordsWrite data exceeded descriptor dataSize');
       expect(applyStub.called).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- Enforces RecordsWrite descriptor `dataSize` as a hard cap on sync data streams fetched through MessagesRead and RecordsRead.
- Treats descriptor-size overruns as terminal invalid sync outcomes during both push and pull admission.
- Keeps `maxQueryPageInlineBytes` query-page budgeting deferred, matching the updated plan comments.

## Test plan
- [x] Agent sync stream-cap and admission regressions
- [x] Agent lint
- [x] Agent dependency graph build