### PR TITLE
fix(dwn-sdk-js): avoid runtime Ajv for protocol tags

### DIFF
--- a/.changeset/dwn-sdk-csp-tags.md
+++ b/.changeset/dwn-sdk-csp-tags.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+fix(dwn-sdk-js): validate protocol tags without runtime Ajv compilation

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -5,8 +5,8 @@ import type { ProtocolDefinition, ProtocolRuleSet, ProtocolType, ProtocolTypes }
 
 import { ProtocolRecordLimitStrategy } from '../types/protocols-types.js';
 
-import Ajv from 'ajv/dist/2020.js';
 import { Records } from '../utils/records.js';
+import { validateProtocolTags } from '../utils/protocol-tags.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { getTypeName, parseCrossProtocolRef } from '../utils/protocols.js';
 
@@ -282,7 +282,7 @@ export function verifySizeLimit(
 }
 
 /**
- * Verifies record tags against the `$tags` schema in the rule set using JSON Schema (Ajv).
+ * Verifies record tags against the `$tags` schema in the rule set.
  * Checks required tags, additional properties, and schema conformance.
  */
 export function verifyTagsIfNeeded(
@@ -291,30 +291,13 @@ export function verifyTagsIfNeeded(
 ): void {
   if (ruleSet.$tags !== undefined) {
     const { tags = {}, protocol, protocolPath } = incomingMessage.message.descriptor;
+    const schemaError = validateProtocolTags(
+      ruleSet.$tags,
+      tags,
+      `${protocol}/${protocolPath}/$tags`,
+    );
 
-    const { $allowUndefinedTags, $requiredTags, ...properties } = ruleSet.$tags;
-
-    // if $allowUndefinedTags is set to false and there are properties not defined in the schema, an error is thrown
-    const additionalProperties = $allowUndefinedTags || false;
-
-    // if $requiredTags is set, all required tags must be present
-    const required = $requiredTags || [];
-
-    const ajv = new Ajv.default();
-    const compiledTags = ajv.compile({
-      type: 'object',
-      properties,
-      required,
-      additionalProperties,
-    });
-
-    const validSchema = compiledTags(tags);
-    if (!validSchema) {
-      // the `dataVar` is used to add a qualifier to the error message.
-      // For example. If the error is related to a tag `status` in a protocol `https://example.protocol` with the protocolPath `example/path`
-      // the error would be described as `https://example.protocol/example/path/$tags/status'
-      // without this decorator it would show up as `data/status` which may be confusing.
-      const schemaError = ajv.errorsText(compiledTags.errors, { dataVar: `${protocol}/${protocolPath}/$tags` });
+    if (schemaError !== undefined) {
       throw new DwnError(DwnErrorCode.ProtocolAuthorizationTagsInvalidSchema, `tags schema validation error: ${schemaError}`);
     }
   }

--- a/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
+++ b/packages/dwn-sdk-js/src/interfaces/protocols-configure.ts
@@ -7,12 +7,12 @@ import type {
 } from '../types/protocols-types.js';
 
 import { AbstractMessage } from '../core/abstract-message.js';
-import Ajv from 'ajv/dist/2020.js';
 import { DwnConstant } from '../core/dwn-constant.js';
 import { Message } from '../core/message.js';
 import { PermissionGrant } from '../protocols/permission-grant.js';
 import { ProtocolsGrantAuthorization } from '../core/protocols-grant-authorization.js';
 import { Time } from '../utils/time.js';
+import { validateProtocolTagSchemaDefinition } from '../utils/protocol-tags.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 import { isCrossProtocolRef, parseCrossProtocolRef } from '../utils/protocols.js';
@@ -265,16 +265,18 @@ export class ProtocolsConfigure extends AbstractMessage<ProtocolsConfigureMessag
       }
     }
 
-    if (ruleSet.$tags) {
-      const ajv = new Ajv.default();
+    if (ruleSet.$tags !== undefined) {
       const { $allowUndefinedTags, $requiredTags, ...tagProperties } = ruleSet.$tags;
 
-      // we validate each tag's expected schema to ensure it is a valid JSON schema
+      // validate each tag's schema against the DWN-supported tag schema subset
       for (const tag in tagProperties) {
         const tagSchemaDefinition = tagProperties[tag];
+        const schemaError = validateProtocolTagSchemaDefinition(
+          tagSchemaDefinition,
+          `${ruleSetProtocolPath}/$tags/${tag}`,
+        );
 
-        if (!ajv.validateSchema(tagSchemaDefinition as Record<string, unknown>)) {
-          const schemaError = ajv.errorsText(ajv.errors, { dataVar: `${ruleSetProtocolPath}/$tags/${tag}` });
+        if (schemaError !== undefined) {
           throw new DwnError(DwnErrorCode.ProtocolsConfigureInvalidTagSchema, `tags schema validation error: ${schemaError}`);
         }
       }

--- a/packages/dwn-sdk-js/src/utils/protocol-tags.ts
+++ b/packages/dwn-sdk-js/src/utils/protocol-tags.ts
@@ -1,0 +1,366 @@
+import type { ProtocolTagSchema, ProtocolTagsDefinition } from '../types/protocols-types.js';
+
+type TagSchema = ProtocolTagSchema | Record<string, unknown>;
+
+type TagValidationError = {
+  instancePath: string;
+  message: string;
+};
+
+const allowedTagTypes = new Set(['string', 'number', 'integer', 'boolean', 'array']);
+const allowedArrayItemTypes = new Set(['string', 'number', 'integer']);
+const numericConstraintKeywords = [ 'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum' ];
+const stringConstraintKeywords = [ 'minLength', 'maxLength' ];
+const arrayConstraintKeywords = [ 'minItems', 'maxItems', 'minContains', 'maxContains' ];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function pathSegment(segment: string | number): string {
+  return String(segment).replaceAll('~', '~0').replaceAll('/', '~1');
+}
+
+function appendPath(path: string, segment: string | number): string {
+  return `${path}/${pathSegment(segment)}`;
+}
+
+function hasOwnProperty(value: Record<string, unknown>, property: string): boolean {
+  return Object.hasOwn(value, property);
+}
+
+function addError(errors: TagValidationError[], instancePath: string, message: string): void {
+  errors.push({ instancePath, message });
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((value, index) => valuesEqual(value, right[index]));
+  }
+
+  if (isRecord(left) && isRecord(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+
+    return leftKeys.length === rightKeys.length
+      && leftKeys.every(key => Object.hasOwn(right, key) && valuesEqual(left[key], right[key]));
+  }
+
+  return false;
+}
+
+function getTagSchemas(tagsDefinition: ProtocolTagsDefinition): Record<string, TagSchema> {
+  const schemas: Record<string, TagSchema> = {};
+
+  for (const [ tag, schema ] of Object.entries(tagsDefinition)) {
+    if (tag === '$requiredTags' || tag === '$allowUndefinedTags') {
+      continue;
+    }
+
+    schemas[tag] = schema as TagSchema;
+  }
+
+  return schemas;
+}
+
+function validateSchemaConstraintTypes(
+  schema: Record<string, unknown>,
+  dataPath: string,
+  errors: TagValidationError[],
+): void {
+  if (schema.enum !== undefined) {
+    if (!Array.isArray(schema.enum) || schema.enum.length === 0) {
+      addError(errors, appendPath(dataPath, 'enum'), 'must be non-empty array');
+    }
+  }
+
+  for (const keyword of numericConstraintKeywords) {
+    if (schema[keyword] !== undefined && !isNumber(schema[keyword])) {
+      addError(errors, appendPath(dataPath, keyword), 'must be number');
+    }
+  }
+
+  for (const keyword of [ ...stringConstraintKeywords, ...arrayConstraintKeywords ]) {
+    if (schema[keyword] !== undefined && (!Number.isInteger(schema[keyword]) || (schema[keyword] as number) < 0)) {
+      addError(errors, appendPath(dataPath, keyword), 'must be integer');
+    }
+  }
+
+  if (schema.uniqueItems !== undefined && typeof schema.uniqueItems !== 'boolean') {
+    addError(errors, appendPath(dataPath, 'uniqueItems'), 'must be boolean');
+  }
+}
+
+function validateTagSubschemaDefinition(
+  schema: unknown,
+  dataPath: string,
+  allowedTypes: Set<string>,
+  errors: TagValidationError[],
+): void {
+  if (!isRecord(schema)) {
+    addError(errors, dataPath, 'must be object');
+    return;
+  }
+
+  if (schema.type !== undefined && (typeof schema.type !== 'string' || !allowedTypes.has(schema.type))) {
+    addError(errors, appendPath(dataPath, 'type'), 'must be equal to one of the allowed values');
+  }
+
+  validateSchemaConstraintTypes(schema, dataPath, errors);
+}
+
+/**
+ * Validates DWN protocol tag schema definitions without invoking Ajv's runtime compiler.
+ *
+ * The broader protocol message shape is already checked by the precompiled
+ * ProtocolRuleSet validator. This function covers the tag-schema constraints
+ * that are deliberately modeled as a small DWN subset rather than arbitrary
+ * JSON Schema.
+ */
+export function validateProtocolTagSchemaDefinition(
+  schema: unknown,
+  dataVar: string,
+): string | undefined {
+  const errors: TagValidationError[] = [];
+
+  validateTagSubschemaDefinition(schema, '', allowedTagTypes, errors);
+
+  if (isRecord(schema)) {
+    if (schema.items !== undefined) {
+      validateTagSubschemaDefinition(schema.items, '/items', allowedArrayItemTypes, errors);
+    }
+
+    if (schema.contains !== undefined) {
+      validateTagSubschemaDefinition(schema.contains, '/contains', allowedArrayItemTypes, errors);
+    }
+  }
+
+  return formatTagValidationErrors(errors, dataVar);
+}
+
+function validateType(type: unknown, value: unknown, dataPath: string, errors: TagValidationError[]): boolean {
+  switch (type) {
+  case undefined:
+    return true;
+  case 'string':
+    if (typeof value === 'string') {
+      return true;
+    }
+    addError(errors, dataPath, 'must be string');
+    return false;
+  case 'number':
+    if (isNumber(value)) {
+      return true;
+    }
+    addError(errors, dataPath, 'must be number');
+    return false;
+  case 'integer':
+    if (isNumber(value) && Number.isInteger(value)) {
+      return true;
+    }
+    addError(errors, dataPath, 'must be integer');
+    return false;
+  case 'boolean':
+    if (typeof value === 'boolean') {
+      return true;
+    }
+    addError(errors, dataPath, 'must be boolean');
+    return false;
+  case 'array':
+    if (Array.isArray(value)) {
+      return true;
+    }
+    addError(errors, dataPath, 'must be array');
+    return false;
+  default:
+    addError(errors, dataPath, 'must match a supported tag schema type');
+    return false;
+  }
+}
+
+function validateEnum(schema: Record<string, unknown>, value: unknown, dataPath: string, errors: TagValidationError[]): void {
+  if (Array.isArray(schema.enum) && !schema.enum.some(allowed => valuesEqual(allowed, value))) {
+    addError(errors, dataPath, 'must be equal to one of the allowed values');
+  }
+}
+
+function validateNumberConstraints(
+  schema: Record<string, unknown>,
+  value: unknown,
+  dataPath: string,
+  errors: TagValidationError[],
+): void {
+  if (!isNumber(value)) {
+    return;
+  }
+
+  if (isNumber(schema.minimum) && value < schema.minimum) {
+    addError(errors, dataPath, `must be >= ${schema.minimum}`);
+  }
+
+  if (isNumber(schema.maximum) && value > schema.maximum) {
+    addError(errors, dataPath, `must be <= ${schema.maximum}`);
+  }
+
+  if (isNumber(schema.exclusiveMinimum) && value <= schema.exclusiveMinimum) {
+    addError(errors, dataPath, `must be > ${schema.exclusiveMinimum}`);
+  }
+
+  if (isNumber(schema.exclusiveMaximum) && value >= schema.exclusiveMaximum) {
+    addError(errors, dataPath, `must be < ${schema.exclusiveMaximum}`);
+  }
+}
+
+function validateStringConstraints(
+  schema: Record<string, unknown>,
+  value: unknown,
+  dataPath: string,
+  errors: TagValidationError[],
+): void {
+  if (typeof value !== 'string') {
+    return;
+  }
+
+  if (Number.isInteger(schema.minLength) && value.length < (schema.minLength as number)) {
+    addError(errors, dataPath, `must NOT have fewer than ${schema.minLength} characters`);
+  }
+
+  if (Number.isInteger(schema.maxLength) && value.length > (schema.maxLength as number)) {
+    addError(errors, dataPath, `must NOT have more than ${schema.maxLength} characters`);
+  }
+}
+
+function validateArrayConstraints(
+  schema: Record<string, unknown>,
+  value: unknown,
+  dataPath: string,
+  errors: TagValidationError[],
+): void {
+  if (!Array.isArray(value)) {
+    return;
+  }
+
+  if (Number.isInteger(schema.minItems) && value.length < (schema.minItems as number)) {
+    addError(errors, dataPath, `must NOT have fewer than ${schema.minItems} items`);
+  }
+
+  if (Number.isInteger(schema.maxItems) && value.length > (schema.maxItems as number)) {
+    addError(errors, dataPath, `must NOT have more than ${schema.maxItems} items`);
+  }
+
+  if (schema.uniqueItems === true) {
+    for (let i = 0; i < value.length; i++) {
+      for (let j = i + 1; j < value.length; j++) {
+        if (valuesEqual(value[i], value[j])) {
+          addError(errors, dataPath, 'must NOT have duplicate items');
+          return;
+        }
+      }
+    }
+  }
+}
+
+function validateTagValue(
+  schema: unknown,
+  value: unknown,
+  dataPath: string,
+  errors: TagValidationError[],
+): void {
+  if (!isRecord(schema)) {
+    addError(errors, dataPath, 'must match a supported tag schema');
+    return;
+  }
+
+  const validType = validateType(schema.type, value, dataPath, errors);
+  if (!validType) {
+    return;
+  }
+
+  validateEnum(schema, value, dataPath, errors);
+  validateNumberConstraints(schema, value, dataPath, errors);
+  validateStringConstraints(schema, value, dataPath, errors);
+  validateArrayConstraints(schema, value, dataPath, errors);
+
+  if (Array.isArray(value) && isRecord(schema.items)) {
+    value.forEach((item, index) => validateTagValue(schema.items, item, appendPath(dataPath, index), errors));
+  }
+
+  if (Array.isArray(value) && isRecord(schema.contains)) {
+    validateContains(schema, value, dataPath, errors);
+  }
+}
+
+function validateContains(
+  schema: Record<string, unknown>,
+  value: unknown[],
+  dataPath: string,
+  errors: TagValidationError[],
+): void {
+  const minimumCount = Number.isInteger(schema.minContains) ? schema.minContains as number : 1;
+  const maximumCount = Number.isInteger(schema.maxContains) ? schema.maxContains as number : undefined;
+  const validItemCount = value.filter(item => {
+    const itemErrors: TagValidationError[] = [];
+    validateTagValue(schema.contains, item, dataPath, itemErrors);
+    return itemErrors.length === 0;
+  }).length;
+
+  if (validItemCount < minimumCount || (maximumCount !== undefined && validItemCount > maximumCount)) {
+    const message = maximumCount === undefined
+      ? `must contain at least ${minimumCount} valid item(s)`
+      : `must contain at least ${minimumCount} and no more than ${maximumCount} valid item(s)`;
+    addError(errors, dataPath, message);
+  }
+}
+
+/**
+ * Validates a record's `descriptor.tags` against a protocol rule set `$tags` definition.
+ */
+export function validateProtocolTags(
+  tagsDefinition: ProtocolTagsDefinition,
+  tags: Record<string, unknown>,
+  dataVar: string,
+): string | undefined {
+  const errors: TagValidationError[] = [];
+  const tagSchemas = getTagSchemas(tagsDefinition);
+  const requiredTags = Array.isArray(tagsDefinition.$requiredTags) ? tagsDefinition.$requiredTags : [];
+
+  for (const requiredTag of requiredTags) {
+    if (!hasOwnProperty(tags, requiredTag)) {
+      addError(errors, '', `must have required property '${requiredTag}'`);
+    }
+  }
+
+  if (tagsDefinition.$allowUndefinedTags !== true) {
+    for (const tag of Object.keys(tags)) {
+      if (tagSchemas[tag] === undefined) {
+        addError(errors, '', 'must NOT have additional properties');
+      }
+    }
+  }
+
+  for (const [ tag, schema ] of Object.entries(tagSchemas)) {
+    if (hasOwnProperty(tags, tag)) {
+      validateTagValue(schema, tags[tag], appendPath('', tag), errors);
+    }
+  }
+
+  return formatTagValidationErrors(errors, dataVar);
+}
+
+function formatTagValidationErrors(errors: TagValidationError[], dataVar: string): string | undefined {
+  if (errors.length === 0) {
+    return undefined;
+  }
+
+  return errors
+    .map(error => `${dataVar}${error.instancePath} ${error.message}`)
+    .join(', ');
+}

--- a/packages/dwn-sdk-js/tests/utils/protocol-tags.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/protocol-tags.spec.ts
@@ -1,0 +1,124 @@
+import type { RecordsWrite } from '../../src/interfaces/records-write.js';
+import type { ProtocolDefinition, ProtocolRuleSet } from '../../src/types/protocols-types.js';
+
+import { Jws } from '../../src/utils/jws.js';
+import { ProtocolsConfigure } from '../../src/interfaces/protocols-configure.js';
+import { TestDataGenerator } from './test-data-generator.js';
+import { verifyTagsIfNeeded } from '../../src/core/protocol-authorization-validation.js';
+import { describe, expect, it } from 'bun:test';
+import { validateProtocolTags, validateProtocolTagSchemaDefinition } from '../../src/utils/protocol-tags.js';
+
+async function withBlockedFunction<T>(callback: () => T | Promise<T>): Promise<T> {
+  const originalFunction = globalThis.Function;
+  const mutableGlobal = globalThis as { Function: FunctionConstructor };
+
+  mutableGlobal.Function = function blockedFunction(): never {
+    throw new Error('Function constructor blocked by CSP');
+  } as unknown as FunctionConstructor;
+
+  try {
+    return await callback();
+  } finally {
+    mutableGlobal.Function = originalFunction;
+  }
+}
+
+function stubRecordsWrite(ruleSetProtocolPath: string, tags: Record<string, unknown>): RecordsWrite {
+  return {
+    message: {
+      descriptor: {
+        protocol     : 'https://example.com/protocol',
+        protocolPath : ruleSetProtocolPath,
+        tags,
+      },
+    },
+  } as unknown as RecordsWrite;
+}
+
+describe('protocol tag validation', () => {
+  it('validates tag schema definitions without runtime code generation', async () => {
+    const schemaError = await withBlockedFunction(() => validateProtocolTagSchemaDefinition(
+      {
+        type     : 'array',
+        contains : {
+          type    : 'number',
+          minimum : 'ten',
+        },
+      },
+      'foo/$tags/score',
+    ));
+
+    expect(schemaError).toBe('foo/$tags/score/contains/minimum must be number');
+  });
+
+  it('validates record tags without runtime code generation', async () => {
+    const schemaError = await withBlockedFunction(() => validateProtocolTags(
+      {
+        $requiredTags       : [ 'status' ],
+        $allowUndefinedTags : false,
+        status              : {
+          type : 'string',
+          enum : [ 'draft', 'published' ],
+        },
+      },
+      {
+        status : 'archived',
+        extra  : true,
+      },
+      'https://example.com/protocol/foo/$tags',
+    ));
+
+    expect(schemaError).toContain('https://example.com/protocol/foo/$tags must NOT have additional properties');
+    expect(schemaError).toContain('https://example.com/protocol/foo/$tags/status must be equal to one of the allowed values');
+  });
+
+  it('allows ProtocolsConfigure.create with tag schemas when unsafe-eval is unavailable', async () => {
+    const alice = await TestDataGenerator.generatePersona();
+    const protocolDefinition: ProtocolDefinition = {
+      protocol  : 'https://example.com/protocol',
+      published : true,
+      types     : {
+        foo: {},
+      },
+      structure: {
+        foo: {
+          $tags: {
+            status: {
+              type : 'string',
+              enum : [ 'draft', 'published' ],
+            },
+          },
+        },
+      },
+    };
+
+    const protocolsConfigure = await withBlockedFunction(() => ProtocolsConfigure.create({
+      definition : protocolDefinition,
+      signer     : Jws.createSigner(alice),
+    }));
+
+    expect(protocolsConfigure.message.descriptor.definition).toBeDefined();
+  });
+
+  it('allows protocol authorization tag checks when unsafe-eval is unavailable', async () => {
+    const ruleSet: ProtocolRuleSet = {
+      $tags: {
+        score: {
+          type    : 'number',
+          minimum : 0,
+          maximum : 100,
+        },
+      },
+    };
+
+    await withBlockedFunction(() => verifyTagsIfNeeded(
+      stubRecordsWrite('foo', { score: 42 }),
+      ruleSet,
+    ));
+
+    await expect(withBlockedFunction(() => verifyTagsIfNeeded(
+      stubRecordsWrite('foo', { score: 101 }),
+      ruleSet,
+    ))).rejects.toThrow('https://example.com/protocol/foo/$tags/score must be <= 100');
+  });
+});


### PR DESCRIPTION
## Summary
- replace runtime Ajv usage for protocol tag schema checks with a CSP-safe validator for the DWN tag schema subset
- use the same CSP-safe path when authorizing record tags against protocol `$tags` rules
- add regression tests that block `globalThis.Function` to simulate pages without `unsafe-eval`
- add a patch changeset for `@enbox/dwn-sdk-js`

## Notes
- Ajv remains only in the existing build-time precompiler and JSON-schema tests. Runtime `src` and built ESM source no longer import or compile Ajv for protocol tags.
- The browser bundle still contains the existing precompiled-validator `ajv/dist/runtime/ucs2length` helper string/import, but that path is a static helper for generated validators, not runtime schema compilation.

## Verification
- `bun run build`
- `bun run --filter @enbox/dwn-sdk-js lint`
- `bun run --filter @enbox/dwn-sdk-js build`
- `bun run --filter @enbox/dwn-sdk-js test:node`
- `bun run --filter @enbox/dwn-sdk-js test:browser`
- `git diff --check`
- runtime source search for `new Ajv`, `ajv.compile`, and `ajv/dist/2020` in `packages/dwn-sdk-js/src` and built ESM source
