### PR TITLE
fix(dwn-sdk-js): require parent context for nested queries

### DIFF
--- a/.changeset/nested-query-context.md
+++ b/.changeset/nested-query-context.md
@@ -4,4 +4,4 @@
 "@enbox/auth": patch
 ---
 
-Require nested protocol Query, Count, and Subscribe filters to pin the direct parent contextId, consolidate permission revocation checks onto the canonical per-grant predicate, and route delegated sync scope derivation through the permissions API.
+Require nested protocol Query, Count, and Subscribe filters to pin the direct parent contextId, make permission revocation filtering opt-in with scalar per-grant checks, and route delegated sync scope derivation through the permissions API.

--- a/.changeset/nested-query-context.md
+++ b/.changeset/nested-query-context.md
@@ -1,6 +1,7 @@
 ---
 "@enbox/dwn-sdk-js": patch
 "@enbox/agent": patch
+"@enbox/auth": patch
 ---
 
-Require nested protocol Query, Count, and Subscribe filters to pin the direct parent contextId, and keep agent permission revocation checks scoped without cross-context nested queries.
+Require nested protocol Query, Count, and Subscribe filters to pin the direct parent contextId, keep permission revocation lookups scoped without cross-context nested queries, and keep delegated sync scope derivation compatible with that rule.

--- a/.changeset/nested-query-context.md
+++ b/.changeset/nested-query-context.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+---
+
+Require nested protocol Query, Count, and Subscribe filters to pin the direct parent contextId, and scope agent permission revocation lookups per grant context.

--- a/.changeset/nested-query-context.md
+++ b/.changeset/nested-query-context.md
@@ -4,4 +4,4 @@
 "@enbox/auth": patch
 ---
 
-Require nested protocol Query, Count, and Subscribe filters to pin the direct parent contextId, keep permission revocation lookups scoped without cross-context nested queries, and keep delegated sync scope derivation compatible with that rule.
+Require nested protocol Query, Count, and Subscribe filters to pin the direct parent contextId, consolidate permission revocation checks onto the canonical per-grant predicate, and route delegated sync scope derivation through the permissions API.

--- a/.changeset/nested-query-context.md
+++ b/.changeset/nested-query-context.md
@@ -3,4 +3,4 @@
 "@enbox/agent": patch
 ---
 
-Require nested protocol Query, Count, and Subscribe filters to pin the direct parent contextId, and scope agent permission revocation lookups per grant context.
+Require nested protocol Query, Count, and Subscribe filters to pin the direct parent contextId, and keep agent permission revocation checks scoped without cross-context nested queries.

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -1,7 +1,7 @@
-import type { EnboxAgent } from './types/agent.js';
 import type { CreateGrantParams, CreateRequestParams, CreateRevocationParams, FetchPermissionRequestParams, FetchPermissionsParams, GetPermissionParams, IsGrantRevokedParams, PermissionGrantEntry, PermissionRequestEntry, PermissionRevocationEntry, PermissionsApi } from './types/permissions.js';
 import type { DwnDataEncodedRecordsWriteMessage, DwnMessageParams, DwnRecordsPermissionScope, ProcessDwnRequest } from './types/dwn.js';
