### PR TITLE
feat(agent): add protocol reference index

### DIFF
--- a/.changeset/green-rivers-reference.md
+++ b/.changeset/green-rivers-reference.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Add the device-local protocol reference index used by scoped sync visibility.

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -538,6 +538,7 @@ export class AgentDwnApi {
     // Post-write key delivery and reply decryption are independent — run in parallel.
     await Promise.all([
       this.postWriteKeyDelivery(request, message, reply),
+      this.maybeAssertProtocolSelfReference(request, message, reply),
       this.maybeDecryptReply(request, reply),
     ]);
 
@@ -669,6 +670,41 @@ export class AgentDwnApi {
     // Returns an object containing the reply from processing the message, the original message,
     // and the content identifier (CID) of the message.
     return { reply, message, messageCid };
+  }
+
+  private async maybeAssertProtocolSelfReference<T extends DwnInterface>(
+    request: ProcessDwnRequest<T>,
+    message: DwnMessage[T],
+    reply: DwnMessageReply[T],
+  ): Promise<void> {
+    if (
+      !isDwnRequest(request, DwnInterface.ProtocolsConfigure) ||
+      request.store === false ||
+      reply.status.code < 200 ||
+      reply.status.code >= 300
+    ) {
+      return;
+    }
+    if (this._agent === undefined) {
+      return;
+    }
+
+    const definition = (message.descriptor as { definition?: unknown }).definition;
+    if (!this.isProtocolDefinition(definition)) {
+      return;
+    }
+
+    await this._agent.sync.assertProtocolSelfReference({
+      definition,
+      identity : request.target,
+      protocol : definition.protocol,
+    });
+  }
+
+  private isProtocolDefinition(value: unknown): value is ProtocolDefinition {
+    return typeof value === 'object' &&
+      value !== null &&
+      typeof (value as { protocol?: unknown }).protocol === 'string';
   }
 
   /**

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -30,6 +30,7 @@ export * from './dwn-encryption.js';
 export * from './dwn-key-delivery.js';
 export * from './dwn-type-guards.js';
 export * from './protocol-utils.js';
+export * from './protocol-reference-index.js';
 export * from './hd-identity-vault.js';
 export * from './identity-api.js';
 export * from './local-dwn.js';

--- a/packages/agent/src/protocol-reference-index.ts
+++ b/packages/agent/src/protocol-reference-index.ts
@@ -1,0 +1,249 @@
+import type { AbstractLevel } from 'abstract-level';
+
+import type { ProtocolReference, SyncIdentityOptions } from './types/sync.js';
+
+import { lexicographicalCompare, normalizeSyncProtocols } from './types/sync.js';
+
+const KEY_SEP = '^';
+const WILDCARD_PROTOCOL = '*';
+
+type LevelBatchOperation =
+  | { type: 'del'; key: string }
+  | { type: 'put'; key: string; value: string };
+
+/**
+ * Device-local protocol reference index. Rows are keyed by tenant, protocol,
+ * and referencer; active visibility is simply row existence.
+ */
+export class ProtocolReferenceIndex {
+  private readonly _sublevel: AbstractLevel<string | Buffer | Uint8Array, string, string>;
+
+  public static readonly wildcardProtocol = WILDCARD_PROTOCOL;
+
+  public constructor(db: AbstractLevel<string | Buffer | Uint8Array>) {
+    this._sublevel = db.sublevel('protocolReferences') as unknown as AbstractLevel<string | Buffer | Uint8Array, string, string>;
+  }
+
+  public async assertSelfReference(tenantDid: string, protocol: string): Promise<void> {
+    await this.putReference({
+      tenantDid,
+      protocol,
+      kind       : 'self',
+      referencer : ProtocolReferenceIndex.selfReferencer(),
+    });
+  }
+
+  public async deleteSelfReference(tenantDid: string, protocol: string): Promise<void> {
+    await this.deleteReference(tenantDid, protocol, ProtocolReferenceIndex.selfReferencer());
+  }
+
+  public async replaceScopeReferences(
+    tenantDid: string,
+    identityDid: string,
+    protocols: SyncIdentityOptions['protocols'],
+  ): Promise<void> {
+    const referencer = ProtocolReferenceIndex.scopeReferencer(identityDid);
+    const batch = await this.deleteReferencesByReferencerBatch(tenantDid, referencer);
+
+    if (protocols === 'all') {
+      batch.push(this.putReferenceOperation({
+        tenantDid,
+        protocol : WILDCARD_PROTOCOL,
+        kind     : 'scope-all',
+        referencer,
+      }));
+    } else {
+      for (const protocol of normalizeSyncProtocols(protocols)) {
+        batch.push(this.putReferenceOperation({
+          tenantDid,
+          protocol,
+          kind: 'scope',
+          referencer,
+        }));
+      }
+    }
+
+    await this.applyBatch(batch);
+  }
+
+  public async deleteScopeReferences(tenantDid: string, identityDid: string): Promise<void> {
+    await this.deleteReferencesByReferencer(tenantDid, ProtocolReferenceIndex.scopeReferencer(identityDid));
+  }
+
+  public async replaceClosureReferences(
+    tenantDid: string,
+    sourceProtocol: string,
+    targetProtocols: Iterable<string>,
+  ): Promise<void> {
+    const referencer = ProtocolReferenceIndex.closureReferencer(sourceProtocol);
+    const batch = await this.deleteReferencesByReferencerBatch(tenantDid, referencer);
+    const targets = [...new Set(targetProtocols)].sort(lexicographicalCompare);
+
+    for (const protocol of targets) {
+      if (protocol === sourceProtocol) {
+        continue;
+      }
+      batch.push(this.putReferenceOperation({
+        tenantDid,
+        protocol,
+        kind: 'closure',
+        referencer,
+        sourceProtocol,
+      }));
+    }
+
+    await this.applyBatch(batch);
+  }
+
+  public async clearDerivedReferences(tenantDid: string): Promise<void> {
+    const batch: LevelBatchOperation[] = [];
+    for await (const [key, value] of this.iterateTenantRows(tenantDid)) {
+      const reference = JSON.parse(value) as ProtocolReference;
+      if (reference.kind !== 'self') {
+        batch.push({ type: 'del', key });
+      }
+    }
+    await this.applyBatch(batch);
+  }
+
+  public async getReferences(tenantDid: string): Promise<ProtocolReference[]> {
+    const references: ProtocolReference[] = [];
+    for await (const [, value] of this.iterateTenantRows(tenantDid)) {
+      references.push(JSON.parse(value) as ProtocolReference);
+    }
+
+    references.sort((a, b) =>
+      lexicographicalCompare(a.protocol, b.protocol) ||
+      lexicographicalCompare(a.referencer, b.referencer)
+    );
+    return references;
+  }
+
+  public async getSelfReferencedProtocols(tenantDid: string): Promise<string[]> {
+    const protocols: string[] = [];
+    for (const reference of await this.getReferences(tenantDid)) {
+      if (reference.kind === 'self') {
+        protocols.push(reference.protocol);
+      }
+    }
+    return protocols;
+  }
+
+  public async getExactReferencedProtocols(tenantDid: string): Promise<string[]> {
+    const protocols = new Set<string>();
+    for (const reference of await this.getReferences(tenantDid)) {
+      if (reference.protocol !== WILDCARD_PROTOCOL) {
+        protocols.add(reference.protocol);
+      }
+    }
+    return [...protocols].sort(lexicographicalCompare);
+  }
+
+  public async hasReference(tenantDid: string, protocol: string): Promise<boolean> {
+    if (await this.hasProtocolRow(tenantDid, WILDCARD_PROTOCOL)) {
+      return true;
+    }
+    return this.hasProtocolRow(tenantDid, protocol);
+  }
+
+  public static scopeReferencer(identityDid: string): string {
+    return `scope:${identityDid}`;
+  }
+
+  public static closureReferencer(sourceProtocol: string): string {
+    return `closure:${sourceProtocol}`;
+  }
+
+  public static selfReferencer(): string {
+    return 'self';
+  }
+
+  private async putReference(reference: Omit<ProtocolReference, 'createdAt'>): Promise<void> {
+    await this._sublevel.put(
+      ProtocolReferenceIndex.buildKey(reference.tenantDid, reference.protocol, reference.referencer),
+      JSON.stringify({
+        ...reference,
+        createdAt: new Date().toISOString(),
+      } satisfies ProtocolReference),
+    );
+  }
+
+  private putReferenceOperation(reference: Omit<ProtocolReference, 'createdAt'>): LevelBatchOperation {
+    return {
+      type  : 'put',
+      key   : ProtocolReferenceIndex.buildKey(reference.tenantDid, reference.protocol, reference.referencer),
+      value : JSON.stringify({
+        ...reference,
+        createdAt: new Date().toISOString(),
+      } satisfies ProtocolReference),
+    };
+  }
+
+  private async deleteReference(tenantDid: string, protocol: string, referencer: string): Promise<void> {
+    await this._sublevel.del(ProtocolReferenceIndex.buildKey(tenantDid, protocol, referencer));
+  }
+
+  private async deleteReferencesByReferencer(tenantDid: string, referencer: string): Promise<void> {
+    await this.applyBatch(await this.deleteReferencesByReferencerBatch(tenantDid, referencer));
+  }
+
+  private async deleteReferencesByReferencerBatch(tenantDid: string, referencer: string): Promise<LevelBatchOperation[]> {
+    const batch: LevelBatchOperation[] = [];
+    for await (const [key, value] of this.iterateTenantRows(tenantDid)) {
+      const reference = JSON.parse(value) as ProtocolReference;
+      if (reference.referencer === referencer) {
+        batch.push({ type: 'del', key });
+      }
+    }
+    return batch;
+  }
+
+  private async hasProtocolRow(tenantDid: string, protocol: string): Promise<boolean> {
+    for await (const [, value] of this.iterateProtocolRows(tenantDid, protocol)) {
+      const reference = JSON.parse(value) as ProtocolReference;
+      if (reference.tenantDid === tenantDid && reference.protocol === protocol) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private iterateTenantRows(tenantDid: string): AsyncIterable<[string, string]> {
+    const prefix = ProtocolReferenceIndex.tenantKeyPrefix(tenantDid);
+    return this._sublevel.iterator({
+      gte : prefix,
+      lt  : `${prefix}\xff`,
+    }) as AsyncIterable<[string, string]>;
+  }
+
+  private iterateProtocolRows(tenantDid: string, protocol: string): AsyncIterable<[string, string]> {
+    const prefix = ProtocolReferenceIndex.protocolKeyPrefix(tenantDid, protocol);
+    return this._sublevel.iterator({
+      gte : prefix,
+      lt  : `${prefix}\xff`,
+    }) as AsyncIterable<[string, string]>;
+  }
+
+  private async applyBatch(batch: LevelBatchOperation[]): Promise<void> {
+    if (batch.length === 0) {
+      return;
+    }
+    await this._sublevel.batch(batch);
+  }
+
+  private static tenantKeyPrefix(tenantDid: string): string {
+    return `${ProtocolReferenceIndex.encodeKeyPart(tenantDid)}${KEY_SEP}`;
+  }
+
+  private static protocolKeyPrefix(tenantDid: string, protocol: string): string {
+    return `${ProtocolReferenceIndex.tenantKeyPrefix(tenantDid)}${ProtocolReferenceIndex.encodeKeyPart(protocol)}${KEY_SEP}`;
+  }
+
+  private static buildKey(tenantDid: string, protocol: string, referencer: string): string {
+    return `${ProtocolReferenceIndex.protocolKeyPrefix(tenantDid, protocol)}${ProtocolReferenceIndex.encodeKeyPart(referencer)}`;
+  }
+
+  private static encodeKeyPart(value: string): string {
+    return encodeURIComponent(value);
+  }
+}

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -12,7 +12,7 @@ import { DwnInterfaceName, DwnMethodName, Encoder, Message } from '@enbox/dwn-sd
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
 import type { SyncMessageEntry } from './sync-messages.js';
-import type { DeadLetterCategory, DeadLetterEntry, DirectionCheckpoint, NonEmptyStringArray, PushFailure, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
+import type { DeadLetterCategory, DeadLetterEntry, DirectionCheckpoint, NonEmptyStringArray, ProtocolReference, PushFailure, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 
@@ -22,6 +22,7 @@ import { classifySyncEventScope } from './sync-scope-acceptance.js';
 import { DwnInterface } from './types/dwn.js';
 import { getProtocolClosureEdges } from './sync-scope-closure.js';
 import { isRecordsWrite } from './utils.js';
+import { ProtocolReferenceIndex } from './protocol-reference-index.js';
 import { ReplicationLedger } from './sync-replication-ledger.js';
 import { topologicalSort } from './sync-topological-sort.js';
 import { computeAuthorizationEpoch, computeProjectionId, isTenantInactivePushFailure, isTerminalPushFailure, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
@@ -293,6 +294,12 @@ export class SyncEngineLevel implements SyncEngine {
    * Lazily initialized on first use to avoid sublevel() calls on mock dbs.
    */
   private _ledger?: ReplicationLedger;
+
+  /**
+   * Device-local protocol reference index. Kept beside the sync ledger and
+   * never consulted by the replication feed itself.
+   */
+  private _protocolReferences?: ProtocolReferenceIndex;
 
   /**
    * In-memory cache of active links, keyed by `{did}^{dwnUrl}^{protocol}`.
@@ -582,6 +589,70 @@ export class SyncEngineLevel implements SyncEngine {
     return descriptor.definition;
   }
 
+  private async rebuildDerivedProtocolReferences(): Promise<void> {
+    for await (const [did, options] of this._db.sublevel('registeredIdentities').iterator()) {
+      let parsed: SyncIdentityOptions;
+      try {
+        parsed = JSON.parse(options) as SyncIdentityOptions;
+      } catch (error: unknown) {
+        console.warn(`SyncEngineLevel: Corrupt sync options for ${did}, skipping protocol reference rebuild:`, error);
+        continue;
+      }
+
+      await this.rebuildDerivedProtocolReferencesForIdentity(did, parsed);
+    }
+  }
+
+  private async rebuildDerivedProtocolReferencesForIdentity(did: string, options: SyncIdentityOptions): Promise<void> {
+    await this.protocolReferences.clearDerivedReferences(did);
+    await this.protocolReferences.replaceScopeReferences(did, did, options.protocols);
+
+    const scope = syncScopeFromProtocols(options.protocols);
+    const protocols = protocolsForSyncScope(scope);
+    if (protocols === undefined) {
+      return;
+    }
+
+    const scanned = new Set<string>();
+    const protocolsToScan = [...protocols];
+
+    while (protocolsToScan.length > 0) {
+      const protocol = protocolsToScan.shift();
+      if (protocol === undefined || scanned.has(protocol)) {
+        continue;
+      }
+      scanned.add(protocol);
+
+      const permissionGrantIds = await this.permissionGrantIdsForClosureProtocol(did, options, protocol);
+      if (permissionGrantIds === 'missing') {
+        throw new Error(`SyncEngineLevel: delegate ${options.delegateDid} lacks Messages.Read grants for closure protocol ${protocol}`);
+      }
+
+      const definitions = await this.fetchLocalProtocolHistory(did, protocol, options.delegateDid, permissionGrantIds);
+      const targetProtocols = new Set<string>();
+      for (const definition of definitions) {
+        SyncEngineLevel.collectProtocolReferenceTargets(definition, targetProtocols);
+      }
+
+      await this.protocolReferences.replaceClosureReferences(did, protocol, targetProtocols);
+      for (const targetProtocol of targetProtocols) {
+        if (!scanned.has(targetProtocol)) {
+          protocolsToScan.push(targetProtocol);
+        }
+      }
+    }
+  }
+
+  private static collectProtocolReferenceTargets(definition: ProtocolDefinition, targetProtocols: Set<string>): void {
+    const edges = getProtocolClosureEdges(definition);
+    for (const dependencyProtocol of edges.dependencyProtocols) {
+      targetProtocols.add(dependencyProtocol);
+    }
+    for (const usesProtocol of edges.usesProtocols) {
+      targetProtocols.add(usesProtocol);
+    }
+  }
+
   private static isProtocolDefinition(value: unknown): value is ProtocolDefinition {
     return typeof value === 'object' &&
       value !== null &&
@@ -720,6 +791,13 @@ export class SyncEngineLevel implements SyncEngine {
     return this._ledger;
   }
 
+  private get protocolReferences(): ProtocolReferenceIndex {
+    if (!this._protocolReferences) {
+      this._protocolReferences = new ProtocolReferenceIndex(this._db);
+    }
+    return this._protocolReferences;
+  }
+
   /** LevelDB sublevel for permanently failed messages (dead letters). */
   private get _deadLetters(): AbstractLevel<string | Buffer | Uint8Array, string, string> {
     return this._db.sublevel('deadLetters') as unknown as AbstractLevel<string | Buffer | Uint8Array, string, string>;
@@ -833,6 +911,8 @@ export class SyncEngineLevel implements SyncEngine {
 
     await this.validateSyncScopeClosure(did, options);
     await registeredIdentities.put(did, JSON.stringify(options));
+    await this.protocolReferences.clearDerivedReferences(did);
+    await this.protocolReferences.replaceScopeReferences(did, did, options.protocols);
     this._syncTargetsCache = undefined;
     this._syncTargetsCacheGeneration++;
 
@@ -860,6 +940,7 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     await registeredIdentities.del(did);
+    await this.protocolReferences.clearDerivedReferences(did);
     this._syncTargetsCache = undefined;
     this._syncTargetsCacheGeneration++;
     await this.pruneSupersededDurableLinksForIdentity(did, new Set());
@@ -883,6 +964,38 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
+  public async assertProtocolSelfReference({
+    identity,
+    protocol,
+    definition,
+  }: {
+    identity: string;
+    protocol: string;
+    definition?: ProtocolDefinition;
+  }): Promise<void> {
+    await this.protocolReferences.assertSelfReference(identity, protocol);
+    if (definition !== undefined) {
+      const targetProtocols = new Set<string>();
+      SyncEngineLevel.collectProtocolReferenceTargets(definition, targetProtocols);
+      await this.protocolReferences.replaceClosureReferences(identity, protocol, targetProtocols);
+    }
+  }
+
+  public async releaseProtocolSelfReference({ identity, protocol }: { identity: string, protocol: string }): Promise<void> {
+    await this.protocolReferences.deleteSelfReference(identity, protocol);
+    if (!await this.protocolReferences.hasReference(identity, protocol)) {
+      await this.protocolReferences.replaceClosureReferences(identity, protocol, []);
+    }
+  }
+
+  public async getProtocolReferences(identity: string): Promise<ProtocolReference[]> {
+    return this.protocolReferences.getReferences(identity);
+  }
+
+  public async hasProtocolReference({ identity, protocol }: { identity: string, protocol: string }): Promise<boolean> {
+    return this.protocolReferences.hasReference(identity, protocol);
+  }
+
   public async updateIdentityOptions({ did, options }: { did: string, options: SyncIdentityOptions }): Promise<void> {
     SyncEngineLevel.validateSyncIdentityOptions(options);
 
@@ -894,6 +1007,8 @@ export class SyncEngineLevel implements SyncEngine {
 
     await this.validateSyncScopeClosure(did, options);
     await registeredIdentities.put(did, JSON.stringify(options));
+    await this.protocolReferences.clearDerivedReferences(did);
+    await this.protocolReferences.replaceScopeReferences(did, did, options.protocols);
     this._syncTargetsCache = undefined;
     this._syncTargetsCacheGeneration++;
 
@@ -1038,6 +1153,7 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     this._syncMode = mode;
+    await this.rebuildDerivedProtocolReferences();
 
     if (mode === 'live') {
       await this.startLiveSync(intervalMilliseconds);

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -1,4 +1,4 @@
-import type { ProgressToken } from '@enbox/dwn-sdk-js';
+import type { ProgressToken, ProtocolDefinition } from '@enbox/dwn-sdk-js';
 
 import type { EnboxPlatformAgent } from './agent.js';
 
@@ -27,6 +27,17 @@ export type SyncIdentityOptions = {
    * install or use while applying records for the requested protocol set.
    */
   protocols: 'all' | [string, ...string[]];
+};
+
+export type ProtocolReferenceKind = 'closure' | 'scope' | 'scope-all' | 'self';
+
+export type ProtocolReference = {
+  tenantDid: string;
+  protocol: string;
+  kind: ProtocolReferenceKind;
+  referencer: string;
+  sourceProtocol?: string;
+  createdAt: string;
 };
 
 /**
@@ -529,6 +540,22 @@ export interface SyncEngine {
    * Update the Sync Options for a specific identity, replaces the existing options.
    */
   updateIdentityOptions(params: { did: string, options: SyncIdentityOptions }): Promise<void>;
+  /**
+   * Assert that a local app-surface ProtocolsConfigure keeps the protocol visible.
+   */
+  assertProtocolSelfReference(params: { identity: string, protocol: string, definition?: ProtocolDefinition }): Promise<void>;
+  /**
+   * Release a previously asserted self reference.
+   */
+  releaseProtocolSelfReference(params: { identity: string, protocol: string }): Promise<void>;
+  /**
+   * Return all device-local protocol references for an identity.
+   */
+  getProtocolReferences(identity: string): Promise<ProtocolReference[]>;
+  /**
+   * Test whether an identity has any active reference for a protocol.
+   */
+  hasProtocolReference(params: { identity: string, protocol: string }): Promise<boolean>;
   /**
    * Preforms a one-shot sync operation. If no direction is provided, it will perform both push and pull.
    * @param direction which direction you'd like to perform the sync operation.

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -80,6 +80,38 @@ describe('AgentDwnApi', () => {
     });
   });
 
+  describe('protocol references', () => {
+    it('asserts a self reference after a successful local ProtocolsConfigure', async () => {
+      const { message } = await TestDataGenerator.generateProtocolsConfigure({
+        protocolDefinition: emailProtocolDefinition as ProtocolDefinition,
+      });
+      const processMessage = sinon.stub().resolves({
+        status: { code: 202, detail: 'Accepted' },
+      });
+      const assertProtocolSelfReference = sinon.stub().resolves();
+      const dwnApi = new AgentDwnApi({
+        agent: {
+          sync: { assertProtocolSelfReference },
+        } as any,
+        dwn: { processMessage } as unknown as Dwn,
+      });
+
+      await dwnApi.processRequest({
+        author      : 'did:example:alice',
+        target      : 'did:example:alice',
+        messageType : DwnInterface.ProtocolsConfigure,
+        rawMessage  : message,
+      });
+
+      expect(assertProtocolSelfReference.calledOnceWithExactly({
+        definition : emailProtocolDefinition,
+        identity   : 'did:example:alice',
+        protocol   : emailProtocolDefinition.protocol,
+      })).toBe(true);
+    });
+
+  });
+
   describe('get agent', () => {
     it(`returns the 'agent' instance property`, () => {
       // we are only mocking

--- a/packages/agent/tests/protocol-reference-index.spec.ts
+++ b/packages/agent/tests/protocol-reference-index.spec.ts
@@ -1,0 +1,101 @@
+import { Level } from 'level';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
+
+import { ProtocolReferenceIndex } from '../src/protocol-reference-index.js';
+
+describe('ProtocolReferenceIndex', () => {
+  let db: Level<string, string>;
+  let index: ProtocolReferenceIndex;
+
+  beforeAll(() => {
+    db = new Level<string, string>('__TESTDATA__/protocol-reference-index-spec');
+    index = new ProtocolReferenceIndex(db);
+  });
+
+  afterEach(async () => {
+    await db.clear();
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it('composes independent self and scope references for the same protocol', async () => {
+    await index.assertSelfReference('did:example:alice', 'https://example.com/chat');
+    await index.replaceScopeReferences('did:example:alice', 'did:example:alice', [
+      'https://example.com/chat',
+      'https://example.com/profile',
+    ]);
+
+    expect(await index.hasReference('did:example:alice', 'https://example.com/chat')).toBe(true);
+    expect(await index.hasReference('did:example:alice', 'https://example.com/profile')).toBe(true);
+
+    await index.deleteScopeReferences('did:example:alice', 'did:example:alice');
+
+    const references = await index.getReferences('did:example:alice');
+    expect(references.map(reference => ({
+      kind     : reference.kind,
+      protocol : reference.protocol,
+    }))).toEqual([{
+      kind     : 'self',
+      protocol : 'https://example.com/chat',
+    }]);
+    expect(await index.hasReference('did:example:alice', 'https://example.com/chat')).toBe(true);
+    expect(await index.hasReference('did:example:alice', 'https://example.com/profile')).toBe(false);
+  });
+
+  it('stores protocols all as a wildcard reference', async () => {
+    await index.replaceScopeReferences('did:example:alice', 'did:example:alice', 'all');
+
+    const references = await index.getReferences('did:example:alice');
+    expect(references).toHaveLength(1);
+    expect(references[0].kind).toBe('scope-all');
+    expect(references[0].protocol).toBe(ProtocolReferenceIndex.wildcardProtocol);
+    expect(await index.hasReference('did:example:alice', 'https://example.com/future')).toBe(true);
+  });
+
+  it('rewrites closure references for a source protocol', async () => {
+    await index.replaceClosureReferences('did:example:alice', 'https://example.com/chat', [
+      'https://example.com/profile',
+      'https://example.com/tasks',
+      'https://example.com/chat',
+    ]);
+
+    expect(await index.getExactReferencedProtocols('did:example:alice')).toEqual([
+      'https://example.com/profile',
+      'https://example.com/tasks',
+    ]);
+
+    await index.replaceClosureReferences('did:example:alice', 'https://example.com/chat', [
+      'https://example.com/roles',
+    ]);
+
+    const references = await index.getReferences('did:example:alice');
+    expect(references.map(reference => ({
+      kind           : reference.kind,
+      protocol       : reference.protocol,
+      sourceProtocol : reference.sourceProtocol,
+    }))).toEqual([{
+      kind           : 'closure',
+      protocol       : 'https://example.com/roles',
+      sourceProtocol : 'https://example.com/chat',
+    }]);
+  });
+
+  it('clears derived references without deleting self references', async () => {
+    await index.assertSelfReference('did:example:alice', 'https://example.com/local');
+    await index.replaceScopeReferences('did:example:alice', 'did:example:alice', ['https://example.com/synced']);
+    await index.replaceClosureReferences('did:example:alice', 'https://example.com/synced', ['https://example.com/dep']);
+
+    await index.clearDerivedReferences('did:example:alice');
+
+    const references = await index.getReferences('did:example:alice');
+    expect(references.map(reference => ({
+      kind     : reference.kind,
+      protocol : reference.protocol,
+    }))).toEqual([{
+      kind     : 'self',
+      protocol : 'https://example.com/local',
+    }]);
+  });
+});

--- a/packages/agent/tests/sync-engine-identity.spec.ts
+++ b/packages/agent/tests/sync-engine-identity.spec.ts
@@ -1,7 +1,10 @@
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+
 import sinon from 'sinon';
 
 import { Level } from 'level';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { DwnInterfaceName, DwnMethodName } from '@enbox/dwn-sdk-js';
 
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 
@@ -207,6 +210,222 @@ describe('SyncEngineLevel — identity management', () => {
       });
       const options = await syncEngine.getIdentityOptions('did:example:scope-widen');
       expect(options!.protocols).toBe('all');
+    });
+  });
+
+  describe('protocol reference index', () => {
+    it('should create scope references when registering an identity', async () => {
+      await syncEngine.registerIdentity({
+        did     : 'did:example:refs-register',
+        options : { protocols: ['https://proto.example.com/chat', 'https://proto.example.com/profile'] },
+      });
+
+      const references = await syncEngine.getProtocolReferences('did:example:refs-register');
+      expect(references.map(reference => ({
+        kind     : reference.kind,
+        protocol : reference.protocol,
+      }))).toEqual([
+        {
+          kind     : 'scope',
+          protocol : 'https://proto.example.com/chat',
+        },
+        {
+          kind     : 'scope',
+          protocol : 'https://proto.example.com/profile',
+        },
+      ]);
+    });
+
+    it('should store protocols all as a wildcard scope reference', async () => {
+      await syncEngine.registerIdentity({ did: 'did:example:refs-all', options: { protocols: 'all' } });
+
+      expect(await syncEngine.hasProtocolReference({
+        identity : 'did:example:refs-all',
+        protocol : 'https://proto.example.com/arrives-later',
+      })).toBe(true);
+
+      const references = await syncEngine.getProtocolReferences('did:example:refs-all');
+      expect(references.map(reference => ({
+        kind     : reference.kind,
+        protocol : reference.protocol,
+      }))).toEqual([{
+        kind     : 'scope-all',
+        protocol : '*',
+      }]);
+    });
+
+    it('should rewrite scope references when updating identity options', async () => {
+      await syncEngine.registerIdentity({
+        did     : 'did:example:refs-update',
+        options : { protocols: ['https://proto.example.com/old'] },
+      });
+
+      await syncEngine.updateIdentityOptions({
+        did     : 'did:example:refs-update',
+        options : { protocols: ['https://proto.example.com/new'] },
+      });
+
+      expect(await syncEngine.hasProtocolReference({
+        identity : 'did:example:refs-update',
+        protocol : 'https://proto.example.com/old',
+      })).toBe(false);
+      expect(await syncEngine.hasProtocolReference({
+        identity : 'did:example:refs-update',
+        protocol : 'https://proto.example.com/new',
+      })).toBe(true);
+    });
+
+    it('should leave self references when unregistering an identity', async () => {
+      await syncEngine.assertProtocolSelfReference({
+        identity : 'did:example:refs-self',
+        protocol : 'https://proto.example.com/local',
+      });
+      await syncEngine.registerIdentity({
+        did     : 'did:example:refs-self',
+        options : { protocols: ['https://proto.example.com/synced'] },
+      });
+
+      await syncEngine.unregisterIdentity('did:example:refs-self');
+
+      const references = await syncEngine.getProtocolReferences('did:example:refs-self');
+      expect(references.map(reference => ({
+        kind     : reference.kind,
+        protocol : reference.protocol,
+      }))).toEqual([{
+        kind     : 'self',
+        protocol : 'https://proto.example.com/local',
+      }]);
+    });
+
+    it('should derive closure references from asserted self protocol definitions', async () => {
+      const sourceProtocol = 'https://proto.example.com/self-source';
+      const dependencyProtocol = 'https://proto.example.com/self-dependency';
+      await syncEngine.assertProtocolSelfReference({
+        identity   : 'did:example:refs-self-closure',
+        protocol   : sourceProtocol,
+        definition : {
+          protocol  : sourceProtocol,
+          published : true,
+          uses      : { dep: dependencyProtocol },
+          types     : {},
+          structure : {
+            root: {
+              $actions: [{ role: 'dep:admin', can: ['create'] }],
+            },
+          },
+        },
+      });
+
+      const references = await syncEngine.getProtocolReferences('did:example:refs-self-closure');
+      expect(references.map(reference => ({
+        kind           : reference.kind,
+        protocol       : reference.protocol,
+        sourceProtocol : reference.sourceProtocol,
+      }))).toEqual([
+        {
+          kind           : 'closure',
+          protocol       : dependencyProtocol,
+          sourceProtocol : sourceProtocol,
+        },
+        {
+          kind           : 'self',
+          protocol       : sourceProtocol,
+          sourceProtocol : undefined,
+        },
+      ]);
+    });
+
+    it('should remove a self protocol closure when the last self reference is released', async () => {
+      const sourceProtocol = 'https://proto.example.com/released-source';
+      const dependencyProtocol = 'https://proto.example.com/released-dependency';
+      await syncEngine.assertProtocolSelfReference({
+        identity   : 'did:example:refs-release',
+        protocol   : sourceProtocol,
+        definition : {
+          protocol  : sourceProtocol,
+          published : true,
+          uses      : { dep: dependencyProtocol },
+          types     : {},
+          structure : {
+            root: {
+              child: { $ref: 'dep:item' },
+            },
+          },
+        },
+      });
+
+      await syncEngine.releaseProtocolSelfReference({
+        identity : 'did:example:refs-release',
+        protocol : sourceProtocol,
+      });
+
+      expect(await syncEngine.getProtocolReferences('did:example:refs-release')).toEqual([]);
+    });
+
+    it('should rebuild closure references from retained protocol history at startSync', async () => {
+      const sourceProtocol = 'https://proto.example.com/source';
+      const dependencyProtocol = 'https://proto.example.com/dependency';
+      const sourceDefinition: ProtocolDefinition = {
+        protocol  : sourceProtocol,
+        published : true,
+        uses      : { dep: dependencyProtocol },
+        types     : {},
+        structure : {
+          root: {
+            child: { $ref: 'dep:item' },
+          },
+        },
+      };
+      const agent = {
+        dwn: {
+          getRemoteDwnEndpointUrls : sinon.stub().resolves([]),
+          processRequest           : sinon.stub().callsFake(async (request: any) => {
+            const protocol = request.messageParams.filters[0].protocol;
+            return {
+              reply: {
+                status  : { code: 200, detail: 'OK' },
+                entries : protocol === sourceProtocol ? [{
+                  message: {
+                    descriptor: {
+                      interface  : DwnInterfaceName.Protocols,
+                      method     : DwnMethodName.Configure,
+                      definition : sourceDefinition,
+                    },
+                  },
+                }] : [],
+                drained: true,
+              },
+            };
+          }),
+        },
+      };
+      const engine = new SyncEngineLevel({ db, agent: agent as any });
+
+      await engine.registerIdentity({
+        did     : 'did:example:refs-closure',
+        options : { protocols: [sourceProtocol] },
+      });
+
+      await engine.startSync({ mode: 'poll', interval: '1h' });
+      await engine.stopSync();
+
+      const references = await engine.getProtocolReferences('did:example:refs-closure');
+      expect(references.map(reference => ({
+        kind           : reference.kind,
+        protocol       : reference.protocol,
+        sourceProtocol : reference.sourceProtocol,
+      }))).toEqual([
+        {
+          kind           : 'closure',
+          protocol       : dependencyProtocol,
+          sourceProtocol : sourceProtocol,
+        },
+        {
+          kind           : 'scope',
+          protocol       : sourceProtocol,
+          sourceProtocol : undefined,
+        },
+      ]);
     });
   });
 

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -1908,6 +1908,7 @@ describe('SyncEngineLevel', () => {
         const syncSpy = sinon.spy(SyncEngineLevel.prototype as any, 'sync');
 
         const startPromise = testHarness.agent.sync.startSync({ interval: '500ms' });
+        await clock.tickAsync(0);
 
         // expect the immediate sync call
         expect(syncSpy.callCount).toBe(1);
@@ -1951,6 +1952,7 @@ describe('SyncEngineLevel', () => {
         const syncSpy = sinon.spy(SyncEngineLevel.prototype as any, 'sync');
 
         const startPromise = testHarness.agent.sync.startSync({ interval: '500ms' });
+        await clock.tickAsync(0);
 
         // expect the immediate sync call
         expect(syncSpy.callCount).toBe(1);
@@ -2012,6 +2014,7 @@ describe('SyncEngineLevel', () => {
         const syncSpy = sinon.spy(SyncEngineLevel.prototype as any, 'sync');
 
         const startPromise = testHarness.agent.sync.startSync({ interval: '500ms' });
+        await clock.tickAsync(0);
 
         // expect the immediate sync call
         expect(syncSpy.callCount).toBe(1);
@@ -2075,12 +2078,14 @@ describe('SyncEngineLevel', () => {
 
         const syncSpy = sinon.spy(SyncEngineLevel.prototype as any, 'sync');
 
-        testHarness.agent.sync.startSync({ interval: '500ms' });
+        const startPromise = testHarness.agent.sync.startSync({ interval: '500ms' });
+        await clock.tickAsync(0);
 
         // expect the immediate sync call
         expect(syncSpy.callCount).toBe(1);
 
         await clock.tickAsync(10); // enough time for the sync round trip to complete
+        await startPromise;
 
         // cause getSyncTargets to take longer than the 2 second timeout
         getSyncTargetsStub.returns(new Promise<any[]>((resolve) => {

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import { AbstractLevel } from 'abstract-level';
 import { Convert } from '@enbox/common';
 import { CryptoUtils } from '@enbox/crypto';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { DwnConstant, DwnInterfaceName, DwnMethodName, Jws, Message, PermissionsProtocol, Time } from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from '../src/types/dwn.js';
@@ -1655,6 +1655,16 @@ describe('SyncEngineLevel', () => {
     });
 
     describe('startSync()', () => {
+      let rebuildDerivedProtocolReferencesStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        rebuildDerivedProtocolReferencesStub = sinon.stub(SyncEngineLevel.prototype as any, 'rebuildDerivedProtocolReferences').resolves();
+      });
+
+      afterEach(() => {
+        rebuildDerivedProtocolReferencesStub.restore();
+      });
+
       it('calls sync() in each interval', async () => {
         await testHarness.agent.sync.registerIdentity({
           did     : alice.did.uri,
@@ -1868,6 +1878,16 @@ describe('SyncEngineLevel', () => {
     });
 
     describe('stopSync()', () => {
+      let rebuildDerivedProtocolReferencesStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        rebuildDerivedProtocolReferencesStub = sinon.stub(SyncEngineLevel.prototype as any, 'rebuildDerivedProtocolReferences').resolves();
+      });
+
+      afterEach(() => {
+        rebuildDerivedProtocolReferencesStub.restore();
+      });
+
       it('stops the sync interval', async () => {
         await testHarness.agent.sync.registerIdentity({
           did     : alice.did.uri,
@@ -3491,6 +3511,16 @@ describe('SyncEngineLevel', () => {
   });
 
   describe('startSync with mode parameter', () => {
+    let rebuildDerivedProtocolReferencesStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      rebuildDerivedProtocolReferencesStub = sinon.stub(SyncEngineLevel.prototype as any, 'rebuildDerivedProtocolReferences').resolves();
+    });
+
+    afterEach(() => {
+      rebuildDerivedProtocolReferencesStub.restore();
+    });
+
     it('should accept poll mode with interval and default to poll', async () => {
       // The existing `startSync({ interval })` signature should default to poll mode.
       const syncEngine = new SyncEngineLevel({ db: testHarness.syncStore, agent: testHarness.agent });


### PR DESCRIPTION
## Summary
- add the device-local protocol reference index for self, scope, wildcard scope, and closure references
- wire identity registration updates and startSync-derived closure rebuilds into SyncEngineLevel
- assert self references from successful local ProtocolsConfigure requests without touching replicated apply
- expose minimal sync inspection helpers and add focused coverage

## Test plan
- [x] lint
- [x] agent build
- [x] focused protocol reference and sync identity tests
