### PR TITLE
refactor(agent): consolidate duplicated sync fetch helpers

### DIFF
--- a/.changeset/sync-shared-fetch-helpers.md
+++ b/.changeset/sync-shared-fetch-helpers.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Consolidate the sync push/pull dependency-closure fetch helpers (grant resolution, dependency-ref utilities, protocol-config helpers) that were duplicated verbatim in `sync-messages.ts` and `sync-admit-closure.ts` into a shared `sync-fetch-helpers.ts` module. The shared grant resolver also narrows its error handling so unexpected grant-lookup failures (store/network/parse errors) surface instead of being silently swallowed as "no grant".

--- a/packages/agent/src/sync-admit-closure.ts
+++ b/packages/agent/src/sync-admit-closure.ts
@@ -26,6 +26,14 @@ import {
   SyncDataSizeLimitExceededError,
   SyncPullAbortedError,
 } from './sync-messages.js';
+import {
+  dependencyKey,
+  hasTerminalDependency,
+  isTenantProtocolConfig,
+  missingDependencyDetail,
+  newestProtocolConfig,
+  resolveDelegatePermissionGrantId,
+} from './sync-fetch-helpers.js';
 import { DwnInterfaceName, DwnMethodName, Encoder, Message, RecordsWrite } from '@enbox/dwn-sdk-js';
 
 export type AdmitOutcome =
