### PR TITLE
chore(agent): clean up legacy sync engine state

### DIFF
--- a/.changeset/sync-agent-engine-cleanup.md
+++ b/.changeset/sync-agent-engine-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+chore: remove legacy sync engine state and stale ordering wrappers

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -8,7 +8,6 @@ export type * from './types/sync.js';
 export {
   computeAuthorizationEpoch,
   computeProjectionId,
-  MAX_PENDING_TOKENS,
   normalizeSyncProtocols,
   protocolsForSyncScope,
   singleProtocolForSyncScope,

--- a/packages/agent/src/sync-admission-order.ts
+++ b/packages/agent/src/sync-admission-order.ts
@@ -173,7 +173,7 @@ function getInvokedRoleKey(
 
 /**
  * Builds a dependency graph from the fetched messages and returns them in
- * topological order so that dependencies are processed before dependents.
+ * dependency order so that dependencies are processed before dependents.
  *
  * Dependencies:
  * - ProtocolsConfigure must come before any RecordsWrite using that protocol
@@ -182,7 +182,7 @@ function getInvokedRoleKey(
  * - Initial write must come before update writes (same recordId, not initial)
  * - Permission grants must come before messages that invoke them
  */
-export function topologicalSort<T extends { message: GenericMessage }>(
+export function orderMessagesForAdmission<T extends { message: GenericMessage }>(
   messages: T[]
 ): T[] {
   return buildMessageDependencyGraph(messages).sorted;

--- a/packages/agent/src/sync-admit-closure.ts
+++ b/packages/agent/src/sync-admit-closure.ts
@@ -17,7 +17,7 @@ import type { SyncScope } from './types/sync.js';
 import { classifySyncMessageScope } from './sync-scope-acceptance.js';
 import { DwnInterface } from './types/dwn.js';
 import { KeyDeliveryProtocolDefinition } from './store-data-protocols.js';
-import { topologicalSort } from './sync-topological-sort.js';
+import { orderMessagesForAdmission } from './sync-admission-order.js';
 
 import {
   capRecordsWriteDataStream,
@@ -108,7 +108,7 @@ class AdmitClosureContext {
     const retry: SyncMessageEntry[] = [];
     const appliedCids: string[] = [];
 
-    for (const entry of topologicalSort(pending)) {
+    for (const entry of orderMessagesForAdmission(pending)) {
       this.assertShouldContinue();
       const result = await this.admitEntry(rootCid, entry);
       switch (result.kind) {

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -23,8 +23,7 @@ import { DwnInterface } from './types/dwn.js';
 import { getProtocolClosureEdges } from './sync-scope-closure.js';
 import { isRecordsWrite } from './utils.js';
 import { ReplicationLedger } from './sync-replication-ledger.js';
-import { topologicalSort } from './sync-topological-sort.js';
-import { computeAuthorizationEpoch, computeProjectionId, isTenantInactivePushFailure, isTerminalPushFailure, lexicographicalCompare, MAX_PENDING_TOKENS, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
+import { computeAuthorizationEpoch, computeProjectionId, isTenantInactivePushFailure, isTerminalPushFailure, lexicographicalCompare, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { fetchRemoteMessages, pushMessages, queryLocalMessageFeed, queryRemoteMessageFeed, SyncPullAbortedError } from './sync-messages.js';
 import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, resolveMessagesScopes, SyncProtocolRootPermissionGrantMissingError, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
@@ -44,6 +43,9 @@ const PUSH_DEBOUNCE_MS = 100;
 
 /** Default durable-feed page size for engine replay. */
 const FEED_PAGE_LIMIT = 100;
+
+/** Maximum concurrent live-pull deliveries waiting for earlier ordinals to commit. */
+const MAX_IN_FLIGHT_PULL_DELIVERIES = 100;
 
 /** Page size for local retained ProtocolsConfigure history scans. */
 const PROTOCOL_HISTORY_PAGE_LIMIT = 500;
@@ -1233,10 +1235,10 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   // ---------------------------------------------------------------------------
-  // Per-link repair and degraded-poll orchestration
+  // Per-link repair orchestration
   // ---------------------------------------------------------------------------
 
-  /** Maximum consecutive repair attempts before falling back to degraded_poll. */
+  /** Maximum consecutive repair attempts before the link becomes terminal-incomplete. */
   private static readonly MAX_REPAIR_ATTEMPTS = 3;
 
   /** Maximum repeated verified feed mismatches before pausing the link as terminal-incomplete. */
@@ -1244,9 +1246,6 @@ export class SyncEngineLevel implements SyncEngine {
 
   /** Maximum age for a repeatedly deferred pull entry before it is dead-lettered and skipped. */
   private static readonly DEFERRED_PULL_DEAD_LETTER_AFTER_MS = 24 * 60 * 60 * 1000;
-
-  /** Per-link degraded-poll interval timers. */
-  private readonly _degradedPollTimers: Map<string, ReturnType<typeof setInterval>> = new Map();
 
   /** Per-link repair attempt counters. */
   private readonly _repairAttempts: Map<string, number> = new Map();
@@ -1324,11 +1323,6 @@ export class SyncEngineLevel implements SyncEngine {
       clearTimeout(retryTimer);
       this._repairRetryTimers.delete(linkKey);
     }
-    const degradedTimer = this._degradedPollTimers.get(linkKey);
-    if (degradedTimer) {
-      clearInterval(degradedTimer);
-      this._degradedPollTimers.delete(linkKey);
-    }
     const reconcileTimer = this._reconcileTimers.get(linkKey);
     if (reconcileTimer) {
       clearTimeout(reconcileTimer);
@@ -1369,13 +1363,11 @@ export class SyncEngineLevel implements SyncEngine {
 
   /**
    * Schedule a retry for a failed repair. Uses exponential backoff.
-   * No-op if the link is already in `degraded_poll` (timer loop owns retries)
-   * or if a retry is already scheduled.
+   * No-op if the link is terminal-incomplete or a retry is already scheduled.
    */
   private scheduleRepairRetry(linkKey: string): void {
-    // Don't schedule if already in degraded_poll or retry pending.
     const link = this._activeLinks.get(linkKey);
-    if (!link || link.status === 'degraded_poll') { return; }
+    if (!link || link.status === 'terminal_incomplete') { return; }
     if (this._repairRetryTimers.has(linkKey)) { return; }
 
     // attempts is already post-increment from doRepairLink, so subtract 1
@@ -1398,7 +1390,7 @@ export class SyncEngineLevel implements SyncEngine {
       try {
         await this.repairLink(linkKey);
       } catch {
-        // repairLink handles max attempts → degraded_poll internally.
+        // repairLink handles max attempts → terminal-incomplete internally.
         // If still below max, schedule another retry.
         if (currentLink.status === 'repairing') {
           this.scheduleRepairRetry(linkKey);
@@ -1420,13 +1412,10 @@ export class SyncEngineLevel implements SyncEngine {
     const promise = this.doRepairLink(linkKey).finally(() => {
       this._activeRepairs.delete(linkKey);
 
-      // Post-repair reconcile: if doRepairLink() marked needsReconcile
-      // (to close the gap between feed catch-up and new push subscription),
-      // schedule reconciliation NOW — after _activeRepairs is cleared so
-      // scheduleReconcile() won't skip it.
+      // Close the gap between feed catch-up and the reopened push subscription.
       const link = this._activeLinks.get(linkKey);
-      if (link?.needsReconcile && link.status === 'live') {
-        this.scheduleReconcile(linkKey, 500);
+      if (link?.status === 'live') {
+        this.scheduleLinkReconcile(linkKey, link, 'post-repair-gap', 500);
       }
     });
     this._activeRepairs.set(linkKey, promise);
@@ -1435,9 +1424,8 @@ export class SyncEngineLevel implements SyncEngine {
 
   /**
    * Internal repair implementation. Replays durable feed entries for a single
-   * link, then attempts to re-establish live
-   * subscriptions. If repair succeeds, transitions to `live`. If it fails,
-   * throws so callers (degraded_poll timer, startup) can handle retry scheduling.
+   * link, then attempts to re-establish live subscriptions. If repair succeeds,
+   * transitions to `live`. If it fails, throws so callers can retry.
    */
   private async doRepairLink(linkKey: string): Promise<void> {
     const link = this._activeLinks.get(linkKey);
@@ -1509,13 +1497,6 @@ export class SyncEngineLevel implements SyncEngine {
       if (this._engineGeneration !== generation || isStaleLink()) { return; }
 
       // Step 5: Reopen subscriptions.
-      // Mark needsReconcile BEFORE reopening — local push starts from "now",
-      // so any writes between durable feed replay (step 3) and the new push
-      // subscription are picked up by a short post-reopen reconcile.
-      link.needsReconcile = true;
-      await this.ledger.saveLink(link);
-      if (this._engineGeneration !== generation || isStaleLink()) { return; }
-
       const target = {
         did,
         dwnUrl,
@@ -1552,10 +1533,8 @@ export class SyncEngineLevel implements SyncEngine {
       }
       if (this._engineGeneration !== generation || isStaleLink()) { return; }
 
-      // Note: post-repair reconcile to close the repair-window gap is
-      // scheduled by repairLink() AFTER _activeRepairs is cleared — not
-      // here, because scheduleReconcile() would skip it while _activeRepairs
-      // still contains this link.
+      // Note: post-repair reconcile to close the repair-window gap is scheduled
+      // by repairLink() AFTER _activeRepairs is cleared.
 
       // Step 6: Clean up repair context and transition to live.
       this._repairContext.delete(linkKey);
@@ -1577,19 +1556,19 @@ export class SyncEngineLevel implements SyncEngine {
 
     } catch (error: any) {
       // If teardown occurred during repair or the link was replaced by a
-      // hot-remove + re-add, don't retry or enter degraded_poll.
+      // hot-remove + re-add, don't retry or terminalize the replacement link.
       if (this._engineGeneration !== generation || isStaleLink()) { return; }
 
       console.error(`SyncEngineLevel: Repair failed for ${did} -> ${dwnUrl} (attempt ${attempts})`, error);
       this.emitEvent({ type: 'repair:failed', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, attempt: attempts, error: String(error.message ?? error) });
 
       if (attempts >= SyncEngineLevel.MAX_REPAIR_ATTEMPTS) {
-        console.warn(`SyncEngineLevel: Max repair attempts reached for ${did} -> ${dwnUrl}, entering degraded_poll`);
-        await this.enterDegradedPoll(linkKey);
+        console.warn(`SyncEngineLevel: Max repair attempts reached for ${did} -> ${dwnUrl}, entering terminal_incomplete`);
+        await this.transitionToTerminalIncomplete(linkKey, link);
         return;
       }
 
-      // Re-throw so callers (degraded_poll timer) can handle retry scheduling.
+      // Re-throw so callers can handle retry scheduling.
       throw error;
     }
   }
@@ -1621,87 +1600,6 @@ export class SyncEngineLevel implements SyncEngine {
     this._localSubscriptions = this._localSubscriptions.filter(s => s !== pushSub);
   }
 
-  /**
-   * Transition a link to `degraded_poll` and start a per-link polling timer.
-   * The timer runs durable feed repair at a reduced frequency (30s with jitter)
-   * and attempts to re-establish live subscriptions after each successful repair.
-   */
-  private async enterDegradedPoll(linkKey: string): Promise<void> {
-    const link = this._activeLinks.get(linkKey);
-    if (!link) { return; }
-    link.connectivity = 'offline';
-
-    const prevDegradedStatus = link.status;
-    await this.ledger.setStatus(link, 'degraded_poll');
-    this._repairAttempts.delete(linkKey);
-    const eventScope = syncEventScope(link.scope);
-    this.emitEvent({ type: 'link:status-change', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope, from: prevDegradedStatus, to: 'degraded_poll' });
-    this.emitEvent({ type: 'degraded-poll:entered', tenantDid: link.tenantDid, remoteEndpoint: link.remoteEndpoint, ...eventScope });
-
-    // Clear any existing timer for this link.
-    const existing = this._degradedPollTimers.get(linkKey);
-    if (existing) { clearInterval(existing); }
-
-    // Schedule per-link polling with jitter (15-30 seconds).
-    // Rejection sampling: mask to 14 bits ([0, 16383]), reject >= 15000.
-    const baseInterval = 15_000;
-    const randomBuf = new Uint32Array(1);
-    let jitter: number;
-    do {
-      crypto.getRandomValues(randomBuf);
-      jitter = randomBuf[0] & 0x3FFF;
-    } while (jitter >= baseInterval);
-    const interval = baseInterval + jitter;
-
-    const pollGeneration = this._engineGeneration;
-    const timer = setInterval(async (): Promise<void> => {
-      // Bail if teardown occurred since this timer was created.
-      if (this._engineGeneration !== pollGeneration) {
-        clearInterval(timer);
-        this._degradedPollTimers.delete(linkKey);
-        return;
-      }
-
-      // Resolve the *current* link from _activeLinks on each tick, not the
-      // captured callback reference. After hot-remove + re-add, the captured
-      // `link` object is stale and must not be used for status checks or
-      // ledger writes.
-      const currentLink = this._activeLinks.get(linkKey);
-      if (currentLink?.status !== 'degraded_poll') {
-        clearInterval(timer);
-        this._degradedPollTimers.delete(linkKey);
-        return;
-      }
-
-      try {
-        // Attempt repair. Reset attempt counter so repairLink doesn't
-        // immediately re-enter degraded_poll on failure.
-        this._repairAttempts.set(linkKey, 0);
-        await this.ledger.setStatus(currentLink, 'repairing');
-        await this.repairLink(linkKey);
-
-        // If repairLink succeeded, link is now 'live' — stop polling.
-        if ((currentLink.status as string) === 'live') {
-          clearInterval(timer);
-          this._degradedPollTimers.delete(linkKey);
-        }
-      } catch {
-        // Repair failed — restore degraded_poll status so the timer continues.
-        // This is critical: repairLink sets status to 'repairing' internally,
-        // and if we don't restore degraded_poll, the next tick would see
-        // status !== 'degraded_poll' and stop the timer permanently.
-        if (this._activeLinks.get(linkKey) === currentLink) {
-          await this.ledger.setStatus(currentLink, 'degraded_poll');
-        }
-      }
-    }, interval);
-
-    this._degradedPollTimers.set(linkKey, timer);
-  }
-
-  /**
-   * Tears down all live subscriptions and push listeners.
-   */
   // ---------------------------------------------------------------------------
   // Browser connectivity: online/offline + visibilitychange
   // ---------------------------------------------------------------------------
@@ -1809,7 +1707,7 @@ export class SyncEngineLevel implements SyncEngine {
     this.stopBrowserConnectivityListeners();
 
     // Increment generation to invalidate all in-flight async operations
-    // (repairs, retry timers, degraded-poll ticks). Any async work that
+    // (repairs, retry timers). Any async work that
     // captured the previous generation will bail on its next checkpoint.
     this._engineGeneration++;
 
@@ -1841,11 +1739,7 @@ export class SyncEngineLevel implements SyncEngine {
     }
     this._localSubscriptions = [];
 
-    // Clear degraded-poll timers and repair state.
-    for (const timer of this._degradedPollTimers.values()) {
-      clearInterval(timer);
-    }
-    this._degradedPollTimers.clear();
+    // Clear repair state.
     this._repairAttempts.clear();
     this._activeRepairs.clear();
     for (const timer of this._repairRetryTimers.values()) {
@@ -1889,7 +1783,7 @@ export class SyncEngineLevel implements SyncEngine {
 
       const subscriptionResult = await this.openLinkSubscriptions({ ...target, linkKey });
       if (subscriptionResult === LinkSubscriptionOpenResult.ReadyForLive) {
-        await this.markLinkLive(target, link, linkKey);
+        await this.markLinkLive(target, link);
       } else if (subscriptionResult === LinkSubscriptionOpenResult.Polling) {
         await this.markLinkPolling(target, link);
       }
@@ -1931,7 +1825,7 @@ export class SyncEngineLevel implements SyncEngine {
     return LinkSubscriptionOpenResult.ReadyForLive;
   }
 
-  private async markLinkLive(target: SyncTarget, link: ReplicationLinkState, linkKey: string): Promise<void> {
+  private async markLinkLive(target: SyncTarget, link: ReplicationLinkState): Promise<void> {
     this.emitEvent({
       type           : 'link:status-change',
       tenantDid      : target.did,
@@ -1941,10 +1835,6 @@ export class SyncEngineLevel implements SyncEngine {
       to             : 'live'
     });
     await this.ledger.setStatus(link, 'live');
-
-    if (link.needsReconcile) {
-      this.scheduleReconcile(linkKey, 1000);
-    }
   }
 
   private async markLinkPolling(target: SyncTarget, link: ReplicationLinkState): Promise<void> {
@@ -2095,9 +1985,6 @@ export class SyncEngineLevel implements SyncEngine {
       }
     }
 
-    for (const [key, timer] of this._degradedPollTimers) {
-      if (this.isLinkKeyForDid(key, did)) { clearInterval(timer); this._degradedPollTimers.delete(key); }
-    }
     for (const key of this._repairAttempts.keys()) {
       if (this.isLinkKeyForDid(key, did)) { this._repairAttempts.delete(key); }
     }
@@ -2361,14 +2248,13 @@ export class SyncEngineLevel implements SyncEngine {
       await this.ledger.saveLink(link);
     }
 
-    this.markPullLinkOnline({ did, dwnUrl, eventScope, linkKey, link });
+    this.markPullLinkOnline({ did, dwnUrl, eventScope, link });
   }
 
-  private markPullLinkOnline({ did, dwnUrl, eventScope, linkKey, link }: {
+  private markPullLinkOnline({ did, dwnUrl, eventScope, link }: {
     did: string;
     dwnUrl: string;
     eventScope: SyncEventScope;
-    linkKey: string;
     link?: ReplicationLinkState;
   }): void {
     if (!link) {
@@ -2380,9 +2266,6 @@ export class SyncEngineLevel implements SyncEngine {
     link.connectivity = 'online';
     if (previous !== 'online') {
       this.emitEvent({ type: 'link:connectivity-change', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, from: previous, to: 'online' });
-    }
-    if (link.needsReconcile) {
-      this.scheduleReconcile(linkKey, 500);
     }
   }
 
@@ -2424,7 +2307,7 @@ export class SyncEngineLevel implements SyncEngine {
     { did, dwnUrl, linkKey, link, isStale }: LivePullContext,
     subMessage: Extract<SubscriptionMessage, { type: 'event' }>,
   ): Promise<boolean> {
-    // Guard: if the link is not live (e.g., repairing, degraded_poll, paused),
+    // Guard: if the link is not live (e.g., repairing, paused),
     // skip all processing. Old subscription handlers may still fire after the
     // link transitions — these events should be ignored entirely, not just
     // skipped at the checkpoint level.
@@ -2522,7 +2405,7 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     if (context.link !== undefined) {
-      this.markLinkNeedsReconcile(context.linkKey, context.link, `pull-${outcome.kind}`);
+      this.scheduleLinkReconcile(context.linkKey, context.link, `pull-${outcome.kind}`);
     }
     return { messageCid: rootCid, admitted: false };
   }
@@ -2617,7 +2500,7 @@ export class SyncEngineLevel implements SyncEngine {
       this.emitPullCheckpointAdvance(link);
     }
 
-    if (delivery.runtime.inflight.size > MAX_PENDING_TOKENS) {
+    if (delivery.runtime.inflight.size > MAX_IN_FLIGHT_PULL_DELIVERIES) {
       console.warn(`SyncEngineLevel: Pull in-flight overflow for ${did} -> ${dwnUrl}, transitioning to repairing`);
       await this.transitionToRepairing(linkKey, link);
     }
@@ -2682,7 +2565,6 @@ export class SyncEngineLevel implements SyncEngine {
     // not admission failures. Recording them as `admit-failed` would suppress
     // the root permanently during reconcile.
     if (link && !isStale()) {
-      this.markLinkNeedsReconcile(linkKey, link, 'pull-error');
       await this.transitionToRepairing(linkKey, link);
     }
   }
@@ -2732,7 +2614,7 @@ export class SyncEngineLevel implements SyncEngine {
           return;
         }
         if (scopeClassification === 'unknown') {
-          this.markLinkNeedsReconcile(pushLinkKey, pushLink, 'push-scope-unclassified');
+          this.scheduleLinkReconcile(pushLinkKey, pushLink, 'push-scope-unclassified');
           return;
         }
       }
@@ -2948,10 +2830,6 @@ export class SyncEngineLevel implements SyncEngine {
       this._pushRuntimes.delete(linkKey);
     }
 
-    const link = this._activeLinks.get(linkKey);
-    if (link?.status === 'live' && link.needsReconcile) {
-      this.scheduleReconcile(linkKey, 500);
-    }
   }
 
   private finishPushFlush(linkKey: string, pushRuntime: PushRuntimeState): void {
@@ -2999,9 +2877,8 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   /**
-   * Re-queues a failed push batch for retry, or marks the link
-   * `needsReconcile` if retries are exhausted. Bounded to prevent
-   * infinite retry loops.
+   * Re-queues a failed push batch for retry, or schedules a feed check when
+   * retries are exhausted. Bounded to prevent infinite retry loops.
    */
   private async requeueOrReconcile(targetKey: string, pending: {
     did: string; dwnUrl: string; delegateDid?: string; protocol?: string;
@@ -3019,13 +2896,13 @@ export class SyncEngineLevel implements SyncEngine {
     };
     if (pending.entries.length === 0) {
       this.stopPushRuntime(targetKey, pushRuntime);
-      this.markLinkNeedsReconcileIfActive(targetKey, link, 'push-terminal');
+      this.scheduleLinkReconcileIfActive(targetKey, link, 'push-terminal');
       return;
     }
 
     if (pending.entries.some(entry => entry.lastFailure !== undefined && isTenantInactivePushFailure(entry.lastFailure))) {
       this.stopPushRuntime(targetKey, pushRuntime);
-      this.markLinkNeedsReconcileIfActive(
+      this.scheduleLinkReconcileIfActive(
         targetKey,
         link,
         'push-tenant-inactive',
@@ -3036,7 +2913,7 @@ export class SyncEngineLevel implements SyncEngine {
 
     if (pending.retryCount >= maxRetries) {
       this.stopPushRuntime(targetKey, pushRuntime);
-      this.markLinkNeedsReconcileIfActive(targetKey, link, 'push-retry-exhausted');
+      this.scheduleLinkReconcileIfActive(targetKey, link, 'push-retry-exhausted');
       return;
     }
 
@@ -3116,7 +2993,6 @@ export class SyncEngineLevel implements SyncEngine {
     this._feedConvergenceFailures.set(linkKey, { attempts, signature });
 
     if (attempts >= SyncEngineLevel.MAX_FEED_CONVERGENCE_ATTEMPTS) {
-      link.needsReconcile = false;
       await this.transitionToTerminalIncomplete(linkKey, link);
       return;
     }
@@ -3178,7 +3054,7 @@ export class SyncEngineLevel implements SyncEngine {
     await this.ledger.saveLink(link);
 
     if (activeLink?.status === 'live') {
-      await this.persistLinkNeedsReconcile(linkKey, activeLink, reason, 0);
+      this.scheduleLinkReconcile(linkKey, activeLink, reason, 0);
     }
   }
 
@@ -3189,7 +3065,7 @@ export class SyncEngineLevel implements SyncEngine {
     this._pushRuntimes.delete(targetKey);
   }
 
-  private markLinkNeedsReconcileIfActive(
+  private scheduleLinkReconcileIfActive(
     linkKey: string,
     link: ReplicationLinkState | undefined,
     reason: string,
@@ -3199,7 +3075,7 @@ export class SyncEngineLevel implements SyncEngine {
       return;
     }
 
-    this.markLinkNeedsReconcile(linkKey, link, reason, delayMs);
+    this.scheduleLinkReconcile(linkKey, link, reason, delayMs);
   }
 
   private schedulePushRetry(targetKey: string, pushRuntime: PushRuntimeState, pending: {
@@ -3218,16 +3094,12 @@ export class SyncEngineLevel implements SyncEngine {
     }, delayMs);
   }
 
-  private markLinkNeedsReconcile(linkKey: string, link: ReplicationLinkState, reason: string, delayMs?: number): void {
-    void this.persistLinkNeedsReconcile(linkKey, link, reason, delayMs).catch((error: unknown) => {
-      console.error(`SyncEngineLevel: Failed to mark link for reconciliation ${link.tenantDid} -> ${link.remoteEndpoint}`, error);
-    });
-  }
+  private scheduleLinkReconcile(linkKey: string, link: ReplicationLinkState, reason: string, delayMs?: number): void {
+    if (link.status !== 'live') {
+      return;
+    }
 
-  private async persistLinkNeedsReconcile(linkKey: string, link: ReplicationLinkState, reason: string, delayMs?: number): Promise<void> {
-    if (!link.needsReconcile) {
-      link.needsReconcile = true;
-      await this.ledger.saveLink(link);
+    if (this.scheduleReconcile(linkKey, delayMs)) {
       this.emitEvent({
         type           : 'reconcile:needed',
         tenantDid      : link.tenantDid,
@@ -3236,8 +3108,6 @@ export class SyncEngineLevel implements SyncEngine {
         reason,
       });
     }
-
-    this.scheduleReconcile(linkKey, delayMs);
   }
 
   private getAuthorizationGrantIds(authorization: SyncAuthorization): NonEmptyStringArray | undefined {
@@ -4282,10 +4152,9 @@ export class SyncEngineLevel implements SyncEngine {
    * Schedule a per-link reconciliation after a short debounce. Coalesces
    * repeated requests for the same link.
    */
-  private scheduleReconcile(linkKey: string, delayMs: number = 1500): void {
-    if (this._reconcileTimers.has(linkKey)) { return; }
-    if (this._reconcileInFlight.has(linkKey)) { return; }
-    if (this._activeRepairs.has(linkKey)) { return; }
+  private scheduleReconcile(linkKey: string, delayMs: number = 1500): boolean {
+    if (this._reconcileTimers.has(linkKey)) { return false; }
+    if (this._activeRepairs.has(linkKey)) { return false; }
 
     const generation = this._engineGeneration;
     const timer = setTimeout((): void => {
@@ -4301,11 +4170,12 @@ export class SyncEngineLevel implements SyncEngine {
       });
     }, delayMs);
     this._reconcileTimers.set(linkKey, timer);
+    return true;
   }
 
   /**
    * Run durable feed reconciliation for a single link. Deduplicates concurrent calls.
-   * On success, clears `needsReconcile`. On failure, schedules retry.
+   * On success, emits completion. On failure, schedules retry.
    */
   private async reconcileLink(linkKey: string): Promise<void> {
     const existing = this._reconcileInFlight.get(linkKey);
@@ -4313,17 +4183,9 @@ export class SyncEngineLevel implements SyncEngine {
 
     const promise = this.doReconcileLink(linkKey).finally(() => {
       this._reconcileInFlight.delete(linkKey);
-      this.scheduleReconcileIfStillNeeded(linkKey, 5000);
     });
     this._reconcileInFlight.set(linkKey, promise);
     return promise;
-  }
-
-  private scheduleReconcileIfStillNeeded(linkKey: string, delayMs: number): void {
-    const link = this._activeLinks.get(linkKey);
-    if (link?.status === 'live' && link.needsReconcile) {
-      this.scheduleReconcile(linkKey, delayMs);
-    }
   }
 
   /**
@@ -4334,7 +4196,7 @@ export class SyncEngineLevel implements SyncEngine {
     const link = this._activeLinks.get(linkKey);
     if (!link) { return; }
 
-    // Only reconcile live links — repairing/degraded links have their own
+    // Only reconcile live links — repairing links have their own
     // recovery path.
     if (link.status !== 'live') {
       return;
@@ -4389,7 +4251,6 @@ export class SyncEngineLevel implements SyncEngine {
 
       if (reconcileOutcome.converged) {
         this._feedConvergenceFailures.delete(linkKey);
-        await this.ledger.clearNeedsReconcile(link);
         this.emitEvent({ type: 'reconcile:completed', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope });
       } else if (!isStaleLink()) {
         // Feed fingerprints still differ — retry after a delay. This can
@@ -4491,7 +4352,7 @@ export class SyncEngineLevel implements SyncEngine {
 
   /**
    * Reads missing messages from the local DWN and pushes them to the remote DWN
-   * in dependency order (topological sort).
+   * in dependency order.
    */
   private async pushMessages({ did, dwnUrl, delegateDid, permissionGrantIds, messageCids }: {
     did: string;
@@ -4505,20 +4366,6 @@ export class SyncEngineLevel implements SyncEngine {
       agent          : this.agent,
       permissionsApi : this._permissionsApi,
     });
-  }
-
-  // ---------------------------------------------------------------------------
-  // Dependency-aware topological sort — delegates to sync-topological-sort.ts
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Delegate to the standalone `topologicalSort` function.
-   * Tests call `SyncEngineLevel.topologicalSort(...)` so this static method must remain.
-   */
-  public static topologicalSort<T extends { message: GenericMessage }>(
-    messages: T[]
-  ): T[] {
-    return topologicalSort(messages);
   }
 
   // ---------------------------------------------------------------------------
@@ -4641,15 +4488,11 @@ export class SyncEngineLevel implements SyncEngine {
     // affect health. Endpoint-level orphan cleanup is a separate GC concern.
     const currentLinkIdentityKeys = await this.getCurrentDurableLinkIdentityKeys();
     let degradedLinkCount = 0;
-    let reconcileNeededCount = 0;
     const allLinks = await this.ledger.getAllLinks();
     for (const link of allLinks) {
       const isCurrentLink = currentLinkIdentityKeys === undefined || currentLinkIdentityKeys.has(this.getDurableLinkIdentityKey(link));
       if (isCurrentLink && SyncEngineLevel.isUnhealthyLinkStatus(link.status)) {
         degradedLinkCount++;
-      }
-      if (isCurrentLink && link.needsReconcile) {
-        reconcileNeededCount++;
       }
     }
 
@@ -4658,8 +4501,7 @@ export class SyncEngineLevel implements SyncEngine {
       failedMessageCount    : failedMessageCount,
       admissionFailureCount : admissionFailureCount,
       degradedLinkCount     : degradedLinkCount,
-      reconcileNeededCount  : reconcileNeededCount,
-      syncHealthy           : failedMessageCount === 0 && degradedLinkCount === 0 && reconcileNeededCount === 0,
+      syncHealthy           : failedMessageCount === 0 && degradedLinkCount === 0,
     };
   }
 
@@ -4698,7 +4540,7 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private static isUnhealthyLinkStatus(status: ReplicationLinkState['status']): boolean {
-    return status === 'repairing' || status === 'degraded_poll' || status === 'terminal_incomplete';
+    return status === 'repairing' || status === 'terminal_incomplete';
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -29,7 +29,7 @@ import { DwnInterface } from './types/dwn.js';
 import { DwnRpcError } from '@enbox/dwn-clients';
 import { isRecordsWrite } from './utils.js';
 import { toMessagesPermissionGrantIds } from './sync-permission-grants.js';
-import { getRoleKey, topologicalSort } from './sync-topological-sort.js';
+import { getRoleKey, orderMessagesForAdmission } from './sync-admission-order.js';
 
 /** Maximum data size (in bytes) to buffer in memory for retry. Larger payloads are re-fetched. */
 const MAX_BUFFER_SIZE = 1_048_576; // 1 MB
@@ -470,7 +470,7 @@ class RemoteApplyPushContext {
       rootEntries.push(...root.entries);
     }
 
-    for (const rootEntry of topologicalSort(rootEntries)) {
+    for (const rootEntry of orderMessagesForAdmission(rootEntries)) {
       const rootCid = await this.rememberEntry(rootEntry);
       if (failedByRoot.has(rootCid)) {
         continue;
@@ -492,7 +492,7 @@ class RemoteApplyPushContext {
     let pending = [rootEntry];
     for (let pass = 0; pass < MAX_PUSH_ADMISSION_PASSES && pending.length > 0; pass++) {
       const retry: SyncMessageEntry[] = [];
-      for (const entry of topologicalSort(pending)) {
+      for (const entry of orderMessagesForAdmission(pending)) {
         const result = await this.pushEntry(rootCid, entry);
         switch (result.kind) {
           case 'applied':

--- a/packages/agent/src/sync-replication-ledger.ts
+++ b/packages/agent/src/sync-replication-ledger.ts
@@ -98,7 +98,6 @@ export class ReplicationLedger {
       connectivity       : 'unknown',
       pull               : {},
       push               : {},
-      needsReconcile     : false,
       delegateDid        : params.delegateDid,
     };
 
@@ -227,28 +226,4 @@ export class ReplicationLedger {
     checkpoint.receivedToken = token;
   }
 
-  // ---------------------------------------------------------------------------
-  // Reconciliation helpers
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Mark a link as needing durable feed reconciliation and persist.
-   * Idempotent — no-op if already set.
-   */
-  public async markNeedsReconcile(link: ReplicationLinkState, _reason?: string): Promise<void> {
-    if (!link.needsReconcile) {
-      link.needsReconcile = true;
-      await this.saveLink(link);
-    }
-  }
-
-  /**
-   * Clear the reconciliation flag after successful durable feed reconciliation.
-   */
-  public async clearNeedsReconcile(link: ReplicationLinkState): Promise<void> {
-    if (link.needsReconcile) {
-      link.needsReconcile = false;
-      await this.saveLink(link);
-    }
-  }
 }

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -208,14 +208,6 @@ export async function computeAuthorizationEpoch(input:
 // ---------------------------------------------------------------------------
 
 /**
- * Maximum number of in-flight deliveries (runtime ordinals) a link may
- * accumulate before transitioning to `repairing`. This is the overflow
- * threshold for the engine's in-memory delivery tracker, not for durable
- * checkpoint state. Normative per the sync redesign RFC.
- */
-export const MAX_PENDING_TOKENS = 100;
-
-/**
  * Tracks directional (pull or push) replay progression for a single
  * replication link. All tokens belong to the same `(streamId, epoch)`.
  *
@@ -250,11 +242,10 @@ export type DirectionCheckpoint = {
  * - `live` — actively receiving events via subscription.
  * - `polling` — current link is reconciled by periodic durable feed sync; live subscription is not supported for its scope.
  * - `repairing` — gap detected or pending overflow; running durable feed repair.
- * - `degraded_poll` — subscription failed; polling at reduced frequency.
  * - `terminal_incomplete` — admission failed with a terminal dependency error; requires a new scope/authorization epoch.
  * - `paused` — explicitly paused by the application.
  */
-export type LinkStatus = 'initializing' | 'live' | 'polling' | 'repairing' | 'degraded_poll' | 'terminal_incomplete' | 'paused';
+export type LinkStatus = 'initializing' | 'live' | 'polling' | 'repairing' | 'terminal_incomplete' | 'paused';
 
 /**
  * Durable state of a single replication link. Persisted to LevelDB and
@@ -288,14 +279,6 @@ export type ReplicationLinkState = {
 
   /** Push-direction replication checkpoint (local → remote). */
   push: DirectionCheckpoint;
-
-  /**
-   * Whether this link needs durable feed reconciliation. Set when push fails after
-   * retry exhaustion, when the link reconnects after an outage, or when
-   * the remote epoch changes. Cleared after successful reconciliation.
-   * Persisted so recovery survives app/browser restart.
-   */
-  needsReconcile?: boolean;
 
   /** Per-link connectivity state. Used to compute the aggregate engine-level state. */
   connectivity: SyncConnectivityState;
@@ -416,7 +399,6 @@ export type SyncEvent =
   | SyncEventBase & { type: 'repair:started'; attempt: number }
   | SyncEventBase & { type: 'repair:completed' }
   | SyncEventBase & { type: 'repair:failed'; attempt: number; error: string }
-  | SyncEventBase & { type: 'degraded-poll:entered' }
   | SyncEventBase & { type: 'gap:detected'; reason: string };
 
 export type SyncEventListener = (event: SyncEvent) => void;
@@ -469,11 +451,9 @@ export type SyncHealthSummary = {
    * to callers.
    */
   admissionFailureCount: number;
-  /** Number of current sync links in 'repairing', 'degraded_poll', or terminal-incomplete status. */
+  /** Number of current sync links in `repairing` or `terminal_incomplete` status. */
   degradedLinkCount: number;
-  /** Number of current sync links waiting for reconciliation. */
-  reconcileNeededCount: number;
-  /** True only when there are no failed messages, degraded links, or pending reconciliations. */
+  /** True only when there are no failed messages or degraded links. */
   syncHealthy: boolean;
 };
 
@@ -555,7 +535,7 @@ export interface SyncEngine {
   /**
    * Subscribe to sync engine events. Returns an unsubscribe function.
    * Events are emitted at key state transitions: checkpoint advancement,
-   * link status changes, repair, degraded_poll, gap detection.
+   * link status changes, repair, gap detection.
    */
   on(listener: SyncEventListener): () => void;
 

--- a/packages/agent/tests/sync-admission-order.spec.ts
+++ b/packages/agent/tests/sync-admission-order.spec.ts
@@ -3,7 +3,7 @@ import type { GenericMessage } from '@enbox/dwn-sdk-js';
 import { describe, expect, it } from 'bun:test';
 import { DwnInterfaceName, DwnMethodName, PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
-import { topologicalSort } from '../src/sync-topological-sort.js';
+import { orderMessagesForAdmission } from '../src/sync-admission-order.js';
 
 type SortEntry = { message: GenericMessage };
 
@@ -36,15 +36,15 @@ function makeAuthorizedMessage(
   } as unknown as GenericMessage;
 }
 
-describe('topologicalSort', () => {
+describe('orderMessagesForAdmission', () => {
   it('should return empty array for empty input', () => {
-    const result = topologicalSort([]);
+    const result = orderMessagesForAdmission([]);
     expect(result).toEqual([]);
   });
 
   it('should return single-element array unchanged', () => {
     const msg: SortEntry = { message: makeMessage() };
-    const result = topologicalSort([msg]);
+    const result = orderMessagesForAdmission([msg]);
     expect(result).toEqual([msg]);
   });
 
@@ -67,7 +67,7 @@ describe('topologicalSort', () => {
     };
 
     // Input order: records first, protocol second — sort should reverse.
-    const result = topologicalSort([recordsWriteMsg, configureMsg]);
+    const result = orderMessagesForAdmission([recordsWriteMsg, configureMsg]);
     expect(result[0]).toBe(configureMsg);
     expect(result[1]).toBe(recordsWriteMsg);
   });
@@ -104,7 +104,7 @@ describe('topologicalSort', () => {
       } as unknown as GenericMessage,
     };
 
-    const result = topologicalSort([profileRecord, profileConfigure, socialConfigure]);
+    const result = orderMessagesForAdmission([profileRecord, profileConfigure, socialConfigure]);
     expect(result[0]).toBe(socialConfigure);
     expect(result[1]).toBe(profileConfigure);
     expect(result[2]).toBe(profileRecord);
@@ -130,7 +130,7 @@ describe('topologicalSort', () => {
       } as unknown as GenericMessage,
     };
 
-    const result = topologicalSort([updateWrite, initialWrite]);
+    const result = orderMessagesForAdmission([updateWrite, initialWrite]);
     expect(result[0]).toBe(initialWrite);
     expect(result[1]).toBe(updateWrite);
   });
@@ -156,7 +156,7 @@ describe('topologicalSort', () => {
       } as unknown as GenericMessage,
     };
 
-    const result = topologicalSort([child, parent]);
+    const result = orderMessagesForAdmission([child, parent]);
     expect(result[0]).toBe(parent);
     expect(result[1]).toBe(child);
   });
@@ -179,7 +179,7 @@ describe('topologicalSort', () => {
       }),
     };
 
-    const result = topologicalSort([deleteMsg, initialWrite]);
+    const result = orderMessagesForAdmission([deleteMsg, initialWrite]);
     expect(result[0]).toBe(initialWrite);
     expect(result[1]).toBe(deleteMsg);
   });
@@ -203,7 +203,7 @@ describe('topologicalSort', () => {
       ),
     };
 
-    const result = topologicalSort([dependentMsg, grantMsg]);
+    const result = orderMessagesForAdmission([dependentMsg, grantMsg]);
     expect(result[0]).toBe(grantMsg);
     expect(result[1]).toBe(dependentMsg);
   });
@@ -231,7 +231,7 @@ describe('topologicalSort', () => {
       ),
     };
 
-    const result = topologicalSort([dependentMsg, grantMsg]);
+    const result = orderMessagesForAdmission([dependentMsg, grantMsg]);
     expect(result[0]).toBe(grantMsg);
     expect(result[1]).toBe(dependentMsg);
   });
@@ -267,7 +267,7 @@ describe('topologicalSort', () => {
       } as unknown as GenericMessage,
     };
 
-    const result = topologicalSort([dependentMsg, roleMsg]);
+    const result = orderMessagesForAdmission([dependentMsg, roleMsg]);
     expect(result[0]).toBe(roleMsg);
     expect(result[1]).toBe(dependentMsg);
   });
@@ -320,7 +320,7 @@ describe('topologicalSort', () => {
       } as unknown as GenericMessage,
     };
 
-    const result = topologicalSort([dependentMsg, otherRole, matchingRole]);
+    const result = orderMessagesForAdmission([dependentMsg, otherRole, matchingRole]);
     expect(result.indexOf(matchingRole)).toBeLessThan(result.indexOf(dependentMsg));
     expect(result.includes(otherRole)).toBe(true);
   });
@@ -338,7 +338,7 @@ describe('topologicalSort', () => {
       } as unknown as GenericMessage,
     };
 
-    const result = topologicalSort([selfRef]);
+    const result = orderMessagesForAdmission([selfRef]);
     expect(result.length).toBe(1);
     expect(result[0]).toBe(selfRef);
   });
@@ -379,7 +379,7 @@ describe('topologicalSort', () => {
       } as unknown as GenericMessage,
     };
 
-    const result = topologicalSort([msgA, msgB, independent]);
+    const result = orderMessagesForAdmission([msgA, msgB, independent]);
     // The independent node should be first; the cycle nodes appended at the end.
     expect(result.length).toBe(3);
     expect(result[0]).toBe(independent);
@@ -393,7 +393,7 @@ describe('topologicalSort', () => {
     const msg2: SortEntry = { message: makeMessage({ interface: DwnInterfaceName.Protocols, method: DwnMethodName.Query }) };
     const msg3: SortEntry = { message: makeMessage({ interface: DwnInterfaceName.Protocols, method: DwnMethodName.Query }) };
 
-    const result = topologicalSort([msg1, msg2, msg3]);
+    const result = orderMessagesForAdmission([msg1, msg2, msg3]);
     expect(result.length).toBe(3);
   });
 });

--- a/packages/agent/tests/sync-characterization.spec.ts
+++ b/packages/agent/tests/sync-characterization.spec.ts
@@ -76,7 +76,6 @@ describe('SyncEngineLevel — characterization tests', () => {
     status             : 'initializing',
     pull               : {},
     connectivity       : 'unknown',
-    needsReconcile     : false,
     ...overrides,
   });
 
@@ -165,36 +164,6 @@ describe('SyncEngineLevel — characterization tests', () => {
     expect((engine as any)._pushRuntimes.size).toBe(0);
   });
 
-  it('schedules reconciliation on startup when a link is already marked needsReconcile', async () => {
-    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
-    const { agent } = createLiveMockAgent();
-    const engine = new SyncEngineLevel({ db, agent });
-
-    const link = makeLink({ needsReconcile: true });
-
-    sinon.stub(engine, 'sync').resolves();
-    sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
-    sinon.stub(engine as any, 'openLivePullSubscription').resolves();
-    sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
-    const reconcileStub = sinon.stub(engine as any, 'reconcileLink').resolves();
-    (engine as any)._ledger = {
-      getOrCreateLink : sinon.stub().resolves(link),
-      setStatus       : sinon.stub().callsFake(async (l: any, status: string): Promise<void> => {
-        l.status = status;
-      }),
-      saveLink: sinon.stub().resolves(),
-    };
-
-    await engine.startSync({ mode: 'live', interval: '30s' });
-    await clock.tickAsync(1_000);
-
-    expect(reconcileStub.calledOnce).toBe(true);
-    expect(reconcileStub.firstCall.args[0]).toBe(linkKey);
-
-    await engine.stopSync();
-    clock.restore();
-  });
-
   it('routes ProgressGap startup failures into repair using projection authorization link identity', async () => {
     const { agent } = createLiveMockAgent();
     const engine = new SyncEngineLevel({ db, agent });
@@ -221,39 +190,4 @@ describe('SyncEngineLevel — characterization tests', () => {
     expect(transitionStub.firstCall.args[1]).toBe(link);
   });
 
-  it('schedules reconciliation when EOSE arrives for a live dirty link', async () => {
-    const { agent, getRemoteHandler } = createLiveMockAgent();
-    const engine = new SyncEngineLevel({ db, agent });
-
-    const link = makeLink({ status: 'live', needsReconcile: true });
-
-    const saveLinkStub = sinon.stub().resolves();
-    sinon.stub(engine as any, 'scheduleReconcile').callsFake((): void => {});
-    sinon.stub(engine, 'sync').resolves();
-    sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
-    sinon.stub(engine as any, 'openLocalPushSubscription').resolves();
-    (engine as any)._ledger = {
-      getOrCreateLink : sinon.stub().resolves(link),
-      saveLink        : saveLinkStub,
-      setStatus       : sinon.stub().callsFake(async (l: any, status: string): Promise<void> => {
-        l.status = status;
-      }),
-    };
-
-    await engine.startSync({ mode: 'live', interval: '30s' });
-
-    const handler = getRemoteHandler();
-    expect(handler).toBeDefined();
-
-    await handler!({
-      type   : 'eose',
-      cursor : { streamId: 's1', epoch: 'e1', position: '5', messageCid: 'cid-5' },
-    });
-
-    expect((engine as any).scheduleReconcile.called).toBe(true);
-    expect((engine as any).scheduleReconcile.lastCall.args[0]).toBe(linkKey);
-    expect((engine as any).scheduleReconcile.lastCall.args[1]).toBe(500);
-
-    await engine.stopSync();
-  });
 });

--- a/packages/agent/tests/sync-engine-identity.spec.ts
+++ b/packages/agent/tests/sync-engine-identity.spec.ts
@@ -384,14 +384,6 @@ describe('SyncEngineLevel — identity management', () => {
     });
   });
 
-  describe('topologicalSort (static)', () => {
-    it('should delegate to the standalone topologicalSort function', () => {
-      const messages = [{ message: { descriptor: { interface: 'Records', method: 'Write' } } }];
-      const result = SyncEngineLevel.topologicalSort(messages as any);
-      expect(result).toEqual(messages);
-    });
-  });
-
   describe('stopSync', () => {
     it('should stop when there is no sync in progress', async () => {
       const engine = new SyncEngineLevel({ db });
@@ -599,24 +591,6 @@ describe('SyncEngineLevel — identity management', () => {
       clearTimeout(bobTimer);
     });
 
-    it('removeIdentityFromLiveSync should clear degraded-poll timers for the target DID', async () => {
-      const engine = new SyncEngineLevel({ db });
-      (engine as any)._liveSubscriptions = [];
-      (engine as any)._localSubscriptions = [];
-
-      const aliceTimer = setInterval(() => {}, 60_000);
-      const bobTimer = setInterval(() => {}, 60_000);
-      (engine as any)._degradedPollTimers.set('did:example:alice^https://dwn.example.com^scope1', aliceTimer);
-      (engine as any)._degradedPollTimers.set('did:example:bob^https://dwn.example.com^scope2', bobTimer);
-
-      await (engine as any).removeIdentityFromLiveSync('did:example:alice');
-
-      expect((engine as any)._degradedPollTimers.has('did:example:alice^https://dwn.example.com^scope1')).toBe(false);
-      expect((engine as any)._degradedPollTimers.has('did:example:bob^https://dwn.example.com^scope2')).toBe(true);
-
-      clearInterval(bobTimer);
-    });
-
     it('removeIdentityFromLiveSync should clear repair attempts and retry timers for the target DID', async () => {
       const engine = new SyncEngineLevel({ db });
       (engine as any)._liveSubscriptions = [];
@@ -756,7 +730,6 @@ describe('SyncEngineLevel — identity management', () => {
         status             : 'initializing',
         pull               : {},
         connectivity       : 'unknown',
-        needsReconcile     : false,
       }));
       sinon.stub(engine as any, 'ledger').get(() => ({
         getOrCreateLink : ledgerStub,
@@ -795,7 +768,6 @@ describe('SyncEngineLevel — identity management', () => {
         status             : 'initializing',
         pull               : {},
         connectivity       : 'unknown',
-        needsReconcile     : false,
       }));
       sinon.stub(engine as any, 'ledger').get(() => ({
         getOrCreateLink : ledgerStub,
@@ -829,7 +801,6 @@ describe('SyncEngineLevel — identity management', () => {
           status             : 'initializing',
           pull               : {},
           connectivity       : 'unknown',
-          needsReconcile     : false,
         })),
         saveLink  : sinon.stub().resolves(),
         setStatus : sinon.stub().resolves(),

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -1,6 +1,6 @@
 import type { BearerIdentity } from '../src/bearer-identity.js';
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
 import type { SyncIdentityOptions } from '../src/index.js';
-import type { GenericMessage, ProtocolDefinition } from '@enbox/dwn-sdk-js';
 
 import sinon from 'sinon';
 
@@ -8,7 +8,7 @@ import { AbstractLevel } from 'abstract-level';
 import { Convert } from '@enbox/common';
 import { CryptoUtils } from '@enbox/crypto';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { DwnConstant, DwnInterfaceName, DwnMethodName, Jws, Message, PermissionsProtocol, Time } from '@enbox/dwn-sdk-js';
+import { DwnConstant, DwnInterfaceName, DwnMethodName, Jws, Message, Time } from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from '../src/types/dwn.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
@@ -3181,7 +3181,6 @@ describe('SyncEngineLevel', () => {
           });
           const linkKey = linkKeyFor(did, testDwnUrls[0], originalLink);
           originalLink.status = 'live';
-          originalLink.needsReconcile = true;
           syncEngine['_activeLinks'].set(linkKey, originalLink);
 
           // Stub the feed reconcile path to capture the shouldContinue callback.
@@ -3202,9 +3201,8 @@ describe('SyncEngineLevel', () => {
           await syncEngine['doReconcileLink'](linkKey);
 
           expect(capturedShouldContinue).toBeDefined();
-          // The old reconcile aborted — needsReconcile was NOT cleared.
           const currentLink = syncEngine['_activeLinks'].get(linkKey)!;
-          expect(currentLink.needsReconcile).toBe(true);
+          expect(currentLink).not.toBe(originalLink);
         });
 
         it('should bail old repair when the same link key is re-added during in-flight repair', async () => {
@@ -3248,241 +3246,6 @@ describe('SyncEngineLevel', () => {
           expect(syncEngine['_activeLinks'].get(linkKey)).not.toBe(link);
         });
       });
-    });
-  });
-
-  describe('topologicalSort', () => {
-    // Helper to create a minimal mock GenericMessage with the given descriptor fields.
-    function mockMessage(
-      overrides: Record<string, unknown>,
-      topLevel?: Record<string, unknown>
-    ): { message: GenericMessage } {
-      const descriptor = {
-        interface        : DwnInterfaceName.Records,
-        method           : DwnMethodName.Write,
-        messageTimestamp : Time.getCurrentTimestamp(),
-        ...overrides,
-      };
-      return {
-        message: { descriptor, ...topLevel } as unknown as GenericMessage,
-      };
-    }
-
-    function withAuthorizationPayload(
-      entry: { message: GenericMessage },
-      payloadProperties: Record<string, unknown>,
-      author = 'did:example:alice'
-    ): { message: GenericMessage } {
-      const payload = Buffer.from(JSON.stringify(payloadProperties)).toString('base64url');
-      const protectedHeader = Buffer.from(JSON.stringify({ alg: 'EdDSA', kid: `${author}#key-1` })).toString('base64url');
-      return {
-        ...entry,
-        message: {
-          ...entry.message,
-          authorization: {
-            signature: {
-              payload,
-              signatures: [{ protected: protectedHeader, signature: 'fake' }],
-            },
-          },
-        } as unknown as GenericMessage,
-      };
-    }
-
-    it('returns messages unchanged when there is only one message', () => {
-      const msg = mockMessage({});
-      const result = SyncEngineLevel.topologicalSort([msg]);
-      expect(result).toHaveLength(1);
-      expect(result[0]).toBe(msg);
-    });
-
-    it('sorts ProtocolsConfigure before RecordsWrite that references the protocol', () => {
-      const protocolUrl = 'https://example.com/proto';
-      const recordsWrite = mockMessage(
-        { protocol: protocolUrl },
-        { recordId: 'rec-1' }
-      );
-      const protocolsConfigure = mockMessage({
-        interface  : DwnInterfaceName.Protocols,
-        method     : DwnMethodName.Configure,
-        definition : { protocol: protocolUrl },
-      });
-      // Pass in reverse order: records first, protocol second.
-      const result = SyncEngineLevel.topologicalSort([recordsWrite, protocolsConfigure]);
-      expect(result[0]).toBe(protocolsConfigure);
-      expect(result[1]).toBe(recordsWrite);
-    });
-
-    it('sorts initial write before update write for the same recordId', () => {
-      const ts1 = '2024-01-01T00:00:00.000000Z';
-      const ts2 = '2024-01-02T00:00:00.000000Z';
-      const update = mockMessage(
-        { dateCreated: ts1, messageTimestamp: ts2 },
-        { recordId: 'rec-1' }
-      );
-      const initial = mockMessage(
-        { dateCreated: ts1, messageTimestamp: ts1 },
-        { recordId: 'rec-1' }
-      );
-      // Pass update first.
-      const result = SyncEngineLevel.topologicalSort([update, initial]);
-      expect(result[0]).toBe(initial);
-      expect(result[1]).toBe(update);
-    });
-
-    it('sorts permission grant before a message that references it via permissionGrantId', () => {
-      const grantRecordId = 'grant-record-1';
-      const grant = mockMessage(
-        {
-          protocol         : PermissionsProtocol.uri,
-          protocolPath     : PermissionsProtocol.grantPath,
-          dateCreated      : '2024-01-01T00:00:00.000000Z',
-          messageTimestamp : '2024-01-01T00:00:00.000000Z',
-        },
-        { recordId: grantRecordId }
-      );
-      const dependent = withAuthorizationPayload(
-        mockMessage({
-          permissionGrantId : grantRecordId,
-          messageTimestamp  : '2024-01-02T00:00:00.000000Z',
-        }),
-        { permissionGrantId: grantRecordId }
-      );
-      // Pass dependent first, grant second.
-      const result = SyncEngineLevel.topologicalSort([dependent, grant]);
-      expect(result[0]).toBe(grant);
-      expect(result[1]).toBe(dependent);
-    });
-
-    it('does not crash when permissionGrantId references a grant not in the batch', () => {
-      const msg1 = mockMessage({ messageTimestamp: '2024-01-01T00:00:00.000000Z' });
-      const msg2 = withAuthorizationPayload(
-        mockMessage({
-          permissionGrantId : 'grant-not-in-batch',
-          messageTimestamp  : '2024-01-02T00:00:00.000000Z',
-        }),
-        { permissionGrantId: 'grant-not-in-batch' }
-      );
-      // Should not throw; no edge is added because the grant is not in the batch.
-      const result = SyncEngineLevel.topologicalSort([msg1, msg2]);
-      expect(result).toHaveLength(2);
-    });
-
-    it('handles combined protocol, parent, and grant dependencies', () => {
-      const protocolUrl = 'https://example.com/proto';
-      const grantRecordId = 'grant-1';
-      const parentRecordId = 'parent-1';
-
-      const protocolsConfigure = mockMessage({
-        interface        : DwnInterfaceName.Protocols,
-        method           : DwnMethodName.Configure,
-        definition       : { protocol: protocolUrl },
-        messageTimestamp : '2024-01-01T00:00:00.000000Z',
-      });
-      const grant = mockMessage(
-        {
-          protocol         : PermissionsProtocol.uri,
-          protocolPath     : PermissionsProtocol.grantPath,
-          dateCreated      : '2024-01-01T00:00:00.000000Z',
-          messageTimestamp : '2024-01-01T00:00:00.000000Z',
-        },
-        { recordId: grantRecordId }
-      );
-      const parent = mockMessage(
-        {
-          protocol         : protocolUrl,
-          dateCreated      : '2024-01-02T00:00:00.000000Z',
-          messageTimestamp : '2024-01-02T00:00:00.000000Z',
-        },
-        { recordId: parentRecordId }
-      );
-      const child = withAuthorizationPayload(
-        mockMessage(
-          {
-            protocol          : protocolUrl,
-            parentId          : parentRecordId,
-            permissionGrantId : grantRecordId,
-            dateCreated       : '2024-01-03T00:00:00.000000Z',
-            messageTimestamp  : '2024-01-03T00:00:00.000000Z',
-          },
-          { recordId: 'child-1' }
-        ),
-        { permissionGrantId: grantRecordId }
-      );
-
-      // Pass in reverse dependency order.
-      const result = SyncEngineLevel.topologicalSort([child, parent, grant, protocolsConfigure]);
-
-      // ProtocolsConfigure must come before parent and child (both reference the protocol).
-      const configIdx = result.indexOf(protocolsConfigure);
-      const parentIdx = result.indexOf(parent);
-      const childIdx = result.indexOf(child);
-      const grantIdx = result.indexOf(grant);
-
-      expect(configIdx).toBeLessThan(parentIdx);
-      expect(configIdx).toBeLessThan(childIdx);
-      expect(parentIdx).toBeLessThan(childIdx);
-      expect(grantIdx).toBeLessThan(childIdx);
-    });
-
-    it('preserves extra properties on message entries through the sort', () => {
-      const protocolUrl = 'https://example.com/proto';
-      const dataBytes = new Uint8Array([1, 2, 3]);
-      const recordsWrite = {
-        ...mockMessage(
-          { protocol: protocolUrl },
-          { recordId: 'rec-1' }
-        ),
-        dataBytes,
-      };
-      const protocolsConfigure = {
-        ...mockMessage({
-          interface  : DwnInterfaceName.Protocols,
-          method     : DwnMethodName.Configure,
-          definition : { protocol: protocolUrl },
-        }),
-      };
-      // Pass in reverse order: records first, protocol second.
-      const result = SyncEngineLevel.topologicalSort([recordsWrite, protocolsConfigure]);
-      expect(result[0]).toBe(protocolsConfigure);
-      expect(result[1]).toBe(recordsWrite);
-      // Verify the dataBytes property survived the sort.
-      expect((result[1] as typeof recordsWrite).dataBytes).toBe(dataBytes);
-    });
-
-    it('sorts RecordsDelete after ProtocolsConfigure for the same protocol', () => {
-      const protocolUrl = 'https://example.com/proto';
-      const recordId = 'rec-1';
-      const ts = '2024-01-01T00:00:00.000000Z';
-      const initialWrite = mockMessage(
-        {
-          protocol         : protocolUrl,
-          dateCreated      : ts,
-          messageTimestamp : ts,
-        },
-        { recordId }
-      );
-      // RecordsDelete has recordId in the descriptor (accessed via msg.descriptor.recordId).
-      const deleteMsg = mockMessage({
-        interface        : DwnInterfaceName.Records,
-        method           : DwnMethodName.Delete,
-        protocol         : protocolUrl,
-        recordId,
-        messageTimestamp : '2024-01-02T00:00:00.000000Z',
-      });
-      // Delete depends on initial write (not directly on ProtocolsConfigure,
-      // but the initial write depends on ProtocolsConfigure).
-      const protocolsConfigure = mockMessage({
-        interface  : DwnInterfaceName.Protocols,
-        method     : DwnMethodName.Configure,
-        definition : { protocol: protocolUrl },
-      });
-      const result = SyncEngineLevel.topologicalSort([deleteMsg, initialWrite, protocolsConfigure]);
-      const configIdx = result.indexOf(protocolsConfigure);
-      const writeIdx = result.indexOf(initialWrite);
-      const deleteIdx = result.indexOf(deleteMsg);
-      expect(configIdx).toBeLessThan(writeIdx);
-      expect(writeIdx).toBeLessThan(deleteIdx);
     });
   });
 

--- a/packages/agent/tests/sync-engine-private.spec.ts
+++ b/packages/agent/tests/sync-engine-private.spec.ts
@@ -99,8 +99,8 @@ describe('SyncEngineLevel — private methods', () => {
   // Track every SyncEngineLevel created in this suite so `afterEach` can
   // clear any pending timers before the next test (and before `afterAll`
   // closes the shared Level DB). Tests that exercise code paths which
-  // schedule setTimeout/setInterval callbacks (repair retries, reconcile,
-  // degraded polling, push debounces) would otherwise let those callbacks
+  // schedule setTimeout callbacks (repair retries, reconcile,
+  // push debounces) would otherwise let those callbacks
   // fire after teardown, triggering unhandled `LEVEL_DATABASE_NOT_OPEN`
   // rejections when `ledger.saveLink()` hits the closed DB.
   const createdEngines: SyncEngineLevel[] = [];
@@ -165,11 +165,6 @@ describe('SyncEngineLevel — private methods', () => {
     }
     repairRetryTimers.clear();
 
-    const degradedPollTimers = (engine as any)._degradedPollTimers as Map<string, ReturnType<typeof setInterval>>;
-    for (const timer of degradedPollTimers.values()) {
-      clearInterval(timer);
-    }
-    degradedPollTimers.clear();
   };
 
   beforeAll(async () => {
@@ -2094,7 +2089,7 @@ describe('SyncEngineLevel — private methods', () => {
       })).toBe(false);
     });
 
-    it('should reset feed checkpoints and mark a live link for reconcile when verified fingerprints diverge', async () => {
+    it('should reset feed checkpoints and schedule a live link for reconcile when verified fingerprints diverge', async () => {
       const mockAgent = { agentDid: 'did:example:agent', did: { dereference: sinon.stub() } } as any;
       const engine = createEngine({ db, agent: mockAgent });
       const target = syncTarget('did:example:1', 'https://dwn.example.com');
@@ -2109,7 +2104,6 @@ describe('SyncEngineLevel — private methods', () => {
       link.status = 'live';
       link.pull = { contiguousAppliedToken: token, receivedToken: token };
       link.push = { contiguousAppliedToken: token, receivedToken: token };
-      link.needsReconcile = false;
       (engine as any)._activeLinks.set(linkKey, link);
       sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
       ((engine as any).verifyFeedConvergence).resolves({
@@ -2126,7 +2120,6 @@ describe('SyncEngineLevel — private methods', () => {
       expect(link.pull.receivedToken).toBeUndefined();
       expect(link.push.contiguousAppliedToken).toBeUndefined();
       expect(link.push.receivedToken).toBeUndefined();
-      expect(link.needsReconcile).toBe(true);
       expect(scheduleStub.calledOnceWith(linkKey, 0)).toBe(true);
     });
 
@@ -2145,7 +2138,6 @@ describe('SyncEngineLevel — private methods', () => {
       link.status = 'live';
       link.pull = { contiguousAppliedToken: token, receivedToken: token };
       link.push = { contiguousAppliedToken: token, receivedToken: token };
-      link.needsReconcile = false;
       await (engine as any).ledger.saveLink(link);
       (engine as any)._activeLinks.set(linkKey, link);
       sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
@@ -2165,7 +2157,6 @@ describe('SyncEngineLevel — private methods', () => {
 
       const [finalLink] = await (engine as any).ledger.getLinksForTenant(target.did);
       expect(finalLink.status).toBe('terminal_incomplete');
-      expect(finalLink.needsReconcile).toBe(false);
       expect(scheduleStub.callCount).toBe(2);
       expect(events.some(event =>
         event.type === 'link:status-change' &&
@@ -2190,7 +2181,6 @@ describe('SyncEngineLevel — private methods', () => {
       link.status = 'live';
       link.pull = { contiguousAppliedToken: token, receivedToken: token };
       link.push = { contiguousAppliedToken: token, receivedToken: token };
-      link.needsReconcile = false;
       (engine as any)._activeLinks.set(linkKey, link);
       const localFingerprint = await fingerprintFromCids(['cid-terminal']);
       const remoteFingerprint = await fingerprintFromCids([]);
@@ -2220,7 +2210,6 @@ describe('SyncEngineLevel — private methods', () => {
       expect(link.pull.receivedToken).toBeUndefined();
       expect(link.push.contiguousAppliedToken).toBeUndefined();
       expect(link.push.receivedToken).toBeUndefined();
-      expect(link.needsReconcile).toBe(true);
       expect(scheduleStub.calledOnceWith(linkKey, 0)).toBe(true);
     });
 
@@ -2321,7 +2310,6 @@ describe('SyncEngineLevel — private methods', () => {
       const linkKey = (engine as any).getReplicationLinkKey(target, link);
       link.status = 'live';
       link.pull = { contiguousAppliedToken: pullCursor, receivedToken: pullCursor };
-      link.needsReconcile = false;
       await (engine as any).ledger.saveLink(link);
       (engine as any)._activeLinks.set(linkKey, link);
 
@@ -2342,7 +2330,6 @@ describe('SyncEngineLevel — private methods', () => {
       expect(finalLink.pull.receivedToken).toBeUndefined();
       expect(finalLink.push.contiguousAppliedToken).toEqual(pushCursor);
       expect(finalLink.push.receivedToken).toEqual(pushCursor);
-      expect(finalLink.needsReconcile).toBe(false);
       expect(pushMessagesStub.calledOnce).toBe(true);
       expect(feedQueriesFromStart).toBe(feedQueriesAtTerminal);
       expect(scheduleStub.callCount).toBe(2);
@@ -2383,7 +2370,6 @@ describe('SyncEngineLevel — private methods', () => {
       link.status = 'live';
       link.pull = { contiguousAppliedToken: token, receivedToken: token };
       link.push = { contiguousAppliedToken: token, receivedToken: token };
-      link.needsReconcile = false;
       await (engine as any).ledger.saveLink(link);
       (engine as any)._activeLinks.set(linkKey, link);
       sinon.stub(engine as any, 'getSyncTargets').resolves([target]);
@@ -2401,7 +2387,6 @@ describe('SyncEngineLevel — private methods', () => {
       expect(storedLink.status).toBe('live');
       expect(storedLink.pull.contiguousAppliedToken).toEqual(token);
       expect(storedLink.push.contiguousAppliedToken).toEqual(token);
-      expect(storedLink.needsReconcile).toBe(false);
       expect(scheduleStub.called).toBe(false);
     });
 
@@ -2851,7 +2836,6 @@ describe('SyncEngineLevel — private methods', () => {
         status             : 'initializing',
         pull               : {},
         connectivity       : 'online',
-        needsReconcile     : false,
       } as any;
 
       sinon.stub(engine as any, 'getOrCreateReplicationLink').resolves(link);
@@ -3218,26 +3202,6 @@ describe('SyncEngineLevel — private methods', () => {
       // Runtime should be cleaned up (success + no pending entries + no timer).
       // retryCount was reset to 0, enabling deletion.
       expect((engine as any)._pushRuntimes.has('key1')).toBe(false);
-    });
-
-    it('should schedule reconcile after a successful retry on a dirty live link', () => {
-      const engine = createEngine({ db });
-      const linkKey = 'key1';
-      const pushRuntime = (engine as any).getOrCreatePushRuntime(linkKey, {
-        did    : 'did:example:alice',
-        dwnUrl : 'https://dwn.example.com',
-      });
-      (engine as any)._activeLinks.set(linkKey, {
-        tenantDid      : 'did:example:alice',
-        remoteEndpoint : 'https://dwn.example.com',
-        status         : 'live',
-        needsReconcile : true,
-      });
-      const scheduleStub = sinon.stub(engine as any, 'scheduleReconcile');
-
-      (engine as any).cleanupSuccessfulPushRuntime(linkKey, pushRuntime);
-
-      expect(scheduleStub.calledOnceWith(linkKey, 500)).toBe(true);
     });
 
     it('should not let stale retryCount leak to subsequent batches', async () => {
@@ -3656,7 +3620,7 @@ describe('SyncEngineLevel — private methods', () => {
       const link = {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
-        pull               : {}, connectivity       : 'unknown', needsReconcile     : false,
+        pull               : {}, connectivity       : 'unknown',
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -3690,7 +3654,7 @@ describe('SyncEngineLevel — private methods', () => {
       const link = {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
-        pull               : {}, connectivity       : 'online', needsReconcile     : false,
+        pull               : {}, connectivity       : 'online',
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -3727,7 +3691,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' },
         scope              : { kind: 'protocolSet', protocols: ['https://example.com/profile'] }, status             : 'live',
-        pull               : {}, connectivity       : 'online', needsReconcile     : false,
+        pull               : {}, connectivity       : 'online',
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -3770,7 +3734,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' },
         scope              : { kind: 'protocolSet', protocols: ['https://example.com/profile'] }, status             : 'live',
-        pull               : {}, connectivity       : 'online', needsReconcile     : false,
+        pull               : {}, connectivity       : 'online',
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -3805,7 +3769,7 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' },
         scope              : { kind: 'protocolSet', protocols: ['https://example.com/profile'] }, status             : 'live',
-        pull               : {}, connectivity       : 'online', needsReconcile     : false,
+        pull               : {}, connectivity       : 'online',
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -3841,7 +3805,7 @@ describe('SyncEngineLevel — private methods', () => {
       const link = {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
-        pull               : {}, connectivity       : 'online', needsReconcile     : false,
+        pull               : {}, connectivity       : 'online',
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -3878,7 +3842,7 @@ describe('SyncEngineLevel — private methods', () => {
       const link = {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
-        pull               : {}, connectivity       : 'online', needsReconcile     : false,
+        pull               : {}, connectivity       : 'online',
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -3914,7 +3878,6 @@ describe('SyncEngineLevel — private methods', () => {
       });
       expect(link.pull.contiguousAppliedToken).toEqual(eventCursor);
       expect(link.status).toBe('live');
-      expect(link.needsReconcile).toBe(false);
 
       (engine as any)._liveSubscriptions = [];
     });
@@ -3930,7 +3893,7 @@ describe('SyncEngineLevel — private methods', () => {
       const link = {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'live',
-        pull               : { contiguousAppliedToken: previousCursor }, connectivity       : 'online', needsReconcile     : false,
+        pull               : { contiguousAppliedToken: previousCursor }, connectivity       : 'online',
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -4111,7 +4074,7 @@ describe('SyncEngineLevel — private methods', () => {
       (engine as any)._localSubscriptions = [];
     });
 
-    it('should mark the link for reconcile when a scoped local RecordsDelete cannot be classified', async () => {
+    it('should schedule reconcile when a scoped local RecordsDelete cannot be classified', async () => {
       let capturedHandler: any;
       const mockAgent = {
         agentDid : 'did:example:agent',
@@ -4128,15 +4091,13 @@ describe('SyncEngineLevel — private methods', () => {
         },
       } as any;
       const engine = createEngine({ db, agent: mockAgent });
-      sinon.stub(engine as any, 'scheduleReconcile').returns(undefined);
-      const saveLinkStub = sinon.stub().resolves();
-      overrideLedger(engine, { saveLink: saveLinkStub });
+      const scheduleStub = sinon.stub(engine as any, 'scheduleReconcile').returns(true);
       const pushLinkKey = 'did:example:alice^https://dwn.example.com';
       const link = {
         tenantDid      : 'did:example:alice',
         remoteEndpoint : 'https://dwn.example.com',
         scope          : { kind: 'protocolSet', protocols: ['https://example.com/profile'] },
-        needsReconcile : false,
+        status         : 'live',
       };
       (engine as any)._activeLinks.set(pushLinkKey, link);
 
@@ -4150,8 +4111,7 @@ describe('SyncEngineLevel — private methods', () => {
       });
       await Promise.resolve();
 
-      expect(link.needsReconcile).toBe(true);
-      expect(saveLinkStub.calledOnce).toBe(true);
+      expect(scheduleStub.calledOnceWith(pushLinkKey)).toBe(true);
       expect((engine as any)._pushRuntimes.size).toBe(0);
       (engine as any)._localSubscriptions = [];
     });
@@ -4421,7 +4381,7 @@ describe('SyncEngineLevel — private methods', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Repair orchestration and degraded polling
+  // Repair orchestration
   // ---------------------------------------------------------------------------
 
   describe('repairLink', () => {
@@ -4450,7 +4410,7 @@ describe('SyncEngineLevel — private methods', () => {
       expect(link.status).toBe('live');
     });
 
-    it('should track repair attempts and enter degraded_poll after max attempts', async () => {
+    it('should track repair attempts and enter terminal_incomplete after max attempts', async () => {
       const engine = createEngine({ db });
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
@@ -4466,21 +4426,23 @@ describe('SyncEngineLevel — private methods', () => {
       sinon.stub(console, 'error');
       sinon.stub(console, 'warn');
 
-      const saveStub = sinon.stub().resolves();
-      overrideLedger(engine, { saveLink: saveStub, setStatus: sinon.stub().resolves() });
+      const setStatusStub = sinon.stub().callsFake(async (l: any, status: string): Promise<void> => { l.status = status; });
+      overrideLedger(engine, { saveLink: sinon.stub().resolves(), setStatus: setStatusStub });
 
-      const enterDegradedStub = sinon.stub(engine as any, 'enterDegradedPoll').resolves();
+      const closeLinkSubscriptionsStub = (engine as any).closeLinkSubscriptions;
 
       const maxAttempts = (SyncEngineLevel as any).MAX_REPAIR_ATTEMPTS;
       for (let i = 0; i < maxAttempts; i++) {
         try {
           await (engine as any).repairLink(linkKey);
         } catch {
-          // Expected — doRepairLink re-throws on failure (except when entering degraded_poll).
+          // Expected — doRepairLink re-throws while retry attempts remain.
         }
       }
 
-      expect(enterDegradedStub.calledOnce).toBe(true);
+      expect(link.status).toBe('terminal_incomplete');
+      expect(setStatusStub.calledWith(link, 'terminal_incomplete')).toBe(true);
+      expect(closeLinkSubscriptionsStub.callCount).toBe(maxAttempts + 1);
     });
 
     it('should deduplicate concurrent repair calls for the same link', async () => {
@@ -4564,34 +4526,6 @@ describe('SyncEngineLevel — private methods', () => {
       // Since the handler checks status before calling drain, we verify the
       // link's checkpoint is unchanged when status is repairing.
       expect(link.pull.contiguousAppliedToken).toEqual(token(1));
-    });
-  });
-
-  describe('degraded_poll', () => {
-    it('should set up a polling timer when entering degraded_poll', async () => {
-      const engine = createEngine({ db });
-      const linkKey = 'did:example:alice^https://dwn.example.com';
-
-      const link = {
-        tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
-        projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
-        pull               : {},
-      } as any;
-      (engine as any)._activeLinks.set(linkKey, link);
-
-      const setStatusStub = sinon.stub();
-      overrideLedger(engine, { setStatus: setStatusStub });
-
-      await (engine as any).enterDegradedPoll(linkKey);
-
-      // Link should be in degraded_poll.
-      expect(setStatusStub.calledWith(link, 'degraded_poll')).toBe(true);
-
-      // A timer should be registered.
-      expect((engine as any)._degradedPollTimers.has(linkKey)).toBe(true);
-
-      // Clean up timer.
-      clearInterval((engine as any)._degradedPollTimers.get(linkKey));
     });
   });
 
@@ -4804,7 +4738,6 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
         pull               : {},
-        needsReconcile     : false,
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -4824,11 +4757,9 @@ describe('SyncEngineLevel — private methods', () => {
       // After repair completes:
       // 1. _activeRepairs should be cleared
       expect((engine as any)._activeRepairs.has(linkKey)).toBe(false);
-      // 2. needsReconcile should have been set (by doRepairLink before reopen)
-      expect(link.needsReconcile).toBe(true);
-      // 3. Link should be live
+      // 2. Link should be live
       expect(link.status).toBe('live');
-      // 4. A reconcile timer should be scheduled (the main assertion)
+      // 3. A reconcile timer should be scheduled after repair completes.
       expect((engine as any)._reconcileTimers.has(linkKey)).toBe(true);
 
       // Clean up the timer.
@@ -4844,7 +4775,6 @@ describe('SyncEngineLevel — private methods', () => {
         tenantDid          : 'did:example:alice', remoteEndpoint     : 'https://dwn.example.com',
         projectionId       : 'projection-test', authorizationEpoch : 'authorization-test', authorization      : { kind: 'owner' }, scope              : { kind: 'full' }, status             : 'repairing',
         pull               : {},
-        needsReconcile     : false,
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
       (engine as any).getOrCreateRuntime(linkKey);
@@ -4852,7 +4782,7 @@ describe('SyncEngineLevel — private methods', () => {
       sinon.stub(engine as any, 'closeLinkSubscriptions').resolves();
       const pullStub = (engine as any).pullRemoteFeedForSyncTarget;
       pullStub.callsFake(async (): Promise<Record<string, never>> => {
-        link.status = 'degraded_poll';
+        link.status = 'terminal_incomplete';
         return {};
       });
       const openPullStub = sinon.stub(engine as any, 'openLivePullSubscription').resolves();
@@ -4927,11 +4857,11 @@ describe('SyncEngineLevel — private methods', () => {
   // ---------------------------------------------------------------------------
 
   describe('scheduleRepairRetry', () => {
-    it('should not schedule if link is in degraded_poll', () => {
+    it('should not schedule if link is terminal_incomplete', () => {
       const engine = createEngine({ db });
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
-      (engine as any)._activeLinks.set(linkKey, { status: 'degraded_poll' });
+      (engine as any)._activeLinks.set(linkKey, { status: 'terminal_incomplete' });
 
       (engine as any).scheduleRepairRetry(linkKey);
 
@@ -5000,7 +4930,6 @@ describe('SyncEngineLevel — private methods', () => {
           status             : 'initializing',
           pull               : {},
           connectivity       : 'unknown',
-          needsReconcile     : false,
         };
       });
       overrideLedger(engine, {
@@ -5053,7 +4982,6 @@ describe('SyncEngineLevel — private methods', () => {
             status             : 'initializing',
             pull               : {},
             connectivity       : 'unknown',
-            needsReconcile     : false,
           };
         }),
         setStatus: setStatusStub,
@@ -5069,11 +4997,11 @@ describe('SyncEngineLevel — private methods', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Push simplification — opportunistic push + needsReconcile
+  // Push simplification — opportunistic push + feed reconciliation
   // ---------------------------------------------------------------------------
 
-  describe('opportunistic push + needsReconcile', () => {
-    it('should dead-letter terminal push failures immediately and mark link needsReconcile', async () => {
+  describe('opportunistic push + feed reconciliation', () => {
+    it('should dead-letter terminal push failures immediately and schedule reconciliation', async () => {
       const engine = createEngine({ db });
       const linkKey = 'did:example:alice^https://dwn.example.com';
 
@@ -5082,13 +5010,11 @@ describe('SyncEngineLevel — private methods', () => {
         remoteEndpoint : 'https://dwn.example.com',
         status         : 'live',
         pull           : {},
-        needsReconcile : false,
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
 
-      const saveStub = sinon.stub().resolves();
-      overrideLedger(engine, { saveLink: saveStub });
       const deadLetterStub = sinon.stub(engine as any, 'recordDeadLetter').resolves();
+      const scheduleStub = sinon.stub(engine as any, 'scheduleReconcile').returns(true);
 
       await (engine as any).requeueOrReconcile(linkKey, {
         did     : 'did:example:alice',
@@ -5100,10 +5026,10 @@ describe('SyncEngineLevel — private methods', () => {
         retryCount: 0,
       });
 
-      expect(link.needsReconcile).toBe(true);
       expect(deadLetterStub.calledOnce).toBe(true);
       expect(deadLetterStub.firstCall.args[0].category).toBe('admit-failed');
       expect(deadLetterStub.firstCall.args[0].errorCode).toBe('Invalid');
+      expect(scheduleStub.calledOnceWith(linkKey)).toBe(true);
 
       expect((engine as any)._pushRuntimes.has(linkKey)).toBe(false);
     });
@@ -5125,7 +5051,7 @@ describe('SyncEngineLevel — private methods', () => {
       expect(requeued.retryCount).toBe(1);
     });
 
-    it('should mark tenant-inactive push failures for reconcile without retrying the message', async () => {
+    it('should schedule tenant-inactive push failures for reconciliation without retrying the message', async () => {
       const engine = createEngine({ db });
       const linkKey = 'did:example:alice^https://dwn.example.com';
       const link = {
@@ -5133,14 +5059,11 @@ describe('SyncEngineLevel — private methods', () => {
         remoteEndpoint : 'https://dwn.example.com',
         status         : 'live',
         pull           : {},
-        needsReconcile : false,
       } as any;
       (engine as any)._activeLinks.set(linkKey, link);
 
-      const saveStub = sinon.stub().resolves();
-      overrideLedger(engine, { saveLink: saveStub });
       const deadLetterStub = sinon.stub(engine as any, 'recordDeadLetter').resolves();
-      const scheduleStub = sinon.stub(engine as any, 'scheduleReconcile');
+      const scheduleStub = sinon.stub(engine as any, 'scheduleReconcile').returns(true);
 
       await (engine as any).requeueOrReconcile(linkKey, {
         did     : 'did:example:alice',
@@ -5158,8 +5081,6 @@ describe('SyncEngineLevel — private methods', () => {
         retryCount: 0,
       });
 
-      expect(link.needsReconcile).toBe(true);
-      expect(saveStub.calledOnce).toBe(true);
       expect(deadLetterStub.called).toBe(false);
       expect((engine as any)._pushRuntimes.has(linkKey)).toBe(false);
       await Promise.resolve();
@@ -5173,7 +5094,6 @@ describe('SyncEngineLevel — private methods', () => {
         status         : 'live',
         pull           : {},
         push           : {},
-        needsReconcile : false,
       } as any;
 
       expect(link.push).toEqual({});
@@ -5196,27 +5116,21 @@ describe('SyncEngineLevel — private methods', () => {
         status             : 'live',
         pull               : {},
         push               : {},
-        needsReconcile     : true,
         ...overrides,
       };
     }
 
-    it('should clear needsReconcile when feed fingerprints converge after reconciliation', async () => {
+    it('should emit reconcile:completed when feed fingerprints converge after reconciliation', async () => {
       const engine = createEngine({ db });
       const linkKey = 'did:example:alice^https://dwn.example.com';
       const link = makeLiveLink();
       (engine as any)._activeLinks.set(linkKey, link);
-
-      const clearStub = sinon.stub().callsFake(async (l: any): Promise<void> => { l.needsReconcile = false; });
-      overrideLedger(engine, { clearNeedsReconcile: clearStub, saveLink: sinon.stub().resolves() });
 
       const events: any[] = [];
       engine.on((event) => { events.push(event); });
 
       await (engine as any).doReconcileLink(linkKey);
 
-      expect(link.needsReconcile).toBe(false);
-      expect(clearStub.calledOnce).toBe(true);
       expect(events.some(e => e.type === 'reconcile:completed')).toBe(true);
     });
 
@@ -5232,9 +5146,6 @@ describe('SyncEngineLevel — private methods', () => {
         admittedCids: ['cid-protocol', 'cid-profile'],
       });
 
-      const clearStub = sinon.stub().callsFake(async (l: any): Promise<void> => { l.needsReconcile = false; });
-      overrideLedger(engine, { clearNeedsReconcile: clearStub, saveLink: sinon.stub().resolves() });
-
       const events: any[] = [];
       engine.on((event) => { events.push(event); });
 
@@ -5246,7 +5157,7 @@ describe('SyncEngineLevel — private methods', () => {
       expect(appliedEvent.protocol).toBe('https://example.com/profile');
     });
 
-    it('should NOT clear needsReconcile when feed fingerprints still differ after reconciliation', async () => {
+    it('should schedule a retry when feed fingerprints still differ after reconciliation', async () => {
       const engine = createEngine({ db });
       const linkKey = 'did:example:alice^https://dwn.example.com';
       const link = makeLiveLink();
@@ -5259,13 +5170,7 @@ describe('SyncEngineLevel — private methods', () => {
         pushFailures      : [],
       });
 
-      const clearStub = sinon.stub().resolves();
-      overrideLedger(engine, { clearNeedsReconcile: clearStub, saveLink: sinon.stub().resolves() });
-
       await (engine as any).doReconcileLink(linkKey);
-
-      expect(link.needsReconcile).toBe(true);
-      expect(clearStub.called).toBe(false);
 
       expect((engine as any)._reconcileTimers.has(linkKey)).toBe(true);
       clearTimeout((engine as any)._reconcileTimers.get(linkKey));
@@ -5283,8 +5188,6 @@ describe('SyncEngineLevel — private methods', () => {
         remoteFingerprint : 'remote-fingerprint',
         pushFailures      : [],
       });
-      overrideLedger(engine, { clearNeedsReconcile: sinon.stub().resolves(), saveLink: sinon.stub().resolves() });
-
       await (engine as any).reconcileLink(linkKey);
 
       expect((engine as any)._reconcileTimers.has(linkKey)).toBe(true);
@@ -5318,20 +5221,6 @@ describe('SyncEngineLevel — private methods', () => {
       expect(pullStub.called).toBe(false);
     });
 
-    it('should clear needsReconcile when feed fingerprints already match', async () => {
-      const engine = createEngine({ db });
-      const linkKey = 'did:example:alice^https://dwn.example.com';
-      const link = makeLiveLink();
-      (engine as any)._activeLinks.set(linkKey, link);
-
-      const clearStub = sinon.stub().callsFake(async (l: any): Promise<void> => { l.needsReconcile = false; });
-      overrideLedger(engine, { clearNeedsReconcile: clearStub, saveLink: sinon.stub().resolves() });
-
-      await (engine as any).doReconcileLink(linkKey);
-
-      expect(link.needsReconcile).toBe(false);
-    });
-
     it('should bail on generation mismatch during reconciliation', async () => {
       const engine = createEngine({ db });
       const linkKey = 'did:example:alice^https://dwn.example.com';
@@ -5348,7 +5237,6 @@ describe('SyncEngineLevel — private methods', () => {
       await (engine as any).doReconcileLink(linkKey);
 
       expect(pushStub.called).toBe(false);
-      expect(link.needsReconcile).toBe(true);
     });
 
     it('should schedule retry on reconciliation error', async () => {
@@ -5364,7 +5252,6 @@ describe('SyncEngineLevel — private methods', () => {
 
       // Should schedule a retry reconcile.
       expect((engine as any)._reconcileTimers.has(linkKey)).toBe(true);
-      expect(link.needsReconcile).toBe(true);
       clearTimeout((engine as any)._reconcileTimers.get(linkKey));
     });
 
@@ -5416,14 +5303,15 @@ describe('SyncEngineLevel — private methods', () => {
       expect((engine as any)._reconcileTimers.has(linkKey)).toBe(false);
     });
 
-    it('scheduleReconcile should not schedule if reconcile is already in-flight', () => {
+    it('scheduleReconcile should schedule a follow-up if reconcile is already in-flight', () => {
       const engine = createEngine({ db });
       const linkKey = 'did:example:alice^https://dwn.example.com';
       (engine as any)._reconcileInFlight.set(linkKey, Promise.resolve());
 
       (engine as any).scheduleReconcile(linkKey, 100);
 
-      expect((engine as any)._reconcileTimers.has(linkKey)).toBe(false);
+      expect((engine as any)._reconcileTimers.has(linkKey)).toBe(true);
+      clearTimeout((engine as any)._reconcileTimers.get(linkKey));
     });
 
     it('doReconcileLink should run feed pull and feed push', async () => {
@@ -5434,9 +5322,6 @@ describe('SyncEngineLevel — private methods', () => {
 
       const pullStub = (engine as any).pullRemoteFeedForSyncTarget;
       const pushStub = (engine as any).pushLocalFeedForSyncTarget;
-
-      const clearStub = sinon.stub().callsFake(async (l: any): Promise<void> => { l.needsReconcile = false; });
-      overrideLedger(engine, { clearNeedsReconcile: clearStub, saveLink: sinon.stub().resolves() });
 
       await (engine as any).doReconcileLink(linkKey);
 
@@ -5454,20 +5339,17 @@ describe('SyncEngineLevel — private methods', () => {
         pushFailures: [{ cid: 'local-cid-1', kind: 'Invalid', terminal: true, detail: 'bad request' }],
       });
 
-      const clearStub = sinon.stub().resolves();
-      overrideLedger(engine, { clearNeedsReconcile: clearStub, saveLink: sinon.stub().resolves() });
       const deadLetterStub = sinon.stub(engine as any, 'recordDeadLetter').resolves();
 
       await (engine as any).doReconcileLink(linkKey);
 
-      expect(clearStub.called).toBe(false);
       expect(deadLetterStub.calledOnce).toBe(true);
       expect(deadLetterStub.firstCall.args[0].messageCid).toBe('local-cid-1');
       expect(deadLetterStub.firstCall.args[0].errorCode).toBe('Invalid');
       expect((engine as any)._pushRuntimes.has(linkKey)).toBe(false);
     });
 
-    it('doReconcileLink should keep needsReconcile when dead-lettered local feed entries still diverge', async () => {
+    it('doReconcileLink should schedule retry when dead-lettered local feed entries still diverge', async () => {
       const engine = createEngine({ db });
       const events: any[] = [];
       engine.on((event) => { events.push(event); });
@@ -5495,14 +5377,11 @@ describe('SyncEngineLevel — private methods', () => {
         pushFailures      : [],
       });
 
-      const clearStub = sinon.stub().callsFake(async (l: any): Promise<void> => { l.needsReconcile = false; });
-      overrideLedger(engine, { clearNeedsReconcile: clearStub, saveLink: sinon.stub().resolves() });
-
       await (engine as any).doReconcileLink(linkKey);
 
-      expect(clearStub.called).toBe(false);
-      expect(link.needsReconcile).toBe(true);
       expect(events.some(event => event.type === 'reconcile:completed')).toBe(false);
+      expect((engine as any)._reconcileTimers.has(linkKey)).toBe(true);
+      clearTimeout((engine as any)._reconcileTimers.get(linkKey));
     });
 
     it('doReconcileLink should abort if the active link epoch changes during pull', async () => {
@@ -5519,15 +5398,11 @@ describe('SyncEngineLevel — private methods', () => {
         return {};
       });
       const pushStub = (engine as any).pushLocalFeedForSyncTarget;
-      const clearStub = sinon.stub().callsFake(async (l: any): Promise<void> => { l.needsReconcile = false; });
-      overrideLedger(engine, { clearNeedsReconcile: clearStub, saveLink: sinon.stub().resolves() });
 
       await (engine as any).doReconcileLink(linkKey);
 
       expect(pullStub.calledOnce).toBe(true);
       expect(pushStub.called).toBe(false);
-      expect(clearStub.called).toBe(false);
-      expect(link.needsReconcile).toBe(true);
     });
   });
 
@@ -6322,31 +6197,6 @@ describe('SyncEngineLevel — private methods', () => {
       expect(link.status).toBe('repairing');
     });
 
-    it('should mark and clear needsReconcile', async () => {
-      const link = await ledger.getOrCreateLink({
-        tenantDid      : 'did:example:reconcile-test',
-        remoteEndpoint : 'https://dwn.example.com',
-        scope          : { kind: 'full' },
-        ...ownerAuthorization,
-      });
-
-      expect(link.needsReconcile).toBe(false);
-
-      await ledger.markNeedsReconcile(link, 'test reason');
-      expect(link.needsReconcile).toBe(true);
-
-      // Idempotent — second call should be a no-op.
-      await ledger.markNeedsReconcile(link);
-      expect(link.needsReconcile).toBe(true);
-
-      await ledger.clearNeedsReconcile(link);
-      expect(link.needsReconcile).toBe(false);
-
-      // Idempotent — second clear should be a no-op.
-      await ledger.clearNeedsReconcile(link);
-      expect(link.needsReconcile).toBe(false);
-    });
-
     it('should compare token positions correctly', () => {
       const a = { streamId: 's', epoch: 'e', position: '10', messageCid: 'a' };
       const b = { streamId: 's', epoch: 'e', position: '20', messageCid: 'b' };
@@ -6568,33 +6418,6 @@ describe('SyncEngineLevel — private methods', () => {
       expect(health.syncHealthy).toBe(false);
     });
 
-    it('should surface links needing reconcile in sync health', async () => {
-      const engine = createEngine({ db });
-      const ownerEpoch = await computeAuthorizationEpoch({ kind: 'owner' });
-      await engine.registerIdentity({
-        did     : 'did:needs-reconcile-health',
-        options : { protocols: 'all' },
-      });
-      const target = syncTarget('did:needs-reconcile-health', 'https://dwn.example.com', {
-        authorizationEpoch: ownerEpoch,
-      });
-
-      const ledger = (engine as any).ledger;
-      const link = await ledger.getOrCreateLink({
-        tenantDid          : target.did,
-        remoteEndpoint     : target.dwnUrl,
-        scope              : target.scope,
-        authorization      : target.authorization,
-        authorizationEpoch : target.authorizationEpoch,
-      });
-      link.needsReconcile = true;
-      await ledger.saveLink(link);
-
-      const health = await engine.getSyncHealth();
-      expect(health.reconcileNeededCount).toBe(1);
-      expect(health.syncHealthy).toBe(false);
-    });
-
     it('should scope admission dead-letter scans to the active tenant', async () => {
       const engine = createEngine({ db });
       const iteratorOptions: any[] = [];
@@ -6694,7 +6517,7 @@ describe('SyncEngineLevel — private methods', () => {
         authorization      : targetA.authorization,
         authorizationEpoch : targetA.authorizationEpoch,
       });
-      await ledger.setStatus(link1, 'degraded_poll');
+      await ledger.setStatus(link1, 'terminal_incomplete');
 
       const link2 = await ledger.getOrCreateLink({
         tenantDid          : targetB.did,
@@ -6777,7 +6600,7 @@ describe('SyncEngineLevel — private methods', () => {
         authorization      : target.authorization,
         authorizationEpoch : target.authorizationEpoch,
       });
-      await ledger.setStatus(link, 'degraded_poll');
+      await ledger.setStatus(link, 'terminal_incomplete');
 
       const health = await engine.getSyncHealth();
       expect(health.degradedLinkCount).toBe(1);

--- a/packages/agent/tests/sync-replication-ledger.spec.ts
+++ b/packages/agent/tests/sync-replication-ledger.spec.ts
@@ -53,7 +53,6 @@ describe('ReplicationLedger', () => {
       expect(link.authorization).toEqual({ kind: 'owner' });
       expect(link.status).toBe('initializing');
       expect(link.pull.contiguousAppliedToken).toBeUndefined();
-      expect(link.needsReconcile).toBe(false);
     });
 
     it('should return existing link on second call', async () => {

--- a/packages/agent/tests/utils/local-dwn-rpc-shim.ts
+++ b/packages/agent/tests/utils/local-dwn-rpc-shim.ts
@@ -1,7 +1,7 @@
 /**
  * A local DWN RPC shim that routes sendDwnRequest calls to an in-process
  * DWN instance instead of over the network. Used for testing live sync
- * flows (subscriptions, repair, degraded_poll) without external infrastructure.
+ * flows (subscriptions and repair) without external infrastructure.
  *
  * Handles both regular requests and subscription requests by routing them
  * to the in-process DWN's processMessage with the appropriate options.


### PR DESCRIPTION
## Summary
- remove the legacy durable needsReconcile flag and degraded_poll repair loop from the feed-only sync engine
- rename the admission ordering helper away from the obsolete topologicalSort surface and trim stale tests
- keep terminal_incomplete as the durable feed-only degraded state and schedule reconciliation ephemerally

## Test plan
- [x] bun run lint
- [x] bunx turbo run build --filter=@enbox/agent
- [x] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node