### PR TITLE
Add connect session metadata and 24-hour expiry

### DIFF
--- a/.changeset/connect-session-metadata.md
+++ b/.changeset/connect-session-metadata.md
@@ -1,0 +1,9 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+"@enbox/api": patch
+"@enbox/auth": patch
+"@enbox/browser": patch
+---
+
+Add bounded, display-only connect session metadata to permission grants and default connect-created grants to a hard 24-hour expiration.

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -17,8 +17,8 @@ import type { DerivedPrivateJwk } from '@enbox/dwn-sdk-js';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PrivateKeyJwk } from '@enbox/crypto';
 import type { RequireOnly } from '@enbox/common';
+import type { ConnectSessionMetadata, ConnectSessionTransport, DwnDataEncodedRecordsWriteMessage, DwnPermissionScope, DwnProtocolDefinition, DwnRecordsPermissionScope } from './types/dwn.js';
 import type { DidDocument, PortableDid } from '@enbox/dids';
-import type { DwnDataEncodedRecordsWriteMessage, DwnPermissionScope, DwnProtocolDefinition, DwnRecordsPermissionScope } from './types/dwn.js';
 
 /**
  * The protocols of permissions requested, along with the definition and permission scopes for each protocol.
@@ -32,6 +32,45 @@ export type ConnectPermissionRequest = {
 
   /** The scope of the permissions being requested for the given protocol */
   permissionScopes: DwnPermissionScope[];
+};
+
+/**
+ * Client/environment details captured by the connect client for wallet session display.
+ *
+ * This data is self-reported by the requester, unauthenticated, and intended
+ * only as display hints. Wallets must not treat it as verified app identity.
+ */
+export type ConnectClientMetadata = {
+  /** Origin of the requesting app, when known. */
+  origin?: string;
+  /** Browser user agent string, when available. */
+  userAgent?: string;
+  /** Platform/device hint, when available. */
+  platform?: string;
+  /** Primary language, when available. */
+  language?: string;
+  /** Language preference list, when available. */
+  languages?: string[];
+  /** IANA timezone, when available. */
+  timezone?: string;
+};
+
+export type CreateConnectSessionMetadataOptions = {
+  id?: string;
+  appName?: string;
+  appIcon?: string;
+  clientMetadata?: ConnectClientMetadata;
+  transport?: ConnectSessionTransport;
+  createdAt?: string;
+  expiresAt?: string;
+  ttlSeconds?: number;
+};
+
+export type ConnectPermissionGrantOptions = {
+  /** Grant expiration timestamp. Defaults to the connect session expiration. */
+  dateExpires?: string;
+  /** Session metadata attached to every grant created by the approval. */
+  connectSession?: ConnectSessionMetadata;
 };
 
 /**
@@ -112,7 +151,7 @@ import {
   X25519,
   XChaCha20Poly1305,
 } from '@enbox/crypto';
-import { DwnInterfaceName, DwnMethodName, HdKey, KeyDerivationScheme, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName, HdKey, KeyDerivationScheme, PermissionsProtocol, Time } from '@enbox/dwn-sdk-js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
@@ -154,6 +193,27 @@ const CONNECT_REQUEST_TIMEOUT_MS = 10_000;
 /** Log namespace used for wallet-side connect critical-path timings. */
 const CONNECT_PERF_LOG_PREFIX = '[connect.perf]';
 
+/**
+ * Default lifetime for app delegate grants created by a connect approval.
+ *
+ * This is a hard grant expiry. There is intentionally no renewal path in this
+ * protocol layer yet; clients should treat expired connect grants as
+ * reconnect-required.
+ */
+export const CONNECT_SESSION_DEFAULT_TTL_SECONDS = 24 * 60 * 60;
+
+const CONNECT_SESSION_METADATA_LIMITS = {
+  id        : 128,
+  appName   : 128,
+  appIcon   : 2048,
+  origin    : 512,
+  userAgent : 512,
+  platform  : 128,
+  language  : 64,
+  languages : 16,
+  timezone  : 128,
+} as const;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -194,6 +254,12 @@ export type EnboxConnectRequest = {
 
   /** Human-readable name of the requesting application, shown in the consent UI. */
   appName: string;
+
+  /** Optional icon URL for the requesting application, shown in the consent UI. */
+  appIcon?: string;
+
+  /** Optional client/environment metadata for wallet session display. */
+  clientMetadata?: ConnectClientMetadata;
 
   /** DWN protocols and permission scopes being requested. */
   permissionRequests: ConnectPermissionRequest[];
@@ -486,6 +552,13 @@ function requireOptionalString(payload: Record<string, unknown>, field: string, 
   }
 }
 
