### PR TITLE
docs(agent): correct stale MAX_ADMISSION_PASSES comment

### DIFF
--- a/packages/agent/src/sync-admit-closure.ts
+++ b/packages/agent/src/sync-admit-closure.ts
@@ -54,9 +54,10 @@ type AdmissionEntryResult =
   | { kind: 'retry'; entries: SyncMessageEntry[] }
   | { kind: 'done'; outcome: AdmitOutcome };
 
-// Replication handlers currently report one missing dependency per rejected apply.
-// Keep a high safety cap so deep but valid closures can converge while still
-// bounding work against malformed or adversarial remotes.
+// applyReplicatedMessage reports the full set of missing ancestors in a single
+// Incomplete, so a well-formed closure converges in a handful of passes. Keep a
+// high cap anyway as a safety bound against malformed or adversarial remotes (and
+// dependencies that only become fetchable across passes).
 const MAX_ADMISSION_PASSES = 128;
 
 /**


### PR DESCRIPTION
## Summary

Corrects a stale code comment in the sync admission loop (`packages/agent/src/sync-admit-closure.ts`). The comment claimed:

> Replication handlers currently report one missing dependency per rejected apply.

That stopped being true once `applyReplicatedMessage` was changed to emit the **full** missing-ancestor chain in a single `Incomplete` outcome. The rationale for the `MAX_ADMISSION_PASSES = 128` cap is updated to match: a well-formed closure now converges in a handful of passes, so the cap is a safety bound against malformed or adversarial remotes (and dependencies that only become fetchable across passes), not a per-dependency budget.

Comment-only change — no behavior change.

### Context

Fallout from auditing the now-closed closure-phase issues (#991/#993/#995). The audit confirmed the agent dependency mirror and the classifier/repair slop are already deleted on `main`; this stale comment was the one concrete code artifact left behind.

## Test plan

- [ ] N/A — documentation-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