-import type { PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData } from '@enbox/dwn-sdk-js';
+import type { EnboxAgent, EnboxPlatformAgent } from './types/agent.js';
+import type { Filter, MessageStore, PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 
 import { isRecordsType } from './dwn-api.js';
 import { Convert, TtlCache } from '@enbox/common';
@@ -28,6 +28,10 @@ export class AgentPermissionsApi implements PermissionsApi {
 
   constructor({ agent }: { agent?: EnboxAgent } = {}) {
     this._agent = agent;
+  }
+
+  private static hasDwnApi(agent: EnboxAgent): agent is EnboxAgent & Pick<EnboxPlatformAgent, 'dwn'> {
+    return 'dwn' in agent;
   }
 
   async getPermissionForRequest({
@@ -106,8 +110,6 @@ export class AgentPermissionsApi implements PermissionsApi {
     const grantMessages = reply.entries! as DwnDataEncodedRecordsWriteMessage[];
 
     // Build a set of revoked grant IDs so that revoked grants can be filtered out.
-    // Revocation records are nested under the grant context, so each candidate grant
-    // must be checked within its direct parent context.
     const revokedGrantIds = checkRevoked
       ? await this.fetchRevokedGrantIds({ author, target, grantor, grantMessages, remote, tags })
       : new Set<string>();
@@ -139,6 +141,72 @@ export class AgentPermissionsApi implements PermissionsApi {
       return new Set<string>();
     }
 
+    const locallyRevokedGrantIds = await this.fetchRevokedGrantIdsFromLocalStore({ target, grantor, grantMessages, remote, tags });
+    if (locallyRevokedGrantIds !== undefined) {
+      return locallyRevokedGrantIds;
+    }
+
+    return this.fetchRevokedGrantIdsByGrantContext({ author, target, grantor, grantMessages, remote, tags });
+  }
+
+  private async fetchRevokedGrantIdsFromLocalStore({ target, grantor, grantMessages, remote, tags }: {
+    target: string;
+    grantor?: string;
+    grantMessages: DwnDataEncodedRecordsWriteMessage[];
+    remote: boolean;
+    tags?: { protocol: string };
+  }): Promise<Set<string> | undefined> {
+    const messageStore = this.getLocalMessageStore(remote);
+    if (messageStore === undefined) {
+      return undefined;
+    }
+
+    const grantRecordIds = grantMessages.map(grantMessage => grantMessage.recordId);
+    const filter: Filter = {
+      isLatestBaseState : true,
+      parentId          : grantRecordIds,
+      protocol          : PermissionsProtocol.uri,
+      protocolPath      : PermissionsProtocol.revocationPath,
+    };
+
+    if (grantor !== undefined) {
+      filter.author = grantor;
+    }
+
+    if (tags !== undefined) {
+      filter['tag.protocol'] = tags.protocol;
+    }
+
+    const grantRecordIdSet = new Set(grantRecordIds);
+    const { messages: revocationMessages } = await messageStore.query(target, [filter]);
+    const revokedGrantIds = new Set<string>();
+    for (const revocationMessage of revocationMessages as RecordsWriteMessage[]) {
+      const grantRecordId = revocationMessage.descriptor.parentId;
+      if (grantRecordId !== undefined && grantRecordIdSet.has(grantRecordId)) {
+        revokedGrantIds.add(grantRecordId);
+      }
+    }
+
+    return revokedGrantIds;
+  }
+
+  private getLocalMessageStore(remote: boolean): MessageStore | undefined {
+    const agent = this.agent;
+    if (remote || !AgentPermissionsApi.hasDwnApi(agent) || agent.dwn.isRemoteMode) {
+      return undefined;
+    }
+
+    return agent.dwn.node?.storage?.messageStore;
+  }
+
+  private async fetchRevokedGrantIdsByGrantContext({ author, target, grantor, grantMessages, remote, tags }: {
+    author: string;
+    target: string;
+    grantor?: string;
+    grantMessages: DwnDataEncodedRecordsWriteMessage[];
+    remote: boolean;
+    tags?: { protocol: string };
+  }): Promise<Set<string>> {
     const revokedGrantIds = new Set<string>();
     await Promise.all(grantMessages.map(async (grantMessage): Promise<void> => {
       const revocationParams: ProcessDwnRequest<DwnInterface.RecordsQuery> = {

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -162,23 +162,27 @@ export class AgentPermissionsApi implements PermissionsApi {
     }
 
     const grantRecordIds = grantMessages.map(grantMessage => grantMessage.recordId);
-    const filter: Filter = {
-      isLatestBaseState : true,
-      parentId          : grantRecordIds,
-      protocol          : PermissionsProtocol.uri,
-      protocolPath      : PermissionsProtocol.revocationPath,
-    };
+    const filters = grantRecordIds.map((parentId): Filter => {
+      const filter: Filter = {
+        isLatestBaseState : true,
+        parentId,
+        protocol          : PermissionsProtocol.uri,
+        protocolPath      : PermissionsProtocol.revocationPath,
+      };
 
-    if (grantor !== undefined) {
-      filter.author = grantor;
-    }
+      if (grantor !== undefined) {
+        filter.author = grantor;
+      }
 
-    if (tags !== undefined) {
-      filter['tag.protocol'] = tags.protocol;
-    }
+      if (tags !== undefined) {
+        filter['tag.protocol'] = tags.protocol;
+      }
+
+      return filter;
+    });
 
     const grantRecordIdSet = new Set(grantRecordIds);
-    const { messages: revocationMessages } = await messageStore.query(target, [filter]);
+    const { messages: revocationMessages } = await messageStore.query(target, filters);
     const revokedGrantIds = new Set<string>();
     for (const revocationMessage of revocationMessages as RecordsWriteMessage[]) {
       const grantRecordId = revocationMessage.descriptor.parentId;

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -1,12 +1,12 @@
 import type { CreateGrantParams, CreateRequestParams, CreateRevocationParams, FetchPermissionRequestParams, FetchPermissionsParams, GetPermissionParams, IsGrantRevokedParams, PermissionGrantEntry, PermissionRequestEntry, PermissionRevocationEntry, PermissionsApi } from './types/permissions.js';
 import type { DwnDataEncodedRecordsWriteMessage, DwnMessageParams, DwnRecordsPermissionScope, ProcessDwnRequest } from './types/dwn.js';
 import type { EnboxAgent, EnboxPlatformAgent } from './types/agent.js';
-import type { Filter, GenericMessage, MessageStore, PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData } from '@enbox/dwn-sdk-js';
+import type { MessageStore, PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData } from '@enbox/dwn-sdk-js';
 
 import { isRecordsType } from './dwn-api.js';
 import { Convert, TtlCache } from '@enbox/common';
 import { DwnInterface, DwnPermissionGrant, DwnPermissionRequest } from './types/dwn.js';
-import { DwnMethodName, PermissionScopeMatcher, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+import { PermissionScopeMatcher, PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
 export class AgentPermissionsApi implements PermissionsApi {
 
@@ -104,11 +104,10 @@ export class AgentPermissionsApi implements PermissionsApi {
     }
 
     const grantMessages = reply.entries! as DwnDataEncodedRecordsWriteMessage[];
-    const revocationMessageStore = this.getLocalRevocationMessageStore({ author, target, remote });
 
     // Build a set of revoked grant IDs so that revoked grants can be filtered out.
     const revokedGrantIds = checkRevoked
-      ? await this.fetchRevokedGrantIds({ author, target, grantor, grantMessages, messageStore: revocationMessageStore, remote, tags })
+      ? await this.fetchRevokedGrantIds({ author, target, grantMessages, remote })
       : new Set<string>();
 
     const grants:PermissionGrantEntry[] = [];
@@ -126,72 +125,49 @@ export class AgentPermissionsApi implements PermissionsApi {
   /**
    * Fetch all revocation record IDs for grants, returned as a Set of parent grant record IDs.
    */
-  private async fetchRevokedGrantIds({ author, target, grantor, grantMessages, messageStore, remote, tags }: {
+  private async fetchRevokedGrantIds({ author, target, grantMessages, remote }: {
     author: string;
     target: string;
-    grantor?: string;
     grantMessages: DwnDataEncodedRecordsWriteMessage[];
-    messageStore?: MessageStore;
     remote: boolean;
-    tags?: { protocol: string };
   }): Promise<Set<string>> {
     if (grantMessages.length === 0) {
       return new Set<string>();
     }
 
-    if (messageStore !== undefined) {
-      return this.fetchRevokedGrantIdsFromLocalStore({ target, grantor, grantMessages, messageStore, tags });
-    }
-
-    return this.fetchRevokedGrantIdsByGrantContext({ author, target, grantor, grantMessages, remote, tags });
-  }
-
-  private async fetchRevokedGrantIdsFromLocalStore({ target, grantor, grantMessages, messageStore, tags }: {
-    target: string;
-    grantor?: string;
-    grantMessages: DwnDataEncodedRecordsWriteMessage[];
-    messageStore: MessageStore;
-    tags?: { protocol: string };
-  }): Promise<Set<string>> {
-    const grantRecordIds = grantMessages.map(grantMessage => grantMessage.recordId);
-    const filter: Filter = {
-      isLatestBaseState : true,
-      method            : DwnMethodName.Write,
-      parentId          : grantRecordIds,
-      protocol          : PermissionsProtocol.uri,
-      protocolPath      : PermissionsProtocol.revocationPath,
-    };
-
-    if (grantor !== undefined) {
-      filter.author = grantor;
-    }
-    if (tags !== undefined) {
-      filter['tag.protocol'] = tags.protocol;
-    }
-
-    const grantRecordIdSet = new Set(grantRecordIds);
-    const { messages: revocationMessages } = await messageStore.query(target, [filter]);
+    // Bulk grant listings are local/synced views: owner reads can use the local
+    // store predicate directly, while cross-tenant or remote reads go through
+    // the message path for authorization and authoritative remote state.
+    const messageStore = this.getOwnerLocalMessageStore({ author, target, remote });
     const revokedGrantIds = new Set<string>();
-    for (const revocationMessage of revocationMessages) {
-      const grantRecordId = AgentPermissionsApi.parentIdFromRecordsWrite(revocationMessage);
-      if (grantRecordId !== undefined && grantRecordIdSet.has(grantRecordId)) {
-        revokedGrantIds.add(grantRecordId);
+    await Promise.all(grantMessages.map(async (grantMessage): Promise<void> => {
+      const revoked = messageStore !== undefined
+        ? await this.isGrantRevokedInLocalStore(target, grantMessage.recordId, messageStore)
+        : await this.isGrantRevoked({
+          author,
+          target,
+          grantRecordId: grantMessage.recordId,
+          remote,
+        });
+      if (revoked) {
+        revokedGrantIds.add(grantMessage.recordId);
       }
-    }
+    }));
 
     return revokedGrantIds;
   }
 
-  private static parentIdFromRecordsWrite(message: GenericMessage): string | undefined {
-    if (message.descriptor.method !== DwnMethodName.Write) {
-      return undefined;
-    }
-
-    const { parentId } = message.descriptor as { parentId?: unknown };
-    return typeof parentId === 'string' ? parentId : undefined;
+  private async isGrantRevokedInLocalStore(tenant: string, grantRecordId: string, messageStore: MessageStore): Promise<boolean> {
+    const { messages } = await messageStore.query(
+      tenant,
+      [PermissionsProtocol.grantRevocationFilter(grantRecordId)],
+      undefined,
+      { limit: 1 },
+    );
+    return messages.length > 0;
   }
 
-  private getLocalRevocationMessageStore({ author, target, remote }: {
+  private getOwnerLocalMessageStore({ author, target, remote }: {
     author: string;
     target: string;
     remote: boolean;
@@ -206,47 +182,6 @@ export class AgentPermissionsApi implements PermissionsApi {
     }
 
     return dwn.node.storage.messageStore;
-  }
-
-  private async fetchRevokedGrantIdsByGrantContext({ author, target, grantor, grantMessages, remote, tags }: {
-    author: string;
-    target: string;
-    grantor?: string;
-    grantMessages: DwnDataEncodedRecordsWriteMessage[];
-    remote: boolean;
-    tags?: { protocol: string };
-  }): Promise<Set<string>> {
-    const revokedGrantIds = new Set<string>();
-    await Promise.all(grantMessages.map(async (grantMessage): Promise<void> => {
-      const revocationParams: ProcessDwnRequest<DwnInterface.RecordsQuery> = {
-        author,
-        target,
-        messageType   : DwnInterface.RecordsQuery,
-        messageParams : {
-          filter: {
-            author       : grantor, // revocations are authored by the same grantor
-            contextId    : grantMessage.contextId,
-            protocol     : PermissionsProtocol.uri,
-            protocolPath : PermissionsProtocol.revocationPath,
-            tags,
-          }
-        }
-      };
-
-      const { reply: revocationReply } = remote
-        ? await this.agent.sendDwnRequest(revocationParams)
-        : await this.agent.processDwnRequest(revocationParams);
-
-      if (revocationReply.status.code !== 200) {
-        throw new Error(`PermissionsApi: Failed to fetch revocations: ${revocationReply.status.detail}`);
-      }
-
-      if ((revocationReply.entries ?? []).length > 0) {
-        revokedGrantIds.add(grantMessage.recordId);
-      }
-    }));
-
-    return revokedGrantIds;
   }
 
   async fetchRequests({
@@ -291,15 +226,16 @@ export class AgentPermissionsApi implements PermissionsApi {
     grantRecordId,
     remote = false
   }: IsGrantRevokedParams): Promise<boolean> {
+    const revocationFilter = PermissionsProtocol.grantRevocationFilter(grantRecordId);
     const params: ProcessDwnRequest<DwnInterface.RecordsRead> = {
       author,
       target,
       messageType   : DwnInterface.RecordsRead,
       messageParams : {
         filter: {
-          parentId     : grantRecordId,
+          parentId     : revocationFilter.parentId as string,
           protocol     : PermissionsProtocol.uri,
-          protocolPath : PermissionsProtocol.revocationPath,
+          protocolPath : revocationFilter.protocolPath as string,
         }
       }
     };

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -1,17 +1,21 @@
+import type { EnboxAgent } from './types/agent.js';
 import type { CreateGrantParams, CreateRequestParams, CreateRevocationParams, FetchPermissionRequestParams, FetchPermissionsParams, GetPermissionParams, IsGrantRevokedParams, PermissionGrantEntry, PermissionRequestEntry, PermissionRevocationEntry, PermissionsApi } from './types/permissions.js';
 import type { DwnDataEncodedRecordsWriteMessage, DwnMessageParams, DwnRecordsPermissionScope, ProcessDwnRequest } from './types/dwn.js';
-import type { EnboxAgent, EnboxPlatformAgent } from './types/agent.js';
-import type { MessageStore, PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData } from '@enbox/dwn-sdk-js';
+import type { PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData } from '@enbox/dwn-sdk-js';
 
 import { isRecordsType } from './dwn-api.js';
+import { mapConcurrent } from './utils.js';
 import { Convert, TtlCache } from '@enbox/common';
 import { DwnInterface, DwnPermissionGrant, DwnPermissionRequest } from './types/dwn.js';
 import { PermissionScopeMatcher, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+
+const REVOCATION_CHECK_CONCURRENCY = 8;
 
 export class AgentPermissionsApi implements PermissionsApi {
 
   /** cache for fetching a permission {@link PermissionGrant}, keyed by a specific MessageType and protocol */
   private readonly _cachedPermissions: TtlCache<string, PermissionGrantEntry> = new TtlCache({ ttl: 60 * 1000 });
+  private readonly _revokedGrantIds = new Set<string>();
 
   private _agent?: EnboxAgent;
 
@@ -47,10 +51,11 @@ export class AgentPermissionsApi implements PermissionsApi {
     }
 
     const permissionGrants = await this.fetchGrants({
-      author  : delegateDid,
-      target  : delegateDid,
-      grantor : connectedDid,
-      grantee : delegateDid,
+      author       : delegateDid,
+      target       : delegateDid,
+      grantor      : connectedDid,
+      grantee      : delegateDid,
+      checkRevoked : true,
     });
 
     // get the delegate grants that match the messageParams and are associated with the connectedDid as the grantor
@@ -77,7 +82,7 @@ export class AgentPermissionsApi implements PermissionsApi {
     grantor,
     protocol,
     remote = false,
-    checkRevoked = true,
+    checkRevoked = false,
   }: FetchPermissionsParams): Promise<PermissionGrantEntry[]> {
 
     // filter by a protocol using tags if provided
@@ -105,7 +110,9 @@ export class AgentPermissionsApi implements PermissionsApi {
 
     const grantMessages = reply.entries! as DwnDataEncodedRecordsWriteMessage[];
 
-    // Build a set of revoked grant IDs so that revoked grants can be filtered out.
+    // Revocation filtering is opt-in and intentionally checks one grant at a
+    // time. If this becomes hot, add a dedicated revocation-read path instead
+    // of broad nested queries or parentId set filters.
     const revokedGrantIds = checkRevoked
       ? await this.fetchRevokedGrantIds({ author, target, grantMessages, remote })
       : new Set<string>();
@@ -123,7 +130,7 @@ export class AgentPermissionsApi implements PermissionsApi {
   }
 
   /**
-   * Fetch all revocation record IDs for grants, returned as a Set of parent grant record IDs.
+   * Fetches the grant record IDs that have a stored revocation.
    */
   private async fetchRevokedGrantIds({ author, target, grantMessages, remote }: {
     author: string;
@@ -135,53 +142,25 @@ export class AgentPermissionsApi implements PermissionsApi {
       return new Set<string>();
     }
 
-    // Bulk grant listings are local/synced views: owner reads can use the local
-    // store predicate directly, while cross-tenant or remote reads go through
-    // the message path for authorization and authoritative remote state.
-    const messageStore = this.getOwnerLocalMessageStore({ author, target, remote });
     const revokedGrantIds = new Set<string>();
-    await Promise.all(grantMessages.map(async (grantMessage): Promise<void> => {
-      const revoked = messageStore !== undefined
-        ? await this.isGrantRevokedInLocalStore(target, grantMessage.recordId, messageStore)
-        : await this.isGrantRevoked({
-          author,
-          target,
-          grantRecordId: grantMessage.recordId,
-          remote,
-        });
+    await mapConcurrent(grantMessages, REVOCATION_CHECK_CONCURRENCY, async (grantMessage): Promise<void> => {
+      if (this._revokedGrantIds.has(grantMessage.recordId)) {
+        revokedGrantIds.add(grantMessage.recordId);
+        return;
+      }
+
+      const revoked = await this.isGrantRevoked({
+        author,
+        target,
+        grantRecordId: grantMessage.recordId,
+        remote,
+      });
       if (revoked) {
         revokedGrantIds.add(grantMessage.recordId);
       }
-    }));
+    });
 
     return revokedGrantIds;
-  }
-
-  private async isGrantRevokedInLocalStore(tenant: string, grantRecordId: string, messageStore: MessageStore): Promise<boolean> {
-    const { messages } = await messageStore.query(
-      tenant,
-      [PermissionsProtocol.grantRevocationFilter(grantRecordId)],
-      undefined,
-      { limit: 1 },
-    );
-    return messages.length > 0;
-  }
-
-  private getOwnerLocalMessageStore({ author, target, remote }: {
-    author: string;
-    target: string;
-    remote: boolean;
-  }): MessageStore | undefined {
-    if (remote || author !== target) {
-      return undefined;
-    }
-
-    const dwn = (this.agent as Partial<EnboxPlatformAgent>).dwn;
-    if (dwn === undefined || dwn.isRemoteMode) {
-      return undefined;
-    }
-
-    return dwn.node.storage.messageStore;
   }
 
   async fetchRequests({
@@ -226,16 +205,19 @@ export class AgentPermissionsApi implements PermissionsApi {
     grantRecordId,
     remote = false
   }: IsGrantRevokedParams): Promise<boolean> {
-    const revocationFilter = PermissionsProtocol.grantRevocationFilter(grantRecordId);
+    if (this._revokedGrantIds.has(grantRecordId)) {
+      return true;
+    }
+
     const params: ProcessDwnRequest<DwnInterface.RecordsRead> = {
       author,
       target,
       messageType   : DwnInterface.RecordsRead,
       messageParams : {
         filter: {
-          parentId     : revocationFilter.parentId as string,
+          parentId     : grantRecordId,
           protocol     : PermissionsProtocol.uri,
-          protocolPath : revocationFilter.protocolPath as string,
+          protocolPath : PermissionsProtocol.revocationPath,
         }
       }
     };
@@ -246,6 +228,7 @@ export class AgentPermissionsApi implements PermissionsApi {
       return false;
     } else if (revocationReply.status.code === 200) {
       // a revocation was found, the grant is revoked
+      this._revokedGrantIds.add(grantRecordId);
       return true;
     }
 
@@ -391,6 +374,9 @@ export class AgentPermissionsApi implements PermissionsApi {
     if (reply.status.code !== 202) {
       throw new Error(`PermissionsApi: Failed to create revocation: ${reply.status.detail}`);
     }
+    if (store) {
+      this._revokedGrantIds.add(grant.id);
+    }
 
     const dataEncodedMessage: DwnDataEncodedRecordsWriteMessage = {
       ...message!,
@@ -402,6 +388,7 @@ export class AgentPermissionsApi implements PermissionsApi {
 
   async clear():Promise<void> {
     this._cachedPermissions.clear();
+    this._revokedGrantIds.clear();
   }
 
   /**

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -1,12 +1,12 @@
 import type { CreateGrantParams, CreateRequestParams, CreateRevocationParams, FetchPermissionRequestParams, FetchPermissionsParams, GetPermissionParams, IsGrantRevokedParams, PermissionGrantEntry, PermissionRequestEntry, PermissionRevocationEntry, PermissionsApi } from './types/permissions.js';
 import type { DwnDataEncodedRecordsWriteMessage, DwnMessageParams, DwnRecordsPermissionScope, ProcessDwnRequest } from './types/dwn.js';
 import type { EnboxAgent, EnboxPlatformAgent } from './types/agent.js';
-import type { Filter, MessageStore, PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
+import type { Filter, GenericMessage, MessageStore, PermissionGrant, PermissionGrantData, PermissionRequestData, PermissionRevocationData } from '@enbox/dwn-sdk-js';
 
 import { isRecordsType } from './dwn-api.js';
 import { Convert, TtlCache } from '@enbox/common';
 import { DwnInterface, DwnPermissionGrant, DwnPermissionRequest } from './types/dwn.js';
-import { PermissionScopeMatcher, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+import { DwnMethodName, PermissionScopeMatcher, PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
 export class AgentPermissionsApi implements PermissionsApi {
 
@@ -28,10 +28,6 @@ export class AgentPermissionsApi implements PermissionsApi {
 
   constructor({ agent }: { agent?: EnboxAgent } = {}) {
     this._agent = agent;
-  }
-
-  private static hasDwnApi(agent: EnboxAgent): agent is EnboxAgent & Pick<EnboxPlatformAgent, 'dwn'> {
-    return 'dwn' in agent;
   }
 
   async getPermissionForRequest({
@@ -108,10 +104,11 @@ export class AgentPermissionsApi implements PermissionsApi {
     }
 
     const grantMessages = reply.entries! as DwnDataEncodedRecordsWriteMessage[];
+    const revocationMessageStore = this.getLocalRevocationMessageStore({ author, target, remote });
 
     // Build a set of revoked grant IDs so that revoked grants can be filtered out.
     const revokedGrantIds = checkRevoked
-      ? await this.fetchRevokedGrantIds({ author, target, grantor, grantMessages, remote, tags })
+      ? await this.fetchRevokedGrantIds({ author, target, grantor, grantMessages, messageStore: revocationMessageStore, remote, tags })
       : new Set<string>();
 
     const grants:PermissionGrantEntry[] = [];
@@ -129,11 +126,12 @@ export class AgentPermissionsApi implements PermissionsApi {
   /**
    * Fetch all revocation record IDs for grants, returned as a Set of parent grant record IDs.
    */
-  private async fetchRevokedGrantIds({ author, target, grantor, grantMessages, remote, tags }: {
+  private async fetchRevokedGrantIds({ author, target, grantor, grantMessages, messageStore, remote, tags }: {
     author: string;
     target: string;
     grantor?: string;
     grantMessages: DwnDataEncodedRecordsWriteMessage[];
+    messageStore?: MessageStore;
     remote: boolean;
     tags?: { protocol: string };
   }): Promise<Set<string>> {
@@ -141,51 +139,41 @@ export class AgentPermissionsApi implements PermissionsApi {
       return new Set<string>();
     }
 
-    const locallyRevokedGrantIds = await this.fetchRevokedGrantIdsFromLocalStore({ target, grantor, grantMessages, remote, tags });
-    if (locallyRevokedGrantIds !== undefined) {
-      return locallyRevokedGrantIds;
+    if (messageStore !== undefined) {
+      return this.fetchRevokedGrantIdsFromLocalStore({ target, grantor, grantMessages, messageStore, tags });
     }
 
     return this.fetchRevokedGrantIdsByGrantContext({ author, target, grantor, grantMessages, remote, tags });
   }
 
-  private async fetchRevokedGrantIdsFromLocalStore({ target, grantor, grantMessages, remote, tags }: {
+  private async fetchRevokedGrantIdsFromLocalStore({ target, grantor, grantMessages, messageStore, tags }: {
     target: string;
     grantor?: string;
     grantMessages: DwnDataEncodedRecordsWriteMessage[];
-    remote: boolean;
+    messageStore: MessageStore;
     tags?: { protocol: string };
-  }): Promise<Set<string> | undefined> {
-    const messageStore = this.getLocalMessageStore(remote);
-    if (messageStore === undefined) {
-      return undefined;
+  }): Promise<Set<string>> {
+    const grantRecordIds = grantMessages.map(grantMessage => grantMessage.recordId);
+    const filter: Filter = {
+      isLatestBaseState : true,
+      method            : DwnMethodName.Write,
+      parentId          : grantRecordIds,
+      protocol          : PermissionsProtocol.uri,
+      protocolPath      : PermissionsProtocol.revocationPath,
+    };
+
+    if (grantor !== undefined) {
+      filter.author = grantor;
+    }
+    if (tags !== undefined) {
+      filter['tag.protocol'] = tags.protocol;
     }
 
-    const grantRecordIds = grantMessages.map(grantMessage => grantMessage.recordId);
-    const filters = grantRecordIds.map((parentId): Filter => {
-      const filter: Filter = {
-        isLatestBaseState : true,
-        parentId,
-        protocol          : PermissionsProtocol.uri,
-        protocolPath      : PermissionsProtocol.revocationPath,
-      };
-
-      if (grantor !== undefined) {
-        filter.author = grantor;
-      }
-
-      if (tags !== undefined) {
-        filter['tag.protocol'] = tags.protocol;
-      }
-
-      return filter;
-    });
-
     const grantRecordIdSet = new Set(grantRecordIds);
-    const { messages: revocationMessages } = await messageStore.query(target, filters);
+    const { messages: revocationMessages } = await messageStore.query(target, [filter]);
     const revokedGrantIds = new Set<string>();
-    for (const revocationMessage of revocationMessages as RecordsWriteMessage[]) {
-      const grantRecordId = revocationMessage.descriptor.parentId;
+    for (const revocationMessage of revocationMessages) {
+      const grantRecordId = AgentPermissionsApi.parentIdFromRecordsWrite(revocationMessage);
       if (grantRecordId !== undefined && grantRecordIdSet.has(grantRecordId)) {
         revokedGrantIds.add(grantRecordId);
       }
@@ -194,13 +182,30 @@ export class AgentPermissionsApi implements PermissionsApi {
     return revokedGrantIds;
   }
 
-  private getLocalMessageStore(remote: boolean): MessageStore | undefined {
-    const agent = this.agent;
-    if (remote || !AgentPermissionsApi.hasDwnApi(agent) || agent.dwn.isRemoteMode) {
+  private static parentIdFromRecordsWrite(message: GenericMessage): string | undefined {
+    if (message.descriptor.method !== DwnMethodName.Write) {
       return undefined;
     }
 
-    return agent.dwn.node?.storage?.messageStore;
+    const { parentId } = message.descriptor as { parentId?: unknown };
+    return typeof parentId === 'string' ? parentId : undefined;
+  }
+
+  private getLocalRevocationMessageStore({ author, target, remote }: {
+    author: string;
+    target: string;
+    remote: boolean;
+  }): MessageStore | undefined {
+    if (remote || author !== target) {
+      return undefined;
+    }
+
+    const dwn = (this.agent as Partial<EnboxPlatformAgent>).dwn;
+    if (dwn === undefined || dwn.isRemoteMode) {
+      return undefined;
+    }
+
+    return dwn.node.storage.messageStore;
   }
 
   private async fetchRevokedGrantIdsByGrantContext({ author, target, grantor, grantMessages, remote, tags }: {

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -103,14 +103,17 @@ export class AgentPermissionsApi implements PermissionsApi {
       throw new Error(`PermissionsApi: Failed to fetch grants: ${reply.status.detail}`);
     }
 
+    const grantMessages = reply.entries! as DwnDataEncodedRecordsWriteMessage[];
+
     // Build a set of revoked grant IDs so that revoked grants can be filtered out.
-    // Uses a single batch query for all revocations rather than N individual reads.
+    // Revocation records are nested under the grant context, so each candidate grant
+    // must be checked within its direct parent context.
     const revokedGrantIds = checkRevoked
-      ? await this.fetchRevokedGrantIds({ author, target, grantor, remote, tags })
+      ? await this.fetchRevokedGrantIds({ author, target, grantor, grantMessages, remote, tags })
       : new Set<string>();
 
     const grants:PermissionGrantEntry[] = [];
-    for (const entry of reply.entries! as DwnDataEncodedRecordsWriteMessage[]) {
+    for (const entry of grantMessages) {
       if (revokedGrantIds.has(entry.recordId)) {
         continue;
       }
@@ -123,43 +126,48 @@ export class AgentPermissionsApi implements PermissionsApi {
 
   /**
    * Fetch all revocation record IDs for grants, returned as a Set of parent grant record IDs.
-   * Issues a single RecordsQuery for all revocation records, optionally scoped to a grantor and protocol.
    */
-  private async fetchRevokedGrantIds({ author, target, grantor, remote, tags }: {
+  private async fetchRevokedGrantIds({ author, target, grantor, grantMessages, remote, tags }: {
     author: string;
     target: string;
     grantor?: string;
+    grantMessages: DwnDataEncodedRecordsWriteMessage[];
     remote: boolean;
     tags?: { protocol: string };
   }): Promise<Set<string>> {
-    const revocationParams: ProcessDwnRequest<DwnInterface.RecordsQuery> = {
-      author,
-      target,
-      messageType   : DwnInterface.RecordsQuery,
-      messageParams : {
-        filter: {
-          author       : grantor, // revocations are authored by the same grantor
-          protocol     : PermissionsProtocol.uri,
-          protocolPath : PermissionsProtocol.revocationPath,
-          tags,
-        }
-      }
-    };
-
-    const { reply: revocationReply } = remote
-      ? await this.agent.sendDwnRequest(revocationParams)
-      : await this.agent.processDwnRequest(revocationParams);
-
-    if (revocationReply.status.code !== 200) {
-      throw new Error(`PermissionsApi: Failed to fetch revocations: ${revocationReply.status.detail}`);
+    if (grantMessages.length === 0) {
+      return new Set<string>();
     }
 
     const revokedGrantIds = new Set<string>();
-    for (const entry of revocationReply.entries! as DwnDataEncodedRecordsWriteMessage[]) {
-      if (entry.descriptor.parentId !== undefined) {
-        revokedGrantIds.add(entry.descriptor.parentId);
+    await Promise.all(grantMessages.map(async (grantMessage): Promise<void> => {
+      const revocationParams: ProcessDwnRequest<DwnInterface.RecordsQuery> = {
+        author,
+        target,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : {
+          filter: {
+            author       : grantor, // revocations are authored by the same grantor
+            contextId    : grantMessage.contextId,
+            protocol     : PermissionsProtocol.uri,
+            protocolPath : PermissionsProtocol.revocationPath,
+            tags,
+          }
+        }
+      };
+
+      const { reply: revocationReply } = remote
+        ? await this.agent.sendDwnRequest(revocationParams)
+        : await this.agent.processDwnRequest(revocationParams);
+
+      if (revocationReply.status.code !== 200) {
+        throw new Error(`PermissionsApi: Failed to fetch revocations: ${revocationReply.status.detail}`);
       }
-    }
+
+      if ((revocationReply.entries ?? []).length > 0) {
+        revokedGrantIds.add(grantMessage.recordId);
+      }
+    }));
 
     return revokedGrantIds;
   }

--- a/packages/agent/src/sync-permission-grants.ts
+++ b/packages/agent/src/sync-permission-grants.ts
@@ -93,10 +93,11 @@ export async function resolveMessagesScopes({
 
   const now = new Date().toISOString();
   const permissionGrants = (await permissionsApi.fetchGrants({
-    author  : delegateDid,
-    target  : delegateDid,
-    grantor : did,
-    grantee : delegateDid,
+    author       : delegateDid,
+    target       : delegateDid,
+    grantor      : did,
+    grantee      : delegateDid,
+    checkRevoked : true,
   })).filter(entry => isActiveMessagesGrant(entry, did, delegateDid, now));
 
   if (requestedScope.kind === 'full') {

--- a/packages/agent/src/types/permissions.ts
+++ b/packages/agent/src/types/permissions.ts
@@ -7,7 +7,7 @@ export type FetchPermissionsParams = {
   grantor?: string;
   protocol?: string;
   remote?: boolean;
-  /** Whether to filter out revoked grants. Defaults to `true`. */
+  /** Whether to filter out revoked grants. Defaults to `false`. */
   checkRevoked?: boolean;
 };
 

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -4699,6 +4699,7 @@ describe('Unified Key Delivery - Write Side (PR C)', () => {
         filter: {
           protocol     : chatProtocol.protocol,
           protocolPath : 'thread/participant',
+          contextId    : threadContextId,
         }
       },
       encryption: true,
@@ -4808,6 +4809,7 @@ describe('Unified Key Retrieval - Read Side (PR D)', () => {
         filter: {
           protocol     : chatProtocol.protocol,
           protocolPath : 'thread/chat',
+          contextId    : threadContextId,
         }
       },
       encryption: true,

--- a/packages/agent/tests/e2e-delegate-multiparty.spec.ts
+++ b/packages/agent/tests/e2e-delegate-multiparty.spec.ts
@@ -420,7 +420,13 @@ describe('e2e: delegate + multi-party encrypted protocol', () => {
         author        : walletIdentity.did.uri,
         target        : walletIdentity.did.uri,
         messageType   : DwnInterface.RecordsQuery,
-        messageParams : { filter: { protocol: chatProtocol.protocol, protocolPath: 'thread/chat' } },
+        messageParams : {
+          filter: {
+            protocol     : chatProtocol.protocol,
+            protocolPath : 'thread/chat',
+            contextId    : threadContextId,
+          }
+        },
       });
       const chatWrite = chatQuery.entries![0] as RecordsWriteMessage;
       expect(chatWrite.encryption).toBeDefined();

--- a/packages/agent/tests/e2e-encrypted-sync.spec.ts
+++ b/packages/agent/tests/e2e-encrypted-sync.spec.ts
@@ -484,6 +484,7 @@ describe('e2e: multi-party encrypted thread with key delivery', () => {
         filter: {
           protocol     : chatProtocol.protocol,
           protocolPath : 'thread/chat',
+          contextId    : threadContextId,
         }
       },
     });

--- a/packages/agent/tests/e2e-grant-revocation.spec.ts
+++ b/packages/agent/tests/e2e-grant-revocation.spec.ts
@@ -759,7 +759,11 @@ describe('e2e: grant revocation stops future delivery', () => {
         target        : ownerDid,
         messageType   : DwnInterface.RecordsQuery,
         messageParams : {
-          filter: { protocol: PermissionsProtocol.uri, protocolPath: 'grant/revocation' },
+          filter: {
+            protocol     : PermissionsProtocol.uri,
+            protocolPath : 'grant/revocation',
+            contextId    : sessionGrant.message.recordId,
+          },
         },
       });
       expect((revQ.entries ?? []).length).toBeGreaterThanOrEqual(1);
@@ -984,7 +988,11 @@ describe('e2e: grant revocation stops future delivery', () => {
         target        : ownerDid,
         messageType   : DwnInterface.RecordsQuery,
         messageParams : {
-          filter: { protocol: PermissionsProtocol.uri, protocolPath: 'grant/revocation' },
+          filter: {
+            protocol     : PermissionsProtocol.uri,
+            protocolPath : 'grant/revocation',
+            contextId    : sessionGrant.message.recordId,
+          },
         },
       });
       expect((revQ.entries ?? []).length).toBeGreaterThanOrEqual(1);
@@ -1191,7 +1199,11 @@ describe('e2e: grant revocation stops future delivery', () => {
         target        : ownerDid,
         messageType   : DwnInterface.RecordsQuery,
         messageParams : {
-          filter: { protocol: PermissionsProtocol.uri, protocolPath: 'grant/revocation' },
+          filter: {
+            protocol     : PermissionsProtocol.uri,
+            protocolPath : 'grant/revocation',
+            contextId    : sessionGrant.message.recordId,
+          },
         },
       });
 

--- a/packages/agent/tests/e2e/owner-profile-sync.e2e.spec.ts
+++ b/packages/agent/tests/e2e/owner-profile-sync.e2e.spec.ts
@@ -426,6 +426,7 @@ describe('E2E: same-owner profile sync convergence', () => {
     expect(pulledProfile.contextId).toBe(profileRecord.contextId);
 
     const pulledAvatar = await expectRecord(walletA, did, {
+      contextId    : profileRecord.contextId,
       protocol     : profileProtocol.protocol,
       protocolPath : 'profile/avatar',
       recordId     : avatarRecord.recordId,
@@ -434,6 +435,7 @@ describe('E2E: same-owner profile sync convergence', () => {
     expect(pulledAvatar.descriptor.parentId).toBe(profileRecord.recordId);
 
     const pulledHero = await expectRecord(walletA, did, {
+      contextId    : profileRecord.contextId,
       protocol     : profileProtocol.protocol,
       protocolPath : 'profile/hero',
       recordId     : heroRecord.recordId,
@@ -565,6 +567,7 @@ describe('E2E: same-owner identity discovery and profile sync convergence', () =
     expect(pulledProfile.contextId).toBe(profileRecord.contextId);
 
     const pulledAvatar = await expectRecord(walletA, did, {
+      contextId    : profileRecord.contextId,
       protocol     : profileProtocol.protocol,
       protocolPath : 'profile/avatar',
       recordId     : avatarRecord.recordId,
@@ -572,6 +575,7 @@ describe('E2E: same-owner identity discovery and profile sync convergence', () =
     expect(pulledAvatar.descriptor.parentId).toBe(profileRecord.recordId);
 
     const pulledHero = await expectRecord(walletA, did, {
+      contextId    : profileRecord.contextId,
       protocol     : profileProtocol.protocol,
       protocolPath : 'profile/hero',
       recordId     : heroRecord.recordId,

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -342,6 +342,16 @@ describe('AgentPermissionsApi', () => {
           protocol  : 'http://example.com/remote-revocation-test'
         }
       });
+      const writeRevocationMessage = {
+        ...writeGrant.message,
+        contextId  : `${writeGrant.message.contextId}/remote-revocation`,
+        recordId   : 'remote-revocation',
+        descriptor : {
+          ...writeGrant.message.descriptor,
+          parentId     : writeGrant.message.recordId,
+          protocolPath : PermissionsProtocol.revocationPath,
+        },
+      };
 
       const sendDwnRequestStub = spyOn(testHarness.agent, 'sendDwnRequest').mockImplementation(async (request) => {
         const filter = 'messageParams' in request
@@ -355,7 +365,7 @@ describe('AgentPermissionsApi', () => {
           };
         }
 
-        const entries = filter.contextId === writeGrant.message.contextId ? [writeGrant.message] : [];
+        const entries = filter.contextId === writeGrant.message.contextId ? [writeRevocationMessage] : [];
         return {
           messageCid : '',
           reply      : { entries, status: { code: 200, detail: 'OK' } }
@@ -569,11 +579,12 @@ describe('AgentPermissionsApi', () => {
       expect(revocationQueryCalls.length).toBe(1);
 
       const revocationFilters = revocationQueryCalls[0][1] as Array<Record<string, unknown>>;
-      const parentIds = revocationFilters.map(filter => filter.parentId);
-      expect(parentIds.length).toBe(2);
-      expect(parentIds.includes(writeGrant.message.recordId)).toBe(true);
-      expect(parentIds.includes(readGrant.message.recordId)).toBe(true);
-      expect(revocationFilters.every(filter => typeof filter.parentId === 'string')).toBe(true);
+      expect(revocationFilters.length).toBe(1);
+      expect(revocationFilters[0].method).toBe(DwnMethodName.Write);
+      expect(revocationFilters[0].parentId).toEqual(expect.arrayContaining([
+        writeGrant.message.recordId,
+        readGrant.message.recordId,
+      ]));
     });
 
     it('should use only 1 DWN roundtrip when checkRevoked is false', async () => {

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -365,10 +365,11 @@ describe('AgentPermissionsApi', () => {
       });
 
       const grants = await testHarness.agent.permissions.fetchGrants({
-        author   : aliceDid.uri,
-        target   : aliceDid.uri,
-        protocol : 'http://example.com/remote-revocation-test',
-        remote   : true,
+        author       : aliceDid.uri,
+        target       : aliceDid.uri,
+        protocol     : 'http://example.com/remote-revocation-test',
+        remote       : true,
+        checkRevoked : true,
       });
 
       expect(grants.length).toBe(1);
@@ -444,7 +445,7 @@ describe('AgentPermissionsApi', () => {
       }
     });
 
-    it('should filter out revoked grants by default', async () => {
+    it('should filter out revoked grants when checkRevoked is true', async () => {
       // create two grants
       const grant1 = await testHarness.agent.permissions.createGrant({
         store       : true,
@@ -485,17 +486,18 @@ describe('AgentPermissionsApi', () => {
         grant  : grant1.grant,
       });
 
-      // default (checkRevoked: true) should only return the non-revoked grant
+      // checkRevoked filters out revoked grants.
       grants = await testHarness.agent.permissions.fetchGrants({
-        author   : aliceDid.uri,
-        target   : aliceDid.uri,
-        protocol : 'http://example.com/revocation-test',
+        author       : aliceDid.uri,
+        target       : aliceDid.uri,
+        protocol     : 'http://example.com/revocation-test',
+        checkRevoked : true,
       });
       expect(grants.length).toBe(1);
       expect(grants[0].grant.id).toBe(grant2.grant.id);
     });
 
-    it('should include revoked grants when checkRevoked is false', async () => {
+    it('should include revoked grants when checkRevoked is omitted or false', async () => {
       // create a grant and revoke it
       const grant = await testHarness.agent.permissions.createGrant({
         store       : true,
@@ -516,8 +518,17 @@ describe('AgentPermissionsApi', () => {
         grant  : grant.grant,
       });
 
-      // with checkRevoked: false, the revoked grant should still be returned
-      const grants = await testHarness.agent.permissions.fetchGrants({
+      // without checkRevoked, the revoked grant should still be returned.
+      let grants = await testHarness.agent.permissions.fetchGrants({
+        author   : aliceDid.uri,
+        target   : aliceDid.uri,
+        protocol : 'http://example.com/revocation-test-2',
+      });
+      expect(grants.length).toBe(1);
+      expect(grants[0].grant.id).toBe(grant.grant.id);
+
+      // with checkRevoked: false, the revoked grant should still be returned.
+      grants = await testHarness.agent.permissions.fetchGrants({
         author       : aliceDid.uri,
         target       : aliceDid.uri,
         protocol     : 'http://example.com/revocation-test-2',
@@ -527,7 +538,7 @@ describe('AgentPermissionsApi', () => {
       expect(grants[0].grant.id).toBe(grant.grant.id);
     });
 
-    it('should check local revocations through the canonical per-grant message store predicate', async () => {
+    it('should check revocations through one message-path read per grant when checkRevoked is true', async () => {
       const writeGrant = await testHarness.agent.permissions.createGrant({
         store       : true,
         author      : aliceDid.uri,
@@ -555,34 +566,47 @@ describe('AgentPermissionsApi', () => {
         author : aliceDid.uri,
         grant  : writeGrant.grant,
       });
+      await testHarness.agent.permissions.clear();
 
-      const messageStoreQuerySpy = spyOn(testHarness.agent.dwn.node.storage.messageStore, 'query');
+      const processDwnRequestSpy = spyOn(testHarness.agent, 'processDwnRequest');
 
       const grants = await testHarness.agent.permissions.fetchGrants({
-        author   : aliceDid.uri,
-        target   : aliceDid.uri,
-        protocol : 'http://example.com/revocation-roundtrip-test',
+        author       : aliceDid.uri,
+        target       : aliceDid.uri,
+        protocol     : 'http://example.com/revocation-roundtrip-test',
+        checkRevoked : true,
       });
 
       expect(grants.length).toBe(1);
       expect(grants[0].message.recordId).toBe(readGrant.message.recordId);
 
-      const revocationQueryCalls = messageStoreQuerySpy.mock.calls.filter(([, filters]) =>
-        (filters as Array<Record<string, unknown>>).some(filter => filter.protocolPath === PermissionsProtocol.revocationPath)
-      );
-      expect(revocationQueryCalls.length).toBe(2);
+      const revocationFilters = processDwnRequestSpy.mock.calls
+        .filter(([request]) => request.messageType === DwnInterface.RecordsRead)
+        .map(([request]) => request.messageParams.filter as Record<string, unknown>);
+      expect(revocationFilters.length).toBe(2);
 
-      const revocationFilters = revocationQueryCalls.map(([, filters]) => (filters as Array<Record<string, unknown>>)[0]);
       expect(revocationFilters.map(filter => filter.parentId).sort()).toEqual([
         readGrant.message.recordId,
         writeGrant.message.recordId,
       ].sort());
-      expect(revocationFilters.every(filter => filter.isLatestBaseState === true)).toBe(true);
+      expect(revocationFilters.every(filter => filter.protocol === PermissionsProtocol.uri)).toBe(true);
       expect(revocationFilters.every(filter => filter.protocolPath === PermissionsProtocol.revocationPath)).toBe(true);
       expect(revocationFilters.every(filter => !Array.isArray(filter.parentId))).toBe(true);
-      expect(revocationFilters.every(filter => filter.author === undefined)).toBe(true);
-      expect(revocationFilters.every(filter => filter['tag.protocol'] === undefined)).toBe(true);
-      expect(revocationQueryCalls.every(([, , , pagination]) => pagination?.limit === 1)).toBe(true);
+
+      const grantsAgain = await testHarness.agent.permissions.fetchGrants({
+        author       : aliceDid.uri,
+        target       : aliceDid.uri,
+        protocol     : 'http://example.com/revocation-roundtrip-test',
+        checkRevoked : true,
+      });
+      expect(grantsAgain.length).toBe(1);
+      expect(grantsAgain[0].message.recordId).toBe(readGrant.message.recordId);
+
+      const repeatedRevocationFilters = processDwnRequestSpy.mock.calls
+        .filter(([request]) => request.messageType === DwnInterface.RecordsRead)
+        .map(([request]) => request.messageParams.filter as Record<string, unknown>);
+      expect(repeatedRevocationFilters.length).toBe(3);
+      expect(repeatedRevocationFilters[2].parentId).toBe(readGrant.message.recordId);
     });
 
     it('should use the message path for cross-tenant local revocation checks', async () => {
@@ -597,7 +621,6 @@ describe('AgentPermissionsApi', () => {
           protocol  : 'http://example.com/cross-tenant-revocation-test'
         }
       });
-      const messageStoreQuerySpy = spyOn(testHarness.agent.dwn.node.storage.messageStore, 'query');
       const processDwnRequestStub = spyOn(testHarness.agent, 'processDwnRequest').mockImplementation(async (request) => {
         const filter = 'messageParams' in request
           ? request.messageParams.filter as Record<string, unknown>
@@ -617,13 +640,13 @@ describe('AgentPermissionsApi', () => {
       });
 
       const grants = await testHarness.agent.permissions.fetchGrants({
-        author   : bobDid.uri,
-        target   : aliceDid.uri,
-        protocol : 'http://example.com/cross-tenant-revocation-test',
+        author       : bobDid.uri,
+        target       : aliceDid.uri,
+        protocol     : 'http://example.com/cross-tenant-revocation-test',
+        checkRevoked : true,
       });
 
       expect(grants.length).toBe(1);
-      expect(messageStoreQuerySpy).not.toHaveBeenCalled();
 
       const revocationFilters = processDwnRequestStub.mock.calls
         .filter(([request]) => request.messageType === DwnInterface.RecordsRead)

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -8,7 +8,7 @@ import { Convert } from '@enbox/common';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { TestAgent } from './utils/test-agent.js';
 import { DwnInterface, DwnPermissionGrant, type PermissionGrantEntry } from '../src/index.js';
-import { DwnInterfaceName, DwnMethodName, Time } from '@enbox/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName, PermissionsProtocol, Time } from '@enbox/dwn-sdk-js';
 
 
 describe('AgentPermissionsApi', () => {
@@ -462,8 +462,8 @@ describe('AgentPermissionsApi', () => {
       expect(grants[0].grant.id).toBe(grant.grant.id);
     });
 
-    it('should query revocations once per candidate grant when checking revocations', async () => {
-      await testHarness.agent.permissions.createGrant({
+    it('should batch local revocation checks through one message store query', async () => {
+      const writeGrant = await testHarness.agent.permissions.createGrant({
         store       : true,
         author      : aliceDid.uri,
         grantedTo   : aliceDid.uri,
@@ -474,7 +474,7 @@ describe('AgentPermissionsApi', () => {
           protocol  : 'http://example.com/revocation-roundtrip-test'
         }
       });
-      await testHarness.agent.permissions.createGrant({
+      const readGrant = await testHarness.agent.permissions.createGrant({
         store       : true,
         author      : aliceDid.uri,
         grantedTo   : aliceDid.uri,
@@ -485,18 +485,33 @@ describe('AgentPermissionsApi', () => {
           protocol  : 'http://example.com/revocation-roundtrip-test'
         }
       });
+      await testHarness.agent.permissions.createRevocation({
+        store  : true,
+        author : aliceDid.uri,
+        grant  : writeGrant.grant,
+      });
 
-      const processDwnRequestSpy = spyOn(testHarness.agent, 'processDwnRequest');
+      const messageStoreQuerySpy = spyOn(testHarness.agent.dwn.node.storage.messageStore, 'query');
 
-      // fetch grants with revocation check (default)
-      await testHarness.agent.permissions.fetchGrants({
+      const grants = await testHarness.agent.permissions.fetchGrants({
         author   : aliceDid.uri,
         target   : aliceDid.uri,
         protocol : 'http://example.com/revocation-roundtrip-test',
       });
 
-      // expect one grants query plus one revocation query per candidate grant
-      expect(processDwnRequestSpy).toHaveBeenCalledTimes(3);
+      expect(grants.length).toBe(1);
+      expect(grants[0].message.recordId).toBe(readGrant.message.recordId);
+
+      const revocationQueryCalls = messageStoreQuerySpy.mock.calls.filter(([, filters]) =>
+        (filters as Array<Record<string, unknown>>).some(filter => filter.protocolPath === PermissionsProtocol.revocationPath)
+      );
+      expect(revocationQueryCalls.length).toBe(1);
+
+      const revocationFilter = (revocationQueryCalls[0][1] as Array<Record<string, unknown>>)[0];
+      const parentIds = revocationFilter.parentId as string[];
+      expect(parentIds.length).toBe(2);
+      expect(parentIds.includes(writeGrant.message.recordId)).toBe(true);
+      expect(parentIds.includes(readGrant.message.recordId)).toBe(true);
     });
 
     it('should use only 1 DWN roundtrip when checkRevoked is false', async () => {

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -319,7 +319,7 @@ describe('AgentPermissionsApi', () => {
       expect(sendDwnRequestStub).toHaveBeenCalled();
     });
 
-    it('should fall back to scoped remote revocation queries when checking remote grants', async () => {
+    it('should fall back to single-grant remote revocation reads when checking remote grants', async () => {
       const writeGrant = await testHarness.agent.permissions.createGrant({
         store       : false,
         author      : aliceDid.uri,
@@ -342,33 +342,25 @@ describe('AgentPermissionsApi', () => {
           protocol  : 'http://example.com/remote-revocation-test'
         }
       });
-      const writeRevocationMessage = {
-        ...writeGrant.message,
-        contextId  : `${writeGrant.message.contextId}/remote-revocation`,
-        recordId   : 'remote-revocation',
-        descriptor : {
-          ...writeGrant.message.descriptor,
-          parentId     : writeGrant.message.recordId,
-          protocolPath : PermissionsProtocol.revocationPath,
-        },
-      };
 
       const sendDwnRequestStub = spyOn(testHarness.agent, 'sendDwnRequest').mockImplementation(async (request) => {
         const filter = 'messageParams' in request
           ? request.messageParams.filter as Record<string, unknown>
           : {};
 
-        if (filter.protocolPath === PermissionsProtocol.grantPath) {
+        if (request.messageType === DwnInterface.RecordsQuery && filter.protocolPath === PermissionsProtocol.grantPath) {
           return {
             messageCid : '',
             reply      : { entries: [writeGrant.message, readGrant.message], status: { code: 200, detail: 'OK' } }
           };
         }
 
-        const entries = filter.contextId === writeGrant.message.contextId ? [writeRevocationMessage] : [];
+        const status = filter.parentId === writeGrant.message.recordId
+          ? { code: 200, detail: 'OK' }
+          : { code: 404, detail: 'Not Found' };
         return {
           messageCid : '',
-          reply      : { entries, status: { code: 200, detail: 'OK' } }
+          reply      : { status }
         };
       });
 
@@ -386,8 +378,10 @@ describe('AgentPermissionsApi', () => {
         .map(([request]) => ('messageParams' in request ? request.messageParams.filter as Record<string, unknown> : {}))
         .filter(filter => filter.protocolPath === PermissionsProtocol.revocationPath);
       expect(revocationFilters.length).toBe(2);
-      expect(revocationFilters.some(filter => filter.contextId === writeGrant.message.contextId)).toBe(true);
-      expect(revocationFilters.some(filter => filter.contextId === readGrant.message.contextId)).toBe(true);
+      expect(revocationFilters.some(filter => filter.parentId === writeGrant.message.recordId)).toBe(true);
+      expect(revocationFilters.some(filter => filter.parentId === readGrant.message.recordId)).toBe(true);
+      expect(revocationFilters.every(filter => filter.contextId === undefined)).toBe(true);
+      expect(revocationFilters.every(filter => !Array.isArray(filter.parentId))).toBe(true);
     });
 
     it('filter by protocol', async () => {
@@ -533,7 +527,7 @@ describe('AgentPermissionsApi', () => {
       expect(grants[0].grant.id).toBe(grant.grant.id);
     });
 
-    it('should batch local revocation checks through one message store query', async () => {
+    it('should check local revocations through the canonical per-grant message store predicate', async () => {
       const writeGrant = await testHarness.agent.permissions.createGrant({
         store       : true,
         author      : aliceDid.uri,
@@ -576,15 +570,69 @@ describe('AgentPermissionsApi', () => {
       const revocationQueryCalls = messageStoreQuerySpy.mock.calls.filter(([, filters]) =>
         (filters as Array<Record<string, unknown>>).some(filter => filter.protocolPath === PermissionsProtocol.revocationPath)
       );
-      expect(revocationQueryCalls.length).toBe(1);
+      expect(revocationQueryCalls.length).toBe(2);
 
-      const revocationFilters = revocationQueryCalls[0][1] as Array<Record<string, unknown>>;
-      expect(revocationFilters.length).toBe(1);
-      expect(revocationFilters[0].method).toBe(DwnMethodName.Write);
-      expect(revocationFilters[0].parentId).toEqual(expect.arrayContaining([
-        writeGrant.message.recordId,
+      const revocationFilters = revocationQueryCalls.map(([, filters]) => (filters as Array<Record<string, unknown>>)[0]);
+      expect(revocationFilters.map(filter => filter.parentId).sort()).toEqual([
         readGrant.message.recordId,
-      ]));
+        writeGrant.message.recordId,
+      ].sort());
+      expect(revocationFilters.every(filter => filter.isLatestBaseState === true)).toBe(true);
+      expect(revocationFilters.every(filter => filter.protocolPath === PermissionsProtocol.revocationPath)).toBe(true);
+      expect(revocationFilters.every(filter => !Array.isArray(filter.parentId))).toBe(true);
+      expect(revocationFilters.every(filter => filter.author === undefined)).toBe(true);
+      expect(revocationFilters.every(filter => filter['tag.protocol'] === undefined)).toBe(true);
+      expect(revocationQueryCalls.every(([, , , pagination]) => pagination?.limit === 1)).toBe(true);
+    });
+
+    it('should use the message path for cross-tenant local revocation checks', async () => {
+      const writeGrant = await testHarness.agent.permissions.createGrant({
+        store       : false,
+        author      : aliceDid.uri,
+        grantedTo   : bobDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Write,
+          protocol  : 'http://example.com/cross-tenant-revocation-test'
+        }
+      });
+      const messageStoreQuerySpy = spyOn(testHarness.agent.dwn.node.storage.messageStore, 'query');
+      const processDwnRequestStub = spyOn(testHarness.agent, 'processDwnRequest').mockImplementation(async (request) => {
+        const filter = 'messageParams' in request
+          ? request.messageParams.filter as Record<string, unknown>
+          : {};
+
+        if (request.messageType === DwnInterface.RecordsQuery && filter.protocolPath === PermissionsProtocol.grantPath) {
+          return {
+            messageCid : '',
+            reply      : { entries: [writeGrant.message], status: { code: 200, detail: 'OK' } }
+          };
+        }
+
+        return {
+          messageCid : '',
+          reply      : { status: { code: 404, detail: 'Not Found' } }
+        };
+      });
+
+      const grants = await testHarness.agent.permissions.fetchGrants({
+        author   : bobDid.uri,
+        target   : aliceDid.uri,
+        protocol : 'http://example.com/cross-tenant-revocation-test',
+      });
+
+      expect(grants.length).toBe(1);
+      expect(messageStoreQuerySpy).not.toHaveBeenCalled();
+
+      const revocationFilters = processDwnRequestStub.mock.calls
+        .filter(([request]) => request.messageType === DwnInterface.RecordsRead)
+        .map(([request]) => request.messageParams.filter as Record<string, unknown>);
+      expect(revocationFilters).toEqual([{
+        parentId     : writeGrant.message.recordId,
+        protocol     : PermissionsProtocol.uri,
+        protocolPath : PermissionsProtocol.revocationPath,
+      }]);
     });
 
     it('should use only 1 DWN roundtrip when checkRevoked is false', async () => {

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -568,11 +568,12 @@ describe('AgentPermissionsApi', () => {
       );
       expect(revocationQueryCalls.length).toBe(1);
 
-      const revocationFilter = (revocationQueryCalls[0][1] as Array<Record<string, unknown>>)[0];
-      const parentIds = revocationFilter.parentId as string[];
+      const revocationFilters = revocationQueryCalls[0][1] as Array<Record<string, unknown>>;
+      const parentIds = revocationFilters.map(filter => filter.parentId);
       expect(parentIds.length).toBe(2);
       expect(parentIds.includes(writeGrant.message.recordId)).toBe(true);
       expect(parentIds.includes(readGrant.message.recordId)).toBe(true);
+      expect(revocationFilters.every(filter => typeof filter.parentId === 'string')).toBe(true);
     });
 
     it('should use only 1 DWN roundtrip when checkRevoked is false', async () => {

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -462,17 +462,41 @@ describe('AgentPermissionsApi', () => {
       expect(grants[0].grant.id).toBe(grant.grant.id);
     });
 
-    it('should use only 2 DWN roundtrips when checking revocations', async () => {
+    it('should query revocations once per candidate grant when checking revocations', async () => {
+      await testHarness.agent.permissions.createGrant({
+        store       : true,
+        author      : aliceDid.uri,
+        grantedTo   : aliceDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Write,
+          protocol  : 'http://example.com/revocation-roundtrip-test'
+        }
+      });
+      await testHarness.agent.permissions.createGrant({
+        store       : true,
+        author      : aliceDid.uri,
+        grantedTo   : aliceDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Read,
+          protocol  : 'http://example.com/revocation-roundtrip-test'
+        }
+      });
+
       const processDwnRequestSpy = spyOn(testHarness.agent, 'processDwnRequest');
 
       // fetch grants with revocation check (default)
       await testHarness.agent.permissions.fetchGrants({
-        author : aliceDid.uri,
-        target : aliceDid.uri,
+        author   : aliceDid.uri,
+        target   : aliceDid.uri,
+        protocol : 'http://example.com/revocation-roundtrip-test',
       });
 
-      // expect exactly 2 calls: one for grants query, one for revocations query
-      expect(processDwnRequestSpy).toHaveBeenCalledTimes(2);
+      // expect one grants query plus one revocation query per candidate grant
+      expect(processDwnRequestSpy).toHaveBeenCalledTimes(3);
     });
 
     it('should use only 1 DWN roundtrip when checkRevoked is false', async () => {

--- a/packages/agent/tests/permissions-api.spec.ts
+++ b/packages/agent/tests/permissions-api.spec.ts
@@ -319,6 +319,67 @@ describe('AgentPermissionsApi', () => {
       expect(sendDwnRequestStub).toHaveBeenCalled();
     });
 
+    it('should fall back to scoped remote revocation queries when checking remote grants', async () => {
+      const writeGrant = await testHarness.agent.permissions.createGrant({
+        store       : false,
+        author      : aliceDid.uri,
+        grantedTo   : aliceDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Write,
+          protocol  : 'http://example.com/remote-revocation-test'
+        }
+      });
+      const readGrant = await testHarness.agent.permissions.createGrant({
+        store       : false,
+        author      : aliceDid.uri,
+        grantedTo   : aliceDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Read,
+          protocol  : 'http://example.com/remote-revocation-test'
+        }
+      });
+
+      const sendDwnRequestStub = spyOn(testHarness.agent, 'sendDwnRequest').mockImplementation(async (request) => {
+        const filter = 'messageParams' in request
+          ? request.messageParams.filter as Record<string, unknown>
+          : {};
+
+        if (filter.protocolPath === PermissionsProtocol.grantPath) {
+          return {
+            messageCid : '',
+            reply      : { entries: [writeGrant.message, readGrant.message], status: { code: 200, detail: 'OK' } }
+          };
+        }
+
+        const entries = filter.contextId === writeGrant.message.contextId ? [writeGrant.message] : [];
+        return {
+          messageCid : '',
+          reply      : { entries, status: { code: 200, detail: 'OK' } }
+        };
+      });
+
+      const grants = await testHarness.agent.permissions.fetchGrants({
+        author   : aliceDid.uri,
+        target   : aliceDid.uri,
+        protocol : 'http://example.com/remote-revocation-test',
+        remote   : true,
+      });
+
+      expect(grants.length).toBe(1);
+      expect(grants[0].message.recordId).toBe(readGrant.message.recordId);
+
+      const revocationFilters = sendDwnRequestStub.mock.calls
+        .map(([request]) => ('messageParams' in request ? request.messageParams.filter as Record<string, unknown> : {}))
+        .filter(filter => filter.protocolPath === PermissionsProtocol.revocationPath);
+      expect(revocationFilters.length).toBe(2);
+      expect(revocationFilters.some(filter => filter.contextId === writeGrant.message.contextId)).toBe(true);
+      expect(revocationFilters.some(filter => filter.contextId === readGrant.message.contextId)).toBe(true);
+    });
+
     it('filter by protocol', async () => {
       // create a grant for permission-1
       const protocol1Grant = await testHarness.agent.permissions.createGrant({

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -46,7 +46,7 @@ export type FetchRequestsRequest = Omit<FetchPermissionRequestParams, 'author' |
  * Represents the request payload for fetching permission grants from a Decentralized Web Node (DWN).
  *
  * Optionally, specify a remote DWN target in the `from` property to fetch requests from.
- * Revoked grants are filtered out by default; set `checkRevoked: false` to include them.
+ * Set `checkRevoked: true` to perform explicit per-grant revocation checks.
  */
 export type FetchGrantsRequest = Omit<FetchPermissionsParams, 'author' | 'target' | 'remote'> & {
   /** Optional DID specifying the remote target DWN tenant to be queried. */

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -1324,6 +1324,7 @@ describe('DwnApi', () => {
         // query for child records to confirm it exists
         const { status: childrenStatus, records: childrenRecords } = await dwnAlice.records.query({
           filter: {
+            contextId    : parentRecord.contextId,
             protocol     : protocol.definition.protocol,
             protocolPath : 'foo/bar'
           }
@@ -1343,6 +1344,7 @@ describe('DwnApi', () => {
         // query for child records to confirm it was deleted
         const { status: childrenStatusAfterDelete, records: childrenRecordsAfterDelete } = await dwnAlice.records.query({
           filter: {
+            contextId    : parentRecord.contextId,
             protocol     : protocol.definition.protocol,
             protocolPath : 'foo/bar'
           }

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -3348,35 +3348,17 @@ describe('DwnApi', () => {
       expect(fetchedGrantsCarol[0].id).toBe(grantFromCarol.id);
     });
 
-    it('should filter out revoked grants by default', async () => {
-      // alice creates a grant for bob and stores it
-      const bobGrant = await dwnAlice.permissions.grant({
-        store       : true,
-        grantedTo   : bobDid.uri,
-        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
-        scope       : {
-          interface : DwnInterfaceName.Records,
-          method    : DwnMethodName.Write,
-          protocol  : 'http://example.com/protocol'
-        }
-      });
+    it('passes checkRevoked through to fetchGrants only when requested', async () => {
+      const fetchGrantsSpy = sinon.spy(AgentPermissionsApi.prototype, 'fetchGrants');
 
-      // query for the grants — should include the grant
-      let fetchedGrants = await dwnAlice.permissions.queryGrants();
-      expect(fetchedGrants.length).toBe(1);
-      expect(fetchedGrants[0].id).toBe(bobGrant.id);
+      await dwnAlice.permissions.queryGrants();
+      expect(fetchGrantsSpy.args[0][0].checkRevoked).toBeUndefined();
 
-      // revoke the grant
-      await bobGrant.revoke();
+      await dwnAlice.permissions.queryGrants({ checkRevoked: false });
+      expect(fetchGrantsSpy.args[1][0].checkRevoked).toBe(false);
 
-      // default query should now exclude the revoked grant
-      fetchedGrants = await dwnAlice.permissions.queryGrants();
-      expect(fetchedGrants.length).toBe(0);
-
-      // with checkRevoked: false, the revoked grant should still be returned
-      fetchedGrants = await dwnAlice.permissions.queryGrants({ checkRevoked: false });
-      expect(fetchedGrants.length).toBe(1);
-      expect(fetchedGrants[0].id).toBe(bobGrant.id);
+      await dwnAlice.permissions.queryGrants({ checkRevoked: true });
+      expect(fetchGrantsSpy.args[2][0].checkRevoked).toBe(true);
     });
   });
 });

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -3634,6 +3634,7 @@ describe('Record', () => {
       // query for child records to confirm it exists
       const { status: childrenStatus, records: childrenRecords } = await dwnAlice.records.query({
         filter: {
+          contextId    : parentRecord.contextId,
           protocol     : protocol.definition.protocol,
           protocolPath : 'foo/bar'
         }
@@ -3650,6 +3651,7 @@ describe('Record', () => {
       // query for child records to confirm it was deleted
       const { status: childrenStatusAfterDelete, records: childrenRecordsAfterDelete } = await dwnAlice.records.query({
         filter: {
+          contextId    : parentRecord.contextId,
           protocol     : protocol.definition.protocol,
           protocolPath : 'foo/bar'
         }
@@ -3732,6 +3734,7 @@ describe('Record', () => {
       const { status: childrenStatus, records: childrenRecords } = await dwnAlice.records.query({
         from   : aliceDid.uri,
         filter : {
+          contextId    : parentRecord.contextId,
           protocol     : protocol.definition.protocol,
           protocolPath : 'foo/bar'
         }
@@ -3751,6 +3754,7 @@ describe('Record', () => {
       const { status: childrenStatusAfterDelete, records: childrenRecordsAfterDelete } = await dwnAlice.records.query({
         from   : aliceDid.uri,
         filter : {
+          contextId    : parentRecord.contextId,
           protocol     : protocol.definition.protocol,
           protocolPath : 'foo/bar'
         }

--- a/packages/api/tests/typed-protocol.spec.ts
+++ b/packages/api/tests/typed-protocol.spec.ts
@@ -715,13 +715,25 @@ describe('TypedProtocol API', () => {
         it('should recognize all valid paths from the protocol structure', async () => {
           // Verify all expected paths are valid by performing operations on them.
           // If collectPaths is wrong, _assertReady would throw 'invalid protocol path'.
+          const { record: listRecord } = await typed.records.create('list', {
+            data: { name: 'Path Test' },
+          });
+          const { record: taskRecord } = await typed.records.create('list/task', {
+            data            : { title: 'Path task', completed: false },
+            parentContextId : listRecord.contextId,
+          });
+
           const { status: listStatus } = await typed.records.query('list');
           expect(listStatus.code).toBe(200);
 
-          const { status: taskStatus } = await typed.records.query('list/task');
+          const { status: taskStatus } = await typed.records.query('list/task', {
+            filter: { contextId: listRecord.contextId },
+          });
           expect(taskStatus.code).toBe(200);
 
-          const { status: attachmentStatus } = await typed.records.query('list/task/attachment');
+          const { status: attachmentStatus } = await typed.records.query('list/task/attachment', {
+            filter: { contextId: taskRecord.contextId },
+          });
           expect(attachmentStatus.code).toBe(200);
         });
 

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -16,7 +16,7 @@
 
 import type { GenericMessage } from '@enbox/dwn-sdk-js';
 import type { PortableDid } from '@enbox/dids';
-import type { AgentSessionIdentity, BearerIdentity, DelegateContextKey, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, EnboxUserAgent } from '@enbox/agent';
+import type { AgentSessionIdentity, BearerIdentity, DelegateContextKey, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, EnboxUserAgent, PermissionGrantEntry } from '@enbox/agent';
 
 import type { AuthEventEmitter } from '../events.js';
 import type { PasswordProvider } from '../password-provider.js';
@@ -333,54 +333,14 @@ export async function deriveActiveSyncScope(
   userAgent: EnboxUserAgent,
   delegateDid: string,
 ): Promise<'all' | string[]> {
-  // Query grants and the permissions protocol in parallel. Revocations are nested
-  // under grants, so the second query intentionally avoids a protocolPath filter
-  // and filters revocation entries client-side.
-  const [grantResponse, revocationResponse] = await Promise.all([
-    userAgent.processDwnRequest({
-      author        : delegateDid,
-      target        : delegateDid,
-      messageType   : DwnInterface.RecordsQuery,
-      messageParams : { filter: { protocol: PermissionsProtocol.uri, protocolPath: PermissionsProtocol.grantPath } },
-    }),
-    userAgent.processDwnRequest({
-      author        : delegateDid,
-      target        : delegateDid,
-      messageType   : DwnInterface.RecordsQuery,
-      messageParams : { filter: { protocol: PermissionsProtocol.uri } },
-    }),
-  ]);
+  const grantEntries: PermissionGrantEntry[] = await userAgent.permissions.fetchGrants({
+    author       : delegateDid,
+    target       : delegateDid,
+    grantee      : delegateDid,
+    checkRevoked : true,
+  });
 
-  if (grantResponse.reply.status.code !== 200 || !grantResponse.reply.entries) {
-    return [];
-  }
-  // Fail closed: if we can't verify revocations, treat as zero grants.
-  if (revocationResponse.reply.status.code !== 200) { return []; }
-
-  // Build the set of revoked grant IDs from revocation parent context.
-  // `descriptor.parentId` is the canonical location; the top-level
-  // `parentId` is a legacy/alternate-format fallback. Typed narrowly
-  // (no `any`) so additions to the shape land in the type system.
-  const revokedGrantIds = new Set<string>();
-  if (revocationResponse.reply.entries) {
-    for (const entry of revocationResponse.reply.entries as DwnDataEncodedRecordsWriteMessage[]) {
-      if (entry.descriptor.protocolPath !== PermissionsProtocol.revocationPath) {
-        continue;
-      }
-
-      const parentId =
-        entry.descriptor.parentId
-        ?? (entry as { parentId?: string }).parentId;
-      if (parentId) { revokedGrantIds.add(parentId); }
-    }
-  }
-
-  // Parse grants and filter out revoked ones before deriving scope.
-  const grants = (grantResponse.reply.entries as DwnDataEncodedRecordsWriteMessage[])
-    .map((entry) => DwnPermissionGrant.parse(entry))
-    .filter((grant) => !revokedGrantIds.has(grant.id));
-
-  return deriveSyncScopeFromGrants(grants);
+  return deriveSyncScopeFromGrants(grantEntries.map(({ grant }) => grant));
 }
 
 // ─── toSyncIdentityProtocols ────────────────────────────────────

--- a/packages/auth/src/connect/lifecycle.ts
+++ b/packages/auth/src/connect/lifecycle.ts
@@ -14,6 +14,7 @@
  * @internal
  */
 
+import type { GenericMessage } from '@enbox/dwn-sdk-js';
 import type { PortableDid } from '@enbox/dids';
 import type { AgentSessionIdentity, BearerIdentity, DelegateContextKey, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, EnboxUserAgent } from '@enbox/agent';
 
@@ -22,8 +23,6 @@ import type { PasswordProvider } from '../password-provider.js';
 import type { IdentitySyncProtocols, RegistrationOptions, StorageAdapter, SyncOption } from '../types.js';
 
 import { Convert } from '@enbox/common';
-import type { GenericMessage } from '@enbox/dwn-sdk-js';
-
 import { DataStream, PermissionsProtocol } from '@enbox/dwn-sdk-js';
 import { DwnInterface, DwnPermissionGrant, HdIdentityVaultRecoveryPhraseMismatchError, KeyDeliveryProtocolDefinition } from '@enbox/agent';
 
@@ -334,7 +333,9 @@ export async function deriveActiveSyncScope(
   userAgent: EnboxUserAgent,
   delegateDid: string,
 ): Promise<'all' | string[]> {
-  // Query grants and revocations in parallel.
+  // Query grants and the permissions protocol in parallel. Revocations are nested
+  // under grants, so the second query intentionally avoids a protocolPath filter
+  // and filters revocation entries client-side.
   const [grantResponse, revocationResponse] = await Promise.all([
     userAgent.processDwnRequest({
       author        : delegateDid,
@@ -346,7 +347,7 @@ export async function deriveActiveSyncScope(
       author        : delegateDid,
       target        : delegateDid,
       messageType   : DwnInterface.RecordsQuery,
-      messageParams : { filter: { protocol: PermissionsProtocol.uri, protocolPath: PermissionsProtocol.revocationPath } },
+      messageParams : { filter: { protocol: PermissionsProtocol.uri } },
     }),
   ]);
 
@@ -363,6 +364,10 @@ export async function deriveActiveSyncScope(
   const revokedGrantIds = new Set<string>();
   if (revocationResponse.reply.entries) {
     for (const entry of revocationResponse.reply.entries as DwnDataEncodedRecordsWriteMessage[]) {
+      if (entry.descriptor.protocolPath !== PermissionsProtocol.revocationPath) {
+        continue;
+      }
+
       const parentId =
         entry.descriptor.parentId
         ?? (entry as { parentId?: string }).parentId;

--- a/packages/auth/tests/grant-revocation.spec.ts
+++ b/packages/auth/tests/grant-revocation.spec.ts
@@ -90,7 +90,8 @@ function buildRevocationAgent(opts: {
 
   // Mock permissions.createRevocation
   (agent as any).permissions = {
-    createRevocation: async (params: any): Promise<any> => {
+    fetchGrants      : async (): Promise<any[]> => [],
+    createRevocation : async (params: any): Promise<any> => {
       if (opts.revocationError) { throw new Error('revocation failed'); }
       opts.revocationCalls?.push(params);
       return {

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -5,7 +5,8 @@
 
 import type { EnboxUserAgent } from '@enbox/agent';
 
-import { InMemorySecretStore } from '@enbox/agent';
+import { PermissionsProtocol } from '@enbox/dwn-sdk-js';
+import { DwnPermissionGrant, InMemorySecretStore } from '@enbox/agent';
 
 /** Minimal BearerIdentity-like object for testing. */
 export interface MockIdentity {
@@ -86,6 +87,7 @@ export interface MockAgentOverrides {
   syncClose?: () => Promise<void>;
   syncHasActiveSubscriptions?: boolean;
   processDwnRequest?: (params: any) => Promise<any>;
+  permissionsFetchGrants?: (params: any) => Promise<any[]>;
   rpcGetServerInfo?: (url: string) => Promise<any>;
   vaultIsInitialized?: () => Promise<boolean>;
   vaultIsLocked?: () => boolean;
@@ -106,6 +108,39 @@ export interface MockAgentOverrides {
  */
 export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAgent {
   const defaultIdentity = createMockIdentity();
+  const processDwnRequest = overrides.processDwnRequest ?? (async (params: any): Promise<any> => {
+    // RecordsQuery returns 200 with empty entries (used by _deriveProtocolsFromGrants).
+    // All other DWN messages return 202 Accepted.
+    if (params?.messageType === 'RecordsQuery') {
+      return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+    }
+    return { reply: { status: { code: 202, detail: 'Accepted' } } };
+  });
+  const permissionsFetchGrants = overrides.permissionsFetchGrants ?? (async (params: any): Promise<any[]> => {
+    const tags = params.protocol !== undefined ? { protocol: params.protocol } : undefined;
+    const { reply } = await processDwnRequest({
+      author        : params.author,
+      target        : params.target,
+      messageType   : 'RecordsQuery',
+      messageParams : {
+        filter: {
+          author       : params.grantor,
+          recipient    : params.grantee,
+          protocol     : PermissionsProtocol.uri,
+          protocolPath : PermissionsProtocol.grantPath,
+          tags,
+        },
+      },
+    });
+    if (reply.status.code !== 200) {
+      throw new Error(`mock fetchGrants failed: ${reply.status.detail}`);
+    }
+
+    return (reply.entries ?? []).map((entry: any) => ({
+      grant   : DwnPermissionGrant.parse(entry),
+      message : entry,
+    }));
+  });
 
   return {
     agentDid : { uri: 'did:dht:testagent' },
@@ -155,14 +190,11 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
       ensureKeyDeliveryProtocol         : overrides.dwnEnsureKeyDeliveryProtocol ?? (async (): Promise<void> => {}),
     },
 
-    processDwnRequest: overrides.processDwnRequest ?? (async (params: any): Promise<any> => {
-      // RecordsQuery returns 200 with empty entries (used by _deriveProtocolsFromGrants).
-      // All other DWN messages return 202 Accepted.
-      if (params?.messageType === 'RecordsQuery') {
-        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
-      }
-      return { reply: { status: { code: 202, detail: 'Accepted' } } };
-    }),
+    processDwnRequest,
+
+    permissions: {
+      fetchGrants: permissionsFetchGrants,
+    },
 
     rpc: {
       getServerInfo: overrides.rpcGetServerInfo ?? (async (): Promise<any> => ({

--- a/packages/auth/tests/lifecycle.spec.ts
+++ b/packages/auth/tests/lifecycle.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { Convert } from '@enbox/common';
+import { DwnPermissionGrant } from '@enbox/agent';
 import { PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
 import { AuthEventEmitter } from '../src/events.js';
@@ -75,6 +76,27 @@ function buildGrantMessage(protocol: string, grantId: string): any {
         signatures: [{ protected: btoa(JSON.stringify({ kid: 'did:dht:owner1#sig' })) }],
       },
     },
+  };
+}
+
+function buildGrantEntry(protocol: string, grantId: string): any {
+  const message = buildGrantMessage(protocol, grantId);
+  return {
+    grant: DwnPermissionGrant.parse(message),
+    message,
+  };
+}
+
+function buildUnscopedGrantEntry(
+  grantId: string,
+  scopeInterface = 'Messages',
+  scopeMethod = 'Read',
+  dateExpires = '2040-06-25T16:09:16.693356Z',
+): any {
+  const message = buildUnscopedGrantMessage(grantId, scopeInterface, scopeMethod, dateExpires);
+  return {
+    grant: DwnPermissionGrant.parse(message),
+    message,
   };
 }
 
@@ -228,17 +250,10 @@ describe('deriveSyncScopeFromGrants', () => {
 describe('deriveActiveSyncScope', () => {
   test('returns protocols from active Messages.Read grants', async () => {
     const agent = createMockAgent({
-      processDwnRequest: async (params: any) => {
-        const filter = params?.messageParams?.filter;
-        if (filter?.protocolPath === 'grant') {
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            buildGrantMessage('https://proto.example/a', 'g1'),
-            buildGrantMessage('https://proto.example/b', 'g2'),
-          ] } };
-        }
-        // No revocations.
-        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
-      },
+      permissionsFetchGrants: async () => [
+        buildGrantEntry('https://proto.example/a', 'g1'),
+        buildGrantEntry('https://proto.example/b', 'g2'),
+      ],
     });
 
     const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
@@ -246,29 +261,22 @@ describe('deriveActiveSyncScope', () => {
   });
 
   test('excludes revoked grants', async () => {
+    let fetchParams: any;
     const agent = createMockAgent({
-      processDwnRequest: async (params: any) => {
-        const filter = params?.messageParams?.filter;
-        if (filter?.protocolPath === 'grant') {
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            buildGrantMessage('https://proto.example/valid', 'g-valid'),
-            buildGrantMessage('https://proto.example/revoked', 'g-revoked'),
-          ] } };
-        }
-        if (filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined) {
-          return { reply: { status: { code: 400, detail: 'nested revocation queries require contextId' } } };
-        }
-        if (filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined) {
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            { descriptor: { parentId: 'g-revoked', protocolPath: PermissionsProtocol.revocationPath } },
-          ] } };
-        }
-        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      permissionsFetchGrants: async (params: any) => {
+        fetchParams = params;
+        return [buildGrantEntry('https://proto.example/valid', 'g-valid')];
       },
     });
 
     const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
     expect(result).toEqual(['https://proto.example/valid']);
+    expect(fetchParams).toEqual({
+      author       : 'did:delegate',
+      target       : 'did:delegate',
+      grantee      : 'did:delegate',
+      checkRevoked : true,
+    });
   });
 
   test('does not issue an unscoped nested revocation query', async () => {
@@ -277,19 +285,12 @@ describe('deriveActiveSyncScope', () => {
       processDwnRequest: async (params: any) => {
         const filter = params?.messageParams?.filter;
         filters.push(filter);
-        if (filter?.protocolPath === PermissionsProtocol.grantPath) {
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            buildGrantMessage('https://proto.example/a', 'g1'),
-          ] } };
-        }
         if (filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined) {
           return { reply: { status: { code: 400, detail: 'nested revocation queries require contextId' } } };
         }
-        if (filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined) {
-          return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
-        }
         return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
       },
+      permissionsFetchGrants: async () => [buildGrantEntry('https://proto.example/a', 'g1')],
     });
 
     const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
@@ -297,51 +298,28 @@ describe('deriveActiveSyncScope', () => {
     expect(filters.some(filter =>
       filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined
     )).toBe(false);
-    expect(filters.some(filter =>
-      filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined
-    )).toBe(true);
+    expect(filters.length).toBe(0);
   });
 
-  test('fails closed when revocation query fails', async () => {
+  test('throws when grant fetching fails', async () => {
     const agent = createMockAgent({
-      processDwnRequest: async (params: any) => {
-        const filter = params?.messageParams?.filter;
-        if (filter?.protocolPath === 'grant') {
-          // Grants query succeeds with active grants.
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            buildGrantMessage('https://proto.example/a', 'g1'),
-          ] } };
-        }
-        // Revocation query fails — cannot verify revocation status.
-        return { reply: { status: { code: 500, detail: 'Internal Error' } } };
-      },
+      permissionsFetchGrants: async () => { throw new Error('Internal Error'); },
     });
 
-    // Should return [] (fail closed), NOT ['https://proto.example/a'].
-    const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
-    expect(result).toEqual([]);
+    await expect(deriveActiveSyncScope(agent as any, 'did:delegate')).rejects.toThrow('Internal Error');
   });
 
-  test('returns empty when grant query fails', async () => {
+  test('throws when the grant query fails', async () => {
     const agent = createMockAgent({
-      processDwnRequest: async () => ({ reply: { status: { code: 500, detail: 'Error' } } }),
+      permissionsFetchGrants: async () => { throw new Error('Error'); },
     });
 
-    const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
-    expect(result).toEqual([]);
+    await expect(deriveActiveSyncScope(agent as any, 'did:delegate')).rejects.toThrow('Error');
   });
 
   test('returns all for unscoped Messages.Read grant', async () => {
     const agent = createMockAgent({
-      processDwnRequest: async (params: any) => {
-        const filter = params?.messageParams?.filter;
-        if (filter?.protocolPath === 'grant') {
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            buildUnscopedGrantMessage('g-unscoped'),
-          ] } };
-        }
-        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
-      },
+      permissionsFetchGrants: async () => [buildUnscopedGrantEntry('g-unscoped')],
     });
 
     const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
@@ -350,23 +328,7 @@ describe('deriveActiveSyncScope', () => {
 
   test('excludes revoked wildcard grant', async () => {
     const agent = createMockAgent({
-      processDwnRequest: async (params: any) => {
-        const filter = params?.messageParams?.filter;
-        if (filter?.protocolPath === 'grant') {
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            buildUnscopedGrantMessage('g-unscoped'),
-          ] } };
-        }
-        if (filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined) {
-          return { reply: { status: { code: 400, detail: 'nested revocation queries require contextId' } } };
-        }
-        if (filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined) {
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            { descriptor: { parentId: 'g-unscoped', protocolPath: PermissionsProtocol.revocationPath } },
-          ] } };
-        }
-        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
-      },
+      permissionsFetchGrants: async () => [],
     });
 
     const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
@@ -375,15 +337,7 @@ describe('deriveActiveSyncScope', () => {
 
   test('excludes expired wildcard grant', async () => {
     const agent = createMockAgent({
-      processDwnRequest: async (params: any) => {
-        const filter = params?.messageParams?.filter;
-        if (filter?.protocolPath === 'grant') {
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            buildUnscopedGrantMessage('g-expired', 'Messages', 'Read', '2020-01-01T00:00:00Z'),
-          ] } };
-        }
-        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
-      },
+      permissionsFetchGrants: async () => [buildUnscopedGrantEntry('g-expired', 'Messages', 'Read', '2020-01-01T00:00:00Z')],
     });
 
     const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
@@ -392,16 +346,10 @@ describe('deriveActiveSyncScope', () => {
 
   test('wildcard wins when mixed with scoped grants', async () => {
     const agent = createMockAgent({
-      processDwnRequest: async (params: any) => {
-        const filter = params?.messageParams?.filter;
-        if (filter?.protocolPath === 'grant') {
-          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            buildGrantMessage('https://proto.example/chat', 'g-scoped'),
-            buildUnscopedGrantMessage('g-unscoped'),
-          ] } };
-        }
-        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
-      },
+      permissionsFetchGrants: async () => [
+        buildGrantEntry('https://proto.example/chat', 'g-scoped'),
+        buildUnscopedGrantEntry('g-unscoped'),
+      ],
     });
 
     const result = await deriveActiveSyncScope(agent as any, 'did:delegate');

--- a/packages/auth/tests/lifecycle.spec.ts
+++ b/packages/auth/tests/lifecycle.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { Convert } from '@enbox/common';
+import { PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
 import { AuthEventEmitter } from '../src/events.js';
 import { MemoryStorage } from '../src/storage/storage.js';
@@ -254,9 +255,12 @@ describe('deriveActiveSyncScope', () => {
             buildGrantMessage('https://proto.example/revoked', 'g-revoked'),
           ] } };
         }
-        if (filter?.protocolPath === 'grant/revocation') {
+        if (filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined) {
+          return { reply: { status: { code: 400, detail: 'nested revocation queries require contextId' } } };
+        }
+        if (filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined) {
           return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            { descriptor: { parentId: 'g-revoked' } },
+            { descriptor: { parentId: 'g-revoked', protocolPath: PermissionsProtocol.revocationPath } },
           ] } };
         }
         return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
@@ -265,6 +269,37 @@ describe('deriveActiveSyncScope', () => {
 
     const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
     expect(result).toEqual(['https://proto.example/valid']);
+  });
+
+  test('does not issue an unscoped nested revocation query', async () => {
+    const filters: any[] = [];
+    const agent = createMockAgent({
+      processDwnRequest: async (params: any) => {
+        const filter = params?.messageParams?.filter;
+        filters.push(filter);
+        if (filter?.protocolPath === PermissionsProtocol.grantPath) {
+          return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
+            buildGrantMessage('https://proto.example/a', 'g1'),
+          ] } };
+        }
+        if (filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined) {
+          return { reply: { status: { code: 400, detail: 'nested revocation queries require contextId' } } };
+        }
+        if (filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined) {
+          return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+        }
+        return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };
+      },
+    });
+
+    const result = await deriveActiveSyncScope(agent as any, 'did:delegate');
+    expect(result).toEqual(['https://proto.example/a']);
+    expect(filters.some(filter =>
+      filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined
+    )).toBe(false);
+    expect(filters.some(filter =>
+      filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined
+    )).toBe(true);
   });
 
   test('fails closed when revocation query fails', async () => {
@@ -322,9 +357,12 @@ describe('deriveActiveSyncScope', () => {
             buildUnscopedGrantMessage('g-unscoped'),
           ] } };
         }
-        if (filter?.protocolPath === 'grant/revocation') {
+        if (filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined) {
+          return { reply: { status: { code: 400, detail: 'nested revocation queries require contextId' } } };
+        }
+        if (filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined) {
           return { reply: { status  : { code: 200, detail: 'OK' }, entries : [
-            { descriptor: { parentId: 'g-unscoped' } },
+            { descriptor: { parentId: 'g-unscoped', protocolPath: PermissionsProtocol.revocationPath } },
           ] } };
         }
         return { reply: { status: { code: 200, detail: 'OK' }, entries: [] } };

--- a/packages/auth/tests/session-restore.spec.ts
+++ b/packages/auth/tests/session-restore.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
+import { DwnPermissionGrant } from '@enbox/agent';
 import { PermissionsProtocol } from '@enbox/dwn-sdk-js';
 
 import { AuthEventEmitter } from '../src/events.js';
@@ -602,37 +603,15 @@ describe('restoreSession', () => {
         firstLaunch               : async () => false,
         identityConnectedIdentity : async () => identity,
         syncRegisterIdentity      : async (params) => { registerCalls.push(params); },
-        processDwnRequest         : async (params: any) => {
+        permissionsFetchGrants    : async () => {
+          const validGrant = buildMockGrantEntry('https://proto.example/valid');
+          return [{ grant: DwnPermissionGrant.parse(validGrant), message: validGrant }];
+        },
+        processDwnRequest: async (params: any) => {
           if (params?.messageType === 'RecordsQuery') {
             const filter = params.messageParams?.filter;
-            if (filter?.protocolPath === 'grant') {
-              // Return two grants: one valid, one that will be revoked.
-              return {
-                reply: {
-                  status  : { code: 200, detail: 'OK' },
-                  entries : [
-                    buildMockGrantEntry('https://proto.example/valid'),
-                    buildMockGrantEntry('https://proto.example/revoked'),
-                  ],
-                },
-              };
-            }
             if (filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined) {
               return { reply: { status: { code: 400, detail: 'nested revocation queries require contextId' } } };
-            }
-            if (filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined) {
-              // Return a revocation for the second grant.
-              return {
-                reply: {
-                  status  : { code: 200, detail: 'OK' },
-                  entries : [{
-                    descriptor: {
-                      parentId     : 'grant-https://proto.example/revoked',
-                      protocolPath : PermissionsProtocol.revocationPath,
-                    },
-                  }],
-                },
-              };
             }
           }
           return { reply: { status: { code: 202, detail: 'Accepted' } } };

--- a/packages/auth/tests/session-restore.spec.ts
+++ b/packages/auth/tests/session-restore.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
+import { PermissionsProtocol } from '@enbox/dwn-sdk-js';
+
 import { AuthEventEmitter } from '../src/events.js';
 import { MemoryStorage } from '../src/storage/storage.js';
 import { STORAGE_KEYS } from '../src/types.js';
@@ -615,12 +617,20 @@ describe('restoreSession', () => {
                 },
               };
             }
-            if (filter?.protocolPath === 'grant/revocation') {
+            if (filter?.protocolPath === PermissionsProtocol.revocationPath && filter.contextId === undefined) {
+              return { reply: { status: { code: 400, detail: 'nested revocation queries require contextId' } } };
+            }
+            if (filter?.protocol === PermissionsProtocol.uri && filter.protocolPath === undefined) {
               // Return a revocation for the second grant.
               return {
                 reply: {
                   status  : { code: 200, detail: 'OK' },
-                  entries : [{ descriptor: { parentId: 'grant-https://proto.example/revoked' } }],
+                  entries : [{
+                    descriptor: {
+                      parentId     : 'grant-https://proto.example/revoked',
+                      protocolPath : PermissionsProtocol.revocationPath,
+                    },
+                  }],
                 },
               };
             }

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -159,6 +159,7 @@ export enum DwnErrorCode {
   RecordsAuthorDelegatedGrantNotADelegatedGrant = 'RecordsAuthorDelegatedGrantNotADelegatedGrant',
   RecordsDecryptNoMatchingKeyEncryptedFound = 'RecordsDecryptNoMatchingKeyEncryptedFound',
   RecordsCountFilterMissingRequiredProperties = 'RecordsCountFilterMissingRequiredProperties',
+  RecordsCountNestedProtocolPathContextIdInvalid = 'RecordsCountNestedProtocolPathContextIdInvalid',
 
   RecordsQueryCreateFilterPublishedSortInvalid = 'RecordsQueryCreateFilterPublishedSortInvalid',
   RecordsQueryParseFilterPublishedSortInvalid = 'RecordsQueryParseFilterPublishedSortInvalid',
@@ -178,11 +179,13 @@ export enum DwnErrorCode {
   RecordsOwnerDelegatedGrantNotADelegatedGrant = 'RecordsOwnerDelegatedGrantNotADelegatedGrant',
 
   RecordsQueryFilterMissingRequiredProperties = 'RecordsQueryFilterMissingRequiredProperties',
+  RecordsQueryNestedProtocolPathContextIdInvalid = 'RecordsQueryNestedProtocolPathContextIdInvalid',
 
   RecordsReadCreateFilterPublishedSortInvalid = 'RecordsReadCreateFilterPublishedSortInvalid',
   RecordsReadParseFilterPublishedSortInvalid = 'RecordsReadParseFilterPublishedSortInvalid',
   RecordsSubscribeEventLogUnimplemented = 'RecordsSubscribeEventLogUnimplemented',
   RecordsSubscribeFilterMissingRequiredProperties = 'RecordsSubscribeFilterMissingRequiredProperties',
+  RecordsSubscribeNestedProtocolPathContextIdInvalid = 'RecordsSubscribeNestedProtocolPathContextIdInvalid',
 
   RecordsWriteAttestationIntegrityMoreThanOneSignature = 'RecordsWriteAttestationIntegrityMoreThanOneSignature',
   RecordsWriteAttestationIntegrityDescriptorCidMismatch = 'RecordsWriteAttestationIntegrityDescriptorCidMismatch',

--- a/packages/dwn-sdk-js/src/core/validation-state-reader.ts
+++ b/packages/dwn-sdk-js/src/core/validation-state-reader.ts
@@ -9,7 +9,6 @@ import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../types/pro
 
 import { FilterUtility } from '../utils/filter.js';
 import { PermissionGrant } from '../protocols/permission-grant.js';
-import { PERMISSIONS_REVOCATION_PATH } from './constants.js';
 import { PermissionsProtocol } from '../protocols/permissions.js';
 import { RecordsWrite } from '../interfaces/records-write.js';
 import { SortDirection } from '../types/query-types.js';
@@ -195,11 +194,7 @@ export class StoreValidationStateReader implements ValidationStateReader {
 
   /** @inheritdoc */
   public async fetchOldestGrantRevocation(tenant: string, permissionGrantId: string): Promise<GenericMessage | undefined> {
-    const query: Filter = {
-      parentId          : permissionGrantId,
-      protocolPath      : PERMISSIONS_REVOCATION_PATH,
-      isLatestBaseState : true
-    };
+    const query = PermissionsProtocol.grantRevocationFilter(permissionGrantId);
     const { messages } = await this.messageStore.query(
       tenant,
       [query],

--- a/packages/dwn-sdk-js/src/interfaces/records-count.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-count.ts
@@ -40,7 +40,7 @@ export class RecordsCount extends AbstractMessage<RecordsCountMessage> {
     await Records.validateDelegatedGrantReferentialIntegrity(message, signaturePayload);
     Records.validateNestedProtocolPathQueryScope(
       message.descriptor.filter,
-      DwnErrorCode.RecordsCountFilterMissingRequiredProperties,
+      DwnErrorCode.RecordsCountNestedProtocolPathContextIdInvalid,
       'RecordsCount'
     );
 

--- a/packages/dwn-sdk-js/src/interfaces/records-count.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-count.ts
@@ -38,6 +38,11 @@ export class RecordsCount extends AbstractMessage<RecordsCountMessage> {
     }
 
     await Records.validateDelegatedGrantReferentialIntegrity(message, signaturePayload);
+    Records.validateNestedProtocolPathQueryScope(
+      message.descriptor.filter,
+      DwnErrorCode.RecordsCountFilterMissingRequiredProperties,
+      'RecordsCount'
+    );
 
     if (signaturePayload?.protocolRole !== undefined) {
       if (message.descriptor.filter.protocolPath === undefined) {

--- a/packages/dwn-sdk-js/src/interfaces/records-query.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-query.ts
@@ -52,6 +52,11 @@ export class RecordsQuery extends AbstractMessage<RecordsQueryMessage> {
     }
 
     await Records.validateDelegatedGrantReferentialIntegrity(message, signaturePayload);
+    Records.validateNestedProtocolPathQueryScope(
+      message.descriptor.filter,
+      DwnErrorCode.RecordsQueryFilterMissingRequiredProperties,
+      'RecordsQuery'
+    );
 
     if (signaturePayload?.protocolRole !== undefined) {
       if (message.descriptor.filter.protocolPath === undefined) {

--- a/packages/dwn-sdk-js/src/interfaces/records-query.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-query.ts
@@ -54,7 +54,7 @@ export class RecordsQuery extends AbstractMessage<RecordsQueryMessage> {
     await Records.validateDelegatedGrantReferentialIntegrity(message, signaturePayload);
     Records.validateNestedProtocolPathQueryScope(
       message.descriptor.filter,
-      DwnErrorCode.RecordsQueryFilterMissingRequiredProperties,
+      DwnErrorCode.RecordsQueryNestedProtocolPathContextIdInvalid,
       'RecordsQuery'
     );
 

--- a/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
@@ -50,7 +50,7 @@ export class RecordsSubscribe extends AbstractMessage<RecordsSubscribeMessage> {
     await Records.validateDelegatedGrantReferentialIntegrity(message, signaturePayload);
     Records.validateNestedProtocolPathQueryScope(
       message.descriptor.filter,
-      DwnErrorCode.RecordsSubscribeFilterMissingRequiredProperties,
+      DwnErrorCode.RecordsSubscribeNestedProtocolPathContextIdInvalid,
       'RecordsSubscribe'
     );
 

--- a/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-subscribe.ts
@@ -48,6 +48,11 @@ export class RecordsSubscribe extends AbstractMessage<RecordsSubscribeMessage> {
     }
 
     await Records.validateDelegatedGrantReferentialIntegrity(message, signaturePayload);
+    Records.validateNestedProtocolPathQueryScope(
+      message.descriptor.filter,
+      DwnErrorCode.RecordsSubscribeFilterMissingRequiredProperties,
+      'RecordsSubscribe'
+    );
 
     if (signaturePayload?.protocolRole !== undefined) {
       if (message.descriptor.filter.protocolPath === undefined) {

--- a/packages/dwn-sdk-js/src/protocols/permissions.ts
+++ b/packages/dwn-sdk-js/src/protocols/permissions.ts
@@ -113,6 +113,17 @@ export class PermissionsProtocol implements CoreProtocol {
   public static readonly revocationPath = 'grant/revocation';
 
   /**
+   * Canonical store predicate for the latest revocation of a permission grant.
+   */
+  public static grantRevocationFilter(grantId: string): Filter {
+    return {
+      isLatestBaseState : true,
+      parentId          : grantId,
+      protocolPath      : PermissionsProtocol.revocationPath,
+    };
+  }
+
+  /**
    * The definition of the Permissions protocol.
    */
   public static readonly definition: ProtocolDefinition = {

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -320,10 +320,12 @@ export class Records {
     }
 
     const expectedParentDepth = protocolPath.split('/').length - 1;
-    const actualContextDepth = contextId !== undefined && contextId.length > 0
-      ? contextId.split('/').length
-      : undefined;
-    if (actualContextDepth === expectedParentDepth) {
+    const contextIdSegments = contextId?.split('/');
+    if (
+      contextIdSegments !== undefined &&
+      contextIdSegments.length === expectedParentDepth &&
+      contextIdSegments.every(segment => segment.length > 0)
+    ) {
       return;
     }
 

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -305,6 +305,34 @@ export class Records {
     return filterCopy;
   }
 
+  /**
+   * Nested protocol-path queries must pin one parent context. Otherwise the same
+   * protocol type is read across every parent instance.
+   */
+  public static validateNestedProtocolPathQueryScope(
+    filter: RecordsFilter,
+    errorCode: DwnErrorCode,
+    operationName: string,
+  ): void {
+    const { contextId, protocolPath } = filter;
+    if (protocolPath === undefined || !protocolPath.includes('/')) {
+      return;
+    }
+
+    const expectedParentDepth = protocolPath.split('/').length - 1;
+    const actualContextDepth = contextId !== undefined && contextId.length > 0
+      ? contextId.split('/').length
+      : undefined;
+    if (actualContextDepth === expectedParentDepth) {
+      return;
+    }
+
+    throw new DwnError(
+      errorCode,
+      `${operationName} for nested protocol path '${protocolPath}' must include the direct parent contextId in the filter`
+    );
+  }
+
 
   public static isStartsWithFilter(filter: RecordsWriteTagsFilter): filter is StartsWithFilter {
     return typeof filter === 'object' && ('startsWith' in filter && typeof filter.startsWith === 'string');

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -315,15 +315,14 @@ export class Records {
     operationName: string,
   ): void {
     const { contextId, protocolPath } = filter;
-    if (protocolPath === undefined || !protocolPath.includes('/')) {
+    if (!protocolPath?.includes('/')) {
       return;
     }
 
     const expectedParentDepth = protocolPath.split('/').length - 1;
     const contextIdSegments = contextId?.split('/');
     if (
-      contextIdSegments !== undefined &&
-      contextIdSegments.length === expectedParentDepth &&
+      contextIdSegments?.length === expectedParentDepth &&
       contextIdSegments.every(segment => segment.length > 0)
     ) {
       return;

--- a/packages/dwn-sdk-js/tests/dwn.spec.ts
+++ b/packages/dwn-sdk-js/tests/dwn.spec.ts
@@ -232,7 +232,7 @@ export function testDwnClass(): void {
           author       : bob,
           protocolRole : 'threads:thread/participant',
           filter       : {
-            contextId    : 'thread-context/comment-context',
+            contextId    : 'thread-context',
             protocol     : commentsProtocol.protocol,
             protocolPath : 'thread/comment',
           },

--- a/packages/dwn-sdk-js/tests/features/author-delegated-grant.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/author-delegated-grant.spec.ts
@@ -770,7 +770,10 @@ export function testAuthorDelegatedGrant(): void {
       // sanity verify the chat message is still in Bob's DWN
       const recordsQueryByBob = await TestDataGenerator.generateRecordsQuery({
         author : bob,
-        filter : { protocolPath: 'thread/chat' }
+        filter : {
+          protocolPath : 'thread/chat',
+          contextId    : threadRecord.message.contextId
+        }
       });
       const bobRecordsQueryReply = await dwn.processMessage(bob.did, recordsQueryByBob.message);
       expect(bobRecordsQueryReply.status.code).toBe(200);
@@ -1310,7 +1313,10 @@ export function testAuthorDelegatedGrant(): void {
       // sanity verify the chat message is still in Bob's DWN
       const recordsQueryByBob = await TestDataGenerator.generateRecordsQuery({
         author : bob,
-        filter : { protocolPath: 'thread/chat' }
+        filter : {
+          protocolPath : 'thread/chat',
+          contextId    : threadRecord.message.contextId
+        }
       });
       const bobRecordsQueryReply = await dwn.processMessage(bob.did, recordsQueryByBob.message);
       expect(bobRecordsQueryReply.status.code).toBe(200);

--- a/packages/dwn-sdk-js/tests/features/records-nested-query-scope.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-nested-query-scope.spec.ts
@@ -29,10 +29,18 @@ export function testRecordsNestedQueryScope(): void {
       protocol  : 'http://nested-query-scope.xyz',
       published : true,
       types     : {
-        avatar  : {},
-        profile : {},
+        avatar    : {},
+        channel   : {},
+        community : {},
+        message   : {},
+        profile   : {},
       },
       structure: {
+        community: {
+          channel: {
+            message: {},
+          },
+        },
         profile: {
           avatar: {},
         },
@@ -140,7 +148,7 @@ export function testRecordsNestedQueryScope(): void {
       const recordsQuery = await TestDataGenerator.generateRecordsQuery({ author: alice, filter });
       const queryReply = await dwn.processMessage(alice.did, recordsQuery.message) as RecordsQueryReply;
       expect(queryReply.status.code).toBe(400);
-      expect(queryReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
+      expect(queryReply.status.detail).toContain(DwnErrorCode.RecordsQueryNestedProtocolPathContextIdInvalid);
       expect(queryReply.entries).toBeUndefined();
 
       const childScopedQuery = await TestDataGenerator.generateRecordsQuery({
@@ -149,12 +157,12 @@ export function testRecordsNestedQueryScope(): void {
       });
       const childScopedQueryReply = await dwn.processMessage(alice.did, childScopedQuery.message) as RecordsQueryReply;
       expect(childScopedQueryReply.status.code).toBe(400);
-      expect(childScopedQueryReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
+      expect(childScopedQueryReply.status.detail).toContain(DwnErrorCode.RecordsQueryNestedProtocolPathContextIdInvalid);
 
       const recordsCount = await TestDataGenerator.generateRecordsCount({ author: alice, filter });
       const countReply = await dwn.processMessage(alice.did, recordsCount.message) as RecordsCountReply;
       expect(countReply.status.code).toBe(400);
-      expect(countReply.status.detail).toContain(DwnErrorCode.RecordsCountFilterMissingRequiredProperties);
+      expect(countReply.status.detail).toContain(DwnErrorCode.RecordsCountNestedProtocolPathContextIdInvalid);
       expect(countReply.count).toBeUndefined();
 
       const streamedRecordIds: string[] = [];
@@ -170,10 +178,59 @@ export function testRecordsNestedQueryScope(): void {
         },
       }) as RecordsSubscribeReply;
       expect(subscribeReply.status.code).toBe(400);
-      expect(subscribeReply.status.detail).toContain(DwnErrorCode.RecordsSubscribeFilterMissingRequiredProperties);
+      expect(subscribeReply.status.detail).toContain(DwnErrorCode.RecordsSubscribeNestedProtocolPathContextIdInvalid);
       expect(subscribeReply.subscription).toBeUndefined();
       expect(subscribeReply.entries).toBeUndefined();
       expect(streamedRecordIds).toEqual([]);
+    });
+
+    it('should reject malformed nested query context IDs that can span direct parents', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      await installProtocol(alice);
+
+      const community = await writeProtocolRecord({
+        author       : alice,
+        dateCreated  : '2026-04-01T00:00:00.000000Z',
+        protocolPath : 'community',
+      });
+      const channel1 = await writeProtocolRecord({
+        author          : alice,
+        dateCreated     : '2026-04-02T00:00:00.000000Z',
+        parentContextId : community.message.contextId,
+        protocolPath    : 'community/channel',
+      });
+      const channel2 = await writeProtocolRecord({
+        author          : alice,
+        dateCreated     : '2026-04-03T00:00:00.000000Z',
+        parentContextId : community.message.contextId,
+        protocolPath    : 'community/channel',
+      });
+      await writeProtocolRecord({
+        author          : alice,
+        dateCreated     : '2026-04-04T00:00:00.000000Z',
+        parentContextId : channel1.message.contextId,
+        protocolPath    : 'community/channel/message',
+      });
+      await writeProtocolRecord({
+        author          : alice,
+        dateCreated     : '2026-04-05T00:00:00.000000Z',
+        parentContextId : channel2.message.contextId,
+        protocolPath    : 'community/channel/message',
+      });
+
+      const recordsQuery = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : {
+          contextId    : `${community.message.contextId}/`,
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'community/channel/message',
+        },
+      });
+
+      const queryReply = await dwn.processMessage(alice.did, recordsQuery.message) as RecordsQueryReply;
+      expect(queryReply.status.code).toBe(400);
+      expect(queryReply.status.detail).toContain(DwnErrorCode.RecordsQueryNestedProtocolPathContextIdInvalid);
+      expect(queryReply.entries).toBeUndefined();
     });
 
     it('should allow scoped nested Query, Count, and Subscribe requests for one parent context', async () => {

--- a/packages/dwn-sdk-js/tests/features/records-nested-query-scope.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-nested-query-scope.spec.ts
@@ -1,0 +1,280 @@
+import type { DidResolver } from '@enbox/dids';
+import type { EventLog } from '../../src/types/subscriptions.js';
+import type { DataStore, MessageStore, ProtocolDefinition, RecordsCountReply, RecordsQueryReply, RecordsReadReply, RecordsSubscribeReply, ResumableTaskStore } from '../../src/index.js';
+import type { GenerateRecordsWriteOutput, Persona } from '../utils/test-data-generator.js';
+
+import sinon from 'sinon';
+
+import { DidKey } from '@enbox/dids';
+import { Dwn } from '../../src/dwn.js';
+import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { Jws } from '../../src/utils/jws.js';
+import { RecordsRead } from '../../src/interfaces/records-read.js';
+import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { TestEventLog } from '../test-event-stream.js';
+import { TestStores } from '../test-stores.js';
+import { UniversalResolver } from '@enbox/dids';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+export function testRecordsNestedQueryScope(): void {
+  describe('Records nested query scope', () => {
+    let didResolver: DidResolver;
+    let messageStore: MessageStore;
+    let dataStore: DataStore;
+    let resumableTaskStore: ResumableTaskStore;
+    let eventLog: EventLog;
+    let dwn: Dwn;
+
+    const protocolDefinition: ProtocolDefinition = {
+      protocol  : 'http://nested-query-scope.xyz',
+      published : true,
+      types     : {
+        avatar  : {},
+        profile : {},
+      },
+      structure: {
+        profile: {
+          avatar: {},
+        },
+      },
+    };
+
+    beforeAll(async () => {
+      didResolver = new UniversalResolver({ didResolvers: [DidKey] });
+
+      const stores = TestStores.get();
+      messageStore = stores.messageStore;
+      dataStore = stores.dataStore;
+      resumableTaskStore = stores.resumableTaskStore;
+      eventLog = TestEventLog.get();
+
+      dwn = await Dwn.create({ didResolver, messageStore, dataStore, eventLog, resumableTaskStore });
+    });
+
+    beforeEach(async () => {
+      sinon.restore();
+
+      await messageStore.clear();
+      await dataStore.clear();
+      await resumableTaskStore.clear();
+    });
+
+    afterAll(async () => {
+      await dwn.close();
+    });
+
+    async function installProtocol(author: Persona): Promise<void> {
+      const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+        author,
+        protocolDefinition,
+      });
+
+      const reply = await dwn.processMessage(author.did, protocolConfig.message);
+      expect(reply.status.code).toBe(202);
+    }
+
+    async function writeProfile(author: Persona, dateCreated: string): Promise<GenerateRecordsWriteOutput> {
+      return writeProtocolRecord({
+        author,
+        dateCreated,
+        protocolPath: 'profile',
+      });
+    }
+
+    async function writeAvatar(author: Persona, parentContextId: string, dateCreated: string): Promise<GenerateRecordsWriteOutput> {
+      return writeProtocolRecord({
+        author,
+        dateCreated,
+        parentContextId,
+        protocolPath: 'profile/avatar',
+      });
+    }
+
+    async function writeProtocolRecord(input: {
+      author: Persona;
+      dateCreated: string;
+      parentContextId?: string;
+      protocolPath: string;
+    }): Promise<GenerateRecordsWriteOutput> {
+      const record = await TestDataGenerator.generateRecordsWrite({
+        author           : input.author,
+        protocol         : protocolDefinition.protocol,
+        protocolPath     : input.protocolPath,
+        parentContextId  : input.parentContextId,
+        dateCreated      : input.dateCreated,
+        messageTimestamp : input.dateCreated,
+      });
+
+      const reply = await dwn.processMessage(input.author.did, record.message, { dataStream: record.dataStream });
+      expect(reply.status.code).toBe(202);
+      return record;
+    }
+
+    async function seedNestedRecords(): Promise<{
+      alice: Persona;
+      profile1: GenerateRecordsWriteOutput;
+      profile2: GenerateRecordsWriteOutput;
+      profile1Avatar1: GenerateRecordsWriteOutput;
+      profile1Avatar2: GenerateRecordsWriteOutput;
+      profile2Avatar: GenerateRecordsWriteOutput;
+    }> {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      await installProtocol(alice);
+
+      const profile1 = await writeProfile(alice, '2026-01-01T00:00:00.000000Z');
+      const profile2 = await writeProfile(alice, '2026-01-02T00:00:00.000000Z');
+      const profile1Avatar1 = await writeAvatar(alice, profile1.message.contextId, '2026-02-01T00:00:00.000000Z');
+      const profile1Avatar2 = await writeAvatar(alice, profile1.message.contextId, '2026-02-02T00:00:00.000000Z');
+      const profile2Avatar = await writeAvatar(alice, profile2.message.contextId, '2026-03-01T00:00:00.000000Z');
+
+      return { alice, profile1, profile2, profile1Avatar1, profile1Avatar2, profile2Avatar };
+    }
+
+    it('should reject nested Query, Count, and Subscribe requests that do not pin the direct parent context', async () => {
+      const { alice, profile1Avatar1 } = await seedNestedRecords();
+      const filter = {
+        protocol     : protocolDefinition.protocol,
+        protocolPath : 'profile/avatar',
+      };
+
+      const recordsQuery = await TestDataGenerator.generateRecordsQuery({ author: alice, filter });
+      const queryReply = await dwn.processMessage(alice.did, recordsQuery.message) as RecordsQueryReply;
+      expect(queryReply.status.code).toBe(400);
+      expect(queryReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
+      expect(queryReply.entries).toBeUndefined();
+
+      const childScopedQuery = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { ...filter, contextId: profile1Avatar1.message.contextId },
+      });
+      const childScopedQueryReply = await dwn.processMessage(alice.did, childScopedQuery.message) as RecordsQueryReply;
+      expect(childScopedQueryReply.status.code).toBe(400);
+      expect(childScopedQueryReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
+
+      const recordsCount = await TestDataGenerator.generateRecordsCount({ author: alice, filter });
+      const countReply = await dwn.processMessage(alice.did, recordsCount.message) as RecordsCountReply;
+      expect(countReply.status.code).toBe(400);
+      expect(countReply.status.detail).toContain(DwnErrorCode.RecordsCountFilterMissingRequiredProperties);
+      expect(countReply.count).toBeUndefined();
+
+      const streamedRecordIds: string[] = [];
+      const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({ author: alice, filter });
+      const subscribeReply = await dwn.processMessage(alice.did, recordsSubscribe.message, {
+        subscriptionHandler: (subscriptionMessage): void => {
+          if (subscriptionMessage.type === 'event') {
+            const { message } = subscriptionMessage.event;
+            if ('recordId' in message && typeof message.recordId === 'string') {
+              streamedRecordIds.push(message.recordId);
+            }
+          }
+        },
+      }) as RecordsSubscribeReply;
+      expect(subscribeReply.status.code).toBe(400);
+      expect(subscribeReply.status.detail).toContain(DwnErrorCode.RecordsSubscribeFilterMissingRequiredProperties);
+      expect(subscribeReply.subscription).toBeUndefined();
+      expect(subscribeReply.entries).toBeUndefined();
+      expect(streamedRecordIds).toEqual([]);
+    });
+
+    it('should allow scoped nested Query, Count, and Subscribe requests for one parent context', async () => {
+      const { alice, profile1, profile1Avatar1, profile1Avatar2 } = await seedNestedRecords();
+      const filter = {
+        protocol     : protocolDefinition.protocol,
+        protocolPath : 'profile/avatar',
+        contextId    : profile1.message.contextId,
+      };
+
+      const firstPageQuery = await TestDataGenerator.generateRecordsQuery({
+        author     : alice,
+        filter,
+        pagination : { limit: 1 },
+      });
+      const firstPageReply = await dwn.processMessage(alice.did, firstPageQuery.message) as RecordsQueryReply;
+      expect(firstPageReply.status.code).toBe(200);
+      expect(firstPageReply.entries?.map((entry): string => entry.recordId)).toEqual([profile1Avatar1.message.recordId]);
+      expect(firstPageReply.cursor).toBeDefined();
+
+      const secondPageQuery = await TestDataGenerator.generateRecordsQuery({
+        author     : alice,
+        filter,
+        pagination : { cursor: firstPageReply.cursor! },
+      });
+      const secondPageReply = await dwn.processMessage(alice.did, secondPageQuery.message) as RecordsQueryReply;
+      expect(secondPageReply.status.code).toBe(200);
+      expect(secondPageReply.entries?.map((entry): string => entry.recordId)).toEqual([profile1Avatar2.message.recordId]);
+      expect(secondPageReply.cursor).toBeUndefined();
+
+      const recordsCount = await TestDataGenerator.generateRecordsCount({ author: alice, filter });
+      const countReply = await dwn.processMessage(alice.did, recordsCount.message) as RecordsCountReply;
+      expect(countReply.status.code).toBe(200);
+      expect(countReply.count).toBe(2);
+
+      const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({
+        author     : alice,
+        filter,
+        pagination : { limit: 1 },
+      });
+      const subscribeReply = await dwn.processMessage(alice.did, recordsSubscribe.message, {
+        subscriptionHandler: (): void => {},
+      }) as RecordsSubscribeReply;
+      expect(subscribeReply.status.code).toBe(200);
+      expect(subscribeReply.entries?.map((entry): string => entry.recordId)).toEqual([profile1Avatar1.message.recordId]);
+      expect(subscribeReply.cursor).toBeDefined();
+      await subscribeReply.subscription?.close();
+    });
+
+    it('should keep top-level protocol queries unchanged with or without contextId', async () => {
+      const { alice, profile1, profile2 } = await seedNestedRecords();
+      const rootFilter = {
+        protocol     : protocolDefinition.protocol,
+        protocolPath : 'profile',
+      };
+
+      const recordsQuery = await TestDataGenerator.generateRecordsQuery({ author: alice, filter: rootFilter });
+      const queryReply = await dwn.processMessage(alice.did, recordsQuery.message) as RecordsQueryReply;
+      expect(queryReply.status.code).toBe(200);
+      expect(queryReply.entries?.map((entry): string => entry.recordId)).toEqual([
+        profile1.message.recordId,
+        profile2.message.recordId,
+      ]);
+
+      const scopedRootQuery = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { ...rootFilter, contextId: profile1.message.contextId },
+      });
+      const scopedRootReply = await dwn.processMessage(alice.did, scopedRootQuery.message) as RecordsQueryReply;
+      expect(scopedRootReply.status.code).toBe(200);
+      expect(scopedRootReply.entries?.map((entry): string => entry.recordId)).toEqual([profile1.message.recordId]);
+
+      const recordsCount = await TestDataGenerator.generateRecordsCount({ author: alice, filter: rootFilter });
+      const countReply = await dwn.processMessage(alice.did, recordsCount.message) as RecordsCountReply;
+      expect(countReply.status.code).toBe(200);
+      expect(countReply.count).toBe(2);
+
+      const recordsSubscribe = await TestDataGenerator.generateRecordsSubscribe({ author: alice, filter: rootFilter });
+      const subscribeReply = await dwn.processMessage(alice.did, recordsSubscribe.message, {
+        subscriptionHandler: (): void => {},
+      }) as RecordsSubscribeReply;
+      expect(subscribeReply.status.code).toBe(200);
+      expect(subscribeReply.entries?.map((entry): string => entry.recordId)).toEqual([
+        profile1.message.recordId,
+        profile2.message.recordId,
+      ]);
+      await subscribeReply.subscription?.close();
+    });
+
+    it('should read an individual nested record by id without contextId', async () => {
+      const { alice, profile1Avatar1 } = await seedNestedRecords();
+      const recordsRead = await RecordsRead.create({
+        signer : Jws.createSigner(alice),
+        filter : { recordId: profile1Avatar1.message.recordId },
+      });
+
+      const readReply = await dwn.processMessage(alice.did, recordsRead.message) as RecordsReadReply;
+      expect(readReply.status.code).toBe(200);
+      expect(readReply.entry?.recordsWrite?.recordId).toBe(profile1Avatar1.message.recordId);
+    });
+  });
+}
+
+testRecordsNestedQueryScope();

--- a/packages/dwn-sdk-js/tests/features/records-record-limit.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-record-limit.spec.ts
@@ -518,7 +518,7 @@ export function testRecordsRecordLimit(): void {
         expect((await readRecord({ author: alice, recordId: record2.message.recordId })).status.code).toBe(200);
       });
 
-      it('should project occupancy independently per exact parent context without scanning broad cross-context queries', async () => {
+      it('should project occupancy independently per exact parent context and reject broad cross-context queries', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
         const protocolDefinition: ProtocolDefinition = {
@@ -617,14 +617,16 @@ export function testRecordsRecordLimit(): void {
           room2Messages[0].message.recordId,
           room2Messages[1].message.recordId,
         ]);
-        expect((await queryProtocolRecordIds({ author: alice, protocol, protocolPath: 'room/message' })).recordIds).toEqual([
-          room1Messages[0].message.recordId,
-          room1Messages[1].message.recordId,
-          room1Messages[2].message.recordId,
-          room2Messages[0].message.recordId,
-          room2Messages[1].message.recordId,
-          room2Messages[2].message.recordId,
-        ]);
+        const broadQuery = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : {
+            protocol,
+            protocolPath: 'room/message',
+          },
+        });
+        const broadReply = await dwn.processMessage(alice.did, broadQuery.message) as RecordsQueryReply;
+        expect(broadReply.status.code).toBe(400);
+        expect(broadReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
       });
 
       it('should paginate over the projected occupant set for max:N scopes', async () => {

--- a/packages/dwn-sdk-js/tests/features/records-record-limit.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-record-limit.spec.ts
@@ -626,7 +626,7 @@ export function testRecordsRecordLimit(): void {
         });
         const broadReply = await dwn.processMessage(alice.did, broadQuery.message) as RecordsQueryReply;
         expect(broadReply.status.code).toBe(400);
-        expect(broadReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
+        expect(broadReply.status.detail).toContain(DwnErrorCode.RecordsQueryNestedProtocolPathContextIdInvalid);
       });
 
       it('should paginate over the projected occupant set for max:N scopes', async () => {

--- a/packages/dwn-sdk-js/tests/features/records-squash.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-squash.spec.ts
@@ -247,7 +247,8 @@ export function testRecordsSquash(): void {
           author : alice,
           filter : {
             protocol,
-            protocolPath: 'document/patch',
+            protocolPath : 'document/patch',
+            contextId    : documentContextId,
           },
         });
         const queryReply = await dwn.processMessage(alice.did, query.message);
@@ -305,7 +306,8 @@ export function testRecordsSquash(): void {
           author : alice,
           filter : {
             protocol,
-            protocolPath: 'document/patch',
+            protocolPath : 'document/patch',
+            contextId    : documentContextId,
           },
         });
         const queryReply = await dwn.processMessage(alice.did, query.message);
@@ -385,7 +387,8 @@ export function testRecordsSquash(): void {
           author : alice,
           filter : {
             protocol,
-            protocolPath: 'document/patch',
+            protocolPath : 'document/patch',
+            contextId    : documentContextId,
           },
         });
         const queryReply = await dwn.processMessage(alice.did, query.message);
@@ -600,6 +603,7 @@ export function testRecordsSquash(): void {
           filter : {
             protocol     : editorSquashProtocol.protocol,
             protocolPath : 'document/patch',
+            contextId    : documentContextId,
           },
         });
         const queryReply = await dwn.processMessage(alice.did, query.message);
@@ -1161,6 +1165,7 @@ export function testRecordsSquash(): void {
           filter : {
             protocol     : deletableSquashProtocol.protocol,
             protocolPath : 'document/patch',
+            contextId    : documentContextId,
           },
         });
         const queryReply = await dwn.processMessage(alice.did, query.message);

--- a/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
@@ -3138,7 +3138,7 @@ export function testRecordsQueryHandler(): void {
           });
           const chatQueryReply = await dwn.processMessage(alice.did, chatQuery.message) as RecordsQueryReply;
           expect(chatQueryReply.status.code).toBe(400);
-          expect(chatQueryReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
+          expect(chatQueryReply.status.detail).toContain(DwnErrorCode.RecordsQueryNestedProtocolPathContextIdInvalid);
         });
 
         it('rejects root-filter queries that invoke a nested role without a contextId', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
@@ -3141,6 +3141,33 @@ export function testRecordsQueryHandler(): void {
           expect(chatQueryReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
         });
 
+        it('rejects root-filter queries that invoke a nested role without a contextId', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition = threadRoleProtocolDefinition;
+
+          const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author: alice,
+            protocolDefinition
+          });
+          const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
+          expect(protocolsConfigureReply.status.code).toBe(202);
+
+          const threadQuery = await TestDataGenerator.generateRecordsQuery({
+            author : bob,
+            filter : {
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'thread',
+            },
+            protocolRole: 'thread/participant',
+          });
+
+          const threadQueryReply = await dwn.processMessage(alice.did, threadQuery.message) as RecordsQueryReply;
+          expect(threadQueryReply.status.code).toBe(401);
+          expect(threadQueryReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationMissingContextId);
+        });
+
         it('should reject root-level role authorized queries if a matching root-level role record is not found for the message author', async () => {
           // scenario: Alice creates a thread and writes some chat messages writes a chat message.
           //           Bob invokes a root-level role but fails because he does not actually have a role.
@@ -3546,17 +3573,18 @@ export function testRecordsQueryHandler(): void {
             expect(daveRoleQueryReply.status.code).toBe(401);
             expect(daveRoleQueryReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationMatchingRoleRecordNotFound);
 
-            // Dave without a role still must pin the nested query to a single parent context.
+            // Dave without a role still gets an empty result, not an error, when the nested query pins a single parent context.
             const daveNoRoleQuery = await TestDataGenerator.generateRecordsQuery({
               author : dave,
               filter : {
+                contextId    : threadRecord.message.contextId,
                 protocol     : mixedProtocol.protocol,
                 protocolPath : 'thread/chat',
               },
             });
             const daveNoRoleQueryReply = await dwn.processMessage(alice.did, daveNoRoleQuery.message) as RecordsQueryReply;
-            expect(daveNoRoleQueryReply.status.code).toBe(400);
-            expect(daveNoRoleQueryReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
+            expect(daveNoRoleQueryReply.status.code).toBe(200);
+            expect(daveNoRoleQueryReply.entries?.length).toBe(0);
           });
         });
       });

--- a/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
@@ -3137,8 +3137,8 @@ export function testRecordsQueryHandler(): void {
             protocolRole: 'thread/participant',
           });
           const chatQueryReply = await dwn.processMessage(alice.did, chatQuery.message) as RecordsQueryReply;
-          expect(chatQueryReply.status.code).toBe(401);
-          expect(chatQueryReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationMissingContextId);
+          expect(chatQueryReply.status.code).toBe(400);
+          expect(chatQueryReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
         });
 
         it('should reject root-level role authorized queries if a matching root-level role record is not found for the message author', async () => {
@@ -3546,7 +3546,7 @@ export function testRecordsQueryHandler(): void {
             expect(daveRoleQueryReply.status.code).toBe(401);
             expect(daveRoleQueryReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationMatchingRoleRecordNotFound);
 
-            // Dave without a role — should get 200 but zero results (no records addressed to him)
+            // Dave without a role still must pin the nested query to a single parent context.
             const daveNoRoleQuery = await TestDataGenerator.generateRecordsQuery({
               author : dave,
               filter : {
@@ -3555,8 +3555,8 @@ export function testRecordsQueryHandler(): void {
               },
             });
             const daveNoRoleQueryReply = await dwn.processMessage(alice.did, daveNoRoleQuery.message) as RecordsQueryReply;
-            expect(daveNoRoleQueryReply.status.code).toBe(200);
-            expect(daveNoRoleQueryReply.entries?.length).toBe(0);
+            expect(daveNoRoleQueryReply.status.code).toBe(400);
+            expect(daveNoRoleQueryReply.status.detail).toContain(DwnErrorCode.RecordsQueryFilterMissingRequiredProperties);
           });
         });
       });

--- a/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
@@ -1062,8 +1062,8 @@ export function testRecordsSubscribeHandler(): void {
             protocolRole: 'thread/participant',
           });
           const chatSubscribeReply = await dwn.processMessage(alice.did, chatSubscribe.message);
-          expect(chatSubscribeReply.status.code).toBe(401);
-          expect(chatSubscribeReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationMissingContextId);
+          expect(chatSubscribeReply.status.code).toBe(400);
+          expect(chatSubscribeReply.status.detail).toContain(DwnErrorCode.RecordsSubscribeFilterMissingRequiredProperties);
           expect(chatSubscribeReply.subscription).toBeUndefined();
         });
 

--- a/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
@@ -1063,8 +1063,36 @@ export function testRecordsSubscribeHandler(): void {
           });
           const chatSubscribeReply = await dwn.processMessage(alice.did, chatSubscribe.message);
           expect(chatSubscribeReply.status.code).toBe(400);
-          expect(chatSubscribeReply.status.detail).toContain(DwnErrorCode.RecordsSubscribeFilterMissingRequiredProperties);
+          expect(chatSubscribeReply.status.detail).toContain(DwnErrorCode.RecordsSubscribeNestedProtocolPathContextIdInvalid);
           expect(chatSubscribeReply.subscription).toBeUndefined();
+        });
+
+        it('rejects root-filter subscriptions that invoke a nested role without a contextId', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition = threadRoleProtocolDefinition;
+
+          const protocolsConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author: alice,
+            protocolDefinition
+          });
+          const protocolsConfigureReply = await dwn.processMessage(alice.did, protocolsConfig.message);
+          expect(protocolsConfigureReply.status.code).toBe(202);
+
+          const threadSubscribe = await TestDataGenerator.generateRecordsSubscribe({
+            author : bob,
+            filter : {
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'thread',
+            },
+            protocolRole: 'thread/participant',
+          });
+
+          const threadSubscribeReply = await dwn.processMessage(alice.did, threadSubscribe.message);
+          expect(threadSubscribeReply.status.code).toBe(401);
+          expect(threadSubscribeReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationMissingContextId);
+          expect(threadSubscribeReply.subscription).toBeUndefined();
         });
 
         it('rejects role authorized subscriptions if the request author does not have a matching root-level role', async () => {

--- a/packages/dwn-sdk-js/tests/protocols/permissions.spec.ts
+++ b/packages/dwn-sdk-js/tests/protocols/permissions.spec.ts
@@ -63,6 +63,14 @@ describe('PermissionsProtocol', () => {
       expect(revocation.$immutable).toBe(true);
     });
 
+    it('should define the canonical grant revocation store filter', () => {
+      expect(PermissionsProtocol.grantRevocationFilter('grant-id')).toEqual({
+        isLatestBaseState : true,
+        parentId          : 'grant-id',
+        protocolPath      : PermissionsProtocol.revocationPath,
+      });
+    });
+
     it('should pass ProtocolsConfigure validation without $immutable warnings', async () => {
       // `$immutable: true` combined with `update`/`co-update` actions triggers a `console.warn`
       // during ProtocolsConfigure rule-set validation. No permission record path grants update

--- a/packages/dwn-sdk-js/tests/test-suite.ts
+++ b/packages/dwn-sdk-js/tests/test-suite.ts
@@ -25,6 +25,7 @@ import { testRecordsCountHandler } from './handlers/records-count.spec.js';
 import { testRecordsDeleteHandler } from './handlers/records-delete.spec.js';
 import { testRecordsDelivery } from './features/records-delivery.spec.js';
 import { testRecordsImmutable } from './features/records-immutable.spec.js';
+import { testRecordsNestedQueryScope } from './features/records-nested-query-scope.spec.js';
 import { testRecordsPrune } from './features/records-prune.spec.js';
 import { testRecordsPruneCrossProtocol } from './features/records-prune-cross-protocol.spec.js';
 import { testRecordsQueryHandler } from './handlers/records-query.spec.js';
@@ -86,6 +87,7 @@ export class TestSuite {
     testProtocolUpdateAction();
     testRecordsDelivery();
     testRecordsImmutable();
+    testRecordsNestedQueryScope();
     testRecordsPrune();
     testRecordsPruneCrossProtocol();
     testRecordsRecordLimit();


### PR DESCRIPTION
## Summary

- require Records Query, Count, and Subscribe filters for nested protocol paths to pin the direct parent contextId, with dedicated validation errors
- reject malformed contextId values that can span multiple parent contexts
- keep root protocol-path queries and RecordsRead-by-id behavior unchanged
- add a canonical permission-grant revocation predicate for validation-time store reads
- make grant revocation filtering opt-in; when enabled, the agent checks one scalar grant revocation at a time through the message path and caches positive revocations because they are final
- route delegated sync scope derivation through permissions.fetchGrants({ checkRevoked: true }) instead of reimplementing grant and revocation reads in auth

## Verification

Local focused lint and affected node test suites are passing. CI will run on the PR branch.