### PR TITLE
refactor(encryption): discriminate key wrap inputs

### DIFF
--- a/.changeset/key-wrap-abstraction.md
+++ b/.changeset/key-wrap-abstraction.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+---
+
+refactor: make DWN key wrapping algorithm-discriminated

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -793,6 +793,7 @@ export class AgentDwnApi {
       }
 
       inputs.push({
+        algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
         derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
         epoch            : audienceEpoch.epoch,
         keyId            : audienceEpoch.keyId,

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -131,6 +131,7 @@ export function buildEncryptionInput(
     initializationVector : iv,
     key                  : dek,
     keyEncryptionInputs  : [{
+      algorithm: KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
       keyId,
       publicKey,
       derivationScheme,
@@ -270,7 +271,7 @@ export function buildKmsDecryptCallback(
       });
     },
     decrypt: async (fullDerivationPath, keyUnwrapPayload): Promise<Uint8Array> => {
-      return keyManager.jweKeyUnwrap({
+      return keyManager.unwrapContentKey({
         keyUri,
         derivationPath     : fullDerivationPath,
         encryptedKey       : keyUnwrapPayload.encryptedKey,

--- a/packages/agent/src/local-key-manager.ts
+++ b/packages/agent/src/local-key-manager.ts
@@ -423,11 +423,11 @@ export class LocalKeyManager implements AgentKeyManager {
   }
 
   /**
-   * Unwraps a JWE-encrypted Content Encryption Key (CEK) using a derived X25519 private key.
+   * Unwraps a DWN content-encryption key using a derived X25519 private key.
    * Performs X25519 key agreement with the ephemeral public key, derives the KEK via
    * HKDF-SHA256, and unwraps the CEK with AES-256 Key Unwrap.
    */
-  public async jweKeyUnwrap({
+  public async unwrapContentKey({
     keyUri,
     derivationPath,
     encryptedKey,

--- a/packages/agent/src/types/dwn.ts
+++ b/packages/agent/src/types/dwn.ts
@@ -266,6 +266,7 @@ export {
   DateSort as DwnDateSort,
   DwnConstant,
   ContentEncryptionAlgorithm as DwnContentEncryptionAlgorithm,
+  KeyAgreementAlgorithm as DwnKeyAgreementAlgorithm,
   KeyDerivationScheme as DwnKeyDerivationScheme,
   PermissionGrant as DwnPermissionGrant,
   PermissionRequest as DwnPermissionRequest,

--- a/packages/agent/src/types/key-manager.ts
+++ b/packages/agent/src/types/key-manager.ts
@@ -43,7 +43,7 @@ export interface AgentKeyManager extends KeyManager,
   }): Promise<PublicKeyJwk>;
 
   /**
-   * Unwraps a JWE-encrypted Content Encryption Key (CEK) using a derived X25519 private key.
+   * Unwraps a DWN content-encryption key using a derived X25519 private key.
    *
    * This method:
    * 1. Derives the leaf private key via HKDF through the derivation path
@@ -54,11 +54,11 @@ export interface AgentKeyManager extends KeyManager,
    *
    * @param params.keyUri - URI of the stored ancestor private key (X25519)
    * @param params.derivationPath - Array of HKDF path segments to derive the leaf key
-   * @param params.encryptedKey - The wrapped CEK bytes from the JWE recipient
-   * @param params.ephemeralPublicKey - Ephemeral X25519 public key from the JWE recipient header
+   * @param params.encryptedKey - The wrapped CEK bytes from the key-encryption entry
+   * @param params.ephemeralPublicKey - Ephemeral X25519 public key from the key-encryption entry
    * @returns The unwrapped CEK bytes (typically 32 bytes for AES-256)
    */
-  jweKeyUnwrap(params: {
+  unwrapContentKey(params: {
     keyUri: KeyIdentifier;
     derivationPath: string[];
     encryptedKey: Uint8Array;

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -9,6 +9,7 @@ import {
   DwnInterfaceName,
   DwnMethodName,
   EncryptionProtocol,
+  KeyAgreementAlgorithm,
   KeyDerivationScheme,
   Message,
   TestDataGenerator,
@@ -2649,10 +2650,14 @@ describe('Encryption Callback Factories', () => {
       // Wrap a random 32-byte CEK using the DWN key-agreement envelope.
       const { CryptoUtils } = await import('@enbox/crypto');
       const cek = CryptoUtils.randomBytes(32);
-      const wrapped = await Encryption.wrapKey(leafPublicKeyJwk, cek, {
-        derivationScheme : KeyDerivationScheme.ProtocolPath,
-        keyId            : await Encryption.getKeyId(leafPublicKeyJwk),
-        publicKey        : leafPublicKeyJwk,
+      const wrapped = await Encryption.wrapKey({
+        cek,
+        keyInput: {
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+          derivationScheme : KeyDerivationScheme.ProtocolPath,
+          keyId            : await Encryption.getKeyId(leafPublicKeyJwk),
+          publicKey        : leafPublicKeyJwk,
+        },
       });
 
       // Get key decrypter and decrypt

--- a/packages/agent/tests/dwn-encryption.spec.ts
+++ b/packages/agent/tests/dwn-encryption.spec.ts
@@ -88,7 +88,7 @@ describe('dwn-encryption', () => {
     it('should return a KeyDecrypter with correct rootKeyId and derivationScheme', () => {
       const mockAgent = {
         keyManager: {
-          jweKeyUnwrap: sinon.stub().resolves(new Uint8Array(32)),
+          unwrapContentKey: sinon.stub().resolves(new Uint8Array(32)),
         },
       } as any;
 
@@ -101,10 +101,10 @@ describe('dwn-encryption', () => {
       expect(typeof result.decrypt).toBe('function');
     });
 
-    it('should call keyManager.jweKeyUnwrap when decrypt is called', async () => {
-      const jweKeyUnwrapStub = sinon.stub().resolves(new Uint8Array(32));
+    it('should call keyManager.unwrapContentKey when decrypt is called', async () => {
+      const unwrapContentKeyStub = sinon.stub().resolves(new Uint8Array(32));
       const mockAgent = {
-        keyManager: { jweKeyUnwrap: jweKeyUnwrapStub },
+        keyManager: { unwrapContentKey: unwrapContentKeyStub },
       } as any;
 
       const decrypter = buildKmsDecryptCallback(mockAgent, 'root-key-id', 'key-uri', KeyDerivationScheme.ProtocolPath);
@@ -116,8 +116,8 @@ describe('dwn-encryption', () => {
 
       await decrypter.decrypt(['path', 'to', 'key'], mockPayload);
 
-      expect(jweKeyUnwrapStub.calledOnce).toBe(true);
-      expect(jweKeyUnwrapStub.firstCall.args[0]).toEqual({
+      expect(unwrapContentKeyStub.calledOnce).toBe(true);
+      expect(unwrapContentKeyStub.firstCall.args[0]).toEqual({
         keyUri             : 'key-uri',
         derivationPath     : ['path', 'to', 'key'],
         encryptedKey       : mockPayload.encryptedKey,
@@ -179,8 +179,8 @@ describe('dwn-encryption', () => {
           }),
         },
         keyManager: {
-          getKeyUri    : sinon.stub().resolves('key-uri-1'),
-          jweKeyUnwrap : sinon.stub(),
+          getKeyUri        : sinon.stub().resolves('key-uri-1'),
+          unwrapContentKey : sinon.stub(),
         },
       } as any;
 
@@ -238,8 +238,8 @@ describe('dwn-encryption', () => {
           }),
         },
         keyManager: {
-          getKeyUri    : sinon.stub().resolves('key-uri-1'),
-          jweKeyUnwrap : sinon.stub(),
+          getKeyUri        : sinon.stub().resolves('key-uri-1'),
+          unwrapContentKey : sinon.stub(),
         },
       } as any;
 
@@ -324,8 +324,8 @@ describe('dwn-encryption', () => {
       } as any;
       const mockAgent = {
         keyManager: {
-          getKeyUri    : sinon.stub().rejects(new Error('owner KMS fallback should not be used')),
-          jweKeyUnwrap : sinon.stub().rejects(new Error('owner KMS fallback should not be used')),
+          getKeyUri        : sinon.stub().rejects(new Error('owner KMS fallback should not be used')),
+          unwrapContentKey : sinon.stub().rejects(new Error('owner KMS fallback should not be used')),
         },
       } as any;
       const delegateCache = {
@@ -344,7 +344,7 @@ describe('dwn-encryption', () => {
       );
 
       expect(mockAgent.keyManager.getKeyUri.called).toBe(false);
-      expect(mockAgent.keyManager.jweKeyUnwrap.called).toBe(false);
+      expect(mockAgent.keyManager.unwrapContentKey.called).toBe(false);
       expect(Encoder.bytesToString(await DataStream.toBytes(reply.entry.data))).toBe('delivered key plaintext');
     });
   });
@@ -535,8 +535,8 @@ describe('dwn-encryption', () => {
           }),
         },
         keyManager: {
-          getKeyUri    : sinon.stub().resolves('key-uri-1'),
-          jweKeyUnwrap : sinon.stub().resolves(new Uint8Array(32)),
+          getKeyUri        : sinon.stub().resolves('key-uri-1'),
+          unwrapContentKey : sinon.stub().resolves(new Uint8Array(32)),
         },
       } as any;
 
@@ -606,8 +606,8 @@ describe('dwn-encryption', () => {
         }),
       },
       keyManager: {
-        getKeyUri    : sinon.stub().resolves('key-uri-1'),
-        jweKeyUnwrap : sinon.stub(),
+        getKeyUri        : sinon.stub().resolves('key-uri-1'),
+        unwrapContentKey : sinon.stub(),
       },
     });
 
@@ -747,8 +747,8 @@ describe('dwn-encryption', () => {
           }),
         },
         keyManager: {
-          getKeyUri    : sinon.stub().resolves('grantee-key-uri'),
-          jweKeyUnwrap : sinon.stub(),
+          getKeyUri        : sinon.stub().resolves('grantee-key-uri'),
+          unwrapContentKey : sinon.stub(),
         },
         permissions: {
           isGrantRevoked: sinon.stub().resolves(grantRevoked),
@@ -911,7 +911,7 @@ describe('dwn-encryption', () => {
           derivePrivateKeyBytes : sinon.stub().resolves(rolePathPrivateKeyBytes),
           derivePublicKey       : sinon.stub(),
           getKeyUri             : sinon.stub().resolves('recipient-key-uri'),
-          jweKeyUnwrap          : sinon.stub(),
+          unwrapContentKey      : sinon.stub(),
         },
         processDwnRequest,
         secrets: {

--- a/packages/agent/tests/e2e-delegate-encrypted.spec.ts
+++ b/packages/agent/tests/e2e-delegate-encrypted.spec.ts
@@ -644,7 +644,7 @@ describe('e2e: delegate + encrypted protocol', () => {
       );
       expect(grantApplyReply.status.code).toBe(202);
 
-      const kmsUnwrapSpy = sinon.spy(delegateHarness.agent.keyManager, 'jweKeyUnwrap');
+      const kmsUnwrapSpy = sinon.spy(delegateHarness.agent.keyManager, 'unwrapContentKey');
 
       // Step 5: Copy the encrypted protocol + record to the delegate's DWN
       // (simulates sync bringing over the data)

--- a/packages/agent/tests/local-key-manager.spec.ts
+++ b/packages/agent/tests/local-key-manager.spec.ts
@@ -5,7 +5,7 @@ import type { PrivateKeyJwk, PublicKeyJwk } from '@enbox/dwn-sdk-js';
 import { Convert } from '@enbox/common';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { CryptoErrorCode, CryptoUtils, Ed25519, X25519 } from '@enbox/crypto';
-import { Encryption, HdKey, KeyDerivationScheme } from '@enbox/dwn-sdk-js';
+import { Encryption, HdKey, KeyAgreementAlgorithm, KeyDerivationScheme } from '@enbox/dwn-sdk-js';
 
 import type { EnboxPlatformAgent } from '../src/types/agent.js';
 
@@ -519,8 +519,8 @@ describe('LocalKeyManager', () => {
         });
       });
 
-      describe('jweKeyUnwrap()', () => {
-        it('should unwrap a JWE-encrypted key using a derived X25519 key', async () => {
+      describe('unwrapContentKey()', () => {
+        it('should unwrap a DWN key using a derived X25519 key', async () => {
           // Generate an X25519 key pair
           const keyUri = await testHarness.agent.keyManager.generateKey({ algorithm: 'X25519' });
 
@@ -535,14 +535,18 @@ describe('LocalKeyManager', () => {
           const leafPublicKeyJwk = await X25519.getPublicKey({ key: leafPrivateKeyJwk }) as PublicKeyJwk;
 
           const plaintext = CryptoUtils.randomBytes(32); // Simulated CEK
-          const wrapped = await Encryption.wrapKey(leafPublicKeyJwk, plaintext, {
-            derivationScheme : KeyDerivationScheme.ProtocolPath,
-            keyId            : await Encryption.getKeyId(leafPublicKeyJwk),
-            publicKey        : leafPublicKeyJwk,
+          const wrapped = await Encryption.wrapKey({
+            cek      : plaintext,
+            keyInput : {
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+              derivationScheme : KeyDerivationScheme.ProtocolPath,
+              keyId            : await Encryption.getKeyId(leafPublicKeyJwk),
+              publicKey        : leafPublicKeyJwk,
+            },
           });
 
           // Unwrap using the key manager method
-          const unwrapped = await testHarness.agent.keyManager.jweKeyUnwrap({
+          const unwrapped = await testHarness.agent.keyManager.unwrapContentKey({
             keyUri,
             derivationPath,
             encryptedKey       : wrapped.encryptedKey,
@@ -572,17 +576,21 @@ describe('LocalKeyManager', () => {
           const leafPublicKeyJwk = await X25519.getPublicKey({ key: leafPrivateKeyJwk }) as PublicKeyJwk;
 
           const plaintext = CryptoUtils.randomBytes(32);
-          const wrapped = await Encryption.wrapKey(leafPublicKeyJwk, plaintext, {
-            derivationScheme : KeyDerivationScheme.ProtocolPath,
-            keyId            : await Encryption.getKeyId(leafPublicKeyJwk),
-            publicKey        : leafPublicKeyJwk,
+          const wrapped = await Encryption.wrapKey({
+            cek      : plaintext,
+            keyInput : {
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+              derivationScheme : KeyDerivationScheme.ProtocolPath,
+              keyId            : await Encryption.getKeyId(leafPublicKeyJwk),
+              publicKey        : leafPublicKeyJwk,
+            },
           });
 
           // Attempt to unwrap with wrong derivation path
           const wrongPath = ['wrong', 'path'];
 
           try {
-            await testHarness.agent.keyManager.jweKeyUnwrap({
+            await testHarness.agent.keyManager.unwrapContentKey({
               keyUri,
               derivationPath     : wrongPath,
               encryptedKey       : wrapped.encryptedKey,

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -8,7 +8,7 @@ import { utils as didUtils } from '@enbox/dids';
 import { processConnectedGrants } from '@enbox/auth';
 import { Stream } from '@enbox/common';
 import {
-  DwnConstant, DwnContentEncryptionAlgorithm, DwnDateSort, DwnInterface, DwnKeyDerivationScheme,
+  DwnConstant, DwnContentEncryptionAlgorithm, DwnDateSort, DwnInterface, DwnKeyAgreementAlgorithm, DwnKeyDerivationScheme,
   dwnMessageConstructors, EnboxConnectProtocol, EnboxUserAgent, getRecordAuthor,
   getRecordProtocolRole, PlatformAgentTestHarness,
 } from '@enbox/agent';
@@ -704,6 +704,7 @@ describe('Record', () => {
       initializationVector : TestDataGenerator.randomBytes(16),
       key                  : TestDataGenerator.randomBytes(32),
       keyEncryptionInputs  : [{
+        algorithm        : DwnKeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
         derivationScheme : DwnKeyDerivationScheme.ProtocolPath,
         keyId            : encryptionKeyId,
         publicKey        : encryptionPublicKeyJwk as DwnPublicKeyJwk,
@@ -2390,6 +2391,7 @@ describe('Record', () => {
         initializationVector : TestDataGenerator.randomBytes(16),
         key                  : TestDataGenerator.randomBytes(32),
         keyEncryptionInputs  : [{
+          algorithm        : DwnKeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
           derivationScheme : DwnKeyDerivationScheme.ProtocolPath,
           keyId            : encryptionKeyId,
           publicKey        : encryptionPublicKeyJwk as DwnPublicKeyJwk,

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -41,13 +41,14 @@ export type { MessagesSubscribeOptions } from './interfaces/messages-subscribe.j
 export { Encryption, ContentEncryptionAlgorithm, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME } from './utils/encryption.js';
 export type {
   DwnEncryption,
-  KeyEncryption,
-  KeyEncryptionInput,
   KeyUnwrapPayload,
   ProtocolPathKeyEncryption,
   ProtocolPathKeyEncryptionInput,
   RoleAudienceKeyEncryption,
   RoleAudienceKeyEncryptionInput,
+  X25519KeyEncryption,
+  X25519KeyEncryptionInput,
+  X25519KeyWrapInput,
 } from './utils/encryption.js';
 export { RecordsWrite } from './interfaces/records-write.js';
 export type { EncryptionInput, RecordsWriteOptions, CreateFromOptions } from './interfaces/records-write.js';

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -96,9 +96,9 @@ export type RecordsWriteOptions = {
 
 export type {
   EncryptionInput,
-  KeyEncryptionInput,
   ProtocolPathKeyEncryptionInput,
   RoleAudienceKeyEncryptionInput,
+  X25519KeyEncryptionInput,
 } from '../utils/encryption.js';
 
 export type CreateFromOptions = {

--- a/packages/dwn-sdk-js/src/utils/encryption.ts
+++ b/packages/dwn-sdk-js/src/utils/encryption.ts
@@ -23,51 +23,48 @@ const AES_CTR_COUNTER_LENGTH_BYTES = 16;
 const AES_CTR_COUNTER_LENGTH_BITS = 128;
 const KEK_INFO_PREFIX = KeyAgreementAlgorithm.X25519HkdfSha256A256Kw;
 
-export type ProtocolPathKeyEncryption = {
+export type X25519KeyEncryptionBase = {
   algorithm: KeyAgreementAlgorithm.X25519HkdfSha256A256Kw;
   keyId: string;
-  derivationScheme: KeyDerivationScheme.ProtocolPath;
   ephemeralPublicKey: PublicKeyJwk;
   encryptedKey: string;
 };
 
-export type RoleAudienceKeyEncryption = {
-  algorithm: KeyAgreementAlgorithm.X25519HkdfSha256A256Kw;
-  keyId: string;
+export type ProtocolPathKeyEncryption = X25519KeyEncryptionBase & {
+  derivationScheme: KeyDerivationScheme.ProtocolPath;
+};
+
+export type RoleAudienceKeyEncryption = X25519KeyEncryptionBase & {
   derivationScheme: typeof ROLE_AUDIENCE_DERIVATION_SCHEME;
   protocol: string;
   role: string;
   epoch: number;
-  ephemeralPublicKey: PublicKeyJwk;
-  encryptedKey: string;
 };
-
-export type KeyEncryption = ProtocolPathKeyEncryption | RoleAudienceKeyEncryption;
 
 export type X25519KeyEncryption = ProtocolPathKeyEncryption | RoleAudienceKeyEncryption;
 
 export type DwnEncryption = {
   algorithm: ContentEncryptionAlgorithm.A256CTR;
   initializationVector: string;
-  keyEncryption: KeyEncryption[];
+  keyEncryption: X25519KeyEncryption[];
 };
 
-export type ProtocolPathKeyEncryptionInput = {
+export type X25519KeyEncryptionInputBase = {
+  algorithm: KeyAgreementAlgorithm.X25519HkdfSha256A256Kw;
   keyId: string;
   publicKey: PublicKeyJwk;
+};
+
+export type ProtocolPathKeyEncryptionInput = X25519KeyEncryptionInputBase & {
   derivationScheme: KeyDerivationScheme.ProtocolPath;
 };
 
-export type RoleAudienceKeyEncryptionInput = {
-  keyId: string;
-  publicKey: PublicKeyJwk;
+export type RoleAudienceKeyEncryptionInput = X25519KeyEncryptionInputBase & {
   derivationScheme: typeof ROLE_AUDIENCE_DERIVATION_SCHEME;
   protocol: string;
   role: string;
   epoch: number;
 };
-
-export type KeyEncryptionInput = ProtocolPathKeyEncryptionInput | RoleAudienceKeyEncryptionInput;
 
 export type X25519KeyEncryptionInput = ProtocolPathKeyEncryptionInput | RoleAudienceKeyEncryptionInput;
 
@@ -75,13 +72,19 @@ export type EncryptionInput = {
   algorithm?: ContentEncryptionAlgorithm;
   key: Uint8Array;
   initializationVector: Uint8Array;
-  keyEncryptionInputs: KeyEncryptionInput[];
+  keyEncryptionInputs: X25519KeyEncryptionInput[];
 };
 
 export type KeyUnwrapPayload = {
   encryptedKey: Uint8Array;
   ephemeralPublicKey: PublicKeyJwk;
-  keyEncryption: KeyEncryption;
+  keyEncryption: X25519KeyEncryption;
+};
+
+export type X25519KeyWrapInput = {
+  cek: Uint8Array;
+  keyInput: X25519KeyEncryptionInput;
+  ephemeralPrivateKey?: Jwk;
 };
 
 export class Encryption {
@@ -137,31 +140,25 @@ export class Encryption {
     return Encryption.toStream(plaintext);
   }
 
-  public static async wrapKey(
-    recipientPublicKey: PublicKeyJwk,
-    cek: Uint8Array,
-    keyInput: KeyEncryptionInput,
-    ephemeralPrivateKey?: Jwk,
-  ): Promise<{ encryptedKey: Uint8Array; ephemeralPublicKey: PublicKeyJwk }> {
-    return Encryption.wrapX25519Key(recipientPublicKey, cek, keyInput, ephemeralPrivateKey);
+  public static async wrapKey(input: X25519KeyWrapInput): Promise<{ encryptedKey: Uint8Array; ephemeralPublicKey: PublicKeyJwk }> {
+    if (Encryption.isX25519KeyAgreementAlgorithm(input.keyInput.algorithm)) {
+      return Encryption.wrapX25519Key(input);
+    }
+
+    throw new Error(Encryption.unsupportedKeyAgreementAlgorithmMessage(input.keyInput.algorithm));
   }
 
-  private static async wrapX25519Key(
-    recipientPublicKey: PublicKeyJwk,
-    cek: Uint8Array,
-    keyInput: X25519KeyEncryptionInput,
-    ephemeralPrivateKey?: Jwk,
-  ): Promise<{ encryptedKey: Uint8Array; ephemeralPublicKey: PublicKeyJwk }> {
-    Encryption.validateContentEncryptionKey(cek);
+  private static async wrapX25519Key(input: X25519KeyWrapInput): Promise<{ encryptedKey: Uint8Array; ephemeralPublicKey: PublicKeyJwk }> {
+    Encryption.validateContentEncryptionKey(input.cek);
 
-    const privateKey = ephemeralPrivateKey ?? await X25519.generateKey();
+    const privateKey = input.ephemeralPrivateKey ?? await X25519.generateKey();
     const publicKey = await X25519.getPublicKey({ key: privateKey }) as PublicKeyJwk;
     const sharedSecret = await X25519.sharedSecret({
       privateKeyA : privateKey,
-      publicKeyB  : recipientPublicKey as Jwk,
+      publicKeyB  : input.keyInput.publicKey as Jwk,
     });
-    const kek = await Encryption.deriveKek(sharedSecret, keyInput);
-    const cekJwk = Encryption.toA256CtrJwk(cek);
+    const kek = await Encryption.deriveKek(sharedSecret, input.keyInput);
+    const cekJwk = Encryption.toA256CtrJwk(input.cek);
     const kekJwk: Jwk = { alg: 'A256KW', k: Encoder.bytesToBase64Url(kek), kty: 'oct' };
     const encryptedKey = await AesKw.wrapKey({ encryptionKey: kekJwk, unwrappedKey: cekJwk });
 
@@ -170,13 +167,13 @@ export class Encryption {
 
   public static async unwrapKey(
     recipientPrivateKey: Jwk,
-    keyEncryption: KeyEncryption,
+    keyEncryption: X25519KeyEncryption,
   ): Promise<Uint8Array> {
-    if (keyEncryption.algorithm === KeyAgreementAlgorithm.X25519HkdfSha256A256Kw) {
+    if (Encryption.isX25519KeyAgreementAlgorithm(keyEncryption.algorithm)) {
       return Encryption.unwrapX25519Key(recipientPrivateKey, keyEncryption);
     }
 
-    throw new Error(`Unsupported key agreement algorithm: ${(keyEncryption as KeyEncryption).algorithm}`);
+    throw new Error(Encryption.unsupportedKeyAgreementAlgorithmMessage(keyEncryption.algorithm));
   }
 
   private static async unwrapX25519Key(
@@ -204,7 +201,7 @@ export class Encryption {
     const algorithm = encryptionInput.algorithm ?? ContentEncryptionAlgorithm.A256CTR;
     Encryption.validateContentEncryptionParameters(algorithm, encryptionInput.key, encryptionInput.initializationVector);
 
-    const keyEncryption: KeyEncryption[] = [];
+    const keyEncryption: X25519KeyEncryption[] = [];
     for (const keyInput of encryptionInput.keyEncryptionInputs) {
       keyEncryption.push(await Encryption.buildKeyEncryptionEntry(encryptionInput.key, keyInput));
     }
@@ -236,15 +233,14 @@ export class Encryption {
 
   private static async buildKeyEncryptionEntry(
     cek: Uint8Array,
-    keyInput: KeyEncryptionInput,
-  ): Promise<KeyEncryption> {
-    const { encryptedKey, ephemeralPublicKey } = await Encryption.wrapKey(
-      keyInput.publicKey,
+    keyInput: X25519KeyEncryptionInput,
+  ): Promise<X25519KeyEncryption> {
+    const { encryptedKey, ephemeralPublicKey } = await Encryption.wrapKey({
       cek,
       keyInput,
-    );
+    });
     const common = {
-      algorithm    : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+      algorithm    : keyInput.algorithm,
       encryptedKey : Encoder.bytesToBase64Url(encryptedKey),
       ephemeralPublicKey,
       keyId        : keyInput.keyId,
@@ -266,15 +262,15 @@ export class Encryption {
     };
   }
 
-  private static validateKeyEncryptionEntry(entry: KeyEncryption): void {
-    if (entry.algorithm === KeyAgreementAlgorithm.X25519HkdfSha256A256Kw) {
+  private static validateKeyEncryptionEntry(entry: X25519KeyEncryption): void {
+    if (Encryption.isX25519KeyAgreementAlgorithm(entry.algorithm)) {
       Encryption.validateX25519KeyEncryptionEntry(entry);
       return;
     }
 
     throw new DwnError(
       DwnErrorCode.RecordsWriteValidateIntegrityEncryptionEphemeralPublicKeyInvalid,
-      `Unsupported key agreement algorithm: ${(entry as KeyEncryption).algorithm}`
+      Encryption.unsupportedKeyAgreementAlgorithmMessage(entry.algorithm)
     );
   }
 
@@ -304,10 +300,17 @@ export class Encryption {
 
   private static getKekInfo(keyEncryption: X25519KeyEncryptionInput | X25519KeyEncryption): string {
     if (keyEncryption.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME) {
-      return `${KEK_INFO_PREFIX}|roleAudience|${keyEncryption.protocol}|${keyEncryption.role}|${keyEncryption.epoch}|${keyEncryption.keyId}`;
+      return JSON.stringify([
+        KEK_INFO_PREFIX,
+        ROLE_AUDIENCE_DERIVATION_SCHEME,
+        keyEncryption.protocol,
+        keyEncryption.role,
+        keyEncryption.epoch,
+        keyEncryption.keyId,
+      ]);
     }
 
-    return `${KEK_INFO_PREFIX}|protocolPath|${keyEncryption.keyId}`;
+    return JSON.stringify([KEK_INFO_PREFIX, KeyDerivationScheme.ProtocolPath, keyEncryption.keyId]);
   }
 
   private static validateContentEncryptionParameters(
@@ -336,6 +339,14 @@ export class Encryption {
     if (sharedSecret.every((byte): boolean => byte === 0)) {
       throw new Error('X25519 shared secret MUST NOT be all zeros.');
     }
+  }
+
+  private static isX25519KeyAgreementAlgorithm(algorithm: unknown): algorithm is KeyAgreementAlgorithm.X25519HkdfSha256A256Kw {
+    return algorithm === KeyAgreementAlgorithm.X25519HkdfSha256A256Kw;
+  }
+
+  private static unsupportedKeyAgreementAlgorithmMessage(algorithm: unknown): string {
+    return `Unsupported key agreement algorithm: ${String(algorithm)}`;
   }
 
   private static toA256CtrJwk(keyBytes: Uint8Array): Jwk {

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -1,8 +1,8 @@
 import type { DerivedPrivateJwk } from './hd-key.js';
 import type { Jwk } from '@enbox/crypto';
 import type { KeyDecrypter } from '../types/encryption-types.js';
-import type { KeyEncryption } from './encryption.js';
 import type { PublicKeyJwk } from '../types/jose-types.js';
+import type { X25519KeyEncryption } from './encryption.js';
 import type { Filter, KeyValues, StartsWithFilter } from '../types/query-types.js';
 import type { GenericMessage, GenericSignaturePayload, MessageSort } from '../types/message-types.js';
 import type { RecordsCountMessage, RecordsDeleteMessage, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsSubscribeMessage, RecordsWriteDescriptor, RecordsWriteMessage, RecordsWriteTags, RecordsWriteTagsFilter } from '../types/records-types.js';
@@ -132,7 +132,7 @@ export class Records {
   private static async findMatchingKeyEncryption(
     recordsWrite: RecordsWriteMessage,
     keyOrDecrypter: DerivedPrivateJwk | KeyDecrypter,
-  ): Promise<{ fullDerivationPath: string[]; leafPrivateKey?: Jwk; matchingKeyEncryption?: KeyEncryption }> {
+  ): Promise<{ fullDerivationPath: string[]; leafPrivateKey?: Jwk; matchingKeyEncryption?: X25519KeyEncryption }> {
     const { encryption } = recordsWrite;
     const fullDerivationPath = Records.constructKeyDerivationPath(keyOrDecrypter.derivationScheme, recordsWrite);
 

--- a/packages/dwn-sdk-js/tests/core/validation-read-closure.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/validation-read-closure.spec.ts
@@ -24,7 +24,7 @@ import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { Time } from '../../src/utils/time.js';
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
-import { ContentEncryptionAlgorithm, Encryption, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/utils/encryption.js';
+import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/utils/encryption.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
 import { EncryptionProtocol, KeyDerivationScheme, Protocols } from '../../src/index.js';
@@ -261,11 +261,13 @@ describe('validation read closure', () => {
         key                  : dataEncryptionKey,
         keyEncryptionInputs  : [
           {
+            algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
             keyId            : await Encryption.getKeyId(protocolPathPublicKey),
             publicKey        : protocolPathPublicKey,
             derivationScheme : KeyDerivationScheme.ProtocolPath,
           },
           {
+            algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
             keyId            : roleKeyId,
             publicKey        : rolePublicKey,
             derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,

--- a/packages/dwn-sdk-js/tests/fuzz/encryption.fuzz.spec.ts
+++ b/packages/dwn-sdk-js/tests/fuzz/encryption.fuzz.spec.ts
@@ -46,11 +46,15 @@ describe('Encryption — fuzz', () => {
       fc.asyncProperty(
         aes256Key(),
         async (cek): Promise<void> => {
-          const wrapped = await Encryption.wrapKey(
-            recipientPublicKey,
+          const wrapped = await Encryption.wrapKey({
             cek,
-            { derivationScheme: KeyDerivationScheme.ProtocolPath, keyId, publicKey: recipientPublicKey },
-          );
+            keyInput: {
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+              derivationScheme : KeyDerivationScheme.ProtocolPath,
+              keyId,
+              publicKey        : recipientPublicKey,
+            },
+          });
           const unwrapped = await Encryption.unwrapKey(recipientPrivateKey, {
             algorithm          : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
             derivationScheme   : KeyDerivationScheme.ProtocolPath,

--- a/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
@@ -23,7 +23,7 @@ import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { ContentEncryptionAlgorithm, Encryption } from '../../src/utils/encryption.js';
+import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm } from '../../src/utils/encryption.js';
 import { DataStoreLevel, DwnConstant, MessageStoreLevel, PermissionsProtocol, Time } from '../../src/index.js';
 import { DataStream, DateSort, Dwn, Jws, Protocols, ProtocolsConfigure, ProtocolsQuery, Records, RecordsDelete, RecordsRead , RecordsWrite } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
@@ -1901,6 +1901,7 @@ export function testRecordsReadHandler(): void {
             initializationVector : dataEncryptionInitializationVector,
             key                  : dataEncryptionKey,
             keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
               keyId            : await Encryption.getKeyId(publicJwk!),
               publicKey        : publicJwk!,
               derivationScheme : KeyDerivationScheme.ProtocolPath

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -41,7 +41,7 @@ import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { Time } from '../../src/utils/time.js';
-import { ContentEncryptionAlgorithm, Encryption, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/utils/encryption.js';
+import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/utils/encryption.js';
 import { CoreProtocolRegistry, DataStoreLevel, DwnConstant, DwnInterfaceName, DwnMethodName, EncryptionProtocol, KeyDerivationScheme, MessageStoreLevel, PermissionsProtocol, Protocols, RecordsDelete, RecordsQuery } from '../../src/index.js';
 import { defaultTestProtocolDefinition, TestDataGenerator } from '../utils/test-data-generator.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
@@ -2790,6 +2790,7 @@ export function testRecordsWriteHandler(): void {
             initializationVector : dataEncryptionInitializationVector,
             key                  : dataEncryptionKey,
             keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
               keyId            : await Encryption.getKeyId(encryptionPublicKey),
               publicKey        : encryptionPublicKey,
               derivationScheme : KeyDerivationScheme.ProtocolPath
@@ -2865,6 +2866,7 @@ export function testRecordsWriteHandler(): void {
             initializationVector : dataEncryptionInitializationVector,
             key                  : dataEncryptionKey,
             keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
               keyId            : await Encryption.getKeyId(protocolPathPublicKey),
               publicKey        : protocolPathPublicKey,
               derivationScheme : KeyDerivationScheme.ProtocolPath,
@@ -2977,11 +2979,13 @@ export function testRecordsWriteHandler(): void {
             key                  : dataEncryptionKey,
             keyEncryptionInputs  : [
               {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
                 keyId            : await Encryption.getKeyId(protocolPathPublicKey),
                 publicKey        : protocolPathPublicKey,
                 derivationScheme : KeyDerivationScheme.ProtocolPath,
               },
               {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
                 keyId            : roleKeyId,
                 publicKey        : rolePublicKey,
                 derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
@@ -3335,6 +3339,7 @@ export function testRecordsWriteHandler(): void {
             initializationVector : dataEncryptionInitializationVector,
             key                  : dataEncryptionKey,
             keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
               keyId            : await Encryption.getKeyId(alice.encryptionKeyPair.publicJwk),
               publicKey        : alice.encryptionKeyPair.publicJwk,
               derivationScheme : KeyDerivationScheme.ProtocolPath
@@ -3387,6 +3392,7 @@ export function testRecordsWriteHandler(): void {
             initializationVector : dataEncryptionInitializationVector,
             key                  : dataEncryptionKey,
             keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
               derivationScheme : KeyDerivationScheme.ProtocolPath,
               keyId            : await Encryption.getKeyId(alice.encryptionKeyPair.publicJwk),
               publicKey        : alice.encryptionKeyPair.publicJwk,
@@ -3444,6 +3450,7 @@ export function testRecordsWriteHandler(): void {
             initializationVector : dataEncryptionInitializationVector,
             key                  : dataEncryptionKey,
             keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
               derivationScheme : KeyDerivationScheme.ProtocolPath,
               keyId            : await Encryption.getKeyId(alice.encryptionKeyPair.publicJwk),
               publicKey        : alice.encryptionKeyPair.publicJwk,

--- a/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
@@ -20,6 +20,7 @@ import {
   Encoder,
   HdKey,
   Jws,
+  KeyAgreementAlgorithm,
   KeyDerivationScheme,
   Message,
   MessageStoreLevel,
@@ -346,6 +347,7 @@ describe('RecordsWrite', () => {
         initializationVector : dataEncryptionInitializationVector,
         key                  : dataEncryptionKey,
         keyEncryptionInputs  : [{
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
           derivationScheme : KeyDerivationScheme.ProtocolPath,
           keyId            : await Encryption.getKeyId(publicKey),
           publicKey,
@@ -383,6 +385,7 @@ describe('RecordsWrite', () => {
           initializationVector : TestDataGenerator.randomBytes(16),
           key                  : TestDataGenerator.randomBytes(32),
           keyEncryptionInputs  : [{
+            algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
             derivationScheme : KeyDerivationScheme.ProtocolPath,
             keyId            : await Encryption.getKeyId(publicKey),
             publicKey,
@@ -411,6 +414,7 @@ describe('RecordsWrite', () => {
           initializationVector : TestDataGenerator.randomBytes(16),
           key                  : TestDataGenerator.randomBytes(32),
           keyEncryptionInputs  : [{
+            algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
             derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
             epoch            : 1,
             keyId            : await Encryption.getKeyId(publicKey),
@@ -497,7 +501,8 @@ describe('RecordsWrite', () => {
         initializationVector : dataEncryptionInitializationVector,
         key                  : dataEncryptionKey,
         keyEncryptionInputs  : [{
-          derivationScheme: KeyDerivationScheme.ProtocolPath,
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+          derivationScheme : KeyDerivationScheme.ProtocolPath,
           keyId,
           publicKey,
         }],
@@ -536,6 +541,7 @@ describe('RecordsWrite', () => {
         initializationVector : dataEncryptionInitializationVector,
         key                  : dataEncryptionKey,
         keyEncryptionInputs  : [{
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
           derivationScheme : KeyDerivationScheme.ProtocolPath,
           keyId            : await Encryption.getKeyId(publicKey),
           publicKey,
@@ -754,6 +760,7 @@ describe('RecordsWrite', () => {
         initializationVector : dataEncryptionIV,
         key                  : dataEncryptionKey,
         keyEncryptionInputs  : [{
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
           keyId            : await Encryption.getKeyId(alice.encryptionKeyPair.publicJwk),
           publicKey        : alice.encryptionKeyPair.publicJwk,
           derivationScheme : KeyDerivationScheme.ProtocolPath,
@@ -770,6 +777,7 @@ describe('RecordsWrite', () => {
         initializationVector : dataEncryptionIV,
         key                  : dataEncryptionKey,
         keyEncryptionInputs  : [{
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
           keyId            : await Encryption.getKeyId(bob.encryptionKeyPair.publicJwk),
           publicKey        : bob.encryptionKeyPair.publicJwk,
           derivationScheme : KeyDerivationScheme.ProtocolPath,

--- a/packages/dwn-sdk-js/tests/protocols/encryption.spec.ts
+++ b/packages/dwn-sdk-js/tests/protocols/encryption.spec.ts
@@ -17,6 +17,7 @@ import {
   Encryption,
   EncryptionProtocol,
   Jws,
+  KeyAgreementAlgorithm,
   KeyDerivationScheme,
   RecordsWrite,
   Time,
@@ -1099,6 +1100,7 @@ async function createAudienceKeyMessage(input: {
       initializationVector : TestDataGenerator.randomBytes(16),
       key                  : TestDataGenerator.randomBytes(32),
       keyEncryptionInputs  : [{
+        algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
         derivationScheme : KeyDerivationScheme.ProtocolPath,
         keyId,
         publicKey        : input.publicKeyJwk,
@@ -1145,6 +1147,7 @@ async function createGrantKeyMessage(input: {
       initializationVector : TestDataGenerator.randomBytes(16),
       key                  : TestDataGenerator.randomBytes(32),
       keyEncryptionInputs  : [{
+        algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
         derivationScheme : KeyDerivationScheme.ProtocolPath,
         keyId            : await Encryption.getKeyId(publicKey),
         publicKey,

--- a/packages/dwn-sdk-js/tests/scenarios/end-to-end-tests.spec.ts
+++ b/packages/dwn-sdk-js/tests/scenarios/end-to-end-tests.spec.ts
@@ -20,6 +20,7 @@ import {
   Encryption,
   EncryptionProtocol,
   Jws,
+  KeyAgreementAlgorithm,
   Protocols,
   Records,
   RecordsRead,
@@ -180,11 +181,13 @@ export function testEndToEndScenarios(): void {
         key                  : dataEncryptionKey,
         keyEncryptionInputs  : [
           {
+            algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
             keyId            : await Encryption.getKeyId(protocolPathPublicKey),
             publicKey        : protocolPathPublicKey,
             derivationScheme : KeyDerivationScheme.ProtocolPath,
           },
           {
+            algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
             keyId            : roleKeyId,
             publicKey        : rolePublicKey,
             derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,

--- a/packages/dwn-sdk-js/tests/utils/encryption.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/encryption.spec.ts
@@ -12,7 +12,7 @@ import { KeyDerivationScheme } from '../../src/utils/hd-key.js';
 import { Records } from '../../src/utils/records.js';
 import { TestDataGenerator } from './test-data-generator.js';
 import { X25519 } from '@enbox/crypto';
-import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm } from '../../src/utils/encryption.js';
+import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/utils/encryption.js';
 import { describe, expect, it } from 'bun:test';
 
 const boundarySizes = [0, 1, 15, 16, 17, 32, 256];
@@ -37,6 +37,7 @@ async function createEncryptedRecordFixture(plaintext = TestDataGenerator.random
     initializationVector : iv,
     key                  : cek,
     keyEncryptionInputs  : [{
+      algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
       derivationScheme : KeyDerivationScheme.ProtocolPath,
       keyId,
       publicKey        : recipientPublicKey,
@@ -119,11 +120,15 @@ describe('Encryption', () => {
       const cek = TestDataGenerator.randomBytes(32);
       const keyId = await Encryption.getKeyId(recipientPublicKey);
 
-      const { encryptedKey, ephemeralPublicKey } = await Encryption.wrapKey(
-        recipientPublicKey,
+      const { encryptedKey, ephemeralPublicKey } = await Encryption.wrapKey({
         cek,
-        { derivationScheme: KeyDerivationScheme.ProtocolPath, keyId, publicKey: recipientPublicKey },
-      );
+        keyInput: {
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+          derivationScheme : KeyDerivationScheme.ProtocolPath,
+          keyId,
+          publicKey        : recipientPublicKey,
+        },
+      });
 
       const unwrappedCek = await Encryption.unwrapKey(recipientPrivateKey, {
         algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
@@ -141,10 +146,15 @@ describe('Encryption', () => {
       const recipientPublicKey = await X25519.getPublicKey({ key: recipientPrivateKey }) as PublicKeyJwk;
       const cek = TestDataGenerator.randomBytes(32);
       const keyId = await Encryption.getKeyId(recipientPublicKey);
-      const keyInput = { derivationScheme: KeyDerivationScheme.ProtocolPath, keyId, publicKey: recipientPublicKey } as const;
+      const keyInput = {
+        algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+        derivationScheme : KeyDerivationScheme.ProtocolPath,
+        keyId,
+        publicKey        : recipientPublicKey,
+      } as const;
 
-      const wrappedKey1 = await Encryption.wrapKey(recipientPublicKey, cek, keyInput);
-      const wrappedKey2 = await Encryption.wrapKey(recipientPublicKey, cek, keyInput);
+      const wrappedKey1 = await Encryption.wrapKey({ cek, keyInput });
+      const wrappedKey2 = await Encryption.wrapKey({ cek, keyInput });
 
       expect(ArrayUtility.byteArraysEqual(wrappedKey1.encryptedKey, wrappedKey2.encryptedKey)).toBe(false);
 
@@ -166,6 +176,101 @@ describe('Encryption', () => {
       expect(ArrayUtility.byteArraysEqual(unwrapped1, cek)).toBe(true);
       expect(ArrayUtility.byteArraysEqual(unwrapped2, cek)).toBe(true);
     });
+
+    it('should domain-separate role-audience KEKs without delimiter ambiguity', async () => {
+      const recipientPrivateKey = await X25519.generateKey();
+      const recipientPublicKey = await X25519.getPublicKey({ key: recipientPrivateKey }) as PublicKeyJwk;
+      const ephemeralPrivateKey = await X25519.generateKey();
+      const cek = TestDataGenerator.randomBytes(32);
+      const keyId = await Encryption.getKeyId(recipientPublicKey);
+      const baseKeyInput = {
+        algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+        derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+        epoch            : 1,
+        keyId,
+        publicKey        : recipientPublicKey,
+      } as const;
+
+      const wrappedKey1 = await Encryption.wrapKey({
+        cek,
+        ephemeralPrivateKey,
+        keyInput: {
+          ...baseKeyInput,
+          protocol : 'https://example.com/a|b',
+          role     : 'c',
+        },
+      });
+      const wrappedKey2 = await Encryption.wrapKey({
+        cek,
+        ephemeralPrivateKey,
+        keyInput: {
+          ...baseKeyInput,
+          protocol : 'https://example.com/a',
+          role     : 'b|c',
+        },
+      });
+
+      expect(ArrayUtility.byteArraysEqual(wrappedKey1.encryptedKey, wrappedKey2.encryptedKey)).toBe(false);
+
+      const unwrapped1 = await Encryption.unwrapKey(recipientPrivateKey, {
+        ...baseKeyInput,
+        encryptedKey       : Encoder.bytesToBase64Url(wrappedKey1.encryptedKey),
+        ephemeralPublicKey : wrappedKey1.ephemeralPublicKey,
+        protocol           : 'https://example.com/a|b',
+        role               : 'c',
+      });
+      const unwrapped2 = await Encryption.unwrapKey(recipientPrivateKey, {
+        ...baseKeyInput,
+        encryptedKey       : Encoder.bytesToBase64Url(wrappedKey2.encryptedKey),
+        ephemeralPublicKey : wrappedKey2.ephemeralPublicKey,
+        protocol           : 'https://example.com/a',
+        role               : 'b|c',
+      });
+
+      expect(ArrayUtility.byteArraysEqual(unwrapped1, cek)).toBe(true);
+      expect(ArrayUtility.byteArraysEqual(unwrapped2, cek)).toBe(true);
+    });
+
+    it('should reject unsupported key agreement algorithms', async () => {
+      const recipientPrivateKey = await X25519.generateKey();
+      const recipientPublicKey = await X25519.getPublicKey({ key: recipientPrivateKey }) as PublicKeyJwk;
+      const cek = TestDataGenerator.randomBytes(32);
+      const keyId = await Encryption.getKeyId(recipientPublicKey);
+      const unsupportedAlgorithm = 'unsupported-key-agreement';
+      const unsupportedMessage = `Unsupported key agreement algorithm: ${unsupportedAlgorithm}`;
+      const unsupportedKeyInput = {
+        algorithm        : unsupportedAlgorithm,
+        derivationScheme : KeyDerivationScheme.ProtocolPath,
+        keyId,
+        publicKey        : recipientPublicKey,
+      } as unknown as Parameters<typeof Encryption.wrapKey>[0]['keyInput'];
+
+      await expect(Encryption.wrapKey({ cek, keyInput: unsupportedKeyInput })).rejects.toThrow(unsupportedMessage);
+
+      const wrappedKey = await Encryption.wrapKey({
+        cek,
+        keyInput: {
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+          derivationScheme : KeyDerivationScheme.ProtocolPath,
+          keyId,
+          publicKey        : recipientPublicKey,
+        },
+      });
+      const unsupportedKeyEncryption = {
+        algorithm          : unsupportedAlgorithm,
+        derivationScheme   : KeyDerivationScheme.ProtocolPath,
+        encryptedKey       : Encoder.bytesToBase64Url(wrappedKey.encryptedKey),
+        ephemeralPublicKey : wrappedKey.ephemeralPublicKey,
+        keyId,
+      } as unknown as Parameters<typeof Encryption.unwrapKey>[1];
+
+      await expect(Encryption.unwrapKey(recipientPrivateKey, unsupportedKeyEncryption)).rejects.toThrow(unsupportedMessage);
+      expect(() => Encryption.validateEncryptionProperty({
+        algorithm            : ContentEncryptionAlgorithm.A256CTR,
+        initializationVector : Encoder.bytesToBase64Url(TestDataGenerator.randomBytes(16)),
+        keyEncryption        : [unsupportedKeyEncryption],
+      })).toThrow(unsupportedMessage);
+    });
   });
 
   describe('buildEncryptionProperty', () => {
@@ -180,6 +285,7 @@ describe('Encryption', () => {
         initializationVector : iv,
         key                  : cek,
         keyEncryptionInputs  : [{
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
           derivationScheme : KeyDerivationScheme.ProtocolPath,
           keyId,
           publicKey        : recipientPublicKey,

--- a/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
+++ b/packages/dwn-sdk-js/tests/utils/test-data-generator.ts
@@ -47,7 +47,7 @@ import { Secp256k1 } from '../../src/utils/secp256k1.js';
 import { sha256 } from 'multiformats/hashes/sha2';
 import { Time } from '../../src/utils/time.js';
 import { X25519 } from '@enbox/crypto';
-import { ContentEncryptionAlgorithm, Encryption } from '../../src/utils/encryption.js';
+import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm } from '../../src/utils/encryption.js';
 import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
 
 /**
@@ -611,6 +611,7 @@ export class TestDataGenerator {
 
       const protocolPathDerivedPublicKeyJwk = protocolRuleSetSegment.$keyAgreement?.publicKeyJwk;
       const protocolPathDerivedKeyEncryptionInput: ProtocolPathKeyEncryptionInput = {
+        algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
         keyId            : await Encryption.getKeyId(protocolPathDerivedPublicKeyJwk!),
         publicKey        : protocolPathDerivedPublicKeyJwk!,
         derivationScheme : KeyDerivationScheme.ProtocolPath


### PR DESCRIPTION
## Summary
- make DWN key wrapping take an algorithm-discriminated request object instead of X25519-specific positional arguments
- carry the key-agreement algorithm through protocol-path and role-audience encryption inputs
- keep record-facing key-wrap guards explicit and encode HKDF KEK context without delimiter ambiguity
- rename the agent KMS CEK unwrap hook from `jweKeyUnwrap` to `unwrapContentKey` and update encryption/API fixtures

## Test plan
- [x] `bun run lint`
- [x] `bun run --filter @enbox/dwn-sdk-js build`
- [x] `bun run --filter @enbox/agent build`
- [x] `bun run --filter @enbox/agent build && bun run --filter @enbox/auth build && bun run --filter @enbox/api build`
- [x] `bun test tests/utils/encryption.spec.ts tests/fuzz/encryption.fuzz.spec.ts` from `packages/dwn-sdk-js`
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/dwn-encryption.spec.ts tests/local-key-manager.spec.ts` from `packages/agent`
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/e2e-delegate-encrypted.spec.ts` from `packages/agent`
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/e2e-multi-agent-sync.spec.ts` from `packages/agent` with local DWN server rate limits disabled
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node` from `packages/agent` with local DWN server rate limits disabled: 1263 pass, 4 skip, 0 fail
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun test tests/record.spec.ts` from `packages/api` with local DWN server rate limits disabled
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node` from `packages/api` with local DWN server rate limits disabled: 565 pass, 0 fail

Note: `@enbox/agent` must be built after `@enbox/dwn-sdk-js`; running both package builds in parallel can fail while `dwn-sdk-js` is rebuilding its `dist`.
