### PR TITLE
docs: tighten README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <h1 align="center">en<strong>b</strong>ox</h1>
 
 <p align="center">
-  <strong>The decentralised backend for web apps.</strong>
+  <strong>The decentralized backend for web apps.</strong>
 </p>
 
 <p align="center">
@@ -18,41 +18,29 @@
   <a href="https://www.npmjs.com/package/@enbox/api"><img src="https://img.shields.io/npm/v/@enbox/api?style=flat-square&label=%40enbox%2Fapi&color=357ec7" alt="npm"></a>
 </p>
 
----
-
 > [!CAUTION]
 > **Research Preview -- Not Production Ready**
 >
-> Enbox is under heavy, active development. You should expect:
->
-> - **Breaking API changes** without prior deprecation
-> - **Data loss** -- preview DWN servers may be wiped at any time
-> - **Security gaps** -- the codebase has not been audited; do not store sensitive data
-> - **Missing documentation** -- some features are undocumented or partially documented
->
-> We are not yet accepting external contributions. If you build on Enbox today, pin your
-> dependencies and be prepared to adapt. This notice will be removed when Enbox reaches
-> a stable release.
+> Enbox is under active development. APIs may break, preview DWN servers may be
+> wiped, and the code has not been externally audited. Do not store sensitive or
+> irreplaceable data yet. We are not accepting external contributions while the
+> core APIs are still changing.
 
----
+## What Enbox Provides
 
