### PR TITLE
feat(agent): resolve delegated encryption keys from durable grants

### DIFF
--- a/.changeset/durable-grantkey-resolution.md
+++ b/.changeset/durable-grantkey-resolution.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Add durable grantKey production and cache-miss decryption resolution for delegated encrypted reads.

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -1,13 +1,15 @@
 import type {
+  DataEncodedRecordsWriteMessage,
   DerivedPrivateJwk,
   EncryptionInput,
   EncryptionKeyDeriver,
   KeyDecrypter,
+  PermissionGrant,
   RecordsQueryReply,
   RecordsReadReply,
   RecordsWriteMessage,
 } from '@enbox/dwn-sdk-js';
-import type { KeyIdentifier, PublicKeyJwk } from '@enbox/crypto';
+import type { KeyIdentifier, PrivateKeyJwk, PublicKeyJwk } from '@enbox/crypto';
 
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type {
@@ -20,15 +22,47 @@ import {
   Cid,
   ContentEncryptionAlgorithm,
   DataStream,
+  DwnInterfaceName,
+  DwnMethodName,
+  PermissionGrant as DwnPermissionGrant,
   Encoder,
   Encryption,
+  EncryptionProtocol,
+  HdKey,
   KeyDerivationScheme,
+  Message,
   Records,
 } from '@enbox/dwn-sdk-js';
 import { Ed25519, X25519 } from '@enbox/crypto';
 
 import { DwnInterface } from './types/dwn.js';
 import { isDwnRequest } from './dwn-type-guards.js';
+
+const GRANT_KEY_DERIVATION_PATH = [
+  KeyDerivationScheme.ProtocolPath,
+  EncryptionProtocol.uri,
+  EncryptionProtocol.grantKeyPath,
+];
+
+type DelegateDecryptionKeyCache = {
+  get(key: string): DelegateDecryptionKeyEntry[] | undefined;
+  set?(key: string, value: DelegateDecryptionKeyEntry[]): void;
+};
+
+type GrantKeyScope = {
+  scheme: typeof KeyDerivationScheme.ProtocolPath;
+  protocol: string;
+  protocolPath?: string;
+};
+
+type GrantKeyPayload = {
+  grantId: string;
+  scope: GrantKeyScope;
+  derivationPath: string[];
+  keyId: string;
+  publicKeyJwk: PublicKeyJwk;
+  privateKeyJwk: PrivateKeyJwk;
+};
 
 /**
  * Returns the IV/counter byte length for DWN content encryption.
@@ -281,6 +315,87 @@ export type DelegateDecryptionKeyEntry = {
 };
 
 /**
+ * Creates durable grantKey records for read grants that carry encrypted protocol access.
+ *
+ * The record payload delivers the owner-derived ProtocolPath private key. The record
+ * itself is encrypted to the grantee's own Encryption Protocol `grantKey` path.
+ */
+export async function createGrantKeyRecordsForGrants(params: {
+  agent: EnboxPlatformAgent;
+  ownerDid: string;
+  granteeDid: string;
+  granteeRootPrivateKey: PrivateKeyJwk;
+  grantMessages: DataEncodedRecordsWriteMessage[];
+}): Promise<DataEncodedRecordsWriteMessage[]> {
+  const grantKeyRecords: DataEncodedRecordsWriteMessage[] = [];
+
+  for (const grantMessage of params.grantMessages) {
+    const grant = DwnPermissionGrant.parse(grantMessage);
+    if (!isGrantKeyEligibleGrant(grant)) {
+      continue;
+    }
+
+    const payload = await buildGrantKeyPayload(params.agent, params.ownerDid, grant);
+    const payloadBytes = Encoder.objectToBytes(payload);
+    const contentEncryptionAlgorithm = ContentEncryptionAlgorithm.A256CTR;
+    const dataEncryptionKey = crypto.getRandomValues(new Uint8Array(32));
+    const dataEncryptionIV = crypto.getRandomValues(new Uint8Array(ivLength(contentEncryptionAlgorithm)));
+    const granteeGrantKeyPublicKey = await derivePublicKeyFromPrivateKey(
+      params.granteeRootPrivateKey,
+      GRANT_KEY_DERIVATION_PATH,
+    );
+    const granteeGrantKeyKeyId = await Encryption.getKeyId(granteeGrantKeyPublicKey);
+    const encryptionInput = buildEncryptionInput(
+      dataEncryptionKey,
+      dataEncryptionIV,
+      granteeGrantKeyKeyId,
+      granteeGrantKeyPublicKey,
+      KeyDerivationScheme.ProtocolPath,
+    );
+    const { encryptedBytes, dataCid, dataSize } = await encryptAndComputeCid(
+      payloadBytes,
+      dataEncryptionKey,
+      dataEncryptionIV,
+      contentEncryptionAlgorithm,
+    );
+
+    const { reply, message } = await params.agent.processDwnRequest({
+      author        : params.ownerDid,
+      target        : params.ownerDid,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        recipient    : params.granteeDid,
+        protocol     : EncryptionProtocol.uri,
+        protocolPath : EncryptionProtocol.grantKeyPath,
+        schema       : EncryptionProtocol.definition.types.grantKey.schema,
+        dataFormat   : 'application/json',
+        dataCid,
+        dataSize,
+        encryptionInput,
+        tags         : {
+          grantId  : grant.id,
+          protocol : grant.scope.protocol,
+          ...(grant.scope.protocolPath ? { protocolPath: grant.scope.protocolPath } : {}),
+          keyId    : payload.keyId,
+        },
+      },
+      dataStream: DataStream.fromBytes(encryptedBytes),
+    });
+
+    if (reply.status.code !== 202 && reply.status.code !== 409) {
+      throw new Error(`AgentDwnApi: Failed to create grantKey record: ${reply.status.detail}`);
+    }
+
+    grantKeyRecords.push({
+      ...message!,
+      encodedData: Encoder.bytesToBase64Url(encryptedBytes),
+    } as DataEncodedRecordsWriteMessage);
+  }
+
+  return grantKeyRecords;
+}
+
+/**
  * Resolves the appropriate KeyDecrypter for a record's encryption scheme.
  *
  * Owners derive protocol-path keys directly from KMS. Delegates use delivered
@@ -298,44 +413,39 @@ export async function resolveKeyDecrypter(
   authorDid: string,
   recordsWrite: RecordsWriteMessage,
   targetDid: string | undefined,
-  delegateDecryptionKeyCache?: { get(key: string): DelegateDecryptionKeyEntry[] | undefined },
+  delegateDecryptionKeyCache?: DelegateDecryptionKeyCache,
   granteeDid?: string,
 ): Promise<KeyDecrypter> {
-  void targetDid;
-
   if (granteeDid !== undefined) {
     const protocol = recordsWrite.descriptor.protocol;
     const protocolPath = recordsWrite.descriptor.protocolPath;
     if (protocol) {
       const cacheKey = `ddk~${granteeDid}`;
-      const allKeys = delegateDecryptionKeyCache?.get(cacheKey);
-      if (allKeys) {
-        const keysForProtocol = allKeys.filter((key) => key.protocol === protocol);
+      const cachedKey = findCoveringDelegateKey(delegateDecryptionKeyCache?.get(cacheKey), protocol, protocolPath);
+      if (cachedKey !== undefined) {
+        return buildProtocolPathSubtreeDecrypter(cachedKey.derivedPrivateKey);
+      }
 
-        if (protocolPath) {
-          const exactKey = keysForProtocol.find(
-            (key) => key.scope.kind === 'protocolPath' && key.scope.protocolPath === protocolPath
+      if (targetDid !== undefined && delegateDecryptionKeyCache?.set !== undefined) {
+        const hydratedKeys = await resolveGrantKeyRecords({
+          agent,
+          grantorDid: targetDid,
+          granteeDid,
+          protocol,
+          protocolPath,
+        });
+
+        if (hydratedKeys.length > 0) {
+          const mergedKeys = mergeDelegateDecryptionKeys(
+            delegateDecryptionKeyCache.get(cacheKey) ?? [],
+            hydratedKeys,
           );
-          if (exactKey) {
-            return buildProtocolPathSubtreeDecrypter(exactKey.derivedPrivateKey);
-          }
+          delegateDecryptionKeyCache.set(cacheKey, mergedKeys);
 
-          const ancestorKey = keysForProtocol
-            .filter((key): key is DelegateDecryptionKeyEntry & {
-              scope: { kind: 'protocolPath'; protocolPath: string }
-            } =>
-              key.scope.kind === 'protocolPath' &&
-              protocolPath.startsWith(key.scope.protocolPath + '/')
-            )
-            .sort((a, b): number => b.scope.protocolPath.length - a.scope.protocolPath.length)[0];
-          if (ancestorKey !== undefined) {
-            return buildProtocolPathSubtreeDecrypter(ancestorKey.derivedPrivateKey);
+          const hydratedKey = findCoveringDelegateKey(mergedKeys, protocol, protocolPath);
+          if (hydratedKey !== undefined) {
+            return buildProtocolPathSubtreeDecrypter(hydratedKey.derivedPrivateKey);
           }
-        }
-
-        const wideKey = keysForProtocol.find((key) => key.scope.kind === 'protocol');
-        if (wideKey) {
-          return buildProtocolPathSubtreeDecrypter(wideKey.derivedPrivateKey);
         }
       }
     }
@@ -363,7 +473,7 @@ export async function maybeDecryptReply<T extends DwnInterface>(
   request: ProcessDwnRequest<T> | SendDwnRequest<T>,
   reply: DwnMessageReply[T],
   agent: EnboxPlatformAgent,
-  delegateDecryptionKeyCache?: { get(key: string): DelegateDecryptionKeyEntry[] | undefined },
+  delegateDecryptionKeyCache?: DelegateDecryptionKeyCache,
 ): Promise<void> {
   if (!('encryption' in request) || !request.encryption) {
     return;
@@ -433,4 +543,335 @@ export async function maybeDecryptReply<T extends DwnInterface>(
       }
     }
   }
+}
+
+function isGrantKeyEligibleGrant(grant: PermissionGrant): grant is PermissionGrant & {
+  scope: PermissionGrant['scope'] & {
+    interface: typeof DwnInterfaceName.Records;
+    method: typeof DwnMethodName.Read;
+    protocol: string;
+    protocolPath?: string;
+  };
+} {
+  return grant.scope.interface === DwnInterfaceName.Records &&
+    grant.scope.method === DwnMethodName.Read &&
+    'protocol' in grant.scope &&
+    typeof grant.scope.protocol === 'string' &&
+    !('contextId' in grant.scope && grant.scope.contextId !== undefined);
+}
+
+async function buildGrantKeyPayload(
+  agent: EnboxPlatformAgent,
+  ownerDid: string,
+  grant: PermissionGrant & {
+    scope: PermissionGrant['scope'] & {
+      protocol: string;
+      protocolPath?: string;
+    };
+  },
+): Promise<GrantKeyPayload> {
+  const { keyUri } = await getEncryptionKeyInfo(agent, ownerDid);
+  const derivationPath = getScopeDerivationPath(grant.scope.protocol, grant.scope.protocolPath);
+  const privateKeyBytes = await agent.keyManager.derivePrivateKeyBytes({
+    keyUri,
+    derivationPath,
+  });
+  const privateKeyJwk = await X25519.bytesToPrivateKey({ privateKeyBytes }) as PrivateKeyJwk;
+  const publicKeyJwk = await X25519.getPublicKey({ key: privateKeyJwk }) as PublicKeyJwk;
+  const keyId = await Encryption.getKeyId(publicKeyJwk);
+
+  return {
+    grantId : grant.id,
+    scope   : {
+      scheme   : KeyDerivationScheme.ProtocolPath,
+      protocol : grant.scope.protocol,
+      ...(grant.scope.protocolPath ? { protocolPath: grant.scope.protocolPath } : {}),
+    },
+    derivationPath,
+    keyId,
+    publicKeyJwk,
+    privateKeyJwk,
+  };
+}
+
+async function derivePublicKeyFromPrivateKey(
+  privateKey: PrivateKeyJwk,
+  derivationPath: string[],
+): Promise<PublicKeyJwk> {
+  const privateKeyBytes = await X25519.privateKeyToBytes({ privateKey });
+  const derivedPrivateKeyBytes = await HdKey.derivePrivateKeyBytes(privateKeyBytes, derivationPath);
+  const derivedPrivateKeyJwk = await X25519.bytesToPrivateKey({ privateKeyBytes: derivedPrivateKeyBytes });
+  return X25519.getPublicKey({ key: derivedPrivateKeyJwk }) as Promise<PublicKeyJwk>;
+}
+
+function getScopeDerivationPath(protocol: string, protocolPath?: string): string[] {
+  return [
+    KeyDerivationScheme.ProtocolPath,
+    protocol,
+    ...(protocolPath ? protocolPath.split('/') : []),
+  ];
+}
+
+function findCoveringDelegateKey(
+  allKeys: DelegateDecryptionKeyEntry[] | undefined,
+  protocol: string,
+  protocolPath: string | undefined,
+): DelegateDecryptionKeyEntry | undefined {
+  if (allKeys === undefined) {
+    return undefined;
+  }
+
+  const keysForProtocol = allKeys.filter((key) => key.protocol === protocol);
+
+  if (protocolPath !== undefined) {
+    const exactKey = keysForProtocol.find(
+      (key) => key.scope.kind === 'protocolPath' && key.scope.protocolPath === protocolPath
+    );
+    if (exactKey !== undefined) {
+      return exactKey;
+    }
+
+    const ancestorKey = keysForProtocol
+      .filter((key): key is DelegateDecryptionKeyEntry & {
+        scope: { kind: 'protocolPath'; protocolPath: string }
+      } =>
+        key.scope.kind === 'protocolPath' &&
+        protocolPath.startsWith(key.scope.protocolPath + '/')
+      )
+      .sort((a, b): number => b.scope.protocolPath.length - a.scope.protocolPath.length)[0];
+    if (ancestorKey !== undefined) {
+      return ancestorKey;
+    }
+  }
+
+  return keysForProtocol.find((key) => key.scope.kind === 'protocol');
+}
+
+function mergeDelegateDecryptionKeys(
+  existingKeys: DelegateDecryptionKeyEntry[],
+  newKeys: DelegateDecryptionKeyEntry[],
+): DelegateDecryptionKeyEntry[] {
+  const merged = new Map<string, DelegateDecryptionKeyEntry>();
+  for (const key of existingKeys) {
+    merged.set(getDelegateDecryptionKeyCacheKey(key), key);
+  }
+  for (const key of newKeys) {
+    merged.set(getDelegateDecryptionKeyCacheKey(key), key);
+  }
+  return [...merged.values()];
+}
+
+function getDelegateDecryptionKeyCacheKey(key: DelegateDecryptionKeyEntry): string {
+  return key.scope.kind === 'protocol'
+    ? `${key.protocol}~protocol`
+    : `${key.protocol}~protocolPath~${key.scope.protocolPath}`;
+}
+
+async function resolveGrantKeyRecords(params: {
+  agent: EnboxPlatformAgent;
+  grantorDid: string;
+  granteeDid: string;
+  protocol: string;
+  protocolPath?: string;
+}): Promise<DelegateDecryptionKeyEntry[]> {
+  const { reply } = await params.agent.processDwnRequest({
+    author        : params.granteeDid,
+    target        : params.grantorDid,
+    messageType   : DwnInterface.RecordsQuery,
+    messageParams : {
+      filter: {
+        recipient    : params.granteeDid,
+        protocol     : EncryptionProtocol.uri,
+        protocolPath : EncryptionProtocol.grantKeyPath,
+        tags         : { protocol: params.protocol },
+      },
+    },
+  });
+
+  if (reply.status.code !== 200 || reply.entries === undefined || reply.entries.length === 0) {
+    return [];
+  }
+
+  const granteeDecrypter = await getKeyDecrypter(params.agent, params.granteeDid);
+  const resolvedKeys: DelegateDecryptionKeyEntry[] = [];
+
+  for (const entry of reply.entries) {
+    const grantKeyMessage = entry as RecordsWriteMessage & { encodedData?: string };
+    if (Message.getAuthor(grantKeyMessage) !== params.grantorDid) {
+      continue;
+    }
+
+    const encryptedData = await getGrantKeyEncryptedData(params.agent, params.granteeDid, params.grantorDid, grantKeyMessage);
+    if (encryptedData === undefined) {
+      continue;
+    }
+
+    try {
+      const decryptedStream = await Records.decrypt(
+        grantKeyMessage,
+        granteeDecrypter,
+        DataStream.fromBytes(encryptedData),
+      );
+      const payload = Encoder.bytesToObject(await DataStream.toBytes(decryptedStream)) as GrantKeyPayload;
+      const grant = await readPermissionGrant(params.agent, params.granteeDid, params.grantorDid, payload.grantId);
+
+      await verifyGrantKeyPayload({
+        payload,
+        grant,
+        grantKeyMessage,
+        grantorDid   : params.grantorDid,
+        granteeDid   : params.granteeDid,
+        protocol     : params.protocol,
+        protocolPath : params.protocolPath,
+      });
+
+      resolvedKeys.push({
+        protocol : payload.scope.protocol,
+        scope    : payload.scope.protocolPath === undefined
+          ? { kind: 'protocol' }
+          : { kind: 'protocolPath', protocolPath: payload.scope.protocolPath },
+        derivedPrivateKey: {
+          rootKeyId         : payload.keyId,
+          keyId             : payload.keyId,
+          derivationScheme  : KeyDerivationScheme.ProtocolPath,
+          derivationPath    : payload.derivationPath,
+          derivedPrivateKey : payload.privateKeyJwk,
+        },
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  return resolvedKeys;
+}
+
+async function getGrantKeyEncryptedData(
+  agent: EnboxPlatformAgent,
+  granteeDid: string,
+  grantorDid: string,
+  grantKeyMessage: RecordsWriteMessage & { encodedData?: string },
+): Promise<Uint8Array | undefined> {
+  if (grantKeyMessage.encodedData !== undefined) {
+    return Encoder.base64UrlToBytes(grantKeyMessage.encodedData);
+  }
+
+  const { reply } = await agent.processDwnRequest({
+    author        : granteeDid,
+    target        : grantorDid,
+    messageType   : DwnInterface.RecordsRead,
+    messageParams : { filter: { recordId: grantKeyMessage.recordId } },
+  });
+
+  if (reply.status.code !== 200 || reply.entry?.data === undefined) {
+    return undefined;
+  }
+
+  return DataStream.toBytes(reply.entry.data);
+}
+
+async function readPermissionGrant(
+  agent: EnboxPlatformAgent,
+  granteeDid: string,
+  grantorDid: string,
+  grantId: string,
+): Promise<PermissionGrant> {
+  const { reply } = await agent.processDwnRequest({
+    author        : granteeDid,
+    target        : grantorDid,
+    messageType   : DwnInterface.RecordsRead,
+    messageParams : { filter: { recordId: grantId } },
+  });
+
+  if (reply.status.code !== 200 || reply.entry?.recordsWrite === undefined || reply.entry.data === undefined) {
+    throw new Error(`AgentDwnApi: unable to read permission grant '${grantId}'.`);
+  }
+
+  const grantData = await DataStream.toBytes(reply.entry.data);
+  return DwnPermissionGrant.parse({
+    ...reply.entry.recordsWrite,
+    encodedData: Encoder.bytesToBase64Url(grantData),
+  } as DataEncodedRecordsWriteMessage);
+}
+
+async function verifyGrantKeyPayload(params: {
+  payload: GrantKeyPayload;
+  grant: PermissionGrant;
+  grantKeyMessage: RecordsWriteMessage;
+  grantorDid: string;
+  granteeDid: string;
+  protocol: string;
+  protocolPath?: string;
+}): Promise<void> {
+  const { payload, grant, grantKeyMessage } = params;
+  const tags = grantKeyMessage.descriptor.tags ?? {};
+
+  if (payload.grantId !== tags.grantId ||
+      payload.scope.protocol !== tags.protocol ||
+      payload.keyId !== tags.keyId ||
+      payload.scope.protocolPath !== tags.protocolPath) {
+    throw new Error('grantKey payload does not match record tags.');
+  }
+
+  if (grant.id !== payload.grantId ||
+      grant.grantor !== params.grantorDid ||
+      grant.grantee !== params.granteeDid ||
+      !grantScopeCoversPayload(grant, payload)) {
+    throw new Error('grantKey payload is not covered by the referenced grant.');
+  }
+
+  if (payload.scope.scheme !== KeyDerivationScheme.ProtocolPath ||
+      payload.scope.protocol !== params.protocol ||
+      !scopeCoversRecord(payload.scope, params.protocol, params.protocolPath)) {
+    throw new Error('grantKey scope does not cover encrypted record.');
+  }
+
+  const expectedDerivationPath = getScopeDerivationPath(payload.scope.protocol, payload.scope.protocolPath);
+  if (!arrayEquals(payload.derivationPath, expectedDerivationPath)) {
+    throw new Error('grantKey derivationPath does not match scope.');
+  }
+
+  const publicKeyId = await Encryption.getKeyId(payload.publicKeyJwk);
+  const publicKeyFromPrivate = await X25519.getPublicKey({ key: payload.privateKeyJwk }) as PublicKeyJwk;
+  const privateKeyId = await Encryption.getKeyId(publicKeyFromPrivate);
+  if (payload.keyId !== publicKeyId || payload.keyId !== privateKeyId) {
+    throw new Error('grantKey keyId does not match delivered key material.');
+  }
+}
+
+function grantScopeCoversPayload(grant: PermissionGrant, payload: GrantKeyPayload): boolean {
+  if (!isGrantKeyEligibleGrant(grant)) {
+    return false;
+  }
+
+  if (grant.scope.protocol !== payload.scope.protocol) {
+    return false;
+  }
+
+  if (grant.scope.protocolPath === undefined) {
+    return true;
+  }
+
+  return payload.scope.protocolPath !== undefined &&
+    isBoundaryAwareSubtree(grant.scope.protocolPath, payload.scope.protocolPath);
+}
+
+function scopeCoversRecord(scope: GrantKeyScope, protocol: string, protocolPath: string | undefined): boolean {
+  if (scope.protocol !== protocol) {
+    return false;
+  }
+
+  if (scope.protocolPath === undefined) {
+    return true;
+  }
+
+  return protocolPath !== undefined && isBoundaryAwareSubtree(scope.protocolPath, protocolPath);
+}
+
+function isBoundaryAwareSubtree(scopePath: string, candidatePath: string): boolean {
+  return candidatePath === scopePath || candidatePath.startsWith(scopePath + '/');
+}
+
+function arrayEquals(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
 }

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -15,10 +15,10 @@
 
 import type { DerivedPrivateJwk } from '@enbox/dwn-sdk-js';
 import type { EnboxPlatformAgent } from './types/agent.js';
-import type { PrivateKeyJwk } from '@enbox/crypto';
 import type { RequireOnly } from '@enbox/common';
+import type { BearerDid, DidDocument, PortableDid } from '@enbox/dids';
 import type { ConnectSessionMetadata, ConnectSessionTransport, DwnDataEncodedRecordsWriteMessage, DwnPermissionScope, DwnProtocolDefinition, DwnRecordsPermissionScope } from './types/dwn.js';
-import type { DidDocument, PortableDid } from '@enbox/dids';
+import type { JoseHeaderParams, Jwk, PrivateKeyJwk } from '@enbox/crypto';
 
 /**
  * The protocols of permissions requested, along with the definition and permission scopes for each protocol.
@@ -112,11 +112,7 @@ export type DelegateDecryptionKey =
     derivedPrivateKey: DerivedPrivateJwk;
   };
 
-import type {
-  JoseHeaderParams,
-  Jwk } from '@enbox/crypto';
-
-import { type BearerDid, DidJwk } from '@enbox/dids';
+import { DidJwk } from '@enbox/dids';
 import { concatenateUrl, Convert, logger, nowMs, timed } from '@enbox/common';
 import {
   CryptoUtils,
@@ -130,8 +126,8 @@ import { DwnInterfaceName, DwnMethodName, KeyDerivationScheme, PermissionsProtoc
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnInterface } from './types/dwn.js';
-import { getEncryptionKeyInfo } from './dwn-encryption.js';
 import { isRecordPermissionScope } from './dwn-api.js';
+import { createGrantKeyRecordsForGrants as createGrantKeyRecordsForGrantsFn, getEncryptionKeyInfo } from './dwn-encryption.js';
 import { mapConcurrent, mapConcurrentSettled } from './utils.js';
 
 // ---------------------------------------------------------------------------
@@ -1028,6 +1024,61 @@ async function createPermissionGrants(
   return permissionGrants.map((g) => g.message);
 }
 
+async function fanOutDataEncodedRecords(
+  ownerDid: string,
+  agent: EnboxPlatformAgent,
+  records: DwnDataEncodedRecordsWriteMessage[],
+): Promise<void> {
+  if (records.length === 0) {
+    return;
+  }
+
+  const dwnEndpointUrls = await agent.dwn.getDwnEndpointUrlsForTarget(ownerDid);
+  const sendTasks = records.flatMap((record, recordIndex) => {
+    const { encodedData, ...rawMessage } = record;
+    const data = Convert.base64Url(encodedData).toUint8Array();
+    return dwnEndpointUrls.map((dwnUrl) => ({ recordIndex, dwnUrl, rawMessage, data }));
+  });
+
+  const settled = await mapConcurrentSettled(
+    sendTasks,
+    CONNECT_FANOUT_CONCURRENCY,
+    async ({ recordIndex, dwnUrl, rawMessage, data }) => {
+      const reply = await agent.rpc.sendDwnRequest({
+        dwnUrl,
+        targetDid : ownerDid,
+        message   : rawMessage,
+        data      : new Blob([data as BlobPart]),
+        signal    : AbortSignal.timeout(CONNECT_REQUEST_TIMEOUT_MS),
+      });
+      return { recordIndex, dwnUrl, reply };
+    },
+  );
+
+  const successPerRecord = new Array<boolean>(records.length).fill(false);
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i];
+    if (result.status === 'rejected') {
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      logger.error(`Record send to ${sendTasks[i].dwnUrl} failed: ${reason}`);
+      continue;
+    }
+
+    const { recordIndex, dwnUrl, reply } = result.value;
+    if (reply.status.code === 202 || reply.status.code === 409) {
+      successPerRecord[recordIndex] = true;
+    } else {
+      logger.error(`Record send to ${dwnUrl} returned ${reply.status.code}: ${reply.status.detail}`);
+    }
+  }
+
+  for (let i = 0; i < successPerRecord.length; i++) {
+    if (!successPerRecord[i]) {
+      throw new Error('Could not send grantKey record to any DWN endpoint.');
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Protocol installation
 // ---------------------------------------------------------------------------
@@ -1296,6 +1347,7 @@ async function submitConnectResponse(
     // ProtocolPath keys are either protocol-wide or path-subtree.
     // Write-only delegates receive no decryption capability.
     const delegateDecryptionKeys: DelegateDecryptionKey[] = [];
+    const durableGrantKeyRecords: DwnDataEncodedRecordsWriteMessage[] = [];
 
     const delegateGrants = await timed(
       `${CONNECT_PERF_LOG_PREFIX} permissionGrants.fanout (protocols=${numProtocols})`,
@@ -1315,8 +1367,9 @@ async function submitConnectResponse(
 
             const hasEncryptedTypes = Object.values(protocolDefinition.types ?? {})
               .some((type: any) => type?.encryptionRequired === true);
+            const hasEncryptedReadScopes = hasEncryptedTypes && permissionScopes.some(isConnectReadScope);
 
-            if (hasEncryptedTypes) {
+            if (hasEncryptedReadScopes) {
               const keys = await deriveScopedDecryptionKeys(
                 agent, selectedDid, protocolDefinition.protocol,
                 permissionScopes, protocolDefinition,
@@ -1324,18 +1377,36 @@ async function submitConnectResponse(
               delegateDecryptionKeys.push(...keys);
             }
 
-            return EnboxConnectProtocol.createPermissionGrants(
+            const grants = await EnboxConnectProtocol.createPermissionGrants(
               selectedDid,
               delegateBearerDid,
               agent,
               permissionScopes,
               { connectSession },
             );
+
+            if (hasEncryptedReadScopes) {
+              const grantKeyRecords = await EnboxConnectProtocol.createGrantKeyRecordsForGrants({
+                agent,
+                ownerDid              : selectedDid,
+                granteeDid            : delegateBearerDid.uri,
+                granteeRootPrivateKey : delegateX25519PrivateKey as PrivateKeyJwk,
+                grantMessages         : grants,
+              });
+              durableGrantKeyRecords.push(...grantKeyRecords);
+            }
+
+            return grants;
           }
         );
 
         return (await Promise.all(delegateGrantPromises)).flat();
       },
+    );
+
+    await timed(
+      `${CONNECT_PERF_LOG_PREFIX} grantKeys.fanout (n=${durableGrantKeyRecords.length})`,
+      () => fanOutDataEncodedRecords(selectedDid, agent, durableGrantKeyRecords),
     );
 
     // Create per-grant contextId-scoped revocation grants.
@@ -1524,6 +1595,7 @@ export const EnboxConnectProtocol = {
   createConnectResponse,
   createConnectSessionMetadata,
   createPermissionGrants,
+  createGrantKeyRecordsForGrants: createGrantKeyRecordsForGrantsFn,
   submitConnectResponse,
   deriveScopedDecryptionKeys,
 };

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -1434,6 +1434,7 @@ describe('enbox connect', () => {
       }];
 
       sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+      const grantKeyStub = sinon.stub(EnboxConnectProtocol, 'createGrantKeyRecordsForGrants').resolves([]);
       sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
         grant   : {} as any,
         message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
@@ -1493,6 +1494,7 @@ describe('enbox connect', () => {
 
       expect(response.delegateDecryptionKeys).toHaveLength(1);
       expect(response.delegateDecryptionKeys![0].scope.kind).toBe('protocol');
+      expect(grantKeyStub.calledOnce).toBe(true);
       expect(response.delegateDecryptionKeys![0].derivedPrivateKey.derivationPath).toEqual([
         'protocolPath',
         mixedProtocol.protocol,

--- a/packages/agent/tests/dwn-encryption.spec.ts
+++ b/packages/agent/tests/dwn-encryption.spec.ts
@@ -2,14 +2,19 @@ import type { DerivedPrivateJwk, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 
 import sinon from 'sinon';
 
+import { X25519 } from '@enbox/crypto';
 import { afterEach, describe, expect, it } from 'bun:test';
 import {
   ContentEncryptionAlgorithm,
   DataStream,
+  DwnInterfaceName,
+  DwnMethodName,
   Encoder,
   Encryption,
+  EncryptionProtocol,
   HdKey,
   KeyDerivationScheme,
+  Records,
   TestDataGenerator,
 } from '@enbox/dwn-sdk-js';
 
@@ -559,6 +564,134 @@ describe('dwn-encryption', () => {
       },
     });
 
+    const makeGrantKeyResolverFixture = async ({
+      grantScopeProtocolPath,
+      payloadScopeProtocolPath,
+      recordProtocolPath = 'message',
+      mutatePayload,
+    }: {
+      grantScopeProtocolPath?: string;
+      payloadScopeProtocolPath?: string;
+      recordProtocolPath?: string;
+      mutatePayload?: (payload: any) => void;
+    } = {}): Promise<{
+      delegateCache: { get: sinon.SinonStub; set: sinon.SinonStub };
+      mockAgent: any;
+      recordsWrite: RecordsWriteMessage;
+    }> => {
+      const protocol = 'https://proto.example.com';
+      const grantor = await TestDataGenerator.generatePersona({ did: 'did:example:alice' });
+      const grantee = await TestDataGenerator.generatePersona({ did: 'did:example:delegate' });
+      const grant = await TestDataGenerator.generateGrantCreate({
+        author    : grantor,
+        grantedTo : grantee,
+        delegated : true,
+        scope     : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Read,
+          protocol,
+          ...(grantScopeProtocolPath !== undefined ? { protocolPath: grantScopeProtocolPath } : {}),
+        },
+        dateExpires: '2040-06-25T16:09:16.693356Z',
+      });
+
+      const privateKeyJwk = await X25519.generateKey();
+      const publicKeyJwk = await X25519.getPublicKey({ key: privateKeyJwk });
+      const keyId = await Encryption.getKeyId(publicKeyJwk);
+      const payload = {
+        grantId : grant.dataEncodedMessage.recordId,
+        scope   : {
+          scheme: KeyDerivationScheme.ProtocolPath,
+          protocol,
+          ...(payloadScopeProtocolPath !== undefined ? { protocolPath: payloadScopeProtocolPath } : {}),
+        },
+        derivationPath: [
+          KeyDerivationScheme.ProtocolPath,
+          protocol,
+          ...(payloadScopeProtocolPath !== undefined ? payloadScopeProtocolPath.split('/') : []),
+        ],
+        keyId,
+        publicKeyJwk,
+        privateKeyJwk,
+      };
+      mutatePayload?.(payload);
+
+      const grantKeyWrite = await TestDataGenerator.generateRecordsWrite({
+        author       : grantor,
+        recipient    : grantee.did,
+        protocol     : EncryptionProtocol.uri,
+        protocolPath : EncryptionProtocol.grantKeyPath,
+        schema       : EncryptionProtocol.definition.types.grantKey.schema,
+        dataFormat   : 'application/json',
+        data         : new Uint8Array([1, 2, 3]),
+        tags         : {
+          grantId  : payload.grantId,
+          protocol : payload.scope.protocol,
+          ...(payload.scope.protocolPath !== undefined ? { protocolPath: payload.scope.protocolPath } : {}),
+          keyId    : payload.keyId,
+        },
+      });
+      const grantKeyMessage = {
+        ...grantKeyWrite.message,
+        encodedData: Encoder.bytesToBase64Url(grantKeyWrite.dataBytes!),
+      };
+
+      sinon.stub(Records, 'decrypt').resolves(DataStream.fromBytes(Encoder.objectToBytes(payload)));
+
+      const processDwnRequest = sinon.stub();
+      processDwnRequest.onFirstCall().resolves({
+        reply: {
+          status  : { code: 200, detail: 'OK' },
+          entries : [grantKeyMessage],
+        },
+      });
+      processDwnRequest.onSecondCall().resolves({
+        reply: {
+          status : { code: 200, detail: 'OK' },
+          entry  : {
+            recordsWrite : grant.message,
+            data         : DataStream.fromBytes(grant.dataBytes),
+          },
+        },
+      });
+
+      const mockAgent = {
+        did: {
+          resolve: sinon.stub().resolves({
+            didDocument: {
+              id                 : grantee.did,
+              keyAgreement       : ['#enc'],
+              verificationMethod : [{
+                id           : `${grantee.did}#enc`,
+                type         : 'JsonWebKey2020',
+                controller   : grantee.did,
+                publicKeyJwk : grantee.encryptionKeyPair.publicJwk,
+              }],
+            },
+            didResolutionMetadata: {},
+          }),
+        },
+        keyManager: {
+          getKeyUri    : sinon.stub().resolves('grantee-key-uri'),
+          jweKeyUnwrap : sinon.stub(),
+        },
+        processDwnRequest,
+      };
+
+      return {
+        mockAgent,
+        delegateCache: {
+          get : sinon.stub().returns(undefined),
+          set : sinon.stub(),
+        },
+        recordsWrite: {
+          recordId   : 'rec-grant-key-validation',
+          contextId  : 'rec-grant-key-validation',
+          descriptor : { protocol, protocolPath: recordProtocolPath },
+        } as unknown as RecordsWriteMessage,
+      };
+    };
+
     it('should return a ProtocolPath key decrypter when record has no context encryption', async () => {
       const mockAgent = makeAliceAgent();
 
@@ -745,6 +878,92 @@ describe('dwn-encryption', () => {
       )).rejects.toThrow('no delivered decryption key covers encrypted record');
 
       expect(mockAgent.keyManager.getKeyUri.called).toBe(false);
+    });
+
+    it('should fail closed for a delegate when no durable grantKey covers the record', async () => {
+      const mockAgent = {
+        ...makeAliceAgent(),
+        processDwnRequest: sinon.stub().resolves({
+          reply: {
+            status  : { code: 200, detail: 'OK' },
+            entries : [],
+          },
+        }),
+      };
+      const delegateCache = {
+        get : sinon.stub().returns(undefined),
+        set : sinon.stub(),
+      };
+
+      const recordsWrite = {
+        recordId   : 'rec-no-grant-key',
+        contextId  : 'rec-no-grant-key',
+        descriptor : { protocol: 'https://proto.example.com', protocolPath: 'message' },
+      } as unknown as RecordsWriteMessage;
+
+      await expect(resolveKeyDecrypter(
+        mockAgent, 'did:example:alice', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      )).rejects.toThrow('no delivered decryption key covers encrypted record');
+
+      expect(mockAgent.processDwnRequest.calledOnce).toBe(true);
+      expect(mockAgent.processDwnRequest.firstCall.args[0].messageParams.filter).toEqual({
+        recipient    : 'did:example:delegate',
+        protocol     : EncryptionProtocol.uri,
+        protocolPath : EncryptionProtocol.grantKeyPath,
+        tags         : { protocol: 'https://proto.example.com' },
+      });
+      expect(delegateCache.set.called).toBe(false);
+      expect(mockAgent.keyManager.getKeyUri.called).toBe(false);
+    });
+
+    it('should reject a durable grantKey whose scope does not cover the encrypted record', async () => {
+      const { mockAgent, delegateCache, recordsWrite } = await makeGrantKeyResolverFixture({
+        grantScopeProtocolPath   : 'message/reply',
+        payloadScopeProtocolPath : 'message/reply',
+        recordProtocolPath       : 'message',
+      });
+
+      await expect(resolveKeyDecrypter(
+        mockAgent, 'did:example:delegate', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      )).rejects.toThrow('no delivered decryption key covers encrypted record');
+
+      expect(delegateCache.set.called).toBe(false);
+    });
+
+    it('should reject a durable grantKey whose keyId does not match the delivered key material', async () => {
+      const { mockAgent, delegateCache, recordsWrite } = await makeGrantKeyResolverFixture({
+        mutatePayload: (payload): void => {
+          payload.keyId = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+        },
+      });
+
+      await expect(resolveKeyDecrypter(
+        mockAgent, 'did:example:delegate', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      )).rejects.toThrow('no delivered decryption key covers encrypted record');
+
+      expect(delegateCache.set.called).toBe(false);
+    });
+
+    it('should reject a durable grantKey whose derivationPath does not match its scope', async () => {
+      const { mockAgent, delegateCache, recordsWrite } = await makeGrantKeyResolverFixture({
+        mutatePayload: (payload): void => {
+          payload.derivationPath = [KeyDerivationScheme.ProtocolPath, 'https://proto.example.com', 'other'];
+        },
+      });
+
+      await expect(resolveKeyDecrypter(
+        mockAgent, 'did:example:delegate', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      )).rejects.toThrow('no delivered decryption key covers encrypted record');
+
+      expect(delegateCache.set.called).toBe(false);
     });
   });
 });

--- a/packages/agent/tests/e2e-delegate-encrypted.spec.ts
+++ b/packages/agent/tests/e2e-delegate-encrypted.spec.ts
@@ -16,11 +16,14 @@
 import type { BearerIdentity } from '../src/bearer-identity.js';
 import type { ProtocolDefinition, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 
+import { DidJwk } from '@enbox/dids';
+import { Ed25519 } from '@enbox/crypto';
 import sinon from 'sinon';
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { ContentEncryptionAlgorithm, DataStream, DwnInterfaceName, DwnMethodName, Encoder, KeyDerivationScheme } from '@enbox/dwn-sdk-js';
 
+import { createGrantKeyRecordsForGrants } from '../src/dwn-encryption.js';
 import { DwnInterface } from '../src/types/dwn.js';
 import { EnboxConnectProtocol } from '../src/enbox-connect-protocol.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
@@ -92,6 +95,21 @@ async function queryRawEntry(
   return reply.entries?.[0] as RecordsWriteMessage | undefined;
 }
 
+async function applyDataEncodedRecord(
+  harness: PlatformAgentTestHarness,
+  tenantDid: string,
+  record: RecordsWriteMessage & { encodedData: string },
+): Promise<void> {
+  const { encodedData, ...rawMessage } = record;
+  const applyReply = await harness.agent.dwn.processRawMessage(
+    tenantDid,
+    rawMessage as any,
+    { dataStream: DataStream.fromBytes(Encoder.base64UrlToBytes(encodedData)) },
+  );
+
+  expect([202, 409]).toContain(applyReply.status.code);
+}
+
 // ─── Tests ──────────────────────────────────────────────────────
 
 describe('e2e: delegate + encrypted protocol', () => {
@@ -132,6 +150,10 @@ describe('e2e: delegate + encrypted protocol', () => {
       name        : 'Alice',
       testDwnUrls : [testDwnUrl],
     });
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   // ─── 1. Protocol installation during connect ────────────────
@@ -220,6 +242,164 @@ describe('e2e: delegate + encrypted protocol', () => {
   // ─── 3. Delegate reads decrypt ciphertext ───────────────────
 
   describe('delegate encrypted reads with delivered key', () => {
+    it('should hydrate delivered keys from durable grantKey records on cache miss', async () => {
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: delegateReadableEncryptedNoteProtocol },
+        encryption    : true,
+      });
+
+      const noteData = 'Secret note from durable grantKey';
+      const { message: noteWrite } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : delegateReadableEncryptedNoteProtocol.protocol,
+          protocolPath : 'note',
+          schema       : 'https://schemas.xyz/note',
+          dataFormat   : 'text/plain',
+          data         : new TextEncoder().encode(noteData),
+        },
+        encryption: true,
+      });
+      const noteRecordId = (noteWrite as RecordsWriteMessage).recordId;
+
+      const delegateBearerDid = await DidJwk.create();
+      const delegatePortableDid = await delegateBearerDid.export();
+      const delegateX25519PrivateKey = await Ed25519.convertPrivateKeyToX25519({
+        privateKey: delegatePortableDid.privateKeys![0],
+      });
+      delegatePortableDid.privateKeys!.push(delegateX25519PrivateKey);
+      await delegateHarness.agent.did.import({
+        portableDid : delegatePortableDid,
+        tenant      : delegateHarness.agent.agentDid.uri,
+      });
+
+      const delegateDid = delegateBearerDid.uri;
+      const readGrant = await walletHarness.agent.permissions.createGrant({
+        author      : walletIdentity.did.uri,
+        dateExpires : '2040-06-25T16:09:16.693356Z',
+        delegated   : true,
+        grantedTo   : delegateDid,
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Read,
+          protocol  : delegateReadableEncryptedNoteProtocol.protocol,
+        },
+        store: true,
+      });
+
+      await applyDataEncodedRecord(
+        delegateHarness,
+        walletIdentity.did.uri,
+        readGrant.message as RecordsWriteMessage & { encodedData: string },
+      );
+
+      const grantKeyRecords = await createGrantKeyRecordsForGrants({
+        agent                 : walletHarness.agent,
+        ownerDid              : walletIdentity.did.uri,
+        granteeDid            : delegateDid,
+        granteeRootPrivateKey : delegateX25519PrivateKey as any,
+        grantMessages         : [readGrant.message as any],
+      });
+      expect(grantKeyRecords).toHaveLength(1);
+      await applyDataEncodedRecord(
+        delegateHarness,
+        walletIdentity.did.uri,
+        grantKeyRecords[0] as RecordsWriteMessage & { encodedData: string },
+      );
+
+      const { reply: protoQueryReply } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsQuery,
+        messageParams : { filter: { protocol: delegateReadableEncryptedNoteProtocol.protocol } },
+      });
+      const protocolApplyReply = await delegateHarness.agent.dwn.processRawMessage(
+        walletIdentity.did.uri,
+        protoQueryReply.entries![0] as any,
+      );
+      expect(protocolApplyReply.status.code).toBe(202);
+
+      const { reply: recordQueryReply } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsQuery,
+        messageParams : { filter: { protocol: delegateReadableEncryptedNoteProtocol.protocol } },
+      });
+
+      for (const entry of recordQueryReply.entries ?? []) {
+        const { reply: readReply } = await walletHarness.agent.processDwnRequest({
+          author        : walletIdentity.did.uri,
+          target        : walletIdentity.did.uri,
+          messageType   : DwnInterface.RecordsRead,
+          messageParams : { filter: { recordId: (entry as RecordsWriteMessage).recordId } },
+        });
+
+        if (readReply.entry?.recordsWrite && readReply.entry?.data) {
+          const dataBytes = await DataStream.toBytes(readReply.entry.data);
+          const recordApplyReply = await delegateHarness.agent.dwn.processRawMessage(
+            walletIdentity.did.uri,
+            readReply.entry.recordsWrite as any,
+            { dataStream: DataStream.fromBytes(dataBytes) },
+          );
+          expect(recordApplyReply.status.code).toBe(202);
+        }
+      }
+
+      delegateHarness.agent.dwn.clearDelegateDecryptionKeys(delegateDid);
+      expect(await delegateHarness.agent.did.get({ didUri: walletIdentity.did.uri })).toBeUndefined();
+      const kmsUnwrapSpy = sinon.spy(delegateHarness.agent.keyManager, 'jweKeyUnwrap');
+
+      const { reply: decryptedReply } = await delegateHarness.agent.processDwnRequest({
+        author        : delegateDid,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : {
+          filter            : { recordId: noteRecordId },
+          permissionGrantId : readGrant.grant.id,
+        },
+        encryption : true,
+        granteeDid : delegateDid,
+      });
+
+      expect(decryptedReply.status.code).toBe(200);
+      expect(decryptedReply.entry?.data).toBeDefined();
+      expect(kmsUnwrapSpy.called).toBe(true);
+
+      const decryptedBytes = await DataStream.toBytes(decryptedReply.entry!.data!);
+      expect(new TextDecoder().decode(decryptedBytes)).toBe(noteData);
+
+      const revocation = await walletHarness.agent.permissions.createRevocation({
+        author : walletIdentity.did.uri,
+        grant  : readGrant.grant,
+        store  : true,
+      });
+      await applyDataEncodedRecord(
+        delegateHarness,
+        walletIdentity.did.uri,
+        revocation.message as RecordsWriteMessage & { encodedData: string },
+      );
+
+      delegateHarness.agent.dwn.clearDelegateDecryptionKeys(delegateDid);
+      const { reply: revokedReply } = await delegateHarness.agent.processDwnRequest({
+        author        : delegateDid,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : {
+          filter            : { recordId: noteRecordId },
+          permissionGrantId : readGrant.grant.id,
+        },
+        encryption : true,
+        granteeDid : delegateDid,
+      });
+
+      expect(revokedReply.status.code).toBe(401);
+    });
+
     it('should decrypt records using only a delivered protocol path key from a distinct delegate KMS', async () => {
       // Step 1: Install encrypted protocol on wallet
       await walletHarness.agent.processDwnRequest({
@@ -735,7 +915,7 @@ describe('e2e: delegate + encrypted protocol', () => {
           delegateHarness.agent,
           walletIdentity.did.uri,
           commentWrite,
-          walletIdentity.did.uri,
+          undefined,
           cache,
           siblingDelegateDid,
         )


### PR DESCRIPTION
## Summary
- create durable `grantKey` records for encrypted read grants during connect
- resolve delegated decrypt cache misses from synced/queryable `grantKey` records
- verify referenced grant, scope, derivation path, and key metadata before caching delivered keys

## Test plan
- [x] `bun run lint`
- [x] `bun run --filter @enbox/agent build`
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 TEST_DWN_URL=http://localhost:3011 bun run test:node` from `packages/agent`
- [x] targeted durable grant-key tests in `dwn-encryption`, `e2e-delegate-encrypted`, and `connect`

Closes #1081