+function requireOptionalObject(payload: Record<string, unknown>, field: string, context: string): void {
+  const value = payload[field];
+  if (value !== undefined && (typeof value !== 'object' || value === null || Array.isArray(value))) {
+    fail(context, field, 'must be an object when present');
+  }
+}
+
 function requireOptionalArray(payload: Record<string, unknown>, field: string, context: string): void {
   if (payload[field] !== undefined && !Array.isArray(payload[field])) {
     fail(context, field, 'must be an array when present');
@@ -510,6 +583,8 @@ function assertConnectRequest(payload: Record<string, unknown>): asserts payload
   const ctx = 'invalid connect request';
   requireString(payload, 'clientDid', ctx);
   requireString(payload, 'appName', ctx);
+  requireOptionalString(payload, 'appIcon', ctx);
+  requireOptionalObject(payload, 'clientMetadata', ctx);
   requireArray(payload, 'permissionRequests', ctx);
   requireString(payload, 'nonce', ctx);
   requireString(payload, 'state', ctx);
@@ -838,6 +913,79 @@ function isConnectReadScope(scope: DwnPermissionScope): scope is DwnRecordsPermi
   return isRecordPermissionScope(scope) && scope.method === DwnMethodName.Read;
 }
 
+function randomSessionId(): string {
+  return Convert.uint8Array(CryptoUtils.randomBytes(16)).toBase64Url();
+}
+
+function boundedSessionString(value: string | undefined, maxLength: number): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined;
+  }
+  return value.slice(0, maxLength);
+}
+
+function boundedSessionStringArray(values: string[] | undefined): string[] | undefined {
+  if (!Array.isArray(values)) {
+    return undefined;
+  }
+
+  const bounded = values
+    .filter((value) => typeof value === 'string' && value.length > 0)
+    .slice(0, CONNECT_SESSION_METADATA_LIMITS.languages)
+    .map((value) => value.slice(0, CONNECT_SESSION_METADATA_LIMITS.language));
+
+  return bounded.length > 0 ? bounded : undefined;
+}
+
+function createConnectSessionMetadata(
+  options: CreateConnectSessionMetadataOptions = {},
+): ConnectSessionMetadata {
+  const createdAt = options.createdAt ?? Time.getCurrentTimestamp();
+  const expiresAt = options.expiresAt ?? Time.createOffsetTimestamp({
+    seconds: options.ttlSeconds ?? CONNECT_SESSION_DEFAULT_TTL_SECONDS,
+  }, createdAt);
+  const clientMetadata = options.clientMetadata ?? {};
+  const appName = boundedSessionString(options.appName, CONNECT_SESSION_METADATA_LIMITS.appName);
+  const appIcon = boundedSessionString(options.appIcon, CONNECT_SESSION_METADATA_LIMITS.appIcon);
+  const origin = boundedSessionString(clientMetadata.origin, CONNECT_SESSION_METADATA_LIMITS.origin);
+  const userAgent = boundedSessionString(clientMetadata.userAgent, CONNECT_SESSION_METADATA_LIMITS.userAgent);
+  const platform = boundedSessionString(clientMetadata.platform, CONNECT_SESSION_METADATA_LIMITS.platform);
+  const language = boundedSessionString(clientMetadata.language, CONNECT_SESSION_METADATA_LIMITS.language);
+  const languages = boundedSessionStringArray(clientMetadata.languages);
+  const timezone = boundedSessionString(clientMetadata.timezone, CONNECT_SESSION_METADATA_LIMITS.timezone);
+
+  return {
+    id: boundedSessionString(options.id, CONNECT_SESSION_METADATA_LIMITS.id) ?? randomSessionId(),
+    createdAt,
+    expiresAt,
+    ...(appName ? { appName } : {}),
+    ...(appIcon ? { appIcon } : {}),
+    ...(origin ? { origin } : {}),
+    ...(userAgent ? { userAgent } : {}),
+    ...(platform ? { platform } : {}),
+    ...(language ? { language } : {}),
+    ...(languages ? { languages } : {}),
+    ...(timezone ? { timezone } : {}),
+    ...(options.transport ? { transport: options.transport } : {}),
+  };
+}
+
+function resolveConnectPermissionGrantOptions(
+  options?: ConnectPermissionGrantOptions,
+): { dateExpires: string; connectSession: ConnectSessionMetadata } {
+  if (options?.dateExpires && options.connectSession?.expiresAt && options.dateExpires !== options.connectSession.expiresAt) {
+    throw new Error('Connect grant dateExpires must match connectSession.expiresAt.');
+  }
+
+  const connectSession = options?.connectSession ?? createConnectSessionMetadata({
+    expiresAt: options?.dateExpires,
+  });
+  return {
+    dateExpires: options?.dateExpires ?? connectSession.expiresAt,
+    connectSession,
+  };
+}
+
 /**
  * Creates permission grants that assign the requested scopes to a delegate DID.
  */
