### PR TITLE
fix(auth): preserve agent DID recovery sync scope

### DIFF
--- a/.changeset/fix-agent-did-recovery-scope.md
+++ b/.changeset/fix-agent-did-recovery-scope.md
@@ -1,0 +1,5 @@
+---
+"@enbox/auth": patch
+---
+
+fix: preserve and repair agent DID recovery sync scope

--- a/packages/auth/src/connect/recovery.ts
+++ b/packages/auth/src/connect/recovery.ts
@@ -32,16 +32,26 @@ export const AGENT_DID_SYNC_PROTOCOLS: [string, ...string[]] = [
  *
  * This is a prerequisite for both normal operation (pushing identity
  * metadata to the remote) and seed phrase recovery (pulling it back).
- * Silently succeeds if the agent DID is already registered.
+ * Repairs the registration if the agent DID was already registered with stale options.
  */
 export async function registerAgentDidForSync(userAgent: EnboxUserAgent): Promise<void> {
+  const options = { protocols: AGENT_DID_SYNC_PROTOCOLS };
   try {
     await userAgent.sync.registerIdentity({
-      did     : userAgent.agentDid.uri,
-      options : { protocols: AGENT_DID_SYNC_PROTOCOLS },
+      did: userAgent.agentDid.uri,
+      options,
     });
-  } catch {
-    // Already registered from a previous session.
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : '';
+    if (message.includes('already registered')) {
+      await userAgent.sync.updateIdentityOptions({
+        did: userAgent.agentDid.uri,
+        options,
+      });
+      return;
+    }
+
+    throw error;
   }
 }
 

--- a/packages/auth/src/connect/vault.ts
+++ b/packages/auth/src/connect/vault.ts
@@ -136,7 +136,7 @@ export async function vaultConnect(
     // Persisted delegate identities need their sync scope refreshed from
     // current grants so revoked protocols do not keep syncing after restore.
     await registerSyncScopeForIdentity({ userAgent, connectedDid, delegateDid });
-  } else if (!isNewIdentity && sync !== 'off') {
+  } else if (!isNewIdentity && identity && sync !== 'off') {
     await registerSyncScopeForIdentity({ userAgent, connectedDid, identitySyncProtocols });
   }
 

--- a/packages/auth/tests/recovery.spec.ts
+++ b/packages/auth/tests/recovery.spec.ts
@@ -27,12 +27,26 @@ describe('registerAgentDidForSync', () => {
     expect(syncCalls[0].options.protocols).toEqual(AGENT_DID_SYNC_PROTOCOLS);
   });
 
-  test('silently succeeds when already registered', async () => {
+  test('repairs stale options when already registered', async () => {
+    const updateCalls: any[] = [];
     const agent = createMockAgent({
-      syncRegisterIdentity: async () => { throw new Error('already registered'); },
+      syncRegisterIdentity      : async () => { throw new Error('already registered'); },
+      syncUpdateIdentityOptions : async (params) => { updateCalls.push(params); },
     });
 
     await expect(registerAgentDidForSync(agent)).resolves.toBeUndefined();
+    expect(updateCalls).toEqual([{
+      did     : 'did:dht:testagent',
+      options : { protocols: AGENT_DID_SYNC_PROTOCOLS },
+    }]);
+  });
+
+  test('throws when sync registration fails for another reason', async () => {
+    const agent = createMockAgent({
+      syncRegisterIdentity: async () => { throw new Error('storage unavailable'); },
+    });
+
+    await expect(registerAgentDidForSync(agent)).rejects.toThrow('storage unavailable');
   });
 });
 

--- a/packages/auth/tests/vault-connect.spec.ts
+++ b/packages/auth/tests/vault-connect.spec.ts
@@ -171,11 +171,16 @@ describe('vaultConnect', () => {
     });
 
     await vaultConnect(
-      { userAgent: agent, emitter, storage },
+      {
+        userAgent                    : agent,
+        emitter,
+        storage,
+        defaultIdentitySyncProtocols : ['https://proto.example/profile'],
+      },
       { password: 'test-pass' },
     );
 
-    // Only agent DID registration (no identity created)
+    // Only recovery registration; app identity scope must not overwrite the agent DID.
     expect(syncCalls).toHaveLength(1);
     expect(syncCalls[0].did).toBe('did:dht:testagent');
     expect(syncCalls[0].options.protocols).toEqual([


### PR DESCRIPTION
Summary
- Keep first-launch agent-only sessions from overwriting the agent DID recovery sync scope with app identity protocols.
- Make agent DID recovery registration repair stale existing options via updateIdentityOptions.
- Add auth regression coverage and a patch changeset.

Test plan
- [x] bun run lint
- [x] bunx turbo run build --filter=@enbox/auth...
- [x] bun run test:node (packages/auth)
- [x] bun test tests/recovery.spec.ts (packages/auth)
- [x] Manual deployed-server repro: repaired saved wallet-1 scope, pushed recovery records, verified Fly + AWS expose identity-store/jwk-store feed entries, then restored wallet-2 from phrase and recovered the original identity.