### PR TITLE
docs(agent): correct stale encryption gap comments and issue refs

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -736,12 +736,15 @@ export class AgentDwnApi {
 
       // Owner-authored multi-party root records get context-key delivery below
       // (participant, delegate, and cross-device paths). The externally-authored
-      // multi-party root record is the open gap: it lands ProtocolPath-encrypted to
-      // the owner only, so other context-key holders cannot decrypt it. Closing this
-      // needs a normal authored DWN write because a signed message cannot be rewritten
-      // by the owner; the mechanism is still open.
-      // Open issue https://github.com/enboxorg/enbox/issues/923: resolve externally-authored
-      // multi-party root-record context-key access.
+      // multi-party root record remains the open gap: it lands ProtocolPath-encrypted
+      // to the owner only, so other context-key holders cannot decrypt it.
+      //
+      // A prior "reactive upgrade" path had the owner re-encrypt the root under the
+      // context key after the fact, but it bypassed DWN message processing and was
+      // non-atomic, so it was removed (see #109). A correct fix must go through a
+      // normal authored DWN write — a signed message cannot be silently rewritten by
+      // the owner — and no replacement mechanism exists yet. Related open tracking:
+      // #523 (participant context-establishment delivery) and #99 (broader encryption).
       const newParticipants = detectNewParticipantsFn({
         protocolDefinition,
         protocolPath : writeParams.protocolPath,
@@ -1790,8 +1793,10 @@ export class AgentDwnApi {
    * into `_delegateContextKeyCache`. It works when the delegate cache is
    * on the same agent instance that creates the root record.
    *
-   * Cross-device DWN-based delivery (where the owner's agent and the
-   * delegate's agent are separate processes) is a documented follow-up.
+   * Cross-device delivery (where the owner's agent and the delegate's agent
+   * are separate processes) is handled separately by
+   * `deliverContextKeyToDelegatesViaDwn()`, which writes `contextKey` records
+   * to the owner's DWN for the delegate to fetch (see #826).
    *
    * @param protocol - The protocol URI
    * @param rootContextId - The root context ID of the new context

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -331,8 +331,9 @@ export type EnboxConnectResponse = {
    *
    * Contexts created after connect are delivered automatically by
    * `postWriteKeyDelivery()` when the owner creates a new multi-party root
-   * record on the same agent instance (same-process delivery).
-   * Cross-device delivery is a documented follow-up.
+   * record: same-process via direct cache injection, and cross-device via
+   * `contextKey` records written to the owner's DWN for the delegate to
+   * fetch (see #826).
    */
   delegateContextKeys?: DelegateContextKey[];
 


### PR DESCRIPTION
## Summary

Comment-only corrections in `@enbox/agent` so the encryption-gap notes match what the code actually does and point at the right issues. No behavior change.

- **Externally-authored multi-party root record** (`dwn-api.ts`): the comment pointed at **#923** as the "open issue" for this gap. #923 is a **closed** test-gap issue (auto-closed via an unrelated security batch, #926), not the design tracker. Rewrote the note to describe the real state:
  - the reactive owner-side re-encryption ("upgrade") path that used to cover this was **removed** after **#109** flagged it as non-atomic and bypassing DWN message processing;
  - no replacement mechanism exists yet;
  - related open tracking is **#523** (participant context-establishment delivery) and **#99** (broader encryption work).
- **Cross-device delegate context-key delivery** (`dwn-api.ts`, `enbox-connect-protocol.ts`): two doc comments still called this "a documented follow-up." It **shipped in #826** via `deliverContextKeyToDelegatesViaDwn()`. Updated both to describe the same-process (cache injection) vs cross-device (`contextKey` records on the owner's DWN) split.

Deliberately scoped tight: no new issues opened, and accurate references (e.g. the `#99` full-context-derivation TODO in `dwn-sdk-js`, and the `#890` epk-privacy note) were left as-is.

## Test plan

- [x] `bun run --filter @enbox/agent lint` — clean (comment-only)
- [x] Verified `deliverContextKeyToDelegatesViaDwn()` and `postWriteKeyDelivery()` exist and are wired before referencing them
- [x] Confirmed #923 is CLOSED and #109/#523/#99/#826 states via `gh`