@@ -847,8 +995,10 @@ async function createPermissionGrants(
   agent: EnboxPlatformAgent,
   scopes: DwnPermissionScope[],
   delegateKeyDeliveryData?: { rootKeyId: string; publicKeyJwk: Record<string, any> },
+  options?: ConnectPermissionGrantOptions,
 ): Promise<DwnDataEncodedRecordsWriteMessage[]> {
   const permissionsApi = new AgentPermissionsApi({ agent });
+  const { dateExpires, connectSession } = resolveConnectPermissionGrantOptions(options);
 
   logger.log(`Creating permission grants for ${scopes.length} scopes...`);
   for (const scope of scopes) {
@@ -865,12 +1015,13 @@ async function createPermissionGrants(
 
       return permissionsApi.createGrant({
         delegated,
-        store       : true,
-        grantedTo   : delegateBearerDid.uri,
+        store     : true,
+        grantedTo : delegateBearerDid.uri,
         scope,
-        dateExpires : '2040-06-25T16:09:16.693356Z', // TODO: make dateExpires configurable
-        author      : selectedDid,
+        dateExpires,
+        author    : selectedDid,
         delegateKeyDelivery,
+        connectSession,
       });
     })
   );
@@ -1336,6 +1487,12 @@ async function submitConnectResponse(
   try {
     const delegateBearerDid = await timed(`${CONNECT_PERF_LOG_PREFIX} delegateDid.create`, () => DidJwk.create());
     const delegatePortableDid = await delegateBearerDid.export();
+    const connectSession = createConnectSessionMetadata({
+      appName        : connectRequest.appName,
+      appIcon        : connectRequest.appIcon,
+      clientMetadata : connectRequest.clientMetadata,
+      transport      : 'relay',
+    });
 
     // Add X25519 key derived from the delegate's Ed25519 key.
     // did:jwk only supports one verification method, but DWN encryption
@@ -1459,6 +1616,7 @@ async function submitConnectResponse(
               agent,
               permissionScopes,
               delegateKeyDeliveryData,
+              { connectSession },
             );
           }
         );
@@ -1487,6 +1645,9 @@ async function submitConnectResponse(
     // createGrant is local-only (storage + signing) so it's cheap, but we still
     // cap parallelism to avoid head-of-line blocking when sessionGrantCount is
     // large (e.g. dapp requesting many scopes at once).
+    // Revocation grants share the same hard expiry but do not duplicate
+    // connectSession display metadata; session grouping should use the
+    // user-facing permission grants.
     const revGrantResults = await timed(
       `${CONNECT_PERF_LOG_PREFIX} revocationGrants.create (n=${sessionGrantCount})`,
       () => mapConcurrent(
@@ -1503,7 +1664,7 @@ async function submitConnectResponse(
               protocol  : PermissionsProtocol.uri,
               contextId : grantMessage.recordId,
             },
-            dateExpires : '2040-06-25T16:09:16.693356Z',
+            dateExpires : connectSession.expiresAt,
             author      : selectedDid,
           }).then((revGrant) => ({ grantMessage, revGrant })),
       ),
