### PR TITLE
fix(agent): validate sync scope closure

### DIFF
--- a/.changeset/sync-scope-closure.md
+++ b/.changeset/sync-scope-closure.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+fix: validate sync protocol scope closure during registration

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1,7 +1,7 @@
 import type { AbstractLevel } from 'abstract-level';
 
 import type { DwnSubscriptionHandler, ResubscribeFactory } from '@enbox/dwn-clients';
-import type { GenericMessage, MessageEvent, MessagesFilter, MessagesQueryReply, MessagesQueryReplyEntry, MessagesSubscribeReply, ProgressToken, RecordsQueryReply, SubscriptionMessage } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, MessageEvent, MessagesFilter, MessagesQueryReply, MessagesQueryReplyEntry, MessagesSubscribeReply, ProgressToken, ProtocolDefinition, RecordsQueryReply, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
 import ms from 'ms';
 
@@ -20,12 +20,13 @@ import { admitClosure } from './sync-admit-closure.js';
 import { buildLinkId } from './sync-link-id.js';
 import { classifySyncEventScope } from './sync-scope-acceptance.js';
 import { DwnInterface } from './types/dwn.js';
+import { getProtocolClosureEdges } from './sync-scope-closure.js';
 import { isRecordsWrite } from './utils.js';
 import { ReplicationLedger } from './sync-replication-ledger.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { computeAuthorizationEpoch, computeProjectionId, isTenantInactivePushFailure, isTerminalPushFailure, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { fetchRemoteMessages, pushMessages, queryLocalMessageFeed, queryRemoteMessageFeed, SyncPullAbortedError } from './sync-messages.js';
