### PR TITLE
fix: Replace computed DwnInterface enum values with string literals (Sonar code smell)

### DIFF
--- a/packages/agent/src/types/dwn.ts
+++ b/packages/agent/src/types/dwn.ts
@@ -79,17 +79,17 @@ import {
 export interface DwnDidService extends DidService {}
 
 export enum DwnInterface {
-  MessagesQuery = DwnInterfaceName.Messages + DwnMethodName.Query,
-  MessagesRead = DwnInterfaceName.Messages + DwnMethodName.Read,
-  MessagesSubscribe = DwnInterfaceName.Messages + DwnMethodName.Subscribe,
-  MessagesSync = DwnInterfaceName.Messages + DwnMethodName.Sync,
-  ProtocolsConfigure = DwnInterfaceName.Protocols + DwnMethodName.Configure,
-  ProtocolsQuery = DwnInterfaceName.Protocols + DwnMethodName.Query,
-  RecordsDelete = DwnInterfaceName.Records + DwnMethodName.Delete,
-  RecordsQuery = DwnInterfaceName.Records + DwnMethodName.Query,
-  RecordsRead = DwnInterfaceName.Records + DwnMethodName.Read,
-  RecordsSubscribe = DwnInterfaceName.Records + DwnMethodName.Subscribe,
-  RecordsWrite = DwnInterfaceName.Records + DwnMethodName.Write
+  MessagesQuery = 'MessagesQuery',
+  MessagesRead = 'MessagesRead',
+  MessagesSubscribe = 'MessagesSubscribe',
+  MessagesSync = 'MessagesSync',
+  ProtocolsConfigure = 'ProtocolsConfigure',
+  ProtocolsQuery = 'ProtocolsQuery',
+  RecordsDelete = 'RecordsDelete',
+  RecordsQuery = 'RecordsQuery',
+  RecordsRead = 'RecordsRead',
+  RecordsSubscribe = 'RecordsSubscribe',
+  RecordsWrite = 'RecordsWrite'
 }
 
 export type DwnRecordsInterfaces =


### PR DESCRIPTION
## Summary

Closes #1019

## What this PR does

Replace the computed expressions in the `DwnInterface` enum with their equivalent string literal values. Change each member from the pattern `Name = DwnInterfaceName.X + DwnMethodName.Y` to `Name = 'Name'` (e.g., `MessagesQuery = 'MessagesQuery'`). Apply this change to all 11 members of the enum to satisfy the SonarCloud rule requiring explicit literal values.

## Validation

- [x] Ran `turbo run lint --filter='!@enbox/docs'` locally -- passed

---
*Automated contribution by OpenClaw.*