### PR TITLE
test(agent): cover large data live sync paths

### DIFF
--- a/packages/agent/tests/e2e/live-sync-convergence.e2e.spec.ts
+++ b/packages/agent/tests/e2e/live-sync-convergence.e2e.spec.ts
@@ -15,6 +15,7 @@ import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
 
 import { Convert } from '@enbox/common';
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { DataStream, DwnConstant } from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from '../../src/types/dwn.js';
 import { PlatformAgentTestHarness } from '../../src/test-harness.js';
@@ -22,6 +23,7 @@ import { TestAgent } from '../utils/test-agent.js';
 import { testDwnUrl } from '../utils/test-config.js';
 
 const testDwnUrls = [testDwnUrl];
+const largeDataSize = DwnConstant.maxDataSizeAllowedToBeEncoded + 1_000;
 
 const chatProtocol: ProtocolDefinition = {
   published : true,
@@ -169,8 +171,111 @@ describe('E2E: live sync convergence', () => {
     }, 10_000);
   }, 20_000);
 
+  it('should push a large locally written record to the remote DWN via live sync', async () => {
+    const dataBytes = largePayloadBytes(0x61);
+    const writeResult = await harness.agent.dwn.processRequest({
+      author        : aliceDid,
+      target        : aliceDid,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : chatProtocol.protocol,
+        protocolPath : 'message',
+        schema       : chatProtocol.types.message.schema,
+        dataFormat   : 'text/plain',
+      },
+      dataStream: new Blob([dataBytes]),
+    });
+    expect(writeResult.reply.status.code).toBe(202);
+
+    await expectLargeRecordData('remote', writeResult.message!.recordId, dataBytes);
+  }, 30_000);
+
+  it('should pull a large remote-only record to local via live sync', async () => {
+    const dataBytes = largePayloadBytes(0x62);
+    const remoteWrite = await harness.agent.dwn.sendRequest({
+      author        : aliceDid,
+      target        : aliceDid,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : chatProtocol.protocol,
+        protocolPath : 'message',
+        schema       : chatProtocol.types.message.schema,
+        dataFormat   : 'text/plain',
+      },
+      dataStream: new Blob([dataBytes]),
+    });
+    expect(remoteWrite.reply.status.code).toBe(202);
+
+    await expectLargeRecordData('local', remoteWrite.message!.recordId, dataBytes);
+  }, 30_000);
+
   it('should report healthy sync with zero failed messages', async () => {
     const health = await harness.agent.sync.getSyncHealth();
     expect(health.failedMessageCount).toBe(0);
   });
+
+  function largePayloadBytes(fill: number): Uint8Array {
+    return new Uint8Array(largeDataSize).fill(fill);
+  }
+
+  async function expectLargeRecordData(
+    location: 'local' | 'remote',
+    recordId: string,
+    expectedBytes: Uint8Array,
+  ): Promise<void> {
+    await waitFor(async () => {
+      const record = await readRecordData(location, recordId);
+      return record !== undefined &&
+        record.dataSize === expectedBytes.byteLength &&
+        bytesEqual(record.dataBytes, expectedBytes);
+    }, 15_000);
+
+    const record = await readRecordData(location, recordId);
+    expect(record).toBeDefined();
+    expect(record!.dataSize).toBe(expectedBytes.byteLength);
+    expect(record!.dataBytes.byteLength).toBe(expectedBytes.byteLength);
+    expect(bytesEqual(record!.dataBytes, expectedBytes)).toBe(true);
+  }
+
+  async function readRecordData(
+    location: 'local' | 'remote',
+    recordId: string,
+  ): Promise<{ dataBytes: Uint8Array; dataSize: number } | undefined> {
+    const request = {
+      author        : aliceDid,
+      target        : aliceDid,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId } },
+    };
+    const { reply } = location === 'local'
+      ? await harness.agent.dwn.processRequest(request)
+      : await harness.agent.dwn.sendRequest(request);
+
+    if (reply.status.code !== 200 || reply.entry?.data === undefined) {
+      return undefined;
+    }
+
+    const dataSize = reply.entry.recordsWrite?.descriptor.dataSize;
+    if (typeof dataSize !== 'number') {
+      return undefined;
+    }
+
+    return {
+      dataBytes: await DataStream.toBytes(reply.entry.data),
+      dataSize,
+    };
+  }
+
+  function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+    if (a.byteLength !== b.byteLength) {
+      return false;
+    }
+
+    for (let i = 0; i < a.byteLength; i++) {
+      if (a[i] !== b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
 });

