### PR TITLE
chore(sync): remove same-CID data completion

### DIFF
--- a/.changeset/quiet-logs-drop.md
+++ b/.changeset/quiet-logs-drop.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/dwn-sql-store": patch
+---
+
+chore: remove same-CID data completion from replication feeds

--- a/docs/architecture/cloudflare-do-dwn-deployment.md
+++ b/docs/architecture/cloudflare-do-dwn-deployment.md
@@ -179,7 +179,6 @@ CREATE TABLE messageStoreMessages (
   squash INTEGER,
   attester TEXT,
   seq INTEGER NOT NULL,
-  redeliverSeq INTEGER,
   fingerprintScopes TEXT NOT NULL,
   UNIQUE(tenant, messageCid)
 );
@@ -195,7 +194,6 @@ CREATE INDEX idx_tenant_dateCreated ON messageStoreMessages(tenant, dateCreated)
 CREATE INDEX idx_tenant_datePub ON messageStoreMessages(tenant, datePublished);
 CREATE INDEX idx_tenant_contextId ON messageStoreMessages(tenant, contextId, messageTimestamp);
 CREATE INDEX idx_tenant_seq ON messageStoreMessages(tenant, seq);
-CREATE INDEX idx_tenant_redeliverSeq ON messageStoreMessages(tenant, redeliverSeq);
 CREATE INDEX idx_tenant_protocol_seq ON messageStoreMessages(tenant, protocol, seq);
 
 -- Tags (identical to dwn-sql-store messageStoreRecordsTags)

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -48,8 +48,6 @@ export enum DwnErrorCode {
   IndexInvalidSortPropertyInMemory = 'IndexInvalidSortPropertyInMemory',
   IndexMissingIndexableProperty = 'IndexMissingIndexableProperty',
   JwsDecodePlainObjectPayloadInvalid = 'JwsDecodePlainObjectPayloadInvalid',
-  MessageStoreCompleteDataAlreadyStamped = 'MessageStoreCompleteDataAlreadyStamped',
-  MessageStoreCompleteDataMessageNotFound = 'MessageStoreCompleteDataMessageNotFound',
   MessageStoreDeleteLogEntryMissing = 'MessageStoreDeleteLogEntryMissing',
   MessageStoreFingerprintScopeMutation = 'MessageStoreFingerprintScopeMutation',
   MessageStorePreSubstrateLayout = 'MessageStorePreSubstrateLayout',

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -48,29 +48,13 @@ export class RecordsWriteHandler implements MethodHandler {
     // mutable validation. An already-stored message has already passed
     // admission; replay should not be reinterpreted against current protocol,
     // parent, role, grant, or record-limit state.
-    //
-    // Exception: an initial write may have been stored earlier without data
-    // (204). A later delivery of the same message with data must be allowed
-    // to complete the record.
     const incomingCid = await Message.getCid(message);
-    let isDataCompletion = false;
     for (const existingMessage of existingMessages) {
       if (await Message.getCid(existingMessage) !== incomingCid) {
         continue;
       }
 
-      const canCompleteMissingData = await this.existingInitialWriteLacksData(
-        tenant,
-        existingMessage as RecordsWriteMessage,
-        message,
-        dataStream !== undefined,
-      );
-
-      if (!canCompleteMissingData) {
-        return { status: { code: 409, detail: 'Conflict' } };
-      }
-
-      isDataCompletion = true;
+      return { status: { code: 409, detail: 'Conflict' } };
     }
 
     const newMessageIsInitialWrite = await recordsWrite.isInitialWrite();
@@ -125,30 +109,9 @@ export class RecordsWriteHandler implements MethodHandler {
     }
 
     if (!incomingMessageIsNewest) {
-      // Allow re-processing when the existing record was stored as an
-      // initial write without data (isLatestBaseState = false, status 204)
-      // and the incoming message now supplies data.  This happens during
-      // sync when a live pull initially stores the message without data
-      // and a subsequent poll or retry delivers the same message with data.
-      //
-      // We detect the incomplete state by checking whether the existing
-      // message is an initial write that lacks both inline encodedData and
-      // DataStore data — indicating it was stored without data.
-      let existingLacksData = false;
-      if (newestExistingMessage) {
-        existingLacksData = await this.existingInitialWriteLacksData(
-          tenant,
-          newestExistingMessage as RecordsWriteMessage,
-          message,
-          dataStream !== undefined,
-        );
-      }
-
-      if (!existingLacksData) {
-        return {
-          status: { code: 409, detail: 'Conflict' }
-        };
-      }
+      return {
+        status: { code: 409, detail: 'Conflict' }
+      };
     }
 
     // Look up the core protocol (if any) for the incoming message so that lifecycle hooks
@@ -198,14 +161,9 @@ export class RecordsWriteHandler implements MethodHandler {
 
       const indexes = await recordsWrite.constructIndexes(isLatestBaseState);
       const messageCid = await Message.getCid(message);
-      if (isDataCompletion) {
-        const completeDataResult = await this.deps.messageStore.completeData(tenant, messageCid, indexes, messageWithOptionalEncodedData.encodedData);
-        position = completeDataResult.position;
-      } else {
-        const putResult = await this.deps.messageStore.put(tenant, messageWithOptionalEncodedData, indexes);
-        position = putResult.position;
-        await this.deps.stateIndex!.insert(tenant, messageCid, indexes);
-      }
+      const putResult = await this.deps.messageStore.put(tenant, messageWithOptionalEncodedData, indexes);
+      position = putResult.position;
+      await this.deps.stateIndex!.insert(tenant, messageCid, indexes);
 
       // NOTE: We only emit a `RecordsWrite` when the message is the latest base state.
       // Because we allow a `RecordsWrite` which is not the latest state to be written, but not queried, we shouldn't emit it either.
@@ -326,31 +284,6 @@ export class RecordsWriteHandler implements MethodHandler {
     }
 
     return messageWithOptionalEncodedData;
-  }
-
-  private async existingInitialWriteLacksData(
-    tenant: string,
-    existingMessage: RecordsWriteMessage,
-    incomingMessage: RecordsWriteMessage,
-    incomingHasData: boolean,
-  ): Promise<boolean> {
-    if (!incomingHasData) {
-      return false;
-    }
-
-    const isInitial = await RecordsWrite.isInitialWrite(existingMessage);
-    if (!isInitial) {
-      return false;
-    }
-
-    const hasInlineData = !!(existingMessage as RecordsQueryReplyEntry).encodedData;
-    const hasStoredData = await this.deps.validationStateReader.hasStoredData(
-      tenant,
-      existingMessage.recordId,
-      incomingMessage.descriptor.dataCid,
-    );
-
-    return !hasInlineData && !hasStoredData;
   }
 
   private async getInitialWrite(

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -53,7 +53,7 @@ export type { MessagesQueryOptions } from './interfaces/messages-query.js';
 export { MessagesSync } from './interfaces/messages-sync.js';
 export type { MessagesSyncOptions } from './interfaces/messages-sync.js';
 export type { UnionMessageReply } from './core/message-reply.js';
-export type { MessageStore, MessageStoreCompleteDataResult, MessageStoreOptions, MessageStorePutResult } from './types/message-store.js';
+export type { MessageStore, MessageStoreOptions, MessageStorePutResult } from './types/message-store.js';
 export { Replication } from './utils/replication.js';
 export type { MessageInterface } from './types/message-interface.js';
 export { PermissionGrant } from './protocols/permission-grant.js';

--- a/packages/dwn-sdk-js/src/store/message-store-level.ts
+++ b/packages/dwn-sdk-js/src/store/message-store-level.ts
@@ -13,7 +13,7 @@ import type {
 import type { Filter, KeyValues, PaginationCursor, QueryOptions } from '../types/query-types.js';
 import type { GenericMessage, MessageSort, Pagination } from '../types/message-types.js';
 import type { LevelDatabase, LevelWrapperBatchOperation } from './level-wrapper.js';
-import type { MessageStore, MessageStoreCompleteDataResult, MessageStoreOptions, MessageStorePutResult } from '../types/message-store.js';
+import type { MessageStore, MessageStoreOptions, MessageStorePutResult } from '../types/message-store.js';
 
 import * as block from 'multiformats/block';
 import * as cbor from '@ipld/dag-cbor';
@@ -84,7 +84,6 @@ const BLOCKS_PARTITION = 'blocks';
 const INDEX_PARTITION = 'idx';
 const LOG_PARTITION = 'log';
 const CID_TO_SEQ_PARTITION = 'cid';
-const REDELIVERY_PARTITION = 'redeliver';
 const FINGERPRINT_PARTITION = 'fp';
 const HEADS_PARTITION = 'heads';
 const META_PARTITION = 'meta';
@@ -95,7 +94,6 @@ const CURRENT_PARTITIONS = new Set([
   INDEX_PARTITION,
   LOG_PARTITION,
   CID_TO_SEQ_PARTITION,
-  REDELIVERY_PARTITION,
   FINGERPRINT_PARTITION,
   HEADS_PARTITION,
   META_PARTITION,
@@ -109,15 +107,13 @@ type LogEntryValue = {
   seq: string;
   /** The CID of the stored message. */
   messageCid: string;
-  /** The row's current query indexes (replaced by `updateIndexes`/`completeData`). */
+  /** The row's current query indexes (replaced by `updateIndexes`). */
   indexes: KeyValues;
   /**
    * The row's fingerprint-domain membership, computed once from the insert-time indexes and
    * persisted so deletion can fold the fingerprints without recomputing from mutated state.
    */
   fingerprintScopes: string[];
-  /** The redelivery stamp position, present only after `completeData` stamped the row. */
-  redeliverSeq?: string;
 };
 
 /**
@@ -132,8 +128,6 @@ type StorePartitions = {
   log: LevelWrapper<string>;
   /** messageCid → seq lookup, tenant-partitioned: `cid!<tenant>!<messageCid>`. */
   cidToSeq: LevelWrapper<string>;
-  /** Redelivery stamps, tenant-partitioned: `redeliver!<tenant>!<paddedRedeliverSeq>`. */
-  redeliveries: LevelWrapper<string>;
   /** Fingerprint domain values, tenant-partitioned: `fp!<tenant>!<domainKey>` → 64-char hex. */
   fingerprints: LevelWrapper<string>;
   /** Per-tenant counter high-water: `heads!<tenant>` → decimal string. */
@@ -145,9 +139,9 @@ type StorePartitions = {
 /**
  * A {@link MessageStore} and {@link ReplicationFeedReader} implementation that works in both the
  * browser and server-side, backed by a SINGLE LevelDB root: message blocks, query indexes, the
- * per-tenant replication log, the cid→seq index, redelivery stamps, fingerprint domains, the
- * tenant counters, and the store epoch are all sublevels of one Level instance, so every mutation
- * commits as one fully atomic batch.
+ * per-tenant replication log, the cid→seq index, fingerprint domains, the tenant counters, and
+ * the store epoch are all sublevels of one Level instance, so every mutation commits as one fully
+ * atomic batch.
  *
  * A per-tenant async write mutex spans seq assignment through batch write, so commit order equals
  * seq order by construction. Seq assignment is gap-free (a failed batch never persists the head),
@@ -229,7 +223,6 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
       blocks       : await binaryView.partition(BLOCKS_PARTITION),
       log          : await root.partition(LOG_PARTITION),
       cidToSeq     : await root.partition(CID_TO_SEQ_PARTITION),
-      redeliveries : await root.partition(REDELIVERY_PARTITION),
       fingerprints : await root.partition(FINGERPRINT_PARTITION),
       heads        : await root.partition(HEADS_PARTITION),
       meta         : await root.partition(META_PARTITION),
@@ -470,7 +463,7 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
       Replication.assertFingerprintScopesUntouched(entry.fingerprintScopes, storedMessage, messageCid, indexes);
 
       // Same row, same seq: indexes replaced; fingerprint scopes carried forward verbatim;
-      // never stamps and never touches the fingerprints or the head.
+      // fingerprints and head stay untouched.
       const updatedEntry: LogEntryValue = { ...entry, indexes };
 
       const operations: LevelWrapperBatchOperation<string>[] = [
@@ -527,78 +520,6 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
     });
   }
 
-  async completeData(
-    tenant: string,
-    messageCid: string,
-    indexes: KeyValues,
-    encodedData?: string,
-    options?: MessageStoreOptions
-  ): Promise<MessageStoreCompleteDataResult> {
-    options?.signal?.throwIfAborted();
-
-    const partitions = await executeUnlessAborted(this.partitions(), options?.signal);
-    const index = await executeUnlessAborted(this.index(), options?.signal);
-
-    return this.withTenantWriteLock(tenant, async () => {
-      const { entry, positionKey, tenantLog } = await this.getLogEntryForMutation(
-        partitions, tenant, messageCid, DwnErrorCode.MessageStoreCompleteDataMessageNotFound
-      );
-
-      if (entry.redeliverSeq !== undefined) {
-        throw new DwnError(
-          DwnErrorCode.MessageStoreCompleteDataAlreadyStamped,
-          `message ${messageCid} is already stamped at position ${entry.redeliverSeq}; the dataless-to-data transition cannot repeat`
-        );
-      }
-
-      const storedMessage = await this.readStoredMessage(
-        partitions, tenant, messageCid, DwnErrorCode.MessageStoreCompleteDataMessageNotFound, options
-      );
-      Replication.assertFingerprintScopesUntouched(entry.fingerprintScopes, storedMessage, messageCid, indexes);
-
-      // The completion is the one substance mutation whose cause does not append a log row, so it
-      // stamps the row for redelivery: same CID, same seq, a second delivery position drawn from
-      // the same tenant counter in the same atomic batch. No fingerprint change — the CID set is
-      // unchanged.
-      const head = await this.getHead(partitions, tenant);
-      const redeliverSeq = head + 1n;
-
-      const updatedEntry: LogEntryValue = { ...entry, indexes, redeliverSeq: redeliverSeq.toString() };
-
-      let blockOperations: LevelWrapperBatchOperation<string>[] = [];
-
-      if (encodedData !== undefined) {
-        const tenantBlocks = await partitions.blocks.partition(tenant);
-        const completedMessage = { ...storedMessage, encodedData };
-        const reEncodedBlock = await block.encode({ value: completedMessage, codec: cbor, hasher: sha256 });
-        const blockOperation = tenantBlocks.createOperation({ type: 'put', key: messageCid, value: reEncodedBlock.bytes });
-        blockOperations = [blockOperation as unknown as LevelWrapperBatchOperation<string>];
-      }
-
-      const tenantRedeliveries = await partitions.redeliveries.partition(tenant);
-      const operations: LevelWrapperBatchOperation<string>[] = [
-        ...blockOperations,
-        ...await index.createDeleteOperations(tenant, messageCid),
-        ...await index.createPutOperations(tenant, messageCid, indexes),
-        tenantLog.createOperation({ type: 'put', key: positionKey, value: JSON.stringify(updatedEntry) }),
-        tenantRedeliveries.createOperation({
-          type  : 'put',
-          key   : Replication.encodePositionKey(redeliverSeq),
-          value : JSON.stringify({ seq: entry.seq, messageCid }),
-        }),
-        partitions.heads.createOperation({ type: 'put', key: tenant, value: redeliverSeq.toString() }),
-      ];
-
-      await partitions.root.batch(operations);
-
-      // Store-owned wake, post-commit — the stamp advances the head, so the same forward drain
-      // delivers the completed row at a strictly increasing position.
-      this.publishWake(tenant, redeliverSeq);
-
-      return { position: await this.buildToken(tenant, redeliverSeq, messageCid) };
-    });
-  }
-
   async delete(tenant: string, cidString: string, options?: MessageStoreOptions): Promise<void> {
     options?.signal?.throwIfAborted();
 
@@ -631,20 +552,12 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
       const tenantBlocks = await partitions.blocks.partition(tenant);
       const blockOperation = tenantBlocks.createOperation({ type: 'del', key: messageCid });
 
-      // Removing the row removes both delivery appearances — the stamp lives and dies with it.
-      let redeliveryOperations: LevelWrapperBatchOperation<string>[] = [];
-      if (entry.redeliverSeq !== undefined) {
-        const tenantRedeliveries = await partitions.redeliveries.partition(tenant);
-        redeliveryOperations = [tenantRedeliveries.createOperation({ type: 'del', key: Replication.encodePositionKey(BigInt(entry.redeliverSeq)) })];
-      }
-
       // XOR is self-inverse: folding the persisted scopes again removes the row's contribution.
       const operations: LevelWrapperBatchOperation<string>[] = [
         blockOperation as unknown as LevelWrapperBatchOperation<string>,
         ...await index.createDeleteOperations(tenant, messageCid),
         tenantLog.createOperation({ type: 'del', key: positionKey }),
         tenantCidToSeq.createOperation({ type: 'del', key: messageCid }),
-        ...redeliveryOperations,
         ...await this.createFingerprintFoldOperations(partitions, tenant, messageCid, entry.fingerprintScopes),
       ];
 
@@ -699,12 +612,10 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
     }
 
     const tenantLog = await partitions.log.partition(tenant);
-    const tenantRedeliveries = await partitions.redeliveries.partition(tenant);
     const tenantBlocks = await partitions.blocks.partition(tenant);
 
     const iteratorRange = { gt: Replication.encodePositionKey(startPosition), lte: Replication.encodePositionKey(head) };
     const logIterator = tenantLog.iterator(iteratorRange);
-    const redeliveryIterator = tenantRedeliveries.iterator(iteratorRange);
 
     const events: EventLogEntry[] = [];
     let drained = true;
@@ -712,8 +623,10 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
     let lastDeliveredPosition: bigint | undefined;
     let lastDeliveredMessageCid: string | undefined;
 
-    for await (const { position, entry } of this.mergePositionStreams(logIterator, redeliveryIterator, tenantLog)) {
+    for await (const [positionKey, serializedEntry] of logIterator) {
+      const position = BigInt(positionKey);
       lastScannedPosition = position;
+      const entry = JSON.parse(serializedEntry) as LogEntryValue;
 
       const event = await this.readEventFromLogEntry(tenantBlocks, position, entry, filters);
       if (event === undefined) {
@@ -742,15 +655,9 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
   private async readEventFromLogEntry(
     tenantBlocks: LevelWrapper<Uint8Array>,
     position: bigint,
-    entry: LogEntryValue | undefined,
+    entry: LogEntryValue,
     filters: Filter[] | undefined,
   ): Promise<EventLogEntry | undefined> {
-    if (entry === undefined) {
-      // A redelivery stamp whose row vanished between the head capture and this lookup —
-      // deletion removes both appearances, so there is nothing to deliver at this position.
-      return undefined;
-    }
-
     if (filters !== undefined && filters.length > 0 && !FilterUtility.matchAnyFilter(entry.indexes, filters)) {
       return undefined;
     }
@@ -764,7 +671,7 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
     const decodedBlock = await block.decode({ bytes, codec: cbor, hasher: sha256 });
     const message = decodedBlock.value as GenericMessage;
     return {
-      seq        : entry.seq, // a redelivered entry carries the row's original seq
+      seq        : entry.seq,
       position   : position.toString(),
       event      : { message },
       indexes    : entry.indexes,
@@ -783,19 +690,13 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
     // position is always 0 regardless of compaction.
     const oldest = await this.buildToken(tenant, 0n);
 
-    // Resolve the head position against either column for the latest token's messageCid.
+    // Resolve the head position for the latest token's messageCid.
     const headKey = Replication.encodePositionKey(head);
     const tenantLog = await partitions.log.partition(tenant);
-    const tenantRedeliveries = await partitions.redeliveries.partition(tenant);
 
     let headMessageCid: string | undefined;
     const headLogEntry = await tenantLog.get(headKey);
-    if (headLogEntry === undefined) {
-      const headRedelivery = await tenantRedeliveries.get(headKey);
-      if (headRedelivery !== undefined) {
-        headMessageCid = (JSON.parse(headRedelivery) as { seq: string, messageCid: string }).messageCid;
-      }
-    } else {
+    if (headLogEntry !== undefined) {
       headMessageCid = (JSON.parse(headLogEntry) as LogEntryValue).messageCid;
     }
 
@@ -968,12 +869,6 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
       return (JSON.parse(serializedEntry) as LogEntryValue).messageCid;
     }
 
-    const tenantRedeliveries = await partitions.redeliveries.partition(tenant);
-    const serializedStamp = await tenantRedeliveries.get(positionKey);
-    if (serializedStamp !== undefined) {
-      return (JSON.parse(serializedStamp) as { seq: string, messageCid: string }).messageCid;
-    }
-
     return undefined;
   }
 
@@ -1033,53 +928,6 @@ export class MessageStoreLevel implements MessageStore, ReplicationFeedReader {
    */
   private static fingerprintKey(scope: string): string {
     return `d${scope}`;
-  }
-
-  /**
-   * Merges the seq range and the redelivery range in ascending position order beneath the
-   * captured head. Position comparisons are numeric via BigInt, never lexicographic. Yields
-   * `entry: undefined` for redelivery stamps whose row disappeared mid-scan.
-   */
-  private async * mergePositionStreams(
-    logIterator: AsyncGenerator<[string, string]>,
-    redeliveryIterator: AsyncGenerator<[string, string]>,
-    tenantLog: LevelWrapper<string>,
-  ): AsyncGenerator<{ position: bigint, entry: LogEntryValue | undefined }> {
-    try {
-      let logNext = await logIterator.next();
-      let redeliveryNext = await redeliveryIterator.next();
-
-      while (!logNext.done || !redeliveryNext.done) {
-        let useLogStream: boolean;
-        if (logNext.done) {
-          useLogStream = false;
-        } else if (redeliveryNext.done) {
-          useLogStream = true;
-        } else {
-          const logPosition = BigInt(logNext.value[0]);
-          const redeliveryPosition = BigInt(redeliveryNext.value[0]);
-          useLogStream = logPosition < redeliveryPosition;
-        }
-
-        if (useLogStream) {
-          const [positionKey, serializedEntry] = logNext.value!;
-          yield { position: BigInt(positionKey), entry: JSON.parse(serializedEntry) as LogEntryValue };
-          logNext = await logIterator.next();
-        } else {
-          const [positionKey, serializedStamp] = redeliveryNext.value!;
-          const stamp = JSON.parse(serializedStamp) as { seq: string, messageCid: string };
-          const serializedEntry = await tenantLog.get(Replication.encodePositionKey(BigInt(stamp.seq)));
-          const entry = serializedEntry === undefined ? undefined : JSON.parse(serializedEntry) as LogEntryValue;
-          yield { position: BigInt(positionKey), entry };
-          redeliveryNext = await redeliveryIterator.next();
-        }
-      }
-    } finally {
-      // Close the underlying Level iterators when the merge is abandoned early (e.g. a row limit
-      // breaks out of the consuming loop). Calling return() on an exhausted generator is a no-op.
-      await logIterator.return(undefined);
-      await redeliveryIterator.return(undefined);
-    }
   }
 
   private async buildToken(tenant: string, position: bigint, messageCid?: string): Promise<ProgressToken> {

--- a/packages/dwn-sdk-js/src/types/message-store.ts
+++ b/packages/dwn-sdk-js/src/types/message-store.ts
@@ -24,17 +24,6 @@ export type MessageStorePutResult = {
   position?: ProgressToken;
 };
 
-/**
- * Result of a {@link MessageStore.completeData} operation.
- */
-export type MessageStoreCompleteDataResult = {
-  /**
-   * The redelivery stamp position assigned to the completed row. Present on
-   * stores that maintain a replication log.
-   */
-  position?: ProgressToken;
-};
-
 export interface MessageStore {
   /**
    * opens a connection to the underlying store
@@ -87,8 +76,8 @@ export interface MessageStore {
   ): Promise<number>;
 
   /**
-   * Replaces the indexes of an existing message in place: same row, same log
-   * sequence, and no redelivery stamp.
+   * Replaces the indexes of an existing message in place: same row and same log
+   * sequence.
    */
   updateIndexes(
     tenant: string,
@@ -99,8 +88,8 @@ export interface MessageStore {
 
   /**
    * Replaces the stored same-CID message payload and indexes in place: same
-   * row, same log sequence, and no redelivery stamp. The replacement message
-   * must resolve to `messageCid` under DWN CID rules.
+   * row and same log sequence. The replacement message must resolve to
+   * `messageCid` under DWN CID rules.
    */
   updateMessageAndIndexes(
     tenant: string,
@@ -109,19 +98,6 @@ export interface MessageStore {
     indexes: KeyValues,
     options?: MessageStoreOptions
   ): Promise<void>;
-
-  /**
-   * Completes a previously dataless row with its inline data and replacement
-   * indexes, assigning a redelivery position when the store supports durable
-   * log stamps.
-   */
-  completeData(
-    tenant: string,
-    messageCid: string,
-    indexes: KeyValues,
-    encodedData?: string,
-    options?: MessageStoreOptions
-  ): Promise<MessageStoreCompleteDataResult>;
 
   /**
    * Deletes the message associated with the id provided.

--- a/packages/dwn-sdk-js/src/types/subscriptions.ts
+++ b/packages/dwn-sdk-js/src/types/subscriptions.ts
@@ -184,11 +184,7 @@ export type EventLogEntry = {
   /** Monotonic sequence number scoped to (instance, tenant), as a decimal string. */
   seq: string;
 
-  /**
-   * The actual delivered log position. This differs from `seq` for redelivery
-   * stamps, where the entry keeps the row's original `seq` but is delivered at
-   * the later redelivery position.
-   */
+  /** The actual delivered log position. Equal to `seq` for store-backed feeds. */
   position?: string;
 
   /** The event payload. */

--- a/packages/dwn-sdk-js/tests/core/validation-read-closure.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/validation-read-closure.spec.ts
@@ -474,7 +474,7 @@ describe('validation read closure', () => {
       snapshot('replicated: initial write accepted by timestamped config');
     }
 
-    // ---- scenario: replicated completion of a dataless stub ----
+    // ---- scenario: replicated same-CID data retry of a dataless stub ----
     {
       await clearStores();
       recorder.clearRecordedReads();
@@ -489,11 +489,11 @@ describe('validation read closure', () => {
       });
       expect((await dwn.applyReplicatedMessage(alice.did, stubMessage)).kind).toBe('Applied');
 
-      // same-CID re-delivery with data completes the record instead of classifying as Duplicate
-      const completionResult = await dwn.applyReplicatedMessage(alice.did, stubMessage, { dataStream: DataStream.fromBytes(stubDataBytes!) });
-      expect(completionResult.kind).toBe('Applied');
+      // same-CID retry with data is not a completion mechanism; fetch-first sync applies once.
+      const retryResult = await dwn.applyReplicatedMessage(alice.did, stubMessage, { dataStream: DataStream.fromBytes(stubDataBytes!) });
+      expect(retryResult.kind).toBe('Superseded');
 
-      snapshot('replicated: same-CID completion of dataless stub');
+      snapshot('replicated: same-CID data retry of dataless stub');
     }
 
     // ---- scenario: replicated tombstone-beaten dataless update missing compacted data ----

--- a/packages/dwn-sdk-js/tests/core/validation-read-trace.json
+++ b/packages/dwn-sdk-js/tests/core/validation-read-trace.json
@@ -50,9 +50,8 @@
   "replicated: initial write accepted by timestamped config": [
     "fetchProtocolDefinition"
   ],
-  "replicated: same-CID completion of dataless stub": [
-    "fetchProtocolDefinition",
-    "hasStoredData"
+  "replicated: same-CID data retry of dataless stub": [
+    "fetchProtocolDefinition"
   ],
   "replicated: tombstone-beaten dataless update missing compacted data": [
     "fetchProtocolDefinition",

--- a/packages/dwn-sdk-js/tests/core/validation-state-reader.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/validation-state-reader.spec.ts
@@ -105,7 +105,7 @@ describe('validation-state reader admission parity', () => {
       expect(replicatedResult.kind).toBe('Applied');
     });
 
-    it('should continue to admit a child after the same dataless parent is completed with data', async () => {
+    it('should continue to admit a child after same-CID data retry is rejected', async () => {
       const alice = await TestDataGenerator.generateDidKeyPersona();
 
       const protocolDefinition = nestedProtocolDefinition;
@@ -126,7 +126,7 @@ describe('validation-state reader admission parity', () => {
       const datalessParentReply = await dwn.processMessage(alice.did, parentMessage);
       expect(datalessParentReply.status.code).toBe(204);
 
-      const { message: childBeforeCompletionMessage, dataStream: childBeforeCompletionDataStream } = await TestDataGenerator.generateRecordsWrite({
+      const { message: childBeforeRetryMessage, dataStream: childBeforeRetryDataStream } = await TestDataGenerator.generateRecordsWrite({
         author          : alice,
         protocol        : protocolDefinition.protocol,
         protocolPath    : 'foo/bar',
@@ -134,18 +134,19 @@ describe('validation-state reader admission parity', () => {
         dataFormat      : 'text/plain',
         parentContextId : parentWrite.message.contextId,
       });
-      const childBeforeCompletionReply = await dwn.processMessage(alice.did, childBeforeCompletionMessage, {
-        dataStream: childBeforeCompletionDataStream,
+      const childBeforeRetryReply = await dwn.processMessage(alice.did, childBeforeRetryMessage, {
+        dataStream: childBeforeRetryDataStream,
       });
-      expect(childBeforeCompletionReply.status.code).toBe(202);
+      expect(childBeforeRetryReply.status.code).toBe(202);
 
-      // Same-CID delivery with data flips the parent from retained ancestry to latest/queryable state.
-      const completedParentReply = await dwn.processMessage(alice.did, parentMessage, {
+      // Same-CID delivery with data is not a completion mechanism; the retained parent still
+      // authorizes children through immutable ancestry facts.
+      const retriedParentReply = await dwn.processMessage(alice.did, parentMessage, {
         dataStream: DataStream.fromBytes(parentDataBytes!),
       });
-      expect(completedParentReply.status.code).toBe(202);
+      expect(retriedParentReply.status.code).toBe(409);
 
-      const { message: childAfterCompletionMessage, dataStream: childAfterCompletionDataStream } = await TestDataGenerator.generateRecordsWrite({
+      const { message: childAfterRetryMessage, dataStream: childAfterRetryDataStream } = await TestDataGenerator.generateRecordsWrite({
         author          : alice,
         protocol        : protocolDefinition.protocol,
         protocolPath    : 'foo/bar',
@@ -153,10 +154,10 @@ describe('validation-state reader admission parity', () => {
         dataFormat      : 'text/plain',
         parentContextId : parentWrite.message.contextId,
       });
-      const childAfterCompletionReply = await dwn.processMessage(alice.did, childAfterCompletionMessage, {
-        dataStream: childAfterCompletionDataStream,
+      const childAfterRetryReply = await dwn.processMessage(alice.did, childAfterRetryMessage, {
+        dataStream: childAfterRetryDataStream,
       });
-      expect(childAfterCompletionReply.status.code).toBe(202);
+      expect(childAfterRetryReply.status.code).toBe(202);
     });
 
     it('should admit a child after a parent update because immutable parent facts are unchanged', async () => {

--- a/packages/dwn-sdk-js/tests/durable-event-log.spec.ts
+++ b/packages/dwn-sdk-js/tests/durable-event-log.spec.ts
@@ -362,45 +362,6 @@ describe('DurableEventLog', () => {
     await scriptedLog.close();
   });
 
-  it('should emit redelivery events at the redelivery cursor position', async () => {
-    const alice = await TestDataGenerator.generateDidKeyPersona();
-    const record = await TestDataGenerator.generateRecordsWrite({ author: alice });
-    const message = { ...record.message } as RecordsWriteMessage & { encodedData?: string };
-    delete message.encodedData;
-
-    const messageCid = await Message.getCid(message);
-    const indexes = await record.recordsWrite.constructIndexes(true);
-    const initialPut = await messageStore.put(alice.did, message, { ...indexes, isLatestBaseState: false });
-    const completion = await messageStore.completeData(
-      alice.did,
-      messageCid,
-      indexes,
-      (record.message as RecordsWriteMessage & { encodedData?: string }).encodedData
-    );
-    expect(completion.position!.position).toBe('2');
-
-    const received: SubscriptionMessage[] = [];
-    await eventLog.subscribe(alice.did, 'redelivery-subscription', (message): void => {
-      received.push(message);
-    }, { cursor: initialPut.position! });
-
-    expect(received[0]).toEqual(expect.objectContaining({
-      type : 'event',
-      seq  : '1',
-      messageCid,
-    }));
-    const redeliveryEvent = received[0];
-    expect(redeliveryEvent.type).toBe('event');
-    if (redeliveryEvent.type !== 'event') {
-      throw new Error('expected a redelivery event');
-    }
-    expect(redeliveryEvent.encodedData).toBe((record.message as RecordsWriteMessage & { encodedData?: string }).encodedData);
-    expect((redeliveryEvent.event.message as RecordsWriteMessage & { encodedData?: string }).encodedData).toBeUndefined();
-    expect(redeliveryEvent.cursor.position).toBe('2');
-    expect(received[1]).toEqual(expect.objectContaining({ type: 'eose' }));
-    expect(received[1].cursor.position).toBe('2');
-  });
-
   it('should attach initial writes to non-initial RecordsWrite events', async () => {
     const alice = await TestDataGenerator.generateDidKeyPersona();
     const initial = await TestDataGenerator.generateRecordsWrite({ author: alice });

--- a/packages/dwn-sdk-js/tests/store/message-store-level.spec.ts
+++ b/packages/dwn-sdk-js/tests/store/message-store-level.spec.ts
@@ -284,7 +284,7 @@ describe('MessageStoreLevel Test Suite', () => {
   });
 
   describe('updateIndexes', () => {
-    it('should replace indexes in place without moving the row, stamping, or stripping inline data', async () => {
+    it('should replace indexes in place without moving the row or stripping inline data', async () => {
       const alice = await TestDataGenerator.generateDidKeyPersona();
       const first = await generateStoredMessage();
       const second = await generateStoredMessage();
@@ -328,7 +328,7 @@ describe('MessageStoreLevel Test Suite', () => {
   });
 
   describe('updateMessageAndIndexes', () => {
-    it('should replace the stored payload and indexes without moving the row or stamping', async () => {
+    it('should replace the stored payload and indexes without moving the row', async () => {
       const alice = await TestDataGenerator.generateDidKeyPersona();
       const first = await generateStoredMessage();
       const second = await generateStoredMessage();
@@ -362,82 +362,6 @@ describe('MessageStoreLevel Test Suite', () => {
 
       await expect(messageStore.updateMessageAndIndexes(alice.did, messageCid, message, { ...indexes, protocol: 'https://example.com/other' }))
         .rejects.toThrow(DwnErrorCode.MessageStoreFingerprintScopeMutation);
-    });
-  });
-
-  describe('completeData', () => {
-    it('should update the existing row and redeliver it at a later position exactly once', async () => {
-      const alice = await TestDataGenerator.generateDidKeyPersona();
-      const stub = await generateStoredMessage();
-      const other = await generateStoredMessage();
-
-      await messageStore.put(alice.did, stub.message, { ...stub.indexes, isLatestBaseState: false });
-      await messageStore.put(alice.did, other.message, other.indexes);
-
-      const result = await messageStore.completeData(alice.did, stub.messageCid, stub.indexes, 'aGVsbG8');
-      expect(result.position!.position).toBe('3');
-      expect(result.position!.messageCid).toBe(stub.messageCid);
-      expect(wakes.map((wake) => wake.seq)).toEqual(['1', '2', '3']);
-
-      const storedMessage = await messageStore.get(alice.did, stub.messageCid);
-      expect(storedMessage!.encodedData).toBe('aGVsbG8');
-
-      const { events, cursor, drained } = await messageStore.logRead(alice.did);
-      expect(events.map((entry) => entry.messageCid)).toEqual([stub.messageCid, other.messageCid, stub.messageCid]);
-      expect(events.filter((entry) => entry.messageCid === stub.messageCid).map((entry) => entry.seq)).toEqual(['1', '1']);
-      expect(cursor!.position).toBe('3');
-      expect(drained).toBe(true);
-
-      await expect(messageStore.completeData(alice.did, stub.messageCid, stub.indexes, 'aGVsbG8'))
-        .rejects.toThrow(DwnErrorCode.MessageStoreCompleteDataAlreadyStamped);
-    });
-
-    it('should complete dataless permission records without changing permission fingerprint scope', async () => {
-      const alice = await TestDataGenerator.generateDidKeyPersona();
-      const scopedProtocol = 'https://example.com/photos';
-      const grant = await generateStoredMessage({
-        protocol : PermissionsProtocol.uri,
-        tags     : { protocol: scopedProtocol },
-      });
-      const grantFingerprint = await cidFingerprint(grant.messageCid);
-      const { 'tag.protocol': _tagProtocol, ...datalessGrantIndexes } = grant.indexes;
-
-      await messageStore.put(alice.did, grant.message, { ...datalessGrantIndexes, isLatestBaseState: false });
-      expect(await messageStore.fingerprint(alice.did, [Replication.permissionDomain(scopedProtocol)])).toBe(grantFingerprint);
-      const datalessFiltered = await messageStore.logRead(alice.did, { filters: [{ 'tag.protocol': scopedProtocol }] });
-      expect(datalessFiltered.events).toHaveLength(0);
-
-      const result = await messageStore.completeData(alice.did, grant.messageCid, grant.indexes, 'aGVsbG8');
-
-      expect(result.position!.position).toBe('2');
-      expect(await messageStore.fingerprint(alice.did, [Replication.permissionDomain(scopedProtocol)])).toBe(grantFingerprint);
-      const { events } = await messageStore.logRead(alice.did);
-      expect(events.map((entry) => entry.indexes['tag.protocol'])).toEqual([scopedProtocol, scopedProtocol]);
-    });
-
-    it('should reject missing messages', async () => {
-      const alice = await TestDataGenerator.generateDidKeyPersona();
-      const { messageCid, indexes } = await generateStoredMessage();
-
-      await expect(messageStore.completeData(alice.did, messageCid, indexes))
-        .rejects.toThrow(DwnErrorCode.MessageStoreCompleteDataMessageNotFound);
-    });
-
-    it('should resume from a cursor whose redelivery position was deleted', async () => {
-      const alice = await TestDataGenerator.generateDidKeyPersona();
-      const stub = await generateStoredMessage();
-      const later = await generateStoredMessage();
-
-      await messageStore.put(alice.did, stub.message, { ...stub.indexes, isLatestBaseState: false });
-      const completion = await messageStore.completeData(alice.did, stub.messageCid, stub.indexes, 'aGVsbG8');
-      await messageStore.put(alice.did, later.message, later.indexes);
-      await messageStore.delete(alice.did, stub.messageCid);
-
-      const { events, cursor, drained } = await messageStore.logRead(alice.did, { cursor: completion.position });
-
-      expect(events.map((entry) => entry.messageCid)).toEqual([later.messageCid]);
-      expect(cursor!.position).toBe('3');
-      expect(drained).toBe(true);
     });
   });
 
@@ -551,7 +475,6 @@ describe('MessageStoreLevel Test Suite', () => {
 
       await messageStore.put(alice.did, first.message, first.indexes);
       await messageStore.put(alice.did, second.message, { ...second.indexes, isLatestBaseState: false });
-      await messageStore.completeData(alice.did, second.messageCid, second.indexes, 'aGVsbG8');
 
       const boundsBefore = await messageStore.logBounds(alice.did);
       const logBefore = await messageStore.logRead(alice.did);

--- a/packages/dwn-sdk-js/tests/store/message-store.spec.ts
+++ b/packages/dwn-sdk-js/tests/store/message-store.spec.ts
@@ -167,54 +167,6 @@ export function testMessageStore(): void {
           .rejects.toThrow(DwnErrorCode.MessageStoreUpdateMessageAndIndexesCidMismatch);
       });
 
-      it('should complete dataless rows once and reject repeated inline completion', async () => {
-        const alice = await TestDataGenerator.generateDidKeyPersona();
-        const oldSchema = 'https://schema.org/Dataless';
-        const newSchema = 'https://schema.org/Completed';
-        const { message, recordsWrite } = await TestDataGenerator.generateRecordsWrite({ schema: oldSchema });
-        const messageCid = await Message.getCid(message);
-        const latestIndexes = await recordsWrite.constructIndexes(true);
-        const replacementIndexes: KeyValues = {
-          ...latestIndexes,
-          schema: newSchema,
-        };
-
-        await messageStore.put(alice.did, message, await recordsWrite.constructIndexes(false));
-        await messageStore.completeData(alice.did, messageCid, replacementIndexes, 'aGVsbG8');
-
-        const storedMessage = await messageStore.get(alice.did, messageCid) as RecordsWriteMessage & { encodedData?: string };
-        expect(storedMessage.encodedData).toBe('aGVsbG8');
-        expect((await messageStore.query(alice.did, [{ schema: oldSchema }])).messages.length).toBe(0);
-        expect((await messageStore.query(alice.did, [{ schema: newSchema }])).messages.length).toBe(1);
-
-        await expect(messageStore.completeData(alice.did, messageCid, replacementIndexes, 'aGVsbG8'))
-          .rejects.toThrow(DwnErrorCode.MessageStoreCompleteDataAlreadyStamped);
-      });
-
-      it('should complete data-store-backed rows once and reject repeated completion', async () => {
-        const alice = await TestDataGenerator.generateDidKeyPersona();
-        const oldSchema = 'https://schema.org/DatalessLarge';
-        const newSchema = 'https://schema.org/CompletedLarge';
-        const { message, recordsWrite } = await TestDataGenerator.generateRecordsWrite({ schema: oldSchema });
-        const messageCid = await Message.getCid(message);
-        const latestIndexes = await recordsWrite.constructIndexes(true);
-        const replacementIndexes: KeyValues = {
-          ...latestIndexes,
-          schema: newSchema,
-        };
-
-        await messageStore.put(alice.did, message, await recordsWrite.constructIndexes(false));
-        await messageStore.completeData(alice.did, messageCid, replacementIndexes);
-
-        const storedMessage = await messageStore.get(alice.did, messageCid) as RecordsWriteMessage & { encodedData?: string };
-        expect(storedMessage.encodedData).toBeUndefined();
-        expect((await messageStore.query(alice.did, [{ schema: oldSchema }])).messages.length).toBe(0);
-        expect((await messageStore.query(alice.did, [{ schema: newSchema }])).messages.length).toBe(1);
-
-        await expect(messageStore.completeData(alice.did, messageCid, replacementIndexes))
-          .rejects.toThrow(DwnErrorCode.MessageStoreCompleteDataAlreadyStamped);
-      });
-
       it('should index properties with characters beyond just letters and digits', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 

--- a/packages/dwn-sql-store/src/message-store-sql.ts
+++ b/packages/dwn-sql-store/src/message-store-sql.ts
@@ -8,7 +8,6 @@ import type {
   GenericMessage,
   MessageSort,
   MessageStore,
-  MessageStoreCompleteDataResult,
   MessageStoreOptions,
   MessageStorePutResult,
   Pagination,
@@ -49,18 +48,15 @@ type MessageStoreSystemColumn =
   'encodedMessageBytes' |
   'encodedData' |
   'seq' |
-  'redeliverSeq' |
   'fingerprintScopes';
 type MessageStoreIndexColumn = Exclude<keyof DwnDatabaseType['messageStoreMessages'], MessageStoreSystemColumn>;
 type MessageStoreRow = Selectable<DwnDatabaseType['messageStoreMessages']>;
 type MessageStoreExecutor = Kysely<DwnDatabaseType> | Transaction<DwnDatabaseType>;
-type PositionColumn = 'seq' | 'redeliverSeq';
-// Replication positions (`seq`/`redeliverSeq`) must be read through these text columns, populated by
+// Replication positions must be read through these text columns, populated by
 // `Dialect.bigIntColumnAsText` (`CAST(... AS CHAR/TEXT)`). Reading the raw bigint columns instead lets
 // the MySQL/SQLite drivers narrow them to a JS `number`, truncating positions above 2^53.
 type PositionTextColumns = {
   seqText: string | null;
-  redeliverSeqText: string | null;
 };
 type LogRow = MessageStoreRow & PositionTextColumns;
 
@@ -192,7 +188,6 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
           encodedMessageBytes,
           encodedData,
           seq               : seq.toString(),
-          redeliverSeq      : null,
           fingerprintScopes : JSON.stringify(fingerprintScopes),
           ...putIndexes,
         };
@@ -380,33 +375,6 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
     });
   }
 
-  public async completeData(
-    tenant: string,
-    messageCid: string,
-    indexes: KeyValues,
-    encodedData?: string,
-    options?: MessageStoreOptions
-  ): Promise<MessageStoreCompleteDataResult> {
-    this.requireDb('completeData');
-    options?.signal?.throwIfAborted();
-
-    const redeliverSeq = await this.replaceRowIndexes({
-      tenant,
-      messageCid,
-      indexes,
-      encodedData,
-      notFoundErrorCode : DwnErrorCode.MessageStoreCompleteDataMessageNotFound,
-      stampRedelivery   : true,
-    });
-
-    if (redeliverSeq === undefined) {
-      return {};
-    }
-
-    this.publishWake(tenant, redeliverSeq);
-    return { position: await this.buildToken(tenant, redeliverSeq, messageCid) };
-  }
-
   public async delete(
     tenant: string,
     cid: string,
@@ -501,18 +469,11 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
       return { events: [], cursor, drained: true };
     }
 
-    const [originalRows, redeliveryRows] = await Promise.all([
-      this.selectLogRows(db, tenant, 'seq', startPosition, head, filters, maxResults),
-      this.selectLogRows(db, tenant, 'redeliverSeq', startPosition, head, filters, maxResults),
-    ]);
-
-    const mergedRows = MessageStoreSql.mergeRowsByPosition(originalRows, redeliveryRows)
-      .slice(0, maxResults);
-
-    const events = await this.buildEventEntries(db, mergedRows);
+    const rows = await this.selectLogRows(db, tenant, startPosition, head, filters, maxResults);
+    const events = await this.buildEventEntries(db, rows);
     const lastDelivered = events.at(-1);
     const lastDeliveredPosition = lastDelivered === undefined ? undefined : BigInt(lastDelivered.position ?? lastDelivered.seq);
-    const lastScannedPosition = mergedRows.at(-1)?.position ?? startPosition;
+    const lastScannedPosition = rows.at(-1)?.position ?? startPosition;
     const drained = events.length < maxResults || lastScannedPosition >= head;
     const cursorPosition = drained ? head : lastScannedPosition;
     const cursorMessageCid = lastDeliveredPosition === cursorPosition ? lastDelivered?.messageCid : undefined;
@@ -574,13 +535,12 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
     encodedData?: string | null;
     messageForScopeCheck?: GenericMessage;
     notFoundErrorCode: DwnErrorCode;
-    stampRedelivery?: boolean;
-  }): Promise<bigint | undefined> {
-    const { tenant, messageCid, indexes, encodedMessageBytes, encodedData, messageForScopeCheck, notFoundErrorCode, stampRedelivery } = input;
+  }): Promise<void> {
+    const { tenant, messageCid, indexes, encodedMessageBytes, encodedData, messageForScopeCheck, notFoundErrorCode } = input;
     const db = this.requireDb('replaceRowIndexes');
     const { indexes: replacementIndexes, tags } = extractTagsAndSanitizeIndexes(indexes);
 
-    return executeWithTransaction(db, async (tx) => {
+    await executeWithTransaction(db, async (tx) => {
       await this.#dialect.lockReplicationCounter(tx, tenant);
 
       const existingRow = await tx
@@ -594,13 +554,6 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
         throw new DwnError(notFoundErrorCode, `no message found for tenant ${tenant} with CID ${messageCid}`);
       }
 
-      if (stampRedelivery === true && existingRow.redeliverSeq !== null) {
-        throw new DwnError(
-          DwnErrorCode.MessageStoreCompleteDataAlreadyStamped,
-          `message ${messageCid} is already stamped at position ${existingRow.redeliverSeq}; the dataless-to-data transition cannot repeat`
-        );
-      }
-
       const message = messageForScopeCheck ?? await this.parseEncodedMessage(existingRow.encodedMessageBytes, existingRow.encodedData);
       Replication.assertFingerprintScopesUntouched(
         MessageStoreSql.parseFingerprintScopes(existingRow.fingerprintScopes, messageCid),
@@ -609,13 +562,11 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
         indexes
       );
 
-      const redeliverSeq = stampRedelivery === true ? await this.#dialect.incrementReplicationCounter(tx, tenant) : undefined;
       const replacementColumns = {
         ...NULLED_INDEX_COLUMNS,
         ...replacementIndexes,
         ...(encodedMessageBytes !== undefined && { encodedMessageBytes }),
         ...(encodedData !== undefined && { encodedData }),
-        ...(redeliverSeq !== undefined && { redeliverSeq: redeliverSeq.toString() }),
       };
 
       await tx
@@ -632,15 +583,12 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
       if (Object.keys(tags).length > 0) {
         await this.#tags.executeTagsInsert(existingRow.id, tags, tx);
       }
-
-      return redeliverSeq;
     });
   }
 
   private async selectLogRows(
     executor: MessageStoreExecutor,
     tenant: string,
-    positionColumn: PositionColumn,
     startPosition: bigint,
     head: bigint,
     filters: Filter[] | undefined,
@@ -652,13 +600,12 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
       .selectAll('messageStoreMessages')
       .select([
         this.#dialect.bigIntColumnAsText('messageStoreMessages.seq').as('seqText'),
-        this.#dialect.bigIntColumnAsText('messageStoreMessages.redeliverSeq').as('redeliverSeqText'),
       ])
       .distinct()
       .where('tenant', '=', tenant)
-      .where(positionColumn, '>', startPosition.toString())
-      .where(positionColumn, '<=', head.toString())
-      .orderBy(positionColumn, 'asc');
+      .where('seq', '>', startPosition.toString())
+      .where('seq', '<=', head.toString())
+      .orderBy('seq', 'asc');
 
     if (filters !== undefined && filters.length > 0) {
       query = filterSelectQuery(filters, query);
@@ -671,7 +618,7 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
     const rows = await query.execute() as LogRow[];
     return rows.map((row) => ({
       row,
-      position: MessageStoreSql.requirePosition(row, positionColumn),
+      position: MessageStoreSql.requirePosition(row),
     }));
   }
 
@@ -685,7 +632,7 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
     for (const { row, position } of positionedRows) {
       const message = await this.parseEncodedMessage(row.encodedMessageBytes, row.encodedData);
       entries.push({
-        seq        : MessageStoreSql.requirePosition(row, 'seq').toString(),
+        seq        : MessageStoreSql.requirePosition(row).toString(),
         position   : position.toString(),
         event      : { message },
         indexes    : MessageStoreSql.rowToIndexes(row, tagMap.get(row.id)),
@@ -825,10 +772,7 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
       .selectFrom('messageStoreMessages')
       .select('messageCid')
       .where('tenant', '=', tenant)
-      .where(({ eb, or }) => or([
-        eb('seq', '=', positionString),
-        eb('redeliverSeq', '=', positionString),
-      ]))
+      .where('seq', '=', positionString)
       .executeTakeFirst();
 
     return row?.messageCid;
@@ -1042,20 +986,6 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
     return { messageToStore, encodedData };
   }
 
-  private static mergeRowsByPosition<TRow extends MessageStoreRow>(
-    originalRows: Array<{ row: TRow; position: bigint }>,
-    redeliveryRows: Array<{ row: TRow; position: bigint }>,
-  ): Array<{ row: TRow; position: bigint }> {
-    const rows = [...originalRows, ...redeliveryRows];
-    rows.sort((left, right) => {
-      if (left.position === right.position) {
-        return 0;
-      }
-      return left.position < right.position ? -1 : 1;
-    });
-    return rows;
-  }
-
   private static rowToIndexes(row: MessageStoreRow, tags: KeyValues = {}): KeyValues {
     const indexes: KeyValues = {};
 
@@ -1102,16 +1032,15 @@ export class MessageStoreSql implements MessageStore, ReplicationFeedReader {
     return filters.some((filter) => Object.keys(filter).some((key) => key.startsWith('tag.')));
   }
 
-  private static requirePosition(row: MessageStoreRow & Partial<PositionTextColumns>, positionColumn: PositionColumn): bigint {
+  private static requirePosition(row: MessageStoreRow & Partial<PositionTextColumns>): bigint {
     // Prefer the cast text column (BigInt-exact). The raw-column fallback is NOT safe above 2^53 —
     // every position-bearing read (logRead/getHead/increment) selects the `*Text` columns, so the
     // fallback should never carry a real position; it exists only for rows fetched without them.
-    const textValue = positionColumn === 'seq' ? row.seqText : row.redeliverSeqText;
-    const value = textValue ?? row[positionColumn];
+    const value = row.seqText ?? row.seq;
     if (value === null || value === undefined) {
       throw new DwnError(
         DwnErrorCode.MessageStorePreSubstrateLayout,
-        `message ${row.messageCid} is missing replication position ${positionColumn}`
+        `message ${row.messageCid} is missing replication position seq`
       );
     }
 

--- a/packages/dwn-sql-store/src/migrations/004-replication-log.ts
+++ b/packages/dwn-sql-store/src/migrations/004-replication-log.ts
@@ -5,8 +5,8 @@ import type { Kysely, Migration } from 'kysely';
 /**
  * Migration 004: durable replication log substrate for SQL stores.
  *
- * The log is represented by `messageStoreMessages` itself: each live row gets an original `seq`,
- * optional completion `redeliverSeq`, and persisted fingerprint-domain membership. Fresh stores
+ * The log is represented by `messageStoreMessages` itself: each live row gets a `seq`
+ * and persisted fingerprint-domain membership. Fresh stores
  * fill these columns for every write; existing pre-substrate rows are intentionally not backfilled.
  */
 export const migration004ReplicationLog: DwnMigrationFactory = (dialect: Dialect): Migration => ({
@@ -19,23 +19,12 @@ export const migration004ReplicationLog: DwnMigrationFactory = (dialect: Dialect
 
     await db.schema
       .alterTable('messageStoreMessages')
-      .addColumn('redeliverSeq', 'bigint')
-      .execute();
-
-    await db.schema
-      .alterTable('messageStoreMessages')
       .addColumn('fingerprintScopes', 'text')
       .execute();
 
     await db.schema.createIndex('index_messageStoreMessages_tenant_seq')
       .on('messageStoreMessages')
       .columns(['tenant', 'seq'])
-      .unique()
-      .execute();
-
-    await db.schema.createIndex('index_messageStoreMessages_tenant_redeliverSeq')
-      .on('messageStoreMessages')
-      .columns(['tenant', 'redeliverSeq'])
       .unique()
       .execute();
 

--- a/packages/dwn-sql-store/src/types.ts
+++ b/packages/dwn-sql-store/src/types.ts
@@ -10,7 +10,6 @@ type MessageStoreTable = {
   encodedMessageBytes: Uint8Array;
   encodedData: string | null;
   seq: string | null;
-  redeliverSeq: string | null;
   fingerprintScopes: string | null;
   // "indexes" start
   interface: string | null;

--- a/packages/dwn-sql-store/tests/message-store-duplicate.spec.ts
+++ b/packages/dwn-sql-store/tests/message-store-duplicate.spec.ts
@@ -88,11 +88,11 @@ describe('isMessageCidDuplicateKeyError', () => {
     (postgresSeqError as any).code = '23505';
     (postgresSeqError as any).constraint = 'index_messageStoreMessages_tenant_seq';
 
-    const sqliteRedeliveryError = new Error('UNIQUE constraint failed: messageStoreMessages.tenant, messageStoreMessages.redeliverSeq');
-    (sqliteRedeliveryError as any).code = 'SQLITE_CONSTRAINT_UNIQUE';
+    const sqliteSeqError = new Error('UNIQUE constraint failed: messageStoreMessages.tenant, messageStoreMessages.seq');
+    (sqliteSeqError as any).code = 'SQLITE_CONSTRAINT_UNIQUE';
 
     expect(isMessageCidDuplicateKeyError(postgresSeqError)).toBe(false);
-    expect(isMessageCidDuplicateKeyError(sqliteRedeliveryError)).toBe(false);
+    expect(isMessageCidDuplicateKeyError(sqliteSeqError)).toBe(false);
   });
 });
 

--- a/packages/dwn-sql-store/tests/message-store-replication-log.spec.ts
+++ b/packages/dwn-sql-store/tests/message-store-replication-log.spec.ts
@@ -8,7 +8,7 @@ import { MessageStoreSql } from '../src/message-store-sql.js';
 import { runDwnStoreMigrations } from '../src/migration-runner.js';
 import { SqliteDialect } from '../src/dialect/sqlite-dialect.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { DwnErrorCode, Message, PermissionsProtocol, Replication, TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { DwnErrorCode, Message, Replication, TestDataGenerator } from '@enbox/dwn-sdk-js';
 import { testMysqlDialect, testPostgresDialect, testSqliteDialect } from './test-dialects.js';
 
 const ZERO_FINGERPRINT = '0'.repeat(64);
@@ -254,7 +254,6 @@ function runReplicationLogTests(dialect: Dialect): void {
       const alice = await TestDataGenerator.generateDidKeyPersona();
       const highBase = 9_007_199_254_740_992n;
       const expectedPutPosition = highBase + 1n;
-      const expectedRedeliveryPosition = highBase + 2n;
 
       await db
         .insertInto('replicationCounters')
@@ -265,25 +264,20 @@ function runReplicationLogTests(dialect: Dialect): void {
       const put = await messageStore.put(alice.did, stored.message, stored.indexes);
       expect(put.position!.position).toBe(expectedPutPosition.toString());
 
-      const redelivery = await messageStore.completeData(alice.did, stored.messageCid, stored.indexes, 'aGVsbG8');
-      expect(redelivery.position!.position).toBe(expectedRedeliveryPosition.toString());
-
       const { events, cursor, drained } = await messageStore.logRead(alice.did);
       expect(events.map((entry) => entry.position)).toEqual([
         expectedPutPosition.toString(),
-        expectedRedeliveryPosition.toString(),
       ]);
       expect(events.map((entry) => entry.seq)).toEqual([
         expectedPutPosition.toString(),
-        expectedPutPosition.toString(),
       ]);
-      expect(cursor!.position).toBe(expectedRedeliveryPosition.toString());
+      expect(cursor!.position).toBe(expectedPutPosition.toString());
       expect(drained).toBe(true);
 
       // logBounds reads the head via the cast getHead path — assert it also round-trips beyond 2^53.
       const bounds = await messageStore.logBounds(alice.did);
       expect(bounds!.oldest.position).toBe('0');
-      expect(bounds!.latest.position).toBe(expectedRedeliveryPosition.toString());
+      expect(bounds!.latest.position).toBe(expectedPutPosition.toString());
     });
 
     it('should page with high-water cursors and preserve zero-limit cursor semantics', async () => {
@@ -365,86 +359,6 @@ function runReplicationLogTests(dialect: Dialect): void {
 
       await expect(messageStore.updateIndexes(alice.did, first.messageCid, { ...first.indexes, protocol: 'https://example.com/other' }))
         .rejects.toThrow(DwnErrorCode.MessageStoreFingerprintScopeMutation);
-    });
-
-    it('should stamp completeData redelivery once and preserve permission fingerprint scopes', async () => {
-      const alice = await TestDataGenerator.generateDidKeyPersona();
-      const stub = await generateStoredMessage();
-      const other = await generateStoredMessage();
-
-      await messageStore.put(alice.did, stub.message, { ...stub.indexes, isLatestBaseState: false });
-      await messageStore.put(alice.did, other.message, other.indexes);
-
-      const result = await messageStore.completeData(alice.did, stub.messageCid, stub.indexes, 'aGVsbG8');
-      expect(result.position!.position).toBe('3');
-      expect(result.position!.messageCid).toBe(stub.messageCid);
-      expect(wakePublisher.wakes.map((wake) => wake.seq)).toEqual(['1', '2', '3']);
-
-      const storedMessage = await messageStore.get(alice.did, stub.messageCid);
-      expect(storedMessage!.encodedData).toBe('aGVsbG8');
-
-      const { events, cursor, drained } = await messageStore.logRead(alice.did);
-      expect(events.map((entry) => entry.messageCid)).toEqual([stub.messageCid, other.messageCid, stub.messageCid]);
-      expect(events.filter((entry) => entry.messageCid === stub.messageCid).map((entry) => entry.seq)).toEqual(['1', '1']);
-      expect(cursor!.position).toBe('3');
-      expect(drained).toBe(true);
-
-      const boundsBeforeRetry = await messageStore.logBounds(alice.did);
-      const wakeCountBeforeRetry = wakePublisher.wakes.length;
-      await expect(messageStore.completeData(alice.did, stub.messageCid, stub.indexes, 'aGVsbG8'))
-        .rejects.toThrow(DwnErrorCode.MessageStoreCompleteDataAlreadyStamped);
-      expect(wakePublisher.wakes).toHaveLength(wakeCountBeforeRetry);
-      expect((await messageStore.logBounds(alice.did))!.latest).toEqual(boundsBeforeRetry!.latest);
-
-      await messageStore.clear();
-      const scopedProtocol = 'https://example.com/permission-photos';
-      const grant = await generateStoredMessage({
-        protocol : PermissionsProtocol.uri,
-        tags     : { protocol: scopedProtocol },
-      });
-      const grantFingerprint = await cidFingerprint(grant.messageCid);
-      const { 'tag.protocol': _tagProtocol, ...datalessGrantIndexes } = grant.indexes;
-
-      await messageStore.put(alice.did, grant.message, { ...datalessGrantIndexes, isLatestBaseState: false });
-      expect(await messageStore.fingerprint(alice.did, [Replication.permissionDomain(scopedProtocol)])).toBe(grantFingerprint);
-      expect((await messageStore.logRead(alice.did, { filters: [{ 'tag.protocol': scopedProtocol }] })).events).toHaveLength(0);
-
-      const completion = await messageStore.completeData(alice.did, grant.messageCid, grant.indexes, 'aGVsbG8');
-      expect(completion.position!.position).toBe('2');
-      expect(await messageStore.fingerprint(alice.did, [Replication.permissionDomain(scopedProtocol)])).toBe(grantFingerprint);
-      expect((await messageStore.logRead(alice.did)).events.map((entry) => entry.indexes['tag.protocol']))
-        .toEqual([scopedProtocol, scopedProtocol]);
-    });
-
-    it('should page redeliveries by redelivery position on partial pages', async () => {
-      const alice = await TestDataGenerator.generateDidKeyPersona();
-      const first = await generateStoredMessage();
-      const second = await generateStoredMessage();
-      const third = await generateStoredMessage();
-
-      await messageStore.put(alice.did, first.message, first.indexes);
-      await messageStore.put(alice.did, second.message, second.indexes);
-      await messageStore.put(alice.did, third.message, third.indexes);
-      await messageStore.completeData(alice.did, first.messageCid, first.indexes, 'aGVsbG8');
-
-      const firstPage = await messageStore.logRead(alice.did, { limit: 2 });
-      expect(firstPage.events.map((entry) => entry.position)).toEqual(['1', '2']);
-      expect(firstPage.events.map((entry) => entry.messageCid)).toEqual([first.messageCid, second.messageCid]);
-      expect(firstPage.cursor!.position).toBe('2');
-      expect(firstPage.drained).toBe(false);
-
-      const secondPage = await messageStore.logRead(alice.did, { cursor: firstPage.cursor, limit: 2 });
-      expect(secondPage.events.map((entry) => entry.position)).toEqual(['3', '4']);
-      expect(secondPage.events.map((entry) => entry.seq)).toEqual(['3', '1']);
-      expect(secondPage.events.map((entry) => entry.messageCid)).toEqual([third.messageCid, first.messageCid]);
-      expect(secondPage.cursor!.position).toBe('4');
-      expect(secondPage.cursor!.messageCid).toBe(first.messageCid);
-      expect(secondPage.drained).toBe(true);
-
-      const drained = await messageStore.logRead(alice.did, { cursor: secondPage.cursor, limit: 2 });
-      expect(drained.events).toHaveLength(0);
-      expect(drained.cursor).toEqual(secondPage.cursor);
-      expect(drained.drained).toBe(true);
     });
 
     it('should fold protocol configs and tombstones into protocol fingerprints and persist across reopen', async () => {


### PR DESCRIPTION
## Summary
- Remove same-CID data completion from RecordsWrite admission; duplicate delivery now remains conflict/superseded.
- Simplify durable feed positions to seq-only by deleting completion stamps from Level and SQL stores.
- Remove the obsolete schema/docs/test coverage for the old completion path and update validation traces for fetch-first sync.

## Test plan
- [x] Lint
- [x] dwn-sdk-js, dwn-sql-store, dwn-clients, and agent builds
- [x] dwn-sdk-js test suite
- [x] dwn-sql-store test suite
- [x] affected validation closure tests
- [ ] agent test suite locally blocked by localhost Pkarr gateway validation rejecting private/loopback hosts

## Notes
- This intentionally removes the completion/redelivery substrate from the current sync direction; fetch-first sync applies each message once.
