### PR TITLE
fix(ci): dispatch release PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_pr_number:
+        description: "Version packages PR number that requested this CI run"
+        required: false
+        type: string
   workflow_call:
 
 permissions:
@@ -12,8 +18,8 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.release_pr_number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event.inputs.release_pr_number != '' }}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -51,6 +57,7 @@ jobs:
         uses: dorny/paths-filter@v3
         id: src-filter
         with:
+          base: main
           predicate-quantifier: 'every'
           filters: |
             src:
@@ -65,6 +72,7 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          base: main
           filters: |
             workspace:
               - 'package.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       id-token: write
@@ -96,3 +97,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # bun publish reads the npm token from bunfig or NPM_CONFIG_TOKEN
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Dispatch CI for version PR
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: changeset-release/${{ github.ref_name }}
+          RELEASE_PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: |
+          echo "Dispatching CI for version PR #${RELEASE_PR_NUMBER} on ${RELEASE_BRANCH}"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/dispatches" \
+            --method POST \
+            -f ref="${RELEASE_BRANCH}" \
+            -f "inputs[release_pr_number]=${RELEASE_PR_NUMBER}"


### PR DESCRIPTION
Summary
- Add manual dispatch support to CI with release PR-aware concurrency.
- Have the release workflow explicitly dispatch CI for the version packages branch after changesets/action creates or updates the PR.
- Compare dispatched CI runs against main for path filtering so release-branch validation exercises the version PR diff.

Test plan
- [x] bunx js-yaml .github/workflows/ci.yml >/dev/null && bunx js-yaml .github/workflows/release.yml >/dev/null
- [x] go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml
- [x] git diff --check
- [x] bun run lint
- [x] bun run build
- [x] bun run --filter @enbox/agent build
- [x] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node (from packages/agent)