### PR TITLE
feat(agent): add provisionRoleAudienceEpoch for eager epoch provisioning

### DIFF
--- a/.changeset/eager-audience-epoch.md
+++ b/.changeset/eager-audience-epoch.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+feat(agent): add `AgentDwnApi.provisionRoleAudienceEpoch` to eagerly provision a role-audience epoch for a `(protocol, contextId, role)` without adding a member. Mints + persists the audience keypair and writes the public `audienceEpoch` record (idempotent; reused by later member-adds), so records for a role can carry a `roleAudience` entry before any member of that role exists.

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -704,6 +704,64 @@ export class AgentDwnApi {
     throw new Error(`Failed to send DWN RPC request: ${JSON.stringify(errorMessages)}`);
   }
 
+  /**
+   * Eagerly provision a role-audience epoch for `(protocol, contextId, role)`
+   * without adding a member, so records written for the role can carry a
+   * `roleAudience` key-encryption entry before any member of that role exists.
+   *
+   * Mints the audience keypair, persists the private key to the agent's secret
+   * store, and writes the public `audienceEpoch` record. Idempotent: when an
+   * epoch already exists for the tuple it is reused and no new record is
+   * written. Per-member `audienceKey` delivery records are still created when
+   * members are added.
+   *
+   * @throws when the protocol is not installed for `ownerDid`, or `role` is not
+   *   an encrypted audience (a `$role` type carrying `$keyAgreement`).
+   */
+  public async provisionRoleAudienceEpoch(params: {
+    ownerDid : string;
+    protocol : string;
+    role : string;
+    contextId : string;
+  }): Promise<{ epoch: number; keyId: string; created: boolean }> {
+    const { ownerDid, protocol, role, contextId } = params;
+
+    const protocolDefinition = await this.getProtocolDefinition(ownerDid, protocol);
+    if (protocolDefinition === undefined) {
+      throw new Error(`AgentDwnApi: protocol '${protocol}' is not installed for '${ownerDid}'.`);
+    }
+
+    const ruleSet = getRuleSetAtPath(role, protocolDefinition.structure);
+    if (ruleSet?.$role !== true || ruleSet.$keyAgreement?.publicKeyJwk === undefined) {
+      throw new Error(
+        `AgentDwnApi: role '${role}' is not an encrypted audience ` +
+        `(requires $role with $keyAgreement) in protocol '${protocol}'.`,
+      );
+    }
+
+    const existing = await this.queryLatestAudienceEpoch({
+      authorDid : ownerDid,
+      contextId,
+      protocol,
+      role,
+      sourceDid : ownerDid,
+    });
+
+    const audienceKey = await this.getOrCreateAudienceKey({
+      authorDid : ownerDid,
+      contextId,
+      protocol,
+      role,
+      sourceDid : ownerDid,
+    });
+
+    return {
+      created : existing === undefined,
+      epoch   : audienceKey.epoch,
+      keyId   : audienceKey.keyMaterial.keyId,
+    };
+  }
+
   private async provisionAudienceKeyForAcceptedRoleRecord(
     request: ProcessDwnRequest<DwnInterface.RecordsWrite>,
     recordsWrite: RecordsWriteMessage,

--- a/packages/agent/tests/provision-role-audience-epoch.spec.ts
+++ b/packages/agent/tests/provision-role-audience-epoch.spec.ts
@@ -1,0 +1,113 @@
+import type { PrivateKeyJwk } from '@enbox/crypto';
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { EncryptionProtocol, Protocols } from '@enbox/dwn-sdk-js';
+
+import { DwnInterface } from '../src/types/dwn.js';
+import { PlatformAgentTestHarness } from '../src/test-harness.js';
+import { TestAgent } from './utils/test-agent.js';
+import { testDwnUrl } from './utils/test-config.js';
+
+const testDwnUrls = [testDwnUrl];
+const PROTOCOL_URI = 'https://example.org/protocols/eager-audience-test';
+
+/**
+ * Minimal protocol with a top-level `$role` type (`admin`) that can read an
+ * encrypted sibling (`note`). `$keyAgreement` is injected at install, making
+ * `admin` an encrypted audience eligible for role-audience provisioning.
+ */
+function definition(): ProtocolDefinition {
+  return {
+    published : true,
+    protocol  : PROTOCOL_URI,
+    types     : {
+      admin : { dataFormats: ['application/json'] },
+      note  : { dataFormats: ['application/json'], encryptionRequired: true },
+    },
+    structure: {
+      admin : { $role: true, $actions: [{ who: 'anyone', can: ['read'] }] },
+      note  : { $actions: [{ role: 'admin', can: ['read'] }] },
+    },
+  };
+}
+
+describe('AgentDwnApi.provisionRoleAudienceEpoch', () => {
+  let testHarness: PlatformAgentTestHarness;
+  let ownerDid: string;
+
+  async function countAudienceEpochs(): Promise<number> {
+    const { reply } = await testHarness.agent.dwn.processRequest({
+      author        : ownerDid,
+      target        : ownerDid,
+      messageType   : DwnInterface.RecordsQuery,
+      messageParams : {
+        filter: { protocol: EncryptionProtocol.uri, protocolPath: EncryptionProtocol.audienceEpochPath },
+      },
+    });
+    return reply.entries?.length ?? 0;
+  }
+
+  beforeAll(async () => {
+    testHarness = await PlatformAgentTestHarness.setup({ agentClass: TestAgent, agentStores: 'memory' });
+    await testHarness.clearStorage();
+    await testHarness.createAgentDid();
+
+    const owner = await testHarness.createIdentity({ name: 'Owner', testDwnUrls });
+    ownerDid = owner.did.uri;
+
+    const { portableDid } = await testHarness.agent.identity.export({ didUri: ownerDid });
+    const rootPrivateJwk = (portableDid.privateKeys ?? []).find((key): boolean => key.crv === 'X25519') as PrivateKeyJwk;
+    const deriver = await testHarness.agent.dwn.getEncryptionKeyDeriver(ownerDid);
+    const injected = await Protocols.deriveAndInjectPublicEncryptionKeys(definition(), deriver.rootKeyId, rootPrivateJwk);
+
+    const { reply } = await testHarness.agent.dwn.processRequest({
+      author        : ownerDid,
+      target        : ownerDid,
+      messageType   : DwnInterface.ProtocolsConfigure,
+      messageParams : { definition: injected },
+    });
+    expect(reply.status.code).toBe(202);
+  });
+
+  afterAll(async () => {
+    await testHarness.clearStorage();
+    await testHarness.closeStorage();
+  });
+
+  it('mints an epoch and writes the audienceEpoch record for an encrypted role', async () => {
+    const result = await testHarness.agent.dwn.provisionRoleAudienceEpoch({
+      ownerDid,
+      protocol  : PROTOCOL_URI,
+      role      : 'admin',
+      contextId : '',
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.epoch).toBe(1);
+    expect(result.keyId).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(await countAudienceEpochs()).toBe(1);
+  });
+
+  it('is idempotent — reuses the existing epoch and writes no new record', async () => {
+    const first = await testHarness.agent.dwn.provisionRoleAudienceEpoch({
+      ownerDid, protocol: PROTOCOL_URI, role: 'admin', contextId: '',
+    });
+    const again = await testHarness.agent.dwn.provisionRoleAudienceEpoch({
+      ownerDid, protocol: PROTOCOL_URI, role: 'admin', contextId: '',
+    });
+
+    expect(again.created).toBe(false);
+    expect(again.epoch).toBe(first.epoch);
+    expect(again.keyId).toBe(first.keyId);
+    expect(await countAudienceEpochs()).toBe(1);
+  });
+
+  it('throws when the role is not an encrypted audience', async () => {
+    await expect(
+      testHarness.agent.dwn.provisionRoleAudienceEpoch({
+        ownerDid, protocol: PROTOCOL_URI, role: 'note', contextId: '',
+      }),
+    ).rejects.toThrow('not an encrypted audience');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `AgentDwnApi.provisionRoleAudienceEpoch({ ownerDid, protocol, role, contextId })` — a thin public wrapper over the existing `getOrCreateAudienceKey` internal — so a DWN **owner** can mint a role-audience epoch for a `(protocol, contextId, role)` **before any member of that role exists**.

### Why
Role-audience encrypted writes fail closed when a reader role has no `audienceEpoch` (the SDK never self-mints on the write path). Today epochs are minted only when a role member is *added*. Eager provisioning at network/context creation lets records carry a `roleAudience` entry from the start. This unblocks meshd: a node can publish its `endpoint`/`nodeInfo` records readable by `network/member` + `network/node` even before members join.

### Behavior
- Mints the audience keypair, **persists the private key** to the agent's secret store, and writes the public `audienceEpoch` record.
- **Idempotent**: reuses an existing epoch (no new record); a later member-add reuses the eager epoch (no second epoch minted — same author DID).
- Guards that the role is an encrypted audience (`$role` + `$keyAgreement`); throws otherwise.
- Owner is always authorized to write the epoch (`author === tenant`).

## Test plan
- [x] New `tests/provision-role-audience-epoch.spec.ts`: mints + writes the epoch (created/epoch/keyId), **idempotent** (no second record, same epoch/keyId), and **throws** for a non-encrypted role. 3/3 pass.
- [x] `eslint --max-warnings 0` clean; `@enbox/agent` builds.
- [x] Changeset added (patch).