@@ -1650,6 +1811,7 @@ export const EnboxConnectProtocol = {
   createConnectRequest,
   getConnectRequest,
   createConnectResponse,
+  createConnectSessionMetadata,
   createPermissionGrants,
   submitConnectResponse,
   deriveScopedDecryptionKeys,

--- a/packages/agent/src/permissions-api.ts
+++ b/packages/agent/src/permissions-api.ts
@@ -257,6 +257,9 @@ export class AgentPermissionsApi implements PermissionsApi {
     if (createGrantParams.delegateKeyDelivery) {
       permissionGrantData.delegateKeyDelivery = createGrantParams.delegateKeyDelivery;
     }
+    if (createGrantParams.connectSession) {
+      permissionGrantData.connectSession = createGrantParams.connectSession;
+    }
 
     const permissionsGrantBytes = Convert.object(permissionGrantData).toUint8Array();
 

--- a/packages/agent/src/types/dwn.ts
+++ b/packages/agent/src/types/dwn.ts
@@ -274,6 +274,8 @@ export {
 
 // Type-only re-exports (interfaces, type aliases)
 export type {
+  ConnectSessionMetadata,
+  ConnectSessionTransport,
   DataEncodedRecordsWriteMessage as DwnDataEncodedRecordsWriteMessage,
   MessageSigner as DwnSigner,
   MessageSubscription as DwnMessageSubscription,

--- a/packages/agent/src/types/permissions.ts
+++ b/packages/agent/src/types/permissions.ts
@@ -1,4 +1,4 @@
-import type { DwnDataEncodedRecordsWriteMessage, DwnInterface, DwnPermissionGrant, DwnPermissionRequest, DwnPermissionScope } from './dwn.js';
+import type { ConnectSessionMetadata, DwnDataEncodedRecordsWriteMessage, DwnInterface, DwnPermissionGrant, DwnPermissionRequest, DwnPermissionScope } from './dwn.js';
 
 export type FetchPermissionsParams = {
   author: string;
@@ -53,6 +53,8 @@ export type CreateGrantParams = {
     rootKeyId: string;
     publicKeyJwk: Record<string, any>;
   };
+  /** Connect session metadata for grants created by wallet approval flows. */
+  connectSession?: ConnectSessionMetadata;
 };
 
 export type CreateRequestParams = {

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -12,7 +12,7 @@ import { testDwnUrl } from './utils/test-config.js';
 import { type BearerDid, DidDht, DidJwk } from '@enbox/dids';
 import { Convert, logger } from '@enbox/common';
 
-import { AgentPermissionsApi, DwnInterface } from '../src/index.js';
+import { AgentPermissionsApi, DwnInterface, DwnPermissionGrant } from '../src/index.js';
 import {
   EnboxConnectProtocol,
   type EnboxConnectRequest,
@@ -288,6 +288,11 @@ describe('enbox connect', () => {
     });
 
     it('should create permission grants for each selected did', async () => {
+      sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget').resolves(['https://dwn.example']);
+      sinon.stub(testHarness.agent.rpc, 'sendDwnRequest').resolves({
+        status: { code: 202, detail: 'Accepted' },
+      } as any);
+
       const results = await EnboxConnectProtocol.createPermissionGrants(
         providerIdentity.did.uri,
         delegateBearerDid,
@@ -297,6 +302,47 @@ describe('enbox connect', () => {
       const scopesRequested = permissionScopes.length;
       expect(results).toHaveLength(scopesRequested);
       expect(typeof results[0]).toBe('object');
+
+      const grants = results.map((result) => DwnPermissionGrant.parse(result));
+      const firstSession = grants[0].connectSession;
+      expect(firstSession).toBeDefined();
+      expect(firstSession?.id).toBeDefined();
+      expect(firstSession?.expiresAt).not.toBe('2040-06-25T16:09:16.693356Z');
+      expect(Date.parse(firstSession!.expiresAt) - Date.parse(firstSession!.createdAt)).toBe(86_400_000);
+
+      for (const grant of grants) {
+        expect(grant.connectSession?.id).toBe(firstSession?.id);
+        expect(grant.dateExpires).toBe(firstSession?.expiresAt);
+      }
+    });
+
+    it('should bound connect session display metadata', () => {
+      const session = EnboxConnectProtocol.createConnectSessionMetadata({
+        id             : 's'.repeat(200),
+        appName        : 'a'.repeat(200),
+        appIcon        : `https://example.com/${'i'.repeat(3000)}`,
+        transport      : 'postMessage',
+        clientMetadata : {
+          origin    : `https://${'o'.repeat(600)}.example`,
+          userAgent : 'u'.repeat(600),
+          platform  : 'p'.repeat(200),
+          language  : 'l'.repeat(100),
+          languages : Array.from({ length: 20 }, (_, index) => `language-${index}-${'x'.repeat(80)}`),
+          timezone  : 't'.repeat(200),
+        },
+      });
+
+      expect(session.id).toHaveLength(128);
+      expect(session.appName).toHaveLength(128);
+      expect(session.appIcon).toHaveLength(2048);
+      expect(session.origin).toHaveLength(512);
+      expect(session.userAgent).toHaveLength(512);
+      expect(session.platform).toHaveLength(128);
+      expect(session.language).toHaveLength(64);
+      expect(session.languages).toHaveLength(16);
+      expect(session.languages?.every((language) => language.length <= 64)).toBe(true);
+      expect(session.timezone).toHaveLength(128);
+      expect(session.transport).toBe('postMessage');
     });
 
     it('should reject obsolete read-like record grant scopes', async () => {

--- a/packages/api/src/permission-grant.ts
+++ b/packages/api/src/permission-grant.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectSessionMetadata,
   DwnDataEncodedRecordsWriteMessage,
   DwnPermissionConditions,
   DwnPermissionScope,
@@ -69,6 +70,11 @@ export interface PermissionGrantModel {
    * Optional conditions that must be met when the grant is used.
    */
   readonly conditions?: DwnPermissionConditions;
+
+  /**
+   * Optional metadata describing the connect approval session that created this grant.
+   */
+  readonly connectSession?: ConnectSessionMetadata;
 }
 
 /**
@@ -179,6 +185,11 @@ export class PermissionGrant implements PermissionGrantModel {
   /** The conditions under which the grant is valid */
   get conditions(): DwnPermissionConditions {
     return this._grant.conditions;
+  }
+
+  /** Metadata for the connect approval session that created this grant, if present */
+  get connectSession(): ConnectSessionMetadata | undefined {
+    return this._grant.connectSession;
   }
 
   /** The raw `RecordsWrite` DWN message with encoded data that was used to instantiate this grant */
@@ -312,16 +323,17 @@ export class PermissionGrant implements PermissionGrantModel {
    */
   toJSON(): DwnPermissionGrant {
     return {
-      id          : this.id,
-      grantor     : this.grantor,
-      grantee     : this.grantee,
-      dateGranted : this.dateGranted,
-      description : this.description,
-      requestId   : this.requestId,
-      dateExpires : this.dateExpires,
-      delegated   : this.delegated,
-      scope       : this.scope,
-      conditions  : this.conditions
+      id             : this.id,
+      grantor        : this.grantor,
+      grantee        : this.grantee,
+      dateGranted    : this.dateGranted,
+      description    : this.description,
+      requestId      : this.requestId,
+      dateExpires    : this.dateExpires,
+      delegated      : this.delegated,
+      scope          : this.scope,
+      conditions     : this.conditions,
+      connectSession : this.connectSession,
     };
   }
 }

--- a/packages/api/tests/permission-grant.spec.ts
+++ b/packages/api/tests/permission-grant.spec.ts
@@ -64,14 +64,24 @@ describe('PermissionGrant', () => {
 
   describe('parse()',() => {
     it('parses a grant message', async () => {
+      const createdAt = Time.getCurrentTimestamp();
+      const connectSession = {
+        id        : 'session-123',
+        appName   : 'Sample App',
+        origin    : 'https://example.com',
+        transport : 'postMessage',
+        createdAt,
+        expiresAt : Time.createOffsetTimestamp({ seconds: 86_400 }, createdAt),
+      };
       const { grant, message } = await testHarness.agent.permissions.createGrant({
         store       : false,
         author      : aliceDid.uri,
         grantedTo   : bobDid.uri,
         requestId   : '123',
-        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        dateExpires : connectSession.expiresAt,
         description : 'This is a grant',
         scope       : { interface: DwnInterfaceName.Messages, method: DwnMethodName.Read, protocol: protocolUri },
+        connectSession,
       });
 
       const parsedGrant = PermissionGrant.parse({
@@ -92,6 +102,7 @@ describe('PermissionGrant', () => {
       expect(parsedGrant.dateExpires).toBe(grant.dateExpires);
       expect(parsedGrant.description).toBe(grant.description);
       expect(parsedGrant.delegated).toBe(grant.delegated);
+      expect(parsedGrant.connectSession).toEqual(connectSession);
     });
 
     it('throws for an invalid grant', async () => {

--- a/packages/auth/src/connect/wallet.ts
+++ b/packages/auth/src/connect/wallet.ts
@@ -41,6 +41,8 @@ export async function walletConnect(
   // Run the Enbox Connect relay flow.
   const result = await WalletConnect.initClient({
     displayName        : options.displayName,
+    appIcon            : options.appIcon,
+    clientMetadata     : options.clientMetadata,
     connectServerUrl   : options.connectServerUrl,
     walletUri          : options.walletUri ?? 'enbox://connect',
     permissionRequests : options.permissionRequests,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -78,6 +78,7 @@ export type {
   AuthManagerOptions,
   AuthSessionInfo,
   AuthState,
+  ConnectClientMetadata,
   ConnectHandler,
   ConnectOptions,
   ConnectPermissionRequest,

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -4,12 +4,12 @@
  */
 
 import type { PortableDid } from '@enbox/dids';
-import type { AgentSessionIdentity, ConnectPermissionRequest, DelegateContextKey, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, DwnProtocolDefinition, EnboxUserAgent, HdIdentityVault, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
+import type { AgentSessionIdentity, ConnectClientMetadata, ConnectPermissionRequest, DelegateContextKey, DelegateDecryptionKey, DwnDataEncodedRecordsWriteMessage, DwnProtocolDefinition, EnboxUserAgent, HdIdentityVault, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
 
 import type { PasswordProvider } from './password-provider.js';
 
 // Re-export types that consumers will need
-export type { ConnectPermissionRequest, DelegateContextKey, DelegateDecryptionKey, HdIdentityVault, IdentityVaultBackup, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
+export type { ConnectClientMetadata, ConnectPermissionRequest, DelegateContextKey, DelegateDecryptionKey, HdIdentityVault, IdentityVaultBackup, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
 
 // Re-export EnboxUserAgent so consumers don't need a direct @enbox/agent dep
 export type { EnboxUserAgent } from '@enbox/agent';
@@ -557,6 +557,12 @@ export type ConnectOptions = HandlerConnectOptions | VaultConnectOptions;
 export interface WalletConnectOptions {
   /** Display name shown in the wallet during the connect flow. */
   displayName: string;
+
+  /** Optional icon URL shown in the wallet during the connect flow. */
+  appIcon?: string;
+
+  /** Optional client/environment metadata for wallet session display. */
+  clientMetadata?: ConnectClientMetadata;
 
   /** URL of the connect relay server. */
   connectServerUrl: string;

--- a/packages/auth/src/wallet-connect-client.ts
+++ b/packages/auth/src/wallet-connect-client.ts
@@ -12,7 +12,7 @@
  * @module
  */
 
-import type { ConnectPermissionRequest, DwnPermissionScope, DwnProtocolDefinition } from '@enbox/agent';
+import type { ConnectClientMetadata, ConnectPermissionRequest, DwnPermissionScope, DwnProtocolDefinition } from '@enbox/agent';
 import type { ConnectPushedResponse, EnboxConnectResponse } from '@enbox/agent';
 
 import { CryptoUtils } from '@enbox/crypto';
@@ -31,6 +31,12 @@ import { EnboxConnectProtocol, pollWithTtl } from '@enbox/agent';
 export type WalletConnectClientOptions = {
   /** The user-friendly name of the app, displayed in the wallet consent UI. */
   displayName: string;
+
+  /** Optional icon URL for the app, displayed in the wallet consent UI. */
+  appIcon?: string;
+
+  /** Optional client/environment metadata for wallet session display. */
+  clientMetadata?: ConnectClientMetadata;
 
   /** The URL of the connect server which relays messages between the app and wallet. */
   connectServerUrl: string;
@@ -85,6 +91,8 @@ export type ProtocolPermissionOptions = {
  */
 async function initClient({
   displayName,
+  appIcon,
+  clientMetadata,
   connectServerUrl,
   walletUri,
   permissionRequests,
@@ -121,6 +129,8 @@ async function initClient({
     callbackUrl        : callbackEndpoint,
     permissionRequests : permissionRequests,
     appName            : displayName,
+    appIcon,
+    clientMetadata,
   });
 
   // Sign the request as a JWT.

--- a/packages/browser/src/browser-connect-handler.ts
+++ b/packages/browser/src/browser-connect-handler.ts
@@ -74,6 +74,7 @@ export interface BrowserConnectHandlerOptions {
    * Defaults to `${window.location.origin}/favicon.ico` if omitted.
    */
   appIcon?: string;
+
 }
 
 /**

--- a/packages/browser/src/dweb-connect-client.ts
+++ b/packages/browser/src/dweb-connect-client.ts
@@ -9,7 +9,7 @@
  */
 
 import type { PortableDid } from '@enbox/dids';
-import type { ConnectPermissionRequest, DwnDataEncodedRecordsWriteMessage } from '@enbox/agent';
+import type { ConnectClientMetadata, ConnectPermissionRequest, DwnDataEncodedRecordsWriteMessage } from '@enbox/agent';
 import type { ConnectResult, PortableIdentity } from '@enbox/auth';
 
 import type { EncryptedPostMessagePayload } from './dweb-connect-crypto.js';
@@ -56,6 +56,22 @@ export interface DWebConnectClientOptions {
    * from local-DID mode to delegate mode while keeping the same DID.
    */
   portableIdentity?: PortableIdentity;
+}
+
+function collectBrowserClientMetadata(): ConnectClientMetadata {
+  const resolvedOptions = Intl.DateTimeFormat().resolvedOptions();
+  const languages = Array.isArray(globalThis.navigator.languages)
+    ? globalThis.navigator.languages.filter((language) => typeof language === 'string' && language.length > 0)
+    : undefined;
+
+  return {
+    origin    : globalThis.location.origin,
+    userAgent : globalThis.navigator.userAgent,
+    platform  : globalThis.navigator.platform,
+    language  : globalThis.navigator.language,
+    ...(languages && languages.length > 0 ? { languages } : {}),
+    ...(resolvedOptions.timeZone ? { timezone: resolvedOptions.timeZone } : {}),
+  };
 }
 
 /**
@@ -170,6 +186,7 @@ async function initClient(options: DWebConnectClientOptions): Promise<ConnectRes
           ephemeralPublicKey : dappPublicKeyBase64url,
           appName,
           appIcon,
+          clientMetadata     : collectBrowserClientMetadata(),
           portableIdentity,
         }, walletOrigin);
         return;

--- a/packages/dwn-sdk-js/json-schemas/permissions/permission-grant-data.json
+++ b/packages/dwn-sdk-js/json-schemas/permissions/permission-grant-data.json
@@ -38,6 +38,62 @@
           "type": "object"
         }
       }
+    },
+    "connectSession": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "createdAt", "expiresAt"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "appName": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "appIcon": {
+          "type": "string",
+          "maxLength": 2048
+        },
+        "origin": {
+          "type": "string",
+          "maxLength": 512
+        },
+        "userAgent": {
+          "type": "string",
+          "maxLength": 512
+        },
+        "platform": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "language": {
+          "type": "string",
+          "maxLength": 64
+        },
+        "languages": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "string",
+            "maxLength": 64
+          }
+        },
+        "timezone": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "transport": {
+          "enum": ["relay", "postMessage"]
+        },
+        "createdAt": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+        },
+        "expiresAt": {
+          "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/date-time"
+        }
+      }
     }
   }
 }

--- a/packages/dwn-sdk-js/src/protocols/permission-grant.ts
+++ b/packages/dwn-sdk-js/src/protocols/permission-grant.ts
@@ -1,5 +1,5 @@
 import type { DataEncodedRecordsWriteMessage } from '../types/records-types.js';
-import type { PermissionConditions, PermissionGrantData, PermissionScope } from '../types/permission-types.js';
+import type { ConnectSessionMetadata, PermissionConditions, PermissionGrantData, PermissionScope } from '../types/permission-types.js';
 
 import { Encoder } from '../utils/encoder.js';
 import { Message } from '../core/message.js';
@@ -65,6 +65,11 @@ export class PermissionGrant {
    * Optional delegate key-delivery metadata for cross-device context key delivery.
    */
   public readonly delegateKeyDelivery?: { rootKeyId: string; publicKeyJwk: Record<string, any> };
+
+  /**
+   * Optional metadata describing the connect approval session that created this grant.
+   */
+  public readonly connectSession?: ConnectSessionMetadata;
 
   /**
    * Parses a `DataEncodedRecordsWriteMessage` into a `PermissionGrant`.
@@ -138,6 +143,6 @@ export class PermissionGrant {
     this.scope = permissionGrant.scope;
     this.conditions = permissionGrant.conditions;
     this.delegateKeyDelivery = permissionGrant.delegateKeyDelivery;
+    this.connectSession = permissionGrant.connectSession;
   }
 }
-

--- a/packages/dwn-sdk-js/src/protocols/permissions.ts
+++ b/packages/dwn-sdk-js/src/protocols/permissions.ts
@@ -3,9 +3,9 @@ import type { MessagesFilter } from '../types/messages-types.js';
 import type { MessageSigner } from '../types/signer.js';
 import type { ProtocolDefinition } from '../types/protocols-types.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
+import type { ConnectSessionMetadata, PermissionConditions, PermissionGrantData, PermissionRequestData, PermissionRevocationData, PermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
 import type { CoreProtocol, CoreProtocolStores } from '../core/core-protocol.js';
 import type { DataEncodedRecordsWriteMessage, RecordsWriteMessage } from '../types/records-types.js';
-import type { PermissionConditions, PermissionGrantData, PermissionRequestData, PermissionRevocationData, PermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
 
 import { DwnConstant } from '../core/dwn-constant.js';
 import { DwnMethodName } from '../enums/dwn-interface-method.js';
@@ -63,6 +63,7 @@ export type PermissionGrantCreateOptions = {
   delegated?: boolean;
   scope: PermissionScope;
   conditions?: PermissionConditions;
+  connectSession?: ConnectSessionMetadata;
 };
 
 /**
@@ -422,12 +423,13 @@ export class PermissionsProtocol implements CoreProtocol {
     const scope = PermissionsProtocol.normalizePermissionScope(options.scope);
 
     const permissionGrantData: PermissionGrantData = {
-      dateExpires : options.dateExpires,
-      requestId   : options.requestId,
-      description : options.description,
-      delegated   : options.delegated,
+      dateExpires    : options.dateExpires,
+      requestId      : options.requestId,
+      description    : options.description,
+      delegated      : options.delegated,
       scope,
-      conditions  : options.conditions,
+      conditions     : options.conditions,
+      connectSession : options.connectSession,
     };
 
     // If the grant is scoped to a protocol, the protocol tag must be included with the record.

--- a/packages/dwn-sdk-js/src/types/permission-types.ts
+++ b/packages/dwn-sdk-js/src/types/permission-types.ts
@@ -1,6 +1,61 @@
 import type { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
 /**
+ * Metadata describing the connect approval session that created a permission grant.
+ *
+ * Wallets use this to group grants into user-facing app sessions and to
+ * distinguish active sessions from expired permission bundles. App and client
+ * fields are self-reported by the requester, unauthenticated, and intended for
+ * display only. Consumers must not treat them as verified app identity.
+ */
+export type ConnectSessionMetadata = {
+  /** Stable session ID shared by all grants created by one connect approval. */
+  id: string;
+
+  /** Human-readable app name shown during approval. Self-reported display data. */
+  appName?: string;
+
+  /** App icon URL shown during approval. Self-reported display data. */
+  appIcon?: string;
+
+  /** Origin of the requesting app, when known. Self-reported display data. */
+  origin?: string;
+
+  /** User agent string captured by the connect client, when available. Display data only. */
+  userAgent?: string;
+
+  /** Platform/device hint captured by the connect client, when available. */
+  platform?: string;
+
+  /** Primary browser language captured by the connect client, when available. */
+  language?: string;
+
+  /** Browser language preferences captured by the connect client, when available. */
+  languages?: string[];
+
+  /** IANA timezone captured by the connect client, when available. */
+  timezone?: string;
+
+  /** Connect transport that created the session. */
+  transport?: ConnectSessionTransport;
+
+  /** Timestamp when the wallet approved the connect session. */
+  createdAt: string;
+
+  /**
+   * Display timestamp for when the connect session expires.
+   *
+   * The enforcing value is the enclosing permission grant's `dateExpires`.
+   * Consumers must use `dateExpires`, not this metadata field, for any
+   * authorization or security decision.
+   */
+  expiresAt: string;
+};
+
+/** Connect transport that created a connect session. */
+export type ConnectSessionTransport = 'relay' | 'postMessage';
+
+/**
  * Type for the data payload of a permission request message.
  */
 export type PermissionRequestData = {
@@ -63,6 +118,9 @@ export type PermissionGrantData = {
     rootKeyId: string;
     publicKeyJwk: Record<string, any>;
   };
+
+  /** Optional metadata for the connect session that created this grant. */
+  connectSession?: ConnectSessionMetadata;
 };
 
 /**

--- a/packages/dwn-sdk-js/tests/protocols/permission-grant.spec.ts
+++ b/packages/dwn-sdk-js/tests/protocols/permission-grant.spec.ts
@@ -1,4 +1,4 @@
-import type { RecordsPermissionScope } from '../../src/types/permission-types.js';
+import type { ConnectSessionMetadata, RecordsPermissionScope } from '../../src/types/permission-types.js';
 
 import sinon from 'sinon';
 import { afterEach, describe, expect, it } from 'bun:test';
@@ -35,6 +35,69 @@ describe('PermissionGrant', () => {
     expect(parsed.grantee).toBe(bob.did);
     expect(parsed.scope).toEqual(scope);
     expect(parsed.dateExpires).toBeDefined();
+  });
+
+  it('should parse connect session metadata from a permission grant', async () => {
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    const bob = await TestDataGenerator.generateDidKeyPersona();
+    const createdAt = Time.getCurrentTimestamp();
+    const connectSession: ConnectSessionMetadata = {
+      id        : 'session-123',
+      appName   : 'Sample App',
+      appIcon   : 'https://example.com/icon.png',
+      origin    : 'https://example.com',
+      userAgent : 'ExampleBrowser/1.0',
+      platform  : 'MacIntel',
+      language  : 'en-US',
+      languages : ['en-US', 'en'],
+      timezone  : 'America/New_York',
+      transport : 'postMessage',
+      createdAt,
+      expiresAt : Time.createOffsetTimestamp({ seconds: 86_400 }, createdAt),
+    };
+
+    const permissionGrant = await PermissionsProtocol.createGrant({
+      signer      : Jws.createSigner(alice),
+      grantedTo   : bob.did,
+      dateExpires : connectSession.expiresAt,
+      scope       : {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Read,
+        protocol  : 'https://example.com/protocol/test',
+      },
+      connectSession,
+    });
+
+    PermissionsProtocol.validateSchema(permissionGrant.recordsWrite.message, permissionGrant.permissionGrantBytes);
+    const parsed = PermissionGrant.parse(permissionGrant.dataEncodedMessage);
+    expect(parsed.connectSession).toEqual(connectSession);
+    expect(parsed.dateExpires).toBe(connectSession.expiresAt);
+  });
+
+  it('should reject oversized connect session metadata', async () => {
+    const alice = await TestDataGenerator.generateDidKeyPersona();
+    const bob = await TestDataGenerator.generateDidKeyPersona();
+    const createdAt = Time.getCurrentTimestamp();
+    const permissionGrant = await PermissionsProtocol.createGrant({
+      signer      : Jws.createSigner(alice),
+      grantedTo   : bob.did,
+      dateExpires : Time.createOffsetTimestamp({ seconds: 86_400 }, createdAt),
+      scope       : {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Read,
+        protocol  : 'https://example.com/protocol/test',
+      },
+      connectSession: {
+        id        : 'x'.repeat(129),
+        createdAt,
+        expiresAt : Time.createOffsetTimestamp({ seconds: 86_400 }, createdAt),
+      },
+    });
+
+    expect(() => PermissionsProtocol.validateSchema(
+      permissionGrant.recordsWrite.message,
+      permissionGrant.permissionGrantBytes,
+    )).toThrow('must NOT have more than 128 characters');
   });
 
   describe('parse() validation', () => {


### PR DESCRIPTION
## Summary
- add bounded, display-only connectSession metadata to permission grant data, schema, parsers, and the API PermissionGrant model
- default connect-created permission grants to a hard 24-hour expiration instead of the old 2040 timestamp; expired grants require reconnect and renewal is intentionally out of scope for this layer
- thread app icon/client metadata into relay connect requests, while browser popup connect now auto-collects browser metadata only
- sanitize normal connect metadata before persistence, add schema max bounds, and keep client metadata documented as unauthenticated display data
- remove unused client-result connectSession plumbing and the unused auth ConnectSessionMetadata re-export; the supported wallet-facing path is reading grant.connectSession from permission grants
- avoid duplicating connectSession metadata onto revocation grants while keeping revocation grants on the same session expiry
- add a patch changeset

## Verification
- bun run --filter @enbox/dwn-sdk-js build
- bun run --filter @enbox/agent build
- bun run --filter @enbox/auth build
- bun run --filter @enbox/browser build
- bun run --filter @enbox/api build
- bun run --filter @enbox/dwn-sdk-js lint
- bun run --filter @enbox/agent lint
- bun run --filter @enbox/api lint
- bun run --filter @enbox/auth lint
- bun run --filter @enbox/browser lint
- bun test packages/dwn-sdk-js/tests/protocols/permission-grant.spec.ts
- bun test --timeout 10000 packages/agent/tests/connect.spec.ts
- bun test --timeout 10000 packages/auth/tests/wallet-connect-client.spec.ts
- DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test --timeout 10000 packages/api/tests/permission-grant.spec.ts -t "parse"

Latest cleanup checks:
- bun run --filter @enbox/auth lint
- bun run --filter @enbox/browser lint
- bun run --filter @enbox/auth build
- bun run --filter @enbox/browser build

Note: the full packages/api/tests/permission-grant.spec.ts suite still has pre-existing remote DWN/local DID setup failures in this environment (401 remote sends / missing pkarr record). The targeted parse tests that cover this change pass.