### PR TITLE
fix(dwn-sdk-js): project record-limit occupants at read time

### DIFF
--- a/.changeset/record-limit-occupancy-fold.md
+++ b/.changeset/record-limit-occupancy-fold.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/api": patch
+---
+
+Project `$recordLimit` occupants at read time for bounded scopes so over-limit candidates are retained uniformly while concrete Query, Read, Count, and Subscribe paths expose only the ranked occupants. Update singleton repository writes to upsert against the projected occupant.

--- a/packages/api/src/repository.ts
+++ b/packages/api/src/repository.ts
@@ -56,14 +56,18 @@ import type { ProtocolDefinition, ProtocolRuleSet } from '@enbox/dwn-sdk-js';
 // Runtime helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Checks whether a DWN response status indicates that the record limit
- * has been exceeded. The DWN engine returns a 400 status with a detail
- * message containing "record limit" when `$recordLimit` rejects a write.
- */
-function isRecordLimitExceeded(status: { code: number; detail: string }): boolean {
-  return status.code === 400 && status.detail.includes('record limit');
-}
+type SingletonRecord = {
+  id: string;
+  update(options: Record<string, unknown>): Promise<DwnResponseStatus & { record?: unknown }>;
+};
+
+type SingletonQueryResult = {
+  records: SingletonRecord[];
+};
+
+type SingletonWriteResult = DwnResponseStatus & {
+  record?: SingletonRecord;
+};
 
 /**
  * Checks whether a protocol rule set at a given path is a singleton
@@ -110,6 +114,47 @@ function getChildKeys(definition: ProtocolDefinition, path: string): string[] {
   return Object.keys(node).filter((k) => !k.startsWith('$'));
 }
 
+async function querySingletonRecord(
+  typed: TypedEnbox<ProtocolDefinition, SchemaMap>,
+  path: string,
+  options?: Record<string, unknown>,
+): Promise<SingletonRecord | undefined> {
+  const { records } = await typed.records.query(path, options as never) as unknown as SingletonQueryResult;
+  return records[0];
+}
+
+async function updateSingletonRecord(record: SingletonRecord, options: Record<string, unknown>): Promise<unknown> {
+  const { status, record: updatedRecord } = await record.update({
+    data: options.data,
+    ...(options.tags === undefined ? {} : { tags: options.tags }),
+  });
+  return { status, record: updatedRecord };
+}
+
+async function createSingletonRecord(
+  typed: TypedEnbox<ProtocolDefinition, SchemaMap>,
+  path: string,
+  options: Record<string, unknown>,
+): Promise<SingletonWriteResult> {
+  const result = await typed.records.create(path, options as never);
+  return result as unknown as SingletonWriteResult;
+}
+
+async function setSingletonRecord(
+  typed: TypedEnbox<ProtocolDefinition, SchemaMap>,
+  path: string,
+  createOptions: Record<string, unknown>,
+  queryOptions?: Record<string, unknown>,
+): Promise<unknown> {
+  const existingRecord = await querySingletonRecord(typed, path, queryOptions);
+  if (existingRecord !== undefined) {
+    return updateSingletonRecord(existingRecord, createOptions);
+  }
+
+  const createResult = await createSingletonRecord(typed, path, createOptions);
+  return { status: createResult.status, record: createResult.record };
+}
+
 // ---------------------------------------------------------------------------
 // CRUD method builders
 // ---------------------------------------------------------------------------
@@ -153,10 +198,8 @@ function buildRootCollectionMethods(
 /**
  * Build singleton CRUD methods for a root-level path.
  *
- * Uses a create-first strategy: attempts to create a new record, and if the
- * DWN rejects it because the record limit is reached, falls back to querying
- * the existing record and updating it. This avoids the race condition inherent
- * in query-then-create/update.
+ * `set()` preserves singleton upsert semantics over DWN `$recordLimit` scopes:
+ * update the current projected singleton when it exists, otherwise create one.
  */
 function buildRootSingletonMethods(
   typed: TypedEnbox<ProtocolDefinition, SchemaMap>,
@@ -164,22 +207,7 @@ function buildRootSingletonMethods(
 ): Record<string, Function> {
   return {
     async set(options: Record<string, unknown>): Promise<unknown> {
-      // Attempt to create — if limit not yet reached, this succeeds.
-      const createResult = await typed.records.create(path, options as never);
-
-      if (isRecordLimitExceeded(createResult.status)) {
-        // Record limit hit — query existing and update.
-        const { records } = await typed.records.query(path);
-        if (records.length > 0) {
-          const { status, record } = await records[0].update({
-            data: options.data,
-            ...(options.tags === undefined ? {} : { tags: options.tags }),
-          } as never);
-          return { status, record };
-        }
-      }
-
-      return { status: createResult.status, record: createResult.record };
+      return setSingletonRecord(typed, path, options);
     },
 
     async get(): Promise<unknown> {
@@ -247,8 +275,8 @@ function buildNestedCollectionMethods(
 /**
  * Build singleton CRUD methods for a nested path.
  *
- * Uses the same create-first strategy as root singletons to avoid race
- * conditions between concurrent set() calls.
+ * Uses the same singleton upsert strategy as root singletons, scoped to the
+ * parent context.
  */
 function buildNestedSingletonMethods(
   typed: TypedEnbox<ProtocolDefinition, SchemaMap>,
@@ -256,28 +284,11 @@ function buildNestedSingletonMethods(
 ): Record<string, Function> {
   return {
     async set(parentContextId: string, options: Record<string, unknown>): Promise<unknown> {
-      // Attempt to create under this parent — succeeds if no record exists yet.
-      const createResult = await typed.records.create(path, {
+      const queryOptions = { filter: { contextId: parentContextId } };
+      return setSingletonRecord(typed, path, {
         ...options,
         parentContextId,
-      } as never);
-
-      if (isRecordLimitExceeded(createResult.status)) {
-        // Record limit hit — query existing under this parent and update.
-        const { records } = await typed.records.query(path, {
-          filter: { contextId: parentContextId },
-        } as never);
-
-        if (records.length > 0) {
-          const { status, record } = await records[0].update({
-            data: options.data,
-            ...(options.tags === undefined ? {} : { tags: options.tags }),
-          } as never);
-          return { status, record };
-        }
-      }
-
-      return { status: createResult.status, record: createResult.record };
+      }, queryOptions);
     },
 
     async get(parentContextId: string): Promise<unknown> {

--- a/packages/dwn-sdk-js/src/core/dwn-constant.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-constant.ts
@@ -6,4 +6,10 @@ export class DwnConstant {
    * We currently encode using base64url which is a 33% increase in size.
    */
   public static readonly maxDataSizeAllowedToBeEncoded = 30_000;
+
+  /**
+   * Maximum supported `$recordLimit.max`. Read-time occupancy projection may load
+   * up to this many occupants per scope before applying the caller's filter/page.
+   */
+  public static readonly maxRecordLimit = 1000;
 }

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -107,7 +107,6 @@ export enum DwnErrorCode {
   ProtocolAuthorizationMatchingRoleRecordNotFound = 'ProtocolAuthorizationMatchingRoleRecordNotFound',
   ProtocolAuthorizationMaxSizeInvalid = 'ProtocolAuthorizationMaxSizeInvalid',
   ProtocolAuthorizationMinSizeInvalid = 'ProtocolAuthorizationMinSizeInvalid',
-  ProtocolAuthorizationRecordLimitExceeded = 'ProtocolAuthorizationRecordLimitExceeded',
   ProtocolAuthorizationRecordLimitStrategyNotImplemented = 'ProtocolAuthorizationRecordLimitStrategyNotImplemented',
   ProtocolAuthorizationSquashNotEnabled = 'ProtocolAuthorizationSquashNotEnabled',
   ProtocolAuthorizationSquashNotInitialWrite = 'ProtocolAuthorizationSquashNotInitialWrite',

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -371,57 +371,30 @@ export async function verifyAsRoleRecordIfNeeded(
 }
 
 /**
- * Verifies that a new record creation does not exceed the `$recordLimit` defined in the rule set.
+ * Verifies that the `$recordLimit` strategy is supported for a new record creation.
  *
- * This check only applies to initial writes (new records). Updates to existing records are not counted.
- * The count is scoped to the same `protocol + protocolPath` within the parent context:
- * - For root-level records: counted across the entire protocol for the tenant.
- * - For nested records: counted within the parent record's context.
+ * This check only applies to initial writes (new records). Updates to existing records do not
+ * affect record-limit occupancy. The supported `reject` strategy admits every candidate and
+ * projects the visible occupant set at read time, so validation stays independent of arrival order.
  *
- * @throws {DwnError} with `ProtocolAuthorizationRecordLimitExceeded` if the limit is reached and strategy is `reject`.
- * @throws {DwnError} with `ProtocolAuthorizationRecordLimitStrategyNotImplemented` if strategy is not yet implemented.
+ * @throws {DwnError} with `ProtocolAuthorizationRecordLimitStrategyNotImplemented` if strategy is not implemented.
  */
 export async function verifyRecordLimit(
-  tenant: string,
   incomingMessage: RecordsWrite,
   ruleSet: ProtocolRuleSet,
-  validationStateReader: ValidationStateReader,
 ): Promise<void> {
   if (ruleSet.$recordLimit === undefined) {
     return;
   }
 
-  // Only enforce on initial writes — updates to existing records do not count as new records.
+  // Only initial writes can introduce a new record-limit candidate.
   const isInitialWrite = await incomingMessage.isInitialWrite();
   if (!isInitialWrite) {
     return;
   }
 
-  const { max, strategy } = ruleSet.$recordLimit;
-
-  // Count existing records at the same protocol path, scoped by parent context for nested records.
-  const protocolPath = incomingMessage.message.descriptor.protocolPath;
-  const parentContextId = Records.getParentContextFromOfContextId(incomingMessage.message.contextId)!;
-
-  const existingCount = await validationStateReader.countLatestRecordsAtScope({
-    tenant,
-    protocol        : incomingMessage.message.descriptor.protocol,
-    protocolPath,
-    contextIdPrefix : parentContextId === '' ? undefined : parentContextId,
-  });
-
-  if (existingCount >= max) {
-    if (strategy === ProtocolRecordLimitStrategy.Reject) {
-      throw new DwnError(
-        DwnErrorCode.ProtocolAuthorizationRecordLimitExceeded,
-        `record limit of ${max} reached at protocol path '${protocolPath}'` +
-        `${parentContextId === '' ? '' : ` under parent context '${parentContextId}'`}` +
-        `: new records are rejected until existing records are deleted.`
-      );
-    }
-
-    // Future strategies (e.g. purgeOldest) will be implemented here.
-    // For now, any non-reject strategy that somehow passes schema validation is rejected.
+  const { strategy } = ruleSet.$recordLimit;
+  if (strategy !== ProtocolRecordLimitStrategy.Reject) {
     throw new DwnError(
       DwnErrorCode.ProtocolAuthorizationRecordLimitStrategyNotImplemented,
       `record limit strategy '${strategy}' is not yet implemented.`

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -34,7 +34,7 @@ export class ProtocolAuthorization {
     tenant: string,
     incomingMessage: RecordsWrite,
     validationStateReader: ValidationStateReader,
-  ): Promise<void> {
+  ): Promise<ProtocolRuleSet> {
     const protocolDefinitionTimestamp = incomingMessage.message.descriptor.messageTimestamp;
 
     // fetch the protocol definition active at the incoming message timestamp
@@ -82,7 +82,9 @@ export class ProtocolAuthorization {
     await verifySquashEligibility(incomingMessage, ruleSet);
 
     // Verify record count limit
-    await verifyRecordLimit(tenant, incomingMessage, ruleSet, validationStateReader);
+    await verifyRecordLimit(incomingMessage, ruleSet);
+
+    return ruleSet;
   }
 
   /**
@@ -121,9 +123,8 @@ export class ProtocolAuthorization {
     await verifySquashEligibility(incomingMessage, ruleSet);
     ProtocolAuthorization.verifyStoredInitialWriteCreateAction(tenant, incomingMessage, ruleSet);
 
-    // `verifyRecordLimit()` is not replayed here. It is stateful and counts the present
-    // latest live set, which would incorrectly reject the record being revalidated.
-    // Inbound writes continue to enforce record limits at admission time.
+    // `verifyRecordLimit()` is intentionally not replayed here. It only checks strategy
+    // support for new record candidates; read-time occupancy projection decides visibility.
   }
 
   /**

--- a/packages/dwn-sdk-js/src/core/recording-validation-state-reader.ts
+++ b/packages/dwn-sdk-js/src/core/recording-validation-state-reader.ts
@@ -112,17 +112,6 @@ export class RecordingValidationStateReader implements ValidationStateReader {
   }
 
   /** @inheritdoc */
-  public async countLatestRecordsAtScope(input: {
-    tenant: string;
-    protocol: string;
-    protocolPath: string;
-    contextIdPrefix?: string;
-  }): Promise<number> {
-    this.recordedReads.push({ method: 'countLatestRecordsAtScope' });
-    return this.inner.countLatestRecordsAtScope(input);
-  }
-
-  /** @inheritdoc */
   public async fetchLatestSquashRecordAtScope(input: {
     tenant: string;
     protocol: string;

--- a/packages/dwn-sdk-js/src/core/validation-state-reader.ts
+++ b/packages/dwn-sdk-js/src/core/validation-state-reader.ts
@@ -274,28 +274,6 @@ export class StoreValidationStateReader implements ValidationStateReader {
   }
 
   /** @inheritdoc */
-  public async countLatestRecordsAtScope(input: {
-    tenant: string;
-    protocol: string;
-    protocolPath: string;
-    contextIdPrefix?: string;
-  }): Promise<number> {
-    const filter: Filter = {
-      interface         : DwnInterfaceName.Records,
-      method            : DwnMethodName.Write,
-      isLatestBaseState : true,
-      protocol          : input.protocol,
-      protocolPath      : input.protocolPath,
-    };
-
-    if (input.contextIdPrefix !== undefined) {
-      filter.contextId = FilterUtility.constructPrefixFilterAsRangeFilter(input.contextIdPrefix);
-    }
-
-    return this.messageStore.count(input.tenant, [filter]);
-  }
-
-  /** @inheritdoc */
   public async fetchLatestSquashRecordAtScope(input: {
     tenant: string;
     protocol: string;

--- a/packages/dwn-sdk-js/src/dwn.ts
+++ b/packages/dwn-sdk-js/src/dwn.ts
@@ -113,17 +113,6 @@ export class Dwn {
     this.dataStore = config.dataStore;
     this.resumableTaskStore = config.resumableTaskStore;
 
-    this.eventLog = config.eventLog;
-
-    this.storageController = new StorageController({
-      messageStore : this.messageStore,
-      dataStore    : this.dataStore,
-    });
-    this.resumableTaskManager = new ResumableTaskManager(
-      config.resumableTaskStore,
-      this.storageController
-    );
-
     // Initialize the core protocol registry with built-in system protocols.
     this._coreProtocols = new CoreProtocolRegistry();
     this._coreProtocols.register(new PermissionsProtocol());
@@ -135,6 +124,17 @@ export class Dwn {
       coreProtocols : this._coreProtocols,
     });
     this.validationStateReader = config.instrumentValidationStateReader?.(validationStateReader) ?? validationStateReader;
+
+    this.eventLog = config.eventLog;
+
+    this.storageController = new StorageController({
+      messageStore : this.messageStore,
+      dataStore    : this.dataStore,
+    });
+    this.resumableTaskManager = new ResumableTaskManager(
+      config.resumableTaskStore,
+      this.storageController
+    );
 
     // Build the shared dependency bag once; every handler receives the same object
     // and accesses only the dependencies it needs.

--- a/packages/dwn-sdk-js/src/handlers/records-count.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-count.ts
@@ -3,6 +3,7 @@ import type { HandlerDependencies, MethodHandler } from '../types/method-handler
 import type { RecordsCountMessage, RecordsCountReply } from '../types/records-types.js';
 
 import { authenticate } from '../core/auth.js';
+import { countRecordsWithRecordLimitOccupancy } from '../utils/record-limit-occupancy.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
@@ -66,7 +67,7 @@ export class RecordsCountHandler implements MethodHandler {
       isLatestBaseState : true
     };
 
-    return this.deps.messageStore.count(tenant, [countFilter]);
+    return this.countProjectedRecords(tenant, recordsCount, [countFilter]);
   }
 
   /**
@@ -98,7 +99,7 @@ export class RecordsCountHandler implements MethodHandler {
       }
     }
 
-    return this.deps.messageStore.count(tenant, filters);
+    return this.countProjectedRecords(tenant, recordsCount, filters);
   }
 
   /**
@@ -106,7 +107,17 @@ export class RecordsCountHandler implements MethodHandler {
    */
   private async countPublishedRecords(tenant: string, recordsCount: RecordsCount): Promise<number> {
     const filter = RecordsCountHandler.buildPublishedRecordsFilter(recordsCount);
-    return this.deps.messageStore.count(tenant, [filter]);
+    return this.countProjectedRecords(tenant, recordsCount, [filter]);
+  }
+
+  private async countProjectedRecords(tenant: string, recordsCount: RecordsCount, filters: Filter[]): Promise<number> {
+    return countRecordsWithRecordLimitOccupancy({
+      messageStore          : this.deps.messageStore,
+      validationStateReader : this.deps.validationStateReader,
+      tenant,
+      filters,
+      messageTimestamp      : recordsCount.message.descriptor.messageTimestamp,
+    });
   }
 
   private static buildPublishedRecordsFilter(recordsCount: RecordsCount): Filter {

--- a/packages/dwn-sdk-js/src/handlers/records-delete.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-delete.ts
@@ -77,6 +77,7 @@ export class RecordsDeleteHandler implements MethodHandler {
         recordsDelete,
         initialWrite!,
       );
+
     } catch (e) {
       return messageReplyFromError(e, 401);
     }
@@ -125,4 +126,5 @@ export class RecordsDeleteHandler implements MethodHandler {
       await ProtocolAuthorization.authorizeDelete(tenant, recordsDelete, recordsWrite, this.deps.validationStateReader);
     }
   }
+
 };

--- a/packages/dwn-sdk-js/src/handlers/records-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-query.ts
@@ -8,6 +8,7 @@ import { DateSort } from '../types/records-types.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
+import { queryRecordsWithRecordLimitOccupancy } from '../utils/record-limit-occupancy.js';
 import { Records } from '../utils/records.js';
 import { RecordsGrantAuthorization } from '../core/records-grant-authorization.js';
 import { RecordsQuery } from '../interfaces/records-query.js';
@@ -121,7 +122,15 @@ export class RecordsQueryHandler implements MethodHandler {
     };
 
     const messageSort = this.convertDateSort(dateSort);
-    return this.deps.messageStore.query(tenant, [ queryFilter ], messageSort, pagination);
+    return queryRecordsWithRecordLimitOccupancy({
+      messageStore          : this.deps.messageStore,
+      validationStateReader : this.deps.validationStateReader,
+      tenant,
+      filters               : [queryFilter],
+      messageSort,
+      pagination,
+      messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
+    });
   }
 
   /**
@@ -171,7 +180,15 @@ export class RecordsQueryHandler implements MethodHandler {
     }
 
     const messageSort = this.convertDateSort(dateSort);
-    return this.deps.messageStore.query(tenant, filters, messageSort, pagination );
+    return queryRecordsWithRecordLimitOccupancy({
+      messageStore          : this.deps.messageStore,
+      validationStateReader : this.deps.validationStateReader,
+      tenant,
+      filters,
+      messageSort,
+      pagination,
+      messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
+    });
   }
 
   /**
@@ -183,7 +200,15 @@ export class RecordsQueryHandler implements MethodHandler {
     const { dateSort, pagination } = recordsQuery.message.descriptor;
     const filter = RecordsQueryHandler.buildPublishedRecordsFilter(recordsQuery);
     const messageSort = this.convertDateSort(dateSort);
-    return this.deps.messageStore.query(tenant, [ filter ], messageSort, pagination);
+    return queryRecordsWithRecordLimitOccupancy({
+      messageStore          : this.deps.messageStore,
+      validationStateReader : this.deps.validationStateReader,
+      tenant,
+      filters               : [filter],
+      messageSort,
+      pagination,
+      messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
+    });
   }
 
   private static buildPublishedRecordsFilter(recordsQuery: RecordsQuery): Filter {

--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -5,6 +5,7 @@ import type { RecordsDeleteMessage, RecordsQueryReplyEntry, RecordsReadMessage, 
 import { authenticate } from '../core/auth.js';
 import { DataStream } from '../utils/data-stream.js';
 import { Encoder } from '../utils/encoder.js';
+import { isRecordLimitOccupant } from '../utils/record-limit-occupancy.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
@@ -48,7 +49,7 @@ export class RecordsReadHandler implements MethodHandler {
       ...Records.convertFilter(message.descriptor.filter)
     };
     const messageSort = Records.convertDateSort(message.descriptor.dateSort);
-    const { messages: existingMessages } = await this.deps.messageStore.query(tenant, [ query ], messageSort, { limit: 1 });
+    const { messages: existingMessages } = await this.deps.messageStore.query(tenant, [query], messageSort, { limit: 1 });
     if (existingMessages.length === 0) {
       return {
         status: { code: 404, detail: 'Not Found' }
@@ -57,50 +58,24 @@ export class RecordsReadHandler implements MethodHandler {
 
     const matchedMessage = existingMessages[0];
 
-    // If the matched message is a RecordsDelete, authorize against the newest RecordsWrite
-    // (for parity with the live-record path which authorizes against the latest write),
-    // then return 404 with both the RecordsDelete and the initial RecordsWrite.
     if (matchedMessage.descriptor.method === DwnMethodName.Delete) {
-      const recordsDeleteMessage = matchedMessage as RecordsDeleteMessage;
-      const recordId = recordsDeleteMessage.descriptor.recordId;
-
-      const initialWrite = await RecordsWrite.fetchInitialRecordsWriteMessage(this.deps.messageStore, tenant, recordId);
-      if (initialWrite === undefined) {
-        return messageReplyFromError(new DwnError(
-          DwnErrorCode.RecordsReadInitialWriteNotFound,
-          'initial write for deleted record not found'
-        ), 400);
-      }
-
-      // Authorize against the newest RecordsWrite so that mutable properties like `published`
-      // reflect the record's state at the time of deletion, not just the initial write.
-      let newestWrite;
-      try {
-        newestWrite = await RecordsWrite.fetchNewestRecordsWrite(this.deps.messageStore, tenant, recordId);
-      } catch {
-        // If newest write is not found (should not happen since initial write exists),
-        // fall back to the initial write for authorization.
-        newestWrite = initialWrite;
-      }
-      const parsedNewestWrite = await RecordsWrite.parse(newestWrite);
-
-      try {
-        await RecordsReadHandler.authorizeRecordsRead(tenant, recordsRead, parsedNewestWrite, this.deps);
-      } catch (error) {
-        return messageReplyFromError(error, 401);
-      }
-
-      return {
-        status : { code: 404, detail: 'Not Found' },
-        entry  : {
-          recordsDelete: recordsDeleteMessage,
-          initialWrite,
-        }
-      };
+      return this.replyForDeletedRecord(tenant, recordsRead, matchedMessage as RecordsDeleteMessage);
     }
 
     // else the matched message is a RecordsWrite
     const matchedRecordsWrite = matchedMessage as RecordsQueryReplyEntry;
+
+    if (!await isRecordLimitOccupant({
+      messageStore          : this.deps.messageStore,
+      validationStateReader : this.deps.validationStateReader,
+      tenant,
+      message               : matchedRecordsWrite,
+      messageTimestamp      : recordsRead.message.descriptor.messageTimestamp,
+    })) {
+      return {
+        status: { code: 404, detail: 'Not Found' }
+      };
+    }
 
     try {
       const parsedWrite = await RecordsWrite.parse(matchedRecordsWrite);
@@ -151,6 +126,48 @@ export class RecordsReadHandler implements MethodHandler {
 
     return recordsReadReply;
   };
+
+  private async replyForDeletedRecord(
+    tenant: string,
+    recordsRead: RecordsRead,
+    recordsDeleteMessage: RecordsDeleteMessage,
+  ): Promise<RecordsReadReply> {
+    const recordId = recordsDeleteMessage.descriptor.recordId;
+
+    const initialWrite = await RecordsWrite.fetchInitialRecordsWriteMessage(this.deps.messageStore, tenant, recordId);
+    if (initialWrite === undefined) {
+      return messageReplyFromError(new DwnError(
+        DwnErrorCode.RecordsReadInitialWriteNotFound,
+        'initial write for deleted record not found'
+      ), 400);
+    }
+
+    // Authorize against the newest RecordsWrite so that mutable properties like `published`
+    // reflect the record's state at the time of deletion, not just the initial write.
+    let newestWrite;
+    try {
+      newestWrite = await RecordsWrite.fetchNewestRecordsWrite(this.deps.messageStore, tenant, recordId);
+    } catch {
+      // If newest write is not found (should not happen since initial write exists),
+      // fall back to the initial write for authorization.
+      newestWrite = initialWrite;
+    }
+    const parsedNewestWrite = await RecordsWrite.parse(newestWrite);
+
+    try {
+      await RecordsReadHandler.authorizeRecordsRead(tenant, recordsRead, parsedNewestWrite, this.deps);
+    } catch (error) {
+      return messageReplyFromError(error, 401);
+    }
+
+    return {
+      status : { code: 404, detail: 'Not Found' },
+      entry  : {
+        recordsDelete: recordsDeleteMessage,
+        initialWrite,
+      }
+    };
+  }
 
   /**
    * @param messageStore Used to check if the grant has been revoked.

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -1,7 +1,7 @@
 import type { MessageSort } from '../types/message-types.js';
+import type { EventSubscription, ProgressGapInfo, SubscriptionEvent, SubscriptionListener, SubscriptionMessage } from '../types/subscriptions.js';
 import type { Filter, PaginationCursor } from '../types/query-types.js';
 import type { HandlerDependencies, MethodHandler } from '../types/method-handler.js';
-import type { ProgressGapInfo, SubscriptionListener } from '../types/subscriptions.js';
 import type { RecordsQueryReplyEntry, RecordsSubscribeMessage, RecordsSubscribeReply } from '../types/records-types.js';
 
 import { authenticate } from '../core/auth.js';
@@ -16,6 +16,12 @@ import { RecordsWrite } from '../interfaces/records-write.js';
 import { SortDirection } from '../types/query-types.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
+import { isRecordLimitOccupant, queryRecordsWithRecordLimitOccupancy } from '../utils/record-limit-occupancy.js';
+
+type ProjectedRecordsSubscriptionHandler = {
+  listener: SubscriptionListener;
+  setSubscription(subscription: EventSubscription): Promise<void>;
+};
 
 export class RecordsSubscribeHandler implements MethodHandler {
 
@@ -74,6 +80,12 @@ export class RecordsSubscribeHandler implements MethodHandler {
 
     const messageCid = await Message.getCid(message);
     const { cursor: eventLogCursor } = recordsSubscribe.message.descriptor;
+    const projectedSubscriptionHandler = RecordsSubscribeHandler.createRecordLimitOccupancyGuard({
+      deps: this.deps,
+      recordsSubscribe,
+      subscriptionHandler,
+      tenant,
+    });
 
     if (eventLogCursor !== undefined) {
       // ---- Cursor mode: catch-up from EventLog + EOSE + live ----
@@ -82,10 +94,11 @@ export class RecordsSubscribeHandler implements MethodHandler {
       // The subscriptionHandler receives SubscriptionMessage (event + EOSE) directly.
 
       try {
-        const subscription = await this.deps.eventLog!.subscribe(tenant, messageCid, subscriptionHandler, {
+        const subscription = await this.deps.eventLog.subscribe(tenant, messageCid, projectedSubscriptionHandler.listener, {
           cursor  : eventLogCursor,
           filters : eventFilters,
         });
+        await projectedSubscriptionHandler.setSubscription(subscription);
 
         return {
           status: { code: 200, detail: 'OK' },
@@ -106,9 +119,10 @@ export class RecordsSubscribeHandler implements MethodHandler {
     // ---- No cursor: existing behavior (initial snapshot from MessageStore) ----
 
     // Step 1: Register event listener FIRST to ensure no events are missed between query and subscribe
-    const subscription = await this.deps.eventLog!.subscribe(tenant, messageCid, subscriptionHandler, {
+    const subscription = await this.deps.eventLog.subscribe(tenant, messageCid, projectedSubscriptionHandler.listener, {
       filters: eventFilters,
     });
+    await projectedSubscriptionHandler.setSubscription(subscription);
 
     // Step 2: Query for initial snapshot of matching records
     let entries: RecordsQueryReplyEntry[];
@@ -116,8 +130,16 @@ export class RecordsSubscribeHandler implements MethodHandler {
     try {
       const { dateSort, pagination } = recordsSubscribe.message.descriptor;
       const messageSort = RecordsSubscribeHandler.convertDateSort(dateSort);
-      const queryResult = await this.deps.messageStore.query(tenant, queryFilters, messageSort, pagination);
-      entries = queryResult.messages as RecordsQueryReplyEntry[];
+      const queryResult = await queryRecordsWithRecordLimitOccupancy({
+        messageStore          : this.deps.messageStore,
+        validationStateReader : this.deps.validationStateReader,
+        tenant,
+        filters               : queryFilters,
+        messageSort,
+        pagination,
+        messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
+      });
+      entries = queryResult.messages;
       paginationCursor = queryResult.cursor;
 
       // attach initialWrite for non-initial writes
@@ -168,6 +190,101 @@ export class RecordsSubscribeHandler implements MethodHandler {
     default:
       return { dateCreated: SortDirection.Ascending };
     }
+  }
+
+  private static createRecordLimitOccupancyGuard(input: {
+    deps: HandlerDependencies;
+    recordsSubscribe: RecordsSubscribe;
+    subscriptionHandler: SubscriptionListener;
+    tenant: string;
+  }): ProjectedRecordsSubscriptionHandler {
+    const { deps, recordsSubscribe, subscriptionHandler, tenant } = input;
+    let subscription: EventSubscription | undefined;
+    let closeRequested = false;
+    let terminalErrorEmitted = false;
+    let deliveryQueue: Promise<void> = Promise.resolve();
+
+    const closeSubscription = (): void => {
+      if (closeRequested) {
+        return;
+      }
+      closeRequested = true;
+      Promise.resolve(subscription?.close()).catch(() => {});
+    };
+
+    const emitTerminalProjectionError = (cursor: SubscriptionEvent['cursor']): void => {
+      if (terminalErrorEmitted) {
+        return;
+      }
+      terminalErrorEmitted = true;
+      subscriptionHandler({
+        type  : 'error',
+        cursor,
+        error : {
+          code   : 'RecordsSubscribeProjectionFailed',
+          detail : 'record-limit occupancy projection failed during delivery',
+        },
+      });
+    };
+
+    const deliverProjectedEvent = async (subscriptionEvent: SubscriptionEvent): Promise<void> => {
+      const { message } = subscriptionEvent.event;
+      if (Records.isRecordsWrite(message)) {
+        let isOccupant: boolean;
+        try {
+          isOccupant = await isRecordLimitOccupant({
+            messageStore          : deps.messageStore,
+            validationStateReader : deps.validationStateReader,
+            tenant,
+            message,
+            messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
+          });
+        } catch {
+          emitTerminalProjectionError(subscriptionEvent.cursor);
+          closeSubscription();
+          return;
+        }
+
+        if (!isOccupant) {
+          return;
+        }
+      }
+
+      if (!closeRequested) {
+        subscriptionHandler(subscriptionEvent);
+      }
+    };
+
+    const deliverQueuedMessage = async (subscriptionMessage: SubscriptionMessage): Promise<void> => {
+      if (closeRequested) {
+        return;
+      }
+
+      if (subscriptionMessage.type !== 'event') {
+        subscriptionHandler(subscriptionMessage);
+        return;
+      }
+
+      await deliverProjectedEvent(subscriptionMessage);
+    };
+
+    const enqueueDelivery = (subscriptionMessage: SubscriptionMessage): void => {
+      deliveryQueue = deliveryQueue
+        .then(() => deliverQueuedMessage(subscriptionMessage))
+        .catch(() => {});
+    };
+
+    return {
+      listener: (subscriptionMessage: SubscriptionMessage): void => {
+        enqueueDelivery(subscriptionMessage);
+      },
+      setSubscription: async (eventSubscription: EventSubscription): Promise<void> => {
+        subscription = eventSubscription;
+        if (closeRequested) {
+          await eventSubscription.close();
+        }
+      },
+    };
   }
 
   // =============================================

--- a/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
@@ -8,6 +8,7 @@ import type {
 
 import { AbstractMessage } from '../core/abstract-message.js';
 import Ajv from 'ajv/dist/2020.js';
+import { DwnConstant } from '../core/dwn-constant.js';
 import { Message } from '../core/message.js';
 import { PermissionGrant } from '../protocols/permission-grant.js';
 import { ProtocolsGrantAuthorization } from '../core/protocols-grant-authorization.js';
@@ -244,6 +245,13 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
         throw new DwnError(
           DwnErrorCode.ProtocolsConfigureInvalidRecordLimit,
           `Invalid $recordLimit.max value ${max} at protocol path '${ruleSetProtocolPath}': must be an integer >= 1.`
+        );
+      }
+
+      if (max > DwnConstant.maxRecordLimit) {
+        throw new DwnError(
+          DwnErrorCode.ProtocolsConfigureInvalidRecordLimit,
+          `Invalid $recordLimit.max value ${max} at protocol path '${ruleSetProtocolPath}': must be <= ${DwnConstant.maxRecordLimit}.`
         );
       }
 

--- a/packages/dwn-sdk-js/src/types/validation-state-reader.ts
+++ b/packages/dwn-sdk-js/src/types/validation-state-reader.ts
@@ -109,17 +109,6 @@ export interface ValidationStateReader {
   fetchProtocolDefinition(tenant: string, protocolUri: string, messageTimestamp?: string): Promise<ProtocolDefinition>;
 
   /**
-   * Counts the latest-state records at a `$recordLimit` scope:
-   * protocol + protocolPath within the parent context.
-   */
-  countLatestRecordsAtScope(input: {
-    tenant: string;
-    protocol: string;
-    protocolPath: string;
-    contextIdPrefix?: string;
-  }): Promise<number>;
-
-  /**
    * Fetches the latest `$squash: true` record at a protocol path within the parent context.
    * This is the temporal floor used by the squash backstop.
    */

--- a/packages/dwn-sdk-js/src/utils/record-limit-occupancy.ts
+++ b/packages/dwn-sdk-js/src/utils/record-limit-occupancy.ts
@@ -1,0 +1,377 @@
+import type { MessageStore } from '../types/message-store.js';
+import type { ProtocolRecordLimitDefinition } from '../types/protocols-types.js';
+import type { RecordsWriteMessage } from '../types/records-types.js';
+import type { ValidationStateReader } from '../types/validation-state-reader.js';
+import type { Filter, PaginationCursor } from '../types/query-types.js';
+import type { MessageSort, Pagination } from '../types/message-types.js';
+
+import { FilterUtility } from './filter.js';
+import { getRuleSetAtPath } from './protocols.js';
+import { lexicographicalCompare } from './string.js';
+import { ProtocolRecordLimitStrategy } from '../types/protocols-types.js';
+import { Records } from './records.js';
+import { SortDirection } from '../types/query-types.js';
+import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
+import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
+
+type RecordLimitOccupancyDependencies = {
+  messageStore: MessageStore;
+  validationStateReader: ValidationStateReader;
+};
+
+type RecordLimitOccupancyQueryInput = RecordLimitOccupancyDependencies & {
+  tenant: string;
+  filters: Filter[];
+  messageTimestamp: string;
+  messageSort?: MessageSort;
+  pagination?: Pagination;
+};
+
+type RecordLimitScope = {
+  protocol: string;
+  protocolPath: string;
+  parentContextId: string;
+};
+
+type RecordLimitFilterResolution = {
+  projectedFilters: Filter[];
+};
+
+/**
+ * Queries records with bounded `$recordLimit` occupancy projection when every limited filter targets one concrete scope.
+ *
+ * Broad filters keep the store's native query path. Projecting those without a store-level grouping primitive would require
+ * scanning the full matching set, which is worse than leaving them unprojected until a bounded broad-query strategy exists.
+ */
+export async function queryRecordsWithRecordLimitOccupancy(
+  input: RecordLimitOccupancyQueryInput
+): Promise<{ messages: RecordsWriteMessage[]; cursor?: PaginationCursor }> {
+  const filterResolution = await resolveRecordLimitFilters(input);
+  if (filterResolution === undefined) {
+    const { messages, cursor } = await input.messageStore.query(input.tenant, input.filters, input.messageSort, input.pagination);
+    return { messages: messages.filter(Records.isRecordsWrite), cursor };
+  }
+
+  if (filterResolution.projectedFilters.length === 0) {
+    return { messages: [] };
+  }
+
+  const { messages, cursor } = await input.messageStore.query(
+    input.tenant,
+    filterResolution.projectedFilters,
+    input.messageSort,
+    input.pagination
+  );
+
+  return { messages: messages.filter(Records.isRecordsWrite), cursor };
+}
+
+/**
+ * Counts records with bounded `$recordLimit` occupancy projection when every limited filter targets one concrete scope.
+ */
+export async function countRecordsWithRecordLimitOccupancy(input: Omit<RecordLimitOccupancyQueryInput, 'pagination'>): Promise<number> {
+  const filterResolution = await resolveRecordLimitFilters(input);
+  if (filterResolution === undefined) {
+    return input.messageStore.count(input.tenant, input.filters, input.messageSort);
+  }
+
+  if (filterResolution.projectedFilters.length === 0) {
+    return 0;
+  }
+
+  return input.messageStore.count(input.tenant, filterResolution.projectedFilters, input.messageSort);
+}
+
+/**
+ * Returns true when the latest RecordsWrite is visible under the `$recordLimit` projection.
+ */
+export async function isRecordLimitOccupant(input: RecordLimitOccupancyDependencies & {
+  tenant: string;
+  message: RecordsWriteMessage;
+  messageTimestamp: string;
+}): Promise<boolean> {
+  const recordLimit = await getRecordLimitForMessage({
+    messageStore           : input.messageStore,
+    validationStateReader  : input.validationStateReader,
+    tenant                 : input.tenant,
+    message                : input.message,
+    messageTimestamp       : input.messageTimestamp,
+    recordLimitDefinitions : new Map(),
+  });
+
+  if (recordLimit === undefined) {
+    return true;
+  }
+
+  const occupantRecordIds = await findOccupantRecordIds({
+    messageStore : input.messageStore,
+    tenant       : input.tenant,
+    scope        : getRecordLimitScope(input.message),
+    recordLimit,
+  });
+
+  return occupantRecordIds.has(input.message.recordId);
+}
+
+async function resolveRecordLimitFilters(
+  input: Omit<RecordLimitOccupancyQueryInput, 'pagination'>
+): Promise<RecordLimitFilterResolution | undefined> {
+  const recordLimitDefinitions = new Map<string, ProtocolRecordLimitDefinition | undefined>();
+  const projectedFilters: Filter[] = [];
+  let projectionApplied = false;
+
+  for (const filter of input.filters) {
+    const recordLimit = await getRecordLimitForFilter({
+      messageStore          : input.messageStore,
+      validationStateReader : input.validationStateReader,
+      tenant                : input.tenant,
+      filter,
+      messageTimestamp      : input.messageTimestamp,
+      recordLimitDefinitions,
+    });
+
+    if (recordLimit === undefined) {
+      projectedFilters.push(filter);
+      continue;
+    }
+
+    const scope = getRecordLimitScopeFromFilter(filter);
+    if (scope === undefined) {
+      return undefined;
+    }
+
+    const occupantRecordIds = await findOccupantRecordIds({
+      messageStore : input.messageStore,
+      tenant       : input.tenant,
+      scope,
+      recordLimit,
+    });
+
+    const projectedFilter = buildProjectedFilter(filter, occupantRecordIds);
+    if (projectedFilter !== undefined) {
+      projectedFilters.push(projectedFilter);
+    }
+    projectionApplied = true;
+  }
+
+  return projectionApplied ? { projectedFilters } : undefined;
+}
+
+async function getRecordLimitForMessage(input: RecordLimitOccupancyDependencies & {
+  tenant: string;
+  message: RecordsWriteMessage;
+  messageTimestamp: string;
+  recordLimitDefinitions: Map<string, ProtocolRecordLimitDefinition | undefined>;
+}): Promise<ProtocolRecordLimitDefinition | undefined> {
+  const { protocol, protocolPath } = input.message.descriptor;
+  if (protocol === undefined || protocolPath === undefined) {
+    return undefined;
+  }
+
+  return getRecordLimit({
+    validationStateReader  : input.validationStateReader,
+    tenant                 : input.tenant,
+    protocol,
+    protocolPath,
+    messageTimestamp       : input.messageTimestamp,
+    recordLimitDefinitions : input.recordLimitDefinitions,
+  });
+}
+
+async function getRecordLimitForFilter(input: RecordLimitOccupancyDependencies & {
+  tenant: string;
+  filter: Filter;
+  messageTimestamp: string;
+  recordLimitDefinitions: Map<string, ProtocolRecordLimitDefinition | undefined>;
+}): Promise<ProtocolRecordLimitDefinition | undefined> {
+  if (input.filter.interface !== DwnInterfaceName.Records ||
+    input.filter.method !== DwnMethodName.Write ||
+    input.filter.isLatestBaseState !== true
+  ) {
+    return undefined;
+  }
+
+  const { protocol, protocolPath } = input.filter;
+  if (typeof protocol !== 'string' || typeof protocolPath !== 'string') {
+    return undefined;
+  }
+
+  return getRecordLimit({
+    validationStateReader  : input.validationStateReader,
+    tenant                 : input.tenant,
+    protocol,
+    protocolPath,
+    messageTimestamp       : input.messageTimestamp,
+    recordLimitDefinitions : input.recordLimitDefinitions,
+  });
+}
+
+async function getRecordLimit(input: {
+  validationStateReader: ValidationStateReader;
+  tenant: string;
+  protocol: string;
+  protocolPath: string;
+  messageTimestamp: string;
+  recordLimitDefinitions: Map<string, ProtocolRecordLimitDefinition | undefined>;
+}): Promise<ProtocolRecordLimitDefinition | undefined> {
+  const key = `${input.protocol}\u0000${input.protocolPath}`;
+  if (!input.recordLimitDefinitions.has(key)) {
+    let protocolDefinition;
+    try {
+      protocolDefinition = await input.validationStateReader.fetchProtocolDefinition(
+        input.tenant,
+        input.protocol,
+        input.messageTimestamp,
+      );
+    } catch (error) {
+      if (error instanceof DwnError && error.code === DwnErrorCode.ProtocolAuthorizationProtocolNotFound) {
+        input.recordLimitDefinitions.set(key, undefined);
+        return undefined;
+      }
+      throw error;
+    }
+
+    const ruleSet = getRuleSetAtPath(input.protocolPath, protocolDefinition.structure);
+    const recordLimit = ruleSet?.$recordLimit;
+    input.recordLimitDefinitions.set(
+      key,
+      recordLimit?.strategy === ProtocolRecordLimitStrategy.Reject ? recordLimit : undefined
+    );
+  }
+
+  return input.recordLimitDefinitions.get(key);
+}
+
+async function findOccupantRecordIds(input: {
+  messageStore: MessageStore;
+  tenant: string;
+  scope: RecordLimitScope;
+  recordLimit: ProtocolRecordLimitDefinition;
+}): Promise<Set<string>> {
+  const scopeFilter = buildRecordLimitScopeFilter(input.scope);
+  const messageSort = { dateCreated: SortDirection.Ascending };
+  const { messages: firstPage } = await input.messageStore.query(
+    input.tenant,
+    [scopeFilter],
+    messageSort,
+    { limit: input.recordLimit.max }
+  );
+  const firstPageCandidates = firstPage.filter(Records.isRecordsWrite);
+  if (firstPageCandidates.length === 0) {
+    return new Set();
+  }
+
+  const boundaryDateCreated = firstPageCandidates.at(-1)!.descriptor.dateCreated;
+  const beforeBoundary = firstPageCandidates.filter(
+    (message): boolean => message.descriptor.dateCreated < boundaryDateCreated
+  );
+  let boundaryCandidates = firstPageCandidates.filter(
+    (message): boolean => message.descriptor.dateCreated === boundaryDateCreated
+  );
+
+  if (firstPageCandidates.length === input.recordLimit.max) {
+    const { messages } = await input.messageStore.query(
+      input.tenant,
+      [{ ...scopeFilter, dateCreated: boundaryDateCreated }],
+      messageSort
+    );
+    boundaryCandidates = messages.filter(Records.isRecordsWrite);
+  }
+
+  boundaryCandidates.sort(compareRecordLimitCandidates);
+
+  const rankedCandidates = [
+    ...beforeBoundary,
+    ...boundaryCandidates,
+  ];
+
+  return new Set(
+    rankedCandidates
+      .slice(0, input.recordLimit.max)
+      .map((message): string => message.recordId)
+  );
+}
+
+function buildRecordLimitScopeFilter(scope: RecordLimitScope): Filter {
+  const filter: Filter = {
+    interface         : DwnInterfaceName.Records,
+    method            : DwnMethodName.Write,
+    isLatestBaseState : true,
+    protocol          : scope.protocol,
+    protocolPath      : scope.protocolPath,
+  };
+
+  if (scope.parentContextId !== '') {
+    filter.contextId = FilterUtility.constructPrefixFilterAsRangeFilter(scope.parentContextId);
+  }
+
+  return filter;
+}
+
+function getRecordLimitScopeFromFilter(filter: Filter): RecordLimitScope | undefined {
+  const { protocol, protocolPath } = filter;
+  if (typeof protocol !== 'string' || typeof protocolPath !== 'string') {
+    return undefined;
+  }
+
+  if (!protocolPath.includes('/')) {
+    return { protocol, protocolPath, parentContextId: '' };
+  }
+
+  const parentContextId = getExactParentContextIdFromFilter(filter);
+  if (parentContextId === undefined) {
+    return undefined;
+  }
+
+  return { protocol, protocolPath, parentContextId };
+}
+
+function getRecordLimitScope(message: RecordsWriteMessage): RecordLimitScope {
+  return {
+    protocol        : message.descriptor.protocol,
+    protocolPath    : message.descriptor.protocolPath,
+    parentContextId : Records.getParentContextFromOfContextId(message.contextId) ?? '',
+  };
+}
+
+function getExactParentContextIdFromFilter(filter: Filter): string | undefined {
+  const { contextId } = filter;
+  if (contextId === undefined || !FilterUtility.isRangeFilter(contextId)) {
+    return undefined;
+  }
+
+  if (typeof contextId.gte !== 'string' || contextId.lt !== `${contextId.gte}\uffff`) {
+    return undefined;
+  }
+
+  return contextId.gte;
+}
+
+function buildProjectedFilter(filter: Filter, occupantRecordIds: Set<string>): Filter | undefined {
+  let projectedRecordIds = Array.from(occupantRecordIds);
+  const existingRecordIdFilter = filter.recordId;
+  if (typeof existingRecordIdFilter === 'string') {
+    projectedRecordIds = occupantRecordIds.has(existingRecordIdFilter) ? [existingRecordIdFilter] : [];
+  } else if (Array.isArray(existingRecordIdFilter)) {
+    projectedRecordIds = existingRecordIdFilter
+      .filter((recordId): recordId is string => typeof recordId === 'string' && occupantRecordIds.has(recordId));
+  }
+
+  if (projectedRecordIds.length === 0) {
+    return undefined;
+  }
+
+  return {
+    ...filter,
+    recordId: projectedRecordIds,
+  };
+}
+
+function compareRecordLimitCandidates(left: RecordsWriteMessage, right: RecordsWriteMessage): number {
+  const dateComparison = lexicographicalCompare(left.descriptor.dateCreated, right.descriptor.dateCreated);
+  if (dateComparison !== 0) {
+    return dateComparison;
+  }
+
+  return lexicographicalCompare(left.recordId, right.recordId);
+}

--- a/packages/dwn-sdk-js/tests/core/validation-read-closure.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/validation-read-closure.spec.ts
@@ -37,7 +37,6 @@ const VALIDATION_READER_METHODS = new Set<string>([
   'fetchOldestGrantRevocation',
   'fetchNewestRecordsWrite',
   'fetchProtocolDefinition',
-  'countLatestRecordsAtScope',
   'fetchLatestSquashRecordAtScope',
   'hasStoredData',
 ]);
@@ -288,7 +287,7 @@ describe('validation read closure', () => {
       snapshot('live: messages-read of deleted record with grant');
     }
 
-    // ---- scenario: live record-limit rejection ----
+    // ---- scenario: live record-limit candidate admission ----
     {
       await clearStores();
       recorder.clearRecordedReads();
@@ -310,9 +309,9 @@ describe('validation read closure', () => {
       const { message: secondMessage, dataStream: secondDataStream } = await TestDataGenerator.generateRecordsWrite({
         author: alice, protocol: definition.protocol, protocolPath: 'item', schema: 'item', dataFormat: 'text/plain',
       });
-      expect((await dwn.processMessage(alice.did, secondMessage, { dataStream: secondDataStream })).status.code).toBe(400);
+      expect((await dwn.processMessage(alice.did, secondMessage, { dataStream: secondDataStream })).status.code).toBe(202);
 
-      snapshot('live: record-limit rejection');
+      snapshot('live: record-limit candidate admission');
     }
 
     // ---- scenario: live squash backstop ----

--- a/packages/dwn-sdk-js/tests/core/validation-read-trace.json
+++ b/packages/dwn-sdk-js/tests/core/validation-read-trace.json
@@ -24,8 +24,7 @@
     "fetchNewestRecordsWrite",
     "fetchOldestGrantRevocation"
   ],
-  "live: record-limit rejection": [
-    "countLatestRecordsAtScope",
+  "live: record-limit candidate admission": [
     "fetchProtocolDefinition"
   ],
   "live: squash backstop": [

--- a/packages/dwn-sdk-js/tests/dwn.spec.ts
+++ b/packages/dwn-sdk-js/tests/dwn.spec.ts
@@ -10,7 +10,6 @@ import sinon from 'sinon';
 import nestedProtocol from './vectors/protocol-definitions/nested.json' with { type: 'json' };
 
 import { Dwn } from '../src/dwn.js';
-import { StorageController } from '../src/store/storage-controller.js';
 import { TestEventLog } from './test-event-stream.js';
 import { TestStores } from './test-stores.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
@@ -613,8 +612,7 @@ export function testDwnClass(): void {
 
         // replaying the beaten delete through the task path must be a no-op — the same lattice
         // gate as admission — leaving the canonical tombstone as the record's newest message
-        const storageController = new StorageController({ messageStore, dataStore });
-        await storageController.performRecordsDelete({ tenant: alice.did, message: staleDelete.message });
+        await dwn['storageController'].performRecordsDelete({ tenant: alice.did, message: staleDelete.message });
 
         const tombstoneCid = await Message.getCid(recordsDelete.message);
         const staleDeleteCid = await Message.getCid(staleDelete.message);

--- a/packages/dwn-sdk-js/tests/features/records-record-limit.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-record-limit.spec.ts
@@ -1,20 +1,30 @@
 import type { DidResolver } from '@enbox/dids';
 import type { EventLog } from '../../src/types/subscriptions.js';
-import type { DataStore, MessageStore, ProtocolDefinition, ResumableTaskStore } from '../../src/index.js';
+import type { Pagination } from '../../src/types/message-types.js';
+import type { PaginationCursor } from '../../src/types/query-types.js';
+import type {
+  DataStore, MessageStore, ProtocolDefinition, RecordsCountReply, RecordsQueryReply, RecordsReadReply,
+  RecordsSubscribeReply, ResumableTaskStore
+} from '../../src/index.js';
+import type { GenerateRecordsWriteOutput, Persona } from '../utils/test-data-generator.js';
 
 import sinon from 'sinon';
 
 import { DataStream } from '../../src/utils/data-stream.js';
 import { DidKey } from '@enbox/dids';
 import { Dwn } from '../../src/dwn.js';
+import { DwnConstant } from '../../src/core/dwn-constant.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Jws } from '../../src/utils/jws.js';
 import { ProtocolsConfigure } from '../../src/interfaces/protocols-configure.js';
+import { RecordsRead } from '../../src/interfaces/records-read.js';
+import { sleep } from '@enbox/common';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { UniversalResolver } from '@enbox/dids';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { DataStoreLevel, MessageStoreLevel, ResumableTaskStoreLevel } from '../../src/index.js';
 
 export function testRecordsRecordLimit(): void {
   describe('Records $recordLimit', () => {
@@ -50,6 +60,143 @@ export function testRecordsRecordLimit(): void {
     afterAll(async () => {
       await dwn.close();
     });
+
+    async function installProtocol(input: {
+      author: Persona;
+      definition: ProtocolDefinition;
+      targetDwn?: Dwn;
+    }): Promise<void> {
+      const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+        author             : input.author,
+        protocolDefinition : input.definition,
+        messageTimestamp   : '2024-01-01T00:00:00.000000Z',
+      });
+
+      const reply = await (input.targetDwn ?? dwn).processMessage(input.author.did, protocolConfig.message);
+      expect(reply.status.code).toBe(202);
+    }
+
+    async function writeProtocolRecord(input: {
+      author: Persona;
+      protocol: string;
+      protocolPath: string;
+      dateCreated: string;
+      parentContextId?: string;
+      targetDwn?: Dwn;
+    }): Promise<GenerateRecordsWriteOutput> {
+      const record = await TestDataGenerator.generateRecordsWrite({
+        author           : input.author,
+        recipient        : input.author.did,
+        protocol         : input.protocol,
+        protocolPath     : input.protocolPath,
+        parentContextId  : input.parentContextId,
+        dateCreated      : input.dateCreated,
+        messageTimestamp : input.dateCreated,
+      });
+
+      const reply = await (input.targetDwn ?? dwn).processMessage(input.author.did, record.message, { dataStream: record.dataStream });
+      expect(reply.status.code).toBe(202);
+      return record;
+    }
+
+    async function queryProtocolRecordIds(input: {
+      author: Persona;
+      protocol: string;
+      protocolPath: string;
+      contextId?: string;
+      pagination?: Pagination;
+      targetDwn?: Dwn;
+    }): Promise<{ recordIds: string[]; cursor?: PaginationCursor }> {
+      const recordsQuery = await TestDataGenerator.generateRecordsQuery({
+        author : input.author,
+        filter : {
+          protocol     : input.protocol,
+          protocolPath : input.protocolPath,
+          ...(input.contextId === undefined ? {} : { contextId: input.contextId }),
+        },
+        pagination: input.pagination,
+      });
+
+      const reply = await (input.targetDwn ?? dwn).processMessage(input.author.did, recordsQuery.message) as RecordsQueryReply;
+      expect(reply.status.code).toBe(200);
+
+      return {
+        recordIds : reply.entries?.map((entry): string => entry.recordId) ?? [],
+        cursor    : reply.cursor,
+      };
+    }
+
+    async function countProtocolRecords(input: {
+      author: Persona;
+      protocol: string;
+      protocolPath: string;
+      contextId?: string;
+      targetDwn?: Dwn;
+    }): Promise<number> {
+      const recordsCount = await TestDataGenerator.generateRecordsCount({
+        author : input.author,
+        filter : {
+          protocol     : input.protocol,
+          protocolPath : input.protocolPath,
+          ...(input.contextId === undefined ? {} : { contextId: input.contextId }),
+        },
+      });
+
+      const reply = await (input.targetDwn ?? dwn).processMessage(input.author.did, recordsCount.message) as RecordsCountReply;
+      expect(reply.status.code).toBe(200);
+      return reply.count!;
+    }
+
+    async function readRecord(input: {
+      author: Persona;
+      recordId: string;
+      targetDwn?: Dwn;
+    }): Promise<RecordsReadReply> {
+      const recordsRead = await RecordsRead.create({
+        signer : Jws.createSigner(input.author),
+        filter : { recordId: input.recordId },
+      });
+
+      return await (input.targetDwn ?? dwn).processMessage(input.author.did, recordsRead.message) as RecordsReadReply;
+    }
+
+    async function subscribeSnapshotRecordIds(input: {
+      author: Persona;
+      protocol: string;
+      protocolPath: string;
+      targetDwn?: Dwn;
+    }): Promise<string[]> {
+      const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({
+        author : input.author,
+        filter : {
+          protocol     : input.protocol,
+          protocolPath : input.protocolPath,
+        },
+      });
+
+      const reply = await (input.targetDwn ?? dwn).processMessage(
+        input.author.did,
+        recordsSubscribe.message,
+        { subscriptionHandler: () => {} },
+      ) as RecordsSubscribeReply;
+      expect(reply.status.code).toBe(200);
+      await reply.subscription?.close();
+      return reply.entries?.map((entry): string => entry.recordId) ?? [];
+    }
+
+    async function applyReplicatedWrite(input: {
+      targetDwn: Dwn;
+      tenant: string;
+      record: GenerateRecordsWriteOutput;
+    }): Promise<void> {
+      const result = await input.targetDwn.applyReplicatedMessage(input.tenant, input.record.message, {
+        dataStream: DataStream.fromBytes(input.record.dataBytes!),
+      });
+
+      if (result.kind !== 'Applied' && result.kind !== 'Duplicate' && result.kind !== 'Superseded') {
+        throw new Error(`unexpected replicated write result ${result.kind}`);
+      }
+    }
 
     describe('ProtocolsConfigure validation', () => {
       it('should allow $recordLimit with valid max and strategy', async () => {
@@ -101,6 +248,28 @@ export function testRecordsRecordLimit(): void {
           max      : 1,
           strategy : 'reject',
         });
+      });
+
+      it('should reject $recordLimit above the supported max', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const definition: ProtocolDefinition = {
+          protocol  : 'http://example.com/record-limit',
+          published : true,
+          types     : { message: {} },
+          structure : {
+            message: {
+              $recordLimit: { max: DwnConstant.maxRecordLimit + 1, strategy: 'reject' },
+            }
+          }
+        };
+
+        const promise = ProtocolsConfigure.create({
+          signer: Jws.createSigner(alice),
+          definition,
+        });
+
+        await expect(promise).rejects.toThrow(DwnErrorCode.ProtocolsConfigureInvalidRecordLimit);
       });
 
       it('should allow $recordLimit with purgeOldest strategy (schema validation only)', async () => {
@@ -248,49 +417,12 @@ export function testRecordsRecordLimit(): void {
       });
     });
 
-    describe('runtime enforcement — reject strategy', () => {
-      it('should allow writes up to the record limit', async () => {
+    describe('read-time occupancy projection — reject strategy', () => {
+      it('should admit candidates and project Query, Read, and Count to top-ranked occupants', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
         const protocolDefinition: ProtocolDefinition = {
-          protocol  : 'http://record-limit-test.xyz',
-          published : true,
-          types     : { blob: {} },
-          structure : {
-            blob: {
-              $recordLimit: { max: 3, strategy: 'reject' },
-            }
-          }
-        };
-
-        const protocol = protocolDefinition.protocol;
-        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
-          author: alice,
-          protocolDefinition,
-        });
-
-        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
-        expect(configReply.status.code).toBe(202);
-
-        // write 3 records — all should succeed
-        for (let i = 0; i < 3; i++) {
-          const record = await TestDataGenerator.generateRecordsWrite({
-            author       : alice,
-            recipient    : alice.did,
-            protocol,
-            protocolPath : 'blob',
-          });
-
-          const reply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
-          expect(reply.status.code).toBe(202);
-        }
-      });
-
-      it('should reject writes that exceed the record limit', async () => {
-        const alice = await TestDataGenerator.generateDidKeyPersona();
-
-        const protocolDefinition: ProtocolDefinition = {
-          protocol  : 'http://record-limit-test.xyz',
+          protocol  : `http://record-limit-${TestDataGenerator.randomString(12)}.xyz`,
           published : true,
           types     : { blob: {} },
           structure : {
@@ -299,47 +431,52 @@ export function testRecordsRecordLimit(): void {
             }
           }
         };
-
         const protocol = protocolDefinition.protocol;
-        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
-          author: alice,
-          protocolDefinition,
-        });
+        await installProtocol({ author: alice, definition: protocolDefinition });
 
-        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
-        expect(configReply.status.code).toBe(202);
-
-        // write 2 records — both should succeed
-        for (let i = 0; i < 2; i++) {
-          const record = await TestDataGenerator.generateRecordsWrite({
-            author       : alice,
-            recipient    : alice.did,
-            protocol,
-            protocolPath : 'blob',
-          });
-
-          const reply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
-          expect(reply.status.code).toBe(202);
-        }
-
-        // 3rd record should be rejected
-        const record3 = await TestDataGenerator.generateRecordsWrite({
+        const record1 = await writeProtocolRecord({
           author       : alice,
-          recipient    : alice.did,
           protocol,
           protocolPath : 'blob',
+          dateCreated  : '2025-01-01T00:00:00.000000Z',
+        });
+        const duplicateReply = await dwn.processMessage(alice.did, record1.message, {
+          dataStream: DataStream.fromBytes(record1.dataBytes!),
+        });
+        expect(duplicateReply.status.code).toBe(409);
+
+        const record2 = await writeProtocolRecord({
+          author       : alice,
+          protocol,
+          protocolPath : 'blob',
+          dateCreated  : '2025-01-02T00:00:00.000000Z',
+        });
+        const record3 = await writeProtocolRecord({
+          author       : alice,
+          protocol,
+          protocolPath : 'blob',
+          dateCreated  : '2025-01-03T00:00:00.000000Z',
         });
 
-        const reply3 = await dwn.processMessage(alice.did, record3.message, { dataStream: record3.dataStream });
-        expect(reply3.status.code).toBe(400);
-        expect(reply3.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationRecordLimitExceeded);
+        expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'blob' })).recordIds).toEqual([
+          record1.message.recordId,
+          record2.message.recordId,
+        ]);
+        expect(await countProtocolRecords({ author: alice, protocol, protocolPath: 'blob' })).toBe(2);
+
+        const visibleRead = await readRecord({ author: alice, recordId: record1.message.recordId });
+        expect(visibleRead.status.code).toBe(200);
+        expect(visibleRead.entry?.recordsWrite?.recordId).toBe(record1.message.recordId);
+
+        const hiddenRead = await readRecord({ author: alice, recordId: record3.message.recordId });
+        expect(hiddenRead.status.code).toBe(404);
       });
 
-      it('should enforce $recordLimit with max of 1 (singleton pattern)', async () => {
+      it('should promote the next candidate at read time when the current occupant is deleted', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
         const protocolDefinition: ProtocolDefinition = {
-          protocol  : 'http://record-limit-test.xyz',
+          protocol  : `http://record-limit-${TestDataGenerator.randomString(12)}.xyz`,
           published : true,
           types     : { profile: {} },
           structure : {
@@ -348,162 +485,44 @@ export function testRecordsRecordLimit(): void {
             }
           }
         };
-
         const protocol = protocolDefinition.protocol;
-        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
-          author: alice,
-          protocolDefinition,
-        });
+        await installProtocol({ author: alice, definition: protocolDefinition });
 
-        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
-        expect(configReply.status.code).toBe(202);
-
-        // first record should succeed
-        const record1 = await TestDataGenerator.generateRecordsWrite({
+        const record1 = await writeProtocolRecord({
           author       : alice,
-          recipient    : alice.did,
           protocol,
           protocolPath : 'profile',
+          dateCreated  : '2025-01-01T00:00:00.000000Z',
         });
-
-        const reply1 = await dwn.processMessage(alice.did, record1.message, { dataStream: record1.dataStream });
-        expect(reply1.status.code).toBe(202);
-
-        // exact duplicate delivery is idempotent and should not count the
-        // same recordId against its own singleton limit
-        const duplicateReply = await dwn.processMessage(alice.did, record1.message, {
-          dataStream: DataStream.fromBytes(record1.dataBytes!),
-        });
-        expect(duplicateReply.status.code).toBe(409);
-
-        // second record should be rejected
-        const record2 = await TestDataGenerator.generateRecordsWrite({
+        const record2 = await writeProtocolRecord({
           author       : alice,
-          recipient    : alice.did,
           protocol,
           protocolPath : 'profile',
+          dateCreated  : '2025-01-02T00:00:00.000000Z',
         });
 
-        const reply2 = await dwn.processMessage(alice.did, record2.message, { dataStream: record2.dataStream });
-        expect(reply2.status.code).toBe(400);
-        expect(reply2.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationRecordLimitExceeded);
-      });
+        expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'profile' })).recordIds).toEqual([
+          record1.message.recordId,
+        ]);
 
-      it('should allow new writes after records are deleted to free up space', async () => {
-        const alice = await TestDataGenerator.generateDidKeyPersona();
-
-        const protocolDefinition: ProtocolDefinition = {
-          protocol  : 'http://record-limit-test.xyz',
-          published : true,
-          types     : { blob: {} },
-          structure : {
-            blob: {
-              $recordLimit: { max: 1, strategy: 'reject' },
-            }
-          }
-        };
-
-        const protocol = protocolDefinition.protocol;
-        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
-          author: alice,
-          protocolDefinition,
-        });
-
-        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
-        expect(configReply.status.code).toBe(202);
-
-        // write first record
-        const record1 = await TestDataGenerator.generateRecordsWrite({
-          author       : alice,
-          recipient    : alice.did,
-          protocol,
-          protocolPath : 'blob',
-        });
-
-        const reply1 = await dwn.processMessage(alice.did, record1.message, { dataStream: record1.dataStream });
-        expect(reply1.status.code).toBe(202);
-
-        // second write should be rejected
-        const record2 = await TestDataGenerator.generateRecordsWrite({
-          author       : alice,
-          recipient    : alice.did,
-          protocol,
-          protocolPath : 'blob',
-        });
-
-        const reply2 = await dwn.processMessage(alice.did, record2.message, { dataStream: record2.dataStream });
-        expect(reply2.status.code).toBe(400);
-
-        // delete the first record
         const deleteRecord = await TestDataGenerator.generateRecordsDelete({
           author   : alice,
           recordId : record1.message.recordId,
         });
-
         const deleteReply = await dwn.processMessage(alice.did, deleteRecord.message);
         expect(deleteReply.status.code).toBe(202);
 
-        // now a new write should succeed
-        const record3 = await TestDataGenerator.generateRecordsWrite({
-          author       : alice,
-          recipient    : alice.did,
-          protocol,
-          protocolPath : 'blob',
-        });
-
-        const reply3 = await dwn.processMessage(alice.did, record3.message, { dataStream: record3.dataStream });
-        expect(reply3.status.code).toBe(202);
+        expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'profile' })).recordIds).toEqual([
+          record2.message.recordId,
+        ]);
+        expect((await readRecord({ author: alice, recordId: record2.message.recordId })).status.code).toBe(200);
       });
 
-      it('should not count updates toward the record limit', async () => {
+      it('should project occupancy independently per exact parent context without scanning broad cross-context queries', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
         const protocolDefinition: ProtocolDefinition = {
-          protocol  : 'http://record-limit-test.xyz',
-          published : true,
-          types     : { blob: {} },
-          structure : {
-            blob: {
-              $recordLimit: { max: 1, strategy: 'reject' },
-            }
-          }
-        };
-
-        const protocol = protocolDefinition.protocol;
-        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
-          author: alice,
-          protocolDefinition,
-        });
-
-        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
-        expect(configReply.status.code).toBe(202);
-
-        // write the record
-        const record1 = await TestDataGenerator.generateRecordsWrite({
-          author       : alice,
-          recipient    : alice.did,
-          protocol,
-          protocolPath : 'blob',
-        });
-
-        const reply1 = await dwn.processMessage(alice.did, record1.message, { dataStream: record1.dataStream });
-        expect(reply1.status.code).toBe(202);
-
-        // update the same record — should succeed (not counted as new)
-        const updatedRecord = await TestDataGenerator.generateFromRecordsWrite({
-          author        : alice,
-          existingWrite : record1.recordsWrite,
-        });
-
-        const updateReply = await dwn.processMessage(alice.did, updatedRecord.message, { dataStream: updatedRecord.dataStream });
-        expect(updateReply.status.code).toBe(202);
-      });
-
-      it('should enforce $recordLimit per parent context for nested records', async () => {
-        const alice = await TestDataGenerator.generateDidKeyPersona();
-
-        const protocolDefinition: ProtocolDefinition = {
-          protocol  : 'http://record-limit-test.xyz',
+          protocol  : `http://record-limit-${TestDataGenerator.randomString(12)}.xyz`,
           published : true,
           types     : {
             room    : {},
@@ -517,99 +536,356 @@ export function testRecordsRecordLimit(): void {
             }
           }
         };
-
         const protocol = protocolDefinition.protocol;
-        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
-          author: alice,
-          protocolDefinition,
-        });
+        await installProtocol({ author: alice, definition: protocolDefinition });
 
-        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
-        expect(configReply.status.code).toBe(202);
-
-        // create two rooms
-        const room1 = await TestDataGenerator.generateRecordsWrite({
+        const room1 = await writeProtocolRecord({
           author       : alice,
-          recipient    : alice.did,
           protocol,
           protocolPath : 'room',
+          dateCreated  : '2025-01-01T00:00:00.000000Z',
         });
-        const room1Reply = await dwn.processMessage(alice.did, room1.message, { dataStream: room1.dataStream });
-        expect(room1Reply.status.code).toBe(202);
-
-        const room2 = await TestDataGenerator.generateRecordsWrite({
+        const room2 = await writeProtocolRecord({
           author       : alice,
-          recipient    : alice.did,
           protocol,
           protocolPath : 'room',
+          dateCreated  : '2025-01-02T00:00:00.000000Z',
         });
-        const room2Reply = await dwn.processMessage(alice.did, room2.message, { dataStream: room2.dataStream });
-        expect(room2Reply.status.code).toBe(202);
 
-        // write 2 messages in room1 — both should succeed
-        let firstRoom1Message: Awaited<ReturnType<typeof TestDataGenerator.generateRecordsWrite>> | undefined;
-        for (let i = 0; i < 2; i++) {
-          const msg = await TestDataGenerator.generateRecordsWrite({
+        const room1Messages = [
+          await writeProtocolRecord({
             author          : alice,
-            recipient       : alice.did,
             protocol,
             protocolPath    : 'room/message',
             parentContextId : room1.message.contextId,
-          });
-          const msgReply = await dwn.processMessage(alice.did, msg.message, { dataStream: msg.dataStream });
-          expect(msgReply.status.code).toBe(202);
-          firstRoom1Message ??= msg;
-        }
-
-        // exact duplicate nested delivery is idempotent within the parent context
-        const duplicateNestedReply = await dwn.processMessage(alice.did, firstRoom1Message!.message, {
-          dataStream: DataStream.fromBytes(firstRoom1Message!.dataBytes!),
-        });
-        expect(duplicateNestedReply.status.code).toBe(409);
-
-        // 3rd message in room1 should be rejected
-        const msg3 = await TestDataGenerator.generateRecordsWrite({
-          author          : alice,
-          recipient       : alice.did,
-          protocol,
-          protocolPath    : 'room/message',
-          parentContextId : room1.message.contextId,
-        });
-        const msg3Reply = await dwn.processMessage(alice.did, msg3.message, { dataStream: msg3.dataStream });
-        expect(msg3Reply.status.code).toBe(400);
-        expect(msg3Reply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationRecordLimitExceeded);
-
-        // but room2 still has capacity — write 2 messages
-        for (let i = 0; i < 2; i++) {
-          const msg = await TestDataGenerator.generateRecordsWrite({
+            dateCreated     : '2025-02-01T00:00:00.000000Z',
+          }),
+          await writeProtocolRecord({
             author          : alice,
-            recipient       : alice.did,
+            protocol,
+            protocolPath    : 'room/message',
+            parentContextId : room1.message.contextId,
+            dateCreated     : '2025-02-02T00:00:00.000000Z',
+          }),
+          await writeProtocolRecord({
+            author          : alice,
+            protocol,
+            protocolPath    : 'room/message',
+            parentContextId : room1.message.contextId,
+            dateCreated     : '2025-02-03T00:00:00.000000Z',
+          }),
+        ];
+        const room2Messages = [
+          await writeProtocolRecord({
+            author          : alice,
             protocol,
             protocolPath    : 'room/message',
             parentContextId : room2.message.contextId,
-          });
-          const msgReply = await dwn.processMessage(alice.did, msg.message, { dataStream: msg.dataStream });
-          expect(msgReply.status.code).toBe(202);
+            dateCreated     : '2025-03-01T00:00:00.000000Z',
+          }),
+          await writeProtocolRecord({
+            author          : alice,
+            protocol,
+            protocolPath    : 'room/message',
+            parentContextId : room2.message.contextId,
+            dateCreated     : '2025-03-02T00:00:00.000000Z',
+          }),
+          await writeProtocolRecord({
+            author          : alice,
+            protocol,
+            protocolPath    : 'room/message',
+            parentContextId : room2.message.contextId,
+            dateCreated     : '2025-03-03T00:00:00.000000Z',
+          }),
+        ];
+
+        expect((await queryProtocolRecordIds({
+          author       : alice,
+          protocol,
+          protocolPath : 'room/message',
+          contextId    : room1.message.contextId,
+        })).recordIds).toEqual([
+          room1Messages[0].message.recordId,
+          room1Messages[1].message.recordId,
+        ]);
+        expect((await queryProtocolRecordIds({
+          author       : alice,
+          protocol,
+          protocolPath : 'room/message',
+          contextId    : room2.message.contextId,
+        })).recordIds).toEqual([
+          room2Messages[0].message.recordId,
+          room2Messages[1].message.recordId,
+        ]);
+        expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'room/message' })).recordIds).toEqual([
+          room1Messages[0].message.recordId,
+          room1Messages[1].message.recordId,
+          room1Messages[2].message.recordId,
+          room2Messages[0].message.recordId,
+          room2Messages[1].message.recordId,
+          room2Messages[2].message.recordId,
+        ]);
+      });
+
+      it('should paginate over the projected occupant set for max:N scopes', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : `http://record-limit-${TestDataGenerator.randomString(12)}.xyz`,
+          published : true,
+          types     : { item: {} },
+          structure : {
+            item: {
+              $recordLimit: { max: 3, strategy: 'reject' },
+            }
+          }
+        };
+        const protocol = protocolDefinition.protocol;
+        await installProtocol({ author: alice, definition: protocolDefinition });
+
+        const records: GenerateRecordsWriteOutput[] = [];
+        for (let i = 1; i <= 5; i++) {
+          records.push(await writeProtocolRecord({
+            author       : alice,
+            protocol,
+            protocolPath : 'item',
+            dateCreated  : `2025-01-0${i}T00:00:00.000000Z`,
+          }));
         }
 
-        // 3rd message in room2 should also be rejected
-        const msg3Room2 = await TestDataGenerator.generateRecordsWrite({
-          author          : alice,
-          recipient       : alice.did,
+        const page1 = await queryProtocolRecordIds({
+          author       : alice,
           protocol,
-          protocolPath    : 'room/message',
-          parentContextId : room2.message.contextId,
+          protocolPath : 'item',
+          pagination   : { limit: 2 },
         });
-        const msg3Room2Reply = await dwn.processMessage(alice.did, msg3Room2.message, { dataStream: msg3Room2.dataStream });
-        expect(msg3Room2Reply.status.code).toBe(400);
-        expect(msg3Room2Reply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationRecordLimitExceeded);
+        expect(page1.recordIds).toEqual([
+          records[0].message.recordId,
+          records[1].message.recordId,
+        ]);
+        expect(page1.cursor).toBeDefined();
+
+        const page2 = await queryProtocolRecordIds({
+          author       : alice,
+          protocol,
+          protocolPath : 'item',
+          pagination   : { limit: 2, cursor: page1.cursor! },
+        });
+        expect(page2.recordIds).toEqual([records[2].message.recordId]);
+        expect(page2.cursor).toBeUndefined();
+      });
+
+      it('should project RecordsSubscribe snapshots and suppress hidden live writes', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : `http://record-limit-${TestDataGenerator.randomString(12)}.xyz`,
+          published : true,
+          types     : { status: {} },
+          structure : {
+            status: {
+              $recordLimit: { max: 1, strategy: 'reject' },
+            }
+          }
+        };
+        const protocol = protocolDefinition.protocol;
+        await installProtocol({ author: alice, definition: protocolDefinition });
+
+        const visibleRecord = await writeProtocolRecord({
+          author       : alice,
+          protocol,
+          protocolPath : 'status',
+          dateCreated  : '2025-01-01T00:00:00.000000Z',
+        });
+        const hiddenRecord = await writeProtocolRecord({
+          author       : alice,
+          protocol,
+          protocolPath : 'status',
+          dateCreated  : '2025-01-02T00:00:00.000000Z',
+        });
+
+        expect(await subscribeSnapshotRecordIds({ author: alice, protocol, protocolPath: 'status' })).toEqual([
+          visibleRecord.message.recordId,
+        ]);
+
+        const liveRecordIds: string[] = [];
+        const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({
+          author : alice,
+          filter : {
+            protocol,
+            protocolPath: 'status',
+          },
+        });
+        const subscribeReply = await dwn.processMessage(alice.did, recordsSubscribe.message, {
+          subscriptionHandler: (subscriptionMessage): void => {
+            if (subscriptionMessage.type === 'event') {
+              const eventMessage = subscriptionMessage.event.message;
+              if (eventMessage.descriptor.method === 'Write' && 'recordId' in eventMessage && typeof eventMessage.recordId === 'string') {
+                liveRecordIds.push(eventMessage.recordId);
+              }
+            }
+          },
+        }) as RecordsSubscribeReply;
+        expect(subscribeReply.status.code).toBe(200);
+
+        const laterHiddenRecord = await writeProtocolRecord({
+          author       : alice,
+          protocol,
+          protocolPath : 'status',
+          dateCreated  : '2025-01-03T00:00:00.000000Z',
+        });
+        expect(hiddenRecord.message.recordId).not.toBe(laterHiddenRecord.message.recordId);
+        await sleep(100);
+        expect(liveRecordIds).toEqual([]);
+
+        await subscribeReply.subscription?.close();
+      });
+
+      it('should converge projected query results when replicas create max:1 and max:N occupants offline', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const testId = TestDataGenerator.randomString(12);
+        const replicaAStore = new MessageStoreLevel({ location: `__TESTDATA__/record-limit-${testId}/message-a` });
+        const replicaADataStore = new DataStoreLevel({ blockstoreLocation: `__TESTDATA__/record-limit-${testId}/data-a` });
+        const replicaATaskStore = new ResumableTaskStoreLevel({ location: `__TESTDATA__/record-limit-${testId}/task-a` });
+        const replicaBStore = new MessageStoreLevel({ location: `__TESTDATA__/record-limit-${testId}/message-b` });
+        const replicaBDataStore = new DataStoreLevel({ blockstoreLocation: `__TESTDATA__/record-limit-${testId}/data-b` });
+        const replicaBTaskStore = new ResumableTaskStoreLevel({ location: `__TESTDATA__/record-limit-${testId}/task-b` });
+        const replicaA = await Dwn.create({
+          didResolver        : didResolver,
+          messageStore       : replicaAStore,
+          dataStore          : replicaADataStore,
+          resumableTaskStore : replicaATaskStore,
+        });
+        const replicaB = await Dwn.create({
+          didResolver        : didResolver,
+          messageStore       : replicaBStore,
+          dataStore          : replicaBDataStore,
+          resumableTaskStore : replicaBTaskStore,
+        });
+
+        try {
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : `http://record-limit-offline-${testId}.xyz`,
+            published : true,
+            types     : {
+              note    : {},
+              profile : {},
+            },
+            structure: {
+              note: {
+                $recordLimit: { max: 2, strategy: 'reject' },
+              },
+              profile: {
+                $recordLimit: { max: 1, strategy: 'reject' },
+              }
+            }
+          };
+          const protocol = protocolDefinition.protocol;
+          await installProtocol({ author: alice, definition: protocolDefinition, targetDwn: replicaA });
+          await installProtocol({ author: alice, definition: protocolDefinition, targetDwn: replicaB });
+
+          const profileA = await writeProtocolRecord({
+            author       : alice,
+            protocol,
+            protocolPath : 'profile',
+            dateCreated  : '2025-01-01T00:00:00.000000Z',
+            targetDwn    : replicaA,
+          });
+          const profileB = await writeProtocolRecord({
+            author       : alice,
+            protocol,
+            protocolPath : 'profile',
+            dateCreated  : '2025-01-02T00:00:00.000000Z',
+            targetDwn    : replicaB,
+          });
+          const noteA1 = await writeProtocolRecord({
+            author       : alice,
+            protocol,
+            protocolPath : 'note',
+            dateCreated  : '2025-02-01T00:00:00.000000Z',
+            targetDwn    : replicaA,
+          });
+          const noteB = await writeProtocolRecord({
+            author       : alice,
+            protocol,
+            protocolPath : 'note',
+            dateCreated  : '2025-02-02T00:00:00.000000Z',
+            targetDwn    : replicaB,
+          });
+          const noteA2 = await writeProtocolRecord({
+            author       : alice,
+            protocol,
+            protocolPath : 'note',
+            dateCreated  : '2025-02-03T00:00:00.000000Z',
+            targetDwn    : replicaA,
+          });
+
+          await applyReplicatedWrite({ targetDwn: replicaA, tenant: alice.did, record: profileB });
+          await applyReplicatedWrite({ targetDwn: replicaB, tenant: alice.did, record: profileA });
+          await applyReplicatedWrite({ targetDwn: replicaA, tenant: alice.did, record: noteB });
+          await applyReplicatedWrite({ targetDwn: replicaB, tenant: alice.did, record: noteA1 });
+          await applyReplicatedWrite({ targetDwn: replicaB, tenant: alice.did, record: noteA2 });
+
+          const expectedProfileIds = [profileA.message.recordId];
+          const expectedNoteIds = [
+            noteA1.message.recordId,
+            noteB.message.recordId,
+          ];
+          expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'profile', targetDwn: replicaA })).recordIds).toEqual(expectedProfileIds);
+          expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'profile', targetDwn: replicaB })).recordIds).toEqual(expectedProfileIds);
+          expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'note', targetDwn: replicaA })).recordIds).toEqual(expectedNoteIds);
+          expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'note', targetDwn: replicaB })).recordIds).toEqual(expectedNoteIds);
+        } finally {
+          await replicaAStore.clear();
+          await replicaADataStore.clear();
+          await replicaATaskStore.clear();
+          await replicaBStore.clear();
+          await replicaBDataStore.clear();
+          await replicaBTaskStore.clear();
+          await replicaA.close();
+          await replicaB.close();
+        }
+      });
+
+      it('should not count updates toward the record limit', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : `http://record-limit-${TestDataGenerator.randomString(12)}.xyz`,
+          published : true,
+          types     : { blob: {} },
+          structure : {
+            blob: {
+              $recordLimit: { max: 1, strategy: 'reject' },
+            }
+          }
+        };
+        const protocol = protocolDefinition.protocol;
+        await installProtocol({ author: alice, definition: protocolDefinition });
+
+        const record = await writeProtocolRecord({
+          author       : alice,
+          protocol,
+          protocolPath : 'blob',
+          dateCreated  : '2025-01-01T00:00:00.000000Z',
+        });
+        const updatedRecord = await TestDataGenerator.generateFromRecordsWrite({
+          author        : alice,
+          existingWrite : record.recordsWrite,
+        });
+
+        const updateReply = await dwn.processMessage(alice.did, updatedRecord.message, { dataStream: updatedRecord.dataStream });
+        expect(updateReply.status.code).toBe(202);
+        expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'blob' })).recordIds).toEqual([
+          record.message.recordId,
+        ]);
       });
 
       it('should reject purgeOldest strategy at write time with not-implemented error', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
         const protocolDefinition: ProtocolDefinition = {
-          protocol  : 'http://record-limit-test.xyz',
+          protocol  : `http://record-limit-${TestDataGenerator.randomString(12)}.xyz`,
           published : true,
           types     : { blob: {} },
           structure : {
@@ -618,40 +894,20 @@ export function testRecordsRecordLimit(): void {
             }
           }
         };
-
         const protocol = protocolDefinition.protocol;
-        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
-          author: alice,
-          protocolDefinition,
-        });
+        await installProtocol({ author: alice, definition: protocolDefinition });
 