--- a/packages/agent/tests/e2e/sync-perturbation.e2e.spec.ts
+++ b/packages/agent/tests/e2e/sync-perturbation.e2e.spec.ts
@@ -19,7 +19,7 @@ import { SyncEngineLevel } from '../../src/sync-engine-level.js';
 import { TestAgent } from '../utils/test-agent.js';
 import { testDwnUrl } from '../utils/test-config.js';
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
-import { DataStream, RecordsDelete, RecordsWrite } from '@enbox/dwn-sdk-js';
+import { DataStream, DwnConstant, RecordsDelete, RecordsWrite } from '@enbox/dwn-sdk-js';
 import { queryLocalMessageFeed, queryRemoteMessageFeed } from '../../src/sync-messages.js';
 
 type Device = {
@@ -121,6 +121,8 @@ describe('E2E: two-device durable feed perturbation convergence', () => {
 
     const aNote = await writeRecord(deviceA, 'note', 'device-a note before update');
     const bNote = await writeRecord(deviceB, 'note', 'device-b note before delete');
+    const largeNoteData = largeRecordText('device-a large note');
+    const largeNote = await writeRecord(deviceA, 'note', largeNoteData);
     const thread = await writeRecord(deviceA, 'thread', 'device-a thread before prune');
     const reply = await writeRecord(deviceA, 'thread/reply', 'device-a reply before prune', thread.message.contextId);
     await writeRecord(deviceA, 'profile', 'device-a profile candidate');
@@ -151,6 +153,9 @@ describe('E2E: two-device durable feed perturbation convergence', () => {
     expect(snapshots.a.some(entry => entry.recordId === thread.message.recordId)).toBe(false);
     expect(snapshots.a.some(entry => entry.recordId === reply.message.recordId)).toBe(false);
     expect(snapshots.a.find(entry => entry.recordId === aNote.message.recordId)?.data).toBe('device-a note after update');
+    const syncedLargeNote = snapshots.a.find(entry => entry.recordId === largeNote.message.recordId);
+    expect(syncedLargeNote?.data.length).toBe(largeNoteData.length);
+    expect(syncedLargeNote?.data === largeNoteData).toBe(true);
     expect(snapshots.a.find(entry => entry.recordId === bookmark.message.recordId)?.data).toBe('device-b bookmark after config churn');
     await expectRecordLimitOccupantsConverged('profile', 1);
     await expectRecordLimitOccupantsConverged('pin', 2);
@@ -228,6 +233,10 @@ describe('E2E: two-device durable feed perturbation convergence', () => {
     });
     expect(reply.status.code).toBe(202);
     return { message: message! };
+  }
+
+  function largeRecordText(prefix: string): string {
+    return `${prefix}:${'x'.repeat(DwnConstant.maxDataSizeAllowedToBeEncoded + 1_000)}`;
   }
 
   async function updateRecord(device: Device, recordsWriteMessage: RecordsWriteMessage, data: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Add live-sync large DataStore-backed push/pull coverage and verify replicated bytes via `RecordsRead` plus descriptor `dataSize`.
- Extend the two-device perturbation convergence e2e with a large note so the convergence snapshot includes DataStore-backed payload bytes.

## Test plan
- [x] `bun run lint`
- [x] `bun run --filter @enbox/agent build`
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node` from `packages/agent`
- [x] `TEST_DWN_URL=http://localhost:3013 DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/e2e/live-sync-convergence.e2e.spec.ts --timeout 120000` from `packages/agent`
- [x] `TEST_DWN_URL=http://localhost:3013 DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/e2e/sync-perturbation.e2e.spec.ts --timeout 120000` from `packages/agent`
