### PR TITLE
fix(agent): verify durable grant key grants are active

### DIFF
--- a/.changeset/grantkey-active-validation.md
+++ b/.changeset/grantkey-active-validation.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+fix: verify durable grant keys reference active permission grants

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -18,6 +18,11 @@ The agent is the core runtime that ties everything together. It manages:
 - **Permissions** — DWN permission grants, requests, and revocations (`AgentPermissionsApi`)
 - **Wallet connect** — OIDC/SIOPv2-based connection flow for external wallets (`WalletConnect`, `Oidc`)
 
+Durable `grantKey` records hydrate delegate decryption keys for encrypted read grants.
+They are usable only while the referenced permission grant is active. Revocation is
+observed from the grantee's local DWN state, so enforcement follows delivery or sync
+of the revocation record.
+
 ## Installation
 
 ```bash

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -18,6 +18,7 @@ import type {
   SendDwnRequest,
 } from './types/dwn.js';
 
+import { logger } from '@enbox/common';
 import {
   Cid,
   ContentEncryptionAlgorithm,
@@ -740,7 +741,11 @@ async function resolveGrantKeyRecords(params: {
           derivedPrivateKey : payload.privateKeyJwk,
         },
       });
-    } catch {
+    } catch (error) {
+      logger.log(
+        `AgentDwnApi: skipped grantKey '${grantKeyMessage.recordId}' while resolving delegate decryption key: ` +
+        `${error instanceof Error ? error.message : String(error)}`
+      );
       continue;
     }
   }

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -32,6 +32,7 @@ import {
   KeyDerivationScheme,
   Message,
   Records,
+  Time,
 } from '@enbox/dwn-sdk-js';
 import { Ed25519, X25519 } from '@enbox/crypto';
 
@@ -714,6 +715,7 @@ async function resolveGrantKeyRecords(params: {
       );
       const payload = Encoder.bytesToObject(await DataStream.toBytes(decryptedStream)) as GrantKeyPayload;
       const grant = await readPermissionGrant(params.agent, params.granteeDid, params.grantorDid, payload.grantId);
+      await verifyPermissionGrantActive(params.agent, params.granteeDid, params.grantorDid, grant);
 
       await verifyGrantKeyPayload({
         payload,
@@ -792,6 +794,27 @@ async function readPermissionGrant(
     ...reply.entry.recordsWrite,
     encodedData: Encoder.bytesToBase64Url(grantData),
   } as DataEncodedRecordsWriteMessage);
+}
+
+async function verifyPermissionGrantActive(
+  agent: EnboxPlatformAgent,
+  granteeDid: string,
+  grantorDid: string,
+  grant: PermissionGrant,
+): Promise<void> {
+  const now = Time.getCurrentTimestamp();
+  if (now < grant.dateGranted || now >= grant.dateExpires) {
+    throw new Error('grantKey references an inactive permission grant.');
+  }
+
+  const revoked = await agent.permissions.isGrantRevoked({
+    author        : granteeDid,
+    target        : grantorDid,
+    grantRecordId : grant.id,
+  });
+  if (revoked) {
+    throw new Error('grantKey references a revoked permission grant.');
+  }
 }
 
 async function verifyGrantKeyPayload(params: {

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 
 import { CryptoUtils } from '@enbox/crypto';
+import { EncryptionProtocol } from '@enbox/dwn-sdk-js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
@@ -1499,6 +1500,175 @@ describe('enbox connect', () => {
         'protocolPath',
         mixedProtocol.protocol,
       ]);
+    });
+
+    it('should fan out durable grantKey records with their encrypted data during connect', async () => {
+      const encryptedProtocol: DwnProtocolDefinition = {
+        protocol  : 'http://grantkey-fanout-encrypted.xyz',
+        published : true,
+        types     : {
+          note: {
+            schema             : 'http://grantkey-fanout-encrypted.xyz/note',
+            dataFormats        : ['text/plain'],
+            encryptionRequired : true,
+          },
+        },
+        structure: { note: {} },
+      };
+      const readScopes: RecordsPermissionScope[] = [{
+        interface : 'Records' as any,
+        method    : 'Read' as any,
+        protocol  : encryptedProtocol.protocol,
+      }];
+      const grantKeyData = new Uint8Array([9, 8, 7, 6]);
+      const grantKeyRecord = {
+        recordId   : 'grant-key-fanout-record-id',
+        descriptor : {
+          interface    : 'Records',
+          method       : 'Write',
+          recipient    : delegateBearerDid.uri,
+          protocol     : EncryptionProtocol.uri,
+          protocolPath : EncryptionProtocol.grantKeyPath,
+          dataFormat   : 'application/json',
+          tags         : { protocol: encryptedProtocol.protocol },
+        },
+        encodedData: Convert.uint8Array(grantKeyData).toBase64Url(),
+      };
+      const endpoints = ['https://dwn-a.example/', 'https://dwn-b.example/'];
+
+      sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+      sinon.stub(EnboxConnectProtocol, 'createGrantKeyRecordsForGrants').resolves([grantKeyRecord] as any);
+      sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
+        grant   : {} as any,
+        message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
+      });
+      sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
+      sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+
+      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+        baseURL  : 'http://localhost:3000',
+        endpoint : 'callback',
+      });
+      connectRequest = await EnboxConnectProtocol.createConnectRequest({
+        appName            : 'Sample App',
+        clientDid          : clientEphemeralPortableDid.uri,
+        permissionRequests : [{ protocolDefinition: encryptedProtocol, permissionScopes: readScopes }],
+        callbackUrl,
+      });
+
+      const endpointStub = sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget');
+      endpointStub.onFirstCall().resolves(endpoints);
+      endpointStub.onSecondCall().resolves([]);
+      sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
+        messageCid : '',
+        reply      : { status: { code: 202, detail: 'OK' } }
+      });
+      const processDwnRequestStub = sinon.stub(testHarness.agent, 'processDwnRequest');
+      processDwnRequestStub.resolves({
+        messageCid : '',
+        reply      : {
+          status  : { code: 200, detail: 'OK' },
+          entries : [{ descriptor: { interface: 'Protocols', method: 'Configure', definition: encryptedProtocol } }] as any,
+        },
+      });
+      const rpcSendRequestStub = sinon.stub(testHarness.agent.rpc, 'sendDwnRequest')
+        .resolves({ status: { code: 202, detail: 'Accepted' } } as any);
+      sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+      await EnboxConnectProtocol.submitConnectResponse(
+        providerIdentity.did.uri, connectRequest, randomPin, testHarness.agent,
+      );
+
+      expect(rpcSendRequestStub.callCount).toBe(endpoints.length);
+      for (const [index, call] of rpcSendRequestStub.getCalls().entries()) {
+        const request = call.args[0];
+        expect(request.dwnUrl).toBe(endpoints[index]);
+        expect(request.targetDid).toBe(providerIdentity.did.uri);
+        expect((request.message as any).encodedData).toBeUndefined();
+        expect((request.message as any).recordId).toBe(grantKeyRecord.recordId);
+        expect(request.signal).toBeInstanceOf(AbortSignal);
+
+        const sentBytes = new Uint8Array(await (request.data as Blob).arrayBuffer());
+        expect([...sentBytes]).toEqual([...grantKeyData]);
+      }
+    });
+
+    it('should stop connect response delivery when durable grantKey fanout fails for every endpoint', async () => {
+      const encryptedProtocol: DwnProtocolDefinition = {
+        protocol  : 'http://grantkey-fanout-fail-encrypted.xyz',
+        published : true,
+        types     : {
+          note: {
+            schema             : 'http://grantkey-fanout-fail-encrypted.xyz/note',
+            dataFormats        : ['text/plain'],
+            encryptionRequired : true,
+          },
+        },
+        structure: { note: {} },
+      };
+      const readScopes: RecordsPermissionScope[] = [{
+        interface : 'Records' as any,
+        method    : 'Read' as any,
+        protocol  : encryptedProtocol.protocol,
+      }];
+      const grantKeyRecord = {
+        recordId   : 'grant-key-fanout-fail-record-id',
+        descriptor : {
+          interface    : 'Records',
+          method       : 'Write',
+          recipient    : delegateBearerDid.uri,
+          protocol     : EncryptionProtocol.uri,
+          protocolPath : EncryptionProtocol.grantKeyPath,
+          dataFormat   : 'application/json',
+          tags         : { protocol: encryptedProtocol.protocol },
+        },
+        encodedData: Convert.uint8Array(new Uint8Array([1, 2, 3])).toBase64Url(),
+      };
+
+      sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').resolves(permissionGrants as any);
+      sinon.stub(EnboxConnectProtocol, 'createGrantKeyRecordsForGrants').resolves([grantKeyRecord] as any);
+      sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
+        grant   : {} as any,
+        message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
+      });
+      sinon.stub(CryptoUtils, 'randomBytes').returns(encryptionNonce);
+      sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+
+      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+        baseURL  : 'http://localhost:3000',
+        endpoint : 'callback',
+      });
+      connectRequest = await EnboxConnectProtocol.createConnectRequest({
+        appName            : 'Sample App',
+        clientDid          : clientEphemeralPortableDid.uri,
+        permissionRequests : [{ protocolDefinition: encryptedProtocol, permissionScopes: readScopes }],
+        callbackUrl,
+      });
+
+      sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget')
+        .resolves(['https://dwn-a.example/', 'https://dwn-b.example/']);
+      sinon.stub(testHarness.agent, 'sendDwnRequest').resolves({
+        messageCid : '',
+        reply      : { status: { code: 202, detail: 'OK' } }
+      });
+      sinon.stub(testHarness.agent, 'processDwnRequest').resolves({
+        messageCid : '',
+        reply      : {
+          status  : { code: 200, detail: 'OK' },
+          entries : [{ descriptor: { interface: 'Protocols', method: 'Configure', definition: encryptedProtocol } }] as any,
+        },
+      });
+      sinon.stub(testHarness.agent.rpc, 'sendDwnRequest')
+        .resolves({ status: { code: 500, detail: 'nope' } } as any);
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+      await expect(
+        EnboxConnectProtocol.submitConnectResponse(
+          providerIdentity.did.uri, connectRequest, randomPin, testHarness.agent,
+        )
+      ).rejects.toThrow('Could not send grantKey record to any DWN endpoint.');
+
+      expect(fetchStub.called).toBe(false);
     });
 
     it('should throw if a grant that is included in the request does not match the protocol definition', async () => {

--- a/packages/agent/tests/dwn-encryption.spec.ts
+++ b/packages/agent/tests/dwn-encryption.spec.ts
@@ -16,6 +16,7 @@ import {
   KeyDerivationScheme,
   Records,
   TestDataGenerator,
+  Time,
 } from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from '../src/types/dwn.js';
@@ -23,6 +24,7 @@ import {
   buildEncryptionInput,
   buildKmsDecryptCallback,
   buildProtocolPathSubtreeDecrypter,
+  createGrantKeyRecordsForGrants,
   encryptAndComputeCid,
   getEncryptionKeyDeriver,
   getEncryptionKeyInfo,
@@ -541,6 +543,48 @@ describe('dwn-encryption', () => {
     });
   });
 
+  describe('createGrantKeyRecordsForGrants', () => {
+    it('should skip grants that cannot carry durable encrypted read access', async () => {
+      const grantor = await TestDataGenerator.generatePersona({ did: 'did:example:alice' });
+      const grantee = await TestDataGenerator.generatePersona({ did: 'did:example:delegate' });
+      const writeGrant = await TestDataGenerator.generateGrantCreate({
+        author      : grantor,
+        grantedTo   : grantee,
+        delegated   : true,
+        dateExpires : '2040-06-25T16:09:16.693356Z',
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Write,
+          protocol  : 'https://proto.example.com',
+        },
+      });
+      const contextReadGrant = await TestDataGenerator.generateGrantCreate({
+        author      : grantor,
+        grantedTo   : grantee,
+        delegated   : true,
+        dateExpires : '2040-06-25T16:09:16.693356Z',
+        scope       : {
+          interface : DwnInterfaceName.Records,
+          method    : DwnMethodName.Read,
+          protocol  : 'https://proto.example.com',
+          contextId : 'context-a',
+        },
+      });
+      const processDwnRequest = sinon.stub().rejects(new Error('ineligible grants should not write records'));
+
+      const records = await createGrantKeyRecordsForGrants({
+        agent                 : { processDwnRequest } as any,
+        ownerDid              : grantor.did,
+        granteeDid            : grantee.did,
+        granteeRootPrivateKey : await X25519.generateKey(),
+        grantMessages         : [writeGrant.dataEncodedMessage, contextReadGrant.dataEncodedMessage],
+      });
+
+      expect(records).toHaveLength(0);
+      expect(processDwnRequest.called).toBe(false);
+    });
+  });
+
   describe('resolveKeyDecrypter', () => {
     const makeAliceAgent = (): any => ({
       did: {
@@ -566,16 +610,26 @@ describe('dwn-encryption', () => {
 
     const makeGrantKeyResolverFixture = async ({
       grantScopeProtocolPath,
+      grantDateExpires,
       payloadScopeProtocolPath,
       recordProtocolPath = 'message',
+      includeEncodedData = true,
+      grantRevoked = false,
       mutatePayload,
+      mutateRecordTags,
     }: {
       grantScopeProtocolPath?: string;
+      grantDateExpires?: string;
       payloadScopeProtocolPath?: string;
       recordProtocolPath?: string;
+      includeEncodedData?: boolean;
+      grantRevoked?: boolean;
       mutatePayload?: (payload: any) => void;
+      mutateRecordTags?: (tags: Record<string, string>) => void;
     } = {}): Promise<{
       delegateCache: { get: sinon.SinonStub; set: sinon.SinonStub };
+      grantKeyRecordId: string;
+      grantRecordId: string;
       mockAgent: any;
       recordsWrite: RecordsWriteMessage;
     }> => {
@@ -592,7 +646,7 @@ describe('dwn-encryption', () => {
           protocol,
           ...(grantScopeProtocolPath !== undefined ? { protocolPath: grantScopeProtocolPath } : {}),
         },
-        dateExpires: '2040-06-25T16:09:16.693356Z',
+        dateExpires: grantDateExpires ?? '2040-06-25T16:09:16.693356Z',
       });
 
       const privateKeyJwk = await X25519.generateKey();
@@ -615,6 +669,13 @@ describe('dwn-encryption', () => {
         privateKeyJwk,
       };
       mutatePayload?.(payload);
+      const tags = {
+        grantId  : payload.grantId,
+        protocol : payload.scope.protocol,
+        ...(payload.scope.protocolPath !== undefined ? { protocolPath: payload.scope.protocolPath } : {}),
+        keyId    : payload.keyId,
+      };
+      mutateRecordTags?.(tags);
 
       const grantKeyWrite = await TestDataGenerator.generateRecordsWrite({
         author       : grantor,
@@ -624,17 +685,12 @@ describe('dwn-encryption', () => {
         schema       : EncryptionProtocol.definition.types.grantKey.schema,
         dataFormat   : 'application/json',
         data         : new Uint8Array([1, 2, 3]),
-        tags         : {
-          grantId  : payload.grantId,
-          protocol : payload.scope.protocol,
-          ...(payload.scope.protocolPath !== undefined ? { protocolPath: payload.scope.protocolPath } : {}),
-          keyId    : payload.keyId,
-        },
+        tags,
       });
       const grantKeyMessage = {
         ...grantKeyWrite.message,
-        encodedData: Encoder.bytesToBase64Url(grantKeyWrite.dataBytes!),
-      };
+        ...(includeEncodedData ? { encodedData: Encoder.bytesToBase64Url(grantKeyWrite.dataBytes!) } : {}),
+      } as RecordsWriteMessage & { encodedData?: string };
 
       sinon.stub(Records, 'decrypt').resolves(DataStream.fromBytes(Encoder.objectToBytes(payload)));
 
@@ -645,7 +701,20 @@ describe('dwn-encryption', () => {
           entries : [grantKeyMessage],
         },
       });
-      processDwnRequest.onSecondCall().resolves({
+      let nextCallIndex = 1;
+      if (!includeEncodedData) {
+        processDwnRequest.onCall(nextCallIndex).resolves({
+          reply: {
+            status : { code: 200, detail: 'OK' },
+            entry  : {
+              recordsWrite : grantKeyWrite.message,
+              data         : DataStream.fromBytes(grantKeyWrite.dataBytes!),
+            },
+          },
+        });
+        nextCallIndex++;
+      }
+      processDwnRequest.onCall(nextCallIndex).resolves({
         reply: {
           status : { code: 200, detail: 'OK' },
           entry  : {
@@ -654,7 +723,6 @@ describe('dwn-encryption', () => {
           },
         },
       });
-
       const mockAgent = {
         did: {
           resolve: sinon.stub().resolves({
@@ -675,6 +743,9 @@ describe('dwn-encryption', () => {
           getKeyUri    : sinon.stub().resolves('grantee-key-uri'),
           jweKeyUnwrap : sinon.stub(),
         },
+        permissions: {
+          isGrantRevoked: sinon.stub().resolves(grantRevoked),
+        },
         processDwnRequest,
       };
 
@@ -684,7 +755,9 @@ describe('dwn-encryption', () => {
           get : sinon.stub().returns(undefined),
           set : sinon.stub(),
         },
-        recordsWrite: {
+        grantKeyRecordId : grantKeyMessage.recordId,
+        grantRecordId    : grant.dataEncodedMessage.recordId,
+        recordsWrite     : {
           recordId   : 'rec-grant-key-validation',
           contextId  : 'rec-grant-key-validation',
           descriptor : { protocol, protocolPath: recordProtocolPath },
@@ -918,11 +991,107 @@ describe('dwn-encryption', () => {
       expect(mockAgent.keyManager.getKeyUri.called).toBe(false);
     });
 
+    it('should hydrate and cache a path-scoped durable grantKey for descendant records', async () => {
+      const { mockAgent, delegateCache, grantRecordId, recordsWrite } = await makeGrantKeyResolverFixture({
+        grantScopeProtocolPath   : 'message',
+        payloadScopeProtocolPath : 'message',
+        recordProtocolPath       : 'message/reply',
+      });
+
+      const result = await resolveKeyDecrypter(
+        mockAgent, 'did:example:delegate', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      );
+
+      expect(result.derivationScheme).toBe(KeyDerivationScheme.ProtocolPath);
+      expect(delegateCache.set.calledOnce).toBe(true);
+
+      const cachedKeys = delegateCache.set.firstCall.args[1];
+      expect(cachedKeys).toHaveLength(1);
+      expect(cachedKeys[0].protocol).toBe('https://proto.example.com');
+      expect(cachedKeys[0].scope).toEqual({ kind: 'protocolPath', protocolPath: 'message' });
+      expect(mockAgent.processDwnRequest.callCount).toBe(2);
+      expect(mockAgent.permissions.isGrantRevoked.calledOnceWith({
+        author : 'did:example:delegate',
+        target : 'did:example:alice',
+        grantRecordId,
+      })).toBe(true);
+    });
+
+    it('should read durable grantKey data when the query entry omits encodedData', async () => {
+      const { mockAgent, delegateCache, grantKeyRecordId, recordsWrite } = await makeGrantKeyResolverFixture({
+        includeEncodedData: false,
+      });
+
+      const result = await resolveKeyDecrypter(
+        mockAgent, 'did:example:delegate', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      );
+
+      expect(result.derivationScheme).toBe(KeyDerivationScheme.ProtocolPath);
+      expect(delegateCache.set.calledOnce).toBe(true);
+      expect(mockAgent.processDwnRequest.callCount).toBe(3);
+      expect(mockAgent.processDwnRequest.secondCall.args[0]).toMatchObject({
+        author        : 'did:example:delegate',
+        target        : 'did:example:alice',
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : { filter: { recordId: grantKeyRecordId } },
+      });
+    });
+
     it('should reject a durable grantKey whose scope does not cover the encrypted record', async () => {
       const { mockAgent, delegateCache, recordsWrite } = await makeGrantKeyResolverFixture({
         grantScopeProtocolPath   : 'message/reply',
         payloadScopeProtocolPath : 'message/reply',
         recordProtocolPath       : 'message',
+      });
+
+      await expect(resolveKeyDecrypter(
+        mockAgent, 'did:example:delegate', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      )).rejects.toThrow('no delivered decryption key covers encrypted record');
+
+      expect(delegateCache.set.called).toBe(false);
+    });
+
+    it('should reject a durable grantKey when the referenced permission grant has expired', async () => {
+      const { mockAgent, delegateCache, recordsWrite } = await makeGrantKeyResolverFixture({
+        grantDateExpires: Time.createOffsetTimestamp({ seconds: -60 }),
+      });
+
+      await expect(resolveKeyDecrypter(
+        mockAgent, 'did:example:delegate', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      )).rejects.toThrow('no delivered decryption key covers encrypted record');
+
+      expect(delegateCache.set.called).toBe(false);
+      expect(mockAgent.permissions.isGrantRevoked.called).toBe(false);
+    });
+
+    it('should reject a durable grantKey when the referenced permission grant has been revoked', async () => {
+      const { mockAgent, delegateCache, recordsWrite } = await makeGrantKeyResolverFixture({
+        grantRevoked: true,
+      });
+
+      await expect(resolveKeyDecrypter(
+        mockAgent, 'did:example:delegate', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      )).rejects.toThrow('no delivered decryption key covers encrypted record');
+
+      expect(delegateCache.set.called).toBe(false);
+      expect(mockAgent.permissions.isGrantRevoked.calledOnce).toBe(true);
+    });
+
+    it('should reject a durable grantKey whose payload does not match its record tags', async () => {
+      const { mockAgent, delegateCache, recordsWrite } = await makeGrantKeyResolverFixture({
+        mutateRecordTags: (tags): void => {
+          tags.protocol = 'https://proto.example.com/other';
+        },
       });
 
       await expect(resolveKeyDecrypter(

--- a/packages/agent/tests/e2e-delegate-encrypted.spec.ts
+++ b/packages/agent/tests/e2e-delegate-encrypted.spec.ts
@@ -21,7 +21,7 @@ import { Ed25519 } from '@enbox/crypto';
 import sinon from 'sinon';
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { ContentEncryptionAlgorithm, DataStream, DwnInterfaceName, DwnMethodName, Encoder, KeyDerivationScheme } from '@enbox/dwn-sdk-js';
+import { ContentEncryptionAlgorithm, DataStream, DwnInterfaceName, DwnMethodName, Encoder, EncryptionProtocol, KeyDerivationScheme } from '@enbox/dwn-sdk-js';
 
 import { createGrantKeyRecordsForGrants } from '../src/dwn-encryption.js';
 import { DwnInterface } from '../src/types/dwn.js';
@@ -108,6 +108,70 @@ async function applyDataEncodedRecord(
   );
 
   expect([202, 409]).toContain(applyReply.status.code);
+}
+
+async function createImportedDelegateDid(
+  harness: PlatformAgentTestHarness,
+): Promise<{ delegateDid: string; delegateX25519PrivateKey: any }> {
+  const delegateBearerDid = await DidJwk.create();
+  const delegatePortableDid = await delegateBearerDid.export();
+  const delegateX25519PrivateKey = await Ed25519.convertPrivateKeyToX25519({
+    privateKey: delegatePortableDid.privateKeys![0],
+  });
+  delegatePortableDid.privateKeys!.push(delegateX25519PrivateKey);
+  await harness.agent.did.import({
+    portableDid : delegatePortableDid,
+    tenant      : harness.agent.agentDid.uri,
+  });
+
+  return {
+    delegateDid: delegateBearerDid.uri,
+    delegateX25519PrivateKey,
+  };
+}
+
+async function copyProtocolToHarness(
+  source: PlatformAgentTestHarness,
+  destination: PlatformAgentTestHarness,
+  tenantDid: string,
+  protocol: string,
+): Promise<void> {
+  const { reply } = await source.agent.processDwnRequest({
+    author        : tenantDid,
+    target        : tenantDid,
+    messageType   : DwnInterface.ProtocolsQuery,
+    messageParams : { filter: { protocol } },
+  });
+  const applyReply = await destination.agent.dwn.processRawMessage(
+    tenantDid,
+    reply.entries![0] as any,
+  );
+  expect(applyReply.status.code).toBe(202);
+}
+
+async function copyRecordToHarness(
+  source: PlatformAgentTestHarness,
+  destination: PlatformAgentTestHarness,
+  tenantDid: string,
+  recordId: string,
+): Promise<void> {
+  const { reply } = await source.agent.processDwnRequest({
+    author        : tenantDid,
+    target        : tenantDid,
+    messageType   : DwnInterface.RecordsRead,
+    messageParams : { filter: { recordId } },
+  });
+  expect(reply.status.code).toBe(200);
+  expect(reply.entry?.recordsWrite).toBeDefined();
+  expect(reply.entry?.data).toBeDefined();
+
+  const dataBytes = await DataStream.toBytes(reply.entry!.data!);
+  const applyReply = await destination.agent.dwn.processRawMessage(
+    tenantDid,
+    reply.entry!.recordsWrite as any,
+    { dataStream: DataStream.fromBytes(dataBytes) },
+  );
+  expect(applyReply.status.code).toBe(202);
 }
 
 // ─── Tests ──────────────────────────────────────────────────────
@@ -398,6 +462,110 @@ describe('e2e: delegate + encrypted protocol', () => {
       });
 
       expect(revokedReply.status.code).toBe(401);
+    });
+
+    it('should hydrate a protocolPath durable grantKey and decrypt only with the delegate KMS', async () => {
+      await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: multiTypeProtocol },
+        encryption    : true,
+      });
+
+      const noteData = 'Secret path-scoped note from durable grantKey';
+      const { message: noteWrite } = await walletHarness.agent.processDwnRequest({
+        author        : walletIdentity.did.uri,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          protocol     : multiTypeProtocol.protocol,
+          protocolPath : 'note',
+          schema       : 'https://schemas.xyz/note',
+          dataFormat   : 'text/plain',
+          data         : new TextEncoder().encode(noteData),
+        },
+        encryption: true,
+      });
+      const noteRecordId = (noteWrite as RecordsWriteMessage).recordId;
+
+      const { delegateDid, delegateX25519PrivateKey } = await createImportedDelegateDid(delegateHarness);
+      const readGrant = await walletHarness.agent.permissions.createGrant({
+        author      : walletIdentity.did.uri,
+        dateExpires : '2040-06-25T16:09:16.693356Z',
+        delegated   : true,
+        grantedTo   : delegateDid,
+        scope       : {
+          interface    : DwnInterfaceName.Records,
+          method       : DwnMethodName.Read,
+          protocol     : multiTypeProtocol.protocol,
+          protocolPath : 'note',
+        },
+        store: true,
+      });
+
+      await applyDataEncodedRecord(
+        delegateHarness,
+        walletIdentity.did.uri,
+        readGrant.message as RecordsWriteMessage & { encodedData: string },
+      );
+
+      const grantKeyRecords = await createGrantKeyRecordsForGrants({
+        agent                 : walletHarness.agent,
+        ownerDid              : walletIdentity.did.uri,
+        granteeDid            : delegateDid,
+        granteeRootPrivateKey : delegateX25519PrivateKey,
+        grantMessages         : [readGrant.message as any],
+      });
+      expect(grantKeyRecords).toHaveLength(1);
+      expect(grantKeyRecords[0].descriptor.protocol).toBe(EncryptionProtocol.uri);
+      expect(grantKeyRecords[0].descriptor.protocolPath).toBe(EncryptionProtocol.grantKeyPath);
+      expect(grantKeyRecords[0].descriptor.recipient).toBe(delegateDid);
+      expect(grantKeyRecords[0].descriptor.tags).toEqual({
+        grantId      : readGrant.grant.id,
+        protocol     : multiTypeProtocol.protocol,
+        protocolPath : 'note',
+        keyId        : grantKeyRecords[0].descriptor.tags!.keyId,
+      });
+
+      await applyDataEncodedRecord(
+        delegateHarness,
+        walletIdentity.did.uri,
+        grantKeyRecords[0] as RecordsWriteMessage & { encodedData: string },
+      );
+      await copyProtocolToHarness(
+        walletHarness,
+        delegateHarness,
+        walletIdentity.did.uri,
+        multiTypeProtocol.protocol,
+      );
+      await copyRecordToHarness(
+        walletHarness,
+        delegateHarness,
+        walletIdentity.did.uri,
+        noteRecordId,
+      );
+
+      delegateHarness.agent.dwn.clearDelegateDecryptionKeys(delegateDid);
+      expect(await delegateHarness.agent.did.get({ didUri: walletIdentity.did.uri })).toBeUndefined();
+
+      const { reply: decryptedReply } = await delegateHarness.agent.processDwnRequest({
+        author        : delegateDid,
+        target        : walletIdentity.did.uri,
+        messageType   : DwnInterface.RecordsRead,
+        messageParams : {
+          filter            : { recordId: noteRecordId },
+          permissionGrantId : readGrant.grant.id,
+        },
+        encryption : true,
+        granteeDid : delegateDid,
+      });
+
+      expect(decryptedReply.status.code).toBe(200);
+      expect(decryptedReply.entry?.data).toBeDefined();
+
+      const decryptedBytes = await DataStream.toBytes(decryptedReply.entry!.data!);
+      expect(new TextDecoder().decode(decryptedBytes)).toBe(noteData);
     });
 
     it('should decrypt records using only a delivered protocol path key from a distinct delegate KMS', async () => {

--- a/packages/agent/tests/e2e-delegate-encrypted.spec.ts
+++ b/packages/agent/tests/e2e-delegate-encrypted.spec.ts
@@ -23,12 +23,12 @@ import sinon from 'sinon';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { ContentEncryptionAlgorithm, DataStream, DwnInterfaceName, DwnMethodName, Encoder, EncryptionProtocol, KeyDerivationScheme } from '@enbox/dwn-sdk-js';
 
-import { createGrantKeyRecordsForGrants } from '../src/dwn-encryption.js';
 import { DwnInterface } from '../src/types/dwn.js';
 import { EnboxConnectProtocol } from '../src/enbox-connect-protocol.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
+import { createGrantKeyRecordsForGrants, resolveKeyDecrypter } from '../src/dwn-encryption.js';
 
 // ─── Test protocol with encryptionRequired ──────────────────────
 
@@ -416,7 +416,6 @@ describe('e2e: delegate + encrypted protocol', () => {
 
       delegateHarness.agent.dwn.clearDelegateDecryptionKeys(delegateDid);
       expect(await delegateHarness.agent.did.get({ didUri: walletIdentity.did.uri })).toBeUndefined();
-      const kmsUnwrapSpy = sinon.spy(delegateHarness.agent.keyManager, 'jweKeyUnwrap');
 
       const { reply: decryptedReply } = await delegateHarness.agent.processDwnRequest({
         author        : delegateDid,
@@ -432,7 +431,6 @@ describe('e2e: delegate + encrypted protocol', () => {
 
       expect(decryptedReply.status.code).toBe(200);
       expect(decryptedReply.entry?.data).toBeDefined();
-      expect(kmsUnwrapSpy.called).toBe(true);
 
       const decryptedBytes = await DataStream.toBytes(decryptedReply.entry!.data!);
       expect(new TextDecoder().decode(decryptedBytes)).toBe(noteData);
@@ -447,6 +445,20 @@ describe('e2e: delegate + encrypted protocol', () => {
         walletIdentity.did.uri,
         revocation.message as RecordsWriteMessage & { encodedData: string },
       );
+
+      const delegateDecryptionKeyCache = {
+        get : sinon.stub().returns(undefined),
+        set : sinon.stub(),
+      };
+      await expect(resolveKeyDecrypter(
+        delegateHarness.agent,
+        delegateDid,
+        noteWrite as RecordsWriteMessage,
+        walletIdentity.did.uri,
+        delegateDecryptionKeyCache,
+        delegateDid,
+      )).rejects.toThrow('no delivered decryption key covers encrypted record');
+      expect(delegateDecryptionKeyCache.set.called).toBe(false);
 
       delegateHarness.agent.dwn.clearDelegateDecryptionKeys(delegateDid);
       const { reply: revokedReply } = await delegateHarness.agent.processDwnRequest({


### PR DESCRIPTION
## Summary
- reject durable grantKey hydration when the referenced permission grant is expired or revoked
- validate durable grantKey scope, tags, keyId, derivation path, and delivered key material before caching a delegate decryption key
- add resolver, connect fan-out, and delegate E2E coverage for durable grantKey delivery and hydration, including real revocation-backed refusal without owner-key fallback
- add silent-by-default diagnostics for skipped grantKey candidates and document that revocation freshness follows the grantee's local DWN sync state

## Test plan
- [x] `bun run lint`
- [x] `bun run --filter @enbox/agent build`
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/dwn-encryption.spec.ts`
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/e2e-delegate-encrypted.spec.ts`
- [x] `TEST_DWN_URL=http://localhost:3003 DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node` from `packages/agent`
- [x] GitHub CI, including node coverage and SonarCloud