-import { permissionGrantIdsFromEntries, resolveMessagesScopes, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
+import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, resolveMessagesScopes, SyncProtocolRootPermissionGrantMissingError, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
 export type SyncEngineLevelParams = {
   agent?: EnboxPlatformAgent;
@@ -43,6 +44,9 @@ const PUSH_DEBOUNCE_MS = 100;
 
 /** Default durable-feed page size for engine replay. */
 const FEED_PAGE_LIMIT = 100;
+
+/** Page size for local retained ProtocolsConfigure history scans. */
+const PROTOCOL_HISTORY_PAGE_LIMIT = 500;
 
 /** Tracks a live subscription to a remote DWN for one sync target. */
 type LiveSubscription = {
@@ -106,6 +110,15 @@ type SyncReconcileOptions = {
 
 type SyncRunOptions = {
   verifyConvergence?: boolean;
+};
+
+type SyncScopeClosureValidationState = {
+  requestedProtocols: Set<string>;
+  protocolsToScan: string[];
+  scannedProtocols: Set<string>;
+  missingGrantProtocols: Set<string>;
+  nonScopedUsesProtocols: Set<string>;
+  splitDependencyEdges: Map<string, Set<string>>;
 };
 
 type SyncReconcileResult = {
@@ -353,6 +366,250 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
+  private async validateSyncScopeClosure(did: string, options: SyncIdentityOptions): Promise<void> {
+    const scope = syncScopeFromProtocols(options.protocols);
+    if (scope.kind === 'full') {
+      return;
+    }
+
+    const state = SyncEngineLevel.createScopeClosureValidationState(scope.protocols);
+    await this.scanSyncScopeClosure(did, options, state);
+
+    const details = SyncEngineLevel.scopeClosureErrorDetails(options, state);
+    if (details.length > 0) {
+      throw new Error(`SyncEngineLevel: sync scope closure validation failed for ${did}: ${details.join('; ')}`);
+    }
+  }
+
+  private static createScopeClosureValidationState(protocols: NonEmptyStringArray): SyncScopeClosureValidationState {
+    return {
+      requestedProtocols     : new Set(protocols),
+      protocolsToScan        : [...protocols],
+      scannedProtocols       : new Set(),
+      missingGrantProtocols  : new Set(),
+      nonScopedUsesProtocols : new Set(),
+      splitDependencyEdges   : new Map(),
+    };
+  }
+
+  private async scanSyncScopeClosure(
+    did: string,
+    options: SyncIdentityOptions,
+    state: SyncScopeClosureValidationState,
+  ): Promise<void> {
+    while (state.protocolsToScan.length > 0) {
+      const protocol = state.protocolsToScan.shift();
+      if (protocol === undefined || state.scannedProtocols.has(protocol)) {
+        continue;
+      }
+
+      await this.scanSyncScopeProtocol(did, options, protocol, state);
+    }
+  }
+
+  private async scanSyncScopeProtocol(
+    did: string,
+    options: SyncIdentityOptions,
+    protocol: string,
+    state: SyncScopeClosureValidationState,
+  ): Promise<void> {
+    state.scannedProtocols.add(protocol);
+
+    const permissionGrantIds = await this.permissionGrantIdsForClosureProtocol(did, options, protocol);
+    if (permissionGrantIds === 'missing') {
+      state.missingGrantProtocols.add(protocol);
+      return;
+    }
+
+    const definitions = await this.fetchLocalProtocolHistory(did, protocol, options.delegateDid, permissionGrantIds);
+    for (const definition of definitions) {
+      SyncEngineLevel.recordScopeClosureEdges(state, definition);
+    }
+  }
+
+  private static recordScopeClosureEdges(
+    state: SyncScopeClosureValidationState,
+    definition: ProtocolDefinition,
+  ): void {
+    const edges = getProtocolClosureEdges(definition);
+    SyncEngineLevel.recordUsesClosureProtocols(state, edges.usesProtocols);
+    SyncEngineLevel.recordDependencyClosureProtocols(state, definition.protocol, edges.dependencyProtocols);
+  }
+
+  private static recordUsesClosureProtocols(
+    state: SyncScopeClosureValidationState,
+    protocols: string[],
+  ): void {
+    for (const protocol of protocols) {
+      if (!state.requestedProtocols.has(protocol)) {
+        state.nonScopedUsesProtocols.add(protocol);
+      }
+      SyncEngineLevel.enqueueScopeClosureProtocol(state, protocol);
+    }
+  }
+
+  private static recordDependencyClosureProtocols(
+    state: SyncScopeClosureValidationState,
+    sourceProtocol: string,
+    protocols: string[],
+  ): void {
+    for (const protocol of protocols) {
+      if (!state.requestedProtocols.has(protocol)) {
+        SyncEngineLevel.addProtocolEdge(state.splitDependencyEdges, sourceProtocol, protocol);
+      }
+      SyncEngineLevel.enqueueScopeClosureProtocol(state, protocol);
+    }
+  }
+
+  private static enqueueScopeClosureProtocol(state: SyncScopeClosureValidationState, protocol: string): void {
+    if (!state.scannedProtocols.has(protocol)) {
+      state.protocolsToScan.push(protocol);
+    }
+  }
+
+  private static scopeClosureErrorDetails(
+    options: SyncIdentityOptions,
+    state: SyncScopeClosureValidationState,
+  ): string[] {
+    if (state.missingGrantProtocols.size === 0 && state.splitDependencyEdges.size === 0) {
+      return [];
+    }
+
+    const details: string[] = [];
+    if (state.missingGrantProtocols.size > 0) {
+      details.push(
+        `delegate ${options.delegateDid} lacks Messages.Read grants for closure protocols: ` +
+        SyncEngineLevel.formatStringSet(state.missingGrantProtocols)
+      );
+    }
+    if (state.splitDependencyEdges.size > 0) {
+      details.push(`scope splits cross-protocol dependencies: ${SyncEngineLevel.formatProtocolEdges(state.splitDependencyEdges)}`);
+    }
+    if (state.nonScopedUsesProtocols.size > 0) {
+      details.push(`uses protocols outside the sync scope: ${SyncEngineLevel.formatStringSet(state.nonScopedUsesProtocols)}`);
+    }
+
+    return details;
+  }
+
+  private async permissionGrantIdsForClosureProtocol(
+    did: string,
+    options: SyncIdentityOptions,
+    protocol: string,
+  ): Promise<NonEmptyStringArray | undefined | 'missing'> {
+    if (options.delegateDid === undefined) {
+      return undefined;
+    }
+
+    try {
+      const grants = await getMessagesPermissionGrantsForScope({
+        did,
+        delegateDid    : options.delegateDid,
+        protocols      : [protocol],
+        messageType    : DwnInterface.MessagesQuery,
+        permissionsApi : this._permissionsApi,
+      });
+      return permissionGrantIdsFromEntries(grants);
+    } catch (error) {
+      if (error instanceof SyncProtocolRootPermissionGrantMissingError) {
+        return 'missing';
+      }
+      throw error;
+    }
+  }
+
+  private async fetchLocalProtocolHistory(
+    did: string,
+    protocol: string,
+    delegateDid: string | undefined,
+    permissionGrantIds: NonEmptyStringArray | undefined,
+  ): Promise<ProtocolDefinition[]> {
+    const definitions: ProtocolDefinition[] = [];
+    let cursor: ProgressToken | undefined;
+
+    for (;;) {
+      const { reply } = await this.agent.dwn.processRequest({
+        author        : did,
+        target        : did,
+        messageType   : DwnInterface.MessagesQuery,
+        granteeDid    : delegateDid,
+        messageParams : {
+          cursor,
+          filters: [{
+            interface : DwnInterfaceName.Protocols,
+            method    : DwnMethodName.Configure,
+            protocol,
+          }],
+          limit              : PROTOCOL_HISTORY_PAGE_LIMIT,
+          permissionGrantIds : permissionGrantIds,
+        },
+      });
+
+      if (reply.status.code !== 200) {
+        throw new Error(
+          `SyncEngineLevel: local protocol history query failed for ${did} / ${protocol}: ${reply.status.code} ${reply.status.detail}`
+        );
+      }
+
+      for (const entry of reply.entries ?? []) {
+        const definition = SyncEngineLevel.protocolDefinitionFromMessage(entry.message);
+        if (definition !== undefined) {
+          definitions.push(definition);
+        }
+      }
+
+      if (reply.drained === true) {
+        return definitions;
+      }
+      if (reply.cursor === undefined) {
+        throw new Error(`SyncEngineLevel: local protocol history query returned no cursor before drain for ${did} / ${protocol}`);
+      }
+
+      cursor = reply.cursor;
+    }
+  }
+
+  private static protocolDefinitionFromMessage(message: GenericMessage | undefined): ProtocolDefinition | undefined {
+    const descriptor = message?.descriptor as { interface?: string; method?: string; definition?: unknown } | undefined;
+    if (
+      descriptor?.interface !== DwnInterfaceName.Protocols ||
+      descriptor.method !== DwnMethodName.Configure ||
+      !SyncEngineLevel.isProtocolDefinition(descriptor.definition)
+    ) {
+      return undefined;
+    }
+
+    return descriptor.definition;
+  }
+
+  private static isProtocolDefinition(value: unknown): value is ProtocolDefinition {
+    return typeof value === 'object' &&
+      value !== null &&
+      typeof (value as { protocol?: unknown }).protocol === 'string';
+  }
+
+  private static addProtocolEdge(edges: Map<string, Set<string>>, from: string, to: string): void {
+    let targets = edges.get(from);
+    if (targets === undefined) {
+      targets = new Set();
+      edges.set(from, targets);
+    }
+    targets.add(to);
+  }
+
+  private static formatStringSet(values: Set<string>): string {
+    return [...values].sort(lexicographicalCompare).join(', ');
+  }
+
+  private static formatProtocolEdges(edges: Map<string, Set<string>>): string {
+    return [...edges.entries()]
+      .sort(([a], [b]) => lexicographicalCompare(a, b))
+      .flatMap(([from, targets]) => [...targets]
+        .sort(lexicographicalCompare)
+        .map(to => `${from} -> ${to}`))
+      .join(', ');
+  }
+
   private async buildSyncTargetsForEndpoint(did: string, dwnUrl: string, options: SyncIdentityOptions): Promise<SyncTarget[]> {
     const requestedScope = syncScopeFromProtocols(options.protocols);
     const resolutions = await this.buildSyncTargetResolutions(did, requestedScope, options);
@@ -574,6 +831,7 @@ export class SyncEngineLevel implements SyncEngine {
       throw new Error(`SyncEngineLevel: Identity with DID ${did} is already registered.`);
     }
 
+    await this.validateSyncScopeClosure(did, options);
     await registeredIdentities.put(did, JSON.stringify(options));
     this._syncTargetsCache = undefined;
     this._syncTargetsCacheGeneration++;
@@ -634,6 +892,7 @@ export class SyncEngineLevel implements SyncEngine {
       throw new Error(`SyncEngineLevel: Identity with DID ${did} is not registered.`);
     }
 
+    await this.validateSyncScopeClosure(did, options);
     await registeredIdentities.put(did, JSON.stringify(options));
     this._syncTargetsCache = undefined;
     this._syncTargetsCacheGeneration++;

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -12,6 +12,16 @@ export type MessagesScopeResolution = {
   permissionGrants: PermissionGrantEntry[];
 };
 
+export class SyncProtocolRootPermissionGrantMissingError extends Error {
+  public readonly protocol: string;
+
+  public constructor(messageType: DwnInterface, protocol: string) {
+    super(`SyncPermissions: No active protocol-root Messages.Read permission found for ${messageType}: ${protocol}`);
+    this.name = 'SyncProtocolRootPermissionGrantMissingError';
+    this.protocol = protocol;
+  }
+}
+
 /** Returns a sorted, duplicate-free grant ID set, or `undefined` for owner requests. */
 export function toMessagesPermissionGrantIds(permissionGrantIds: string[] | undefined): NonEmptyStringArray | undefined {
   if (permissionGrantIds === undefined || permissionGrantIds.length === 0) {
@@ -121,7 +131,7 @@ function resolveProtocolSetScope(
       continue;
     }
 
-    throw new Error(`SyncPermissions: No active protocol-root Messages.Read permission found for ${messageType}: ${protocol}`);
+    throw new SyncProtocolRootPermissionGrantMissingError(messageType, protocol);
   }
 
   const grants = permissionGrants

--- a/packages/agent/src/sync-scope-closure.ts
+++ b/packages/agent/src/sync-scope-closure.ts
@@ -1,0 +1,79 @@
+import type { ProtocolDefinition, ProtocolRuleSet } from '@enbox/dwn-sdk-js';
+
+import { parseCrossProtocolRef } from '@enbox/dwn-sdk-js';
+
+import { lexicographicalCompare } from './types/sync.js';
+
+export type ProtocolClosureEdges = {
+  dependencyProtocols: string[];
+  usesProtocols: string[];
+};
+
+/**
+ * Extracts the protocol-level closure edges a retained protocol definition can
+ * introduce for sync registration validation.
+ */
+export function getProtocolClosureEdges(definition: ProtocolDefinition): ProtocolClosureEdges {
+  const usesProtocols = sortedUnique(Object.values(definition.uses ?? {}));
+  const dependencyProtocols = sortedUnique(collectDependencyProtocols(definition));
+
+  return { dependencyProtocols, usesProtocols };
+}
+
+function collectDependencyProtocols(definition: ProtocolDefinition): string[] {
+  const protocols: string[] = [];
+  for (const ruleSet of Object.values(definition.structure)) {
+    collectDependencyProtocolsFromRuleSet(ruleSet, definition.uses ?? {}, protocols);
+  }
+
+  return protocols;
+}
+
+function collectDependencyProtocolsFromRuleSet(
+  ruleSet: ProtocolRuleSet,
+  uses: Record<string, string>,
+  protocols: string[],
+): void {
+  collectReferencedProtocol(ruleSet.$ref, uses, protocols);
+
+  for (const actionRule of ruleSet.$actions ?? []) {
+    collectReferencedProtocol(actionRule.role, uses, protocols);
+    collectReferencedProtocol(actionRule.of, uses, protocols);
+  }
+
+  for (const [key, value] of Object.entries(ruleSet)) {
+    if (key.startsWith('$') || !isProtocolRuleSet(value)) {
+      continue;
+    }
+
+    collectDependencyProtocolsFromRuleSet(value, uses, protocols);
+  }
+}
+
+function collectReferencedProtocol(
+  ref: string | undefined,
+  uses: Record<string, string>,
+  protocols: string[],
+): void {
+  if (ref === undefined) {
+    return;
+  }
+
+  const parsed = parseCrossProtocolRef(ref);
+  if (parsed === undefined) {
+    return;
+  }
+
+  const protocol = uses[parsed.alias];
+  if (protocol !== undefined) {
+    protocols.push(protocol);
+  }
+}
+
+function isProtocolRuleSet(value: unknown): value is ProtocolRuleSet {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sortedUnique(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort(lexicographicalCompare);
+}

--- a/packages/agent/tests/sync-engine-identity.spec.ts
+++ b/packages/agent/tests/sync-engine-identity.spec.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
 import { Level } from 'level';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 
@@ -23,6 +23,10 @@ describe('SyncEngineLevel — identity management', () => {
   beforeAll(async () => {
     db = new Level<string, string>('__TESTDATA__/sync-engine-identity-spec');
     syncEngine = new SyncEngineLevel({ db });
+  });
+
+  beforeEach(() => {
+    sinon.stub(SyncEngineLevel.prototype as any, 'validateSyncScopeClosure').resolves();
   });
 
   afterEach(async () => {

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -508,7 +508,7 @@ describe('SyncEngineLevel', () => {
         sendDwnRequestSpy.restore();
       });
 
-      it('should skip the identity when delegate permission grant is missing during pull', async () => {
+      it('should reject delegated scoped registration when the permission grant is missing during pull setup', async () => {
         // create new identity to not conflict the previous tests's remote records
         const aliceSync = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
 
@@ -518,21 +518,13 @@ describe('SyncEngineLevel', () => {
           metadata  : { name: 'Alice Delegate', connectedDid: aliceSync.did.uri }
         });
 
-        await testHarness.agent.sync.registerIdentity({
+        await expect(testHarness.agent.sync.registerIdentity({
           did     : aliceSync.did.uri,
           options : {
             delegateDid : delegateDid.did.uri,
             protocols   : [ 'https://protocol.xyz/foo' ]
           }
-        });
-
-        const warnSpy = sinon.stub(console, 'warn');
-
-        await syncEngine.sync('pull');
-
-        expect(warnSpy.calledWithMatch(
-          `SyncEngineLevel: Unable to resolve sync targets for ${aliceSync.did.uri} at ${testDwnUrl}, skipping identity endpoint:`
-        )).toBe(true);
+        })).rejects.toThrow('lacks Messages.Read grants for closure protocols: https://protocol.xyz/foo');
       });
 
       it('succeeds with only a MessagesSync grant when messages are inlined in the diff response', async () => {
@@ -990,7 +982,7 @@ describe('SyncEngineLevel', () => {
         processRequestSpy.restore();
       });
 
-      it('should skip the identity when delegate permission grant is missing during push', async () => {
+      it('should reject delegated scoped registration when the permission grant is missing during push setup', async () => {
         // create new identity to not conflict the previous tests's remote records
         const aliceSync = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
 
@@ -1000,21 +992,13 @@ describe('SyncEngineLevel', () => {
           metadata  : { name: 'Alice Delegate', connectedDid: aliceSync.did.uri }
         });
 
-        await testHarness.agent.sync.registerIdentity({
+        await expect(testHarness.agent.sync.registerIdentity({
           did     : aliceSync.did.uri,
           options : {
             delegateDid : delegateDid.did.uri,
             protocols   : [ 'https://protocol.xyz/foo' ]
           }
-        });
-
-        const warnSpy = sinon.stub(console, 'warn');
-
-        await syncEngine.sync('push');
-
-        expect(warnSpy.calledWithMatch(
-          `SyncEngineLevel: Unable to resolve sync targets for ${aliceSync.did.uri} at ${testDwnUrl}, skipping identity endpoint:`
-        )).toBe(true);
+        })).rejects.toThrow('lacks Messages.Read grants for closure protocols: https://protocol.xyz/foo');
       });
 
       it('pushes a missing delegate grant dependency before a scoped local record', async () => {

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import { Level } from 'level';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
-import { Message, Replication, TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName, Message, Replication, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
 import { computeAuthorizationEpoch } from '../src/types/sync.js';
 import { DwnInterface } from '../src/types/dwn.js';
@@ -45,6 +45,41 @@ describe('SyncEngineLevel — private methods', () => {
     message: {},
   });
 
+  const protocolDefinition = (
+    protocol: string,
+    overrides: Record<string, unknown> = {},
+  ): any => ({
+    protocol,
+    published : true,
+    types     : {},
+    structure : {},
+    ...overrides,
+  });
+
+  const localProtocolHistoryAgent = (definitionsByProtocol: Map<string, any[]>): any => ({
+    dwn: {
+      processRequest: sinon.stub().callsFake(async (request: any): Promise<any> => {
+        const filter = request.messageParams.filters[0];
+        const definitions = definitionsByProtocol.get(filter.protocol) ?? [];
+        return {
+          reply: {
+            status  : { code: 200, detail: 'OK' },
+            drained : true,
+            entries : definitions.map(definition => ({
+              message: {
+                descriptor: {
+                  interface : DwnInterfaceName.Protocols,
+                  method    : DwnMethodName.Configure,
+                  definition,
+                },
+              },
+            })),
+          },
+        };
+      }),
+    },
+  });
+
   const fingerprintFromCids = async (messageCids: string[]): Promise<string> => {
     let fingerprint = Replication.emptyFingerprint();
     for (const messageCid of messageCids) {
@@ -63,9 +98,12 @@ describe('SyncEngineLevel — private methods', () => {
   const createdEngines: SyncEngineLevel[] = [];
   const createEngine = (
     params: ConstructorParameters<typeof SyncEngineLevel>[0],
-    options: { stubFeedPull?: boolean; stubFeedPush?: boolean; stubFeedVerify?: boolean } = {},
+    options: { stubFeedPull?: boolean; stubFeedPush?: boolean; stubFeedVerify?: boolean; stubScopeClosure?: boolean } = {},
   ): SyncEngineLevel => {
     const engine = new SyncEngineLevel(params);
+    if (options.stubScopeClosure !== false) {
+      sinon.stub(engine as any, 'validateSyncScopeClosure').resolves();
+    }
     if (options.stubFeedPull !== false) {
       sinon.stub(engine as any, 'pullRemoteFeedForSyncTarget').resolves({});
     }
@@ -449,6 +487,166 @@ describe('SyncEngineLevel — private methods', () => {
         protocols      : ['https://example.com/profile', 'https://example.com/social'],
         permissionsApi : permissionsApi as any,
       })).rejects.toThrow('No active protocol-root Messages.Read permission found for MessagesSync: https://example.com/social');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // sync scope closure validation
+  // ---------------------------------------------------------------------------
+
+  describe('sync scope closure validation', () => {
+    const profileProtocol = 'https://example.com/profile';
+    const socialProtocol = 'https://example.com/social';
+
+    it('should reject delegated registration when a retained config uses a protocol without a Messages.Read grant', async () => {
+      const engine = createEngine({
+        db,
+        agent: localProtocolHistoryAgent(new Map([
+          [profileProtocol, [protocolDefinition(profileProtocol, {
+            uses: { social: socialProtocol },
+          })]],
+        ])),
+      }, { stubScopeClosure: false });
+      (engine as any)._permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          messagesGrantEntry('grant-profile', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : profileProtocol,
+          }, {
+            grantor : 'did:example:alice',
+            grantee : 'did:example:delegate',
+          }),
+        ]),
+      };
+
+      await expect(engine.registerIdentity({
+        did     : 'did:example:alice',
+        options : { delegateDid: 'did:example:delegate', protocols: [profileProtocol] },
+      })).rejects.toThrow(`closure protocols: ${socialProtocol}`);
+    });
+
+    it('should reject registration that splits a cross-protocol parent dependency', async () => {
+      const engine = createEngine({
+        db,
+        agent: localProtocolHistoryAgent(new Map([
+          [profileProtocol, [protocolDefinition(profileProtocol, {
+            uses      : { social: socialProtocol },
+            structure : {
+              thread: {
+                $ref: 'social:thread',
+              },
+            },
+          })]],
+        ])),
+      }, { stubScopeClosure: false });
+
+      await expect(engine.registerIdentity({
+        did     : 'did:example:alice',
+        options : { protocols: [profileProtocol] },
+      })).rejects.toThrow(`${profileProtocol} -> ${socialProtocol}`);
+    });
+
+    it('should reject registration that splits a cross-protocol role dependency', async () => {
+      const engine = createEngine({
+        db,
+        agent: localProtocolHistoryAgent(new Map([
+          [profileProtocol, [protocolDefinition(profileProtocol, {
+            uses      : { social: socialProtocol },
+            structure : {
+              post: {
+                $actions: [{ role: 'social:admin', can: ['create'] }],
+              },
+            },
+          })]],
+        ])),
+      }, { stubScopeClosure: false });
+
+      await expect(engine.registerIdentity({
+        did     : 'did:example:alice',
+        options : { protocols: [profileProtocol] },
+      })).rejects.toThrow(`${profileProtocol} -> ${socialProtocol}`);
+    });
+
+    it('should reject delegated registration that grants but does not co-scope a cross-protocol of dependency', async () => {
+      const engine = createEngine({
+        db,
+        agent: localProtocolHistoryAgent(new Map([
+          [profileProtocol, [protocolDefinition(profileProtocol, {
+            uses      : { social: socialProtocol },
+            structure : {
+              post: {
+                $actions: [{ who: 'author', of: 'social:profile', can: ['read'] }],
+              },
+            },
+          })]],
+          [socialProtocol, []],
+        ])),
+      }, { stubScopeClosure: false });
+      (engine as any)._permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          messagesGrantEntry('grant-profile', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : profileProtocol,
+          }, {
+            grantor : 'did:example:alice',
+            grantee : 'did:example:delegate',
+          }),
+          messagesGrantEntry('grant-social', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : socialProtocol,
+          }, {
+            grantor : 'did:example:alice',
+            grantee : 'did:example:delegate',
+          }),
+        ]),
+      };
+
+      await expect(engine.registerIdentity({
+        did     : 'did:example:alice',
+        options : { delegateDid: 'did:example:delegate', protocols: [profileProtocol] },
+      })).rejects.toThrow(`${profileProtocol} -> ${socialProtocol}`);
+    });
+
+    it('should allow delegated registration when transitive uses protocols have grant coverage', async () => {
+      const agent = localProtocolHistoryAgent(new Map([
+        [profileProtocol, [protocolDefinition(profileProtocol, {
+          uses: { social: socialProtocol },
+        })]],
+        [socialProtocol, []],
+      ]));
+      const engine = createEngine({ db, agent }, { stubScopeClosure: false });
+      (engine as any)._permissionsApi = {
+        fetchGrants: sinon.stub().resolves([
+          messagesGrantEntry('grant-profile', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : profileProtocol,
+          }, {
+            grantor : 'did:example:alice',
+            grantee : 'did:example:delegate',
+          }),
+          messagesGrantEntry('grant-social', {
+            interface : 'Messages',
+            method    : 'Read',
+            protocol  : socialProtocol,
+          }, {
+            grantor : 'did:example:alice',
+            grantee : 'did:example:delegate',
+          }),
+        ]),
+      };
+
+      await engine.registerIdentity({
+        did     : 'did:example:alice',
+        options : { delegateDid: 'did:example:delegate', protocols: [profileProtocol] },
+      });
+
+      const options = await engine.getIdentityOptions('did:example:alice');
+      expect(options).toEqual({ delegateDid: 'did:example:delegate', protocols: [profileProtocol] });
+      expect(agent.dwn.processRequest.callCount).toBe(2);
     });
   });
 

--- a/packages/agent/tests/sync-scope.spec.ts
+++ b/packages/agent/tests/sync-scope.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
+import { getProtocolClosureEdges } from '../src/sync-scope-closure.js';
 import {
   computeAuthorizationEpoch,
   computeProjectionId,
@@ -137,6 +138,75 @@ describe('sync scope identity', () => {
 
     expect(projectionId).toBe(sameProjectionId);
     expect(oldEpoch).not.toBe(newEpoch);
+  });
+
+  it('extracts uses and nested cross-protocol dependency references from protocol definitions', () => {
+    const edges = getProtocolClosureEdges({
+      protocol  : 'https://example.com/composed',
+      published : true,
+      uses      : {
+        social : 'https://example.com/social',
+        tasks  : 'https://example.com/tasks',
+      },
+      types     : {},
+      structure : {
+        root: {
+          $actions : [{ who: 'anyone', can: ['create'] }],
+          reply    : {
+            $ref : 'social:thread',
+            note : {
+              $ref: 'tasks:item',
+            },
+          },
+          localRole: {
+            $actions: [{ role: 'social:moderator', can: ['create'] }],
+          },
+          localOf: {
+            $actions: [{ who: 'author', of: 'tasks:item', can: ['read'] }],
+          },
+          localOnly: {
+            $ref     : 'social',
+            $actions : [
+              { role: 'tasks', can: ['create'] },
+              { who: 'recipient', of: 'tasks', can: ['read'] },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(edges).toEqual({
+      dependencyProtocols : ['https://example.com/social', 'https://example.com/tasks'],
+      usesProtocols       : ['https://example.com/social', 'https://example.com/tasks'],
+    });
+  });
+
+  it('does not treat bare local references that match uses aliases as cross-protocol dependencies', () => {
+    const edges = getProtocolClosureEdges({
+      protocol  : 'https://example.com/composed',
+      published : true,
+      uses      : {
+        roles   : 'https://example.com/roles',
+        threads : 'https://example.com/threads',
+      },
+      types     : {},
+      structure : {
+        root: {
+          child: {
+            $ref     : 'threads',
+            $actions : [
+              { role: 'roles', can: ['create'] },
+              { who: 'recipient', of: 'threads', can: ['read'] },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(edges).toEqual({
+      dependencyProtocols : [],
+      usesProtocols       : ['https://example.com/roles', 'https://example.com/threads'],
+    });
   });
 
 });


### PR DESCRIPTION
Summary
- Validate protocol-scoped sync registration and updates against retained local ProtocolsConfigure history.
- Require delegated sync scopes to include Messages.Read grant coverage for transitive `uses` protocols.
- Reject protocol scopes that split cross-protocol apply dependencies, including parent `$ref` edges and `$actions.role` / `$actions.of` edges.

Test plan
- [x] Root lint
- [x] Agent build
- [x] Focused sync scope and registration tests

Notes
- Full local agent test run requires the local DWN test server on `localhost:3000`; without it, server-dependent setup tests fail before exercising this change.