-        const configReply = await dwn.processMessage(alice.did, protocolConfig.message);
-        expect(configReply.status.code).toBe(202);
-
-        // first record should succeed
-        const record1 = await TestDataGenerator.generateRecordsWrite({
+        const record = await TestDataGenerator.generateRecordsWrite({
           author       : alice,
           recipient    : alice.did,
           protocol,
           protocolPath : 'blob',
         });
 
-        const reply1 = await dwn.processMessage(alice.did, record1.message, { dataStream: record1.dataStream });
-        expect(reply1.status.code).toBe(202);
-
-        // second record should fail because purgeOldest is not yet implemented
-        const record2 = await TestDataGenerator.generateRecordsWrite({
-          author       : alice,
-          recipient    : alice.did,
-          protocol,
-          protocolPath : 'blob',
-        });
-
-        const reply2 = await dwn.processMessage(alice.did, record2.message, { dataStream: record2.dataStream });
-        expect(reply2.status.code).toBe(400);
-        expect(reply2.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationRecordLimitStrategyNotImplemented);
+        const reply = await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream });
+        expect(reply.status.code).toBe(400);
+        expect(reply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationRecordLimitStrategyNotImplemented);
       });
-
     });
   });
 }


### PR DESCRIPTION
## Summary

- keeps `$recordLimit` admission uniform: supported `reject` limits retain candidates instead of hard-rejecting over-limit writes, while unsupported strategies still fail at write time
- removes the materialized occupancy fold and the write/delete side effects that made limit enforcement crash-sensitive
- projects record-limit occupants at read time for bounded concrete scopes using deterministic `(dateCreated, recordId)` ranking
- preserves native store pagination, count, and read behavior for non-limited filters and broad cross-context filters instead of fetching entire result sets into memory
- requires Records Query, Count, and Subscribe filters for nested protocol paths to pin the direct parent `contextId`; root paths and `RecordsRead` by id are unchanged
- scopes agent permission revocation lookups per grant context so permission discovery follows the same nested-query rule
- caps `$recordLimit.max` during `ProtocolsConfigure` validation
- simplifies API singleton `set()` to update the projected occupant when present, otherwise create a new record

## Notes

- broad multi-context `$recordLimit` queries intentionally stay on the store-native path until there is a bounded grouping strategy
- no migration required