### PR TITLE
chore(agent): collapse terminal sync status

### DIFF
--- a/.changeset/agent-sync-paused-status.md
+++ b/.changeset/agent-sync-paused-status.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+chore: collapse terminal sync link status into paused state

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1238,10 +1238,10 @@ export class SyncEngineLevel implements SyncEngine {
   // Per-link repair orchestration
   // ---------------------------------------------------------------------------
 
-  /** Maximum consecutive repair attempts before the link becomes terminal-incomplete. */
+  /** Maximum consecutive repair attempts before the link is paused. */
   private static readonly MAX_REPAIR_ATTEMPTS = 3;
 
-  /** Maximum repeated verified feed mismatches before pausing the link as terminal-incomplete. */
+  /** Maximum repeated verified feed mismatches before pausing the link. */
   private static readonly MAX_FEED_CONVERGENCE_ATTEMPTS = 3;
 
   /** Maximum age for a repeatedly deferred pull entry before it is dead-lettered and skipped. */
@@ -1284,7 +1284,7 @@ export class SyncEngineLevel implements SyncEngine {
     link: ReplicationLinkState,
     options?: { resumeToken?: ProgressToken },
   ): Promise<void> {
-    if (link.status === 'terminal_incomplete') {
+    if (link.status === 'paused') {
       return;
     }
 
@@ -1304,15 +1304,15 @@ export class SyncEngineLevel implements SyncEngine {
     });
   }
 
-  private async transitionToTerminalIncomplete(
+  private async transitionToPaused(
     linkKey: string,
     link: ReplicationLinkState,
   ): Promise<void> {
-    if (link.status === 'terminal_incomplete') {
+    if (link.status === 'paused') {
       return;
     }
 
-    await this.setLinkOfflineStatus(link, 'terminal_incomplete');
+    await this.setLinkOfflineStatus(link, 'paused');
 
     await this.closeLinkSubscriptions(link);
 
@@ -1363,11 +1363,11 @@ export class SyncEngineLevel implements SyncEngine {
 
   /**
    * Schedule a retry for a failed repair. Uses exponential backoff.
-   * No-op if the link is terminal-incomplete or a retry is already scheduled.
+   * No-op if the link is paused or a retry is already scheduled.
    */
   private scheduleRepairRetry(linkKey: string): void {
     const link = this._activeLinks.get(linkKey);
-    if (!link || link.status === 'terminal_incomplete') { return; }
+    if (!link || link.status === 'paused') { return; }
     if (this._repairRetryTimers.has(linkKey)) { return; }
 
     // attempts is already post-increment from doRepairLink, so subtract 1
@@ -1390,7 +1390,7 @@ export class SyncEngineLevel implements SyncEngine {
       try {
         await this.repairLink(linkKey);
       } catch {
-        // repairLink handles max attempts → terminal-incomplete internally.
+        // repairLink handles max attempts by pausing the link internally.
         // If still below max, schedule another retry.
         if (currentLink.status === 'repairing') {
           this.scheduleRepairRetry(linkKey);
@@ -1563,8 +1563,8 @@ export class SyncEngineLevel implements SyncEngine {
       this.emitEvent({ type: 'repair:failed', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, attempt: attempts, error: String(error.message ?? error) });
 
       if (attempts >= SyncEngineLevel.MAX_REPAIR_ATTEMPTS) {
-        console.warn(`SyncEngineLevel: Max repair attempts reached for ${did} -> ${dwnUrl}, entering terminal_incomplete`);
-        await this.transitionToTerminalIncomplete(linkKey, link);
+        console.warn(`SyncEngineLevel: Max repair attempts reached for ${did} -> ${dwnUrl}, pausing link`);
+        await this.transitionToPaused(linkKey, link);
         return;
       }
 
@@ -1777,7 +1777,7 @@ export class SyncEngineLevel implements SyncEngine {
       link = await this.getOrCreateReplicationLink(target);
       const linkKey = this.getReplicationLinkKey(target, link);
       this._activeLinks.set(linkKey, link);
-      if (link.status === 'terminal_incomplete') {
+      if (link.status === 'paused') {
         return this.createActiveLinkInitializationResult(link);
       }
 
@@ -2993,7 +2993,7 @@ export class SyncEngineLevel implements SyncEngine {
     this._feedConvergenceFailures.set(linkKey, { attempts, signature });
 
     if (attempts >= SyncEngineLevel.MAX_FEED_CONVERGENCE_ATTEMPTS) {
-      await this.transitionToTerminalIncomplete(linkKey, link);
+      await this.transitionToPaused(linkKey, link);
       return;
     }
 
@@ -3121,7 +3121,7 @@ export class SyncEngineLevel implements SyncEngine {
   ): Promise<SyncReconcileResult> {
     const result = SyncEngineLevel.emptySyncReconcileResult(options);
     const link = await this.getOrCreateReplicationLink(target);
-    if (link.status === 'terminal_incomplete') {
+    if (link.status === 'paused') {
       return result;
     }
 
@@ -4540,7 +4540,7 @@ export class SyncEngineLevel implements SyncEngine {
   }
 
   private static isUnhealthyLinkStatus(status: ReplicationLinkState['status']): boolean {
-    return status === 'repairing' || status === 'terminal_incomplete';
+    return status === 'repairing' || status === 'paused';
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -242,10 +242,9 @@ export type DirectionCheckpoint = {
  * - `live` — actively receiving events via subscription.
  * - `polling` — current link is reconciled by periodic durable feed sync; live subscription is not supported for its scope.
  * - `repairing` — gap detected or pending overflow; running durable feed repair.
- * - `terminal_incomplete` — admission failed with a terminal dependency error; requires a new scope/authorization epoch.
- * - `paused` — explicitly paused by the application.
+ * - `paused` — link retries are stopped until the app updates registration or recreates the link.
  */
-export type LinkStatus = 'initializing' | 'live' | 'polling' | 'repairing' | 'terminal_incomplete' | 'paused';
+export type LinkStatus = 'initializing' | 'live' | 'polling' | 'repairing' | 'paused';
 
 /**
  * Durable state of a single replication link. Persisted to LevelDB and
@@ -451,7 +450,7 @@ export type SyncHealthSummary = {
    * to callers.
    */
   admissionFailureCount: number;
-  /** Number of current sync links in `repairing` or `terminal_incomplete` status. */
+  /** Number of current sync links in `repairing` or `paused` status. */
   degradedLinkCount: number;
   /** True only when there are no failed messages or degraded links. */
   syncHealthy: boolean;

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -2922,6 +2922,26 @@ describe('SyncEngineLevel', () => {
       });
     });
 
+    describe('sync health', () => {
+      it('should report paused current links as degraded', async () => {
+        const did = alice.did.uri;
+        await syncEngine.registerIdentity({
+          did     : did,
+          options : { protocols: 'all' },
+        });
+
+        const [target] = await syncEngine['getSyncTargets']();
+        expect(target).toBeDefined();
+        const link = await syncEngine['getOrCreateReplicationLink'](target!);
+        await syncEngine['ledger'].setStatus(link, 'paused');
+
+        const health = await syncEngine.getSyncHealth();
+
+        expect(health.degradedLinkCount).toBe(1);
+        expect(health.syncHealthy).toBe(false);
+      });
+    });
+
     // -----------------------------------------------------------------------
     // Issue #898: Multi-identity live sync correctness hardening
     // -----------------------------------------------------------------------

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -2942,6 +2942,124 @@ describe('SyncEngineLevel', () => {
       });
     });
 
+    describe('paused repair behavior', () => {
+      it('should not transition paused links back to repairing or schedule repair retries', async () => {
+        const did = alice.did.uri;
+        const dwnUrl = testDwnUrls[0];
+        const link = await syncEngine['ledger'].getOrCreateLink({
+          tenantDid          : did,
+          remoteEndpoint     : dwnUrl,
+          scope              : { kind: 'full' },
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+        });
+        const linkKey = `${did}^${dwnUrl}^${link.projectionId}^${link.authorizationEpoch}`;
+        link.status = 'paused';
+        syncEngine['_activeLinks'].set(linkKey, link);
+
+        const statusSpy = sinon.spy(syncEngine as any, 'setLinkOfflineStatus');
+        const repairStub = sinon.stub(syncEngine as any, 'repairLink').resolves();
+
+        await syncEngine['transitionToRepairing'](linkKey, link);
+        syncEngine['scheduleRepairRetry'](linkKey);
+
+        expect(statusSpy.called).toBe(false);
+        expect(repairStub.called).toBe(false);
+        expect(syncEngine['_repairRetryTimers'].has(linkKey)).toBe(false);
+      });
+
+      it('should pause a live link only once and leave it degraded', async () => {
+        const did = alice.did.uri;
+        const dwnUrl = testDwnUrls[0];
+        const link = await syncEngine['ledger'].getOrCreateLink({
+          tenantDid          : did,
+          remoteEndpoint     : dwnUrl,
+          scope              : { kind: 'full' },
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+        });
+        const linkKey = `${did}^${dwnUrl}^${link.projectionId}^${link.authorizationEpoch}`;
+        link.status = 'live';
+
+        const closeStub = sinon.stub(syncEngine as any, 'closeLinkSubscriptions').resolves();
+
+        await syncEngine['transitionToPaused'](linkKey, link);
+        await syncEngine['transitionToPaused'](linkKey, link);
+
+        expect(link.status).toBe('paused');
+        expect(closeStub.calledOnce).toBe(true);
+      });
+
+      it('should schedule another repair retry when a retry attempt fails below the attempt ceiling', async () => {
+        const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+        try {
+          const did = alice.did.uri;
+          const dwnUrl = testDwnUrls[0];
+          const link = await syncEngine['ledger'].getOrCreateLink({
+            tenantDid          : did,
+            remoteEndpoint     : dwnUrl,
+            scope              : { kind: 'full' },
+            authorization      : { kind: 'owner' },
+            authorizationEpoch : 'owner-epoch',
+          });
+          const linkKey = `${did}^${dwnUrl}^${link.projectionId}^${link.authorizationEpoch}`;
+          link.status = 'repairing';
+          syncEngine['_activeLinks'].set(linkKey, link);
+          syncEngine['_repairAttempts'].set(linkKey, 1);
+
+          const repairStub = sinon.stub(syncEngine as any, 'repairLink').rejects(new Error('still broken'));
+
+          syncEngine['scheduleRepairRetry'](linkKey);
+          await clock.tickAsync(1_000);
+
+          expect(repairStub.calledOnce).toBe(true);
+          expect(syncEngine['_repairRetryTimers'].has(linkKey)).toBe(true);
+        } finally {
+          for (const retryTimer of syncEngine['_repairRetryTimers'].values()) {
+            clearTimeout(retryTimer);
+          }
+          syncEngine['_repairRetryTimers'].clear();
+          clock.restore();
+        }
+      });
+
+      it('should pause the link after repeated feed convergence mismatches', async () => {
+        const did = alice.did.uri;
+        const dwnUrl = testDwnUrls[0];
+        const target = {
+          did                : did,
+          dwnUrl             : dwnUrl,
+          scope              : { kind: 'full' as const },
+          authorization      : { kind: 'owner' as const },
+          authorizationEpoch : 'owner-epoch',
+        };
+        const link = await syncEngine['ledger'].getOrCreateLink({
+          tenantDid          : did,
+          remoteEndpoint     : dwnUrl,
+          scope              : target.scope,
+          authorization      : target.authorization,
+          authorizationEpoch : target.authorizationEpoch,
+        });
+        const linkKey = `${did}^${dwnUrl}^${link.projectionId}^${link.authorizationEpoch}`;
+        const result = {
+          admittedCids       : [],
+          converged          : false,
+          hasActionableDiffs : true,
+          pushFailures       : [],
+        };
+
+        const mismatchStub = sinon.stub(syncEngine as any, 'handleFeedConvergenceMismatch').resolves();
+        const pauseStub = sinon.stub(syncEngine as any, 'transitionToPaused').resolves();
+
+        await syncEngine['handleRepeatedFeedConvergenceMismatch'](target, result, [], { link, linkKey });
+        await syncEngine['handleRepeatedFeedConvergenceMismatch'](target, result, [], { link, linkKey });
+        await syncEngine['handleRepeatedFeedConvergenceMismatch'](target, result, [], { link, linkKey });
+
+        expect(mismatchStub.callCount).toBe(2);
+        expect(pauseStub.calledOnceWith(linkKey, link)).toBe(true);
+      });
+    });
+
     // -----------------------------------------------------------------------
     // Issue #898: Multi-identity live sync correctness hardening
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Summary
- Collapse the private terminal sync-link transition into the existing paused link status.
- Remove terminal_incomplete from the exported LinkStatus union and keep paused links counted as degraded health.
- Add sync-engine coverage proving paused current links make sync health unhealthy.

Test plan
- [x] bun run build
- [x] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/sync-engine-level.spec.ts (from packages/agent)
- [x] bun run --filter @enbox/agent lint
- [x] bun run lint
- [x] bunx changeset status
- [x] bun run --filter @enbox/agent build
- [x] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node (from packages/agent)

Notes
- This removes the active terminal_incomplete sync status surface outside changelogs/lockfile as part of the sync cleanup plan.