-## What is Enbox?
+Enbox is a Bun/TypeScript monorepo for building apps on
+[Decentralized Web Nodes](https://identity.foundation/decentralized-web-node/spec/)
+(DWNs). It includes:
 
-An open-source TypeScript SDK for building apps on [Decentralized Web Nodes](https://identity.foundation/decentralized-web-node/spec/) (DWNs). You get typed schemas, real-time subscriptions, queries, and end-to-end encryption -- but instead of a centralised database, every user gets their own encrypted personal datastore that syncs across devices and apps.
+- A high-level app SDK with typed protocols, record CRUD, subscriptions, and DID helpers.
+- A headless auth layer for local vaults, wallet connect, session restore, and sync startup.
+- An agent runtime with encrypted identity/key stores and live/durable DWN sync.
+- A self-hostable DWN server with HTTP/WebSocket APIs and SQL-backed persistence.
+- Shared DID, crypto, protocol, browser, and codegen packages.
 
-DWN is an [open standard](https://identity.foundation/decentralized-web-node/spec/) maintained by the Decentralized Identity Foundation. Anyone can run a DWN server, and any app that speaks the same protocol can interoperate. Enbox provides the tooling to build on that standard: an SDK, an agent framework, a server implementation, and the cryptographic primitives underneath.
-
-| | Centralised backend | DWN-based (Enbox) |
-|---|---|---|
-| Data ownership | Provider holds all user data | Each user controls their own node |
-| Auth | Email/password, OAuth providers | Decentralized Identifiers (DIDs) + seed phrase recovery |
-| Schema | SQL tables, document collections | Protocol definitions (declarative, portable across apps) |
-| Real-time | Server-pushed change feeds | DWN subscriptions (LiveQuery) |
-| Encryption | At-rest, server-side | End-to-end (two-layer: vault + record-level JWE) |
-| Hosting | Managed cloud, single vendor | Run your own server, use a community node, or both |
-| Lock-in | Data lives in the provider's infra | Data follows the user -- switch apps without losing anything |
-
----
+The model is protocol-first: apps define portable record schemas and access
+rules, users control their DIDs and DWN endpoints, and encrypted data can move
+between apps that understand the same protocol.
 
 ## Quick Start
 
@@ -60,238 +48,126 @@ DWN is an [open standard](https://identity.foundation/decentralized-web-node/spe
 bun add @enbox/api
 ```
 
-### 1. Connect
-
-Create an Enbox instance. Data syncs to whatever DWN endpoint(s) you configure -- a [community node](#dwn-servers), [your own](#run-your-own-node), or both.
-
 ```ts
 import { Enbox, defineProtocol } from '@enbox/api';
 
-const { enbox } = await Enbox.connect({
-  dwnEndpoints   : ['https://enbox-dwn.fly.dev'],   // ← any DWN server
-  createIdentity : true,
+const { enbox, session } = await Enbox.connect({
+  password      : userPassword,
+  createIdentity: true,
+  dwnEndpoints  : ['https://enbox-dwn.fly.dev'],
 });
-```
 
-### 2. Define a protocol
-
-Protocols are declarative schemas -- they describe record types, nesting, access rules, and encryption. Any app that installs the same protocol can read and write the same record shapes.
-
-```ts
 const BookmarkProtocol = defineProtocol({
   protocol  : 'https://example.com/bookmarks',
   published : false,
   types     : {
-    folder: {
-      schema      : 'https://example.com/schemas/folder',
-      dataFormats : ['application/json'],
-    },
     bookmark: {
-      schema              : 'https://example.com/schemas/bookmark',
-      dataFormats         : ['application/json'],
-      encryptionRequired  : true,    // ← end-to-end encrypted at the DWN layer
+      schema             : 'https://example.com/schemas/bookmark',
+      dataFormats        : ['application/json'],
+      encryptionRequired : true,
     },
   },
   structure: {
-    folder: {
-      $tags    : { name: { type: 'string' } },   // queryable server-side
-      bookmark : {},                               // bookmarks nest under folders
+    bookmark: {
+      $tags: { category: { type: 'string' } },
     },
   },
 } as const, {} as {
-  folder:   { name: string };
   bookmark: { url: string; title: string; note?: string };
 });
-```
 
-### 3. Write and query data
-
-```ts
 const bookmarks = enbox.using(BookmarkProtocol);
-await bookmarks.configure();   // install the protocol on the user's DWN
 
-// Create a folder
-const { record: folder } = await bookmarks.records.create('folder', {
-  data : { name: 'Reading List' },
-  tags : { name: 'Reading List' },
+const { record } = await bookmarks.records.create('bookmark', {
+  data : { url: 'https://example.com', title: 'Example' },
+  tags : { category: 'reading' },
 });
 
-// Add a bookmark (nested under the folder, encrypted automatically)
-await bookmarks.records.create('bookmark', {
-  parentContextId : folder.contextId,
-  data            : { url: 'https://example.com', title: 'Example', note: 'Check later' },
+const { records } = await bookmarks.records.query('bookmark', {
+  filter: { tags: { category: 'reading' } },
 });
 
-// Query all folders
-const { records: folders } = await bookmarks.records.query('folder');
-for (const f of folders) {
-  const data = await f.data.json();   // { name: string }
-  console.log(data.name);
-}
+const { liveQuery } = await bookmarks.records.subscribe('bookmark');
+liveQuery.on('create', async (created) => {
+  console.log(await created.data.json());
+});
+
+console.log(session.did, record.id, records.length);
 ```
 
-### 4. Subscribe to changes
+For browser apps, `@enbox/browser` re-exports the main app APIs and adds
+browser-specific connect helpers and DRL polyfills.
 
-```ts
-const { subscription } = await bookmarks.subscribe();
-subscription.on('change', () => {
-  // Re-query or refresh your UI -- changes sync across devices in real time
-});
-```
+See [packages/api/README.md](./packages/api/README.md) and the
+[public docs site](https://enbox-docs.pages.dev) for more examples.
 
-For browser apps, `@enbox/browser` re-exports everything from `@enbox/api` and `@enbox/auth` in a single import plus browser-specific helpers (`BrowserConnectHandler`, wallet-connect, DRL polyfills).
-
-See the [`@enbox/api` README](./packages/api/README.md) for the full API: `repository()` helper, singletons, pagination, permissions, and more.
-
----
-
-## How it works
+## Runtime Model
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./assets/dwn-flow-dark.svg">
-  <img alt="DWN sync flow: Your App → Local DWN → encrypted sync → Remote DWN → other devices" src="./assets/dwn-flow-light.svg">
+  <img alt="DWN sync flow: app to local DWN to remote DWN to other devices" src="./assets/dwn-flow-light.svg">
 </picture>
 
-Your app talks to a **local DWN** running in the browser or on the device. The agent syncs encrypted messages to one or more **remote DWN servers** over HTTP/WebSocket. The remote server stores ciphertext -- it cannot read the data. Other devices and apps sync from the same remote node, staying in sync automatically.
+1. The app talks to an Enbox agent and local DWN.
+2. The agent signs DWN messages with the active DID.
+3. Sync pushes/pulls records to remote DWN servers over HTTP/WebSocket.
+4. Other devices and authorized apps converge through the same remote DWN feed.
 
-**Agent** -- manages DIDs, cryptographic keys, and an encrypted identity vault derived from a 12-word BIP-39 seed phrase. Syncs data between the local DWN and any remote DWN server the user has configured.
-
-**DWN** -- an [open-standard](https://identity.foundation/decentralized-web-node/spec/) personal datastore governed by protocols: declarative schemas that define record types, access control, and encryption rules. Each user controls their own node. The server is interchangeable -- run by you, the user, a community operator, or all three.
-
-**Two-layer encryption** -- (1) a user password encrypts the agent's identity as AES-256-GCM JWE via PBKDF2. (2) Protocol types with `encryptionRequired: true` are encrypted with ECDH-ES+A256KW key agreement using the tenant's X25519 key. Recovery requires only the seed phrase.
-
-### Sending data to another user
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="./assets/dwn-alice-bob-dark.svg">
-  <img alt="Alice-to-Bob flow: Alice writes a record, her agent resolves Bob's DID to discover his DWN endpoint, sends an encrypted message, and Bob's app syncs it" src="./assets/dwn-alice-bob-light.svg">
-</picture>
-
-Alice's app resolves Bob's DID to discover the DWN service endpoint in his DID document, then sends an encrypted record directly to Bob's DWN. Bob's app picks it up on the next sync. No relay, no shared database, no account on Alice's service -- just two DIDs and a protocol they both understand.
-
----
+Encryption has two layers: the local vault protects identity material, and
+protocol types with `encryptionRequired: true` encrypt record data at the DWN
+layer using the tenant's key agreement key.
 
 ## DWN Servers
 
-A DWN server is a multi-tenant node that stores and relays messages on behalf of users. **Anyone can run one** -- it's just an HTTP/WebSocket server backed by a database. There is no central authority; users can point their DID at any server (or several).
-
-We run two preview nodes for development and testing. They are free to use but come with **no uptime, data persistence, or security guarantees**:
+Use the preview endpoints only for development:
 
 | Node | URL | Notes |
 |---|---|---|
-| Fly.io | `https://enbox-dwn.fly.dev` | SQLite-backed, single region |
-| AWS | `https://dev.aws.dwn.enbox.id` | Aurora PostgreSQL, us-east-1 |
+| Fly.io | `https://enbox-dwn.fly.dev` | SQLite-backed preview node |
+| AWS | `https://dev.aws.dwn.enbox.id` | Aurora PostgreSQL preview node |
 
-Set DWN endpoints when creating the auth manager, or override per-identity:
-
-```ts
-import { AuthManager } from '@enbox/auth';
-
-// Default for all identities created through this manager
-const auth = await AuthManager.create({
-  dwnEndpoints: [
-    'https://enbox-dwn.fly.dev',
-    'https://dev.aws.dwn.enbox.id',
-  ],
-});
-
-// Or override for a specific identity
-const session = await auth.connectVault({
-  dwnEndpoints  : ['https://eu.dwn.example.com'],
-  createIdentity: true,
-});
-```
-
-Check server health:
+Run your own node with `@enbox/dwn-server`:
 
 ```bash
-curl https://enbox-dwn.fly.dev/health
-curl https://dev.aws.dwn.enbox.id/health
-```
-
-### Run Your Own Node
-
-The `@enbox/dwn-server` package is a self-hostable DWN server that runs anywhere Docker does. It supports PostgreSQL, SQLite, and MySQL for storage, with optional S3 for large blobs.
-
-```bash
-# Quick start with Docker Compose
 git clone https://github.com/enboxorg/enbox.git
 cd enbox
 docker compose up dwn-server
 ```
 
-Then point your app at it:
-
-```ts
-const auth = await AuthManager.create({
-  dwnEndpoints: ['https://dwn.your-domain.com'],
-});
-```
-
-See [docs/HOSTING.md](./docs/HOSTING.md) for the public deployment guide: Docker Compose configuration, environment variables, production checklist, and Fly.io deployment.
-
----
+See [docs/HOSTING.md](./docs/HOSTING.md) and
+[packages/dwn-server/README.md](./packages/dwn-server/README.md) for hosting
+configuration, storage backends, and registration options.
 
 ## Packages
 
-### Application Layer
+| Package | Role |
+|---|---|
+| [`@enbox/api`](./packages/api) | High-level SDK: `Enbox.connect()`, typed protocols, records, subscriptions |
+| [`@enbox/auth`](./packages/auth) | Headless auth, local vault connect, wallet connect, session restore |
+| [`@enbox/browser`](./packages/browser) | Browser helpers and polyfills |
+| [`@enbox/protocols`](./packages/protocols) | Shared protocol definitions and JSON Schemas |
+| [`@enbox/protocol-codegen`](./packages/protocol-codegen) | TypeScript generation from protocol definitions and schemas |
+| [`@enbox/agent`](./packages/agent) | Identity vault, key management, local DWN, sync engine |
+| [`@enbox/dids`](./packages/dids) | DID creation and resolution |
+| [`@enbox/crypto`](./packages/crypto) | Crypto primitives, JWE, local key management |
+| [`@enbox/common`](./packages/common) | Shared utilities and storage helpers |
+| [`@enbox/dwn-sdk-js`](./packages/dwn-sdk-js) | Core DWN engine and message handlers |
+| [`@enbox/dwn-clients`](./packages/dwn-clients) | DWN HTTP/WebSocket clients and registration client |
+| [`@enbox/dwn-server`](./packages/dwn-server) | Multi-tenant DWN server |
+| [`@enbox/dwn-sql-store`](./packages/dwn-sql-store) | SQL-backed DWN storage |
 
-| Package | npm | What it does |
-|---|---|---|
-| [`@enbox/api`](./packages/api) | [![npm](https://img.shields.io/npm/v/@enbox/api?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/api) | **Start here.** `Enbox.connect()`, typed protocols, queries, subscriptions |
-| [`@enbox/auth`](./packages/auth) | [![npm](https://img.shields.io/npm/v/@enbox/auth?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/auth) | Auth manager: local connect, wallet-connect, session restore |
-| [`@enbox/browser`](./packages/browser) | [![npm](https://img.shields.io/npm/v/@enbox/browser?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/browser) | Browser SDK: `Enbox.connect()`, polyfills, `repository()` helper |
-| [`@enbox/protocols`](./packages/protocols) | [![npm](https://img.shields.io/npm/v/@enbox/protocols?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/protocols) | Pre-built protocol definitions with JSON Schemas |
-| [`@enbox/protocol-codegen`](./packages/protocol-codegen) | [![npm](https://img.shields.io/npm/v/@enbox/protocol-codegen?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/protocol-codegen) | CLI to generate TypeScript types from protocol definitions |
-
-### Agent & Identity
-
-| Package | npm | What it does |
-|---|---|---|
-| [`@enbox/agent`](./packages/agent) | [![npm](https://img.shields.io/npm/v/@enbox/agent?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/agent) | Identity vault, key management, DWN sync engine |
-| [`@enbox/dids`](./packages/dids) | [![npm](https://img.shields.io/npm/v/@enbox/dids?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dids) | DID methods (`did:dht`, `did:jwk`, `did:web`), resolution |
-| [`@enbox/crypto`](./packages/crypto) | [![npm](https://img.shields.io/npm/v/@enbox/crypto?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/crypto) | Ed25519, X25519, secp256k1, AES, PBKDF2, JWE |
-| [`@enbox/common`](./packages/common) | [![npm](https://img.shields.io/npm/v/@enbox/common?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/common) | Shared utilities: `TtlCache`, `LevelStore`, data conversion |
-
-### DWN Infrastructure
-
-| Package | npm | What it does |
-|---|---|---|
-| [`@enbox/dwn-sdk-js`](./packages/dwn-sdk-js) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-sdk-js?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dwn-sdk-js) | DWN protocol engine, message handlers, storage interfaces |
-| [`@enbox/dwn-clients`](./packages/dwn-clients) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-clients?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dwn-clients) | DWN client libraries, JSON-RPC transport |
-| [`@enbox/dwn-server`](./packages/dwn-server) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-server?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dwn-server) | Multi-tenant DWN server (HTTP/WS via Bun.serve) |
-| [`@enbox/dwn-sql-store`](./packages/dwn-sql-store) | [![npm](https://img.shields.io/npm/v/@enbox/dwn-sql-store?color=357ec7&label=)](https://www.npmjs.com/package/@enbox/dwn-sql-store) | SQL-backed storage (PostgreSQL, SQLite, MySQL) |
-| [`@enbox/dwn-relay`](https://github.com/enboxorg/dwn-relay) | -- | DWN relay/cache node ([standalone repo](https://github.com/enboxorg/dwn-relay)) |
-
----
+`@enbox/dwn-relay` lives in a separate repository:
+<https://github.com/enboxorg/dwn-relay>.
 
 ## Development
 
-### Prerequisites
-
-- [Bun](https://bun.sh) >= 1.0
-
-### Setup
-
 ```bash
-git clone https://github.com/enboxorg/enbox.git
-cd enbox
 bun install
 bun run build
+bun run lint
 ```
 
-### Commands
-
-```bash
-bun run build                              # Build all packages
-bun run test:node                          # Run all tests
-bun run lint                               # Lint all packages
-bun run --filter @enbox/agent build        # Build a single package
-```
-
-### Test Infrastructure
-
-Several packages require Docker services (Pkarr relay, PostgreSQL, NATS) and a local DWN server for their full test suites.
+Several test suites require Docker services and a local Pkarr relay:
 
 ```bash
 docker compose -f docker-compose.test.yaml up -d --wait
@@ -300,38 +176,14 @@ export DID_DHT_ALLOW_PRIVATE_GATEWAY=1
 bun run test:node
 ```
 
-See [docs/TESTING.md](./docs/TESTING.md) for the complete testing guide. See [GETTING_STARTED.md](./GETTING_STARTED.md) for a detailed development walkthrough.
-
-### Test Coverage
-
-| Package | Coverage |
-|---|---|
-| `@enbox/api` | [![api](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/api.json&color=2ea043)](packages/api) |
-| `@enbox/agent` | [![agent](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/agent.json&color=2ea043)](packages/agent) |
-| `@enbox/common` | [![common](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/common.json&color=2ea043)](packages/common) |
-| `@enbox/crypto` | [![crypto](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/crypto.json&color=2ea043)](packages/crypto) |
-| `@enbox/dids` | [![dids](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dids.json&color=2ea043)](packages/dids) |
-| `@enbox/dwn-sdk-js` | [![dwn-sdk-js](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sdk-js.json&color=2ea043)](packages/dwn-sdk-js) |
-| `@enbox/dwn-server` | [![dwn-server](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-server.json&color=2ea043)](packages/dwn-server) |
-| `@enbox/dwn-sql-store` | [![dwn-sql-store](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/dwn-sql-store.json&color=2ea043)](packages/dwn-sql-store) |
-
-### Browser Support
-
-Chromium, Firefox, and WebKit are tested via Playwright. Build targets: Chrome 101+, Firefox 108+, Safari 16+.
-
-### Releasing
-
-Packages are published to npm via [Changesets](https://github.com/changesets/changesets). Never bump versions manually -- run `bun changeset`, then CI handles the rest.
-
----
+See [AGENTS.md](./AGENTS.md) for contributor workflow, style, release, and CI
+rules. See [docs/TESTING.md](./docs/TESTING.md) for local service setup and the
+coverage pipeline.
 
 ## Security
 
-If you discover a security vulnerability, please report it responsibly. **Do not open a public issue.** Email [security@enboxorg.com](mailto:security@enboxorg.com) with details. We will acknowledge receipt within 48 hours.
-
-## Status & Contributing
-
-Enbox is a **research preview under heavy development**. APIs will change without notice. We are not yet accepting external contributions -- watch the repo for updates.
+Do not open public issues for vulnerabilities. Email
+[security@enboxorg.com](mailto:security@enboxorg.com) with details.
 
 ## License
 
@@ -339,11 +191,8 @@ Enbox is a **research preview under heavy development**. APIs will change withou
 
 ## Resources
 
-- [Decentralized Web Node Specification](https://identity.foundation/decentralized-web-node/spec/)
+- [Documentation](https://enbox-docs.pages.dev)
+- [DWN Specification](https://identity.foundation/decentralized-web-node/spec/)
 - [DID Core Specification](https://www.w3.org/TR/did-core/)
-- [Enbox Documentation](https://enbox-docs.pages.dev) *(work in progress)*
-- [Hosting Guide](./docs/HOSTING.md)
 
----
-
-<sub>This monorepo consolidates packages from the [decentralized-identity](https://github.com/decentralized-identity) organisation, including [dwn-sdk-js](https://github.com/decentralized-identity/dwn-sdk-js), [dwn-server](https://github.com/decentralized-identity/dwn-server), [dwn-sql-store](https://github.com/decentralized-identity/dwn-sql-store), and the web5-js monorepo.</sub>
+<sub>This monorepo consolidates packages from the [decentralized-identity](https://github.com/decentralized-identity) organization, including [dwn-sdk-js](https://github.com/decentralized-identity/dwn-sdk-js), [dwn-server](https://github.com/decentralized-identity/dwn-server), [dwn-sql-store](https://github.com/decentralized-identity/dwn-sql-store), and the web5-js monorepo.</sub>

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Getting started with the Enbox SDK — decentralised identity, data, and authentication for TypeScript.
+description: Getting started with the Enbox SDK — decentralized identity, data, and authentication for TypeScript.
 ---
 
 ## What is Enbox?

--- a/apps/docs/content/docs/packages/api.mdx
+++ b/apps/docs/content/docs/packages/api.mdx
@@ -1,9 +1,9 @@
 ---
 title: "@enbox/api"
-description: The high-level TypeScript SDK for decentralised identity and data — typed protocols, records CRUD, real-time subscriptions, and anonymous queries.
+description: The high-level TypeScript SDK for decentralized identity and data — typed protocols, records CRUD, real-time subscriptions, and anonymous queries.
 ---
 
-`@enbox/api` is the main package developers use to interact with the Enbox network. It provides a type-safe, protocol-scoped API for creating, reading, updating, deleting, and subscribing to records stored in Decentralised Web Nodes (DWNs).
+`@enbox/api` is the main package developers use to interact with the Enbox network. It provides a type-safe, protocol-scoped API for creating, reading, updating, deleting, and subscribing to records stored in Decentralized Web Nodes (DWNs).
 
 ## Installation
 

--- a/apps/docs/content/docs/packages/dids.mdx
+++ b/apps/docs/content/docs/packages/dids.mdx
@@ -3,7 +3,7 @@ title: "@enbox/dids"
 description: DID creation, resolution, and key management — supporting did:dht, did:jwk, did:key, and did:web methods.
 ---
 
-`@enbox/dids` handles everything related to Decentralised Identifiers (DIDs) — creating them, resolving them, and managing the cryptographic keys they contain.
+`@enbox/dids` handles everything related to Decentralized Identifiers (DIDs) — creating them, resolving them, and managing the cryptographic keys they contain.
 
 ## What it does
 

--- a/apps/docs/content/docs/packages/dwn-sdk-js.mdx
+++ b/apps/docs/content/docs/packages/dwn-sdk-js.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@enbox/dwn-sdk-js"
-description: The Decentralised Web Node protocol engine — message processing, storage interfaces, and protocol rule enforcement.
+description: The Decentralized Web Node protocol engine — message processing, storage interfaces, and protocol rule enforcement.
 ---
 
 `@enbox/dwn-sdk-js` is the core DWN protocol engine. It implements the [DWN specification](https://identity.foundation/decentralized-web-node/spec/) — processing DWN messages, enforcing protocol rules, managing record storage, and handling subscriptions.

--- a/apps/docs/content/docs/packages/dwn-server.mdx
+++ b/apps/docs/content/docs/packages/dwn-server.mdx
@@ -1,9 +1,9 @@
 ---
 title: "@enbox/dwn-server"
-description: Self-hostable Decentralised Web Node server with PostgreSQL, MySQL, SQLite, and LevelDB storage backends.
+description: Self-hostable Decentralized Web Node server with PostgreSQL, MySQL, SQLite, and LevelDB storage backends.
 ---
 
-`@enbox/dwn-server` is a standalone HTTP + WebSocket server that hosts Decentralised Web Nodes (DWNs) for multiple tenants. It implements the [DWN specification](https://identity.foundation/decentralized-web-node/spec/) and is designed to run as a long-lived service — in Docker, on bare metal, or in a cloud environment.
+`@enbox/dwn-server` is a standalone HTTP + WebSocket server that hosts Decentralized Web Nodes (DWNs) for multiple tenants. It implements the [DWN specification](https://identity.foundation/decentralized-web-node/spec/) and is designed to run as a long-lived service — in Docker, on bare metal, or in a cloud environment.
 
 ## Quick start
 

--- a/apps/docs/content/docs/packages/protocols.mdx
+++ b/apps/docs/content/docs/packages/protocols.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@enbox/protocols"
-description: Protocol definitions and type-safe schema helpers for structuring data in Decentralised Web Nodes.
+description: Protocol definitions and type-safe schema helpers for structuring data in Decentralized Web Nodes.
 ---
 
 `@enbox/protocols` provides pre-built protocol definitions and utilities for defining the data structures, access rules, and schemas that govern records in a DWN.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2,60 +2,60 @@
 
 > **Research Preview** -- Enbox is under active development. APIs may change without notice.
 
-[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/LiranCohen/02d15f39a46173a612a8862ec6d7cfcf/raw/api.json)](https://github.com/enboxorg/enbox/actions/workflows/ci.yml)
+High-level SDK for app developers. Start here unless you specifically need the
+lower-level agent, auth, or DWN packages.
 
-The high-level SDK for building decentralized applications with protocol-first data management. This is the main consumer-facing package in the Enbox ecosystem -- most applications only need `@enbox/api`.
-
-## Table of Contents
-
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [Core Concepts](#core-concepts)
-  - [Enbox.connect()](#enboxconnectoptions)
-  - [defineProtocol()](#defineprotocoldefinition-schemamap)
-  - [enbox.using()](#enboxusingprotocol)
-  - [Record Instances](#record-instances)
-  - [LiveQuery (Subscriptions)](#livequery-subscriptions)
-  - [Enbox.anonymous()](#enboxanonymousoptions)
-- [Repository Pattern](#repository-pattern)
-  - [Collections vs Singletons](#collections-vs-singletons)
-  - [Nested Records](#nested-records-1)
-  - [Using Pre-built Protocols](#using-pre-built-protocols)
-- [Cookbook](#cookbook)
-  - [Nested Records](#nested-records)
-  - [Querying with Filters and Pagination](#querying-with-filters-and-pagination)
-  - [Tags](#tags)
-  - [Publishing Records](#publishing-records)
-  - [Reading Public Data Anonymously](#reading-public-data-anonymously)
-  - [Sending Records to Remote DWNs](#sending-records-to-remote-dwns)
-- [Code Generation](#code-generation)
-- [Advanced Usage](#advanced-usage)
-  - [Unscoped DWN Access](#unscoped-dwn-access)
-  - [Permissions](#permissions)
-  - [DID Operations](#did-operations)
-- [Browser Builds — Required Polyfills](#browser-builds--required-polyfills)
-- [API Reference](#api-reference)
-- [License](#license)
-
-## Installation
+## Install
 
 ```bash
 bun add @enbox/api
 ```
 
-## Quick Start
+## Connect
 
 ```ts
-import { defineProtocol, Enbox } from '@enbox/api';
+import { Enbox } from '@enbox/api';
 
-// 1. Connect -- creates or loads a local identity and agent
-const { enbox, session } = await Enbox.connect({ createIdentity: true });
-const myDid = session.did;
+const { auth, enbox, session } = await Enbox.connect({
+  password      : userPassword,
+  createIdentity: true,
+  dwnEndpoints  : ['https://enbox-dwn.fly.dev'],
+});
+```
 
-// 2. Define a protocol with typed data shapes
+`Enbox.connect()` creates an `AuthManager`, connects or restores a session, and
+returns:
+
+| Value | Description |
+|---|---|
+| `auth` | The `AuthManager` that owns the session lifecycle. |
+| `enbox` | The high-level API instance. |
+| `session` | Active DID, delegate DID when present, agent, and first-run recovery phrase. |
+
+Common options:
+
+| Option | Description |
+|---|---|
+| `password` | Local vault password. The default is insecure; production apps should pass one. |
+| `createIdentity` | Create a default identity when no identity exists. |
+| `recoveryPhrase` | Explicit BIP-39 vault recovery. |
+| `dwnEndpoints` | Remote DWN endpoints used for registration and sync. |
+| `sync` | Omit for live sync, pass an interval like `'30s'`, or pass `'off'`. |
+| `protocols` | Protocol scopes for handler-based connect flows. |
+| `connectHandler` | Browser/wallet connect handler. |
+| `registration` | DWN endpoint registration callbacks and token persistence options. |
+
+If you already own an auth session, use `Enbox.fromSession(session)`. If you
+own a raw agent and DID, use `new Enbox({ agent, connectedDid })`.
+
+## Typed Protocols
+
+```ts
+import { Enbox, defineProtocol } from '@enbox/api';
+
 const NotesProtocol = defineProtocol({
   protocol  : 'https://example.com/notes',
-  published : true,
+  published : false,
   types     : {
     note: {
       schema      : 'https://example.com/schemas/note',
@@ -63,462 +63,104 @@ const NotesProtocol = defineProtocol({
     },
   },
   structure: {
-    note: {},
+    note: {
+      $tags: { category: { type: 'string' } },
+    },
   },
 } as const, {} as {
   note: { title: string; body: string };
 });
 
-// 3. Scope all operations to the protocol
+const { enbox } = await Enbox.connect({ password: userPassword, createIdentity: true });
 const notes = enbox.using(NotesProtocol);
 
-// 4. Install the protocol on the local DWN
-await notes.configure();
-
-// 5. Create a record -- path, data, and schema are type-checked
 const { record } = await notes.records.create('note', {
-  data: { title: 'Hello', body: 'World' },
+  data : { title: 'Hello', body: 'World' },
+  tags : { category: 'draft' },
 });
 
-// 6. Query records back -- data is typed automatically
-const { records } = await notes.records.query('note');
-for (const r of records) {
-  const note = await r.data.json(); // { title: string; body: string }
-  console.log(r.id, note.title);
-}
-
-// 7. Send to your remote DWN
-await record.send(myDid);
+const data = await record.data.json(); // { title: string; body: string }
 ```
 
-## Core Concepts
+`defineProtocol()` preserves protocol paths and schema map types at compile
+time. `enbox.using(protocol)` returns a `TypedEnbox` scoped to that protocol, so
+record methods can infer paths and payload shapes.
 
-### `Enbox.connect(options?)`
-
-Connects to a local identity agent. On first launch it creates an identity vault, generates a `did:dht` DID, and starts the sync engine. On subsequent launches it unlocks the existing vault.
+## Records
 
 ```ts
-const { enbox, session } = await Enbox.connect({
-  password      : 'user-chosen-password',
-  createIdentity: true,
+// Create
+const { record } = await notes.records.create('note', {
+  data: { title: 'Launch', body: 'Ship it' },
 });
 
-// session.recoveryPhrase is returned on first launch only -- store it safely.
-```
-
-**Options** (all optional):
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `password` | `string` | Password to protect the local identity vault. **Defaults to an insecure static value** -- always set this in production. |
-| `recoveryPhrase` | `string` | 12-word BIP-39 phrase for explicit vault recovery. |
-| `createIdentity` | `boolean` | Create a default identity when no identity exists. |
-| `sync` | `'off' \| \`${number}s\` \| \`${number}m\` \| \`${number}h\`` | Omit for live sync, pass an interval for polling, or `'off'` to disable sync. |
-| `dwnEndpoints` | `string[]` | Remote DWN service endpoints for registration and sync. |
-| `protocols` | `TypedProtocol[]` | Protocol scopes for handler-based connect flows. |
-| `connectHandler` | `ConnectHandler` | Handler for wallet/browser connect flows. |
-| `agent` | `EnboxPlatformAgent` | Provide a custom agent instance. Defaults to a local `EnboxUserAgent`. |
-| `registration` | `RegistrationOptions` | DWN endpoint registration callbacks and token persistence options. |
-
-**Returns** `{ auth, enbox, session }`.
-
-- `auth` -- the `AuthManager` that owns the session lifecycle
-- `enbox` -- the `Enbox` instance for all subsequent operations
-- `session.did` -- the connected DID URI (e.g. `did:dht:abc...`)
-- `session.recoveryPhrase` -- only returned on first initialization or explicit phrase restore
-- `session.delegateDid` -- only present for delegated sessions
-
----
-
-### `defineProtocol(definition, schemaMap?)`
-
-Creates a typed protocol definition that enables compile-time path autocompletion and data type checking when used with `enbox.using()`.
-
-```ts
-import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
-
-const ChatProtocol = defineProtocol({
-  protocol  : 'https://example.com/chat',
-  published : true,
-  types: {
-    thread  : { schema: 'https://example.com/schemas/thread',  dataFormats: ['application/json'] },
-    message : { schema: 'https://example.com/schemas/message', dataFormats: ['application/json'] },
-  },
-  structure: {
-    thread: {
-      message: {},   // messages are nested under threads
-    },
-  },
-} as const satisfies ProtocolDefinition, {} as {
-  thread  : { title: string; description?: string };
-  message : { text: string };
-});
-```
-
-The second argument is a **phantom type** -- it only exists at compile time. Pass `{} as YourSchemaMap` to map protocol type names to TypeScript interfaces. The runtime value is ignored.
-
-This gives you:
-- **Path autocompletion**: `'thread'`, `'thread/message'` are inferred from `structure`
-- **Typed `data` payloads**: `write('thread', { data: ... })` type-checks against the schema map
-- **Typed `dataFormat`**: restricted to the formats declared in the protocol type
-
----
-
-### `enbox.using(protocol)`
-
-The **primary interface** for all record operations. Returns a `TypedEnbox` instance scoped to the given protocol.
-
-```ts
-const chat = enbox.using(ChatProtocol);
-```
-
-#### `configure()`
-
-Installs the protocol on the local DWN. If already installed with an identical definition, this is a no-op. If the definition has changed, it reconfigures with the updated version.
-
-```ts
-await chat.configure();
-```
-
-#### `records.create(path, request)`
-
-Create a new record at a protocol path. The protocol URI, protocolPath, schema, and dataFormat are automatically injected. Returns a `TypedRecord<T>` where `T` is inferred from the schema map.
-
-```ts
-const { record, status } = await chat.records.create('thread', {
-  data: { title: 'General', description: 'General discussion' },
-});
-
-console.log(status.code);  // 202
-console.log(record.id);    // unique record ID
-
-// record is TypedRecord<{ title: string; description?: string }>
-const data = await record.data.json(); // typed -- no cast needed
-```
-
-To mutate an existing record, use the instance method `record.update()`:
-
-```ts
-const { record: updated } = await record.update({
-  data: { title: 'Updated Title', description: 'New description' },
-});
-```
-
-#### `records.query(path, request?)`
-
-Query records at a protocol path. Returns `TypedRecord<T>[]` with optional pagination.
-
-```ts
-const { records, cursor } = await chat.records.query('thread', {
+// Query
+const { records, cursor } = await notes.records.query('note', {
   dateSort   : 'createdDescending',
   pagination : { limit: 20 },
 });
 
-// records is TypedRecord<{ title: string; description?: string }>[]
-for (const thread of records) {
-  const data = await thread.data.json(); // typed automatically
-  console.log(data.title);
-}
-
-// Fetch next page
-if (cursor) {
-  const { records: nextPage } = await chat.records.query('thread', {
-    pagination: { limit: 20, cursor },
-  });
-}
-```
-
-#### `records.read(path, request)`
-
-Read a single record by filter criteria.
-
-```ts
-const { record } = await chat.records.read('thread', {
-  filter: { recordId: 'bafyrei...' },
+// Read
+const { record: found } = await notes.records.read('note', {
+  filter: { recordId: record.id },
 });
 
-const data = await record.data.json();
-```
-
-#### `records.delete(path, request)`
-
-Delete a record by ID.
-
-```ts
-const { status } = await chat.records.delete('thread', {
-  recordId: record.id,
-});
-```
-
-#### `records.subscribe(path, request?)`
-
-Subscribe to real-time changes. Returns a `TypedLiveQuery<T>` with an initial snapshot of `TypedRecord<T>[]` plus a stream of typed change events.
-
-```ts
-const { liveQuery } = await chat.records.subscribe('thread/message');
-
-// Initial snapshot -- typed records
-for (const msg of liveQuery.records) {
-  const data = await msg.data.json(); // { text: string } -- no cast
-  console.log(data.text);
-}
-
-// Real-time updates -- typed records in handlers
-liveQuery.on('create', (record) => console.log('new:', record.id));
-liveQuery.on('update', (record) => console.log('updated:', record.id));
-liveQuery.on('delete', (record) => console.log('deleted:', record.id));
-```
-
-All methods also accept a `from` option to query a remote DWN:
-
-```ts
-const { records } = await chat.records.query('thread', {
-  from: 'did:dht:other-user...',
-});
-```
-
----
-
-### Record Instances (`TypedRecord<T>`)
-
-Methods like `create`, `query`, and `read` return `TypedRecord<T>` instances -- type-safe wrappers that preserve the data type `T` inferred from the schema map through the entire lifecycle (create, query, read, update, subscribe).
-
-`TypedRecord<T>` exposes a typed `data.json()` that returns `Promise<T>` instead of `Promise<unknown>`, eliminating manual type casts. The underlying `Record` is accessible via `record.rawRecord` if needed.
-
-**Properties**:
-
-| Property | Description |
-|----------|-------------|
-| `id` | Unique record identifier |
-| `contextId` | Context ID (scopes nested records to a parent thread) |
-| `protocol` | Protocol URI |
-| `protocolPath` | Path within the protocol structure (e.g. `'thread/message'`) |
-| `schema` | Schema URI |
-| `dataFormat` | MIME type of the data |
-| `dataCid` | Content-addressed hash of the data |
-| `dataSize` | Size of the data in bytes |
-| `dateCreated` | ISO timestamp of creation |
-| `timestamp` | ISO timestamp of most recent write |
-| `datePublished` | ISO timestamp of publication (if published) |
-| `published` | Whether the record is publicly readable |
-| `author` | DID of the record author |
-| `recipient` | DID of the intended recipient |
-| `parentId` | Record ID of the parent record (for nested structures) |
-| `tags` | Key-value metadata tags |
-| `deleted` | Whether the record has been deleted |
-
-**Data accessors** -- read the record payload in different formats:
-
-```ts
-const obj    = await record.data.json();   // T -- automatically typed from schema map
-const text   = await record.data.text();   // string
-const blob   = await record.data.blob();   // Blob
-const bytes  = await record.data.bytes();  // Uint8Array
-const stream = await record.data.stream(); // ReadableStream
-```
-
-**Mutators**:
-
-```ts
-// Update the record's data
-const { record: updated } = await record.update({
-  data: { title: 'Updated Title', body: '...' },
+// Update
+await found.update({
+  data: { title: 'Launch', body: 'Shipped' },
 });
 
-// Delete the record
-const { status } = await record.delete();
+// Delete
+await found.delete();
 ```
 
-**Side-effect methods**:
+Returned records are `TypedRecord<T>` instances. They expose typed
+`data.json()` plus `data.text()`, `data.bytes()`, `data.blob()`, and
+`data.stream()`.
+
+## Live Queries
 
 ```ts
-// Send the record to a remote DWN
-await record.send(targetDid);
+const { liveQuery } = await notes.records.subscribe('note');
 
-// Persist a remote record to the local DWN
-await record.store();
-
-// Import a record from a remote DWN into the local store
-await record.import();
-```
-
----
-
-### LiveQuery (Subscriptions) -- `TypedLiveQuery<T>`
-
-`records.subscribe()` returns a `TypedLiveQuery<T>` that provides an initial snapshot of `TypedRecord<T>[]` plus a real-time stream of deduplicated, typed change events.
-
-```ts
-const { liveQuery } = await chat.records.subscribe('thread/message');
-
-// Initial snapshot -- TypedRecord<MessageData>[]
-for (const msg of liveQuery.records) {
-  const data = await msg.data.json(); // MessageData -- typed
-  renderMessage(data);
-}
-
-// Real-time changes -- handlers receive TypedRecord<MessageData>
-const offCreate = liveQuery.on('create', (record) => appendMessage(record));
-const offUpdate = liveQuery.on('update', (record) => refreshMessage(record));
-const offDelete = liveQuery.on('delete', (record) => removeMessage(record));
-
-// Catch-all event (receives { type: 'create'|'update'|'delete', record: TypedRecord<T> })
-liveQuery.on('change', ({ type, record }) => {
-  console.log(`${type}: ${record.id}`);
+liveQuery.on('create', async (created) => {
+  console.log(await created.data.json());
 });
 
-// Unsubscribe from a specific handler
-offCreate();
+liveQuery.on('delete', (deleted) => {
+  console.log(deleted.id);
+});
 
-// Close the subscription entirely
 await liveQuery.close();
 ```
 
-The underlying `LiveQuery` is accessible via `liveQuery.rawLiveQuery` if needed. Events are automatically deduplicated against the initial snapshot -- you won't receive a `create` event for records already in the `records` array.
+The initial snapshot is available at `liveQuery.records`. Change events are
+deduplicated against that snapshot.
 
----
+## Repository Helper
 
-### `Enbox.anonymous(options?)`
-
-Creates a lightweight, read-only instance for querying public DWN data. No identity, vault, or signing keys are required.
-
-```ts
-const { dwn } = Enbox.anonymous();
-
-// Query published records from someone's DWN
-const { records } = await dwn.records.query({
-  from   : 'did:dht:alice...',
-  filter : { protocol: 'https://example.com/notes', protocolPath: 'note' },
-});
-
-for (const record of records) {
-  console.log(record.id, await record.data.text());
-}
-
-// Read a specific record
-const { record } = await dwn.records.read({
-  from   : 'did:dht:alice...',
-  filter : { recordId: 'bafyrei...' },
-});
-
-// Count matching records
-const { count } = await dwn.records.count({
-  from   : 'did:dht:alice...',
-  filter : { protocol: 'https://example.com/notes', protocolPath: 'note' },
-});
-
-// Query published protocols
-const { protocols } = await dwn.protocols.query({
-  from: 'did:dht:alice...',
-});
-```
-
-Returns `ReadOnlyRecord` instances (no `update`, `delete`, `send`, or `store` methods). All calls require a `from` DID since the reader has no local DWN.
-
----
-
-## Cookbook
-
-### Nested Records
-
-Protocols support hierarchical record structures. Child records reference their parent via `parentContextId`.
+Use `repository()` when you want a structure-aware object instead of passing
+protocol paths to every call.
 
 ```ts
-const ChatProtocol = defineProtocol({
-  protocol  : 'https://example.com/chat',
-  published : true,
-  types: {
-    thread  : { schema: 'https://example.com/schemas/thread',  dataFormats: ['application/json'] },
-    message : { schema: 'https://example.com/schemas/message', dataFormats: ['application/json'] },
-  },
-  structure: {
-    thread: {
-      message: {},
-    },
-  },
-} as const, {} as {
-  thread  : { title: string };
-  message : { text: string };
+import { repository } from '@enbox/api';
+
+const repo = repository(enbox.using(NotesProtocol));
+
+await repo.note.create({
+  data: { title: 'Hello', body: 'World' },
 });
 
-const chat = enbox.using(ChatProtocol);
-await chat.configure();
-
-// Create a parent thread
-const { record: thread } = await chat.records.create('thread', {
-  data: { title: 'General' },
-});
-
-// Create a message nested under the thread
-const { record: msg } = await chat.records.create('thread/message', {
-  parentContextId : thread.contextId,
-  data            : { text: 'Hello, world!' },
-});
-
-// Query messages within a specific thread
-const { records: messages } = await chat.records.query('thread/message', {
-  filter: { parentId: thread.id },
-});
+const { records } = await repo.note.query();
 ```
 
-### Querying with Filters and Pagination
+Types annotated with `$recordLimit: { max: 1 }` become singletons with
+`set()`, `get()`, and `delete()` instead of collection-style CRUD.
 
-```ts
-// Date-sorted, paginated query
-const { records, cursor } = await notes.records.query('note', {
-  dateSort   : 'createdDescending',
-  pagination : { limit: 10 },
-});
+## Anonymous Reads
 
-// Fetch next page using the cursor
-if (cursor) {
-  const { records: page2 } = await notes.records.query('note', {
-    dateSort   : 'createdDescending',
-    pagination : { limit: 10, cursor },
-  });
-}
-
-// Filter by recipient
-const { records: shared } = await notes.records.query('note', {
-  filter: { recipient: 'did:dht:bob...' },
-});
-
-// Query from a remote DWN
-const { records: remote } = await notes.records.query('note', {
-  from: 'did:dht:alice...',
-});
-```
-
-### Tags
-
-Tags are key-value metadata attached to records, useful for filtering without parsing record data.
-
-```ts
-const { record } = await notes.records.create('note', {
-  data : { title: 'Meeting Notes', body: '...' },
-  tags : { category: 'work', priority: 'high' },
-});
-
-// Query by tag
-const { records } = await notes.records.query('note', {
-  filter: { tags: { category: 'work' } },
-});
-```
-
-> Note: tags must be declared in your protocol's type definition for the DWN engine to index them.
-
-### Publishing Records
-
-Published records are publicly readable by anyone, including anonymous readers.
-
-```ts
-const { record } = await notes.records.create('note', {
-  data      : { title: 'Public Note', body: 'Visible to everyone' },
-  published : true,
-});
-```
-
-### Reading Public Data Anonymously
+`Enbox.anonymous()` creates a read-only API for published records and protocol
+metadata. It has no local identity, so every request needs a `from` DID.
 
 ```ts
 const { dwn } = Enbox.anonymous();
@@ -530,203 +172,12 @@ const { records } = await dwn.records.query({
     protocolPath : 'note',
   },
 });
-
-for (const record of records) {
-  const note = await record.data.json();
-  console.log(note.title);
-}
 ```
 
-### Sending Records to Remote DWNs
+## Advanced DWN Access
 
-Records are initially written to the local DWN. Use `send()` to push them to a remote DWN, or rely on the automatic sync engine.
-
-```ts
-// Explicitly send to your own remote DWN
-await record.send(myDid);
-
-// Send to someone else's DWN (requires protocol permissions)
-await record.send('did:dht:bob...');
-```
-
-The sync engine automatically synchronizes records between local and remote DWNs when sync is enabled. For most use cases, you don't need to call `send()` manually.
-
----
-
-## Repository Pattern
-
-The `repository()` factory provides a higher-level abstraction over `TypedEnbox`. Instead of passing path strings to every call, you get a **structure-aware object** with CRUD methods directly on each protocol type -- with automatic singleton detection.
-
-```ts
-import { defineProtocol, repository, Enbox } from '@enbox/api';
-
-const { enbox } = await Enbox.connect({ password: 'secret' });
-
-const TaskProtocol = defineProtocol({
-  protocol  : 'https://example.com/tasks',
-  published : false,
-  types: {
-    project : { schema: 'https://example.com/schemas/project', dataFormats: ['application/json'] },
-    task    : { schema: 'https://example.com/schemas/task',    dataFormats: ['application/json'] },
-    config  : { schema: 'https://example.com/schemas/config',  dataFormats: ['application/json'] },
-  },
-  structure: {
-    project: {
-      task: {},   // collection -- many tasks per project
-    },
-    config: {
-      $recordLimit: { max: 1, strategy: 'reject' },  // singleton
-    },
-  },
-} as const, {} as {
-  project : { name: string; color?: string };
-  task    : { title: string; completed: boolean };
-  config  : { defaultView: 'list' | 'board' };
-});
-
-const repo = repository(enbox.using(TaskProtocol));
-await repo.configure();
-```
-
-### Collections vs Singletons
-
-The repository automatically detects types with `$recordLimit: { max: 1 }` and provides different APIs:
-
-**Collections** (default) -- `create`, `query`, `get`, `delete`, `subscribe`:
-
-```ts
-// Create
-const { record } = await repo.project.create({
-  data: { name: 'Website Redesign', color: '#3b82f6' },
-});
-
-// Query all
-const { records } = await repo.project.query();
-
-// Query with filters and pagination
-const { records: recent, cursor } = await repo.project.query({
-  dateSort   : 'createdDescending',
-  pagination : { limit: 10 },
-});
-
-// Get by record ID
-const { record: project } = await repo.project.get(recordId);
-
-// Delete
-await repo.project.delete(recordId);
-
-// Subscribe to real-time changes
-const { liveQuery } = await repo.project.subscribe();
-liveQuery.on('create', (record) => console.log('new project:', record.id));
-```
-
-**Singletons** (`$recordLimit: { max: 1 }`) -- `set`, `get`, `delete`:
-
-```ts
-// Set (creates or updates)
-await repo.config.set({
-  data: { defaultView: 'board' },
-});
-
-// Get the single record
-const { record: config } = await repo.config.get();
-const { defaultView } = await config.data.json(); // 'board'
-
-// Delete
-await repo.config.delete(config.id);
-```
-
-### Nested Records
-
-Nested types take `parentContextId` as the first argument:
-
-```ts
-// Create a task under a project
-const { record: task } = await repo.project.task.create(project.contextId, {
-  data: { title: 'Design mockups', completed: false },
-});
-
-// Query tasks within a project
-const { records: tasks } = await repo.project.task.query(project.contextId);
-
-// Subscribe to tasks within a project
-const { liveQuery } = await repo.project.task.subscribe(project.contextId);
-```
-
-### Using Pre-built Protocols
-
-The `@enbox/protocols` package provides ready-to-use protocol definitions. Combined with `repository()`, you get zero-boilerplate typed data access:
-
-```ts
-import { repository, Enbox } from '@enbox/api';
-import {
-  PreferencesProtocol,
-  ProfileProtocol,
-  SocialGraphProtocol,
-} from '@enbox/protocols';
-
-const { enbox } = await Enbox.connect({ password: 'secret' });
-
-// Social Graph -- friend, block, group, member
-const social = repository(enbox.using(SocialGraphProtocol));
-await social.configure();
-
-const { record } = await social.friend.create({
-  data: { did: 'did:dht:alice...', alias: 'Alice' },
-});
-
-// Profile -- profile (singleton), avatar, hero, link, privateNote
-const profile = repository(enbox.using(ProfileProtocol));
-await profile.configure();
-
-await profile.profile.set({
-  data: { displayName: 'Bob', bio: 'Building the decentralized web' },
-});
-
-// Add links nested under the profile
-const { record: p } = await profile.profile.get();
-await profile.profile.link.create(p.contextId, {
-  data: { url: 'https://github.com/bob', title: 'GitHub' },
-});
-
-// Preferences -- theme, locale, privacy (singletons), notification (collection)
-const prefs = repository(enbox.using(PreferencesProtocol));
-await prefs.configure();
-
-await prefs.theme.set({ data: { mode: 'dark', accentColor: '#8b5cf6' } });
-await prefs.locale.set({ data: { language: 'en', timezone: 'America/New_York' } });
-```
-
-See [`@enbox/protocols`](../protocols) for the full catalog of 6 protocols and 19 typed data shapes.
-
----
-
-## Code Generation
-
-For protocols defined externally (e.g. from a spec or shared JSON file), use `@enbox/protocol-codegen` to generate TypeScript types from a protocol definition and JSON Schemas:
-
-```bash
-bunx @enbox/protocol-codegen generate \
-  --definition ./my-protocol.json \
-  --schemas ./schemas/ \
-  --name MyProtocol \
-  --output ./my-protocol.generated.ts
-```
-
-This generates:
-- TypeScript interfaces for each type's JSON Schema (via `json-schema-to-typescript`)
-- A `SchemaMap` mapping type names to generated interfaces
-- A ready-to-use `defineProtocol()` call
-
-See [`@enbox/protocol-codegen`](../protocol-codegen) for full documentation.
-
----
-
-## Advanced Usage
-
-### Unscoped DWN Access
-
-For power users who need direct DWN access without protocol scoping (e.g. cross-protocol queries, raw permission management), import from the `@enbox/api/advanced` sub-path:
+Most apps should use `enbox.using(protocol)`. If you need raw DWN methods, use
+the advanced export:
 
 ```ts
 import { DwnApi } from '@enbox/api/advanced';
@@ -738,148 +189,33 @@ const dwn = new DwnApi({
 });
 ```
 
-The `DwnApi` class provides raw `records`, `protocols`, and `permissions` accessors without automatic protocol/path/schema injection. You must provide those fields manually in every call. Most applications should use `enbox.using()` instead.
+## Browser Builds
 
-### Permissions
+Browser apps typically use `@enbox/browser`, which re-exports the main app APIs
+and adds browser-specific connect helpers. Service workers and custom bundler
+targets may need Node global shims for `global`, `process.env`,
+`process.browser`, and `process.emitWarning`.
 
-The DWN permission system supports fine-grained access control through permission requests, grants, and revocations.
-
-```ts
-// Query existing permission grants
-const grants = await dwn.permissions.queryGrants();
-
-// Request permissions from another DWN
-const request = await dwn.permissions.request({
-  scope: {
-    interface : 'Records',
-    method    : 'Write',
-    protocol  : 'https://example.com/notes',
-  },
-});
-
-// Send the request to the target DWN
-await request.send('did:dht:alice...');
-```
-
-### DID Operations
-
-```ts
-// Resolve any DID
-const { didDocument } = await enbox.did.resolve('did:dht:abc...');
-```
-
----
-
-## Browser Builds — Required Polyfills
-
-The Enbox packages reference several Node.js globals that must be shimmed in browser environments. Most bundlers (Vite, webpack) handle the main bundle automatically, but **secondary build targets** (e.g., service workers, Web Workers) may need explicit configuration.
-
-### Required shims
-
-| Global | Shim value | Used by |
-|--------|-----------|---------|
-| `global` | `globalThis` | `@enbox/agent` transitive deps |
-| `process.env` | `{}` | `@enbox/agent`, `@enbox/dids` |
-| `process.browser` | `true` | `@enbox/agent` transitive deps |
-| `process.emitWarning` | `() => {}` | `@enbox/agent` transitive deps |
-
-### Vite configuration
-
-For the main app bundle, add to `vite.config.ts`:
-
-```ts
-import nodePolyfills from 'vite-plugin-node-stdlib-browser';
-
-export default defineConfig({
-  define: {
-    global: 'globalThis',
-  },
-  plugins: [nodePolyfills()],
-});
-```
-
-### Service workers (VitePWA)
-
-Service workers built via [VitePWA](https://vite-pwa-org.netlify.app/) run in a separate Vite build that does **not** inherit the main app's polyfill plugins. Two additional steps are needed:
-
-1. **Build as IIFE** to compile away `import.meta.url` references:
-   ```ts
-   VitePWA({
-     strategies: 'injectManifest',
-     injectManifest: {
-       rollupFormat: 'iife',
-     },
-   })
-   ```
-
-2. **Prepend a `process` shim** via a Rollup plugin:
-   ```ts
-   VitePWA({
-     injectManifest: {
-       rollupFormat: 'iife',
-       buildPlugins: {
-         rollup: [{
-           name: 'sw-process-shim',
-           renderChunk(code) {
-             const shim = 'if(typeof process==="undefined"){self.process={env:{},browser:true,emitWarning:function(){}};};\n';
-             return { code: shim + code, map: null };
-           },
-         }],
-       },
-     },
-   })
-   ```
-
----
-
-## API Reference
-
-### Main Exports (`@enbox/api`)
+## Exports
 
 | Export | Description |
-|--------|-------------|
-| `Enbox` | Main entry point -- `connect()`, `anonymous()`, `using()` |
-| `defineProtocol()` | Factory for creating typed protocol definitions |
-| `repository()` | Factory for creating structure-aware CRUD repositories from `TypedEnbox` |
-| `TypedEnbox` | Protocol-scoped API returned by `enbox.using()` -- `create`, `query`, `read`, `delete`, `subscribe` |
-| `TypedRecord<T>` | Type-safe record wrapper -- `data.json()` returns `Promise<T>` |
-| `TypedLiveQuery<T>` | Type-safe subscription with `TypedRecord<T>[]` snapshot and typed change events |
-| `Record` | Mutable record instance with data accessors and side-effect methods |
-| `ReadOnlyRecord` | Immutable record for anonymous/read-only access |
-| `LiveQuery` | Real-time subscription with initial snapshot and change events |
-| `Protocol` | Protocol metadata wrapper |
-| `PermissionGrant` | Permission grant record |
-| `PermissionRequest` | Permission request record |
-| `PermissionGrantRevocation` | Permission revocation record |
-| `DidApi` | DID resolution |
-| `VcApi` | Verifiable Credentials (not yet implemented) |
-| `DwnReaderApi` | Read-only DWN API for anonymous access |
+|---|---|
+| `Enbox` | Main app API: `connect()`, `fromSession()`, `anonymous()`, `using()`. |
+| `defineProtocol()` | Creates typed protocol definitions. |
+| `repository()` | Creates structure-aware CRUD repositories. |
+| `TypedEnbox` | Protocol-scoped record API returned by `enbox.using()`. |
+| `TypedRecord<T>` | Type-safe record wrapper. |
+| `TypedLiveQuery<T>` | Typed subscription snapshot and change events. |
+| `Record` / `ReadOnlyRecord` | Mutable and anonymous-read record wrappers. |
+| `DidApi` | DID resolution helpers. |
+| `DwnReaderApi` | Anonymous read-only DWN API. |
 
-### Advanced Export (`@enbox/api/advanced`)
+## Related Packages
 
-| Export | Description |
-|--------|-------------|
-| `DwnApi` | Full unscoped DWN API with `records`, `protocols`, `permissions` |
-
-### Key Types
-
-| Export | Description |
-|--------|-------------|
-| `TypedProtocol<D, M>` | Typed protocol wrapper with definition and schema map |
-| `ProtocolPaths<D>` | Union of valid slash-delimited paths for a protocol definition |
-| `SchemaMap` | Maps protocol type names to TypeScript interfaces |
-| `TypedCreateRequest<D, M, Path>` | Options for `records.create()` |
-| `TypedCreateResponse<T>` | Response from `records.create()` -- `{ status, record: TypedRecord<T> }` |
-| `TypedQueryRequest` | Options for `records.query()` |
-| `TypedQueryResponse<T>` | Response from `records.query()` -- `{ status, records: TypedRecord<T>[], cursor? }` |
-| `TypedSubscribeResponse<T>` | Response from `records.subscribe()` -- `{ status, liveQuery: TypedLiveQuery<T> }` |
-| `Repository<D, M>` | Repository type -- structure-aware Proxy object with CRUD methods |
-| `DataForPath<D, M, Path>` | Resolves TypeScript data type for a protocol path from the schema map |
-| `EnboxConnectOptions` | Options for `Enbox.connect()` |
-| `EnboxConnectResult` | Return type of `Enbox.connect()` |
-| `RecordModel` | Structured data model of a record |
-| `RecordChangeType` | `'create' \| 'update' \| 'delete'` |
-| `RecordChange` | Change event payload `{ type, record }` |
+- [`@enbox/auth`](../auth): Auth lifecycle and session management.
+- [`@enbox/agent`](../agent): Agent runtime, local DWN, key management, sync.
+- [`@enbox/protocols`](../protocols): Ready-to-use protocol definitions.
+- [`@enbox/protocol-codegen`](../protocol-codegen): Type generation from protocol JSON.
 
 ## License
 


### PR DESCRIPTION
## Summary
- rewrite the root README into a shorter current overview with valid Enbox examples
- replace the long @enbox/api README with a compact developer-focused guide
- normalize public docs wording to Decentralized terminology

## Test plan
- [x] docs relative-link scan
- [x] git diff --check
- [x] bun run docs:build
- [x] bun run lint
- [x] bun run --filter @enbox/agent build
- [x] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node (packages/agent)