### PR TITLE
feat(agent): pull sync entries from message feed

### DIFF
--- a/.changeset/agent-sync-feed-pull.md
+++ b/.changeset/agent-sync-feed-pull.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+feat: pull remote sync entries from the durable message feed

--- a/packages/agent/src/sync-admit-closure.ts
+++ b/packages/agent/src/sync-admit-closure.ts
@@ -135,8 +135,16 @@ class AdmitClosureContext {
       };
     }
 
+    const dataStream = await replayableDataStream(entry);
+    if (entryRequiresDataBeforeApply(entry) && dataStream === undefined) {
+      return {
+        kind    : 'done',
+        outcome : { kind: 'failed', rootCid, reason: 'terminal', detail: 'latest records write data is unavailable' },
+      };
+    }
+
     try {
-      return this.admissionResultFromApply(rootCid, entry, cid, await this.applyEntry(entry));
+      return this.admissionResultFromApply(rootCid, entry, cid, await this.applyEntry(entry, dataStream));
     } catch (error: any) {
       if (error instanceof SyncDataSizeLimitExceededError) {
         return {
@@ -255,9 +263,12 @@ class AdmitClosureContext {
     );
   }
 
-  private async applyEntry(entry: SyncMessageEntry): Promise<ReplicationApplyResult> {
+  private async applyEntry(
+    entry: SyncMessageEntry,
+    dataStream: ReadableStream<Uint8Array> | undefined,
+  ): Promise<ReplicationApplyResult> {
     return this.deps.agent.dwn.applyReplicatedMessage(this.deps.did, entry.message, {
-      dataStream: await replayableDataStream(entry),
+      dataStream,
     });
   }
 
@@ -575,6 +586,21 @@ async function replayableDataStream(entry: SyncMessageEntry): Promise<ReadableSt
       controller.close();
     }
   });