@@ -347,7 +355,7 @@ class AdmitClosureContext {
   private async fetchRecordsByRecordId(recordId: string, protocol?: string): Promise<SyncMessageEntry[]> {
     const permissionGrantId = protocol === undefined
       ? undefined
-      : await this.getPermissionGrantId(DwnInterface.RecordsQuery, protocol);
+      : await resolveDelegatePermissionGrantId(this.deps, DwnInterface.RecordsQuery, protocol);
     const granteeDid = permissionGrantId === undefined ? undefined : this.deps.delegateDid;
     const { message } = await this.deps.agent.dwn.processRequest({
       author        : this.deps.delegateDid ?? this.deps.did,
@@ -370,7 +378,7 @@ class AdmitClosureContext {
   }
 
   private async fetchRoleRecord(ref: Extract<DependencyRef, { type: 'Role' }>): Promise<SyncMessageEntry[]> {
-    const permissionGrantId = await this.getPermissionGrantId(DwnInterface.RecordsQuery, ref.protocol);
+    const permissionGrantId = await resolveDelegatePermissionGrantId(this.deps, DwnInterface.RecordsQuery, ref.protocol);
     const granteeDid = permissionGrantId === undefined ? undefined : this.deps.delegateDid;
     const { message } = await this.deps.agent.dwn.processRequest({
       author        : this.deps.delegateDid ?? this.deps.did,
@@ -450,7 +458,7 @@ class AdmitClosureContext {
   private async fetchRecordData(ref: Extract<DependencyRef, { type: 'RecordData' }>): Promise<SyncMessageEntry[]> {
     const permissionGrantId = ref.protocol === undefined
       ? undefined
-      : await this.getPermissionGrantId(DwnInterface.RecordsRead, ref.protocol);
+      : await resolveDelegatePermissionGrantId(this.deps, DwnInterface.RecordsRead, ref.protocol);
     const granteeDid = permissionGrantId === undefined ? undefined : this.deps.delegateDid;
     const { message } = await this.deps.agent.dwn.processRequest({
       author        : this.deps.delegateDid ?? this.deps.did,
@@ -491,7 +499,7 @@ class AdmitClosureContext {
   }
 
   private async fetchProtocol(protocol: string): Promise<ProtocolsConfigureMessage | undefined> {
-    const permissionGrantId = await this.getPermissionGrantId(DwnInterface.ProtocolsQuery, protocol);
+    const permissionGrantId = await resolveDelegatePermissionGrantId(this.deps, DwnInterface.ProtocolsQuery, protocol);
     const granteeDid = permissionGrantId === undefined ? undefined : this.deps.delegateDid;
     const { message } = await this.deps.agent.dwn.processRequest({
       author        : this.deps.delegateDid ?? this.deps.did,
@@ -516,25 +524,6 @@ class AdmitClosureContext {
 
     const configs = reply.entries.filter(isTenantProtocolConfig(this.deps.did, protocol));
     return newestProtocolConfig(configs);
-  }
-
-  private async getPermissionGrantId(messageType: DwnInterface, protocol: string): Promise<string | undefined> {
-    if (this.deps.delegateDid === undefined || this.deps.permissionsApi === undefined) {
-      return undefined;
-    }
-
-    try {
-      const { grant } = await this.deps.permissionsApi.getPermissionForRequest({
-        connectedDid : this.deps.did,
-        delegateDid  : this.deps.delegateDid,
-        protocol,
-        cached       : true,
-        messageType,
-      });
-      return grant.id;
-    } catch {
-      return undefined;
-    }
   }
 
   private async rememberEntries(entries: SyncMessageEntry[]): Promise<void> {
@@ -562,18 +551,6 @@ class AdmitClosureContext {
       }
     }
   }
-}
-
-function hasTerminalDependency(refs: DependencyRef[]): boolean {
-  return refs.some(ref => ref.terminal === true);
-}
-
-function missingDependencyDetail(refs: DependencyRef[]): string {
-  return refs.map(dependencyKey).join(', ');
-}
-
-function dependencyKey(ref: DependencyRef): string {
-  return JSON.stringify(ref);
 }
 
 async function replayableDataStream(entry: SyncMessageEntry): Promise<ReadableStream<Uint8Array> | undefined> {
@@ -610,30 +587,6 @@ async function dedupeEntries(entries: SyncMessageEntry[]): Promise<SyncMessageEn
     byCid.set(await getMessageCid(entry.message), entry);
   }
   return [...byCid.values()];
-}
-
-function isTenantProtocolConfig(tenantDid: string, protocol: string): (message: GenericMessage) => message is ProtocolsConfigureMessage {
-  return (message: GenericMessage): message is ProtocolsConfigureMessage => {
-    if (
-      message.descriptor.interface !== DwnInterfaceName.Protocols ||
-      message.descriptor.method !== DwnMethodName.Configure
-    ) {
-      return false;
-    }
-
-    const definition = (message.descriptor as { definition?: { protocol?: string } }).definition;
-    return definition?.protocol === protocol && Message.getAuthor(message) === tenantDid;
-  };
-}
-
-function newestProtocolConfig(configs: ProtocolsConfigureMessage[]): ProtocolsConfigureMessage | undefined {
-  let newest: ProtocolsConfigureMessage | undefined;
-  for (const config of configs) {
-    if (newest === undefined || config.descriptor.messageTimestamp > newest.descriptor.messageTimestamp) {
-      newest = config;
-    }
-  }
-  return newest;
 }
 
 function isInitialWriteForRecord(message: GenericMessage, recordId: string): message is RecordsWriteMessage {

--- a/packages/agent/src/sync-fetch-helpers.ts
+++ b/packages/agent/src/sync-fetch-helpers.ts
@@ -1,0 +1,88 @@
+import type { DwnInterface } from './types/dwn.js';
+import type { PermissionsApi } from './types/permissions.js';
+import type { DependencyRef, GenericMessage, ProtocolsConfigureMessage } from '@enbox/dwn-sdk-js';
+
+import { DwnInterfaceName, DwnMethodName, Message } from '@enbox/dwn-sdk-js';
+
+/**
+ * Helpers shared by the push (`sync-messages.ts`) and pull (`sync-admit-closure.ts`)
+ * dependency-closure fetch paths. These were previously duplicated verbatim in both
+ * modules; keep them here so the two paths cannot drift.
+ */
+
+/**
+ * Resolves the delegate permission grant ID authorizing a sync fetch request, or
+ * `undefined` for owner requests (no delegate configured) and when no matching grant
+ * exists. Only the expected "no matching grant" case is swallowed; any other error
+ * (store/network failure, revocation-check failure, parse error) surfaces so a real
+ * resolution failure is not silently treated as "no grant".
+ */
+export async function resolveDelegatePermissionGrantId(
+  deps: { did: string; delegateDid?: string; permissionsApi?: PermissionsApi },
+  messageType: DwnInterface,
+  protocol: string,
+): Promise<string | undefined> {
+  if (deps.delegateDid === undefined || deps.permissionsApi === undefined) {
+    return undefined;
+  }
+
+  try {
+    const { grant } = await deps.permissionsApi.getPermissionForRequest({
+      connectedDid : deps.did,
+      delegateDid  : deps.delegateDid,
+      protocol,
+      cached       : true,
+      messageType,
+    });
+    return grant.id;
+  } catch (error: any) {
+    if (error instanceof Error && error.message.includes('No permissions found')) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/** Stable cache/identity key for a dependency reference. */
+export function dependencyKey(ref: DependencyRef): string {
+  return JSON.stringify(ref);
+}
+
+/** Whether any dependency is known to be unreachable (a terminal closure failure). */
+export function hasTerminalDependency(refs: DependencyRef[]): boolean {
+  return refs.some(ref => ref.terminal === true);
+}
+
+/** Human-readable detail listing the missing dependencies. */
+export function missingDependencyDetail(refs: DependencyRef[]): string {
+  return refs.map(dependencyKey).join(', ');
+}
+
+/** Type guard for a `ProtocolsConfigure` message. */
+export function isProtocolsConfigureMessage(message: GenericMessage): message is ProtocolsConfigureMessage {
+  return message.descriptor.interface === DwnInterfaceName.Protocols &&
+    message.descriptor.method === DwnMethodName.Configure &&
+    (message.descriptor as { definition?: unknown }).definition !== undefined;
+}
+
+/** Predicate matching a tenant's own configuration of a given protocol. */
+export function isTenantProtocolConfig(tenantDid: string, protocol: string): (message: GenericMessage) => message is ProtocolsConfigureMessage {
+  return (message: GenericMessage): message is ProtocolsConfigureMessage => {
+    if (!isProtocolsConfigureMessage(message)) {
+      return false;
+    }
+
+    return message.descriptor.definition.protocol === protocol && Message.getAuthor(message) === tenantDid;
+  };
+}
+
+/** Returns the newest protocol configuration by message timestamp. */
+export function newestProtocolConfig(configs: ProtocolsConfigureMessage[]): ProtocolsConfigureMessage | undefined {
+  let newest: ProtocolsConfigureMessage | undefined;
+  for (const config of configs) {
+    if (newest === undefined || config.descriptor.messageTimestamp > newest.descriptor.messageTimestamp) {
+      newest = config;
+    }
+  }
+  return newest;
+}

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -6,7 +6,6 @@ import type {
   MessagesQueryReply,
   MessagesReadReply,
   ProgressToken,
-  ProtocolsConfigureMessage,
   ProtocolsQueryReply,
   RecordsQueryReply,
   RecordsReadReply,
@@ -29,6 +28,14 @@ import { DwnInterface } from './types/dwn.js';
 import { DwnRpcError } from '@enbox/dwn-clients';
 import { isRecordsWrite } from './utils.js';
 import { toMessagesPermissionGrantIds } from './sync-permission-grants.js';
+import {
+  dependencyKey,
+  hasTerminalDependency,
+  isTenantProtocolConfig,
+  missingDependencyDetail,
+  newestProtocolConfig,
+  resolveDelegatePermissionGrantId,
+} from './sync-fetch-helpers.js';
 import { getRoleKey, orderMessagesForAdmission } from './sync-admission-order.js';
 
 /** Maximum data size (in bytes) to buffer in memory for retry. Larger payloads are re-fetched. */
@@ -714,7 +721,7 @@ class RemoteApplyPushContext {
   }
 
   private async fetchProtocolConfig(protocol: string): Promise<FetchDependencyResult> {
-    const permissionGrantId = await this.getPermissionGrantId(DwnInterface.ProtocolsQuery, protocol);
+    const permissionGrantId = await resolveDelegatePermissionGrantId(this.deps, DwnInterface.ProtocolsQuery, protocol);
     const granteeDid = permissionGrantId === undefined ? undefined : this.deps.delegateDid;
     const { reply } = await this.deps.agent.dwn.processRequest({
       author        : this.deps.delegateDid ?? this.deps.did,
@@ -745,7 +752,7 @@ class RemoteApplyPushContext {
   private async fetchRecordsByRecordId(recordId: string, protocol?: string): Promise<FetchDependencyResult> {
     const permissionGrantId = protocol === undefined
       ? undefined
-      : await this.getPermissionGrantId(DwnInterface.RecordsQuery, protocol);
+      : await resolveDelegatePermissionGrantId(this.deps, DwnInterface.RecordsQuery, protocol);
     const granteeDid = permissionGrantId === undefined ? undefined : this.deps.delegateDid;
     const { reply } = await this.deps.agent.dwn.processRequest({
       author        : this.deps.delegateDid ?? this.deps.did,
@@ -771,7 +778,7 @@ class RemoteApplyPushContext {
   }
 
   private async fetchRoleRecord(ref: Extract<DependencyRef, { type: 'Role' }>): Promise<FetchDependencyResult> {
-    const permissionGrantId = await this.getPermissionGrantId(DwnInterface.RecordsQuery, ref.protocol);
+    const permissionGrantId = await resolveDelegatePermissionGrantId(this.deps, DwnInterface.RecordsQuery, ref.protocol);
     const granteeDid = permissionGrantId === undefined ? undefined : this.deps.delegateDid;
     const key = getRoleKey(ref.protocol, ref.protocolPath, ref.recipient, ref.contextPrefix);
     const { reply } = await this.deps.agent.dwn.processRequest({
@@ -805,7 +812,7 @@ class RemoteApplyPushContext {
   private async fetchRecordData(ref: Extract<DependencyRef, { type: 'RecordData' }>): Promise<FetchDependencyResult> {
     const permissionGrantId = ref.protocol === undefined
       ? undefined
-      : await this.getPermissionGrantId(DwnInterface.RecordsRead, ref.protocol);
+      : await resolveDelegatePermissionGrantId(this.deps, DwnInterface.RecordsRead, ref.protocol);
     const granteeDid = permissionGrantId === undefined ? undefined : this.deps.delegateDid;
     const { reply } = await this.deps.agent.dwn.processRequest({
       author        : this.deps.delegateDid ?? this.deps.did,
@@ -884,25 +891,6 @@ class RemoteApplyPushContext {
     return entry;
   }
 
-  private async getPermissionGrantId(messageType: DwnInterface, protocol: string): Promise<string | undefined> {
-    if (this.deps.delegateDid === undefined || this.deps.permissionsApi === undefined) {
-      return undefined;
-    }
-
-    try {
-      const { grant } = await this.deps.permissionsApi.getPermissionForRequest({
-        connectedDid : this.deps.did,
-        delegateDid  : this.deps.delegateDid,
-        protocol,
-        cached       : true,
-        messageType,
-      });
-      return grant.id;
-    } catch {
-      return undefined;
-    }
-  }
-
   private async rememberEntries(entries: SyncMessageEntry[]): Promise<void> {
     for (const entry of entries) {
       await this.rememberEntry(entry);
@@ -945,44 +933,6 @@ function isRecordsWriteMessage(message: GenericMessage): message is RecordsWrite
   return message.descriptor.interface === DwnInterfaceName.Records &&
     message.descriptor.method === DwnMethodName.Write &&
     typeof (message as { recordId?: unknown }).recordId === 'string';
-}
-
-function isProtocolsConfigureMessage(message: GenericMessage): message is ProtocolsConfigureMessage {
-  return message.descriptor.interface === DwnInterfaceName.Protocols &&
-    message.descriptor.method === DwnMethodName.Configure &&
-    (message.descriptor as { definition?: unknown }).definition !== undefined;
-}
-
-function isTenantProtocolConfig(tenantDid: string, protocol: string): (message: GenericMessage) => message is ProtocolsConfigureMessage {
-  return (message: GenericMessage): message is ProtocolsConfigureMessage => {
-    if (!isProtocolsConfigureMessage(message)) {
-      return false;
-    }
-
-    return message.descriptor.definition.protocol === protocol && Message.getAuthor(message) === tenantDid;
-  };
-}
-
-function newestProtocolConfig(configs: ProtocolsConfigureMessage[]): ProtocolsConfigureMessage | undefined {
-  let newest: ProtocolsConfigureMessage | undefined;
-  for (const config of configs) {
-    if (newest === undefined || config.descriptor.messageTimestamp > newest.descriptor.messageTimestamp) {
-      newest = config;
-    }
-  }
-  return newest;
-}
-
-function hasTerminalDependency(refs: DependencyRef[]): boolean {
-  return refs.some(ref => ref.terminal === true);
-}
-
-function missingDependencyDetail(refs: DependencyRef[]): string {
-  return refs.map(dependencyKey).join(', ');
-}
-
-function dependencyKey(ref: DependencyRef): string {
-  return JSON.stringify(ref);
 }
 
 function unreachable(value: never): never {

--- a/packages/agent/tests/sync-fetch-helpers.spec.ts
+++ b/packages/agent/tests/sync-fetch-helpers.spec.ts
@@ -1,0 +1,120 @@
+import sinon from 'sinon';
+
+import { TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { describe, expect, it } from 'bun:test';
+
+import { DwnInterface } from '../src/types/dwn.js';
+import {
+  dependencyKey,
+  hasTerminalDependency,
+  isTenantProtocolConfig,
+  missingDependencyDetail,
+  newestProtocolConfig,
+  resolveDelegatePermissionGrantId,
+} from '../src/sync-fetch-helpers.js';
+
+describe('sync-fetch-helpers', () => {
+  describe('resolveDelegatePermissionGrantId', () => {
+    it('returns undefined when there is no delegate', async () => {
+      const result = await resolveDelegatePermissionGrantId(
+        { did: 'did:example:alice' },
+        DwnInterface.RecordsQuery,
+        'https://example.com/protocol',
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when no permissions API is configured', async () => {
+      const result = await resolveDelegatePermissionGrantId(
+        { did: 'did:example:alice', delegateDid: 'did:example:delegate' },
+        DwnInterface.RecordsQuery,
+        'https://example.com/protocol',
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the grant id when a matching grant exists', async () => {
+      const permissionsApi = { getPermissionForRequest: sinon.stub().resolves({ grant: { id: 'grant-123' } }) };
+      const result = await resolveDelegatePermissionGrantId(
+        { did: 'did:example:alice', delegateDid: 'did:example:delegate', permissionsApi: permissionsApi as any },
+        DwnInterface.RecordsQuery,
+        'https://example.com/protocol',
+      );
+      expect(result).toBe('grant-123');
+      expect(permissionsApi.getPermissionForRequest.firstCall.args[0]).toEqual({
+        cached       : true,
+        connectedDid : 'did:example:alice',
+        delegateDid  : 'did:example:delegate',
+        messageType  : DwnInterface.RecordsQuery,
+        protocol     : 'https://example.com/protocol',
+      });
+    });
+
+    it('returns undefined when no matching grant exists (expected not-found)', async () => {
+      const permissionsApi = {
+        getPermissionForRequest: sinon.stub().rejects(
+          new Error('CachedPermissions: No permissions found for RecordsQuery: https://example.com/protocol')
+        ),
+      };
+      const result = await resolveDelegatePermissionGrantId(
+        { did: 'did:example:alice', delegateDid: 'did:example:delegate', permissionsApi: permissionsApi as any },
+        DwnInterface.RecordsQuery,
+        'https://example.com/protocol',
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('surfaces an unexpected error instead of treating it as no grant', async () => {
+      const permissionsApi = {
+        getPermissionForRequest: sinon.stub().rejects(new Error('PermissionsApi: Failed to fetch grants: 500 boom')),
+      };
+      await expect(resolveDelegatePermissionGrantId(
+        { did: 'did:example:alice', delegateDid: 'did:example:delegate', permissionsApi: permissionsApi as any },
+        DwnInterface.RecordsQuery,
+        'https://example.com/protocol',
+      )).rejects.toThrow('Failed to fetch grants');
+    });
+  });
+
+  describe('dependency ref helpers', () => {
+    it('dependencyKey is stable and distinguishes refs', () => {
+      expect(dependencyKey({ type: 'Protocol', protocol: 'p' }))
+        .toBe(dependencyKey({ type: 'Protocol', protocol: 'p' }));
+      expect(dependencyKey({ type: 'Protocol', protocol: 'p' }))
+        .not.toBe(dependencyKey({ type: 'Protocol', protocol: 'q' }));
+    });
+
+    it('hasTerminalDependency detects a terminal ref', () => {
+      expect(hasTerminalDependency([{ type: 'Protocol', protocol: 'p' }])).toBe(false);
+      expect(hasTerminalDependency([{ type: 'Protocol', protocol: 'p', terminal: true }])).toBe(true);
+    });
+
+    it('missingDependencyDetail lists each ref', () => {
+      const detail = missingDependencyDetail([
+        { type: 'Protocol', protocol: 'p' },
+        { type: 'Grant', permissionGrantId: 'g' },
+      ]);
+      expect(detail).toContain('Protocol');
+      expect(detail).toContain('Grant');
+    });
+  });
+
+  describe('protocol config helpers', () => {
+    it('newestProtocolConfig picks the latest by timestamp', () => {
+      const older = { descriptor: { messageTimestamp: '2024-01-01T00:00:00.000Z' } } as any;
+      const newer = { descriptor: { messageTimestamp: '2024-02-01T00:00:00.000Z' } } as any;
+      expect(newestProtocolConfig([older, newer])).toBe(newer);
+      expect(newestProtocolConfig([newer, older])).toBe(newer);
+      expect(newestProtocolConfig([])).toBeUndefined();
+    });
+
+    it('isTenantProtocolConfig matches the tenant own config for the protocol', async () => {
+      const { message, author } = await TestDataGenerator.generateProtocolsConfigure();
+      const protocol = message.descriptor.definition.protocol;
+
+      expect(isTenantProtocolConfig(author.did, protocol)(message)).toBe(true);
+      expect(isTenantProtocolConfig('did:example:other', protocol)(message)).toBe(false);
+      expect(isTenantProtocolConfig(author.did, 'https://other.example/proto')(message)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates duplicated sync code that the two dependency-closure contexts (`RemoteApplyPushContext` in `sync-messages.ts`, `AdmitClosureContext` in `sync-admit-closure.ts`) carried verbatim. Six functions were byte-identical across the two files:

- `getPermissionGrantId` (the delegate grant resolver)
- `hasTerminalDependency`, `missingDependencyDetail`, `dependencyKey` (dependency-ref helpers)
- `newestProtocolConfig`, `isTenantProtocolConfig` (protocol-config helpers — `isTenantProtocolConfig` had two equivalent implementations; kept the cleaner type-guard one)

They now live in a new `packages/agent/src/sync-fetch-helpers.ts`, imported by both. `getPermissionGrantId` becomes a free function `resolveDelegatePermissionGrantId(deps, …)`, which also makes it directly unit-testable.

### Behavior change (supersedes #1055)

The shared `resolveDelegatePermissionGrantId` narrows its `catch`: only the expected "no matching grant" case returns `undefined`; any other error (store/network failure, revocation-check failure, parse error) now surfaces instead of being silently swallowed. This is the fix from #1055, applied **once** in the shared resolver rather than duplicated in both files — so this PR **supersedes #1055**.

### Deliberately not included

- The `fetch*` helpers (`fetchProtocolConfig`, `fetchRecordsByRecordId`, `fetchRoleRecord`, `fetchRecordData`, …) are near-identical but differ in return-type wrapping (`FetchDependencyResult` vs `SyncMessageEntry[]`). Unifying them needs a shared return shape or a base class — left as a follow-up.
- `rememberEntries` is identical but delegates to a `rememberEntry` that legitimately differs (push buffers data for retry; pull does not), so it stays per-class.

## Test plan

- [x] New `sync-fetch-helpers.spec.ts` — 10 tests (grant resolver incl. not-found-degrades-gracefully / unexpected-error-surfaces; dependency-ref + protocol-config helpers)
- [x] `sync-admit-closure.spec.ts` + `sync-messages.spec.ts` — 56 pass, behavior unchanged
- [x] `bun run --filter @enbox/agent build` (tsc) + `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
