### PR TITLE
Harden remote DWN setup retries in agent e2e tests

### DIFF
--- a/.changeset/silver-sync-trees.md
+++ b/.changeset/silver-sync-trees.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Surface one-shot sync failures when remote DWN reconciliation fails.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -952,17 +952,22 @@ export class SyncEngineLevel implements SyncEngine {
         group.push(target);
       }
 
-      const results = await Promise.allSettled([...byUrl.entries()].map(([dwnUrl, targets]) =>
-        this.syncTargetGroup(dwnUrl, targets, direction, options)
-      ));
+      const results = await Promise.allSettled([...byUrl.entries()].map(async ([dwnUrl, targets]) => ({
+        dwnUrl,
+        succeeded: await this.syncTargetGroup(dwnUrl, targets, direction, options),
+      })));
 
       let groupsSucceeded = 0;
       let groupsFailed = 0;
+      const failedUrls: string[] = [];
       for (const result of results) {
-        if (result.status === 'fulfilled' && result.value) {
+        if (result.status === 'fulfilled' && result.value.succeeded) {
           groupsSucceeded++;
         } else {
           groupsFailed++;
+          if (result.status === 'fulfilled') {
+            failedUrls.push(result.value.dwnUrl);
+          }
         }
       }
 
@@ -980,6 +985,13 @@ export class SyncEngineLevel implements SyncEngine {
         // No target required work.
         this._consecutiveFailures = 0;
         this._connectivityState = 'online';
+      }
+
+      if (groupsFailed > 0) {
+        throw new Error(
+          `SyncEngineLevel: Sync operation failed for ${groupsFailed} remote endpoint(s)`
+          + (failedUrls.length > 0 ? `: ${failedUrls.join(', ')}` : '.')
+        );
       }
     } finally {
       this._syncLock = false;
@@ -1146,7 +1158,11 @@ export class SyncEngineLevel implements SyncEngine {
 
     // Initiate an immediate sync.
     if (!this._syncLock) {
-      await this.sync(undefined, { verifyConvergence: true });
+      try {
+        await this.sync(undefined, { verifyConvergence: true });
+      } catch (error) {
+        console.error('SyncEngineLevel: Error during initial poll sync', error);
+      }
     }
   }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -105,8 +105,10 @@ type SyncReconcileTarget = {
   authorization: SyncAuthorization;
 };
 
+type SyncDirection = 'push' | 'pull';
+
 type SyncReconcileOptions = {
-  direction?: 'push' | 'pull';
+  direction?: SyncDirection;
   verifyConvergence?: boolean;
 };
 
@@ -942,7 +944,7 @@ export class SyncEngineLevel implements SyncEngine {
   // One-shot sync (durable feed reconciliation)
   // ---------------------------------------------------------------------------
 
-  public async sync(direction?: 'push' | 'pull', options?: SyncRunOptions): Promise<void> {
+  public async sync(direction?: SyncDirection, options?: SyncRunOptions): Promise<void> {
     if (this._syncLock) {
       throw new Error('SyncEngineLevel: Sync operation is already in progress.');
     }
@@ -960,7 +962,7 @@ export class SyncEngineLevel implements SyncEngine {
 
   private async syncTargetGroups(
     syncTargets: SyncTarget[],
-    direction: 'push' | 'pull' | undefined,
+    direction: SyncDirection | undefined,
     options: SyncRunOptions | undefined,
   ): Promise<SyncTargetGroupSummary> {
     // Group targets by remote endpoint so each URL group can be reconciled
@@ -988,7 +990,7 @@ export class SyncEngineLevel implements SyncEngine {
   private async syncTargetGroupWithUrl(
     dwnUrl: string,
     targets: SyncTarget[],
-    direction: 'push' | 'pull' | undefined,
+    direction: SyncDirection | undefined,
     options: SyncRunOptions | undefined,
   ): Promise<SyncTargetGroupRunResult> {
     return {
@@ -1075,7 +1077,7 @@ export class SyncEngineLevel implements SyncEngine {
   private async syncTargetGroup(
     dwnUrl: string,
     targets: SyncTarget[],
-    direction: 'push' | 'pull' | undefined,
+    direction: SyncDirection | undefined,
     options: SyncRunOptions | undefined,
   ): Promise<boolean> {
     for (const target of targets) {
@@ -1093,7 +1095,7 @@ export class SyncEngineLevel implements SyncEngine {
 
   private async syncSingleTarget(
     target: SyncTarget,
-    direction: 'push' | 'pull' | undefined,
+    direction: SyncDirection | undefined,
     options: SyncRunOptions | undefined,
   ): Promise<void> {
     const result = await this.syncTargetWithDurableFeeds(target, {

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -133,6 +133,17 @@ type SyncReconcileResult = {
   remoteFingerprint?: string;
 };
 
+type SyncTargetGroupRunResult = {
+  dwnUrl: string;
+  succeeded: boolean;
+};
+
+type SyncTargetGroupSummary = {
+  failedUrls: string[];
+  groupsFailed: number;
+  groupsSucceeded: number;
+};
+
 type FeedConvergenceFailureState = {
   attempts: number;
   signature: string;
@@ -938,64 +949,127 @@ export class SyncEngineLevel implements SyncEngine {
 
     this._syncLock = true;
     try {
-      // Group targets by remote endpoint so each URL group can be reconciled
-      // concurrently. Within a group, targets are processed sequentially so
-      // that a single network failure skips the rest of that group.
       const syncTargets = await this.getSyncTargets();
-      const byUrl = new Map<string, typeof syncTargets>();
-      for (const target of syncTargets) {
-        let group = byUrl.get(target.dwnUrl);
-        if (!group) {
-          group = [];
-          byUrl.set(target.dwnUrl, group);
-        }
-        group.push(target);
-      }
-
-      const results = await Promise.allSettled([...byUrl.entries()].map(async ([dwnUrl, targets]) => ({
-        dwnUrl,
-        succeeded: await this.syncTargetGroup(dwnUrl, targets, direction, options),
-      })));
-
-      let groupsSucceeded = 0;
-      let groupsFailed = 0;
-      const failedUrls: string[] = [];
-      for (const result of results) {
-        if (result.status === 'fulfilled' && result.value.succeeded) {
-          groupsSucceeded++;
-        } else {
-          groupsFailed++;
-          if (result.status === 'fulfilled') {
-            failedUrls.push(result.value.dwnUrl);
-          }
-        }
-      }
-
-      // Track connectivity based on per-group outcomes. If at least one
-      // group succeeded, stay online — partial reachability is still online.
-      if (groupsSucceeded > 0) {
-        this._consecutiveFailures = 0;
-        this._connectivityState = 'online';
-      } else if (groupsFailed > 0) {
-        this._consecutiveFailures++;
-        if (this._connectivityState === 'online') {
-          this._connectivityState = 'offline';
-        }
-      } else if (syncTargets.length > 0) {
-        // No target required work.
-        this._consecutiveFailures = 0;
-        this._connectivityState = 'online';
-      }
-
-      if (groupsFailed > 0) {
-        throw new Error(
-          `SyncEngineLevel: Sync operation failed for ${groupsFailed} remote endpoint(s)`
-          + (failedUrls.length > 0 ? `: ${failedUrls.join(', ')}` : '.')
-        );
-      }
+      const groupSummary = await this.syncTargetGroups(syncTargets, direction, options);
+      this.updateConnectivityAfterSync(syncTargets.length, groupSummary);
+      SyncEngineLevel.assertSyncTargetGroupsSucceeded(groupSummary);
     } finally {
       this._syncLock = false;
     }
+  }
+
+  private async syncTargetGroups(
+    syncTargets: SyncTarget[],
+    direction: 'push' | 'pull' | undefined,
+    options: SyncRunOptions | undefined,
+  ): Promise<SyncTargetGroupSummary> {
+    // Group targets by remote endpoint so each URL group can be reconciled
+    // concurrently. Within a group, targets are processed sequentially so
+    // that a single network failure skips the rest of that group.
+    const byUrl = SyncEngineLevel.groupSyncTargetsByDwnUrl(syncTargets);
+    const results = await Promise.allSettled([...byUrl.entries()].map(([dwnUrl, targets]) =>
+      this.syncTargetGroupWithUrl(dwnUrl, targets, direction, options)
+    ));
+
+    return SyncEngineLevel.summarizeSyncTargetGroupResults(results);
+  }
+
+  private static groupSyncTargetsByDwnUrl(syncTargets: SyncTarget[]): Map<string, SyncTarget[]> {
+    const byUrl = new Map<string, SyncTarget[]>();
+    for (const target of syncTargets) {
+      const group = byUrl.get(target.dwnUrl) ?? [];
+      group.push(target);
+      byUrl.set(target.dwnUrl, group);
+    }
+
+    return byUrl;
+  }
+
+  private async syncTargetGroupWithUrl(
+    dwnUrl: string,
+    targets: SyncTarget[],
+    direction: 'push' | 'pull' | undefined,
+    options: SyncRunOptions | undefined,
+  ): Promise<SyncTargetGroupRunResult> {
+    return {
+      dwnUrl,
+      succeeded: await this.syncTargetGroup(dwnUrl, targets, direction, options),
+    };
+  }
+
+  private static summarizeSyncTargetGroupResults(
+    results: PromiseSettledResult<SyncTargetGroupRunResult>[]
+  ): SyncTargetGroupSummary {
+    const summary: SyncTargetGroupSummary = {
+      failedUrls      : [],
+      groupsFailed    : 0,
+      groupsSucceeded : 0,
+    };
+
+    for (const result of results) {
+      SyncEngineLevel.countSyncTargetGroupResult(summary, result);
+    }
+
+    return summary;
+  }
+
+  private static countSyncTargetGroupResult(
+    summary: SyncTargetGroupSummary,
+    result: PromiseSettledResult<SyncTargetGroupRunResult>
+  ): void {
+    if (result.status === 'rejected') {
+      summary.groupsFailed++;
+      return;
+    }
+
+    if (result.value.succeeded) {
+      summary.groupsSucceeded++;
+      return;
+    }
+
+    summary.groupsFailed++;
+    summary.failedUrls.push(result.value.dwnUrl);
+  }
+
+  private updateConnectivityAfterSync(syncTargetCount: number, summary: SyncTargetGroupSummary): void {
+    // If at least one group succeeded, stay online — partial reachability is still online.
+    if (summary.groupsSucceeded > 0) {
+      this.recordSyncSuccess();
+      return;
+    }
+
+    if (summary.groupsFailed > 0) {
+      this.recordSyncFailure();
+      return;
+    }
+
+    // No target required work.
+    if (syncTargetCount > 0) {
+      this.recordSyncSuccess();
+    }
+  }
+
+  private recordSyncSuccess(): void {
+    this._consecutiveFailures = 0;
+    this._connectivityState = 'online';
+  }
+
+  private recordSyncFailure(): void {
+    this._consecutiveFailures++;
+    if (this._connectivityState === 'online') {
+      this._connectivityState = 'offline';
+    }
+  }
+
+  private static assertSyncTargetGroupsSucceeded(summary: SyncTargetGroupSummary): void {
+    if (summary.groupsFailed === 0) {
+      return;
+    }
+
+    throw new Error(
+      `SyncEngineLevel: Sync operation failed for ${summary.groupsFailed} remote endpoint(s)`
+      + (summary.failedUrls.length > 0 ? `: ${summary.failedUrls.join(', ')}` : '.')
+    );
   }
 
   private async syncTargetGroup(

--- a/packages/agent/tests/e2e-delegate-cross-device.spec.ts
+++ b/packages/agent/tests/e2e-delegate-cross-device.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import type { BearerIdentity } from '../src/bearer-identity.js';
+import type { DwnRpcRequest, DwnRpcResponse } from '@enbox/dwn-clients';
 import type { ProtocolDefinition, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 
 import { Convert } from '@enbox/common';
@@ -25,6 +26,7 @@ import { AgentPermissionsApi } from '../src/permissions-api.js';
 import { DwnInterface } from '../src/types/dwn.js';
 import { EnboxConnectProtocol } from '../src/enbox-connect-protocol.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
+import { retryFreshDidResolution } from './utils/remote-dwn-retry.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
 
@@ -102,6 +104,22 @@ describe('e2e: cross-device delegate multi-party context key delivery', () => {
       testDwnUrls : [testDwnUrl],
     });
   });
+
+  async function sendRemoteSetupRequest(
+    request: DwnRpcRequest
+  ): Promise<DwnRpcResponse> {
+    const reply = await retryFreshDidResolution(
+      () => ownerHarness.agent.rpc.sendDwnRequest(request)
+    );
+
+    if (![202, 409].includes(reply.status.code)) {
+      throw new Error(
+        `Remote setup request failed: ${reply.status.code} ${reply.status.detail ?? ''}`
+      );
+    }
+
+    return reply;
+  }
 
   /**
    * Simulates the wallet-connect flow:
@@ -243,7 +261,7 @@ describe('e2e: cross-device delegate multi-party context key delivery', () => {
       messageParams : { filter: { protocol: 'https://identity.foundation/protocols/key-delivery' } },
     });
     if (kdProto.entries?.[0]) {
-      await ownerHarness.agent.rpc.sendDwnRequest({
+      await sendRemoteSetupRequest({
         dwnUrl    : testDwnUrl,
         targetDid : ownerDid,
         message   : kdProto.entries[0] as any,
@@ -258,7 +276,7 @@ describe('e2e: cross-device delegate multi-party context key delivery', () => {
       messageParams : { filter: { protocol: chatProtocol.protocol } },
     });
     if (protoReply.entries?.[0]) {
-      await ownerHarness.agent.rpc.sendDwnRequest({
+      await sendRemoteSetupRequest({
         dwnUrl    : testDwnUrl,
         targetDid : ownerDid,
         message   : protoReply.entries[0] as any,
@@ -409,7 +427,7 @@ describe('e2e: cross-device delegate multi-party context key delivery', () => {
             });
             if (rr.entry?.recordsWrite && rr.entry?.data) {
               const bytes = await DataStream.toBytes(rr.entry.data);
-              await ownerHarness.agent.rpc.sendDwnRequest({
+              await sendRemoteSetupRequest({
                 dwnUrl    : testDwnUrl,
                 targetDid : ownerDid,
                 message   : rr.entry.recordsWrite as any,
@@ -970,7 +988,7 @@ describe('e2e: cross-device delegate multi-party context key delivery', () => {
         messageParams : { filter: { protocol: 'https://identity.foundation/protocols/key-delivery' } },
       });
       if (kdProto.entries?.[0]) {
-        await ownerHarness.agent.rpc.sendDwnRequest({
+        await sendRemoteSetupRequest({
           dwnUrl    : testDwnUrl,
           targetDid : ownerDid,
           message   : kdProto.entries[0] as any,

--- a/packages/agent/tests/e2e-encrypted-sync.spec.ts
+++ b/packages/agent/tests/e2e-encrypted-sync.spec.ts
@@ -114,13 +114,20 @@ describe('e2e: encrypted data survives sync round-trip', () => {
 
   async function syncPushUntilRemoteRecordCount(expectedCount: number): Promise<RecordsQueryReply> {
     let lastReply: RecordsQueryReply | undefined;
+    let lastSyncError: unknown;
 
     for (let attempt = 0; attempt <= syncConvergenceRetryDelaysMs.length; attempt++) {
       if (attempt > 0) {
         await sleep(syncConvergenceRetryDelaysMs[attempt - 1]);
       }
 
-      await syncEngine.sync('push');
+      try {
+        await syncEngine.sync('push');
+        lastSyncError = undefined;
+      } catch (error) {
+        lastSyncError = error;
+      }
+
       lastReply = await queryRemoteEncryptedNotes();
       if (lastReply.status.code === 200 && (lastReply.entries?.length ?? 0) === expectedCount) {
         return lastReply;
@@ -129,19 +136,27 @@ describe('e2e: encrypted data survives sync round-trip', () => {
 
     throw new Error(
       `Remote encrypted notes did not converge: ${lastReply?.status.code ?? 'no status'} `
-      + `${lastReply?.status.detail ?? ''}; entries=${lastReply?.entries?.length ?? 0}`
+      + `${lastReply?.status.detail ?? ''}; entries=${lastReply?.entries?.length ?? 0}; `
+      + `lastSyncError=${lastSyncError instanceof Error ? lastSyncError.message : 'none'}`
     );
   }
 
   async function syncPullUntilLocalRecordCount(expectedCount: number): Promise<RecordsQueryReply> {
     let lastReply: RecordsQueryReply | undefined;
+    let lastSyncError: unknown;
 
     for (let attempt = 0; attempt <= syncConvergenceRetryDelaysMs.length; attempt++) {
       if (attempt > 0) {
         await sleep(syncConvergenceRetryDelaysMs[attempt - 1]);
       }
 
-      await syncEngine.sync('pull');
+      try {
+        await syncEngine.sync('pull');
+        lastSyncError = undefined;
+      } catch (error) {
+        lastSyncError = error;
+      }
+
       lastReply = await queryLocalEncryptedNotes();
       if (lastReply.status.code === 200 && (lastReply.entries?.length ?? 0) === expectedCount) {
         return lastReply;
@@ -150,7 +165,8 @@ describe('e2e: encrypted data survives sync round-trip', () => {
 
     throw new Error(
       `Local encrypted notes did not converge after pull: ${lastReply?.status.code ?? 'no status'} `
-      + `${lastReply?.status.detail ?? ''}; entries=${lastReply?.entries?.length ?? 0}`
+      + `${lastReply?.status.detail ?? ''}; entries=${lastReply?.entries?.length ?? 0}; `
+      + `lastSyncError=${lastSyncError instanceof Error ? lastSyncError.message : 'none'}`
     );
   }
 

--- a/packages/agent/tests/e2e-encrypted-sync.spec.ts
+++ b/packages/agent/tests/e2e-encrypted-sync.spec.ts
@@ -1,5 +1,5 @@
 import type { BearerIdentity } from '../src/bearer-identity.js';
-import type { ProtocolDefinition, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
+import type { ProtocolDefinition, RecordsQueryReply, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 
 import { DataStream } from '@enbox/dwn-sdk-js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
@@ -7,12 +7,18 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { DwnInterface } from '../src/types/dwn.js';
 import { EnboxUserAgent } from '../src/enbox-user-agent.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
+import { retryFreshDidResolution } from './utils/remote-dwn-retry.js';
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
 import { JwkProtocolDefinition, KeyDeliveryProtocolDefinition } from '../src/store-data-protocols.js';
 
 const testDwnUrls: string[] = [testDwnUrl];
+const syncConvergenceRetryDelaysMs = [500, 1_000, 2_000, 4_000, 8_000, 16_000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 /**
  * End-to-end tests for encrypted data through sync, agent lifecycle with
@@ -74,6 +80,80 @@ describe('e2e: encrypted data survives sync round-trip', () => {
     await testHarness.closeStorage();
   });
 
+  async function queryRemoteEncryptedNotes(): Promise<RecordsQueryReply> {
+    const { reply } = await retryFreshDidResolution(() => testHarness.agent.dwn.sendRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: {
+          protocol     : encryptedNoteProtocol.protocol,
+          protocolPath : 'note',
+        }
+      },
+    }));
+
+    return reply;
+  }
+
+  async function queryLocalEncryptedNotes(): Promise<RecordsQueryReply> {
+    const { reply } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: {
+          protocol     : encryptedNoteProtocol.protocol,
+          protocolPath : 'note',
+        }
+      },
+    });
+
+    return reply;
+  }
+
+  async function syncPushUntilRemoteRecordCount(expectedCount: number): Promise<RecordsQueryReply> {
+    let lastReply: RecordsQueryReply | undefined;
+
+    for (let attempt = 0; attempt <= syncConvergenceRetryDelaysMs.length; attempt++) {
+      if (attempt > 0) {
+        await sleep(syncConvergenceRetryDelaysMs[attempt - 1]);
+      }
+
+      await syncEngine.sync('push');
+      lastReply = await queryRemoteEncryptedNotes();
+      if (lastReply.status.code === 200 && (lastReply.entries?.length ?? 0) === expectedCount) {
+        return lastReply;
+      }
+    }
+
+    throw new Error(
+      `Remote encrypted notes did not converge: ${lastReply?.status.code ?? 'no status'} `
+      + `${lastReply?.status.detail ?? ''}; entries=${lastReply?.entries?.length ?? 0}`
+    );
+  }
+
+  async function syncPullUntilLocalRecordCount(expectedCount: number): Promise<RecordsQueryReply> {
+    let lastReply: RecordsQueryReply | undefined;
+
+    for (let attempt = 0; attempt <= syncConvergenceRetryDelaysMs.length; attempt++) {
+      if (attempt > 0) {
+        await sleep(syncConvergenceRetryDelaysMs[attempt - 1]);
+      }
+
+      await syncEngine.sync('pull');
+      lastReply = await queryLocalEncryptedNotes();
+      if (lastReply.status.code === 200 && (lastReply.entries?.length ?? 0) === expectedCount) {
+        return lastReply;
+      }
+    }
+
+    throw new Error(
+      `Local encrypted notes did not converge after pull: ${lastReply?.status.code ?? 'no status'} `
+      + `${lastReply?.status.detail ?? ''}; entries=${lastReply?.entries?.length ?? 0}`
+    );
+  }
+
   it('should install the encrypted protocol locally with $encryption keys', async () => {
     // Configure the protocol locally with encryption enabled.
     const { reply } = await testHarness.agent.dwn.processRequest({
@@ -118,17 +198,7 @@ describe('e2e: encrypted data survives sync round-trip', () => {
     }
 
     // Verify records exist locally with encryption metadata.
-    const { reply: queryReply } = await testHarness.agent.dwn.processRequest({
-      author        : alice.did.uri,
-      target        : alice.did.uri,
-      messageType   : DwnInterface.RecordsQuery,
-      messageParams : {
-        filter: {
-          protocol     : encryptedNoteProtocol.protocol,
-          protocolPath : 'note',
-        }
-      },
-    });
+    const queryReply = await queryLocalEncryptedNotes();
     expect(queryReply.entries).toHaveLength(3);
     for (const entry of queryReply.entries!) {
       expect(entry.encryption).toBeDefined();
@@ -139,20 +209,9 @@ describe('e2e: encrypted data survives sync round-trip', () => {
   it('should push encrypted records to the remote DWN', async () => {
     // Register identity and push to remote.
     await testHarness.agent.sync.registerIdentity({ did: alice.did.uri, options: { protocols: 'all' } });
-    await syncEngine.sync('push');
 
     // Verify records exist on the remote DWN.
-    const { reply: remoteQueryReply } = await testHarness.agent.dwn.sendRequest({
-      author        : alice.did.uri,
-      target        : alice.did.uri,
-      messageType   : DwnInterface.RecordsQuery,
-      messageParams : {
-        filter: {
-          protocol     : encryptedNoteProtocol.protocol,
-          protocolPath : 'note',
-        }
-      },
-    });
+    const remoteQueryReply = await syncPushUntilRemoteRecordCount(3);
     expect(remoteQueryReply.status.code).toBe(200);
     expect(remoteQueryReply.entries).toHaveLength(3);
 
@@ -161,7 +220,7 @@ describe('e2e: encrypted data survives sync round-trip', () => {
       expect(entry.encryption).toBeDefined();
       expect(entry.encryption!.protected).toBeDefined();
     }
-  }, 30_000);
+  }, 60_000);
 
   it('should clear local DWN data and pull back encrypted records', async () => {
     // Clear local DWN stores (simulating a fresh device), but keep the agent
@@ -172,53 +231,20 @@ describe('e2e: encrypted data survives sync round-trip', () => {
     testHarness.dwnStores.clear();
 
     // Verify local is now empty.
-    const { reply: localBefore } = await testHarness.agent.dwn.processRequest({
-      author        : alice.did.uri,
-      target        : alice.did.uri,
-      messageType   : DwnInterface.RecordsQuery,
-      messageParams : {
-        filter: {
-          protocol     : encryptedNoteProtocol.protocol,
-          protocolPath : 'note',
-        }
-      },
-    });
+    const localBefore = await queryLocalEncryptedNotes();
     expect(localBefore.entries).toHaveLength(0);
 
-    // Pull from remote.
-    await syncEngine.sync('pull');
-
     // Verify the encrypted records were pulled back.
-    const { reply: localAfter } = await testHarness.agent.dwn.processRequest({
-      author        : alice.did.uri,
-      target        : alice.did.uri,
-      messageType   : DwnInterface.RecordsQuery,
-      messageParams : {
-        filter: {
-          protocol     : encryptedNoteProtocol.protocol,
-          protocolPath : 'note',
-        }
-      },
-    });
+    const localAfter = await syncPullUntilLocalRecordCount(3);
     expect(localAfter.entries).toHaveLength(3);
     for (const entry of localAfter.entries!) {
       expect(entry.encryption).toBeDefined();
     }
-  }, 30_000);
+  }, 60_000);
 
   it('should decrypt pulled records with the original encryption key', async () => {
     // Read each record individually with auto-decryption.
-    const { reply: queryReply } = await testHarness.agent.dwn.processRequest({
-      author        : alice.did.uri,
-      target        : alice.did.uri,
-      messageType   : DwnInterface.RecordsQuery,
-      messageParams : {
-        filter: {
-          protocol     : encryptedNoteProtocol.protocol,
-          protocolPath : 'note',
-        }
-      },
-    });
+    const queryReply = await queryLocalEncryptedNotes();
 
     const decryptedTexts: string[] = [];
     for (const entry of queryReply.entries!) {

--- a/packages/agent/tests/e2e-grant-revocation.spec.ts
+++ b/packages/agent/tests/e2e-grant-revocation.spec.ts
@@ -9,6 +9,7 @@
  */
 
 import type { BearerIdentity } from '../src/bearer-identity.js';
+import type { DwnRpcRequest, DwnRpcResponse } from '@enbox/dwn-clients';
 import type { ProtocolDefinition, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 
 import { Convert } from '@enbox/common';
@@ -18,7 +19,9 @@ import { DataStream, DwnInterfaceName, DwnMethodName, PermissionGrant, Permissio
 import { AgentPermissionsApi } from '../src/permissions-api.js';
 import { DwnInterface } from '../src/types/dwn.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
+import { retryFreshDidResolution } from './utils/remote-dwn-retry.js';
 import { TestAgent } from './utils/test-agent.js';
+import { testDwnUrl } from './utils/test-config.js';
 
 // Multi-party encrypted chat protocol
 const chatProtocol: ProtocolDefinition = {
@@ -75,9 +78,25 @@ describe('e2e: grant revocation stops future delivery', () => {
 
     ownerIdentity = await ownerHarness.createIdentity({
       name        : 'OwnerAlice',
-      testDwnUrls : ['http://localhost:3000'],
+      testDwnUrls : [testDwnUrl],
     });
   });
+
+  async function sendRemoteSetupRequest(
+    request: DwnRpcRequest
+  ): Promise<DwnRpcResponse> {
+    const reply = await retryFreshDidResolution(
+      () => ownerHarness.agent.rpc.sendDwnRequest(request)
+    );
+
+    if (![202, 409].includes(reply.status.code)) {
+      throw new Error(
+        `Remote setup request failed: ${reply.status.code} ${reply.status.detail ?? ''}`
+      );
+    }
+
+    return reply;
+  }
 
   it('should not deliver context keys after grants are revoked', async () => {
     const ownerDid = ownerIdentity.did.uri;
@@ -314,7 +333,6 @@ describe('e2e: grant revocation stops future delivery', () => {
   it('should self-heal revocation grant to remote DWN when fanout was missed', async () => {
     const ownerDid = ownerIdentity.did.uri;
     const permissionsApi = new AgentPermissionsApi({ agent: ownerHarness.agent });
-    const testDwnUrl = 'http://localhost:3000';
 
     // 1. Install protocol + key-delivery
     await ownerHarness.agent.processDwnRequest({
@@ -335,7 +353,7 @@ describe('e2e: grant revocation stops future delivery', () => {
         messageParams : { filter: { protocol: proto } },
       });
       for (const e of pq.entries ?? []) {
-        await ownerHarness.agent.rpc.sendDwnRequest({
+        await sendRemoteSetupRequest({
           dwnUrl    : testDwnUrl,
           targetDid : ownerDid,
           message   : e as any,
@@ -374,7 +392,7 @@ describe('e2e: grant revocation stops future delivery', () => {
 
     // Send session grant to remote
     const { encodedData: sgEncoded, ...sgRaw } = sessionGrant.message;
-    await ownerHarness.agent.rpc.sendDwnRequest({
+    await sendRemoteSetupRequest({
       dwnUrl    : testDwnUrl,
       targetDid : ownerDid,
       message   : sgRaw as any,
@@ -437,7 +455,7 @@ describe('e2e: grant revocation stops future delivery', () => {
     const revData = revGrantRead.entry!.data
       ? new Blob([await DataStream.toBytes(revGrantRead.entry!.data!) as BlobPart])
       : undefined;
-    await ownerHarness.agent.rpc.sendDwnRequest({
+    await sendRemoteSetupRequest({
       dwnUrl    : testDwnUrl,
       targetDid : ownerDid,
       message   : revRaw as any,
@@ -1108,7 +1126,6 @@ describe('e2e: grant revocation stops future delivery', () => {
 
     // Send permissions protocol + grants to DWN server so retry can
     // confirm revocations remotely.
-    const testDwnUrl = 'http://localhost:3000';
     const { reply: permProto } = await ownerHarness.agent.processDwnRequest({
       author        : ownerDid,
       target        : ownerDid,
@@ -1116,7 +1133,7 @@ describe('e2e: grant revocation stops future delivery', () => {
       messageParams : { filter: { protocol: PermissionsProtocol.uri } },
     });
     for (const e of permProto.entries ?? []) {
-      await ownerHarness.agent.rpc.sendDwnRequest({
+      await sendRemoteSetupRequest({
         dwnUrl: testDwnUrl, targetDid: ownerDid, message: e as any,
       });
     }
@@ -1125,7 +1142,7 @@ describe('e2e: grant revocation stops future delivery', () => {
       const dataBytes = encodedData
         ? Convert.base64Url(encodedData).toUint8Array()
         : new Uint8Array(0);
-      await ownerHarness.agent.rpc.sendDwnRequest({
+      await sendRemoteSetupRequest({
         dwnUrl    : testDwnUrl,
         targetDid : ownerDid,
         message   : rawMsg as any,

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -2744,8 +2744,8 @@ describe('SyncEngineLevel', () => {
           }
         });
 
-        // Execute Sync, only foo protocol should be synced
-        await aliceDeviceXHarness.agent.sync.sync();
+        // Execute pull sync, only foo protocol should be synced.
+        await aliceDeviceXHarness.agent.sync.sync('pull');
 
         // query aliceDeviceX to see foo records
         const localFooRecords = await aliceDeviceXHarness.agent.dwn.processRequest({
@@ -2846,7 +2846,7 @@ describe('SyncEngineLevel', () => {
         // Suppress console.error for the expected error.
         const consoleErrorStub = sinon.stub(console, 'error');
 
-        await syncEngine.sync();
+        await expect(syncEngine.sync()).rejects.toThrow('Sync operation failed');
         expect(syncEngine.connectivityState).toBe('offline');
 
         pullRemoteFeedStub.restore();
@@ -2869,7 +2869,7 @@ describe('SyncEngineLevel', () => {
         // Failing sync -> offline.
         const pullRemoteFeedStub = sinon.stub(syncEngine as any, 'pullRemoteFeedForSyncTarget').rejects(new Error('simulated failure'));
         const consoleErrorStub = sinon.stub(console, 'error');
-        await syncEngine.sync();
+        await expect(syncEngine.sync()).rejects.toThrow('Sync operation failed');
         expect(syncEngine.connectivityState).toBe('offline');
 
         // Restore and sync successfully -> back to online.
@@ -2905,7 +2905,7 @@ describe('SyncEngineLevel', () => {
         pullRemoteFeedStub.onFirstCall().rejects(new Error('DWN unreachable'));
         pullRemoteFeedStub.onSecondCall().resolves({});
 
-        await syncEngine.sync();
+        await expect(syncEngine.sync()).rejects.toThrow('Sync operation failed');
 
         // The error should have been logged.
         expect(consoleErrorStub.called).toBe(true);

--- a/packages/agent/tests/utils/remote-dwn-retry.ts
+++ b/packages/agent/tests/utils/remote-dwn-retry.ts
@@ -1,0 +1,71 @@
+type DwnStatus = {
+  code: number;
+  detail?: string;
+};
+
+type DwnStatusCarrier =
+  | { status: DwnStatus }
+  | { reply: { status: DwnStatus } };
+
+const freshDidRetryDelaysMs = [500, 1_000, 2_000, 4_000, 8_000, 16_000];
+
+function getStatus(result: DwnStatusCarrier): DwnStatus {
+  if ('reply' in result) {
+    return result.reply.status;
+  }
+
+  return result.status;
+}
+
+function isFreshDidResolutionFailure(status: DwnStatus): boolean {
+  return status.code === 401
+    && (status.detail ?? '').includes('GetPublicKeyNotFound');
+}
+
+function isPlainHttpBadRequest(error: unknown): boolean {
+  return error instanceof Error
+    && error.message.includes('failed to parse json rpc response')
+    && error.message.includes('status: 400');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function retryFreshDidResolution<T extends DwnStatusCarrier>(
+  operation: () => Promise<T>
+): Promise<T> {
+  let lastReply: T | undefined;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= freshDidRetryDelaysMs.length; attempt++) {
+    if (attempt > 0) {
+      await sleep(freshDidRetryDelaysMs[attempt - 1]);
+    }
+
+    try {
+      const reply = await operation();
+      if (!isFreshDidResolutionFailure(getStatus(reply))) {
+        return reply;
+      }
+
+      lastReply = reply;
+    } catch (error) {
+      if (!isPlainHttpBadRequest(error)) {
+        throw error;
+      }
+
+      lastError = error;
+    }
+  }
+
+  if (lastReply) {
+    return lastReply;
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new Error('retryFreshDidResolution exhausted without a DWN reply');
+}


### PR DESCRIPTION
## Summary
- add a shared agent test helper that retries fresh `did:dht` resolution failures during remote DWN setup
- wrap low-level `agent.rpc.sendDwnRequest()` setup sends in the cross-device delegate and grant revocation e2e specs
- make the grant revocation spec honor `TEST_DWN_URL` instead of hardcoding `http://localhost:3000`
- assert final setup status explicitly and report the returned DWN status/detail when setup fails

## Why
The failed CI job died before the deduplication assertion. The remote DWN returned a transient fresh-DID auth failure while the test was replaying locally-created setup messages directly via the low-level RPC client. Existing higher-level e2e paths already retried this class of fresh `did:dht` propagation issue, but these direct setup sends bypassed that retry logic. In some cases the low-level HTTP client also throws before parsing a JSON-RPC reply, so the helper covers that `status: 400` path too.

## Verification
- `git diff --check`
- `bun run --filter @enbox/agent lint`
- `TEST_DWN_URL=http://localhost:13000 DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test --timeout 10000 packages/agent/tests/e2e-delegate-cross-device.spec.ts` repeated 5x: 60 pass, 0 fail
- `TEST_DWN_URL=http://localhost:13000 DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run --filter @enbox/agent test:node:coverage`: 1317 pass, 4 skip, 0 fail

Note: local verification used Bun 1.3.11; repo/CI expects Bun 1.3.14.
