### PR TITLE
fix(agent): surface unexpected grant-lookup errors in sync

### DIFF
--- a/.changeset/sync-grant-lookup-errors.md
+++ b/.changeset/sync-grant-lookup-errors.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Surface unexpected grant-lookup errors during sync. `getPermissionGrantId` in the sync push/pull paths previously swallowed every error and returned `undefined`, hiding real store/network/permissions failures behind the benign "no matching grant" path (the delegate then ran without a grant and failed opaquely). The catch is now narrowed to the expected not-found case; any other error propagates to the sync error handling.

--- a/packages/agent/src/sync-admit-closure.ts
+++ b/packages/agent/src/sync-admit-closure.ts
@@ -532,8 +532,15 @@ class AdmitClosureContext {
         messageType,
       });
       return grant.id;
-    } catch {
-      return undefined;
+    } catch (error: any) {
+      // The only expected failure is "no matching grant exists"; the caller then
+      // proceeds without a delegate grant and the DWN enforces authorization.
+      // Surface anything else (store/network failure, revocation-check failure,
+      // parse error) instead of silently treating it as "no grant".
+      if (error instanceof Error && error.message.includes('No permissions found')) {
+        return undefined;
+      }
+      throw error;
     }
   }
 

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -898,8 +898,15 @@ class RemoteApplyPushContext {
         messageType,
       });
       return grant.id;
-    } catch {
-      return undefined;
+    } catch (error: any) {
+      // The only expected failure is "no matching grant exists"; the caller then
+      // proceeds without a delegate grant and the DWN enforces authorization.
+      // Surface anything else (store/network failure, revocation-check failure,
+      // parse error) instead of silently treating it as "no grant".
+      if (error instanceof Error && error.message.includes('No permissions found')) {
+        return undefined;
+      }
+      throw error;
     }
   }
 

--- a/packages/agent/tests/sync-admit-closure.spec.ts
+++ b/packages/agent/tests/sync-admit-closure.spec.ts
@@ -315,6 +315,89 @@ describe('admitClosure', () => {
     });
   });
 
+  it('fetches role records without a grant when no matching delegate grant exists', async () => {
+    const protocol = 'https://example.com/protocol';
+    const root = await TestDataGenerator.generateRecordsWrite({ protocol });
+    const role = await TestDataGenerator.generateRecordsWrite({
+      protocol,
+      protocolPath : 'thread/member',
+      recipient    : 'did:example:bob',
+    });
+    const rootCid = await Message.getCid(root.message);
+    const roleCid = await Message.getCid(role.message);
+    const agent = createMockAgent();
+    const permissionsApi = {
+      getPermissionForRequest: sinon.stub().rejects(
+        new Error(`CachedPermissions: No permissions found for RecordsQuery: ${protocol}`)
+      ),
+    };
+
+    agent.rpc.sendDwnRequest.resolves({
+      status  : { code: 200 },
+      entries : [role.message],
+    });
+    agent.dwn.applyReplicatedMessage
+      .onFirstCall().resolves({
+        kind    : 'Incomplete',
+        missing : [{
+          type          : 'Role',
+          contextPrefix : 'thread-context',
+          protocol,
+          protocolPath  : 'thread/member',
+          recipient     : 'did:example:bob',
+        }],
+      })
+      .onSecondCall().resolves({ kind: 'Applied' })
+      .onThirdCall().resolves({ kind: 'Applied' });
+
+    const outcome = await admitClosure(rootCid, {
+      did         : 'did:example:alice',
+      dwnUrl      : 'https://dwn.example.com',
+      delegateDid : 'did:example:delegate',
+      agent,
+      permissionsApi,
+      prefetched  : [{ message: root.message }],
+    });
+
+    expect(outcome).toEqual({ kind: 'admitted', appliedCids: [roleCid, rootCid] });
+    const queryCall = agent.dwn.processRequest.firstCall.args[0];
+    expect(queryCall.author).toBe('did:example:delegate');
+    expect(queryCall.granteeDid).toBeUndefined();
+    expect(queryCall.messageParams.permissionGrantId).toBeUndefined();
+  });
+
+  it('surfaces an unexpected grant-lookup error instead of treating it as no grant', async () => {
+    const protocol = 'https://example.com/protocol';
+    const root = await TestDataGenerator.generateRecordsWrite({ protocol });
+    const rootCid = await Message.getCid(root.message);
+    const agent = createMockAgent();
+    const permissionsApi = {
+      getPermissionForRequest: sinon.stub().rejects(
+        new Error('PermissionsApi: Failed to fetch grants: 500 boom')
+      ),
+    };
+
+    agent.dwn.applyReplicatedMessage.onFirstCall().resolves({
+      kind    : 'Incomplete',
+      missing : [{
+        type          : 'Role',
+        contextPrefix : 'thread-context',
+        protocol,
+        protocolPath  : 'thread/member',
+        recipient     : 'did:example:bob',
+      }],
+    });
+
+    await expect(admitClosure(rootCid, {
+      did         : 'did:example:alice',
+      dwnUrl      : 'https://dwn.example.com',
+      delegateDid : 'did:example:delegate',
+      agent,
+      permissionsApi,
+      prefetched  : [{ message: root.message }],
+    })).rejects.toThrow('Failed to fetch grants');
+  });
+
   it('admits dependency chains deeper than the historical eight-pass budget', async () => {
     const chain = await Promise.all(
       Array.from({ length: 10 }, () => TestDataGenerator.generateRecordsWrite())


### PR DESCRIPTION
## Summary

`getPermissionGrantId` — used by the sync push and pull paths to resolve a delegate's permission grant — caught **all** errors with `catch { return undefined; }`. That made a genuine failure (store/network error, revocation-check failure, parse error) indistinguishable from the benign "no matching grant exists" case: the caller would proceed as the delegate *without* a grant, the DWN would reject it, and the real cause was lost.

This narrows the catch to the expected not-found signal (`CachedPermissions: No permissions found`, thrown by `permissionsApi.getPermissionForRequest`) — that case still returns `undefined` and degrades gracefully — while any other error now propagates to the sync error handling (dead-letter / repair), consistent with how `admitEntry` already rethrows unexpected errors.

It fails closed either way (no owner-scope escalation); this is a diagnosability fix. Identical change in both `sync-messages.ts` (push) and `sync-admit-closure.ts` (pull).

### Context

Last remaining engine-side item from the sync-correctness cleanup (the closure-phase slop and the `'all'` default were already resolved; see closed #991/#993/#995).

## Test plan

- [x] `bun test tests/sync-admit-closure.spec.ts` — 16 pass (2 new: not-found degrades gracefully; unexpected error surfaces)
- [x] `bun test tests/sync-messages.spec.ts` — 42 pass (push path unaffected)
- [x] `bun run --filter @enbox/agent build` (tsc) + `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
