### PR TITLE
feat(agent): deliver role audience encryption keys

### DIFF
--- a/.changeset/role-audience-delivery.md
+++ b/.changeset/role-audience-delivery.md
@@ -3,4 +3,4 @@
 "@enbox/agent": patch
 ---
 
-Add role-audience encryption key delivery and decryption support.
+Add initial role-audience encryption key delivery and decryption support. Epoch rotation for membership changes remains tracked separately.

--- a/.changeset/role-audience-delivery.md
+++ b/.changeset/role-audience-delivery.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+---
+
+Add role-audience encryption key delivery and decryption support.

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -7,12 +7,14 @@ import type {
   MessageStore,
   ProgressToken,
   ProtocolDefinition,
+  ProtocolRuleSet,
+  RecordsWriteMessage,
   ReplicationApplyResult,
+  RoleAudienceKeyEncryptionInput,
 } from '@enbox/dwn-sdk-js';
 import type { DwnSubscriptionHandler, ResubscribeFactory } from '@enbox/dwn-clients';
-import type { KeyIdentifier, PublicKeyJwk } from '@enbox/crypto';
+import type { KeyIdentifier, PrivateKeyJwk, PublicKeyJwk } from '@enbox/crypto';
 
-import { CryptoUtils } from '@enbox/crypto';
 import {
   Cid,
   ContentEncryptionAlgorithm,
@@ -21,20 +23,26 @@ import {
   DurableEventLog,
   Dwn,
   DwnMethodName,
+  Encoder,
   Encryption,
+  EncryptionProtocol,
   EventEmitterWakePublisher,
+  getRuleSetAtPath,
   KeyDerivationScheme,
   Message,
   MessageStoreLevel,
+  parseCrossProtocolRef,
   Protocols,
   ResumableTaskStoreLevel,
+  ROLE_AUDIENCE_DERIVATION_SCHEME,
 } from '@enbox/dwn-sdk-js';
 import { Convert, TtlCache } from '@enbox/common';
+import { CryptoUtils, X25519 } from '@enbox/crypto';
 import { DidDht, DidJwk, DidResolverCacheLevel, UniversalResolver } from '@enbox/dids';
 
-import type { DelegateDecryptionKeyEntry } from './dwn-encryption.js';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { LocalDwnStrategy } from './local-dwn.js';
+import type { AudienceDecryptionKeyEntry, AudienceKeyPayload, DelegateDecryptionKeyEntry } from './dwn-encryption.js';
 import type {
   DwnMessage,
   DwnMessageInstance,
@@ -63,7 +71,11 @@ import { isDwnRequest } from './dwn-type-guards.js';
 // Import extracted encryption functions
 import {
   buildEncryptionInput as buildEncryptionInputFn,
+  cacheAudienceDecryptionKey as cacheAudienceDecryptionKeyFn,
+  createAudienceEpochRecord as createAudienceEpochRecordFn,
+  createAudienceKeyRecord as createAudienceKeyRecordFn,
   encryptAndComputeCid as encryptAndComputeCidFn,
+  getCachedAudienceDecryptionKey as getCachedAudienceDecryptionKeyFn,
   getEncryptionKeyDeriver as getEncryptionKeyDeriverFn,
   getEncryptionKeyInfo as getEncryptionKeyInfoFn,
   getKeyDecrypter as getKeyDecrypterFn,
@@ -155,6 +167,15 @@ export class AgentDwnApi {
    * TTL 24 hours (keys are re-populated on session restore).
    */
   private readonly _delegateDecryptionKeyCache = new TtlCache<string, DelegateDecryptionKeyEntry[]>({
+    ttl: 24 * 60 * 60 * 1000
+  });
+
+  /**
+   * Role-audience private keys hydrated from durable audienceKey records.
+   * The vault-backed secret store is the durable cache; this TTL cache avoids
+   * re-reading and re-decrypting the same key during a session.
+   */
+  private readonly _audienceDecryptionKeyCache = new TtlCache<string, AudienceDecryptionKeyEntry>({
     ttl: 24 * 60 * 60 * 1000
   });
 
@@ -472,6 +493,15 @@ export class AgentDwnApi {
       });
     }
 
+    if (reply.status.code === 202 &&
+        isDwnRequest(request, DwnInterface.RecordsWrite) &&
+        !request.rawMessage) {
+      await this.provisionAudienceKeyForAcceptedRoleRecord(
+        request,
+        message as RecordsWriteMessage,
+      );
+    }
+
     await this.maybeDecryptReply(request, reply);
 
     // Returns an object containing the reply from processing the message, the original message,
@@ -666,6 +696,293 @@ export class AgentDwnApi {
     throw new Error(`Failed to send DWN RPC request: ${JSON.stringify(errorMessages)}`);
   }
 
+  private async provisionAudienceKeyForAcceptedRoleRecord(
+    request: ProcessDwnRequest<DwnInterface.RecordsWrite>,
+    recordsWrite: RecordsWriteMessage,
+  ): Promise<void> {
+    const descriptor = recordsWrite.descriptor;
+    if (descriptor.protocol === EncryptionProtocol.uri ||
+        descriptor.protocol === undefined ||
+        descriptor.protocolPath === undefined ||
+        descriptor.recipient === undefined) {
+      return;
+    }
+
+    const protocolDefinition = await this.getProtocolDefinition(request.target, descriptor.protocol, request.granteeDid);
+    if (protocolDefinition === undefined) {
+      return;
+    }
+
+    const ruleSet = getRuleSetAtPath(descriptor.protocolPath, protocolDefinition.structure);
+    if (ruleSet?.$role !== true) {
+      return;
+    }
+
+    const contextId = this.getRoleAudienceContextIdForRecord(recordsWrite, descriptor.protocolPath);
+    if (contextId === undefined) {
+      throw new Error(`AgentDwnApi: Unable to determine role audience context for '${descriptor.protocolPath}'.`);
+    }
+
+    const audienceKey = await this.getOrCreateAudienceKey({
+      authorDid    : request.author,
+      contextId,
+      protocol     : descriptor.protocol,
+      protocolRole : request.messageParams?.protocolRole,
+      role         : descriptor.protocolPath,
+      sourceDid    : request.target,
+    });
+    const recipientRolePublicKey = await this.getRecipientRolePublicKey({
+      protocol     : descriptor.protocol,
+      recipientDid : descriptor.recipient,
+      role         : descriptor.protocolPath,
+    });
+
+    await createAudienceKeyRecordFn({
+      agent        : this.agent,
+      audienceKey,
+      authorDid    : request.author,
+      protocolRole : request.messageParams?.protocolRole,
+      recipientDid : descriptor.recipient,
+      recipientRolePublicKey,
+      sourceDid    : request.target,
+    });
+  }
+
+  private async getRoleAudienceKeyEncryptionInputs(params: {
+    authorDid: string;
+    sourceDid: string;
+    protocol: string;
+    parentContextId?: string;
+    protocolDefinition: ProtocolDefinition;
+    sourceRuleSet: ProtocolRuleSet;
+  }): Promise<RoleAudienceKeyEncryptionInput[]> {
+    const inputs: RoleAudienceKeyEncryptionInput[] = [];
+    const readRules = params.sourceRuleSet.$actions?.filter((rule): boolean =>
+      rule.role !== undefined && rule.can?.includes('read')
+    ) ?? [];
+
+    for (const rule of readRules) {
+      const roleAudience = this.resolveRoleAudienceRule(rule.role!, params.protocolDefinition, params.parentContextId);
+      if (roleAudience === undefined) {
+        continue;
+      }
+
+      const audienceEpoch = await this.queryLatestAudienceEpoch({
+        authorDid : params.authorDid,
+        contextId : roleAudience.contextId,
+        protocol  : roleAudience.protocol,
+        role      : roleAudience.role,
+        sourceDid : params.sourceDid,
+      });
+      if (audienceEpoch === undefined) {
+        throw new Error(
+          `AgentDwnApi: Missing audienceEpoch for encrypted role audience ` +
+          `'${roleAudience.protocol}/${roleAudience.role}' at context '${roleAudience.contextId}'.`
+        );
+      }
+
+      inputs.push({
+        derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+        epoch            : audienceEpoch.epoch,
+        keyId            : audienceEpoch.keyId,
+        protocol         : audienceEpoch.protocol,
+        publicKey        : audienceEpoch.publicKeyJwk,
+        role             : audienceEpoch.role,
+      });
+    }
+
+    return inputs;
+  }
+
+  private resolveRoleAudienceRule(
+    roleRef: string,
+    protocolDefinition: ProtocolDefinition,
+    parentContextId: string | undefined,
+  ): { protocol: string; role: string; contextId: string } | undefined {
+    const parsed = parseCrossProtocolRef(roleRef);
+    const protocol = parsed === undefined
+      ? protocolDefinition.protocol
+      : protocolDefinition.uses?.[parsed.alias];
+    const role = parsed === undefined ? roleRef : parsed.protocolPath;
+    if (protocol === undefined) {
+      return undefined;
+    }
+
+    const contextId = this.getRoleAudienceContextIdForWrite(role, parentContextId);
+    return contextId === undefined ? undefined : { protocol, role, contextId };
+  }
+
+  private getRoleAudienceContextIdForRecord(
+    recordsWrite: RecordsWriteMessage,
+    rolePath: string,
+  ): string | undefined {
+    const parentDepth = rolePath.split('/').length - 1;
+    if (parentDepth === 0) {
+      return '';
+    }
+
+    const contextId = recordsWrite.contextId;
+    if (typeof contextId !== 'string') {
+      return undefined;
+    }
+
+    const contextSegments = contextId.split('/');
+    if (contextSegments.length < parentDepth) {
+      return undefined;
+    }
+
+    return contextSegments.slice(0, parentDepth).join('/');
+  }
+
+  private getRoleAudienceContextIdForWrite(
+    rolePath: string,
+    parentContextId: string | undefined,
+  ): string | undefined {
+    const parentDepth = rolePath.split('/').length - 1;
+    if (parentDepth === 0) {
+      return '';
+    }
+
+    if (parentContextId === undefined) {
+      return undefined;
+    }
+
+    const contextSegments = parentContextId.split('/');
+    if (contextSegments.length < parentDepth) {
+      return undefined;
+    }
+
+    return contextSegments.slice(0, parentDepth).join('/');
+  }
+
+  private async getOrCreateAudienceKey(params: {
+    authorDid: string;
+    sourceDid: string;
+    protocol: string;
+    contextId: string;
+    role: string;
+    protocolRole?: string;
+  }): Promise<AudienceKeyPayload> {
+    const existingEpoch = await this.queryLatestAudienceEpoch(params);
+    if (existingEpoch !== undefined) {
+      const cached = await getCachedAudienceDecryptionKeyFn({
+        agent                      : this.agent,
+        audienceDecryptionKeyCache : this._audienceDecryptionKeyCache,
+        sourceDid                  : params.sourceDid,
+        recipientDid               : params.authorDid,
+        protocol                   : existingEpoch.protocol,
+        contextId                  : existingEpoch.contextId,
+        role                       : existingEpoch.role,
+        epoch                      : existingEpoch.epoch,
+        keyId                      : existingEpoch.keyId,
+      });
+      if (cached === undefined) {
+        throw new Error(
+          `AgentDwnApi: Audience epoch '${existingEpoch.keyId}' exists, but no local private key is available to deliver it.`
+        );
+      }
+      return cached;
+    }
+
+    const privateKeyJwk = await X25519.generateKey() as PrivateKeyJwk;
+    const publicKeyJwk = await X25519.getPublicKey({ key: privateKeyJwk }) as PublicKeyJwk;
+    const audienceKey: AudienceKeyPayload = {
+      protocol  : params.protocol,
+      contextId : params.contextId,
+      role      : params.role,
+      epoch     : 1,
+      keyId     : await Encryption.getKeyId(publicKeyJwk),
+      publicKeyJwk,
+      privateKeyJwk,
+    };
+
+    await createAudienceEpochRecordFn({
+      agent        : this.agent,
+      audienceKey,
+      authorDid    : params.authorDid,
+      protocolRole : params.protocolRole,
+      sourceDid    : params.sourceDid,
+    });
+    await cacheAudienceDecryptionKeyFn({
+      agent                      : this.agent,
+      audienceDecryptionKeyCache : this._audienceDecryptionKeyCache,
+      entry                      : {
+        ...audienceKey,
+        recipientDid : params.authorDid,
+        sourceDid    : params.sourceDid,
+      },
+    });
+
+    return audienceKey;
+  }
+
+  private async queryLatestAudienceEpoch(params: {
+    authorDid: string;
+    sourceDid: string;
+    protocol: string;
+    contextId: string;
+    role: string;
+  }): Promise<Omit<AudienceKeyPayload, 'privateKeyJwk'> | undefined> {
+    const { reply } = await this.processRequest({
+      author        : params.authorDid,
+      target        : params.sourceDid,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: {
+          protocol     : EncryptionProtocol.uri,
+          protocolPath : EncryptionProtocol.audienceEpochPath,
+          tags         : {
+            protocol  : params.protocol,
+            contextId : params.contextId,
+            role      : params.role,
+          },
+        },
+      },
+    });
+
+    if (reply.status.code !== 200 || reply.entries === undefined || reply.entries.length === 0) {
+      return undefined;
+    }
+
+    const epochs = reply.entries
+      .map((entry): Omit<AudienceKeyPayload, 'privateKeyJwk'> | undefined => {
+        if (entry.encodedData === undefined) {
+          return undefined;
+        }
+        return Encoder.base64UrlToObject(entry.encodedData) as Omit<AudienceKeyPayload, 'privateKeyJwk'>;
+      })
+      .filter((entry): entry is Omit<AudienceKeyPayload, 'privateKeyJwk'> => entry !== undefined)
+      .sort((a, b): number => b.epoch - a.epoch);
+
+    return epochs[0];
+  }
+
+  private async getRecipientRolePublicKey(params: {
+    recipientDid: string;
+    protocol: string;
+    role: string;
+  }): Promise<PublicKeyJwk> {
+    let protocolDefinition: ProtocolDefinition | undefined;
+    try {
+      protocolDefinition = await this.getProtocolDefinition(params.recipientDid, params.protocol);
+    } catch {
+      protocolDefinition = undefined;
+    }
+
+    protocolDefinition ??= await this.fetchRemoteProtocolDefinition(params.recipientDid, params.protocol);
+
+    const roleRuleSet = getRuleSetAtPath(params.role, protocolDefinition.structure);
+    const publicKeyJwk = roleRuleSet?.$keyAgreement?.publicKeyJwk;
+    if (publicKeyJwk === undefined) {
+      throw new Error(
+        `AgentDwnApi: Recipient '${params.recipientDid}' has no encryption key for role path ` +
+        `'${params.protocol}/${params.role}'.`
+      );
+    }
+
+    return publicKeyJwk;
+  }
+
   private async constructDwnMessage<T extends DwnInterface>({ request }: {
     request: ProcessDwnRequest<T>
   }): Promise<DwnMessageWithData<T>> {
@@ -807,6 +1124,14 @@ export class AgentDwnApi {
           await Encryption.getKeyId(protocolPathPublicKey), protocolPathPublicKey,
           KeyDerivationScheme.ProtocolPath,
         );
+        encryptionInput.keyEncryptionInputs.push(...await this.getRoleAudienceKeyEncryptionInputs({
+          authorDid       : request.author,
+          parentContextId : messageParams.parentContextId,
+          protocol        : messageParams.protocol,
+          protocolDefinition,
+          sourceDid       : request.target,
+          sourceRuleSet   : ruleSet,
+        }));
 
         // 6. Encrypt data and compute CID.
         const { encryptedBytes, dataCid, dataSize } =
@@ -1091,6 +1416,7 @@ export class AgentDwnApi {
     return maybeDecryptReplyFn(
       request, reply, this.agent,
       this._delegateDecryptionKeyCache,
+      this._audienceDecryptionKeyCache,
     );
   }
 

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -717,6 +717,9 @@ export class AgentDwnApi {
     if (ruleSet?.$role !== true) {
       return;
     }
+    if (ruleSet.$keyAgreement?.publicKeyJwk === undefined) {
+      return;
+    }
 
     const contextId = this.getRoleAudienceContextIdForRecord(recordsWrite, descriptor.protocolPath);
     if (contextId === undefined) {

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -503,7 +503,7 @@ export class AgentDwnApi {
         );
       } catch (error) {
         logger.log(
-          `AgentDwnApi: deferred audienceKey provisioning for role record '${(message as RecordsWriteMessage).recordId}': ` +
+          `AgentDwnApi: audienceKey provisioning failed after accepting role record '${(message as RecordsWriteMessage).recordId}': ` +
           `${error instanceof Error ? error.message : String(error)}`
         );
       }

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -36,7 +36,7 @@ import {
   ResumableTaskStoreLevel,
   ROLE_AUDIENCE_DERIVATION_SCHEME,
 } from '@enbox/dwn-sdk-js';
-import { Convert, TtlCache } from '@enbox/common';
+import { Convert, logger, TtlCache } from '@enbox/common';
 import { CryptoUtils, X25519 } from '@enbox/crypto';
 import { DidDht, DidJwk, DidResolverCacheLevel, UniversalResolver } from '@enbox/dids';
 
@@ -496,10 +496,17 @@ export class AgentDwnApi {
     if (reply.status.code === 202 &&
         isDwnRequest(request, DwnInterface.RecordsWrite) &&
         !request.rawMessage) {
-      await this.provisionAudienceKeyForAcceptedRoleRecord(
-        request,
-        message as RecordsWriteMessage,
-      );
+      try {
+        await this.provisionAudienceKeyForAcceptedRoleRecord(
+          request,
+          message as RecordsWriteMessage,
+        );
+      } catch (error) {
+        logger.log(
+          `AgentDwnApi: deferred audienceKey provisioning for role record '${(message as RecordsWriteMessage).recordId}': ` +
+          `${error instanceof Error ? error.message : String(error)}`
+        );
+      }
     }
 
     await this.maybeDecryptReply(request, reply);

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -923,39 +923,12 @@ async function buildRecipientRolePathDecrypter(params: {
   delegateDecryptionKeyCache?: DelegateDecryptionKeyCache;
 }): Promise<KeyDecrypter | undefined> {
   const derivationPath = getScopeDerivationPath(params.protocol, params.role);
-  let privateKeyJwk: PrivateKeyJwk | undefined;
-
-  if (params.granteeDid !== undefined) {
-    const cacheKey = `ddk~${params.granteeDid}`;
-    let delegateKeys = params.delegateDecryptionKeyCache?.get(cacheKey) ?? [];
-    let coveringKey = findCoveringDelegateKey(delegateKeys, params.protocol, params.role);
-
-    if (coveringKey === undefined && params.delegateDecryptionKeyCache?.set !== undefined) {
-      const hydratedKeys = await resolveGrantKeyRecords({
-        agent        : params.agent,
-        grantorDid   : params.recipientDid,
-        granteeDid   : params.granteeDid,
-        protocol     : params.protocol,
-        protocolPath : params.role,
-      });
-      delegateKeys = mergeDelegateDecryptionKeys(delegateKeys, hydratedKeys);
-      params.delegateDecryptionKeyCache.set(cacheKey, delegateKeys);
-      coveringKey = findCoveringDelegateKey(delegateKeys, params.protocol, params.role);
-    }
-
-    if (coveringKey === undefined) {
-      return undefined;
-    }
-
-    const privateKeyBytes = await Records.derivePrivateKey(coveringKey.derivedPrivateKey, derivationPath);
-    privateKeyJwk = await X25519.bytesToPrivateKey({ privateKeyBytes }) as PrivateKeyJwk;
-  } else {
-    const { keyUri } = await getEncryptionKeyInfo(params.agent, params.recipientDid);
-    const privateKeyBytes = await params.agent.keyManager.derivePrivateKeyBytes({
-      keyUri,
-      derivationPath,
-    });
-    privateKeyJwk = await X25519.bytesToPrivateKey({ privateKeyBytes }) as PrivateKeyJwk;
+  const privateKeyJwk = await getRecipientRolePathPrivateKey({
+    ...params,
+    derivationPath,
+  });
+  if (privateKeyJwk === undefined) {
+    return undefined;
   }
 
   const publicKeyJwk = await X25519.getPublicKey({ key: privateKeyJwk }) as PublicKeyJwk;
@@ -965,6 +938,49 @@ async function buildRecipientRolePathDecrypter(params: {
     privateKeyJwk,
     publicKeyJwk,
   });
+}
+
+async function getRecipientRolePathPrivateKey(params: {
+  agent: EnboxPlatformAgent;
+  recipientDid: string;
+  protocol: string;
+  role: string;
+  derivationPath: string[];
+  granteeDid?: string;
+  delegateDecryptionKeyCache?: DelegateDecryptionKeyCache;
+}): Promise<PrivateKeyJwk | undefined> {
+  if (params.granteeDid === undefined) {
+    const { keyUri } = await getEncryptionKeyInfo(params.agent, params.recipientDid);
+    const privateKeyBytes = await params.agent.keyManager.derivePrivateKeyBytes({
+      keyUri,
+      derivationPath: params.derivationPath,
+    });
+    return X25519.bytesToPrivateKey({ privateKeyBytes }) as Promise<PrivateKeyJwk>;
+  }
+
+  const cacheKey = `ddk~${params.granteeDid}`;
+  let delegateKeys = params.delegateDecryptionKeyCache?.get(cacheKey) ?? [];
+  let coveringKey = findCoveringDelegateKey(delegateKeys, params.protocol, params.role);
+
+  if (coveringKey === undefined && params.delegateDecryptionKeyCache?.set !== undefined) {
+    const hydratedKeys = await resolveGrantKeyRecords({
+      agent        : params.agent,
+      grantorDid   : params.recipientDid,
+      granteeDid   : params.granteeDid,
+      protocol     : params.protocol,
+      protocolPath : params.role,
+    });
+    delegateKeys = mergeDelegateDecryptionKeys(delegateKeys, hydratedKeys);
+    params.delegateDecryptionKeyCache.set(cacheKey, delegateKeys);
+    coveringKey = findCoveringDelegateKey(delegateKeys, params.protocol, params.role);
+  }
+
+  if (coveringKey === undefined) {
+    return undefined;
+  }
+
+  const privateKeyBytes = await Records.derivePrivateKey(coveringKey.derivedPrivateKey, params.derivationPath);
+  return X25519.bytesToPrivateKey({ privateKeyBytes }) as Promise<PrivateKeyJwk>;
 }
 
 async function getAudienceKeyEncryptedData(
@@ -1005,6 +1021,8 @@ async function verifyAudienceKeyPayload(params: {
   const { payload, audienceKeyMessage } = params;
   const tags = audienceKeyMessage.descriptor.tags ?? {};
 
+  assertAudienceKeyPayload(payload);
+
   if (audienceKeyMessage.descriptor.recipient !== params.recipientDid ||
       payload.protocol !== tags.protocol ||
       payload.contextId !== tags.contextId ||
@@ -1025,6 +1043,23 @@ async function verifyAudienceKeyPayload(params: {
   if (payload.keyId !== publicKeyId || payload.keyId !== privateKeyId) {
     throw new Error('audienceKey keyId does not match delivered key material.');
   }
+}
+
+function assertAudienceKeyPayload(payload: unknown): asserts payload is AudienceKeyPayload {
+  if (!isObject(payload) ||
+      typeof payload.protocol !== 'string' ||
+      typeof payload.contextId !== 'string' ||
+      typeof payload.role !== 'string' ||
+      !Number.isInteger(payload.epoch) ||
+      typeof payload.keyId !== 'string' ||
+      !isObject(payload.publicKeyJwk) ||
+      !isObject(payload.privateKeyJwk)) {
+    throw new Error('audienceKey payload is malformed.');
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 async function getCachedAudienceKey(params: {

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -4,6 +4,7 @@ import type {
   EncryptionInput,
   EncryptionKeyDeriver,
   KeyDecrypter,
+  KeyDecrypterDerivationScheme,
   PermissionGrant,
   RecordsQueryReply,
   RecordsReadReply,
@@ -33,6 +34,7 @@ import {
   KeyDerivationScheme,
   Message,
   Records,
+  ROLE_AUDIENCE_DERIVATION_SCHEME,
   Time,
 } from '@enbox/dwn-sdk-js';
 import { Ed25519, X25519 } from '@enbox/crypto';
@@ -51,6 +53,11 @@ type DelegateDecryptionKeyCache = {
   set?(key: string, value: DelegateDecryptionKeyEntry[]): void;
 };
 
+export type AudienceDecryptionKeyCache = {
+  get(key: string): AudienceDecryptionKeyEntry | undefined;
+  set?(key: string, value: AudienceDecryptionKeyEntry): void;
+};
+
 type GrantKeyScope = {
   scheme: typeof KeyDerivationScheme.ProtocolPath;
   protocol: string;
@@ -64,6 +71,21 @@ type GrantKeyPayload = {
   keyId: string;
   publicKeyJwk: PublicKeyJwk;
   privateKeyJwk: PrivateKeyJwk;
+};
+
+export type AudienceKeyPayload = {
+  protocol: string;
+  contextId: string;
+  role: string;
+  epoch: number;
+  keyId: string;
+  publicKeyJwk: PublicKeyJwk;
+  privateKeyJwk: PrivateKeyJwk;
+};
+
+export type AudienceDecryptionKeyEntry = AudienceKeyPayload & {
+  sourceDid: string;
+  recipientDid: string;
 };
 
 /**
@@ -309,6 +331,22 @@ export function buildProtocolPathSubtreeDecrypter(
   };
 }
 
+export function buildFixedPrivateKeyDecrypter(params: {
+  keyId: string;
+  derivationScheme: KeyDecrypterDerivationScheme;
+  publicKeyJwk: PublicKeyJwk;
+  privateKeyJwk: PrivateKeyJwk;
+}): KeyDecrypter {
+  return {
+    rootKeyId        : params.keyId,
+    derivationScheme : params.derivationScheme,
+    derivePublicKey  : async (): Promise<PublicKeyJwk> => params.publicKeyJwk,
+    decrypt          : async (_fullDerivationPath, keyUnwrapPayload): Promise<Uint8Array> => {
+      return Encryption.unwrapKey(params.privateKeyJwk as any, keyUnwrapPayload.keyEncryption);
+    },
+  };
+}
+
 /** Cache entry shape for scope-aware delegate decryption keys. */
 export type DelegateDecryptionKeyEntry = {
   protocol: string;
@@ -397,6 +435,139 @@ export async function createGrantKeyRecordsForGrants(params: {
   return grantKeyRecords;
 }
 
+export async function createAudienceEpochRecord(params: {
+  agent: EnboxPlatformAgent;
+  sourceDid: string;
+  authorDid: string;
+  audienceKey: AudienceKeyPayload;
+  protocolRole?: string;
+}): Promise<DataEncodedRecordsWriteMessage> {
+  const payloadBytes = Encoder.objectToBytes({
+    protocol     : params.audienceKey.protocol,
+    contextId    : params.audienceKey.contextId,
+    role         : params.audienceKey.role,
+    epoch        : params.audienceKey.epoch,
+    keyId        : params.audienceKey.keyId,
+    publicKeyJwk : params.audienceKey.publicKeyJwk,
+  });
+
+  const { reply, message } = await params.agent.processDwnRequest({
+    author        : params.authorDid,
+    target        : params.sourceDid,
+    messageType   : DwnInterface.RecordsWrite,
+    messageParams : {
+      protocol     : EncryptionProtocol.uri,
+      protocolPath : EncryptionProtocol.audienceEpochPath,
+      protocolRole : params.protocolRole,
+      schema       : EncryptionProtocol.definition.types.audienceEpoch.schema,
+      dataFormat   : 'application/json',
+      dataSize     : payloadBytes.length,
+      tags         : {
+        protocol  : params.audienceKey.protocol,
+        contextId : params.audienceKey.contextId,
+        role      : params.audienceKey.role,
+        epoch     : params.audienceKey.epoch,
+        keyId     : params.audienceKey.keyId,
+      },
+    },
+    dataStream: DataStream.fromBytes(payloadBytes),
+  });
+
+  if (reply.status.code !== 202 && reply.status.code !== 409) {
+    throw new Error(`AgentDwnApi: Failed to create audienceEpoch record: ${reply.status.detail}`);
+  }
+
+  return {
+    ...message!,
+    encodedData: Encoder.bytesToBase64Url(payloadBytes),
+  } as DataEncodedRecordsWriteMessage;
+}
+
+export async function createAudienceKeyRecord(params: {
+  agent: EnboxPlatformAgent;
+  sourceDid: string;
+  authorDid: string;
+  recipientDid: string;
+  recipientRolePublicKey: PublicKeyJwk;
+  audienceKey: AudienceKeyPayload;
+  protocolRole?: string;
+}): Promise<DataEncodedRecordsWriteMessage> {
+  const payloadBytes = Encoder.objectToBytes(params.audienceKey);
+  const contentEncryptionAlgorithm = ContentEncryptionAlgorithm.A256CTR;
+  const dataEncryptionKey = crypto.getRandomValues(new Uint8Array(32));
+  const dataEncryptionIV = crypto.getRandomValues(new Uint8Array(ivLength(contentEncryptionAlgorithm)));
+  const recipientRoleKeyId = await Encryption.getKeyId(params.recipientRolePublicKey);
+  const encryptionInput = buildEncryptionInput(
+    dataEncryptionKey,
+    dataEncryptionIV,
+    recipientRoleKeyId,
+    params.recipientRolePublicKey,
+    KeyDerivationScheme.ProtocolPath,
+  );
+  const { encryptedBytes, dataCid, dataSize } = await encryptAndComputeCid(
+    payloadBytes,
+    dataEncryptionKey,
+    dataEncryptionIV,
+    contentEncryptionAlgorithm,
+  );
+
+  const { reply, message } = await params.agent.processDwnRequest({
+    author        : params.authorDid,
+    target        : params.sourceDid,
+    messageType   : DwnInterface.RecordsWrite,
+    messageParams : {
+      recipient    : params.recipientDid,
+      protocol     : EncryptionProtocol.uri,
+      protocolPath : EncryptionProtocol.audienceKeyPath,
+      protocolRole : params.protocolRole,
+      schema       : EncryptionProtocol.definition.types.audienceKey.schema,
+      dataFormat   : 'application/json',
+      dataCid,
+      dataSize,
+      encryptionInput,
+      tags         : {
+        protocol  : params.audienceKey.protocol,
+        contextId : params.audienceKey.contextId,
+        role      : params.audienceKey.role,
+        epoch     : params.audienceKey.epoch,
+        keyId     : params.audienceKey.keyId,
+      },
+    },
+    dataStream: DataStream.fromBytes(encryptedBytes),
+  });
+
+  if (reply.status.code !== 202 && reply.status.code !== 409) {
+    throw new Error(`AgentDwnApi: Failed to create audienceKey record: ${reply.status.detail}`);
+  }
+
+  return {
+    ...message!,
+    encodedData: Encoder.bytesToBase64Url(encryptedBytes),
+  } as DataEncodedRecordsWriteMessage;
+}
+
+export async function cacheAudienceDecryptionKey(params: {
+  agent: EnboxPlatformAgent;
+  audienceDecryptionKeyCache?: AudienceDecryptionKeyCache;
+  entry: AudienceDecryptionKeyEntry;
+}): Promise<void> {
+  await putCachedAudienceKey(params);
+}
+
+export async function getCachedAudienceDecryptionKey(params: {
+  agent: EnboxPlatformAgent;
+  audienceDecryptionKeyCache?: AudienceDecryptionKeyCache;
+  sourceDid: string;
+  recipientDid: string;
+  protocol: string;
+  contextId: string;
+  role: string;
+  epoch: number;
+  keyId: string;
+}): Promise<AudienceDecryptionKeyEntry | undefined> {
+  return getCachedAudienceKey(params);
+}
+
 /**
  * Resolves the appropriate KeyDecrypter for a record's encryption scheme.
  *
@@ -417,6 +588,7 @@ export async function resolveKeyDecrypter(
   targetDid: string | undefined,
   delegateDecryptionKeyCache?: DelegateDecryptionKeyCache,
   granteeDid?: string,
+  audienceDecryptionKeyCache?: AudienceDecryptionKeyCache,
 ): Promise<KeyDecrypter> {
   if (granteeDid !== undefined) {
     const protocol = recordsWrite.descriptor.protocol;
@@ -452,10 +624,36 @@ export async function resolveKeyDecrypter(
       }
     }
 
+    const audienceDecrypter = await resolveRoleAudienceDecrypter({
+      agent,
+      sourceDid    : targetDid,
+      recipientDid : authorDid,
+      granteeDid,
+      recordsWrite,
+      delegateDecryptionKeyCache,
+      audienceDecryptionKeyCache,
+    });
+    if (audienceDecrypter !== undefined) {
+      return audienceDecrypter;
+    }
+
     throw new Error(
       `AgentDwnApi: no delivered decryption key covers encrypted record ` +
       `'${recordsWrite.recordId}' for delegate '${granteeDid}'.`
     );
+  }
+
+  if (targetDid !== undefined && targetDid !== authorDid) {
+    const audienceDecrypter = await resolveRoleAudienceDecrypter({
+      agent,
+      sourceDid    : targetDid,
+      recipientDid : authorDid,
+      recordsWrite,
+      audienceDecryptionKeyCache,
+    });
+    if (audienceDecrypter !== undefined) {
+      return audienceDecrypter;
+    }
   }
 
   return getKeyDecrypter(agent, authorDid);
@@ -476,6 +674,7 @@ export async function maybeDecryptReply<T extends DwnInterface>(
   reply: DwnMessageReply[T],
   agent: EnboxPlatformAgent,
   delegateDecryptionKeyCache?: DelegateDecryptionKeyCache,
+  audienceDecryptionKeyCache?: AudienceDecryptionKeyCache,
 ): Promise<void> {
   if (!('encryption' in request) || !request.encryption) {
     return;
@@ -497,7 +696,7 @@ export async function maybeDecryptReply<T extends DwnInterface>(
         && readReply.entry?.data) {
       const keyDecrypter = await resolveKeyDecrypter(
         agent, encryptedRequest.author, readReply.entry.recordsWrite, encryptedRequest.target,
-        delegateDecryptionKeyCache, granteeDid,
+        delegateDecryptionKeyCache, granteeDid, audienceDecryptionKeyCache,
       );
 
       try {
@@ -524,7 +723,7 @@ export async function maybeDecryptReply<T extends DwnInterface>(
         if (entry.encryption && entry.encodedData) {
           const keyDecrypter = await resolveKeyDecrypter(
             agent, encryptedRequest.author, entry as RecordsWriteMessage, encryptedRequest.target,
-            delegateDecryptionKeyCache, granteeDid,
+            delegateDecryptionKeyCache, granteeDid, audienceDecryptionKeyCache,
           );
 
           try {
@@ -545,6 +744,366 @@ export async function maybeDecryptReply<T extends DwnInterface>(
       }
     }
   }
+}
+
+async function resolveRoleAudienceDecrypter(params: {
+  agent: EnboxPlatformAgent;
+  sourceDid: string | undefined;
+  recipientDid: string;
+  recordsWrite: RecordsWriteMessage;
+  granteeDid?: string;
+  delegateDecryptionKeyCache?: DelegateDecryptionKeyCache;
+  audienceDecryptionKeyCache?: AudienceDecryptionKeyCache;
+}): Promise<KeyDecrypter | undefined> {
+  if (params.sourceDid === undefined || params.recordsWrite.encryption === undefined) {
+    return undefined;
+  }
+
+  const roleAudienceEntries = params.recordsWrite.encryption.keyEncryption.filter((entry): entry is typeof entry & {
+    derivationScheme: typeof ROLE_AUDIENCE_DERIVATION_SCHEME;
+    protocol: string;
+    role: string;
+    epoch: number;
+  } => entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME);
+
+  for (const entry of roleAudienceEntries) {
+    const contextId = getRoleAudienceContextId(params.recordsWrite, entry.role);
+    if (contextId === undefined) {
+      continue;
+    }
+
+    const cachedKey = await getCachedAudienceKey({
+      agent                      : params.agent,
+      audienceDecryptionKeyCache : params.audienceDecryptionKeyCache,
+      sourceDid                  : params.sourceDid,
+      recipientDid               : params.recipientDid,
+      protocol                   : entry.protocol,
+      contextId,
+      role                       : entry.role,
+      epoch                      : entry.epoch,
+      keyId                      : entry.keyId,
+    });
+    if (cachedKey !== undefined) {
+      return buildAudienceContentDecrypter(cachedKey);
+    }
+
+    const hydratedKey = await hydrateAudienceKey({
+      agent                      : params.agent,
+      sourceDid                  : params.sourceDid,
+      recipientDid               : params.recipientDid,
+      granteeDid                 : params.granteeDid,
+      delegateDecryptionKeyCache : params.delegateDecryptionKeyCache,
+      protocol                   : entry.protocol,
+      contextId,
+      role                       : entry.role,
+      epoch                      : entry.epoch,
+      keyId                      : entry.keyId,
+    });
+    if (hydratedKey !== undefined) {
+      await putCachedAudienceKey({
+        agent                      : params.agent,
+        audienceDecryptionKeyCache : params.audienceDecryptionKeyCache,
+        entry                      : hydratedKey,
+      });
+      return buildAudienceContentDecrypter(hydratedKey);
+    }
+  }
+
+  return undefined;
+}
+
+function buildAudienceContentDecrypter(entry: AudienceDecryptionKeyEntry): KeyDecrypter {
+  return buildFixedPrivateKeyDecrypter({
+    derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+    keyId            : entry.keyId,
+    privateKeyJwk    : entry.privateKeyJwk,
+    publicKeyJwk     : entry.publicKeyJwk,
+  });
+}
+
+async function hydrateAudienceKey(params: {
+  agent: EnboxPlatformAgent;
+  sourceDid: string;
+  recipientDid: string;
+  protocol: string;
+  contextId: string;
+  role: string;
+  epoch: number;
+  keyId: string;
+  granteeDid?: string;
+  delegateDecryptionKeyCache?: DelegateDecryptionKeyCache;
+}): Promise<AudienceDecryptionKeyEntry | undefined> {
+  const { reply } = await params.agent.processDwnRequest({
+    author        : params.granteeDid ?? params.recipientDid,
+    target        : params.sourceDid,
+    messageType   : DwnInterface.RecordsQuery,
+    messageParams : {
+      filter: {
+        recipient    : params.recipientDid,
+        protocol     : EncryptionProtocol.uri,
+        protocolPath : EncryptionProtocol.audienceKeyPath,
+        tags         : {
+          protocol  : params.protocol,
+          contextId : params.contextId,
+          role      : params.role,
+          epoch     : params.epoch,
+          keyId     : params.keyId,
+        },
+      },
+    },
+  });
+
+  if (reply.status.code !== 200 || reply.entries === undefined || reply.entries.length === 0) {
+    return undefined;
+  }
+
+  const rolePathDecrypter = await buildRecipientRolePathDecrypter({
+    agent                      : params.agent,
+    recipientDid               : params.recipientDid,
+    granteeDid                 : params.granteeDid,
+    delegateDecryptionKeyCache : params.delegateDecryptionKeyCache,
+    protocol                   : params.protocol,
+    role                       : params.role,
+  });
+  if (rolePathDecrypter === undefined) {
+    return undefined;
+  }
+
+  for (const entry of reply.entries) {
+    const audienceKeyMessage = entry as RecordsWriteMessage & { encodedData?: string };
+    const encryptedData = await getAudienceKeyEncryptedData(
+      params.agent, params.granteeDid ?? params.recipientDid, params.sourceDid, audienceKeyMessage,
+    );
+    if (encryptedData === undefined) {
+      continue;
+    }
+
+    try {
+      const decryptedStream = await Records.decrypt(
+        audienceKeyMessage,
+        rolePathDecrypter,
+        DataStream.fromBytes(encryptedData),
+      );
+      const payload = Encoder.bytesToObject(await DataStream.toBytes(decryptedStream)) as AudienceKeyPayload;
+      await verifyAudienceKeyPayload({
+        payload,
+        audienceKeyMessage,
+        sourceDid    : params.sourceDid,
+        recipientDid : params.recipientDid,
+        protocol     : params.protocol,
+        contextId    : params.contextId,
+        role         : params.role,
+        epoch        : params.epoch,
+        keyId        : params.keyId,
+      });
+
+      return {
+        ...payload,
+        sourceDid    : params.sourceDid,
+        recipientDid : params.recipientDid,
+      };
+    } catch (error) {
+      logger.log(
+        `AgentDwnApi: skipped audienceKey '${audienceKeyMessage.recordId}' while resolving role-audience key: ` +
+        `${error instanceof Error ? error.message : String(error)}`
+      );
+      continue;
+    }
+  }
+
+  return undefined;
+}
+
+async function buildRecipientRolePathDecrypter(params: {
+  agent: EnboxPlatformAgent;
+  recipientDid: string;
+  protocol: string;
+  role: string;
+  granteeDid?: string;
+  delegateDecryptionKeyCache?: DelegateDecryptionKeyCache;
+}): Promise<KeyDecrypter | undefined> {
+  const derivationPath = getScopeDerivationPath(params.protocol, params.role);
+  let privateKeyJwk: PrivateKeyJwk | undefined;
+
+  if (params.granteeDid !== undefined) {
+    const cacheKey = `ddk~${params.granteeDid}`;
+    let delegateKeys = params.delegateDecryptionKeyCache?.get(cacheKey) ?? [];
+    let coveringKey = findCoveringDelegateKey(delegateKeys, params.protocol, params.role);
+
+    if (coveringKey === undefined && params.delegateDecryptionKeyCache?.set !== undefined) {
+      const hydratedKeys = await resolveGrantKeyRecords({
+        agent        : params.agent,
+        grantorDid   : params.recipientDid,
+        granteeDid   : params.granteeDid,
+        protocol     : params.protocol,
+        protocolPath : params.role,
+      });
+      delegateKeys = mergeDelegateDecryptionKeys(delegateKeys, hydratedKeys);
+      params.delegateDecryptionKeyCache.set(cacheKey, delegateKeys);
+      coveringKey = findCoveringDelegateKey(delegateKeys, params.protocol, params.role);
+    }
+
+    if (coveringKey === undefined) {
+      return undefined;
+    }
+
+    const privateKeyBytes = await Records.derivePrivateKey(coveringKey.derivedPrivateKey, derivationPath);
+    privateKeyJwk = await X25519.bytesToPrivateKey({ privateKeyBytes }) as PrivateKeyJwk;
+  } else {
+    const { keyUri } = await getEncryptionKeyInfo(params.agent, params.recipientDid);
+    const privateKeyBytes = await params.agent.keyManager.derivePrivateKeyBytes({
+      keyUri,
+      derivationPath,
+    });
+    privateKeyJwk = await X25519.bytesToPrivateKey({ privateKeyBytes }) as PrivateKeyJwk;
+  }
+
+  const publicKeyJwk = await X25519.getPublicKey({ key: privateKeyJwk }) as PublicKeyJwk;
+  return buildFixedPrivateKeyDecrypter({
+    derivationScheme : KeyDerivationScheme.ProtocolPath,
+    keyId            : await Encryption.getKeyId(publicKeyJwk),
+    privateKeyJwk,
+    publicKeyJwk,
+  });
+}
+
+async function getAudienceKeyEncryptedData(
+  agent: EnboxPlatformAgent,
+  authorDid: string,
+  sourceDid: string,
+  audienceKeyMessage: RecordsWriteMessage & { encodedData?: string },
+): Promise<Uint8Array | undefined> {
+  if (audienceKeyMessage.encodedData !== undefined) {
+    return Encoder.base64UrlToBytes(audienceKeyMessage.encodedData);
+  }
+
+  const { reply } = await agent.processDwnRequest({
+    author        : authorDid,
+    target        : sourceDid,
+    messageType   : DwnInterface.RecordsRead,
+    messageParams : { filter: { recordId: audienceKeyMessage.recordId } },
+  });
+
+  if (reply.status.code !== 200 || reply.entry?.data === undefined) {
+    return undefined;
+  }
+
+  return DataStream.toBytes(reply.entry.data);
+}
+
+async function verifyAudienceKeyPayload(params: {
+  payload: AudienceKeyPayload;
+  audienceKeyMessage: RecordsWriteMessage;
+  sourceDid: string;
+  recipientDid: string;
+  protocol: string;
+  contextId: string;
+  role: string;
+  epoch: number;
+  keyId: string;
+}): Promise<void> {
+  const { payload, audienceKeyMessage } = params;
+  const tags = audienceKeyMessage.descriptor.tags ?? {};
+
+  if (audienceKeyMessage.descriptor.recipient !== params.recipientDid ||
+      payload.protocol !== tags.protocol ||
+      payload.contextId !== tags.contextId ||
+      payload.role !== tags.role ||
+      payload.epoch !== tags.epoch ||
+      payload.keyId !== tags.keyId ||
+      payload.protocol !== params.protocol ||
+      payload.contextId !== params.contextId ||
+      payload.role !== params.role ||
+      payload.epoch !== params.epoch ||
+      payload.keyId !== params.keyId) {
+    throw new Error('audienceKey payload does not match record tags.');
+  }
+
+  const publicKeyId = await Encryption.getKeyId(payload.publicKeyJwk);
+  const publicKeyFromPrivate = await X25519.getPublicKey({ key: payload.privateKeyJwk }) as PublicKeyJwk;
+  const privateKeyId = await Encryption.getKeyId(publicKeyFromPrivate);
+  if (payload.keyId !== publicKeyId || payload.keyId !== privateKeyId) {
+    throw new Error('audienceKey keyId does not match delivered key material.');
+  }
+}
+
+async function getCachedAudienceKey(params: {
+  agent: EnboxPlatformAgent;
+  audienceDecryptionKeyCache?: AudienceDecryptionKeyCache;
+  sourceDid: string;
+  recipientDid: string;
+  protocol: string;
+  contextId: string;
+  role: string;
+  epoch: number;
+  keyId: string;
+}): Promise<AudienceDecryptionKeyEntry | undefined> {
+  const cacheKey = getAudienceDecryptionKeyCacheKey(params);
+  const cached = params.audienceDecryptionKeyCache?.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const secretBytes = await params.agent.secrets.get(cacheKey);
+  if (secretBytes === undefined) {
+    return undefined;
+  }
+
+  const entry = Encoder.bytesToObject(secretBytes) as AudienceDecryptionKeyEntry;
+  params.audienceDecryptionKeyCache?.set?.(cacheKey, entry);
+  return entry;
+}
+
+async function putCachedAudienceKey(params: {
+  agent: EnboxPlatformAgent;
+  audienceDecryptionKeyCache?: AudienceDecryptionKeyCache;
+  entry: AudienceDecryptionKeyEntry;
+}): Promise<void> {
+  const cacheKey = getAudienceDecryptionKeyCacheKey(params.entry);
+  params.audienceDecryptionKeyCache?.set?.(cacheKey, params.entry);
+  await params.agent.secrets.put(cacheKey, Encoder.objectToBytes(params.entry));
+}
+
+function getAudienceDecryptionKeyCacheKey(input: {
+  sourceDid: string;
+  recipientDid: string;
+  protocol: string;
+  contextId: string;
+  role: string;
+  epoch: number;
+  keyId: string;
+}): string {
+  return `audience-key~${Encoder.stringToBase64Url(JSON.stringify([
+    input.sourceDid,
+    input.recipientDid,
+    input.protocol,
+    input.contextId,
+    input.role,
+    input.epoch,
+    input.keyId,
+  ]))}`;
+}
+
+function getRoleAudienceContextId(
+  recordsWrite: RecordsWriteMessage,
+  rolePath: string,
+): string | undefined {
+  const parentDepth = rolePath.split('/').length - 1;
+  if (parentDepth === 0) {
+    return '';
+  }
+
+  const contextId = recordsWrite.contextId;
+  if (typeof contextId !== 'string') {
+    return undefined;
+  }
+
+  const contextSegments = contextId.split('/');
+  if (contextSegments.length < parentDepth) {
+    return undefined;
+  }
+
+  return contextSegments.slice(0, parentDepth).join('/');
 }
 
 function isGrantKeyEligibleGrant(grant: PermissionGrant): grant is PermissionGrant & {

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -4049,7 +4049,7 @@ describe('Role record write behavior', () => {
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
       agentClass  : TestAgent,
-      agentStores : 'dwn'
+      agentStores : 'memory'
     });
   });
 

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -8,6 +8,7 @@ import {
   DataStream,
   DwnInterfaceName,
   DwnMethodName,
+  EncryptionProtocol,
   KeyDerivationScheme,
   Message,
   TestDataGenerator,
@@ -4160,6 +4161,59 @@ describe('Role record write behavior', () => {
       expect(decodedString).toBe(participantData);
     }
   }, 10000);
+
+  it('should not provision audience keys for role records without key agreement', async () => {
+    const bob = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
+
+    await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.ProtocolsConfigure,
+      messageParams : { definition: chatProtocol },
+    });
+
+    const { message: threadMessage } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : chatProtocol.protocol,
+        protocolPath : 'thread',
+        dataFormat   : 'application/json',
+        schema       : 'https://schemas.xyz/thread',
+      },
+      dataStream: new Blob([new TextEncoder().encode('{"title":"Plain Chat"}')]),
+    });
+
+    const { reply: roleReply } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        recipient       : bob.did.uri,
+        protocol        : chatProtocol.protocol,
+        protocolPath    : 'thread/participant',
+        parentContextId : (threadMessage as RecordsWriteMessage).contextId,
+        dataFormat      : 'application/json',
+        schema          : 'https://schemas.xyz/participant',
+      },
+      dataStream: new Blob([new TextEncoder().encode('{"name":"Bob"}')]),
+    });
+    expect(roleReply.status.code).toBe(202);
+
+    const { reply: audienceKeyReply } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: {
+          protocol     : EncryptionProtocol.uri,
+          protocolPath : EncryptionProtocol.audienceKeyPath,
+        },
+      },
+    });
+    expect(audienceKeyReply.entries ?? []).toHaveLength(0);
+  });
 });
 
 describe('Owner encrypted read behavior', () => {

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -4060,6 +4060,10 @@ describe('Role record write behavior', () => {
     alice = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
   });
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   afterAll(async () => {
     await testHarness.clearStorage();
     await testHarness.closeStorage();
@@ -4160,6 +4164,53 @@ describe('Role record write behavior', () => {
       const decodedString = new TextDecoder().decode(decodedBytes);
       expect(decodedString).toBe(participantData);
     }
+  }, 10000);
+
+  it('should accept a role record when audience key delivery is retryable', async () => {
+    const bob = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
+    const roleKeyLookupStub = sinon.stub(testHarness.agent.dwn as any, 'getRecipientRolePublicKey')
+      .rejects(new Error('recipient protocol not installed'));
+
+    await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.ProtocolsConfigure,
+      messageParams : { definition: chatProtocol },
+      encryption    : true,
+    });
+
+    const { message: threadMessage } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : chatProtocol.protocol,
+        protocolPath : 'thread',
+        dataFormat   : 'application/json',
+        schema       : 'https://schemas.xyz/thread',
+      },
+      dataStream : new Blob([new TextEncoder().encode('{"title":"Retryable"}')]),
+      encryption : true,
+    });
+
+    const { reply: roleReply } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        recipient       : bob.did.uri,
+        protocol        : chatProtocol.protocol,
+        protocolPath    : 'thread/participant',
+        parentContextId : (threadMessage as RecordsWriteMessage).contextId,
+        dataFormat      : 'application/json',
+        schema          : 'https://schemas.xyz/participant',
+      },
+      dataStream : new Blob([new TextEncoder().encode('{"name":"Bob"}')]),
+      encryption : true,
+    });
+
+    expect(roleReply.status.code).toBe(202);
+    expect(roleKeyLookupStub.calledOnce).toBe(true);
   }, 10000);
 
   it('should not provision audience keys for role records without key agreement', async () => {

--- a/packages/agent/tests/e2e-encrypted-sync.spec.ts
+++ b/packages/agent/tests/e2e-encrypted-sync.spec.ts
@@ -1,10 +1,12 @@
 import type { BearerIdentity } from '../src/bearer-identity.js';
-import type { ProtocolDefinition, RecordsQueryReply, RecordsWriteMessage, RoleAudienceKeyEncryption } from '@enbox/dwn-sdk-js';
+import type { PublicKeyJwk } from '@enbox/crypto';
+import type { GenericMessage, ProtocolDefinition, RecordsWriteMessage, RoleAudienceKeyEncryption } from '@enbox/dwn-sdk-js';
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import {
   ContentEncryptionAlgorithm,
   DataStream,
+  Encoder,
   EncryptionProtocol,
   KeyDerivationScheme,
   ROLE_AUDIENCE_DERIVATION_SCHEME,
@@ -12,7 +14,6 @@ import {
 
 import { DwnInterface } from '../src/types/dwn.js';
 import { EnboxUserAgent } from '../src/enbox-user-agent.js';
-import { getCachedAudienceDecryptionKey } from '../src/dwn-encryption.js';
 import { JwkProtocolDefinition } from '../src/store-data-protocols.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { requireDwnServer } from './utils/require-dwn-server.js';
@@ -20,6 +21,7 @@ import { retryFreshDidResolution } from './utils/remote-dwn-retry.js';
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
+import { createAudienceKeyRecord, getCachedAudienceDecryptionKey } from '../src/dwn-encryption.js';
 
 const testDwnUrls: string[] = [testDwnUrl];
 const syncConvergenceRetryDelaysMs = [500, 1_000, 2_000, 4_000, 8_000, 16_000];
@@ -435,10 +437,13 @@ describe('e2e: agent lifecycle with encrypted stores', () => {
 describe('e2e: encrypted role-audience records require audience keys', () => {
 
   let testHarness: PlatformAgentTestHarness;
+  let bobHarness: PlatformAgentTestHarness;
   let alice: BearerIdentity;
   let bob: BearerIdentity;
   let carol: BearerIdentity;
+  let separateBob: BearerIdentity;
   const password = 'role-audience-cache-test-password';
+  const bobPassword = 'role-audience-cache-test-bob-password';
 
   // Multi-party chat protocol with $role participants and encrypted data.
   const chatProtocol: ProtocolDefinition = {
@@ -467,24 +472,35 @@ describe('e2e: encrypted role-audience records require audience keys', () => {
       agentStores      : 'dwn',
       testDataLocation : '__TESTDATA__/e2e-multiparty-chat',
     });
+    bobHarness = await PlatformAgentTestHarness.setup({
+      agentClass       : EnboxUserAgent,
+      agentStores      : 'dwn',
+      testDataLocation : '__TESTDATA__/e2e-multiparty-chat-bob',
+    });
   });
 
   beforeEach(async () => {
     await testHarness.clearStorage();
+    await bobHarness.clearStorage();
     await (testHarness.agent as EnboxUserAgent).initialize({ password });
     await (testHarness.agent as EnboxUserAgent).start({ password });
+    await (bobHarness.agent as EnboxUserAgent).initialize({ password: bobPassword });
+    await (bobHarness.agent as EnboxUserAgent).start({ password: bobPassword });
     alice = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
     bob = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
     carol = await testHarness.createIdentity({ name: 'Carol', testDwnUrls });
+    separateBob = await bobHarness.createIdentity({ name: 'Separate Bob', testDwnUrls });
   });
 
   afterAll(async () => {
     await testHarness.clearStorage();
+    await bobHarness.clearStorage();
     await testHarness.closeStorage();
+    await bobHarness.closeStorage();
   });
 
-  async function installChatProtocol(did: string): Promise<void> {
-    const { reply } = await testHarness.agent.dwn.processRequest({
+  async function installChatProtocol(harness: PlatformAgentTestHarness, did: string): Promise<void> {
+    const { reply } = await harness.agent.dwn.processRequest({
       author        : did,
       target        : did,
       messageType   : DwnInterface.ProtocolsConfigure,
@@ -494,14 +510,117 @@ describe('e2e: encrypted role-audience records require audience keys', () => {
     expect(reply.status.code).toBe(202);
   }
 
+  async function copyProtocolToHarness(
+    source: PlatformAgentTestHarness,
+    destination: PlatformAgentTestHarness,
+    tenantDid: string,
+  ): Promise<void> {
+    const { reply } = await source.agent.dwn.processRequest({
+      author        : tenantDid,
+      target        : tenantDid,
+      messageType   : DwnInterface.ProtocolsQuery,
+      messageParams : { filter: { protocol: chatProtocol.protocol } },
+    });
+    expect(reply.status.code).toBe(200);
+    expect(reply.entries).toHaveLength(1);
+
+    const applyReply = await destination.agent.dwn.processRawMessage(
+      tenantDid,
+      reply.entries![0] as GenericMessage,
+    );
+    expect([202, 409]).toContain(applyReply.status.code);
+  }
+
+  async function copyRecordToHarness(
+    source: PlatformAgentTestHarness,
+    destination: PlatformAgentTestHarness,
+    tenantDid: string,
+    recordId: string,
+  ): Promise<void> {
+    const { reply } = await source.agent.dwn.processRequest({
+      author        : tenantDid,
+      target        : tenantDid,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : { filter: { recordId } },
+    });
+    expect(reply.status.code).toBe(200);
+    expect(reply.entry?.data).toBeDefined();
+    expect(reply.entry?.recordsWrite).toBeDefined();
+
+    const dataBytes = await DataStream.toBytes(reply.entry!.data!);
+    const applyReply = await destination.agent.dwn.processRawMessage(
+      tenantDid,
+      reply.entry!.recordsWrite as GenericMessage,
+      { dataStream: DataStream.fromBytes(dataBytes) },
+    );
+    expect([202, 409]).toContain(applyReply.status.code);
+  }
+
+  async function copyDataEncodedRecordToHarness(
+    destination: PlatformAgentTestHarness,
+    tenantDid: string,
+    record: RecordsWriteMessage & { encodedData: string },
+  ): Promise<void> {
+    const { encodedData, ...rawMessage } = record;
+    const applyReply = await destination.agent.dwn.processRawMessage(
+      tenantDid,
+      rawMessage as RecordsWriteMessage,
+      { dataStream: DataStream.fromBytes(Encoder.base64UrlToBytes(encodedData)) },
+    );
+    expect([202, 409]).toContain(applyReply.status.code);
+  }
+
+  async function queryOneEncryptionRecord(params: {
+    protocolPath: string;
+    tags: Record<string, string | number>;
+  }): Promise<RecordsWriteMessage & { encodedData: string }> {
+    const { reply } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: {
+          protocol     : EncryptionProtocol.uri,
+          protocolPath : params.protocolPath,
+        },
+      },
+    });
+    expect(reply.status.code).toBe(200);
+    const matchingEntries = (reply.entries ?? []).filter((entry): boolean =>
+      Object.entries(params.tags).every(([tag, value]): boolean => String(entry.descriptor.tags?.[tag]) === String(value))
+    );
+    expect(matchingEntries).toHaveLength(1);
+    expect(matchingEntries[0].encodedData).toBeDefined();
+    return matchingEntries[0] as RecordsWriteMessage & { encodedData: string };
+  }
+
+  async function getRolePublicKeyFromInstalledProtocol(
+    harness: PlatformAgentTestHarness,
+    did: string,
+  ): Promise<PublicKeyJwk> {
+    const { reply } = await harness.agent.dwn.processRequest({
+      author        : did,
+      target        : did,
+      messageType   : DwnInterface.ProtocolsQuery,
+      messageParams : { filter: { protocol: chatProtocol.protocol } },
+    });
+    expect(reply.status.code).toBe(200);
+    expect(reply.entries).toHaveLength(1);
+
+    const definition = reply.entries![0].descriptor.definition;
+    const publicKeyJwk = definition.structure.thread.participant?.$keyAgreement?.publicKeyJwk;
+    expect(publicKeyJwk).toBeDefined();
+    return publicKeyJwk!;
+  }
+
   it('should install the chat protocol with encryption for Alice', async () => {
-    await installChatProtocol(alice.did.uri);
+    await installChatProtocol(testHarness, alice.did.uri);
   }, 30_000);
 
   it('should deliver an audience key and allow a role holder to decrypt', async () => {
-    await installChatProtocol(alice.did.uri);
-    await installChatProtocol(bob.did.uri);
-    await installChatProtocol(carol.did.uri);
+    await installChatProtocol(testHarness, alice.did.uri);
+    await installChatProtocol(testHarness, bob.did.uri);
+    await installChatProtocol(testHarness, carol.did.uri);
 
     // Alice creates a plaintext thread (root record).
     const { message: threadMsg } = await testHarness.agent.dwn.processRequest({
@@ -639,6 +758,162 @@ describe('e2e: encrypted role-audience records require audience keys', () => {
       encryption: true,
     });
     expect(carolReadReply.status.code).toBe(401);
+  }, 30_000);
+
+  it('should allow a role holder in a separate agent to decrypt with the delivered audience key', async () => {
+    await installChatProtocol(testHarness, alice.did.uri);
+    await installChatProtocol(bobHarness, separateBob.did.uri);
+
+    await copyProtocolToHarness(bobHarness, testHarness, separateBob.did.uri);
+    await copyProtocolToHarness(testHarness, bobHarness, alice.did.uri);
+
+    const { message: threadMessage } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol     : chatProtocol.protocol,
+        protocolPath : 'thread',
+        dataFormat   : 'application/json',
+        schema       : 'https://schemas.xyz/thread',
+      },
+      dataStream: new Blob([new TextEncoder().encode('{"title":"Separate Agent Chat"}')]),
+    });
+    const threadContextId = (threadMessage as RecordsWriteMessage).contextId!;
+
+    const { reply: roleReply, message: roleMessage } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        recipient       : separateBob.did.uri,
+        protocol        : chatProtocol.protocol,
+        protocolPath    : 'thread/participant',
+        parentContextId : threadContextId,
+        dataFormat      : 'application/json',
+        schema          : 'https://schemas.xyz/participant',
+      },
+      dataStream: new Blob([new TextEncoder().encode('{"role":"participant"}')]),
+    });
+    expect(roleReply.status.code).toBe(202);
+
+    const audienceEpoch = await queryOneEncryptionRecord({
+      protocolPath : EncryptionProtocol.audienceEpochPath,
+      tags         : {
+        protocol  : chatProtocol.protocol,
+        contextId : threadContextId,
+        role      : 'thread/participant',
+        epoch     : 1,
+      },
+    });
+    const epochPayload = Encoder.base64UrlToObject(audienceEpoch.encodedData) as {
+      protocol: string;
+      contextId: string;
+      role: string;
+      epoch: number;
+      keyId: string;
+      publicKeyJwk: PublicKeyJwk;
+    };
+    const audienceKey = await getCachedAudienceDecryptionKey({
+      agent        : testHarness.agent,
+      sourceDid    : alice.did.uri,
+      recipientDid : alice.did.uri,
+      protocol     : epochPayload.protocol,
+      contextId    : epochPayload.contextId,
+      role         : epochPayload.role,
+      epoch        : epochPayload.epoch,
+      keyId        : epochPayload.keyId,
+    });
+    expect(audienceKey).toBeDefined();
+    const bobRolePublicKey = await getRolePublicKeyFromInstalledProtocol(bobHarness, separateBob.did.uri);
+    const audienceKeyRecord = await createAudienceKeyRecord({
+      agent                  : testHarness.agent,
+      sourceDid              : alice.did.uri,
+      authorDid              : alice.did.uri,
+      recipientDid           : separateBob.did.uri,
+      recipientRolePublicKey : bobRolePublicKey,
+      audienceKey            : {
+        protocol      : epochPayload.protocol,
+        contextId     : epochPayload.contextId,
+        role          : epochPayload.role,
+        epoch         : epochPayload.epoch,
+        keyId         : epochPayload.keyId,
+        publicKeyJwk  : epochPayload.publicKeyJwk,
+        privateKeyJwk : audienceKey!.privateKeyJwk,
+      },
+    });
+
+    const chatText = 'Bob decrypts this without Alice keys';
+    const { reply: chatReply, message: chatMessage } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol        : chatProtocol.protocol,
+        protocolPath    : 'thread/chat',
+        parentContextId : threadContextId,
+        dataFormat      : 'text/plain',
+        schema          : 'https://schemas.xyz/chat',
+      },
+      dataStream : new Blob([new TextEncoder().encode(chatText)]),
+      encryption : true,
+    });
+    expect(chatReply.status.code).toBe(202);
+
+    const roleAudienceEntry = (chatMessage as RecordsWriteMessage).encryption!.keyEncryption.find(
+      (entry): entry is RoleAudienceKeyEncryption => entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME
+    );
+    expect(roleAudienceEntry).toBeDefined();
+
+    await copyRecordToHarness(testHarness, bobHarness, alice.did.uri, (threadMessage as RecordsWriteMessage).recordId);
+    await copyRecordToHarness(testHarness, bobHarness, alice.did.uri, (roleMessage as RecordsWriteMessage).recordId);
+    await copyDataEncodedRecordToHarness(bobHarness, alice.did.uri, audienceEpoch);
+    await copyDataEncodedRecordToHarness(
+      bobHarness,
+      alice.did.uri,
+      audienceKeyRecord as RecordsWriteMessage & { encodedData: string },
+    );
+    await copyRecordToHarness(testHarness, bobHarness, alice.did.uri, (chatMessage as RecordsWriteMessage).recordId);
+
+    bobHarness.agent.dwn.clearDelegateDecryptionKeys(separateBob.did.uri);
+    expect(await bobHarness.agent.did.get({ didUri: alice.did.uri })).toBeUndefined();
+    const cachedBeforeRead = await getCachedAudienceDecryptionKey({
+      agent        : bobHarness.agent,
+      sourceDid    : alice.did.uri,
+      recipientDid : separateBob.did.uri,
+      protocol     : chatProtocol.protocol,
+      contextId    : threadContextId,
+      role         : 'thread/participant',
+      epoch        : roleAudienceEntry!.epoch,
+      keyId        : roleAudienceEntry!.keyId,
+    });
+    expect(cachedBeforeRead).toBeUndefined();
+
+    const { reply: bobReadReply } = await bobHarness.agent.dwn.processRequest({
+      author        : separateBob.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : {
+        filter       : { recordId: (chatMessage as RecordsWriteMessage).recordId },
+        protocolRole : 'thread/participant',
+      },
+      encryption: true,
+    });
+    expect(bobReadReply.status.code).toBe(200);
+    const decryptedBytes = await DataStream.toBytes(bobReadReply.entry!.data!);
+    expect(new TextDecoder().decode(decryptedBytes)).toBe(chatText);
+
+    const cachedAfterRead = await getCachedAudienceDecryptionKey({
+      agent        : bobHarness.agent,
+      sourceDid    : alice.did.uri,
+      recipientDid : separateBob.did.uri,
+      protocol     : chatProtocol.protocol,
+      contextId    : threadContextId,
+      role         : 'thread/participant',
+      epoch        : roleAudienceEntry!.epoch,
+      keyId        : roleAudienceEntry!.keyId,
+    });
+    expect(cachedAfterRead?.privateKeyJwk.d).toBeDefined();
   }, 30_000);
 
 });

--- a/packages/agent/tests/e2e-encrypted-sync.spec.ts
+++ b/packages/agent/tests/e2e-encrypted-sync.spec.ts
@@ -1,11 +1,18 @@
 import type { BearerIdentity } from '../src/bearer-identity.js';
-import type { ProtocolDefinition, RecordsQueryReply, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
+import type { ProtocolDefinition, RecordsQueryReply, RecordsWriteMessage, RoleAudienceKeyEncryption } from '@enbox/dwn-sdk-js';
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { ContentEncryptionAlgorithm, DataStream, DwnErrorCode, KeyDerivationScheme } from '@enbox/dwn-sdk-js';
+import {
+  ContentEncryptionAlgorithm,
+  DataStream,
+  EncryptionProtocol,
+  KeyDerivationScheme,
+  ROLE_AUDIENCE_DERIVATION_SCHEME,
+} from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from '../src/types/dwn.js';
 import { EnboxUserAgent } from '../src/enbox-user-agent.js';
+import { getCachedAudienceDecryptionKey } from '../src/dwn-encryption.js';
 import { JwkProtocolDefinition } from '../src/store-data-protocols.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { requireDwnServer } from './utils/require-dwn-server.js';
@@ -429,6 +436,9 @@ describe('e2e: encrypted role-audience records require audience keys', () => {
 
   let testHarness: PlatformAgentTestHarness;
   let alice: BearerIdentity;
+  let bob: BearerIdentity;
+  let carol: BearerIdentity;
+  const password = 'role-audience-cache-test-password';
 
   // Multi-party chat protocol with $role participants and encrypted data.
   const chatProtocol: ProtocolDefinition = {
@@ -453,7 +463,7 @@ describe('e2e: encrypted role-audience records require audience keys', () => {
 
   beforeAll(async () => {
     testHarness = await PlatformAgentTestHarness.setup({
-      agentClass       : TestAgent,
+      agentClass       : EnboxUserAgent,
       agentStores      : 'dwn',
       testDataLocation : '__TESTDATA__/e2e-multiparty-chat',
     });
@@ -461,8 +471,11 @@ describe('e2e: encrypted role-audience records require audience keys', () => {
 
   beforeEach(async () => {
     await testHarness.clearStorage();
-    await testHarness.createAgentDid();
+    await (testHarness.agent as EnboxUserAgent).initialize({ password });
+    await (testHarness.agent as EnboxUserAgent).start({ password });
     alice = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
+    bob = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
+    carol = await testHarness.createIdentity({ name: 'Carol', testDwnUrls });
   });
 
   afterAll(async () => {
@@ -470,26 +483,25 @@ describe('e2e: encrypted role-audience records require audience keys', () => {
     await testHarness.closeStorage();
   });
 
-  it('should install the chat protocol with encryption for Alice', async () => {
+  async function installChatProtocol(did: string): Promise<void> {
     const { reply } = await testHarness.agent.dwn.processRequest({
-      author        : alice.did.uri,
-      target        : alice.did.uri,
+      author        : did,
+      target        : did,
       messageType   : DwnInterface.ProtocolsConfigure,
       messageParams : { definition: chatProtocol },
       encryption    : true,
     });
     expect(reply.status.code).toBe(202);
+  }
+
+  it('should install the chat protocol with encryption for Alice', async () => {
+    await installChatProtocol(alice.did.uri);
   }, 30_000);
 
-  it('should reject a role-readable encrypted chat message without a roleAudience entry', async () => {
-    // Install protocol first.
-    await testHarness.agent.dwn.processRequest({
-      author        : alice.did.uri,
-      target        : alice.did.uri,
-      messageType   : DwnInterface.ProtocolsConfigure,
-      messageParams : { definition: chatProtocol },
-      encryption    : true,
-    });
+  it('should deliver an audience key and allow a role holder to decrypt', async () => {
+    await installChatProtocol(alice.did.uri);
+    await installChatProtocol(bob.did.uri);
+    await installChatProtocol(carol.did.uri);
 
     // Alice creates a plaintext thread (root record).
     const { message: threadMsg } = await testHarness.agent.dwn.processRequest({
@@ -507,9 +519,55 @@ describe('e2e: encrypted role-audience records require audience keys', () => {
     expect(threadMsg).toBeDefined();
     const threadContextId = (threadMsg as RecordsWriteMessage).contextId!;
 
-    // The agent does not yet produce role-audience entries, so the DWN must reject.
+    // Without a role audience epoch, the agent cannot produce a complete encrypted write.
     const chatText = 'Hello Bob, this is encrypted!';
-    const { reply: chatReply } = await testHarness.agent.dwn.processRequest({
+    await expect(testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        protocol        : chatProtocol.protocol,
+        protocolPath    : 'thread/chat',
+        parentContextId : threadContextId,
+        dataFormat      : 'text/plain',
+        schema          : 'https://schemas.xyz/chat',
+      },
+      dataStream : new Blob([new TextEncoder().encode(chatText)]),
+      encryption : true,
+    })).rejects.toThrow('Missing audienceEpoch');
+
+    const { reply: roleReply } = await testHarness.agent.dwn.processRequest({
+      author        : alice.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsWrite,
+      messageParams : {
+        recipient       : bob.did.uri,
+        protocol        : chatProtocol.protocol,
+        protocolPath    : 'thread/participant',
+        parentContextId : threadContextId,
+        dataFormat      : 'application/json',
+        schema          : 'https://schemas.xyz/participant',
+      },
+      dataStream: new Blob([new TextEncoder().encode('{"role":"participant"}')]),
+    });
+    expect(roleReply.status.code).toBe(202);
+
+    const { reply: audienceKeyReply } = await testHarness.agent.dwn.processRequest({
+      author        : bob.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: {
+          recipient    : bob.did.uri,
+          protocol     : EncryptionProtocol.uri,
+          protocolPath : EncryptionProtocol.audienceKeyPath,
+        },
+      },
+    });
+    expect(audienceKeyReply.status.code).toBe(200);
+    expect(audienceKeyReply.entries).toHaveLength(1);
+
+    const { reply: chatReply, message: chatMessage } = await testHarness.agent.dwn.processRequest({
       author        : alice.did.uri,
       target        : alice.did.uri,
       messageType   : DwnInterface.RecordsWrite,
@@ -523,8 +581,64 @@ describe('e2e: encrypted role-audience records require audience keys', () => {
       dataStream : new Blob([new TextEncoder().encode(chatText)]),
       encryption : true,
     });
-    expect(chatReply.status.code).toBe(400);
-    expect(chatReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEntryMissing);
+    expect(chatReply.status.code).toBe(202);
+
+    const roleAudienceEntry = (chatMessage as RecordsWriteMessage).encryption!.keyEncryption.find(
+      (entry): entry is RoleAudienceKeyEncryption => entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME
+    );
+    expect(roleAudienceEntry).toBeDefined();
+    expect(roleAudienceEntry!.protocol).toBe(chatProtocol.protocol);
+    expect(roleAudienceEntry!.role).toBe('thread/participant');
+
+    const cachedBeforeRead = await getCachedAudienceDecryptionKey({
+      agent        : testHarness.agent,
+      sourceDid    : alice.did.uri,
+      recipientDid : bob.did.uri,
+      protocol     : chatProtocol.protocol,
+      contextId    : threadContextId,
+      role         : 'thread/participant',
+      epoch        : roleAudienceEntry!.epoch,
+      keyId        : roleAudienceEntry!.keyId,
+    });
+    expect(cachedBeforeRead).toBeUndefined();
+
+    const { reply: bobReadReply } = await testHarness.agent.dwn.processRequest({
+      author        : bob.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : {
+        filter       : { recordId: (chatMessage as RecordsWriteMessage).recordId },
+        protocolRole : 'thread/participant',
+      },
+      encryption: true,
+    });
+    expect(bobReadReply.status.code).toBe(200);
+    const decryptedBytes = await DataStream.toBytes(bobReadReply.entry!.data!);
+    expect(new TextDecoder().decode(decryptedBytes)).toBe(chatText);
+
+    const cachedAfterRead = await getCachedAudienceDecryptionKey({
+      agent        : testHarness.agent,
+      sourceDid    : alice.did.uri,
+      recipientDid : bob.did.uri,
+      protocol     : chatProtocol.protocol,
+      contextId    : threadContextId,
+      role         : 'thread/participant',
+      epoch        : roleAudienceEntry!.epoch,
+      keyId        : roleAudienceEntry!.keyId,
+    });
+    expect(cachedAfterRead?.privateKeyJwk.d).toBeDefined();
+
+    const { reply: carolReadReply } = await testHarness.agent.dwn.processRequest({
+      author        : carol.did.uri,
+      target        : alice.did.uri,
+      messageType   : DwnInterface.RecordsRead,
+      messageParams : {
+        filter       : { recordId: (chatMessage as RecordsWriteMessage).recordId },
+        protocolRole : 'thread/participant',
+      },
+      encryption: true,
+    });
+    expect(carolReadReply.status.code).toBe(401);
   }, 30_000);
 
 });

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -90,7 +90,7 @@ export { Secp256r1 } from './utils/secp256r1.js';
 export type { SupportedCurve } from './jose/algorithms/signing/signature-algorithms.js';
 export type { MessageSigner } from './types/signer.js';
 export { SortDirection } from './types/query-types.js';
-export type { EncryptionKeyDeriver, KeyDecrypter } from './types/encryption-types.js';
+export type { EncryptionKeyDeriver, KeyDecrypter, KeyDecrypterDerivationScheme } from './types/encryption-types.js';
 export { Time } from './utils/time.js';
 export * from './types/permission-types.js';
 export * from './types/records-types.js';

--- a/packages/dwn-sdk-js/src/types/encryption-types.ts
+++ b/packages/dwn-sdk-js/src/types/encryption-types.ts
@@ -2,6 +2,8 @@ import type { KeyDerivationScheme } from '../utils/hd-key.js';
 import type { KeyUnwrapPayload } from '../utils/encryption.js';
 import type { PublicKeyJwk } from './jose-types.js';
 
+export type KeyDecrypterDerivationScheme = KeyDerivationScheme | 'roleAudience';
+
 export interface EncryptionKeyDeriver {
   rootKeyId: string;
   derivationScheme: KeyDerivationScheme;
@@ -11,7 +13,7 @@ export interface EncryptionKeyDeriver {
 
 export interface KeyDecrypter {
   rootKeyId: string;
-  derivationScheme: KeyDerivationScheme;
+  derivationScheme: KeyDecrypterDerivationScheme;
 
   derivePublicKey(fullDerivationPath: string[]): Promise<PublicKeyJwk>;
 

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -11,7 +11,6 @@ import { Cid } from './cid.js';
 import { DataStream } from './data-stream.js';
 import { DateSort } from '../types/records-types.js';
 import { Encoder } from './encoder.js';
-import { Encryption } from './encryption.js';
 import { FilterUtility } from './filter.js';
 import { Jws } from './jws.js';
 import { Message } from '../core/message.js';
@@ -21,6 +20,7 @@ import { SortDirection } from '../types/query-types.js';
 import { X25519 } from '@enbox/crypto';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
+import { Encryption, ROLE_AUDIENCE_DERIVATION_SCHEME } from './encryption.js';
 import { HdKey, KeyDerivationScheme } from './hd-key.js';
 import { normalizeProtocolUrl, normalizeSchemaUrl } from './url.js';
 
@@ -187,13 +187,17 @@ export class Records {
    * Constructs full key derivation path using the specified scheme.
    */
   public static constructKeyDerivationPath(
-    keyDerivationScheme: KeyDerivationScheme,
+    keyDerivationScheme: KeyDerivationScheme | typeof ROLE_AUDIENCE_DERIVATION_SCHEME,
     recordsWriteMessage: RecordsWriteMessage
   ): string[] {
 
     const descriptor = recordsWriteMessage.descriptor;
     if (keyDerivationScheme === KeyDerivationScheme.ProtocolPath) {
       return Records.constructKeyDerivationPathUsingProtocolPathScheme(descriptor);
+    }
+
+    if (keyDerivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME) {
+      return [ROLE_AUDIENCE_DERIVATION_SCHEME];
     }
 
     throw new DwnError(


### PR DESCRIPTION
## Summary

- Adds role-audience `audienceEpoch` / `audienceKey` production when encrypted role records are accepted.
- Adds `roleAudience` CEK wrapping for encrypted records with role-based read rules.
- Hydrates delivered audience keys from durable Encryption Protocol records and caches them in the agent secret store.
- Keeps role writes accepted when initial audience-key provisioning fails after the role record is stored.
- Adds separate-agent role-holder decrypt coverage proving the delivered audience key works without owner KMS material.
- Tracks role-audience epoch rotation in #1088 and recipient-side verifier hardening in #1089.

## Test plan

- [x] `bun run lint`
- [x] `bun run --filter @enbox/agent build`
- [x] `bunx changeset status --since=origin/main`
- [x] `bun test tests/dwn-encryption.spec.ts -t "resolveKeyDecrypter"` (`packages/agent`)
- [x] `bun test tests/e2e-delegate-encrypted.spec.ts -t "resolveKeyDecrypter|durable grantKey|sibling protocolPath"` (`packages/agent`)
- [x] `bun test tests/dwn-api.spec.ts -t "Encryption Callback Factories|Role record write behavior|Owner encrypted read behavior"` (`packages/agent`)
- [x] `bun test tests/dwn-api.spec.ts -t "Role record write behavior"` (`packages/agent`)
- [x] `bun test tests/e2e-encrypted-sync.spec.ts -t "encrypted role-audience"` (`packages/agent`)
- [x] `bun run test:node` (`packages/dwn-sdk-js`)
- [x] `bun test --timeout 10000 .spec.ts -t "updates a record using a different protocolRole|deletes a record using a different protocolRole|SocialGraphProtocol|creates a role record for another user|ensures that a protocolRole"` (`packages/api`; SocialGraph regression passes locally, remote-DWN cases require `localhost:3000`)
- [ ] `bun run test:node` (`packages/agent`) attempted locally; fails because `http://localhost:3000` DWN server is not running in this environment.
