### PR TITLE
fix(agent): resume live sync from durable cursor

### DIFF
--- a/.changeset/live-resubscribe-cursors.md
+++ b/.changeset/live-resubscribe-cursors.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+fix: resume live sync subscriptions from durable applied cursors

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1899,10 +1899,11 @@ export class SyncEngineLevel implements SyncEngine {
 
     // Build a resubscribe factory so the WebSocket client can resume with
     // a fresh cursor-stamped message after reconnection.
-    const resubscribeFactory: ResubscribeFactory = async (resumeCursor?: ProgressToken) => {
-      // On reconnect, use the latest durable checkpoint position if available.
-      // Discard tokens with empty fields to avoid schema validation failures.
-      let effectiveCursor = resumeCursor ?? link?.pull.contiguousAppliedToken ?? cursor;
+    const resubscribeFactory: ResubscribeFactory = async () => {
+      // On reconnect, resume from the latest durable applied checkpoint, not
+      // the transport's last-delivered cursor. The transport may have delivered
+      // an event that has not been locally applied yet.
+      let effectiveCursor = link?.pull.contiguousAppliedToken ?? cursor;
       if (effectiveCursor && (!effectiveCursor.streamId || !effectiveCursor.epoch || !effectiveCursor.position)) {
         effectiveCursor = undefined;
       }

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -1471,6 +1471,30 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._liveSubscriptions = [];
     });
 
+    it('should ignore transport resume cursor and resubscribe from the durable checkpoint', async () => {
+      const { agent, processRequestStub, rpcStub } = createPullMockAgent();
+      const engine = createEngine({ db, agent });
+      const durableCursor = { streamId: 's1', epoch: 'e1', position: '42', messageCid: 'cid-42' };
+      const deliveredCursor = { streamId: 's1', epoch: 'e1', position: '45', messageCid: 'cid-45' };
+
+      const linkKey = 'did:example:alice^https://dwn.example.com^projection-test^authorization-test';
+      const link = {
+        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
+        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test',
+        authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
+        pull               : { contiguousAppliedToken: durableCursor },
+      } as any;
+      (engine as any)._activeLinks.set(linkKey, link);
+
+      await (engine as any).openLivePullSubscription(fullPullTarget({ linkKey }));
+
+      const resubscribeFactory = rpcStub.firstCall.args[0].subscription.resubscribeFactory;
+      await resubscribeFactory(deliveredCursor);
+
+      expect(processRequestStub.secondCall.args[0].messageParams.cursor).toEqual(durableCursor);
+      (engine as any)._liveSubscriptions = [];
+    });
+
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Resume live sync resubscriptions from the ledger's durable applied cursor instead of the WebSocket transport's last-delivered cursor.
- Add a regression test covering an over-advanced transport resume cursor.

## Test plan
- [x] Focused live pull subscription regression passes
- [x] Agent lint passes
- [x] Agent build passes