### PR TITLE
fix(dwn-sdk-js): require Records grants for grantKey

### DIFF
--- a/.changeset/grantkey-records-only.md
+++ b/.changeset/grantkey-records-only.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Restrict grantKey records to Records.Read permission grants.

--- a/packages/agent/tests/dwn-encryption.spec.ts
+++ b/packages/agent/tests/dwn-encryption.spec.ts
@@ -584,6 +584,7 @@ describe('dwn-encryption', () => {
           protocol  : 'https://proto.example.com',
         },
       });
+      // Role-path Write grant coverage belongs to the encryption-control workstream.
       const processDwnRequest = sinon.stub().rejects(new Error('ineligible grants should not write records'));
 
       const records = await createGrantKeyRecordsForGrants({

--- a/packages/agent/tests/dwn-encryption.spec.ts
+++ b/packages/agent/tests/dwn-encryption.spec.ts
@@ -573,6 +573,17 @@ describe('dwn-encryption', () => {
           contextId : 'context-a',
         },
       });
+      const messagesReadGrant = await TestDataGenerator.generateGrantCreate({
+        author      : grantor,
+        grantedTo   : grantee,
+        delegated   : true,
+        dateExpires : '2040-06-25T16:09:16.693356Z',
+        scope       : {
+          interface : DwnInterfaceName.Messages,
+          method    : DwnMethodName.Read,
+          protocol  : 'https://proto.example.com',
+        },
+      });
       const processDwnRequest = sinon.stub().rejects(new Error('ineligible grants should not write records'));
 
       const records = await createGrantKeyRecordsForGrants({
@@ -580,7 +591,7 @@ describe('dwn-encryption', () => {
         ownerDid              : grantor.did,
         granteeDid            : grantee.did,
         granteeRootPrivateKey : await X25519.generateKey(),
-        grantMessages         : [writeGrant.dataEncodedMessage, contextReadGrant.dataEncodedMessage],
+        grantMessages         : [writeGrant.dataEncodedMessage, contextReadGrant.dataEncodedMessage, messagesReadGrant.dataEncodedMessage],
       });
 
       expect(records).toHaveLength(0);

--- a/packages/dwn-sdk-js/src/protocols/encryption.ts
+++ b/packages/dwn-sdk-js/src/protocols/encryption.ts
@@ -40,6 +40,9 @@ export class EncryptionProtocol implements CoreProtocol {
   public static readonly audienceEpochPath = 'audienceEpoch';
   public static readonly audienceKeyPath = 'audienceKey';
   public static readonly grantKeyPath = 'grantKey';
+  private static readonly grantKeyScopeMethodsByInterface: Record<string, DwnMethodName | undefined> = {
+    [DwnInterfaceName.Records]: DwnMethodName.Read,
+  };
 
   public static readonly definition: ProtocolDefinition = {
     published : true,
@@ -409,7 +412,7 @@ export class EncryptionProtocol implements CoreProtocol {
     if (!EncryptionProtocol.isReadScope(grantScope)) {
       throw new DwnError(
         DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
-        'grantKey must reference a read permission grant.'
+        'grantKey must reference a Records.Read permission grant.'
       );
     }
 
@@ -433,8 +436,7 @@ export class EncryptionProtocol implements CoreProtocol {
   }
 
   private static isReadScope(scope: PermissionScope): boolean {
-    return (scope.interface === DwnInterfaceName.Records || scope.interface === DwnInterfaceName.Messages) &&
-      scope.method === DwnMethodName.Read;
+    return Object.is(EncryptionProtocol.grantKeyScopeMethodsByInterface[scope.interface], scope.method);
   }
 
   private static isBoundaryAwareSubtree(scopePath: string, candidatePath: string): boolean {

--- a/packages/dwn-sdk-js/tests/protocols/encryption.spec.ts
+++ b/packages/dwn-sdk-js/tests/protocols/encryption.spec.ts
@@ -509,7 +509,7 @@ describe('EncryptionProtocol', () => {
       await encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant }));
     });
 
-    it('should accept grantKey records covered by a Messages read grant', async () => {
+    it('should reject grantKey records covered only by a Messages read grant', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const bob = await TestDataGenerator.generatePersona();
       const protocol = 'https://example.com/protocol';
@@ -529,7 +529,9 @@ describe('EncryptionProtocol', () => {
 
       const encryptionProtocol = new EncryptionProtocol();
 
-      await encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant }));
+      await expect(
+        encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant }))
+      ).rejects.toThrow(DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch);
     });
 
     it('should reject protocol-scoped grantKey records for protocolPath-scoped read grants', async () => {


### PR DESCRIPTION
## Summary
- rejects grantKey records backed only by Messages.Read grants
- keeps grantKey tied to Records.Read authority on the DWN side
- extends agent producer coverage to confirm Messages.Read grants are skipped for durable key delivery

## Test plan
- [x] bunx turbo run build --filter=@enbox/dwn-sdk-js --filter=@enbox/agent
- [x] GREP="Messages read grant|cannot carry durable encrypted read access|grantKey records covered" bun run test:node-grep
- [x] bun test tests/dwn-encryption.spec.ts -t "cannot carry durable encrypted read access"
- [x] bunx turbo run lint --filter=@enbox/dwn-sdk-js --filter=@enbox/agent

## Notes
Stacked on #1101 for issue #1100. This closes the Records-only grantKey eligibility part of the grantKey coverage work; the role-path coverage expansion is separate.