### PR TITLE
fix(agent): verify delivered audience keys

### DIFF
--- a/.changeset/audience-key-verifier.md
+++ b/.changeset/audience-key-verifier.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+fix: verify delivered audience keys against accepted epochs and role assignments

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -1167,7 +1167,7 @@ async function verifyAudienceKeyRoleAssignment(params: {
     messageType   : DwnInterface.RecordsQuery,
     messageParams : {
       filter: {
-        ...(contextIdPrefix !== undefined ? { contextId: contextIdPrefix } : {}),
+        ...(contextIdPrefix === undefined ? {} : { contextId: contextIdPrefix }),
         recipient    : params.recipientDid,
         protocol     : params.protocol,
         protocolPath : params.role,

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -1083,6 +1083,13 @@ async function verifyAudienceKeyEpoch(params: {
       filter: {
         protocol     : EncryptionProtocol.uri,
         protocolPath : EncryptionProtocol.audienceEpochPath,
+        tags         : {
+          protocol  : params.protocol,
+          contextId : params.contextId,
+          role      : params.role,
+          epoch     : params.epoch,
+          keyId     : params.keyId,
+        },
       },
     },
   });

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -456,6 +456,7 @@ export async function createAudienceEpochRecord(params: {
     target        : params.sourceDid,
     messageType   : DwnInterface.RecordsWrite,
     messageParams : {
+      published    : true,
       protocol     : EncryptionProtocol.uri,
       protocolPath : EncryptionProtocol.audienceEpochPath,
       protocolRole : params.protocolRole,
@@ -886,6 +887,7 @@ async function hydrateAudienceKey(params: {
       );
       const payload = Encoder.bytesToObject(await DataStream.toBytes(decryptedStream)) as AudienceKeyPayload;
       await verifyAudienceKeyPayload({
+        agent        : params.agent,
         payload,
         audienceKeyMessage,
         sourceDid    : params.sourceDid,
@@ -1008,6 +1010,7 @@ async function getAudienceKeyEncryptedData(
 }
 
 async function verifyAudienceKeyPayload(params: {
+  agent: EnboxPlatformAgent;
   payload: AudienceKeyPayload;
   audienceKeyMessage: RecordsWriteMessage;
   sourceDid: string;
@@ -1043,6 +1046,9 @@ async function verifyAudienceKeyPayload(params: {
   if (payload.keyId !== publicKeyId || payload.keyId !== privateKeyId) {
     throw new Error('audienceKey keyId does not match delivered key material.');
   }
+
+  await verifyAudienceKeyEpoch(params);
+  await verifyAudienceKeyRoleAssignment(params);
 }
 
 function assertAudienceKeyPayload(payload: unknown): asserts payload is AudienceKeyPayload {
@@ -1056,6 +1062,150 @@ function assertAudienceKeyPayload(payload: unknown): asserts payload is Audience
       !isObject(payload.privateKeyJwk)) {
     throw new Error('audienceKey payload is malformed.');
   }
+}
+
+async function verifyAudienceKeyEpoch(params: {
+  agent: EnboxPlatformAgent;
+  payload: AudienceKeyPayload;
+  sourceDid: string;
+  recipientDid: string;
+  protocol: string;
+  contextId: string;
+  role: string;
+  epoch: number;
+  keyId: string;
+}): Promise<void> {
+  const { reply } = await params.agent.processDwnRequest({
+    author        : params.recipientDid,
+    target        : params.sourceDid,
+    messageType   : DwnInterface.RecordsQuery,
+    messageParams : {
+      filter: {
+        protocol     : EncryptionProtocol.uri,
+        protocolPath : EncryptionProtocol.audienceEpochPath,
+      },
+    },
+  });
+
+  const entries = reply.status.code === 200 ? reply.entries ?? [] : [];
+  for (const entry of entries.filter((entry): boolean => audienceTagsMatch(entry as RecordsWriteMessage, params))) {
+    const dataBytes = await getAudienceEpochData(
+      params.agent,
+      params.recipientDid,
+      params.sourceDid,
+      entry as RecordsWriteMessage & { encodedData?: string },
+    );
+    if (dataBytes === undefined) {
+      continue;
+    }
+
+    const epochPayload = Encoder.bytesToObject(dataBytes) as Partial<AudienceKeyPayload>;
+    if (epochPayload.protocol === params.payload.protocol &&
+        epochPayload.contextId === params.payload.contextId &&
+        epochPayload.role === params.payload.role &&
+        epochPayload.epoch === params.payload.epoch &&
+        epochPayload.keyId === params.payload.keyId &&
+        isPublicKeyJwkEqual(epochPayload.publicKeyJwk, params.payload.publicKeyJwk)) {
+      return;
+    }
+  }
+
+  throw new Error('audienceKey does not match an accepted audienceEpoch.');
+}
+
+function audienceTagsMatch(entry: RecordsWriteMessage, expected: {
+  protocol: string;
+  contextId: string;
+  role: string;
+  epoch: number;
+  keyId: string;
+}): boolean {
+  const tags = entry.descriptor.tags ?? {};
+  return String(tags.protocol) === expected.protocol &&
+    String(tags.contextId) === expected.contextId &&
+    String(tags.role) === expected.role &&
+    String(tags.epoch) === String(expected.epoch) &&
+    String(tags.keyId) === expected.keyId;
+}
+
+async function getAudienceEpochData(
+  agent: EnboxPlatformAgent,
+  authorDid: string,
+  sourceDid: string,
+  audienceEpochMessage: RecordsWriteMessage & { encodedData?: string },
+): Promise<Uint8Array | undefined> {
+  if (audienceEpochMessage.encodedData !== undefined) {
+    return Encoder.base64UrlToBytes(audienceEpochMessage.encodedData);
+  }
+
+  const { reply } = await agent.processDwnRequest({
+    author        : authorDid,
+    target        : sourceDid,
+    messageType   : DwnInterface.RecordsRead,
+    messageParams : { filter: { recordId: audienceEpochMessage.recordId } },
+  });
+
+  if (reply.status.code !== 200 || reply.entry?.data === undefined) {
+    return undefined;
+  }
+
+  return DataStream.toBytes(reply.entry.data);
+}
+
+async function verifyAudienceKeyRoleAssignment(params: {
+  agent: EnboxPlatformAgent;
+  sourceDid: string;
+  recipientDid: string;
+  protocol: string;
+  contextId: string;
+  role: string;
+}): Promise<void> {
+  const contextIdPrefix = params.contextId === '' ? undefined : params.contextId;
+  const { reply } = await params.agent.processDwnRequest({
+    author        : params.recipientDid,
+    target        : params.sourceDid,
+    messageType   : DwnInterface.RecordsQuery,
+    messageParams : {
+      filter: {
+        ...(contextIdPrefix !== undefined ? { contextId: contextIdPrefix } : {}),
+        recipient    : params.recipientDid,
+        protocol     : params.protocol,
+        protocolPath : params.role,
+      },
+    },
+  });
+
+  const entries = reply.status.code === 200 ? reply.entries ?? [] : [];
+  const hasRoleRecord = entries.some((entry): boolean => {
+    const roleRecord = entry as RecordsWriteMessage;
+    return roleRecord.descriptor.recipient === params.recipientDid &&
+      roleRecord.descriptor.protocol === params.protocol &&
+      roleRecord.descriptor.protocolPath === params.role &&
+      matchesContextIdPrefix(roleRecord.contextId, contextIdPrefix);
+  });
+
+  if (!hasRoleRecord) {
+    throw new Error('audienceKey recipient is not an active holder of the referenced role.');
+  }
+}
+
+function matchesContextIdPrefix(contextId: string | undefined, contextIdPrefix: string | undefined): boolean {
+  if (contextIdPrefix === undefined) {
+    return true;
+  }
+
+  return contextId === contextIdPrefix || contextId?.startsWith(`${contextIdPrefix}/`) === true;
+}
+
+function isPublicKeyJwkEqual(left: unknown, right: PublicKeyJwk): boolean {
+  if (!isObject(left)) {
+    return false;
+  }
+
+  const rightRecord = right as Record<string, unknown>;
+  return left.kty === right.kty &&
+    left.crv === rightRecord.crv &&
+    left.x === rightRecord.x;
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {

--- a/packages/agent/tests/dwn-encryption.spec.ts
+++ b/packages/agent/tests/dwn-encryption.spec.ts
@@ -1,3 +1,4 @@
+import type { AudienceKeyPayload } from '../src/dwn-encryption.js';
 import type { DerivedPrivateJwk, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 
 import sinon from 'sinon';
@@ -15,6 +16,7 @@ import {
   HdKey,
   KeyDerivationScheme,
   Records,
+  ROLE_AUDIENCE_DERIVATION_SCHEME,
   TestDataGenerator,
   Time,
 } from '@enbox/dwn-sdk-js';
@@ -765,6 +767,172 @@ describe('dwn-encryption', () => {
       };
     };
 
+    const makeRoleAudienceResolverFixture = async ({
+      includeAudienceEpoch = true,
+      includeRoleRecord = true,
+      mutateAudienceEpochPayload,
+    }: {
+      includeAudienceEpoch?: boolean;
+      includeRoleRecord?: boolean;
+      mutateAudienceEpochPayload?: (payload: Omit<AudienceKeyPayload, 'privateKeyJwk'>) => void;
+    } = {}): Promise<{
+      audienceCache: { get: sinon.SinonStub; set: sinon.SinonStub };
+      mockAgent: any;
+      recordsWrite: RecordsWriteMessage;
+    }> => {
+      const protocol = 'https://proto.example.com/chat';
+      const contextId = 'thread-1';
+      const role = 'thread/participant';
+      const epoch = 1;
+      const sourceDid = 'did:example:alice';
+      const recipientDid = 'did:example:bob';
+
+      const sourcePersona = await TestDataGenerator.generatePersona({ did: sourceDid });
+      const recipientPersona = await TestDataGenerator.generatePersona({ did: recipientDid });
+      const rolePathPrivateKey = await X25519.generateKey();
+      const rolePathPrivateKeyBytes = await X25519.privateKeyToBytes({ privateKey: rolePathPrivateKey });
+      const audiencePrivateKey = await X25519.generateKey();
+      const audiencePublicKey = await X25519.getPublicKey({ key: audiencePrivateKey });
+      const keyId = await Encryption.getKeyId(audiencePublicKey);
+      const audienceKeyPayload = {
+        protocol,
+        contextId,
+        role,
+        epoch,
+        keyId,
+        publicKeyJwk  : audiencePublicKey,
+        privateKeyJwk : audiencePrivateKey,
+      };
+      const audienceTags = {
+        protocol,
+        contextId,
+        role,
+        epoch,
+        keyId,
+      };
+
+      const audienceKeyWrite = await TestDataGenerator.generateRecordsWrite({
+        author       : sourcePersona,
+        recipient    : recipientDid,
+        protocol     : EncryptionProtocol.uri,
+        protocolPath : EncryptionProtocol.audienceKeyPath,
+        schema       : EncryptionProtocol.definition.types.audienceKey.schema,
+        dataFormat   : 'application/json',
+        data         : new Uint8Array([1, 2, 3]),
+        tags         : audienceTags,
+      });
+      const audienceKeyMessage = {
+        ...audienceKeyWrite.message,
+        encodedData: Encoder.bytesToBase64Url(audienceKeyWrite.dataBytes!),
+      } as RecordsWriteMessage & { encodedData: string };
+
+      const audienceEpochPayload = {
+        protocol,
+        contextId,
+        role,
+        epoch,
+        keyId,
+        publicKeyJwk: audiencePublicKey,
+      };
+      mutateAudienceEpochPayload?.(audienceEpochPayload);
+      const audienceEpochWrite = await TestDataGenerator.generateRecordsWrite({
+        author       : sourcePersona,
+        published    : true,
+        protocol     : EncryptionProtocol.uri,
+        protocolPath : EncryptionProtocol.audienceEpochPath,
+        schema       : EncryptionProtocol.definition.types.audienceEpoch.schema,
+        dataFormat   : 'application/json',
+        data         : Encoder.objectToBytes(audienceEpochPayload),
+        tags         : audienceTags,
+      });
+      const audienceEpochMessage = {
+        ...audienceEpochWrite.message,
+        encodedData: Encoder.bytesToBase64Url(audienceEpochWrite.dataBytes!),
+      } as RecordsWriteMessage & { encodedData: string };
+
+      const roleRecord = {
+        contextId  : `${contextId}/participant-1`,
+        descriptor : {
+          recipient    : recipientDid,
+          protocol,
+          protocolPath : role,
+        },
+      } as RecordsWriteMessage;
+
+      sinon.stub(Records, 'decrypt').resolves(DataStream.fromBytes(Encoder.objectToBytes(audienceKeyPayload)));
+
+      const processDwnRequest = sinon.stub();
+      processDwnRequest.onFirstCall().resolves({
+        reply: {
+          status  : { code: 200, detail: 'OK' },
+          entries : [audienceKeyMessage],
+        },
+      });
+      processDwnRequest.onSecondCall().resolves({
+        reply: {
+          status  : { code: 200, detail: 'OK' },
+          entries : includeAudienceEpoch ? [audienceEpochMessage] : [],
+        },
+      });
+      processDwnRequest.onThirdCall().resolves({
+        reply: {
+          status  : { code: 200, detail: 'OK' },
+          entries : includeRoleRecord ? [roleRecord] : [],
+        },
+      });
+
+      const mockAgent = {
+        did: {
+          resolve: sinon.stub().resolves({
+            didDocument: {
+              id                 : recipientDid,
+              keyAgreement       : ['#enc'],
+              verificationMethod : [{
+                id           : `${recipientDid}#enc`,
+                type         : 'JsonWebKey2020',
+                controller   : recipientDid,
+                publicKeyJwk : recipientPersona.encryptionKeyPair.publicJwk,
+              }],
+            },
+            didResolutionMetadata: {},
+          }),
+        },
+        keyManager: {
+          derivePrivateKeyBytes : sinon.stub().resolves(rolePathPrivateKeyBytes),
+          derivePublicKey       : sinon.stub(),
+          getKeyUri             : sinon.stub().resolves('recipient-key-uri'),
+          jweKeyUnwrap          : sinon.stub(),
+        },
+        processDwnRequest,
+        secrets: {
+          get : sinon.stub().resolves(undefined),
+          put : sinon.stub().resolves(),
+        },
+      };
+
+      return {
+        mockAgent,
+        audienceCache: {
+          get : sinon.stub().returns(undefined),
+          set : sinon.stub(),
+        },
+        recordsWrite: {
+          recordId   : 'rec-role-audience',
+          contextId  : `${contextId}/chat-1`,
+          descriptor : { protocol, protocolPath: 'thread/chat' },
+          encryption : {
+            keyEncryption: [{
+              derivationScheme: ROLE_AUDIENCE_DERIVATION_SCHEME,
+              protocol,
+              role,
+              epoch,
+              keyId,
+            }],
+          },
+        } as unknown as RecordsWriteMessage,
+      };
+    };
+
     it('should return a ProtocolPath key decrypter when record has no context encryption', async () => {
       const mockAgent = makeAliceAgent();
 
@@ -1133,6 +1301,84 @@ describe('dwn-encryption', () => {
       )).rejects.toThrow('no delivered decryption key covers encrypted record');
 
       expect(delegateCache.set.called).toBe(false);
+    });
+
+    it('should hydrate a role-audience key only after verifying the audienceEpoch and role assignment', async () => {
+      const { mockAgent, audienceCache, recordsWrite } = await makeRoleAudienceResolverFixture();
+
+      const result = await resolveKeyDecrypter(
+        mockAgent, 'did:example:bob', recordsWrite, 'did:example:alice',
+        undefined,
+        undefined,
+        audienceCache,
+      );
+
+      expect(result.derivationScheme).toBe(ROLE_AUDIENCE_DERIVATION_SCHEME);
+      expect(audienceCache.set.calledOnce).toBe(true);
+      expect(mockAgent.processDwnRequest.callCount).toBe(3);
+      expect(mockAgent.processDwnRequest.secondCall.args[0].messageParams.filter).toEqual({
+        protocol     : EncryptionProtocol.uri,
+        protocolPath : EncryptionProtocol.audienceEpochPath,
+      });
+      expect(mockAgent.processDwnRequest.thirdCall.args[0].messageParams.filter).toEqual({
+        contextId    : 'thread-1',
+        recipient    : 'did:example:bob',
+        protocol     : 'https://proto.example.com/chat',
+        protocolPath : 'thread/participant',
+      });
+    });
+
+    it('should skip an audienceKey that does not match an accepted audienceEpoch', async () => {
+      const { mockAgent, audienceCache, recordsWrite } = await makeRoleAudienceResolverFixture({
+        includeAudienceEpoch: false,
+      });
+
+      const result = await resolveKeyDecrypter(
+        mockAgent, 'did:example:bob', recordsWrite, 'did:example:alice',
+        undefined,
+        undefined,
+        audienceCache,
+      );
+
+      expect(result.derivationScheme).toBe(KeyDerivationScheme.ProtocolPath);
+      expect(audienceCache.set.called).toBe(false);
+      expect(mockAgent.processDwnRequest.callCount).toBe(2);
+    });
+
+    it('should skip an audienceKey whose key material differs from the accepted audienceEpoch', async () => {
+      const { mockAgent, audienceCache, recordsWrite } = await makeRoleAudienceResolverFixture({
+        mutateAudienceEpochPayload: (payload): void => {
+          payload.publicKeyJwk = { kty: 'OKP', crv: 'X25519', x: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' };
+        },
+      });
+
+      const result = await resolveKeyDecrypter(
+        mockAgent, 'did:example:bob', recordsWrite, 'did:example:alice',
+        undefined,
+        undefined,
+        audienceCache,
+      );
+
+      expect(result.derivationScheme).toBe(KeyDerivationScheme.ProtocolPath);
+      expect(audienceCache.set.called).toBe(false);
+      expect(mockAgent.processDwnRequest.callCount).toBe(2);
+    });
+
+    it('should skip an audienceKey when the recipient has no active role assignment', async () => {
+      const { mockAgent, audienceCache, recordsWrite } = await makeRoleAudienceResolverFixture({
+        includeRoleRecord: false,
+      });
+
+      const result = await resolveKeyDecrypter(
+        mockAgent, 'did:example:bob', recordsWrite, 'did:example:alice',
+        undefined,
+        undefined,
+        audienceCache,
+      );
+
+      expect(result.derivationScheme).toBe(KeyDerivationScheme.ProtocolPath);
+      expect(audienceCache.set.called).toBe(false);
+      expect(mockAgent.processDwnRequest.callCount).toBe(3);
     });
   });
 });

--- a/packages/agent/tests/dwn-encryption.spec.ts
+++ b/packages/agent/tests/dwn-encryption.spec.ts
@@ -777,6 +777,7 @@ describe('dwn-encryption', () => {
       mutateAudienceEpochPayload?: (payload: Omit<AudienceKeyPayload, 'privateKeyJwk'>) => void;
     } = {}): Promise<{
       audienceCache: { get: sinon.SinonStub; set: sinon.SinonStub };
+      audienceKeyId: string;
       mockAgent: any;
       recordsWrite: RecordsWriteMessage;
     }> => {
@@ -911,8 +912,9 @@ describe('dwn-encryption', () => {
       };
 
       return {
+        audienceKeyId : keyId,
         mockAgent,
-        audienceCache: {
+        audienceCache : {
           get : sinon.stub().returns(undefined),
           set : sinon.stub(),
         },
@@ -1304,7 +1306,7 @@ describe('dwn-encryption', () => {
     });
 
     it('should hydrate a role-audience key only after verifying the audienceEpoch and role assignment', async () => {
-      const { mockAgent, audienceCache, recordsWrite } = await makeRoleAudienceResolverFixture();
+      const { mockAgent, audienceCache, audienceKeyId, recordsWrite } = await makeRoleAudienceResolverFixture();
 
       const result = await resolveKeyDecrypter(
         mockAgent, 'did:example:bob', recordsWrite, 'did:example:alice',
@@ -1319,6 +1321,13 @@ describe('dwn-encryption', () => {
       expect(mockAgent.processDwnRequest.secondCall.args[0].messageParams.filter).toEqual({
         protocol     : EncryptionProtocol.uri,
         protocolPath : EncryptionProtocol.audienceEpochPath,
+        tags         : {
+          protocol  : 'https://proto.example.com/chat',
+          contextId : 'thread-1',
+          role      : 'thread/participant',
+          epoch     : 1,
+          keyId     : audienceKeyId,
+        },
       });
       expect(mockAgent.processDwnRequest.thirdCall.args[0].messageParams.filter).toEqual({
         contextId    : 'thread-1',


### PR DESCRIPTION
## Summary
- publish audienceEpoch records so recipients can verify delivered audience keys
- verify hydrated audienceKey payloads against accepted audienceEpoch data and active role assignments before caching
- add resolver negative tests for missing epochs, mismatched epoch key material, and missing role records

## Test plan
- [x] bun run lint
- [x] bun run --filter @enbox/agent build
- [x] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/dwn-encryption.spec.ts
- [x] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/e2e-encrypted-sync.spec.ts -t "encrypted role-audience"
- [x] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 TEST_DWN_URL=http://localhost:3000 bun run test:node

Note: the full agent suite was run with the DWN server held open as a foreground process because the dev helper's background server exited in this tool shell.