### PR TITLE
chore(sync): remove stale legacy sync references

### DIFF
--- a/docs/architecture/cloudflare-do-dwn-deployment.md
+++ b/docs/architecture/cloudflare-do-dwn-deployment.md
@@ -464,8 +464,7 @@ cursor:
 
 **`$delivery` integration:**
 
-The three delivery strategies from `proposals/dwn-delivery-and-sync.md` map
-naturally to this infrastructure:
+The three delivery strategies map naturally to this infrastructure:
 
 | Strategy | Implementation |
 |---|---|
@@ -698,8 +697,8 @@ The Tenant DO reads from R2 directly.
 
 **IPFS as read fallback (relay/cache mode):**
 
-When a Tenant DO operates in cache mode (per `proposals/constrained-dwn-relay-cache.md`),
-it stores only message envelopes and SMT data — record data may not be in R2.
+When a Tenant DO operates in cache mode, it stores only message envelopes and
+replication metadata — record data may not be in R2.
 On `RecordsRead`:
 
 ```
@@ -934,9 +933,9 @@ fingerprints regardless of storage backend.
 
 | Task | Description |
 |---|---|
-| Constrained Tenant DO | Envelope-only storage mode. Skip R2 writes, retain messages + SMT only. |
+| Constrained Tenant DO | Envelope-only storage mode. Skip R2 writes, retain messages + replication metadata only. |
 | IPFS fallback reads | `RecordsRead` fetches from IPFS when R2 data unavailable. |
-| `dataRetention: "cache"` | Service endpoint annotation support per `proposals/constrained-dwn-relay-cache.md`. |
+| `dataRetention: "cache"` | Service endpoint annotation support for cache-mode tenants. |
 | Eviction policy | Alarm-based data eviction (oldest first) when approaching 10 GB SQLite limit. |
 
 ---
@@ -1008,8 +1007,8 @@ fingerprints regardless of storage backend.
 | `docs/architecture/aws-dwn-deployment.md` | Coexists as Provider 2/4. Shares NATS super-cluster. Users choose based on trust, region, or performance preferences. |
 | `docs/architecture/eu-confidential-dwn-deployment.md` | Coexists as Provider 3. CF provider does not offer TEE; users requiring confidential compute use OVHcloud. |
 | `infra/multi-region-plan.md` | NATS super-cluster replaces per-region independent NATS clusters. Sync daemon works unchanged — receives wakes, reads the durable log, pushes to peer endpoints. |
-| `proposals/dwn-delivery-and-sync.md` | Implements all three `$delivery` strategies: Direct and Relay via Queues, Subscribe via NATS + Connection DOs. |
-| `proposals/constrained-dwn-relay-cache.md` | Phase 5 implements relay/cache mode. IPFS fallback enables cache-mode DOs to serve reads without holding full dataset. |
+| `$delivery` strategies | Direct and Relay use Queues; Subscribe uses NATS wakes plus Connection DOs. |
+| Relay/cache mode | Phase 5 implements cache-mode tenants. IPFS fallback enables reads without holding full datasets. |
 | `proposals/push-notifications.md` | Push notifications can hook into NATS wakes via a consumer worker — subscribe to `dwn.wakes.>`, read durable entries, match notification rules, fire APNs/FCM. |
 
 ---

--- a/packages/agent/tests/e2e/live-sync-convergence.e2e.spec.ts
+++ b/packages/agent/tests/e2e/live-sync-convergence.e2e.spec.ts
@@ -5,7 +5,7 @@
  * the remote DWN via live sync push. Then pulls from the remote to verify
  * the round-trip. Proves the full pipeline:
  *   local write -> EventLog -> live push subscription -> remote DWN
- *   remote DWN -> SMT reconciliation -> local pull -> local DWN
+ *   remote DWN -> durable feed pull -> local DWN
  *
  * Requires: DWN server running on localhost:3000 (or TEST_DWN_URL),
  *           Pkarr relay on localhost:7527 (or DID_DHT_GATEWAY_URI).
@@ -124,7 +124,7 @@ describe('E2E: live sync convergence', () => {
     expect(found).toBe(true);
   }, 20_000);
 
-  it('should pull a remote-only record to local via SMT reconciliation', async () => {
+  it('should pull a remote-only record to local via durable feed sync', async () => {
     // Stop sync so we can create a record on the remote that the local
     // agent doesn't know about — then verify pull brings it down.
     await harness.agent.sync.stopSync();
@@ -157,7 +157,7 @@ describe('E2E: live sync convergence', () => {
     });
     expect(beforePull.reply.entries?.length ?? 0).toBe(0);
 
-    // Pull from remote via SMT reconciliation.
+    // Pull from the remote via durable feed sync.
     await harness.agent.sync.sync('pull');
 
     // The record should now exist locally.

--- a/packages/agent/tests/e2e/reconnection.e2e.spec.ts
+++ b/packages/agent/tests/e2e/reconnection.e2e.spec.ts
@@ -7,7 +7,7 @@
  *   3. A record is written directly to the REMOTE DWN (bypassing this agent)
  *   4. JsonRpcSocket auto-reconnect fires, pull subscription re-establishes
  *   5. The remote-only record appears in the local DWN via the recovered
- *      pull subscription (or the SMT integrity check that follows)
+ *      pull subscription (or the durable feed settle check that follows)
  *
  * This isolates the pull reconnection path — the push path uses HTTP and
  * is unaffected by WebSocket drops.

--- a/packages/dwn-sdk-js/src/types/subscriptions.ts
+++ b/packages/dwn-sdk-js/src/types/subscriptions.ts
@@ -88,7 +88,7 @@ export type SubscriptionEvent = {
   cursor : ProgressToken;
   /** The event payload (message + optional initialWrite). */
   event : MessageEvent;
-  /** Original row sequence for this message. Redelivery events keep the row's original sequence. */
+  /** Original row sequence for this message. */
   seq? : string;
   /** CID of the message that produced this event. */
   messageCid? : string;

--- a/proposals/push-notifications.md
+++ b/proposals/push-notifications.md
@@ -23,7 +23,7 @@ Push notifications solve the **"app is not running"** problem. They are the comp
 | EventLog (durable store) | `dwn-sdk-js/src/event-stream/durable-event-log.ts` | Cursor-based replay over the committed message-store feed |
 | EventBus (NATS) | `dwn-server/src/plugins/event-bus-nats.ts` | Cross-process wake fan-out for durable EventLog drains |
 | Admin webhooks | `dwn-server/src/admin/webhook-manager.ts` | Server-to-server HTTP callbacks for admin events only (not DWN message events) |
-| Agent sync engine | `agent/src/sync-engine-level.ts` | Poll (SMT reconciliation) and live (WebSocket subscription) sync modes |
+| Agent sync engine | `agent/src/sync-engine-level.ts` | Poll and live sync over durable feed cursors and WebSocket subscriptions |
 | LiveQuery | `api/src/live-query.ts` | Reactive record change stream with dedup and lifecycle events |
 
 ### What Does Not Exist
@@ -121,7 +121,7 @@ All four levels are supported, configurable per push subscription:
 
 ### 6. Independent from `$delivery`
 
-Push notifications are a **server-to-device** concern, separate from the provider-to-provider delivery system described in `proposals/dwn-delivery-and-sync.md`. They hook into the EventLog directly regardless of how messages arrived at the DWN (direct write, provider-to-provider sync, or relay delivery).
+Push notifications are a **server-to-device** concern, separate from provider-to-provider delivery. They hook into the EventLog directly regardless of how messages arrived at the DWN (direct write, provider-to-provider sync, or relay delivery).
 
 The `$delivery` system handles "how does a message get from DWN A to DWN B." Push notifications handle "how does a user's device find out something happened in their DWN."
 


### PR DESCRIPTION
Summary
- Reword stale SMT/redelivery references to durable feed terminology.
- Remove links to superseded proposal files from Cloudflare and push notification docs.
- Leave terminal_incomplete untouched because it is an active feed-only degraded link state, not legacy sync machinery.

Test plan
- [x] bun run lint
- [x] bun run build
- [x] bun run --filter @enbox/agent build
- [x] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node (from packages/agent)