### PR TITLE
fix: avoid owner signer during delegated sync bootstrap

### DIFF
--- a/.changeset/delegated-sync-grant-bootstrap.md
+++ b/.changeset/delegated-sync-grant-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Fix delegated sync permission grant bootstrap so wallet-connected agents do not need owner signing keys during push reconciliation.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -24,7 +24,7 @@ import { getProtocolClosureEdges } from './sync-scope-closure.js';
 import { isRecordsWrite } from './utils.js';
 import { ReplicationLedger } from './sync-replication-ledger.js';
 import { computeAuthorizationEpoch, computeProjectionId, isTenantInactivePushFailure, isTerminalPushFailure, lexicographicalCompare, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
-import { fetchRemoteMessages, pushMessages, queryLocalMessageFeed, queryRemoteMessageFeed, SyncPullAbortedError } from './sync-messages.js';
+import { fetchRemoteMessages, pushMessageEntries, pushMessages, queryLocalMessageFeed, queryRemoteMessageFeed, SyncPullAbortedError } from './sync-messages.js';
 import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, resolveMessagesScopes, SyncProtocolRootPermissionGrantMissingError, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
 export type SyncEngineLevelParams = {
@@ -3618,18 +3618,20 @@ export class SyncEngineLevel implements SyncEngine {
       return { kind: 'processed', failures: [], hasActionableDiffs: false };
     }
 
-    const grantCids = await this.localPermissionGrantCids(target, shouldContinue);
-    if (grantCids === undefined) {
+    const grantEntries = await this.localPermissionGrantBootstrapEntries(target, shouldContinue);
+    if (grantEntries === undefined) {
       return { kind: 'aborted' };
     }
-    if (grantCids.failures.length > 0 || grantCids.messageCids.length === 0) {
-      return { kind: 'processed', failures: grantCids.failures, hasActionableDiffs: false };
+    if (grantEntries.failures.length > 0 || grantEntries.entries.length === 0) {
+      return { kind: 'processed', failures: grantEntries.failures, hasActionableDiffs: false };
     }
 
-    const result = await this.pushMessages({
-      did         : target.did,
-      dwnUrl      : target.dwnUrl,
-      messageCids : grantCids.messageCids,
+    const result = await this.pushMessageEntries({
+      did                : target.did,
+      dwnUrl             : target.dwnUrl,
+      delegateDid        : target.delegateDid,
+      permissionGrantIds : target.permissionGrantIds,
+      entries            : grantEntries.entries,
     });
     return {
       kind               : 'processed',
@@ -3638,11 +3640,11 @@ export class SyncEngineLevel implements SyncEngine {
     };
   }
 
-  private async localPermissionGrantCids(
+  private async localPermissionGrantBootstrapEntries(
     target: SyncTarget,
     shouldContinue?: () => boolean,
-  ): Promise<{ failures: PushFailure[]; messageCids: string[] } | undefined> {
-    const messageCids = new Set<string>();
+  ): Promise<{ failures: PushFailure[]; entries: SyncMessageEntry[] } | undefined> {
+    const entriesByCid = new Map<string, SyncMessageEntry>();
     const failures: PushFailure[] = [];
 
     for (const permissionGrantId of target.permissionGrantIds ?? []) {
@@ -3660,30 +3662,40 @@ export class SyncEngineLevel implements SyncEngine {
       }
 
       for (const entry of entries) {
-        messageCids.add(await Message.getCid(entry));
+        entriesByCid.set(await Message.getCid(entry.message), entry);
       }
     }
 
-    return { failures, messageCids: [...messageCids] };
+    return { failures, entries: [...entriesByCid.values()] };
   }
 
-  private async localPermissionGrantEntries(target: SyncTarget, permissionGrantId: string): Promise<GenericMessage[]> {
-    const ownerEntries = await this.queryLocalPermissionGrantEntries(target, permissionGrantId, target.did);
-    if (ownerEntries.length > 0 || target.delegateDid === undefined) {
-      return ownerEntries;
+  private async localPermissionGrantEntries(target: SyncTarget, permissionGrantId: string): Promise<SyncMessageEntry[]> {
+    if (target.delegateDid === undefined) {
+      return this.queryLocalPermissionGrantEntries(target, permissionGrantId, target.did);
     }
 
-    return this.queryLocalPermissionGrantEntries(target, permissionGrantId, target.delegateDid);
+    const delegateEntries = await this.queryLocalPermissionGrantEntries(
+      target,
+      permissionGrantId,
+      target.delegateDid,
+      target.delegateDid,
+    );
+    if (delegateEntries.length > 0) {
+      return delegateEntries;
+    }
+
+    return this.queryLocalPermissionGrantEntries(target, permissionGrantId, target.delegateDid, target.did);
   }
 
   private async queryLocalPermissionGrantEntries(
     target: SyncTarget,
     permissionGrantId: string,
     author: string,
-  ): Promise<GenericMessage[]> {
+    tenantDid = target.did,
+  ): Promise<SyncMessageEntry[]> {
     const { reply } = await this.agent.dwn.processRequest({
       author,
-      target        : target.did,
+      target        : tenantDid,
       messageType   : DwnInterface.RecordsQuery,
       messageParams : { filter: { recordId: permissionGrantId } },
     });
@@ -3692,16 +3704,34 @@ export class SyncEngineLevel implements SyncEngine {
       return [];
     }
 
-    const messages: GenericMessage[] = [];
+    const entries: SyncMessageEntry[] = [];
     for (const entry of recordsReply.entries) {
       if (entry.initialWrite !== undefined) {
-        messages.push(entry.initialWrite);
+        entries.push({ message: entry.initialWrite });
       }
       const { encodedData: _encodedData, initialWrite: _initialWrite, ...message } = entry;
-      messages.push(message as GenericMessage);
+      const syncEntry: SyncMessageEntry = { message: message as GenericMessage };
+      if (_encodedData !== undefined) {
+        syncEntry.bufferedData = Encoder.base64UrlToBytes(_encodedData);
+      }
+      entries.push(syncEntry);
     }
 
-    return messages;
+    return entries;
+  }
+
+  private async pushMessageEntries({ did, dwnUrl, delegateDid, permissionGrantIds, entries }: {
+    did: string;
+    dwnUrl: string;
+    delegateDid?: string;
+    permissionGrantIds?: string[];
+    entries: SyncMessageEntry[];
+  }): Promise<PushResult> {
+    return pushMessageEntries({
+      did, dwnUrl, delegateDid, permissionGrantIds, entries,
+      agent          : this.agent,
+      permissionsApi : this._permissionsApi,
+    });
   }
 
   private async collectLocalFeedCids(target: SyncTarget, shouldContinue?: () => boolean): Promise<Set<string> | undefined> {

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -3707,10 +3707,10 @@ export class SyncEngineLevel implements SyncEngine {
     const entries: SyncMessageEntry[] = [];
     for (const entry of recordsReply.entries) {
       if (entry.initialWrite !== undefined) {
-        entries.push({ message: entry.initialWrite });
+        entries.push({ message: SyncEngineLevel.toCanonicalGrantMessage(entry.initialWrite) });
       }
       const { encodedData: _encodedData, initialWrite: _initialWrite, ...message } = entry;
-      const syncEntry: SyncMessageEntry = { message: message as GenericMessage };
+      const syncEntry: SyncMessageEntry = { message: SyncEngineLevel.toCanonicalGrantMessage(message as GenericMessage) };
       if (_encodedData !== undefined) {
         syncEntry.bufferedData = Encoder.base64UrlToBytes(_encodedData);
       }
@@ -3718,6 +3718,30 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     return entries;
+  }
+
+  /**
+   * Reduce a locally-read permission grant to its canonical, owner-authored form
+   * for pushing to the owner's tenant.
+   *
+   * A permission grant is authored (and signed) by the owner. When a
+   * wallet-connected delegate — which does not hold the owner's signing key —
+   * stores the grant on its own tenant, it must attach a `signAsOwner`
+   * `ownerSignature` (the delegate is the tenant owner there). That signature is
+   * tenant-local: pushing such a copy to the owner's tenant is rejected by the
+   * DWN with `RecordsWriteOwnerAndTenantMismatch`, because the ownerSignature's
+   * signer (the delegate) is not the target tenant (the owner). Stripping the
+   * `ownerSignature` restores the exact owner-authored message the owner already
+   * signed, which the owner's tenant accepts on its own authority.
+   */
+  private static toCanonicalGrantMessage(message: GenericMessage): GenericMessage {
+    const authorization = (message as { authorization?: { ownerSignature?: unknown } }).authorization;
+    if (authorization === undefined || authorization.ownerSignature === undefined) {
+      return message;
+    }
+
+    const { ownerSignature: _ownerSignature, ...remainingAuthorization } = authorization;
+    return { ...message, authorization: remainingAuthorization } as GenericMessage;
   }
 
   private async pushMessageEntries({ did, dwnUrl, delegateDid, permissionGrantIds, entries }: {

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -3736,7 +3736,7 @@ export class SyncEngineLevel implements SyncEngine {
    */
   private static toCanonicalGrantMessage(message: GenericMessage): GenericMessage {
     const authorization = (message as { authorization?: { ownerSignature?: unknown } }).authorization;
-    if (authorization === undefined || authorization.ownerSignature === undefined) {
+    if (authorization?.ownerSignature === undefined) {
       return message;
     }
 

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -397,6 +397,26 @@ export async function pushMessages({ did, dwnUrl, delegateDid, permissionGrantId
   return context.push([...new Set(messageCids)]);
 }
 
+export async function pushMessageEntries({ did, dwnUrl, delegateDid, permissionGrantIds, entries, agent, permissionsApi }: {
+  did: string;
+  dwnUrl: string;
+  delegateDid?: string;
+  permissionGrantIds?: string[];
+  entries: SyncMessageEntry[];
+  agent: EnboxPlatformAgent;
+  permissionsApi?: PermissionsApi;
+}): Promise<PushResult> {
+  const context = new RemoteApplyPushContext({
+    did,
+    dwnUrl,
+    delegateDid,
+    permissionGrantIds,
+    agent,
+    permissionsApi,
+  });
+  return context.pushEntries(entries);
+}
+
 /**
  * Reads a message from the local DWN by its CID using MessagesRead.
  */
@@ -461,7 +481,6 @@ class RemoteApplyPushContext {
   }) {}
 
   public async push(rootCids: string[]): Promise<PushResult> {
-    const succeeded: string[] = [];
     const failedByRoot = new Map<string, PushFailure>();
     const rootEntries: SyncMessageEntry[] = [];
 
@@ -476,6 +495,15 @@ class RemoteApplyPushContext {
       }
       rootEntries.push(...root.entries);
     }
+
+    return this.pushEntries(rootEntries, failedByRoot);
+  }
+
+  public async pushEntries(
+    rootEntries: SyncMessageEntry[],
+    failedByRoot = new Map<string, PushFailure>(),
+  ): Promise<PushResult> {
+    const succeeded: string[] = [];
 
     for (const rootEntry of orderMessagesForAdmission(rootEntries)) {
       const rootCid = await this.rememberEntry(rootEntry);

--- a/packages/agent/tests/e2e-multi-agent-sync.spec.ts
+++ b/packages/agent/tests/e2e-multi-agent-sync.spec.ts
@@ -179,6 +179,7 @@ describe('E2E Multi-Agent Sync', () => {
   let messagesReadGrant: { grant: any; message: any };
   let messagesQueryGrant: { grant: any; message: any };
   let recordsQueryGrant: { grant: any; message: any };
+  let recordsWriteGrant: { grant: any; message: any };
 
   beforeAll(async () => {
     // -----------------------------------------------------------------------
@@ -259,6 +260,13 @@ describe('E2E Multi-Agent Sync', () => {
       scope     : { protocol: protocolNotes.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Read },
       delegated : true,
     });
+
+    recordsWriteGrant = await createAndDistributeGrant(primaryHarness, deviceHarness, {
+      grantor   : alice,
+      grantee   : aliceDevice,
+      scope     : { protocol: protocolNotes.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Write },
+      delegated : true,
+    });
   });
 
   afterAll(async () => {
@@ -296,7 +304,7 @@ describe('E2E Multi-Agent Sync', () => {
       // Re-distribute grants to device agent after its store clear.
       // Each grant must be stored on BOTH the device's own tenant (for
       // getPermissionForRequest) AND Alice's tenant (for DWN authorization).
-      for (const g of [messagesReadGrant, messagesQueryGrant, recordsQueryGrant]) {
+      for (const g of [messagesReadGrant, messagesQueryGrant, recordsQueryGrant, recordsWriteGrant]) {
         const data = g.grant.message.encodedData;
         const dataBlob = (): Blob => new Blob([Convert.base64Url(data).toUint8Array()]);
         await deviceHarness.agent.processDwnRequest({
@@ -454,6 +462,43 @@ describe('E2E Multi-Agent Sync', () => {
       const profileRecordIds = profileQuery.reply.entries?.map(e => e.recordId) ?? [];
       expect(profileRecordIds).not.toContain(profileWrite.message!.recordId);
     });
+
+    it('pushes delegated local writes without the owner signing key', async () => {
+      await deviceHarness.agent.sync.registerIdentity({
+        did     : alice.did.uri,
+        options : {
+          protocols   : [protocolNotes.protocol],
+          delegateDid : aliceDevice.did.uri,
+        },
+      });
+
+      const writeResult = await deviceHarness.agent.dwn.processRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        granteeDid    : aliceDevice.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          dataFormat     : 'text/plain',
+          delegatedGrant : recordsWriteGrant.grant.message,
+          protocol       : protocolNotes.protocol,
+          protocolPath   : 'note',
+          schema         : protocolNotes.types.note.schema,
+        },
+        dataStream: new Blob(['Delegate-authored note']),
+      });
+      expect(writeResult.reply.status.code).toBe(202);
+
+      await deviceHarness.agent.sync.sync('push');
+
+      const remoteQuery = await primaryHarness.agent.dwn.sendRequest({
+        author        : alice.did.uri,
+        target        : alice.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { recordId: writeResult.message!.recordId } },
+      });
+      expect(remoteQuery.reply.status.code).toBe(200);
+      expect(remoteQuery.reply.entries?.map(e => e.recordId)).toContain(writeResult.message!.recordId);
+    });
   });
 
   // =========================================================================
@@ -480,7 +525,7 @@ describe('E2E Multi-Agent Sync', () => {
       // Re-distribute grants to device agent after its store clear.
       // Each grant must be stored on BOTH the device's own tenant (for
       // getPermissionForRequest) AND Alice's tenant (for DWN authorization).
-      for (const g of [messagesReadGrant, messagesQueryGrant, recordsQueryGrant]) {
+      for (const g of [messagesReadGrant, messagesQueryGrant, recordsQueryGrant, recordsWriteGrant]) {
         const data = g.grant.message.encodedData;
         const dataBlob = (): Blob => new Blob([Convert.base64Url(data).toUint8Array()]);
         await deviceHarness.agent.processDwnRequest({

--- a/packages/agent/tests/e2e-multi-agent-sync.spec.ts
+++ b/packages/agent/tests/e2e-multi-agent-sync.spec.ts
@@ -1,4 +1,4 @@
-import type { PermissionScope, ProtocolDefinition } from '@enbox/dwn-sdk-js';
+import type { GenericMessage, PermissionScope, ProtocolDefinition } from '@enbox/dwn-sdk-js';
 
 import { Convert } from '@enbox/common';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
@@ -181,6 +181,9 @@ describe('E2E Multi-Agent Sync', () => {
   let recordsQueryGrant: { grant: any; message: any };
   let recordsWriteGrant: { grant: any; message: any };
 
+  /** Alice-authored notes-protocol configuration, mirrored onto the device. */
+  let notesProtocolConfigure: GenericMessage;
+
   beforeAll(async () => {
     // -----------------------------------------------------------------------
     // Set up TWO independent agent instances.
@@ -220,12 +223,15 @@ describe('E2E Multi-Agent Sync', () => {
     // -----------------------------------------------------------------------
     for (const def of [protocolNotes, protocolProfile]) {
       // Install locally on primary agent.
-      await primaryHarness.agent.dwn.processRequest({
+      const { message } = await primaryHarness.agent.dwn.processRequest({
         author        : alice.did.uri,
         target        : alice.did.uri,
         messageType   : DwnInterface.ProtocolsConfigure,
         messageParams : { definition: def },
       });
+      if (def.protocol === protocolNotes.protocol) {
+        notesProtocolConfigure = message as GenericMessage;
+      }
       // Install on remote DWN.
       await primaryHarness.agent.dwn.sendRequest({
         author        : alice.did.uri,
@@ -323,6 +329,17 @@ describe('E2E Multi-Agent Sync', () => {
           dataStream  : dataBlob(),
         });
       }
+
+      // Mirror Alice's notes protocol into the device's copy of Alice's tenant
+      // (signed as owner) so the delegate can author notes records locally —
+      // exactly as the connect flow seeds protocols on a wallet-connected dapp.
+      await deviceHarness.agent.dwn.processRequest({
+        author      : alice.did.uri,
+        target      : alice.did.uri,
+        messageType : DwnInterface.ProtocolsConfigure,
+        rawMessage  : notesProtocolConfigure,
+        signAsOwner : true,
+      });
     });
 
     it('should push from primary agent and pull on device agent', async () => {

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -55,6 +55,77 @@ describe('SyncEngineLevel', () => {
     });
   });
 
+  describe('delegated permission grant bootstrap', () => {
+    it('uses delegate-local grant entries without probing the owner signer', async () => {
+      const ownerDid = 'did:example:owner';
+      const delegateDid = 'did:example:delegate';
+      const permissionGrantId = 'grant-record-id';
+      const dwnUrl = 'https://dwn.example';
+
+      const grantEntry = {
+        authorization : {},
+        descriptor    : { interface: 'Records', method: 'Write' },
+        encodedData   : Convert.uint8Array(Convert.string('grant-data').toUint8Array()).toBase64Url(),
+        recordId      : permissionGrantId,
+      };
+
+      const processRequest = sinon.stub().callsFake(async (request: any) => {
+        if (request.author === ownerDid) {
+          throw new Error(`AgentDwnApi: Unable to get signer for author '${ownerDid}': Key not found`);
+        }
+
+        expect(request.author).toBe(delegateDid);
+        expect(request.target).toBe(delegateDid);
+        expect(request.messageType).toBe(DwnInterface.RecordsQuery);
+        expect(request.messageParams).toEqual({ filter: { recordId: permissionGrantId } });
+
+        return {
+          reply: {
+            status  : { code: 200 },
+            entries : [grantEntry],
+          },
+        };
+      });
+
+      const syncEngine = new SyncEngineLevel({
+        agent : { dwn: { processRequest } } as any,
+        db    : {} as any,
+      });
+      const pushEntries = sinon.stub(syncEngine as any, 'pushMessageEntries').resolves({
+        failed    : [],
+        succeeded : ['grant-cid'],
+      });
+
+      const result = await (syncEngine as any).bootstrapRemotePermissionGrants({
+        authorization: {
+          kind               : 'delegate',
+          delegateDid,
+          permissionGrantIds : [permissionGrantId],
+        },
+        authorizationEpoch : 'epoch',
+        delegateDid,
+        did                : ownerDid,
+        dwnUrl,
+        permissionGrantIds : [permissionGrantId],
+        scope              : { kind: 'protocolSet', protocols: ['https://protocol.example'] },
+      });
+
+      expect(result).toEqual({
+        failures           : [],
+        hasActionableDiffs : true,
+        kind               : 'processed',
+      });
+      expect(processRequest.calledOnce).toBe(true);
+      expect(pushEntries.calledOnce).toBe(true);
+      expect(pushEntries.firstCall.args[0].did).toBe(ownerDid);
+      expect(pushEntries.firstCall.args[0].dwnUrl).toBe(dwnUrl);
+      expect(pushEntries.firstCall.args[0].delegateDid).toBe(delegateDid);
+      expect(pushEntries.firstCall.args[0].permissionGrantIds).toEqual([permissionGrantId]);
+      expect(pushEntries.firstCall.args[0].entries).toHaveLength(1);
+      expect(pushEntries.firstCall.args[0].entries[0].bufferedData).toBeInstanceOf(Uint8Array);
+    });
+  });
+
   describe('with Enbox Platform Agent', () => {
     let alice: BearerIdentity;
     let randomSchema: string;


### PR DESCRIPTION
## Summary

Wallet-connected agents (e.g. the demo dapp) hold only a delegate key, not the owner's `did:dht` signing key. During delegated sync push reconciliation the permission-grant bootstrap failed for them in **two** ways — the second only surfaced after fixing the first:

1. It first read each grant from the **owner's** tenant as the owner (`author: ownerDid`), which throws `AgentDwnApi: Unable to get signer for author '<owner>': Key not found` and aborts the entire target sync (the console-spam symptom seen in the dapp).
2. Reading the grant from the **delegate's own tenant** is not enough on its own: a delegate stores grants there with a `signAsOwner` `ownerSignature`, so pushing that copy to the owner's tenant is rejected by the DWN with `RecordsWriteOwnerAndTenantMismatch`.

## Fix

- Read grant records with the delegate DID against the delegate's own tenant first (no owner key required), and push the already-fetched entries directly instead of re-reading them by CID as the owner.
- **Strip the tenant-local `ownerSignature`** so the bootstrap pushes the *canonical owner-authored grant* the owner already signed — which the owner's tenant (local mirror and remote) accepts on its own authority. This is the byte-for-byte grant the wallet already published during connect, so the remote treats it as a duplicate.
- Multi-agent e2e: seed Alice's notes protocol into the device's copy of Alice's tenant (signed as owner, exactly as the connect flow seeds protocols on a dapp) so the delegate-authored write reaches the bootstrap path it is meant to exercise.
- Patch changeset for `@enbox/agent`.

## Root cause confirmed by tracing the live flow (web-wallet → dapp → @enbox)

- Wallet `createPermissionGrants` stores grants on the owner's tenant and pushes them to every owner DWN endpoint.
- Dapp `@enbox/auth processConnectedGrants` writes each grant to the delegate's own tenant (`signAsOwner`) **and** to the owner's tenant via `processRawMessage`, then `registerIdentity({ did: owner, options: { delegateDid, protocols } })`.
- Sync registration resolves grant IDs via `fetchGrants({ author: delegate, target: delegate })` — the delegate-tenant read is already the working path; the bootstrap now mirrors it (and reduces the grant to its canonical form before pushing).

## Verification

- `bun run --filter @enbox/agent lint` ✅
- `bun run --filter @enbox/agent build` ✅
- `bun test tests/sync-engine-level.spec.ts` — 64 pass ✅ (incl. the previously-regressed `pushes a missing delegate grant dependency before a scoped local record`)
- `bun test tests/sync-messages.spec.ts` — 42 pass ✅
- `bun test tests/e2e-multi-agent-sync.spec.ts` — 6 pass ✅ (incl. `pushes delegated local writes without the owner signing key`)
