### PR TITLE
feat(dwn-sdk-js): reserve encryption control write paths

### DIFF
--- a/.changeset/encryption-control-admission.md
+++ b/.changeset/encryption-control-admission.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Reserve encryption control write paths for protocol-native validation.

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-unidentified.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-unidentified.json
@@ -191,7 +191,7 @@
         },
         "protocolPath": {
           "type": "string",
-          "pattern": "^[a-zA-Z]+(\/[a-zA-Z]+)*$"
+          "pattern": "^(?:[a-zA-Z]+(\/[a-zA-Z]+)*|\\$encryption\/(?:audience|delivery))$"
         },
         "schema": {
           "type": "string"

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -9,6 +9,7 @@ import type { ValidationStateReader } from '../types/validation-state-reader.js'
 import type { ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
 
 import { getRuleSetAtPath } from '../utils/protocols.js';
+import { isEncryptionControlPath } from './constants.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
 
@@ -35,6 +36,13 @@ export class ProtocolAuthorization {
     incomingMessage: RecordsWrite,
     validationStateReader: ValidationStateReader,
   ): Promise<ProtocolRuleSet> {
+    if (isEncryptionControlPath(incomingMessage.message.descriptor.protocolPath)) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+        `reserved encryption control path '${incomingMessage.message.descriptor.protocolPath}' requires encryption control validation.`
+      );
+    }
+
     const protocolDefinitionTimestamp = incomingMessage.message.descriptor.messageTimestamp;
 
     // fetch the protocol definition active at the incoming message timestamp

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -46,6 +46,7 @@ import { CoreProtocolRegistry, DataStoreLevel, DwnConstant, DwnInterfaceName, Dw
 import { defaultTestProtocolDefinition, TestDataGenerator } from '../utils/test-data-generator.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnError, DwnErrorCode } from '../../src/core/dwn-error.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
 
@@ -124,6 +125,41 @@ export function testRecordsWriteHandler(): void {
 
         // Cleanup: unregister the mock so it doesn't affect other tests
         (coreProtocols as any)._protocols.delete(protocolUri);
+      });
+
+      it('should fail closed for exact reserved encryption control paths before ordinary protocol authorization', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+        for (const protocolPath of [ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH]) {
+          const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({
+            author   : alice,
+            protocol : defaultTestProtocolDefinition.protocol,
+            protocolPath,
+          });
+
+          const reply = await dwn.processMessage(alice.did, message, { dataStream });
+
+          expect(reply.status.code).toBe(400);
+          expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateUnexpectedRecord);
+        }
+      });
+
+      it('should not treat lookalike encryption control paths as reserved paths', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
+
+        const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          protocol     : defaultTestProtocolDefinition.protocol,
+          protocolPath : '$encryptionx/audience',
+        });
+
+        const reply = await dwn.processMessage(alice.did, message, { dataStream });
+
+        expect(reply.status.code).toBe(400);
+        expect(reply.status.detail).toContain('SchemaValidatorFailure');
+        expect(reply.status.detail).toContain('protocolPath: must match pattern');
       });
 
       it('should only be able to overwrite existing record if new record has a later `messageTimestamp` value', async () => {

--- a/packages/dwn-sdk-js/tests/validation/json-schemas/records/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/validation/json-schemas/records/records-write.spec.ts
@@ -1,6 +1,7 @@
 import { Message } from '../../../../src/core/message.js';
 import { TestDataGenerator } from '../../../utils/test-data-generator.js';
 import { describe, expect, it } from 'bun:test';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH, ENCRYPTION_CONTROL_ROOT_PATH } from '../../../../src/core/constants.js';
 
 describe('RecordsWrite schema definition', () => {
   it('should allow descriptor with only required properties', async () => {
@@ -158,7 +159,55 @@ describe('RecordsWrite schema definition', () => {
 
     expect(() => {
       Message.validateJsonSchema(invalidMessage);
-    }).toThrow('protocolPath: must match pattern "^[a-zA-Z]+(/[a-zA-Z]+)*$');
+    }).toThrow('protocolPath: must match pattern');
+  });
+
+  it('should allow exact reserved encryption control protocol paths', () => {
+    for (const protocolPath of [ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH]) {
+      const message = {
+        recordId   : 'anyRecordId',
+        contextId  : 'someContext',
+        descriptor : {
+          interface        : 'Records',
+          method           : 'Write',
+          protocol         : 'http://foo.bar',
+          protocolPath,
+          schema           : 'http://foo.bar/schema',
+          dataCid          : 'anyCid',
+          dataFormat       : 'application/json',
+          dataSize         : 123,
+          dateCreated      : '2022-12-19T10:20:30.123456Z',
+          messageTimestamp : '2022-12-19T10:20:30.123456Z'
+        },
+        authorization: TestDataGenerator.generateAuthorization()
+      };
+
+      Message.validateJsonSchema(message);
+    }
+  });
+
+  it('should reject root-only and lookalike encryption control protocol paths', () => {
+    for (const protocolPath of [ENCRYPTION_CONTROL_ROOT_PATH, '$encryptionx/audience', '$encryption/audience/child']) {
+      const message = {
+        recordId   : 'anyRecordId',
+        contextId  : 'someContext',
+        descriptor : {
+          interface        : 'Records',
+          method           : 'Write',
+          protocol         : 'http://foo.bar',
+          protocolPath,
+          schema           : 'http://foo.bar/schema',
+          dataCid          : 'anyCid',
+          dataFormat       : 'application/json',
+          dataSize         : 123,
+          dateCreated      : '2022-12-19T10:20:30.123456Z',
+          messageTimestamp : '2022-12-19T10:20:30.123456Z'
+        },
+        authorization: TestDataGenerator.generateAuthorization()
+      };
+
+      expect(() => Message.validateJsonSchema(message)).toThrow('protocolPath: must match pattern');
+    }
   });
 
   it('should throw if `contextId` is malformed', () => {


### PR DESCRIPTION
## Summary
- allows only the exact reserved encryption control protocol paths through RecordsWrite schema validation
- fails exact reserved control writes closed before ordinary protocol authorization can treat them as app records
- covers exact-path and lookalike-path behavior with schema and handler tests

## Test plan
- [x] bunx turbo run lint --filter=@enbox/dwn-sdk-js
- [x] bun run compile-validators && GREP="reserved encryption control paths|lookalike encryption control|reserved encryption control protocol paths|lookalike encryption control protocol paths" bun run test:node-grep
- [x] bun run --filter @enbox/dwn-sdk-js build
- [x] bun run test:node

## Notes
Stacked on #1101 for issue #1100. This keeps reserved control paths fail-closed until the full control dispatcher and validators land.