+}
+
+function entryRequiresDataBeforeApply(entry: SyncMessageEntry): boolean {
+  return entry.isLatestBaseState === true && recordsWriteRequiresData(entry.message);
+}
+
+function recordsWriteRequiresData(message: GenericMessage): boolean {
+  if (
+    message.descriptor.interface !== DwnInterfaceName.Records ||
+    message.descriptor.method !== DwnMethodName.Write
+  ) {
+    return false;
+  }
+
+  return typeof (message.descriptor as { dataCid?: unknown }).dataCid === 'string';
 }
 
 async function dedupeEntries(entries: SyncMessageEntry[]): Promise<SyncMessageEntry[]> {

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1,7 +1,7 @@
 import type { AbstractLevel } from 'abstract-level';
 
 import type { DwnSubscriptionHandler, ResubscribeFactory } from '@enbox/dwn-clients';
-import type { GenericMessage, MessageEvent, MessagesFilter, MessagesQueryReplyEntry, MessagesSubscribeReply, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, MessageEvent, MessagesFilter, MessagesQueryReply, MessagesQueryReplyEntry, MessagesSubscribeReply, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
 import ms from 'ms';
 
@@ -132,10 +132,6 @@ type SyncReconcileResult = {
   pushFailures?: PushFailure[];
 };
 
-type RecordsWriteDescriptorLike = GenericMessage['descriptor'] & {
-  dataCid?: unknown;
-};
-
 type SingleProtocolReconcileAccumulator = {
   admittedCids: string[];
   converged: boolean;
@@ -149,6 +145,15 @@ type SyncDiffResult = {
   onlyRemote: MessagesSyncDiffEntry[];
   onlyLocal: string[];
 };
+
+type FeedPageAdmissionResult =
+  | { kind: 'aborted' }
+  | { kind: 'deferred'; admittedCids: string[]; detail?: string; hasActionableDiffs: boolean; messageCid: string }
+  | { kind: 'processed'; admittedCids: string[]; hasActionableDiffs: boolean };
+
+type FeedCursorAdvanceResult =
+  | { drained: true }
+  | { cursor: ProgressToken; drained: false };
 
 type ProtocolSetReconcileContext = {
   did: string;
@@ -2866,64 +2871,116 @@ export class SyncEngineLevel implements SyncEngine {
         agent              : this.agent,
       });
 
-      if (reply.status.code === 410 && !resetAfterProgressGap) {
+      if (await this.resetFeedPullAfterProgressGap(reply, link, resetAfterProgressGap)) {
         resetAfterProgressGap = true;
-        ReplicationLedger.resetCheckpoint(link.pull);
-        await this.ledger.saveLink(link);
         cursor = undefined;
         continue;
       }
 
-      if (reply.status.code !== 200) {
-        throw new Error(`SyncEngineLevel: MessagesQuery failed for ${target.did} -> ${target.dwnUrl}: ${reply.status.code} ${reply.status.detail}`);
+      SyncEngineLevel.assertFeedPullSucceeded(reply, target);
+      const pageResult = await this.admitRemoteFeedPage(target, reply.entries ?? [], shouldContinue);
+      if (pageResult.kind === 'aborted') {
+        return { aborted: true };
       }
 
-      for (const entry of reply.entries ?? []) {
-        if (await this.hasAdmissionDeadLetter(target.did, target.dwnUrl, entry.messageCid)) {
-          continue;
+      admittedCids.push(...pageResult.admittedCids);
+      hasActionableDiffs ||= pageResult.hasActionableDiffs;
+      if (pageResult.kind === 'deferred') {
+        if (admittedCids.length > 0) {
+          this.emitReconcileApplied(target, admittedCids);
         }
-
-        const outcome = await this.admitRemoteFeedEntry(target, entry, shouldContinue);
-        if (outcome.kind === 'aborted') {
-          return { aborted: true };
-        }
-
-        if (outcome.kind === 'deferred') {
-          if (admittedCids.length > 0) {
-            this.emitReconcileApplied(target, admittedCids);
-          }
-          throw new Error(`SyncEngineLevel: pull deferred for ${entry.messageCid}: ${outcome.detail ?? 'dependency unavailable'}`);
-        }
-
-        hasActionableDiffs = true;
-        if (outcome.kind === 'admitted') {
-          admittedCids.push(...outcome.appliedCids);
-          for (const cid of outcome.appliedCids) {
-            this.trackRecentlyPulledMessage(cid, target.dwnUrl);
-            void this.clearFailedMessage(cid, target.dwnUrl).catch(() => { /* teardown race */ });
-          }
-        }
+        throw new Error(`SyncEngineLevel: pull deferred for ${pageResult.messageCid}: ${pageResult.detail ?? 'dependency unavailable'}`);
       }
 
-      if (reply.cursor === undefined) {
-        if (reply.drained === true) {
-          return { admittedCids, hasActionableDiffs };
-        }
-        throw new Error(`SyncEngineLevel: MessagesQuery for ${target.did} -> ${target.dwnUrl} returned no cursor before drain`);
-      }
-
-      this.assertFeedCursorProgress(link, cursor, reply.cursor, reply.drained === true, target.dwnUrl);
-      ReplicationLedger.setReceivedToken(link.pull, reply.cursor);
-      ReplicationLedger.commitContiguousToken(link.pull, reply.cursor);
-      await this.ledger.saveLink(link);
-      this.emitPullCheckpointAdvance(link);
-
-      if (reply.drained === true) {
+      const cursorAdvance = await this.advanceFeedPullCursor(link, cursor, reply, target);
+      if (cursorAdvance.drained) {
         return { admittedCids, hasActionableDiffs };
       }
 
-      cursor = reply.cursor;
+      cursor = cursorAdvance.cursor;
     }
+  }
+
+  private async resetFeedPullAfterProgressGap(
+    reply: MessagesQueryReply,
+    link: ReplicationLinkState,
+    alreadyReset: boolean,
+  ): Promise<boolean> {
+    if (reply.status.code !== 410 || alreadyReset) {
+      return false;
+    }
+
+    ReplicationLedger.resetCheckpoint(link.pull);
+    await this.ledger.saveLink(link);
+    return true;
+  }
+
+  private static assertFeedPullSucceeded(reply: MessagesQueryReply, target: SyncTarget): void {
+    if (reply.status.code !== 200) {
+      throw new Error(`SyncEngineLevel: MessagesQuery failed for ${target.did} -> ${target.dwnUrl}: ${reply.status.code} ${reply.status.detail}`);
+    }
+  }
+
+  private async admitRemoteFeedPage(
+    target: SyncTarget,
+    entries: MessagesQueryReplyEntry[],
+    shouldContinue?: () => boolean,
+  ): Promise<FeedPageAdmissionResult> {
+    const admittedCids: string[] = [];
+    let hasActionableDiffs = false;
+
+    for (const entry of entries) {
+      if (await this.hasAdmissionDeadLetter(target.did, target.dwnUrl, entry.messageCid)) {
+        continue;
+      }
+
+      const outcome = await this.admitRemoteFeedEntry(target, entry, shouldContinue);
+      if (outcome.kind === 'aborted') {
+        return { kind: 'aborted' };
+      }
+
+      if (outcome.kind === 'deferred') {
+        return { kind: 'deferred', admittedCids, detail: outcome.detail, hasActionableDiffs, messageCid: entry.messageCid };
+      }
+
+      hasActionableDiffs = true;
+      if (outcome.kind === 'admitted') {
+        admittedCids.push(...outcome.appliedCids);
+        this.trackRemoteFeedAppliedCids(outcome.appliedCids, target.dwnUrl);
+      }
+    }
+
+    return { kind: 'processed', admittedCids, hasActionableDiffs };
+  }
+
+  private trackRemoteFeedAppliedCids(messageCids: string[], dwnUrl: string): void {
+    for (const cid of messageCids) {
+      this.trackRecentlyPulledMessage(cid, dwnUrl);
+      void this.clearFailedMessage(cid, dwnUrl).catch(() => { /* teardown race */ });
+    }
+  }
+
+  private async advanceFeedPullCursor(
+    link: ReplicationLinkState,
+    previousCursor: ProgressToken | undefined,
+    reply: MessagesQueryReply,
+    target: SyncTarget,
+  ): Promise<FeedCursorAdvanceResult> {
+    const drained = reply.drained === true;
+    if (reply.cursor === undefined) {
+      if (drained) {
+        return { drained: true };
+      }
+      throw new Error(`SyncEngineLevel: MessagesQuery for ${target.did} -> ${target.dwnUrl} returned no cursor before drain`);
+    }
+
+    this.assertFeedCursorProgress(link, previousCursor, reply.cursor, drained, target.dwnUrl);
+    ReplicationLedger.setReceivedToken(link.pull, reply.cursor);
+    ReplicationLedger.commitContiguousToken(link.pull, reply.cursor);
+    await this.ledger.saveLink(link);
+    this.emitPullCheckpointAdvance(link);
+
+    return drained ? { drained: true } : { cursor: reply.cursor, drained: false };
   }
 
   private assertFeedCursorProgress(
@@ -3017,7 +3074,9 @@ export class SyncEngineLevel implements SyncEngine {
       }));
     }
 
-    const { encodedData: messageEncodedData, ...message } = entry.message as GenericMessage & { encodedData?: string };
+    const message = { ...entry.message };
+    const messageEncodedData = message.encodedData;
+    delete message.encodedData;
     const syncEntry: SyncMessageEntry = {
       message,
       isLatestBaseState: entry.isLatestBaseState,
@@ -3058,14 +3117,23 @@ export class SyncEngineLevel implements SyncEngine {
       return entry.protocol;
     }
 
-    const protocol = (entry.message?.descriptor ?? prefetched[0]?.message.descriptor) as { protocol?: unknown } | undefined;
-    return typeof protocol?.protocol === 'string' ? protocol.protocol : undefined;
+    return SyncEngineLevel.protocolFromDescriptor(entry.message?.descriptor) ??
+      SyncEngineLevel.protocolFromDescriptor(prefetched[0]?.message.descriptor);
+  }
+
+  private static protocolFromDescriptor(descriptor: GenericMessage['descriptor'] | undefined): string | undefined {
+    if (descriptor === undefined || !('protocol' in descriptor) || typeof descriptor.protocol !== 'string') {
+      return undefined;
+    }
+
+    return descriptor.protocol;
   }
 
   private static recordsWriteRequiresRemoteData(message: GenericMessage): boolean {
-    const descriptor = message.descriptor as RecordsWriteDescriptorLike;
+    const { descriptor } = message;
     return descriptor.interface === DwnInterfaceName.Records &&
       descriptor.method === DwnMethodName.Write &&
+      'dataCid' in descriptor &&
       typeof descriptor.dataCid === 'string';
   }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -7,7 +7,7 @@ import ms from 'ms';
 
 import { Level } from 'level';
 import { sleep } from '@enbox/common';
-import { Encoder, hashToHex, initDefaultHashes, Message } from '@enbox/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName, Encoder, hashToHex, initDefaultHashes, Message } from '@enbox/dwn-sdk-js';
 
 import type { DwnMessageParams } from './types/dwn.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
@@ -130,6 +130,10 @@ type SyncReconcileResult = {
   ignoredLocalCids?: string[];
   ignoredRemoteCids?: string[];
   pushFailures?: PushFailure[];
+};
+
+type RecordsWriteDescriptorLike = GenericMessage['descriptor'] & {
+  dataCid?: unknown;
 };
 
 type SingleProtocolReconcileAccumulator = {
@@ -542,6 +546,16 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
+  private emitReconcileApplied(target: Pick<SyncTarget, 'did' | 'dwnUrl' | 'scope'>, messageCids: string[]): void {
+    this.emitEvent({
+      type           : 'reconcile:applied',
+      tenantDid      : target.did,
+      remoteEndpoint : target.dwnUrl,
+      ...syncEventScope(target.scope),
+      messageCids,
+    });
+  }
+
   public async clear(): Promise<void> {
     this._syncTargetsCache = undefined;
     this._syncTargetsCacheGeneration++;
@@ -679,24 +693,12 @@ export class SyncEngineLevel implements SyncEngine {
           try {
             const feedPullResult = await this.pullRemoteFeedForSyncTarget(target, { direction });
             if (feedPullResult.admittedCids !== undefined && feedPullResult.admittedCids.length > 0) {
-              this.emitEvent({
-                type           : 'reconcile:applied',
-                tenantDid      : target.did,
-                remoteEndpoint : target.dwnUrl,
-                ...syncEventScope(target.scope),
-                messageCids    : feedPullResult.admittedCids,
-              });
+              this.emitReconcileApplied(target, feedPullResult.admittedCids);
             }
 
             const result = await this.reconcileSyncTarget(target, { direction });
             if (result.admittedCids !== undefined && result.admittedCids.length > 0) {
-              this.emitEvent({
-                type           : 'reconcile:applied',
-                tenantDid      : target.did,
-                remoteEndpoint : target.dwnUrl,
-                ...syncEventScope(target.scope),
-                messageCids    : result.admittedCids,
-              });
+              this.emitReconcileApplied(target, result.admittedCids);
             }
             if (result.pushFailures !== undefined && result.pushFailures.length > 0) {
               const retryableFailures = await this.recordTerminalSyncPushFailures(target, result.pushFailures);
@@ -2887,6 +2889,9 @@ export class SyncEngineLevel implements SyncEngine {
         }
 
         if (outcome.kind === 'deferred') {
+          if (admittedCids.length > 0) {
+            this.emitReconcileApplied(target, admittedCids);
+          }
           throw new Error(`SyncEngineLevel: pull deferred for ${entry.messageCid}: ${outcome.detail ?? 'dependency unavailable'}`);
         }
 
@@ -3058,8 +3063,10 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private static recordsWriteRequiresRemoteData(message: GenericMessage): boolean {
-    return isRecordsWrite(message) &&
-      typeof (message.descriptor as { dataCid?: unknown }).dataCid === 'string';
+    const descriptor = message.descriptor as RecordsWriteDescriptorLike;
+    return descriptor.interface === DwnInterfaceName.Records &&
+      descriptor.method === DwnMethodName.Write &&
+      typeof descriptor.dataCid === 'string';
   }
 
   private async reconcileSyncTarget(

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1,7 +1,7 @@
 import type { AbstractLevel } from 'abstract-level';
 
 import type { DwnSubscriptionHandler, ResubscribeFactory } from '@enbox/dwn-clients';
-import type { GenericMessage, MessageEvent, MessagesSubscribeReply, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, MessageEvent, MessagesFilter, MessagesQueryReplyEntry, MessagesSubscribeReply, MessagesSyncDiffEntry, MessagesSyncReply, ProgressToken, StateIndex, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
 import ms from 'ms';
 
@@ -26,7 +26,7 @@ import { isRecordsWrite } from './utils.js';
 import { ReplicationLedger } from './sync-replication-ledger.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { computeAuthorizationEpoch, computeProjectionId, isTenantInactivePushFailure, isTerminalPushFailure, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
-import { fetchRemoteMessages, getMessageCid, pushMessages, SyncPullAbortedError } from './sync-messages.js';
+import { fetchRemoteMessages, getMessageCid, pushMessages, queryRemoteMessageFeed, SyncPullAbortedError } from './sync-messages.js';
 import { partitionRemoteEntries, SyncLinkReconciler } from './sync-link-reconciler.js';
 import { permissionGrantIdsFromEntries, resolveMessagesScopes, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
@@ -58,6 +58,9 @@ const BATCHED_DIFF_DEPTH = 8;
  * once the in-flight push completes.
  */
 const PUSH_DEBOUNCE_MS = 100;
+
+/** Default durable-feed page size for engine pull replay. */
+const FEED_PULL_PAGE_LIMIT = 100;
 
 /** Tracks a live subscription to a remote DWN for one sync target. */
 type LiveSubscription = {
@@ -674,6 +677,17 @@ export class SyncEngineLevel implements SyncEngine {
       const results = await Promise.allSettled([...byUrl.entries()].map(async ([dwnUrl, targets]) => {
         for (const target of targets) {
           try {
+            const feedPullResult = await this.pullRemoteFeedForSyncTarget(target, { direction });
+            if (feedPullResult.admittedCids !== undefined && feedPullResult.admittedCids.length > 0) {
+              this.emitEvent({
+                type           : 'reconcile:applied',
+                tenantDid      : target.did,
+                remoteEndpoint : target.dwnUrl,
+                ...syncEventScope(target.scope),
+                messageCids    : feedPullResult.admittedCids,
+              });
+            }
+
             const result = await this.reconcileSyncTarget(target, { direction });
             if (result.admittedCids !== undefined && result.admittedCids.length > 0) {
               this.emitEvent({
@@ -2085,14 +2099,13 @@ export class SyncEngineLevel implements SyncEngine {
     context: LivePullContext,
     subMessage: Extract<SubscriptionMessage, { type: 'event' }>,
   ): Promise<void> {
-    const event = subMessage.event;
     if (await this.shouldSkipLivePullEvent(context, subMessage)) {
       return;
     }
 
     const delivery = this.startPullDelivery(context, subMessage.cursor);
     try {
-      const result = await this.processLivePullEvent(context, event);
+      const result = await this.processLivePullEvent(context, subMessage);
       if (!result) { return; }
 
       if (result.admitted) {
@@ -2167,12 +2180,20 @@ export class SyncEngineLevel implements SyncEngine {
     return { runtime, ordinal };
   }
 
-  private async processLivePullEvent(context: LivePullContext, event: MessageEvent): Promise<LivePullProcessResult | undefined> {
+  private async processLivePullEvent(
+    context: LivePullContext,
+    subMessage: Extract<SubscriptionMessage, { type: 'event' }>,
+  ): Promise<LivePullProcessResult | undefined> {
+    const event = subMessage.event;
     const dataStreamFactory = await this.createLivePullDataStreamFactory(context, event);
     const rootCid = await Message.getCid(event.message);
-    const prefetched: SyncMessageEntry[] = [{ message: event.message, dataStreamFactory }];
+    const prefetched: SyncMessageEntry[] = [{
+      message           : event.message,
+      dataStreamFactory : dataStreamFactory,
+      isLatestBaseState : subMessage.isLatestBaseState,
+    }];
     if (event.initialWrite !== undefined) {
-      prefetched.push({ message: event.initialWrite });
+      prefetched.push({ message: event.initialWrite, isLatestBaseState: false });
     }
 
     const outcome = await admitClosure(rootCid, {
@@ -2802,6 +2823,243 @@ export class SyncEngineLevel implements SyncEngine {
 
   private getAuthorizationGrantIds(authorization: SyncAuthorization): NonEmptyStringArray | undefined {
     return authorization.kind === 'delegate' ? authorization.permissionGrantIds : undefined;
+  }
+
+  private async pullRemoteFeedForSyncTarget(
+    target: SyncTarget,
+    options?: SyncReconcileOptions,
+    shouldContinue?: () => boolean,
+  ): Promise<SyncReconcileResult> {
+    if (options?.direction === 'push') {
+      return {};
+    }
+
+    const link = await this.getOrCreateReplicationLink(target);
+    return this.pullRemoteFeedPages(target, link, shouldContinue);
+  }
+
+  private async pullRemoteFeedPages(
+    target: SyncTarget,
+    link: ReplicationLinkState,
+    shouldContinue?: () => boolean,
+  ): Promise<SyncReconcileResult> {
+    const admittedCids: string[] = [];
+    let hasActionableDiffs = false;
+    let cursor = link.pull.contiguousAppliedToken;
+    let resetAfterProgressGap = false;
+
+    for (;;) {
+      if (SyncEngineLevel.shouldAbortReconcile(shouldContinue)) {
+        return { aborted: true };
+      }
+
+      const reply = await queryRemoteMessageFeed({
+        did                : target.did,
+        dwnUrl             : target.dwnUrl,
+        delegateDid        : target.delegateDid,
+        permissionGrantIds : target.permissionGrantIds,
+        filters            : SyncEngineLevel.messageFeedFiltersForScope(target.scope),
+        cursor,
+        limit              : FEED_PULL_PAGE_LIMIT,
+        agent              : this.agent,
+      });
+
+      if (reply.status.code === 410 && !resetAfterProgressGap) {
+        resetAfterProgressGap = true;
+        ReplicationLedger.resetCheckpoint(link.pull);
+        await this.ledger.saveLink(link);
+        cursor = undefined;
+        continue;
+      }
+
+      if (reply.status.code !== 200) {
+        throw new Error(`SyncEngineLevel: MessagesQuery failed for ${target.did} -> ${target.dwnUrl}: ${reply.status.code} ${reply.status.detail}`);
+      }
+
+      for (const entry of reply.entries ?? []) {
+        if (await this.hasAdmissionDeadLetter(target.did, target.dwnUrl, entry.messageCid)) {
+          continue;
+        }
+
+        const outcome = await this.admitRemoteFeedEntry(target, entry, shouldContinue);
+        if (outcome.kind === 'aborted') {
+          return { aborted: true };
+        }
+
+        if (outcome.kind === 'deferred') {
+          throw new Error(`SyncEngineLevel: pull deferred for ${entry.messageCid}: ${outcome.detail ?? 'dependency unavailable'}`);
+        }
+
+        hasActionableDiffs = true;
+        if (outcome.kind === 'admitted') {
+          admittedCids.push(...outcome.appliedCids);
+          for (const cid of outcome.appliedCids) {
+            this.trackRecentlyPulledMessage(cid, target.dwnUrl);
+            void this.clearFailedMessage(cid, target.dwnUrl).catch(() => { /* teardown race */ });
+          }
+        }
+      }
+
+      if (reply.cursor === undefined) {
+        if (reply.drained === true) {
+          return { admittedCids, hasActionableDiffs };
+        }
+        throw new Error(`SyncEngineLevel: MessagesQuery for ${target.did} -> ${target.dwnUrl} returned no cursor before drain`);
+      }
+
+      this.assertFeedCursorProgress(link, cursor, reply.cursor, reply.drained === true, target.dwnUrl);
+      ReplicationLedger.setReceivedToken(link.pull, reply.cursor);
+      ReplicationLedger.commitContiguousToken(link.pull, reply.cursor);
+      await this.ledger.saveLink(link);
+      this.emitPullCheckpointAdvance(link);
+
+      if (reply.drained === true) {
+        return { admittedCids, hasActionableDiffs };
+      }
+
+      cursor = reply.cursor;
+    }
+  }
+
+  private assertFeedCursorProgress(
+    link: ReplicationLinkState,
+    previousCursor: ProgressToken | undefined,
+    nextCursor: ProgressToken,
+    drained: boolean,
+    dwnUrl: string,
+  ): void {
+    if (!this.isValidProgressToken(nextCursor)) {
+      throw new Error(`SyncEngineLevel: MessagesQuery returned an invalid cursor for ${link.tenantDid} -> ${dwnUrl}`);
+    }
+
+    if (!ReplicationLedger.validateTokenDomain(link.pull, nextCursor)) {
+      throw new Error(`SyncEngineLevel: MessagesQuery token domain mismatch for ${link.tenantDid} -> ${dwnUrl}`);
+    }
+
+    if (previousCursor === undefined) {
+      return;
+    }
+
+    const comparison = ReplicationLedger.comparePosition(nextCursor, previousCursor);
+    if (comparison < 0 || (comparison === 0 && !drained)) {
+      throw new Error(`SyncEngineLevel: MessagesQuery cursor did not advance for ${link.tenantDid} -> ${dwnUrl}`);
+    }
+  }
+
+  private async admitRemoteFeedEntry(
+    target: SyncTarget,
+    entry: MessagesQueryReplyEntry,
+    shouldContinue?: () => boolean,
+  ): Promise<
+    | { kind: 'aborted' }
+    | { kind: 'admitted'; appliedCids: string[] }
+    | { kind: 'dead-lettered' }
+    | { kind: 'deferred'; detail?: string }
+  > {
+    if (SyncEngineLevel.shouldAbortReconcile(shouldContinue)) {
+      return { kind: 'aborted' };
+    }
+
+    const prefetched = await this.syncEntriesFromFeedEntry(target, entry);
+    const outcome = await admitClosure(entry.messageCid, {
+      did                : target.did,
+      dwnUrl             : target.dwnUrl,
+      delegateDid        : target.delegateDid,
+      permissionGrantIds : target.permissionGrantIds,
+      scope              : target.scope,
+      agent              : this.agent,
+      permissionsApi     : this._permissionsApi,
+      prefetched,
+      shouldContinue,
+    });
+
+    if (outcome.kind === 'admitted') {
+      return { kind: 'admitted', appliedCids: outcome.appliedCids };
+    }
+
+    if (outcome.kind === 'deferred') {
+      return { kind: 'deferred', detail: outcome.detail };
+    }
+
+    await this.recordDeadLetter({
+      messageCid     : entry.messageCid,
+      tenantDid      : target.did,
+      remoteEndpoint : target.dwnUrl,
+      protocol       : SyncEngineLevel.protocolFromFeedEntry(entry, prefetched),
+      category       : 'admit-failed',
+      errorCode      : outcome.reason,
+      errorDetail    : outcome.detail ?? 'replicated message admission failed',
+    });
+    return { kind: 'dead-lettered' };
+  }
+
+  private async syncEntriesFromFeedEntry(
+    target: SyncTarget,
+    entry: MessagesQueryReplyEntry,
+  ): Promise<SyncMessageEntry[]> {
+    if (entry.message === undefined) {
+      const fetched = await fetchRemoteMessages({
+        did                : target.did,
+        dwnUrl             : target.dwnUrl,
+        delegateDid        : target.delegateDid,
+        permissionGrantIds : target.permissionGrantIds,
+        messageCids        : [entry.messageCid],
+        agent              : this.agent,
+      });
+      return fetched.map((fetchedEntry): SyncMessageEntry => ({
+        ...fetchedEntry,
+        isLatestBaseState: entry.isLatestBaseState,
+      }));
+    }
+
+    const { encodedData: messageEncodedData, ...message } = entry.message as GenericMessage & { encodedData?: string };
+    const syncEntry: SyncMessageEntry = {
+      message,
+      isLatestBaseState: entry.isLatestBaseState,
+    };
+    const encodedData = entry.encodedData ?? messageEncodedData;
+    if (encodedData !== undefined) {
+      syncEntry.bufferedData = Encoder.base64UrlToBytes(encodedData);
+    } else if (SyncEngineLevel.recordsWriteRequiresRemoteData(message)) {
+      syncEntry.dataStreamFactory = async (): Promise<ReadableStream<Uint8Array> | undefined> => {
+        const fetched = await fetchRemoteMessages({
+          did                : target.did,
+          dwnUrl             : target.dwnUrl,
+          delegateDid        : target.delegateDid,
+          permissionGrantIds : target.permissionGrantIds,
+          messageCids        : [entry.messageCid],
+          agent              : this.agent,
+        });
+        return fetched[0]?.dataStream;
+      };
+    }
+
+    return [syncEntry];
+  }
+
+  private static messageFeedFiltersForScope(scope: SyncScope): MessagesFilter[] | undefined {
+    if (scope.kind === 'full') {
+      return undefined;
+    }
+
+    return scope.protocols.map(protocol => ({ protocol }));
+  }
+
+  private static protocolFromFeedEntry(
+    entry: MessagesQueryReplyEntry,
+    prefetched: SyncMessageEntry[],
+  ): string | undefined {
+    if (entry.protocol !== undefined) {
+      return entry.protocol;
+    }
+
+    const protocol = (entry.message?.descriptor ?? prefetched[0]?.message.descriptor) as { protocol?: unknown } | undefined;
+    return typeof protocol?.protocol === 'string' ? protocol.protocol : undefined;
+  }
+
+  private static recordsWriteRequiresRemoteData(message: GenericMessage): boolean {
+    return isRecordsWrite(message) &&
+      typeof (message.descriptor as { dataCid?: unknown }).dataCid === 'string';
   }
 
   private async reconcileSyncTarget(

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -2855,7 +2855,7 @@ export class SyncEngineLevel implements SyncEngine {
     let cursor = link.pull.contiguousAppliedToken;
     let resetAfterProgressGap = false;
 
-    for (;;) {
+    while (true) {
       if (SyncEngineLevel.shouldAbortReconcile(shouldContinue)) {
         return { aborted: true };
       }

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -40,6 +40,8 @@ export type SyncMessageEntry = {
   dataStream?: ReadableStream<Uint8Array>;
   dataStreamConsumed?: boolean;
   dataStreamFactory?: () => Promise<ReadableStream<Uint8Array> | undefined>;
+  /** Source feed attestation. Latest RecordsWrite entries must carry data before apply. */
+  isLatestBaseState?: boolean;
   /** Buffered data bytes for retry — avoids re-fetching from remote when stream is consumed. */
   bufferedData?: Uint8Array;
 };

--- a/packages/agent/tests/sync-admit-closure.spec.ts
+++ b/packages/agent/tests/sync-admit-closure.spec.ts
@@ -555,6 +555,33 @@ describe('admitClosure', () => {
     expect(agent.dwn.applyReplicatedMessage.callCount).toBe(2);
   });
 
+  it('does not admit a source-latest RecordsWrite when its data is unavailable', async () => {
+    const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+      data     : new Uint8Array([1, 2, 3]),
+      protocol : 'https://example.com/protocol',
+    });
+    const rootCid = await Message.getCid(recordsWrite.message);
+    const agent = createMockAgent();
+
+    const outcome = await admitClosure(rootCid, {
+      did        : 'did:example:alice',
+      dwnUrl     : 'https://dwn.example.com',
+      agent,
+      prefetched : [{
+        message           : recordsWrite.message,
+        isLatestBaseState : true,
+      }],
+    });
+
+    expect(outcome).toEqual({
+      kind    : 'failed',
+      rootCid : rootCid,
+      reason  : 'terminal',
+      detail  : 'latest records write data is unavailable',
+    });
+    expect(agent.dwn.applyReplicatedMessage.called).toBe(false);
+  });
+
   it('fetches the newest tenant protocol config', async () => {
     const protocol = 'https://example.com/protocol';
     const definition = {

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -1529,16 +1529,19 @@ describe('SyncEngineLevel', () => {
         // Second sync — trees are already converged, should short-circuit.
         await syncEngine.sync();
 
-        // The only RPC calls should be the root comparisons (one per DWN URL).
-        // There should be no MessagesRead or MessagesSync subtree/leaves calls
-        // beyond the root check.  With a single DWN URL, we expect exactly 1
-        // root call for pull + 1 for push = 2 calls total.
-        // Each call is a MessagesSync with action: 'root'.
-        const rpcCalls = sendDwnRequestSpy.args;
-        for (const call of rpcCalls) {
-          const message = call[0]?.message as any;
-          expect(message?.descriptor?.action).toBe('root');
-        }
+        const rpcMessages = sendDwnRequestSpy.args.map(call => call[0]?.message as any);
+        const messagesReadCalls = rpcMessages.filter(message =>
+          message?.descriptor?.interface === DwnInterfaceName.Messages &&
+          message?.descriptor?.method === DwnMethodName.Read
+        );
+        const messagesSyncCalls = rpcMessages.filter(message =>
+          message?.descriptor?.interface === DwnInterfaceName.Messages &&
+          message?.descriptor?.method === DwnMethodName.Sync
+        );
+        const nonRootSyncCalls = messagesSyncCalls.filter(message => message?.descriptor?.action !== 'root');
+
+        expect(messagesReadCalls).toHaveLength(0);
+        expect(nonRootSyncCalls).toHaveLength(0);
 
         sendDwnRequestSpy.restore();
       });
@@ -1724,6 +1727,9 @@ describe('SyncEngineLevel', () => {
         const getRemoteRootStub = sinon.stub(SyncEngineLevel.prototype as any, 'getRemoteRoot');
         getRemoteRootStub.resolves('bbb');
 
+        const pullRemoteFeedStub = sinon.stub(SyncEngineLevel.prototype as any, 'pullRemoteFeedForSyncTarget');
+        pullRemoteFeedStub.resolves({});
+
         const syncSpy = sinon.spy(SyncEngineLevel.prototype as any, 'sync');
 
         testHarness.agent.sync.startSync({ interval: '500ms' });
@@ -1748,6 +1754,7 @@ describe('SyncEngineLevel', () => {
         getSyncTargetsStub.restore();
         getLocalRootStub.restore();
         getRemoteRootStub.restore();
+        pullRemoteFeedStub.restore();
         clock.restore();
       });
 

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -54,8 +54,14 @@ describe('SyncEngineLevel — private methods', () => {
   // fire after teardown, triggering unhandled `LEVEL_DATABASE_NOT_OPEN`
   // rejections when `ledger.saveLink()` hits the closed DB.
   const createdEngines: SyncEngineLevel[] = [];
-  const createEngine = (params: ConstructorParameters<typeof SyncEngineLevel>[0]): SyncEngineLevel => {
+  const createEngine = (
+    params: ConstructorParameters<typeof SyncEngineLevel>[0],
+    options: { stubFeedPull?: boolean } = {},
+  ): SyncEngineLevel => {
     const engine = new SyncEngineLevel(params);
+    if (options.stubFeedPull !== false) {
+      sinon.stub(engine as any, 'pullRemoteFeedForSyncTarget').resolves({});
+    }
     createdEngines.push(engine);
     return engine;
   };
@@ -710,6 +716,125 @@ describe('SyncEngineLevel — private methods', () => {
       await engine.sync();
 
       expect(diffStub.called).toBe(false);
+    });
+
+    it('should pull a remote MessagesQuery page and persist the pull checkpoint', async () => {
+      const protocol = 'https://example.com/feed-pull';
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const configure = await TestDataGenerator.generateProtocolsConfigure({
+        author             : alice,
+        protocolDefinition : {
+          protocol,
+          published : true,
+          types     : {
+            post: { schema: 'https://example.com/post', dataFormats: ['text/plain'] },
+          },
+          structure: { post: {} },
+        },
+      });
+      const configureCid = await Message.getCid(configure.message);
+      const cursor = {
+        streamId   : 'stream-1',
+        epoch      : 'epoch-1',
+        position   : '1',
+        messageCid : configureCid,
+      };
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        did               : { dereference: sinon.stub() },
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: { interface: 'Messages', method: 'Query' } } }),
+        dwn               : {
+          applyReplicatedMessage: sinon.stub().resolves({ kind: 'Applied' }),
+        },
+        rpc: {
+          sendDwnRequest: sinon.stub().resolves({
+            status  : { code: 200, detail: 'OK' },
+            entries : [{
+              seq               : '1',
+              messageCid        : configureCid,
+              isLatestBaseState : true,
+              protocol,
+              message           : configure.message,
+            }],
+            cursor  : cursor,
+            drained : true,
+          }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent }, { stubFeedPull: false });
+      const events: any[] = [];
+      engine.on((event) => { events.push(event); });
+
+      sinon.stub(engine as any, 'getSyncTargets').resolves([
+        syncTarget(alice.did, 'https://dwn.example.com', {
+          scope: { kind: 'protocolSet', protocols: [protocol] },
+        }),
+      ]);
+      sinon.stub(engine as any, 'reconcileSyncTarget').resolves({});
+
+      await engine.sync('pull');
+
+      expect(mockAgent.processDwnRequest.firstCall.args[0]).toMatchObject({
+        author        : alice.did,
+        target        : alice.did,
+        messageType   : DwnInterface.MessagesQuery,
+        messageParams : {
+          filters : [{ protocol }],
+          limit   : 100,
+        },
+      });
+      expect(mockAgent.rpc.sendDwnRequest.firstCall.args[0]).toMatchObject({
+        dwnUrl    : 'https://dwn.example.com',
+        targetDid : alice.did,
+      });
+      expect(mockAgent.dwn.applyReplicatedMessage.calledOnce).toBe(true);
+      expect(mockAgent.dwn.applyReplicatedMessage.firstCall.args[1]).toEqual(configure.message);
+
+      const links = await (engine as any).ledger.getLinksForTenant(alice.did);
+      expect(links).toHaveLength(1);
+      expect(links[0].pull.contiguousAppliedToken).toEqual(cursor);
+
+      const appliedEvent = events.find(event => event.type === 'reconcile:applied');
+      expect(appliedEvent.messageCids).toEqual([configureCid]);
+    });
+
+    it('should accept a drained feed page that returns the existing cursor', async () => {
+      const did = 'did:example:feed-caught-up';
+      const cursor = {
+        streamId : 'stream-1',
+        epoch    : 'epoch-1',
+        position : '7',
+      };
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        did               : { dereference: sinon.stub() },
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: { interface: 'Messages', method: 'Query' } } }),
+        dwn               : {
+          applyReplicatedMessage: sinon.stub(),
+        },
+        rpc: {
+          sendDwnRequest: sinon.stub().resolves({
+            status  : { code: 200, detail: 'OK' },
+            entries : [],
+            cursor,
+            drained : true,
+          }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent }, { stubFeedPull: false });
+      const target = syncTarget(did, 'https://dwn.example.com');
+      const link = await (engine as any).getOrCreateReplicationLink(target);
+      ReplicationLedger.commitContiguousToken(link.pull, cursor);
+      await (engine as any).ledger.saveLink(link);
+
+      sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
+      sinon.stub(engine as any, 'reconcileSyncTarget').resolves({});
+
+      await engine.sync('pull');
+
+      expect(mockAgent.dwn.applyReplicatedMessage.called).toBe(false);
+      const links = await (engine as any).ledger.getLinksForTenant(did);
+      expect(links[0].pull.contiguousAppliedToken).toEqual(cursor);
     });
 
     it('should walk tree diff and pull/push when roots differ', async () => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -837,6 +837,332 @@ describe('SyncEngineLevel — private methods', () => {
       expect(links[0].pull.contiguousAppliedToken).toEqual(cursor);
     });
 
+    it('should reset a stale feed checkpoint once after a MessagesQuery progress gap', async () => {
+      const did = 'did:example:feed-reset';
+      const staleCursor = {
+        streamId : 'stream-1',
+        epoch    : 'epoch-1',
+        position : '9',
+      };
+      const resetCursor = {
+        streamId : 'stream-2',
+        epoch    : 'epoch-2',
+        position : '1',
+      };
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        did               : { dereference: sinon.stub() },
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: { interface: 'Messages', method: 'Query' } } }),
+        dwn               : {
+          applyReplicatedMessage: sinon.stub(),
+        },
+        rpc: {
+          sendDwnRequest: sinon.stub()
+            .onFirstCall().resolves({
+              status: { code: 410, detail: 'Progress gap' },
+            })
+            .onSecondCall().resolves({
+              status  : { code: 200, detail: 'OK' },
+              entries : [],
+              cursor  : resetCursor,
+              drained : true,
+            }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent }, { stubFeedPull: false });
+      const target = syncTarget(did, 'https://dwn.example.com');
+      const link = await (engine as any).getOrCreateReplicationLink(target);
+      ReplicationLedger.commitContiguousToken(link.pull, staleCursor);
+      await (engine as any).ledger.saveLink(link);
+
+      sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
+      sinon.stub(engine as any, 'reconcileSyncTarget').resolves({});
+
+      await engine.sync('pull');
+
+      expect(mockAgent.rpc.sendDwnRequest.callCount).toBe(2);
+      expect(mockAgent.processDwnRequest.secondCall.args[0].messageParams.cursor).toBeUndefined();
+      const links = await (engine as any).ledger.getLinksForTenant(did);
+      expect(links[0].pull.contiguousAppliedToken).toEqual(resetCursor);
+    });
+
+    it('should reject a remote feed cursor that moves backwards', async () => {
+      const did = 'did:example:feed-regression';
+      const previousCursor = {
+        streamId : 'stream-1',
+        epoch    : 'epoch-1',
+        position : '7',
+      };
+      const regressedCursor = {
+        streamId : 'stream-1',
+        epoch    : 'epoch-1',
+        position : '6',
+      };
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        did               : { dereference: sinon.stub() },
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: { interface: 'Messages', method: 'Query' } } }),
+        dwn               : {
+          applyReplicatedMessage: sinon.stub(),
+        },
+        rpc: {
+          sendDwnRequest: sinon.stub().resolves({
+            status  : { code: 200, detail: 'OK' },
+            entries : [],
+            cursor  : regressedCursor,
+            drained : false,
+          }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent }, { stubFeedPull: false });
+      const target = syncTarget(did, 'https://dwn.example.com');
+      const link = await (engine as any).getOrCreateReplicationLink(target);
+      ReplicationLedger.commitContiguousToken(link.pull, previousCursor);
+      await (engine as any).ledger.saveLink(link);
+
+      await expect((engine as any).pullRemoteFeedForSyncTarget(target)).rejects.toThrow('cursor did not advance');
+    });
+
+    it('should dead-letter failed feed admission and skip it on retry', async () => {
+      const protocol = 'https://example.com/feed-dead-letter';
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const configure = await TestDataGenerator.generateProtocolsConfigure({
+        author             : alice,
+        protocolDefinition : {
+          protocol,
+          published : true,
+          types     : {
+            post: { schema: 'https://example.com/post', dataFormats: ['text/plain'] },
+          },
+          structure: { post: {} },
+        },
+      });
+      const configureCid = await Message.getCid(configure.message);
+      const cursor = {
+        streamId   : 'stream-1',
+        epoch      : 'epoch-1',
+        position   : '1',
+        messageCid : configureCid,
+      };
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        did               : { dereference: sinon.stub() },
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: { interface: 'Messages', method: 'Query' } } }),
+        dwn               : {
+          applyReplicatedMessage: sinon.stub().resolves({ kind: 'Invalid', reason: 'bad configure' }),
+        },
+        rpc: {
+          sendDwnRequest: sinon.stub().resolves({
+            status  : { code: 200, detail: 'OK' },
+            entries : [{
+              seq               : '1',
+              messageCid        : configureCid,
+              isLatestBaseState : true,
+              protocol,
+              message           : configure.message,
+            }],
+            cursor,
+            drained: true,
+          }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent }, { stubFeedPull: false });
+      const target = syncTarget(alice.did, 'https://dwn.example.com');
+
+      sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
+      sinon.stub(engine as any, 'reconcileSyncTarget').resolves({});
+
+      await engine.sync('pull');
+
+      const failedMessages = await engine.getFailedMessages(alice.did);
+      expect(failedMessages).toHaveLength(1);
+      expect(failedMessages[0]).toMatchObject({
+        messageCid     : configureCid,
+        remoteEndpoint : 'https://dwn.example.com',
+        protocol,
+        category       : 'admit-failed',
+        errorCode      : 'invalid',
+        errorDetail    : 'bad configure',
+      });
+      expect(mockAgent.dwn.applyReplicatedMessage.calledOnce).toBe(true);
+
+      const [link] = await (engine as any).ledger.getLinksForTenant(alice.did);
+      ReplicationLedger.resetCheckpoint(link.pull);
+      await (engine as any).ledger.saveLink(link);
+
+      await engine.sync('pull');
+
+      expect(mockAgent.dwn.applyReplicatedMessage.calledOnce).toBe(true);
+      expect(mockAgent.rpc.sendDwnRequest.callCount).toBe(2);
+    });
+
+    it('should install a data fetch factory for feed RecordsWrite entries without inline data', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+        author : alice,
+        data   : new Uint8Array([1, 2, 3]),
+      });
+      const recordsWriteCid = await Message.getCid(recordsWrite.message);
+      const remoteData = new Uint8Array([1, 2, 3]);
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        did               : { dereference: sinon.stub() },
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: { interface: 'Messages', method: 'Read' } } }),
+        rpc               : {
+          sendDwnRequest: sinon.stub().resolves({
+            status : { code: 200, detail: 'OK' },
+            entry  : {
+              message : recordsWrite.message,
+              data    : new ReadableStream<Uint8Array>({
+                start(controller): void {
+                  controller.enqueue(remoteData);
+                  controller.close();
+                },
+              }),
+            },
+          }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent }, { stubFeedPull: false });
+      const target = syncTarget(alice.did, 'https://dwn.example.com');
+
+      const [entry] = await (engine as any).syncEntriesFromFeedEntry(target, {
+        seq               : '1',
+        messageCid        : recordsWriteCid,
+        isLatestBaseState : true,
+        message           : recordsWrite.message,
+      });
+
+      expect(entry.dataStreamFactory).toBeDefined();
+      const dataStream = await entry.dataStreamFactory!();
+      expect(dataStream).toBeDefined();
+      expect(mockAgent.rpc.sendDwnRequest.calledOnce).toBe(true);
+    });
+
+    it('should continue pulling feed pages until the remote cursor is drained', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const configure1 = await TestDataGenerator.generateProtocolsConfigure({
+        author             : alice,
+        protocolDefinition : {
+          protocol  : 'https://example.com/feed-page-1',
+          published : true,
+          types     : { post: { schema: 'https://example.com/post', dataFormats: ['text/plain'] } },
+          structure : { post: {} },
+        },
+      });
+      const configure2 = await TestDataGenerator.generateProtocolsConfigure({
+        author             : alice,
+        protocolDefinition : {
+          protocol  : 'https://example.com/feed-page-2',
+          published : true,
+          types     : { note: { schema: 'https://example.com/note', dataFormats: ['text/plain'] } },
+          structure : { note: {} },
+        },
+      });
+      const configure1Cid = await Message.getCid(configure1.message);
+      const configure2Cid = await Message.getCid(configure2.message);
+      const cursor1 = {
+        streamId   : 'stream-1',
+        epoch      : 'epoch-1',
+        position   : '1',
+        messageCid : configure1Cid,
+      };
+      const cursor2 = {
+        streamId   : 'stream-1',
+        epoch      : 'epoch-1',
+        position   : '2',
+        messageCid : configure2Cid,
+      };
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        did               : { dereference: sinon.stub() },
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: { interface: 'Messages', method: 'Query' } } }),
+        dwn               : {
+          applyReplicatedMessage: sinon.stub().resolves({ kind: 'Applied' }),
+        },
+        rpc: {
+          sendDwnRequest: sinon.stub()
+            .onFirstCall().resolves({
+              status  : { code: 200, detail: 'OK' },
+              entries : [{
+                seq               : '1',
+                messageCid        : configure1Cid,
+                isLatestBaseState : true,
+                message           : configure1.message,
+              }],
+              cursor  : cursor1,
+              drained : false,
+            })
+            .onSecondCall().resolves({
+              status  : { code: 200, detail: 'OK' },
+              entries : [{
+                seq               : '2',
+                messageCid        : configure2Cid,
+                isLatestBaseState : true,
+                message           : configure2.message,
+              }],
+              cursor  : cursor2,
+              drained : true,
+            }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent }, { stubFeedPull: false });
+      const target = syncTarget(alice.did, 'https://dwn.example.com');
+
+      sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
+      sinon.stub(engine as any, 'reconcileSyncTarget').resolves({});
+
+      await engine.sync('pull');
+
+      expect(mockAgent.processDwnRequest.secondCall.args[0].messageParams.cursor).toEqual(cursor1);
+      expect(mockAgent.dwn.applyReplicatedMessage.callCount).toBe(2);
+      const [link] = await (engine as any).ledger.getLinksForTenant(alice.did);
+      expect(link.pull.contiguousAppliedToken).toEqual(cursor2);
+    });
+
+    it('should emit feed-admitted CIDs before deferred admission stops the endpoint group', async () => {
+      const did = 'did:example:feed-partial-deferred';
+      const cursor = {
+        streamId : 'stream-1',
+        epoch    : 'epoch-1',
+        position : '2',
+      };
+      const mockAgent = {
+        agentDid          : 'did:example:agent',
+        did               : { dereference: sinon.stub() },
+        processDwnRequest : sinon.stub().resolves({ message: { descriptor: { interface: 'Messages', method: 'Query' } } }),
+        rpc               : {
+          sendDwnRequest: sinon.stub().resolves({
+            status  : { code: 200, detail: 'OK' },
+            entries : [
+              { seq: '1', messageCid: 'cid-applied' },
+              { seq: '2', messageCid: 'cid-deferred' },
+            ],
+            cursor,
+            drained: true,
+          }),
+        },
+      } as any;
+      const engine = createEngine({ db, agent: mockAgent }, { stubFeedPull: false });
+      const events: any[] = [];
+      engine.on((event) => { events.push(event); });
+      const target = syncTarget(did, 'https://dwn.example.com');
+
+      sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
+      const reconcileStub = sinon.stub(engine as any, 'reconcileSyncTarget').resolves({});
+      sinon.stub(engine as any, 'admitRemoteFeedEntry')
+        .onFirstCall().resolves({ kind: 'admitted', appliedCids: ['cid-applied'] })
+        .onSecondCall().resolves({ kind: 'deferred', detail: 'dependency unavailable' });
+      sinon.stub(console, 'error');
+
+      await engine.sync('pull');
+
+      const appliedEvent = events.find(event => event.type === 'reconcile:applied');
+      expect(appliedEvent).toBeDefined();
+      expect(appliedEvent.messageCids).toEqual(['cid-applied']);
+      expect(reconcileStub.called).toBe(false);
+    });
+
     it('should walk tree diff and pull/push when roots differ', async () => {
       const mockAgent = { agentDid: 'did:example:agent', did: { dereference: sinon.stub() } } as any;
       const engine = createEngine({ db, agent: mockAgent });


### PR DESCRIPTION
Summary
- Pull remote durable feed pages with MessagesQuery before the existing reconciliation fallback.
- Persist pull checkpoints from feed cursors and emit applied-message events for feed admissions.
- Carry source latest-state metadata into admission and require source-latest RecordsWrite data before apply.

Test plan
- [x] Focused agent sync tests
- [x] Agent build
- [x] Root lint
- [ ] Full agent node suite locally: blocked by missing localhost:3000 DWN server; CI should cover the service-backed run.