### PR TITLE
feat(dwn-sdk-js): validate encryption control records

### DIFF
--- a/.changeset/control-record-validation.md
+++ b/.changeset/control-record-validation.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Add source-protocol encryption control record validation.

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -1,0 +1,728 @@
+import type { RecordsPermissionScope } from '../types/permission-types.js';
+import type { RecordsWrite } from '../interfaces/records-write.js';
+import type { ValidationStateReader } from '../types/validation-state-reader.js';
+import type { EncryptionControlAudiencePayload, EncryptionControlDeliveryTags, RoleAudienceKeyId } from '../types/encryption-types.js';
+import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
+import type { RecordsWriteMessage, RecordsWriteTags } from '../types/records-types.js';
+
+import { checkActor } from './protocol-authorization-action.js';
+import { DwnConstant } from './dwn-constant.js';
+import { Encoder } from '../utils/encoder.js';
+import { Encryption } from '../utils/encryption.js';
+import { EncryptionControlDeliveryRecipientAuthority } from '../types/encryption-types.js';
+import { GrantAuthorization } from './grant-authorization.js';
+import { Jws } from '../utils/jws.js';
+import { Message } from './message.js';
+import { PermissionConditionPublication } from '../types/permission-types.js';
+import { PermissionGrant } from '../protocols/permission-grant.js';
+import { PermissionScopeMatcher } from '../utils/permission-scope.js';
+import { validateJsonSchema } from '../schema-validator.js';
+import { DwnError, DwnErrorCode } from './dwn-error.js';
+import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH, isEncryptionControlPath } from './constants.js';
+import { getRuleSetAtPath, isCrossProtocolRef, parseCrossProtocolRef } from '../utils/protocols.js';
+import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
+
+type RoleAudienceDefinition = {
+  protocolDefinition: ProtocolDefinition;
+  ruleSet: ProtocolRuleSet;
+};
+
+type EffectiveControlActor = {
+  did: string | undefined;
+  grant?: PermissionGrant;
+};
+
+export class EncryptionControl {
+  public static isControlMessage(message: RecordsWriteMessage): boolean {
+    return isEncryptionControlPath(message.descriptor.protocolPath);
+  }
+
+  public static async authorizeWrite(
+    tenant: string,
+    recordsWrite: RecordsWrite,
+    validationStateReader: ValidationStateReader,
+  ): Promise<void> {
+    const recordType = EncryptionControl.getRecordType(recordsWrite.message);
+    const tags = EncryptionControl.getRoleAudienceKeyId(recordsWrite.message, recordType);
+    const { protocolDefinition, ruleSet } = await EncryptionControl.verifyRoleAudienceDefinition(
+      tenant, tags, recordsWrite.message, validationStateReader, recordType
+    );
+    const actor = await EncryptionControl.resolveEffectiveControlActor(tenant, recordsWrite, validationStateReader);
+
+    await EncryptionControl.verifyActorCanCreateRole({
+      tenant,
+      actor,
+      tags,
+      protocolDefinition,
+      ruleSet,
+      validationStateReader,
+      message: recordsWrite.message,
+    });
+  }
+
+  public static async validateReferentialIntegrity(
+    tenant: string,
+    recordsWrite: RecordsWrite,
+    validationStateReader: ValidationStateReader,
+  ): Promise<void> {
+    if (!await recordsWrite.isInitialWrite()) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+        'encryption control records are immutable.'
+      );
+    }
+
+    EncryptionControl.verifyInlineControlRecord(recordsWrite.message);
+
+    const recordType = EncryptionControl.getRecordType(recordsWrite.message);
+    if (recordType === 'audience') {
+      const tags = EncryptionControl.getRoleAudienceKeyId(recordsWrite.message, 'audience');
+      await EncryptionControl.verifyRoleAudienceDefinition(tenant, tags, recordsWrite.message, validationStateReader, 'audience');
+      return;
+    }
+
+    const tags = EncryptionControl.getDeliveryTags(recordsWrite.message);
+    await EncryptionControl.verifyRoleAudienceDefinition(tenant, tags, recordsWrite.message, validationStateReader, 'delivery');
+    const audiences = await validationStateReader.queryAudienceRecords({
+      tenant,
+      protocol  : tags.protocol,
+      rolePath  : tags.rolePath,
+      contextId : tags.contextId,
+      keyId     : tags.keyId,
+    });
+    if (audiences.length === 0) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateDeliveryAudienceMissing,
+        'delivery control record references a missing audience.'
+      );
+    }
+  }
+
+  public static async preProcessWrite(
+    tenant: string,
+    message: RecordsWriteMessage,
+    validationStateReader: ValidationStateReader,
+  ): Promise<void> {
+    EncryptionControl.verifyInlineControlRecord(message);
+
+    switch (message.descriptor.protocolPath) {
+    case ENCRYPTION_CONTROL_AUDIENCE_PATH:
+      await EncryptionControl.preProcessAudience(tenant, message, validationStateReader);
+      return;
+    case ENCRYPTION_CONTROL_DELIVERY_PATH:
+      await EncryptionControl.preProcessDelivery(tenant, message, validationStateReader);
+      return;
+    default:
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+        `unexpected encryption control path '${message.descriptor.protocolPath}'.`
+      );
+    }
+  }
+
+  public static async validateRecord(input: {
+    tenant: string;
+    message: RecordsWriteMessage;
+    dataBytes: Uint8Array;
+    validationStateReader: ValidationStateReader;
+  }): Promise<void> {
+    const { tenant, message, dataBytes, validationStateReader } = input;
+
+    switch (message.descriptor.protocolPath) {
+    case ENCRYPTION_CONTROL_AUDIENCE_PATH:
+      await EncryptionControl.validateAudience(tenant, message, dataBytes, validationStateReader);
+      return;
+    case ENCRYPTION_CONTROL_DELIVERY_PATH:
+      EncryptionControl.verifyEncryptedDelivery(message);
+      return;
+    default:
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+        `unexpected encryption control path '${message.descriptor.protocolPath}'.`
+      );
+    }
+  }
+
+  public static mapErrorToStatusCode(errorCode: string): number | undefined {
+    if (errorCode.startsWith('EncryptionControlValidate')) {
+      return 400;
+    }
+
+    return undefined;
+  }
+
+  private static async preProcessAudience(
+    tenant: string,
+    message: RecordsWriteMessage,
+    validationStateReader: ValidationStateReader,
+  ): Promise<void> {
+    if (message.encryption !== undefined) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+        'audience control records must be plaintext.'
+      );
+    }
+
+    const tags = EncryptionControl.getRoleAudienceKeyId(message, 'audience');
+    await EncryptionControl.verifyRoleAudienceDefinition(tenant, tags, message, validationStateReader, 'audience');
+  }
+
+  private static async preProcessDelivery(
+    tenant: string,
+    message: RecordsWriteMessage,
+    validationStateReader: ValidationStateReader,
+  ): Promise<void> {
+    EncryptionControl.verifyEncryptedDelivery(message);
+
+    if (message.descriptor.recipient === undefined) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateDeliveryRecipientMissing,
+        'delivery control records must have a recipient.'
+      );
+    }
+
+    const tags = EncryptionControl.getDeliveryTags(message);
+    const { protocolDefinition, ruleSet } = await EncryptionControl.verifyRoleAudienceDefinition(
+      tenant, tags, message, validationStateReader, 'delivery'
+    );
+    const audiences = await validationStateReader.queryAudienceRecords({
+      tenant,
+      protocol  : tags.protocol,
+      rolePath  : tags.rolePath,
+      contextId : tags.contextId,
+      keyId     : tags.keyId,
+    });
+    if (audiences.length === 0) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateDeliveryAudienceMissing,
+        'delivery control record references a missing audience.'
+      );
+    }
+
+    await EncryptionControl.verifyDeliveryRecipientAuthority({
+      tenant,
+      message,
+      tags,
+      protocolDefinition,
+      ruleSet,
+      validationStateReader,
+    });
+  }
+
+  private static async validateAudience(
+    tenant: string,
+    message: RecordsWriteMessage,
+    dataBytes: Uint8Array,
+    validationStateReader: ValidationStateReader,
+  ): Promise<void> {
+    if (message.encryption !== undefined) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+        'audience control records must be plaintext.'
+      );
+    }
+
+    const dataObject = JSON.parse(Encoder.bytesToString(dataBytes)) as EncryptionControlAudiencePayload;
+    validateJsonSchema('Audience', dataObject);
+
+    const tags = EncryptionControl.getRoleAudienceKeyId(message, 'audience');
+    EncryptionControl.verifyAudiencePayloadMatchesTags(dataObject, tags);
+
+    const audienceKeyId = await Encryption.getKeyId(dataObject.publicKeyJwk);
+    if (audienceKeyId !== dataObject.keyId) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateAudienceKeyIdMismatch,
+        'audience keyId must match publicKeyJwk thumbprint.'
+      );
+    }
+
+    const { ruleSet } = await EncryptionControl.verifyRoleAudienceDefinition(tenant, tags, message, validationStateReader, 'audience');
+    const sealingKeyId = await Encryption.getKeyId(ruleSet.$keyAgreement!.publicKeyJwk);
+    if (Object.is(sealingKeyId, dataObject.sealedPrivateKey.keyId)) {
+      return;
+    }
+
+    throw new DwnError(
+      DwnErrorCode.EncryptionControlValidateAudienceSealKeyIdMismatch,
+      'audience seal keyId must match the role path $keyAgreement public key thumbprint.'
+    );
+  }
+
+  private static verifyEncryptedDelivery(message: RecordsWriteMessage): void {
+    if (message.encryption === undefined) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+        'delivery control records must be encrypted.'
+      );
+    }
+  }
+
+  private static verifyInlineControlRecord(message: RecordsWriteMessage): void {
+    if (message.descriptor.dataSize > DwnConstant.maxDataSizeAllowedToBeEncoded) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+        'encryption control records must be small enough for inline validation.'
+      );
+    }
+  }
+
+  private static verifyAudiencePayloadMatchesTags(payload: RoleAudienceKeyId, tags: RoleAudienceKeyId): void {
+    if (payload.protocol !== tags.protocol ||
+        payload.rolePath !== tags.rolePath ||
+        payload.contextId !== tags.contextId ||
+        payload.keyId !== tags.keyId) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateAudienceTagsMismatch,
+        'audience tags must match payload fields.'
+      );
+    }
+  }
+
+  private static async verifyRoleAudienceDefinition(
+    tenant: string,
+    tags: RoleAudienceKeyId,
+    message: RecordsWriteMessage,
+    validationStateReader: ValidationStateReader,
+    recordType: 'audience' | 'delivery',
+  ): Promise<RoleAudienceDefinition> {
+    EncryptionControl.verifyRoleAudienceContext(tags.rolePath, tags.contextId);
+
+    if (tags.protocol !== message.descriptor.protocol) {
+      const errorCode = recordType === 'audience'
+        ? DwnErrorCode.EncryptionControlValidateAudienceTagsMismatch
+        : DwnErrorCode.EncryptionControlValidateDeliveryTagsMismatch;
+      throw new DwnError(
+        errorCode,
+        'control record protocol tag must match descriptor protocol.'
+      );
+    }
+
+    const protocolDefinition = await validationStateReader.fetchProtocolDefinition(
+      tenant,
+      tags.protocol,
+      message.descriptor.messageTimestamp,
+    );
+    const ruleSet = getRuleSetAtPath(tags.rolePath, protocolDefinition.structure);
+
+    if (ruleSet?.$role !== true || ruleSet.$keyAgreement === undefined) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateAudienceRolePathInvalid,
+        `role audience path '${tags.rolePath}' must be a role path with $keyAgreement.`
+      );
+    }
+
+    return { protocolDefinition, ruleSet };
+  }
+
+  private static verifyRoleAudienceContext(rolePath: string, contextId: string): void {
+    const parentDepth = rolePath.split('/').length - 1;
+    if ((parentDepth === 0 && contextId !== '') || (parentDepth > 0 && contextId === '')) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateAudienceContextIdInvalid,
+        'role audience contextId is inconsistent with role path depth.'
+      );
+    }
+  }
+
+  private static async resolveEffectiveControlActor(
+    tenant: string,
+    recordsWrite: RecordsWrite,
+    validationStateReader: ValidationStateReader,
+  ): Promise<EffectiveControlActor> {
+    if (recordsWrite.isSignedByAuthorDelegate) {
+      const grant = PermissionGrant.parse(recordsWrite.message.authorization.authorDelegatedGrant!);
+      await GrantAuthorization.performBaseValidation({
+        incomingMessage : recordsWrite.message,
+        expectedGrantor : recordsWrite.author!,
+        expectedGrantee : recordsWrite.signer!,
+        permissionGrant : grant,
+        validationStateReader,
+      });
+      EncryptionControl.verifyGrantConditions(recordsWrite.message, grant);
+      return { did: recordsWrite.signer, grant };
+    }
+
+    if (recordsWrite.isSignedByOwnerDelegate) {
+      const grant = PermissionGrant.parse(recordsWrite.message.authorization.ownerDelegatedGrant!);
+      await GrantAuthorization.performBaseValidation({
+        incomingMessage : recordsWrite.message,
+        expectedGrantor : recordsWrite.owner!,
+        expectedGrantee : recordsWrite.ownerSignatureSigner!,
+        permissionGrant : grant,
+        validationStateReader,
+      });
+      EncryptionControl.verifyGrantConditions(recordsWrite.message, grant);
+      return { did: recordsWrite.ownerSignatureSigner, grant };
+    }
+
+    if (recordsWrite.owner !== undefined) {
+      return { did: recordsWrite.owner };
+    }
+
+    const directGrantId = recordsWrite.signaturePayload === undefined
+      ? undefined
+      : Message.getPermissionGrantId(recordsWrite.signaturePayload);
+    if (directGrantId === undefined) {
+      return { did: recordsWrite.author };
+    }
+
+    const grant = await validationStateReader.fetchGrant(tenant, directGrantId);
+    await GrantAuthorization.performBaseValidation({
+      incomingMessage : recordsWrite.message,
+      expectedGrantor : tenant,
+      expectedGrantee : recordsWrite.author!,
+      permissionGrant : grant,
+      validationStateReader,
+    });
+    EncryptionControl.verifyGrantConditions(recordsWrite.message, grant);
+    return { did: recordsWrite.author, grant };
+  }
+
+  private static async verifyActorCanCreateRole(input: {
+    tenant: string;
+    actor: EffectiveControlActor;
+    tags: RoleAudienceKeyId;
+    protocolDefinition: ProtocolDefinition;
+    ruleSet: ProtocolRuleSet;
+    validationStateReader: ValidationStateReader;
+    message: RecordsWriteMessage;
+  }): Promise<void> {
+    const { tenant, actor, tags, protocolDefinition, ruleSet, validationStateReader, message } = input;
+    if (actor.did === tenant) {
+      return;
+    }
+
+    if (actor.did === undefined) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateAudienceWriterUnauthorized,
+        'control records must be written by a DID authorized to create the referenced role.'
+      );
+    }
+
+    if (actor.grant !== undefined && EncryptionControl.grantCoversRoleCreate(actor.grant, tags)) {
+      return;
+    }
+
+    const recordChain = await EncryptionControl.constructRoleParentChain(tenant, tags, validationStateReader);
+    const signaturePayload = Jws.decodePlainObjectPayload(message.authorization.signature);
+    for (const actionRule of ruleSet.$actions ?? []) {
+      if (!actionRule.can.includes(ProtocolAction.Create)) {
+        continue;
+      }
+
+      if (actionRule.who === ProtocolActor.Anyone) {
+        return;
+      }
+
+      if (await EncryptionControl.roleRuleAllowsActor(
+        tenant,
+        actor.did,
+        actionRule,
+        tags,
+        protocolDefinition,
+        validationStateReader,
+        signaturePayload.protocolRole,
+      )) {
+        return;
+      }
+
+      if (await checkActor(actor.did, actionRule, recordChain, protocolDefinition)) {
+        return;
+      }
+    }
+
+    throw new DwnError(
+      DwnErrorCode.EncryptionControlValidateAudienceWriterUnauthorized,
+      'control records must be written by a DID authorized to create the referenced role.'
+    );
+  }
+
+  private static async verifyDeliveryRecipientAuthority(input: {
+    tenant: string;
+    message: RecordsWriteMessage;
+    tags: EncryptionControlDeliveryTags;
+    protocolDefinition: ProtocolDefinition;
+    ruleSet: ProtocolRuleSet;
+    validationStateReader: ValidationStateReader;
+  }): Promise<void> {
+    const { tags } = input;
+
+    switch (tags.recipientAuthority) {
+    case EncryptionControlDeliveryRecipientAuthority.RoleHolder:
+      if (await EncryptionControl.deliveryRecipientIsRoleHolder(input)) {
+        return;
+      }
+      break;
+    case EncryptionControlDeliveryRecipientAuthority.RoleCreatorGrant:
+      if (await EncryptionControl.deliveryRecipientHasRoleCreateGrant(input)) {
+        return;
+      }
+      break;
+    case EncryptionControlDeliveryRecipientAuthority.RoleCreatorRole:
+      if (await EncryptionControl.deliveryRecipientHasRoleCreateRole(input)) {
+        return;
+      }
+      break;
+    case EncryptionControlDeliveryRecipientAuthority.RoleCreatorAnyone:
+      if (EncryptionControl.anyoneCanCreateRole(input.ruleSet)) {
+        return;
+      }
+      break;
+    default:
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateDeliveryRecipientAuthorityInvalid,
+        `unsupported delivery recipient authority '${tags.recipientAuthority}'.`
+      );
+    }
+
+    throw new DwnError(
+      DwnErrorCode.EncryptionControlValidateDeliveryRecipientUnauthorized,
+      'delivery recipient is not authorized for the referenced audience.'
+    );
+  }
+
+  private static async deliveryRecipientIsRoleHolder(input: {
+    tenant: string;
+    message: RecordsWriteMessage;
+    tags: EncryptionControlDeliveryTags;
+    validationStateReader: ValidationStateReader;
+  }): Promise<boolean> {
+    return EncryptionControl.hasRoleRecord(
+      input.tenant,
+      input.message.descriptor.recipient!,
+      input.tags.protocol,
+      input.tags.rolePath,
+      input.tags.contextId,
+      input.validationStateReader,
+    );
+  }
+
+  private static async deliveryRecipientHasRoleCreateGrant(input: {
+    tenant: string;
+    message: RecordsWriteMessage;
+    tags: EncryptionControlDeliveryTags;
+    validationStateReader: ValidationStateReader;
+  }): Promise<boolean> {
+    if (input.tags.grantId === undefined) {
+      return false;
+    }
+
+    const grant = await input.validationStateReader.fetchGrant(input.tenant, input.tags.grantId);
+    await GrantAuthorization.performBaseValidation({
+      incomingMessage       : input.message,
+      expectedGrantor       : input.tenant,
+      expectedGrantee       : input.message.descriptor.recipient!,
+      permissionGrant       : grant,
+      validationStateReader : input.validationStateReader,
+    });
+    return EncryptionControl.grantCoversRoleCreate(grant, input.tags);
+  }
+
+  private static async deliveryRecipientHasRoleCreateRole(input: {
+    tenant: string;
+    message: RecordsWriteMessage;
+    tags: EncryptionControlDeliveryTags;
+    protocolDefinition: ProtocolDefinition;
+    ruleSet: ProtocolRuleSet;
+    validationStateReader: ValidationStateReader;
+  }): Promise<boolean> {
+    if (input.tags.roleRef === undefined) {
+      return false;
+    }
+
+    for (const actionRule of input.ruleSet.$actions ?? []) {
+      if (!actionRule.can.includes(ProtocolAction.Create) || actionRule.role !== input.tags.roleRef) {
+        continue;
+      }
+
+      if (await EncryptionControl.roleRuleAllowsActor(
+        input.tenant,
+        input.message.descriptor.recipient!,
+        actionRule,
+        input.tags,
+        input.protocolDefinition,
+        input.validationStateReader,
+        input.tags.roleRef,
+      )) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private static anyoneCanCreateRole(ruleSet: ProtocolRuleSet): boolean {
+    return (ruleSet.$actions ?? []).some((actionRule: ProtocolActionRule): boolean =>
+      actionRule.who === ProtocolActor.Anyone && actionRule.can.includes(ProtocolAction.Create)
+    );
+  }
+
+  private static grantCoversRoleCreate(grant: PermissionGrant, tags: RoleAudienceKeyId): boolean {
+    const scope = grant.scope as RecordsPermissionScope;
+    if (scope.interface !== DwnInterfaceName.Records || scope.method !== DwnMethodName.Write) {
+      return false;
+    }
+
+    return PermissionScopeMatcher.matches(scope, {
+      protocol     : tags.protocol,
+      protocolPath : tags.rolePath,
+    });
+  }
+
+  private static verifyGrantConditions(message: RecordsWriteMessage, grant: PermissionGrant): void {
+    if (grant.conditions?.publication === PermissionConditionPublication.Required && message.descriptor.published !== true) {
+      throw new DwnError(
+        DwnErrorCode.RecordsGrantAuthorizationConditionPublicationRequired,
+        'Permission grant requires message to be published'
+      );
+    }
+
+    if (grant.conditions?.publication === PermissionConditionPublication.Prohibited && message.descriptor.published === true) {
+      throw new DwnError(
+        DwnErrorCode.RecordsGrantAuthorizationConditionPublicationProhibited,
+        'Permission grant prohibits message from being published'
+      );
+    }
+  }
+
+  private static async constructRoleParentChain(
+    tenant: string,
+    tags: RoleAudienceKeyId,
+    validationStateReader: ValidationStateReader,
+  ): Promise<RecordsWriteMessage[]> {
+    if (tags.contextId === '') {
+      return [];
+    }
+
+    const parentRecordId = tags.contextId.split('/').pop();
+    if (parentRecordId === undefined || parentRecordId === '') {
+      return [];
+    }
+
+    return validationStateReader.constructRecordChain(tenant, parentRecordId);
+  }
+
+  private static async roleRuleAllowsActor(
+    tenant: string,
+    actor: string,
+    actionRule: ProtocolActionRule,
+    tags: RoleAudienceKeyId,
+    protocolDefinition: ProtocolDefinition,
+    validationStateReader: ValidationStateReader,
+    invokedRole: string | undefined,
+  ): Promise<boolean> {
+    if (actionRule.role === undefined || invokedRole !== actionRule.role) {
+      return false;
+    }
+
+    const resolved = EncryptionControl.resolveRoleReference(actionRule.role, tags.protocol, protocolDefinition);
+    if (resolved === undefined) {
+      return false;
+    }
+
+    return EncryptionControl.hasRoleRecord(tenant, actor, resolved.protocol, resolved.protocolPath, tags.contextId, validationStateReader);
+  }
+
+  private static async hasRoleRecord(
+    tenant: string,
+    actor: string,
+    protocol: string,
+    rolePath: string,
+    contextId: string,
+    validationStateReader: ValidationStateReader,
+  ): Promise<boolean> {
+    const ancestorDepth = rolePath.split('/').length - 1;
+    let contextIdPrefix: string | undefined;
+    if (ancestorDepth > 0) {
+      contextIdPrefix = contextId.split('/').slice(0, ancestorDepth).join('/');
+      if (contextIdPrefix === '') {
+        return false;
+      }
+    }
+
+    return validationStateReader.hasMatchingRoleRecord({
+      tenant,
+      protocol,
+      protocolPath : rolePath,
+      recipient    : actor,
+      contextIdPrefix,
+    });
+  }
+
+  private static resolveRoleReference(
+    roleRef: string,
+    currentProtocol: string,
+    protocolDefinition: ProtocolDefinition,
+  ): { protocol: string; protocolPath: string } | undefined {
+    if (!isCrossProtocolRef(roleRef)) {
+      return { protocol: currentProtocol, protocolPath: roleRef };
+    }
+
+    const parsed = parseCrossProtocolRef(roleRef);
+    if (parsed === undefined) {
+      return undefined;
+    }
+
+    const protocol = protocolDefinition.uses?.[parsed.alias];
+    if (protocol === undefined) {
+      return undefined;
+    }
+
+    return { protocol, protocolPath: parsed.protocolPath };
+  }
+
+  private static getRoleAudienceKeyId(message: RecordsWriteMessage, recordType: 'audience' | 'delivery'): RoleAudienceKeyId {
+    return {
+      protocol  : EncryptionControl.getRequiredStringTag(message, 'protocol', recordType),
+      rolePath  : EncryptionControl.getRequiredStringTag(message, 'rolePath', recordType),
+      contextId : EncryptionControl.getRequiredStringTag(message, 'contextId', recordType),
+      keyId     : EncryptionControl.getRequiredStringTag(message, 'keyId', recordType),
+    };
+  }
+
+  private static getDeliveryTags(message: RecordsWriteMessage): EncryptionControlDeliveryTags {
+    const tags = EncryptionControl.getRoleAudienceKeyId(message, 'delivery');
+    return {
+      ...tags,
+      recipientAuthority : EncryptionControl.getRequiredStringTag(message, 'recipientAuthority', 'delivery') as EncryptionControlDeliveryTags['recipientAuthority'],
+      grantId            : EncryptionControl.getOptionalStringTag(message.descriptor.tags, 'grantId'),
+      roleRef            : EncryptionControl.getOptionalStringTag(message.descriptor.tags, 'roleRef'),
+    };
+  }
+
+  private static getRecordType(message: RecordsWriteMessage): 'audience' | 'delivery' {
+    return message.descriptor.protocolPath === ENCRYPTION_CONTROL_DELIVERY_PATH ? 'delivery' : 'audience';
+  }
+
+  private static getRequiredStringTag(message: RecordsWriteMessage, tag: string, recordType: 'audience' | 'delivery'): string {
+    const value = message.descriptor.tags?.[tag];
+    if (typeof value !== 'string') {
+      const errorCode = recordType === 'audience'
+        ? DwnErrorCode.EncryptionControlValidateAudienceMissingRequiredTag
+        : DwnErrorCode.EncryptionControlValidateDeliveryMissingRequiredTag;
+      throw new DwnError(
+        errorCode,
+        `${recordType} control records must include string tag '${tag}'.`
+      );
+    }
+
+    return value;
+  }
+
+  private static getOptionalStringTag(tags: RecordsWriteTags | undefined, tag: string): string | undefined {
+    const value = tags?.[tag];
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== 'string') {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateDeliveryMissingRequiredTag,
+        `delivery control tag '${tag}' must be a string.`
+      );
+    }
+
+    return value;
+  }
+}

--- a/packages/dwn-sdk-js/src/core/protocol-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization.ts
@@ -8,6 +8,7 @@ import type { RecordsWriteMessage } from '../types/records-types.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
 import type { ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
 
+import { EncryptionControl } from './encryption-control.js';
 import { getRuleSetAtPath } from '../utils/protocols.js';
 import { isEncryptionControlPath } from './constants.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
@@ -37,10 +38,8 @@ export class ProtocolAuthorization {
     validationStateReader: ValidationStateReader,
   ): Promise<ProtocolRuleSet> {
     if (isEncryptionControlPath(incomingMessage.message.descriptor.protocolPath)) {
-      throw new DwnError(
-        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
-        `reserved encryption control path '${incomingMessage.message.descriptor.protocolPath}' requires encryption control validation.`
-      );
+      await EncryptionControl.validateReferentialIntegrity(tenant, incomingMessage, validationStateReader);
+      return {};
     }
 
     const protocolDefinitionTimestamp = incomingMessage.message.descriptor.messageTimestamp;

--- a/packages/dwn-sdk-js/src/core/recording-validation-state-reader.ts
+++ b/packages/dwn-sdk-js/src/core/recording-validation-state-reader.ts
@@ -101,6 +101,18 @@ export class RecordingValidationStateReader implements ValidationStateReader {
   }
 
   /** @inheritdoc */
+  public async queryAudienceRecords(input: {
+    tenant: string;
+    protocol: string;
+    rolePath: string;
+    contextId: string;
+    keyId?: string;
+  }): Promise<RecordsWriteMessage[]> {
+    this.recordedReads.push({ method: 'queryAudienceRecords' });
+    return this.inner.queryAudienceRecords(input);
+  }
+
+  /** @inheritdoc */
   public async fetchGrant(tenant: string, permissionGrantId: string): Promise<PermissionGrant> {
     this.recordedReads.push({ method: 'fetchGrant' });
     return this.inner.fetchGrant(tenant, permissionGrantId);

--- a/packages/dwn-sdk-js/src/core/validation-state-reader.ts
+++ b/packages/dwn-sdk-js/src/core/validation-state-reader.ts
@@ -7,7 +7,6 @@ import type { ValidationStateReader } from '../types/validation-state-reader.js'
 import type { DataEncodedRecordsWriteMessage, RecordsWriteMessage } from '../types/records-types.js';
 import type { ProtocolDefinition, ProtocolsConfigureMessage } from '../types/protocols-types.js';
 
-import { ENCRYPTION_PROTOCOL_URI } from './constants.js';
 import { FilterUtility } from '../utils/filter.js';
 import { PermissionGrant } from '../protocols/permission-grant.js';
 import { PermissionsProtocol } from '../protocols/permissions.js';
@@ -15,6 +14,7 @@ import { RecordsWrite } from '../interfaces/records-write.js';
 import { SortDirection } from '../types/query-types.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_PROTOCOL_URI } from './constants.js';
 import { fetchInitialRecordsWrite, fetchInitialRecordsWriteMessage, getInitialWrite } from '../interfaces/records-write-query.js';
 
 /**
@@ -185,6 +185,33 @@ export class StoreValidationStateReader implements ValidationStateReader {
       'tag.contextId'   : input.contextId,
       'tag.role'        : input.role,
       'tag.epoch'       : input.epoch,
+    };
+
+    if (input.keyId !== undefined) {
+      filter['tag.keyId'] = input.keyId;
+    }
+
+    const { messages } = await this.messageStore.query(input.tenant, [filter]);
+    return messages as RecordsWriteMessage[];
+  }
+
+  /** @inheritdoc */
+  public async queryAudienceRecords(input: {
+    tenant: string;
+    protocol: string;
+    rolePath: string;
+    contextId: string;
+    keyId?: string;
+  }): Promise<RecordsWriteMessage[]> {
+    const filter: Filter = {
+      interface         : DwnInterfaceName.Records,
+      method            : DwnMethodName.Write,
+      isLatestBaseState : true,
+      protocol          : input.protocol,
+      protocolPath      : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+      'tag.protocol'    : input.protocol,
+      'tag.rolePath'    : input.rolePath,
+      'tag.contextId'   : input.contextId,
     };
 
     if (input.keyId !== undefined) {

--- a/packages/dwn-sdk-js/src/handlers/records-delete.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-delete.ts
@@ -6,6 +6,7 @@ import type { HandlerDependencies, MethodHandler } from '../types/method-handler
 
 import { authenticate } from '../core/auth.js';
 import { DwnInterfaceName } from '../enums/dwn-interface-method.js';
+import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
@@ -13,6 +14,7 @@ import { Records } from '../utils/records.js';
 import { RecordsDelete } from '../interfaces/records-delete.js';
 import { RecordsGrantAuthorization } from '../core/records-grant-authorization.js';
 import { ResumableTaskName } from '../core/resumable-task-manager.js';
+import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
 export class RecordsDeleteHandler implements MethodHandler {
 
@@ -71,6 +73,12 @@ export class RecordsDeleteHandler implements MethodHandler {
       // but if the latest record state is a RecordsDelete (ie. when we are pruning a non-prune delete),
       // we'd need to use the initial write because RecordsDelete does not contain the immutable properties needed for processing.
       const initialWrite = await this.deps.validationStateReader.fetchInitialRecordsWrite(tenant, message.descriptor.recordId);
+      if (EncryptionControl.isControlMessage(initialWrite!.message)) {
+        throw new DwnError(
+          DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+          'encryption control records cannot be deleted.'
+        );
+      }
 
       await this.authorizeRecordsDelete(
         tenant,
@@ -79,6 +87,13 @@ export class RecordsDeleteHandler implements MethodHandler {
       );
 
     } catch (e) {
+      if (e instanceof DwnError) {
+        const statusCode = EncryptionControl.mapErrorToStatusCode(e.code);
+        if (statusCode !== undefined) {
+          return messageReplyFromError(e, statusCode);
+        }
+      }
+
       return messageReplyFromError(e, 401);
     }
 

--- a/packages/dwn-sdk-js/src/handlers/records-write.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-write.ts
@@ -8,6 +8,7 @@ import { Cid } from '../utils/cid.js';
 import { DataStream } from '../utils/data-stream.js';
 import { DwnConstant } from '../core/dwn-constant.js';
 import { Encoder } from '../utils/encoder.js';
+import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
@@ -135,6 +136,15 @@ export class RecordsWriteHandler implements MethodHandler {
       if (coreProtocol?.preProcessWrite !== undefined) {
         await coreProtocol.preProcessWrite(tenant, message, this.deps.validationStateReader);
       }
+      if (EncryptionControl.isControlMessage(message)) {
+        await EncryptionControl.preProcessWrite(tenant, message, this.deps.validationStateReader);
+        if (dataStream === undefined) {
+          throw new DwnError(
+            DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+            'encryption control records require data.'
+          );
+        }
+      }
 
       // NOTE: We allow isLatestBaseState to be true ONLY if the incoming message comes with data, or if the incoming message is NOT an initial write
       // This would allow an initial write to be written to the DB without data, but having it not queryable,
@@ -170,6 +180,7 @@ export class RecordsWriteHandler implements MethodHandler {
           error.code === DwnErrorCode.RecordsWriteDataCidMismatch ||
           error.code === DwnErrorCode.RecordsWriteDataSizeMismatch ||
           error.code.startsWith('SchemaValidator') ||
+          EncryptionControl.mapErrorToStatusCode(error.code) !== undefined ||
           this.deps.coreProtocols?.mapErrorToStatusCode(error.code) !== undefined) {
           return messageReplyFromError(error, 400);
         }
@@ -245,6 +256,9 @@ export class RecordsWriteHandler implements MethodHandler {
         : this.deps.coreProtocols?.get(message.descriptor.protocol);
       if (coreProtocol?.validateRecord !== undefined) {
         await coreProtocol.validateRecord(message, dataBytes);
+      }
+      if (EncryptionControl.isControlMessage(message)) {
+        await EncryptionControl.validateRecord({ tenant, message, dataBytes, validationStateReader: this.deps.validationStateReader });
       }
 
       messageWithOptionalEncodedData = await this.cloneAndAddEncodedData(message, dataBytes);
@@ -412,6 +426,11 @@ export class RecordsWriteHandler implements MethodHandler {
         DwnErrorCode.RecordsWriteOwnerAndTenantMismatch,
         `Owner ${recordsWrite.owner} must be the same as tenant ${tenant} when specified.`
       );
+    }
+
+    if (EncryptionControl.isControlMessage(recordsWrite.message)) {
+      await EncryptionControl.authorizeWrite(tenant, recordsWrite, this.deps.validationStateReader);
+      return;
     }
 
     if (recordsWrite.isSignedByAuthorDelegate) {

--- a/packages/dwn-sdk-js/src/types/validation-state-reader.ts
+++ b/packages/dwn-sdk-js/src/types/validation-state-reader.ts
@@ -92,6 +92,17 @@ export interface ValidationStateReader {
   }): Promise<RecordsWriteMessage[]>;
 
   /**
+   * Queries accepted source-protocol-native audience control records by role-audience coordinates.
+   */
+  queryAudienceRecords(input: {
+    tenant: string;
+    protocol: string;
+    rolePath: string;
+    contextId: string;
+    keyId?: string;
+  }): Promise<RecordsWriteMessage[]>;
+
+  /**
    * Fetches the permission grant with the given record ID, with its scope parsed from grant data.
    * @throws {DwnError} with `GrantAuthorizationGrantMissing` when the grant does not exist.
    */

--- a/packages/dwn-sdk-js/tests/core/validation-state-reader.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/validation-state-reader.spec.ts
@@ -13,6 +13,7 @@ import nestedProtocolDefinition from '../vectors/protocol-definitions/nested.jso
 import { DataStream } from '../../src/utils/data-stream.js';
 import { Dwn } from '../../src/dwn.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH } from '../../src/core/constants.js';
 import { EncryptionProtocol } from '../../src/protocols/encryption.js';
 import { Jws } from '../../src/utils/jws.js';
 import { RecordingValidationStateReader } from '../../src/core/recording-validation-state-reader.js';
@@ -900,6 +901,70 @@ describe('StoreValidationStateReader', () => {
       expect(capturedFilters?.[0]['tag.keyId']).toBeUndefined();
     });
   });
+
+  describe('queryAudienceRecords()', () => {
+    it('should query accepted source-protocol audience records by audience coordinates', async () => {
+      const message = { recordId: 'audience1' } as RecordsWriteMessage;
+      let capturedTenant: string | undefined;
+      let capturedFilters: Filter[] | undefined;
+      const messageStore = {
+        query: async (tenant: string, filters: Filter[]): Promise<{ messages: GenericMessage[] }> => {
+          capturedTenant = tenant;
+          capturedFilters = filters;
+          return { messages: [message] };
+        },
+      } as unknown as MessageStore;
+      const reader = new StoreValidationStateReader({
+        dataStore: {} as DataStore,
+        messageStore,
+      });
+
+      const messages = await reader.queryAudienceRecords({
+        tenant    : 'did:example:alice',
+        protocol  : 'https://example.com/protocol/chat',
+        contextId : 'chat1',
+        rolePath  : 'chat/member',
+        keyId     : 'abc',
+      });
+
+      expect(messages).toEqual([message]);
+      expect(capturedTenant).toBe('did:example:alice');
+      expect(capturedFilters).toEqual([{
+        interface         : DwnInterfaceName.Records,
+        method            : DwnMethodName.Write,
+        isLatestBaseState : true,
+        protocol          : 'https://example.com/protocol/chat',
+        protocolPath      : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+        'tag.protocol'    : 'https://example.com/protocol/chat',
+        'tag.rolePath'    : 'chat/member',
+        'tag.contextId'   : 'chat1',
+        'tag.keyId'       : 'abc',
+      }]);
+    });
+
+    it('should omit keyId from source-protocol audience queries when not supplied', async () => {
+      let capturedFilters: Filter[] | undefined;
+      const messageStore = {
+        query: async (_tenant: string, filters: Filter[]): Promise<{ messages: GenericMessage[] }> => {
+          capturedFilters = filters;
+          return { messages: [] };
+        },
+      } as unknown as MessageStore;
+      const reader = new StoreValidationStateReader({
+        dataStore: {} as DataStore,
+        messageStore,
+      });
+
+      await reader.queryAudienceRecords({
+        tenant    : 'did:example:alice',
+        protocol  : 'https://example.com/protocol/chat',
+        contextId : '',
+        rolePath  : 'member',
+      });
+
+      expect(capturedFilters?.[0]['tag.keyId']).toBeUndefined();
+    });
+  });
 });
 
 describe('RecordingValidationStateReader', () => {
@@ -921,6 +986,29 @@ describe('RecordingValidationStateReader', () => {
 
       expect(messages).toEqual([message]);
       expect(reader.reads).toEqual([{ method: 'queryAudienceEpochs' }]);
+
+      reader.clearRecordedReads();
+      expect(reader.reads).toEqual([]);
+    });
+  });
+
+  describe('queryAudienceRecords()', () => {
+    it('should record source-protocol audience reads before delegating', async () => {
+      const message = { recordId: 'audience1' } as RecordsWriteMessage;
+      const inner = {
+        queryAudienceRecords: async (): Promise<RecordsWriteMessage[]> => [message],
+      } as unknown as ValidationStateReader;
+      const reader = new RecordingValidationStateReader(inner);
+
+      const messages = await reader.queryAudienceRecords({
+        tenant    : 'did:example:alice',
+        protocol  : 'https://example.com/protocol/chat',
+        contextId : 'chat1',
+        rolePath  : 'chat/member',
+      });
+
+      expect(messages).toEqual([message]);
+      expect(reader.reads).toEqual([{ method: 'queryAudienceRecords' }]);
 
       reader.clearRecordedReads();
       expect(reader.reads).toEqual([]);

--- a/packages/dwn-sdk-js/tests/handlers/records-delete.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-delete.spec.ts
@@ -5,6 +5,7 @@ import type {
   DataStore,
   MessageStore,
   ProtocolDefinition,
+  ProtocolRuleSet,
   RecordsDeleteMessage,
   RecordsWriteMessage,
   ResumableTaskStore,
@@ -23,6 +24,7 @@ import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread
 
 import { ArrayUtility } from '../../src/utils/array.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH } from '../../src/core/constants.js';
 import { Message } from '../../src/core/message.js';
 import { normalizeSchemaUrl } from '../../src/utils/url.js';
 import { Poller } from '../utils/poller.js';
@@ -32,9 +34,10 @@ import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { Time } from '../../src/utils/time.js';
-import { DataStream, Dwn, Encoder, Jws, MessageStoreLevel, PermissionsProtocol, RecordsDelete, RecordsRead, RecordsWrite } from '../../src/index.js';
+import { DataStream, Dwn, Encoder, Jws, MessageStoreLevel, PermissionsProtocol, Protocols, RecordsDelete, RecordsRead, RecordsWrite } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
+import { Encryption, KeyAgreementAlgorithm } from '../../src/utils/encryption.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
 
@@ -212,6 +215,78 @@ export function testRecordsDeleteHandler(): void {
 
         const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
         expect(deleteReply.status.code).toBe(404);
+      });
+
+      it('should reject deleting encryption control records', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-delete-rejected.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await Protocols.deriveAndInjectPublicEncryptionKeys(
+          protocolDefinition, alice.keyId, alice.encryptionKeyPair.privateJwk
+        );
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author             : alice,
+          protocolDefinition : encryptedProtocolDefinition,
+        });
+        expect((await dwn.processMessage(alice.did, protocolConfig.message)).status.code).toBe(202);
+
+        const roleRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audienceKeyId = await Encryption.getKeyId(alice.encryptionKeyPair.publicJwk);
+        const sealKeyId = await Encryption.getKeyId(roleRuleSet.$keyAgreement!.publicKeyJwk);
+        const audienceData = Encoder.objectToBytes({
+          protocol         : protocolDefinition.protocol,
+          rolePath         : 'member',
+          contextId        : '',
+          keyId            : audienceKeyId,
+          publicKeyJwk     : alice.encryptionKeyPair.publicJwk,
+          sealedPrivateKey : {
+            algorithm          : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+            derivationScheme   : 'seal',
+            keyId              : sealKeyId,
+            ephemeralPublicKey : alice.encryptionKeyPair.publicJwk,
+            encryptedKey       : Encoder.bytesToBase64Url(TestDataGenerator.randomBytes(32)),
+          },
+        });
+        const audience = await RecordsWrite.create({
+          data         : audienceData,
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          schema       : 'https://identity.foundation/dwn/json-schemas/encryption/audience.json',
+          signer       : Jws.createSigner(alice),
+          tags         : {
+            protocol  : protocolDefinition.protocol,
+            rolePath  : 'member',
+            contextId : '',
+            keyId     : audienceKeyId,
+          },
+        });
+        const writeReply = await dwn.processMessage(alice.did, audience.message, { dataStream: DataStream.fromBytes(audienceData) });
+        expect(writeReply.status.code).toBe(202);
+
+        const recordsDelete = await RecordsDelete.create({
+          recordId : audience.message.recordId,
+          signer   : Jws.createSigner(alice),
+        });
+        const deleteReply = await dwn.processMessage(alice.did, recordsDelete.message);
+        expect(deleteReply.status.code).toBe(400);
+        expect(deleteReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateUnexpectedRecord);
+
+        const queryData = await TestDataGenerator.generateRecordsQuery({
+          author : alice,
+          filter : { recordId: audience.message.recordId },
+        });
+        const queryReply = await dwn.processMessage(alice.did, queryData.message);
+        expect(queryReply.status.code).toBe(200);
+        expect(queryReply.entries?.length).toBe(1);
       });
 
       it('should apply a tombstone over a newer RecordsWrite (delete-wins)', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -2,7 +2,8 @@ import type { DidResolver } from '@enbox/dids';
 import type { EncryptionInput } from '../../src/interfaces/records-write.js';
 import type { EventLog } from '../../src/types/subscriptions.js';
 import type { GenerateFromRecordsWriteOut } from '../utils/test-data-generator.js';
-import type { RecordsQueryReplyEntry } from '../../src/types/records-types.js';
+import type { Persona } from '../utils/test-data-generator.js';
+import type { DataEncodedRecordsWriteMessage, RecordsQueryReplyEntry } from '../../src/types/records-types.js';
 import type { DataStore, MessageStore, ResumableTaskStore } from '../../src/index.js';
 import type { ProtocolDefinition, ProtocolRuleSet } from '../../src/types/protocols-types.js';
 
@@ -29,6 +30,9 @@ import { Cid } from '../../src/utils/cid.js';
 import { DataStream } from '../../src/utils/data-stream.js';
 import { Dwn } from '../../src/dwn.js';
 import { Encoder } from '../../src/utils/encoder.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH } from '../../src/core/constants.js';
+import { ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
+import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import { GeneralJwsBuilder } from '../../src/jose/jws/general/builder.js';
 import { Jws } from '../../src/utils/jws.js';
 import { Message } from '../../src/core/message.js';
@@ -46,9 +50,15 @@ import { CoreProtocolRegistry, DataStoreLevel, DwnConstant, DwnInterfaceName, Dw
 import { defaultTestProtocolDefinition, TestDataGenerator } from '../utils/test-data-generator.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnError, DwnErrorCode } from '../../src/core/dwn-error.js';
-import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
+
+type AudienceControlWrite = {
+  dataBytes: Uint8Array;
+  keyId: string;
+  payload: Record<string, unknown>;
+  recordsWrite: RecordsWrite;
+};
 
 export function testRecordsWriteHandler(): void {
   describe('RecordsWriteHandler.handle()', () => {
@@ -91,6 +101,137 @@ export function testRecordsWriteHandler(): void {
         await dwn.close();
       });
 
+      async function installEncryptedProtocol(author: Persona, protocolDefinition: ProtocolDefinition): Promise<ProtocolDefinition> {
+        const encryptedProtocolDefinition = await Protocols.deriveAndInjectPublicEncryptionKeys(
+          protocolDefinition, author.keyId, author.encryptionKeyPair.privateJwk
+        );
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author,
+          protocolDefinition: encryptedProtocolDefinition,
+        });
+        expect((await dwn.processMessage(author.did, protocolConfig.message)).status.code).toBe(202);
+
+        return encryptedProtocolDefinition;
+      }
+
+      async function createAudienceControlWrite(input: {
+        author: Persona;
+        contextId?: string;
+        delegatedGrant?: DataEncodedRecordsWriteMessage;
+        payloadOverrides?: Record<string, unknown>;
+        permissionGrantId?: string;
+        protocol: string;
+        protocolRole?: string;
+        published?: boolean;
+        rolePath: string;
+        roleRuleSet: ProtocolRuleSet;
+        sealKeyId?: string;
+        signer?: Persona;
+        tags?: Record<string, string>;
+      }): Promise<AudienceControlWrite> {
+        const audiencePublicKeyJwk = input.author.encryptionKeyPair.publicJwk;
+        const audienceKeyId = await Encryption.getKeyId(audiencePublicKeyJwk);
+        const sealKeyId = input.sealKeyId ?? await Encryption.getKeyId(input.roleRuleSet.$keyAgreement!.publicKeyJwk);
+        const payload = {
+          protocol         : input.protocol,
+          rolePath         : input.rolePath,
+          contextId        : input.contextId ?? '',
+          keyId            : audienceKeyId,
+          publicKeyJwk     : audiencePublicKeyJwk,
+          sealedPrivateKey : {
+            algorithm          : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+            derivationScheme   : 'seal',
+            keyId              : sealKeyId,
+            ephemeralPublicKey : input.author.encryptionKeyPair.publicJwk,
+            encryptedKey       : Encoder.bytesToBase64Url(TestDataGenerator.randomBytes(32)),
+          },
+          ...input.payloadOverrides,
+        };
+        const dataBytes = Encoder.objectToBytes(payload);
+        const recordsWrite = await RecordsWrite.create({
+          data              : dataBytes,
+          dataFormat        : 'application/json',
+          delegatedGrant    : input.delegatedGrant,
+          permissionGrantId : input.permissionGrantId,
+          protocol          : input.protocol,
+          protocolPath      : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          protocolRole      : input.protocolRole,
+          published         : input.published,
+          schema            : 'https://identity.foundation/dwn/json-schemas/encryption/audience.json',
+          signer            : Jws.createSigner(input.signer ?? input.author),
+          tags              : {
+            protocol  : input.protocol,
+            rolePath  : input.rolePath,
+            contextId : input.contextId ?? '',
+            keyId     : audienceKeyId,
+            ...input.tags,
+          },
+        });
+
+        return {
+          dataBytes,
+          keyId: audienceKeyId,
+          payload,
+          recordsWrite,
+        };
+      }
+
+      async function createDeliveryControlWrite(input: {
+        author: Persona;
+        contextId?: string;
+        keyId: string;
+        protocol: string;
+        recipient: string;
+        recipientAuthority: string;
+        rolePath: string;
+        roleRuleSet: ProtocolRuleSet;
+        grantId?: string;
+        roleRef?: string;
+      }): Promise<{ dataBytes: Uint8Array; recordsWrite: RecordsWrite }> {
+        const tags: Record<string, string> = {
+          protocol           : input.protocol,
+          rolePath           : input.rolePath,
+          contextId          : input.contextId ?? '',
+          keyId              : input.keyId,
+          recipientAuthority : input.recipientAuthority,
+        };
+        if (input.grantId !== undefined) {
+          tags.grantId = input.grantId;
+        }
+        if (input.roleRef !== undefined) {
+          tags.roleRef = input.roleRef;
+        }
+
+        const dataBytes = Encoder.objectToBytes({
+          protocol  : input.protocol,
+          rolePath  : input.rolePath,
+          contextId : input.contextId ?? '',
+          keyId     : input.keyId,
+        });
+        const recordsWrite = await RecordsWrite.create({
+          data            : dataBytes,
+          dataFormat      : 'application/json',
+          encryptionInput : {
+            initializationVector : TestDataGenerator.randomBytes(16),
+            key                  : TestDataGenerator.randomBytes(32),
+            keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+              keyId            : await Encryption.getKeyId(input.roleRuleSet.$keyAgreement!.publicKeyJwk),
+              publicKey        : input.roleRuleSet.$keyAgreement!.publicKeyJwk,
+              derivationScheme : KeyDerivationScheme.ProtocolPath,
+            }],
+          },
+          protocol     : input.protocol,
+          protocolPath : ENCRYPTION_CONTROL_DELIVERY_PATH,
+          recipient    : input.recipient,
+          schema       : 'https://identity.foundation/dwn/json-schemas/encryption/delivery.json',
+          signer       : Jws.createSigner(input.author),
+          tags,
+        });
+
+        return { dataBytes, recordsWrite };
+      }
+
       it('should dispatch preProcessWrite hook via CoreProtocolRegistry and abort before storage on failure', async () => {
         // Register a mock core protocol whose preProcessWrite hook throws.
         // Verify that authorization completes but processMessageWithDataStream is never reached.
@@ -127,22 +268,1027 @@ export function testRecordsWriteHandler(): void {
         (coreProtocols as any)._protocols.delete(protocolUri);
       });
 
-      it('should fail closed for exact reserved encryption control paths before ordinary protocol authorization', async () => {
+      it('should accept tenant-authored audience control records at the reserved source-protocol path', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
-        await TestDataGenerator.installDefaultTestProtocol(dwn, alice);
 
-        for (const protocolPath of [ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH]) {
-          const { message, dataStream } = await TestDataGenerator.generateRecordsWrite({
-            author   : alice,
-            protocol : defaultTestProtocolDefinition.protocol,
-            protocolPath,
-          });
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-audience-accepted.xyz',
+          published : false,
+          types     : {
+            member  : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+            message : { schema: 'http://message-schema', dataFormats: ['text/plain'] },
+          },
+          structure: {
+            member  : { $role: true },
+            message : {},
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const roleRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
 
-          const reply = await dwn.processMessage(alice.did, message, { dataStream });
+        const reply = await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) });
 
-          expect(reply.status.code).toBe(400);
-          expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateUnexpectedRecord);
-        }
+        expect(reply.status.code).toBe(202);
+      });
+
+      it('should reject dataless and update attempts for immutable audience control records', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-audience-immutable.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const roleRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) })).status.code
+        ).toBe(202);
+
+        const updateData = Encoder.objectToBytes({ ...audience.payload, publicKeyJwk: roleRuleSet.$keyAgreement!.publicKeyJwk });
+        const update = await RecordsWrite.createFrom({
+          data                : updateData,
+          recordsWriteMessage : audience.recordsWrite.message,
+          signer              : Jws.createSigner(alice),
+        });
+        const updateReply = await dwn.processMessage(alice.did, update.message, { dataStream: DataStream.fromBytes(updateData) });
+        expect(updateReply.status.code).toBe(400);
+        expect(updateReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateUnexpectedRecord);
+
+        const datalessAudience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
+        const datalessReply = await dwn.processMessage(alice.did, datalessAudience.recordsWrite.message);
+        expect(datalessReply.status.code).toBe(400);
+        expect(datalessReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateUnexpectedRecord);
+      });
+
+      it('should reject audience control records whose seal keyId does not match the role path key', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-audience-seal-mismatch.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const roleRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author    : alice,
+          protocol  : protocolDefinition.protocol,
+          rolePath  : 'member',
+          roleRuleSet,
+          sealKeyId : await Encryption.getKeyId(bob.encryptionKeyPair.publicJwk),
+        });
+
+        const reply = await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) });
+
+        expect(reply.status.code).toBe(400);
+        expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateAudienceSealKeyIdMismatch);
+      });
+
+      it('should reject malformed audience control tags as bad input before authorization', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const dataBytes = Encoder.objectToBytes({
+          protocol         : 'http://encryption-control-audience-malformed-tags.xyz',
+          rolePath         : 'member',
+          contextId        : '',
+          keyId            : await Encryption.getKeyId(alice.encryptionKeyPair.publicJwk),
+          publicKeyJwk     : alice.encryptionKeyPair.publicJwk,
+          sealedPrivateKey : {
+            algorithm          : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+            derivationScheme   : 'seal',
+            keyId              : await Encryption.getKeyId(alice.encryptionKeyPair.publicJwk),
+            ephemeralPublicKey : alice.encryptionKeyPair.publicJwk,
+            encryptedKey       : Encoder.bytesToBase64Url(TestDataGenerator.randomBytes(32)),
+          },
+        });
+        const audience = await RecordsWrite.create({
+          data         : dataBytes,
+          dataFormat   : 'application/json',
+          protocol     : 'http://encryption-control-audience-malformed-tags.xyz',
+          protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          schema       : 'https://identity.foundation/dwn/json-schemas/encryption/audience.json',
+          signer       : Jws.createSigner(alice),
+          tags         : {
+            protocol  : 'http://encryption-control-audience-malformed-tags.xyz',
+            rolePath  : 'member',
+            contextId : '',
+          },
+        });
+
+        const reply = await dwn.processMessage(alice.did, audience.message, { dataStream: DataStream.fromBytes(dataBytes) });
+
+        expect(reply.status.code).toBe(400);
+        expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateAudienceMissingRequiredTag);
+      });
+
+      it('should reject delivery control records that reference a missing audience', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-delivery-missing-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const roleRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const rolePublicKey = roleRuleSet.$keyAgreement!.publicKeyJwk;
+        const missingAudienceKeyId = await Encryption.getKeyId(alice.encryptionKeyPair.publicJwk);
+        const dataBytes = Encoder.objectToBytes({ encrypted: true });
+        const delivery = await RecordsWrite.create({
+          data            : dataBytes,
+          dataFormat      : 'application/json',
+          encryptionInput : {
+            initializationVector : TestDataGenerator.randomBytes(16),
+            key                  : TestDataGenerator.randomBytes(32),
+            keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+              keyId            : await Encryption.getKeyId(rolePublicKey),
+              publicKey        : rolePublicKey,
+              derivationScheme : KeyDerivationScheme.ProtocolPath,
+            }],
+          },
+          protocol     : protocolDefinition.protocol,
+          protocolPath : ENCRYPTION_CONTROL_DELIVERY_PATH,
+          recipient    : alice.did,
+          schema       : 'https://identity.foundation/dwn/json-schemas/encryption/delivery.json',
+          signer       : Jws.createSigner(alice),
+          tags         : {
+            protocol           : protocolDefinition.protocol,
+            rolePath           : 'member',
+            contextId          : '',
+            keyId              : missingAudienceKeyId,
+            recipientAuthority : 'roleHolder',
+          },
+        });
+
+        const reply = await dwn.processMessage(alice.did, delivery.message, { dataStream: DataStream.fromBytes(dataBytes) });
+
+        expect(reply.status.code).toBe(400);
+        expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateDeliveryAudienceMissing);
+      });
+
+      it('should accept delivery control records for recipients authorized to create the role through a role', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-delivery-role-creator.xyz',
+          published : false,
+          types     : {
+            admin  : { schema: 'http://admin-schema', dataFormats: ['application/json'] },
+            member : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            admin  : { $role: true },
+            member : {
+              $role    : true,
+              $actions : [{ role: 'admin', can: ['create'] }],
+            },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const memberRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : memberRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) })).status.code
+        ).toBe(202);
+
+        const adminRole = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('bob is an admin'),
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'admin',
+          recipient    : bob.did,
+          schema       : 'http://admin-schema',
+        });
+        expect((await dwn.processMessage(alice.did, adminRole.message, { dataStream: adminRole.dataStream })).status.code).toBe(202);
+
+        const deliveryData = Encoder.objectToBytes({ encrypted: true });
+        const delivery = await RecordsWrite.create({
+          data            : deliveryData,
+          dataFormat      : 'application/json',
+          encryptionInput : {
+            initializationVector : TestDataGenerator.randomBytes(16),
+            key                  : TestDataGenerator.randomBytes(32),
+            keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+              keyId            : await Encryption.getKeyId(memberRuleSet.$keyAgreement!.publicKeyJwk),
+              publicKey        : memberRuleSet.$keyAgreement!.publicKeyJwk,
+              derivationScheme : KeyDerivationScheme.ProtocolPath,
+            }],
+          },
+          protocol     : protocolDefinition.protocol,
+          protocolPath : ENCRYPTION_CONTROL_DELIVERY_PATH,
+          recipient    : bob.did,
+          schema       : 'https://identity.foundation/dwn/json-schemas/encryption/delivery.json',
+          signer       : Jws.createSigner(alice),
+          tags         : {
+            protocol           : protocolDefinition.protocol,
+            rolePath           : 'member',
+            contextId          : '',
+            keyId              : audience.keyId,
+            recipientAuthority : 'roleCreatorRole',
+            roleRef            : 'admin',
+          },
+        });
+
+        const reply = await dwn.processMessage(alice.did, delivery.message, { dataStream: DataStream.fromBytes(deliveryData) });
+
+        expect(reply.status.code).toBe(202);
+      });
+
+      it('should reject role-creator delivery control records when the role cannot create the audience role', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-delivery-role-creator-rejected.xyz',
+          published : false,
+          types     : {
+            admin  : { schema: 'http://admin-schema', dataFormats: ['application/json'] },
+            member : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            admin  : { $role: true },
+            member : { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const memberRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : memberRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) })).status.code
+        ).toBe(202);
+
+        const adminRole = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('bob is an admin'),
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'admin',
+          recipient    : bob.did,
+          schema       : 'http://admin-schema',
+        });
+        expect((await dwn.processMessage(alice.did, adminRole.message, { dataStream: adminRole.dataStream })).status.code).toBe(202);
+
+        const deliveryData = Encoder.objectToBytes({ encrypted: true });
+        const delivery = await RecordsWrite.create({
+          data            : deliveryData,
+          dataFormat      : 'application/json',
+          encryptionInput : {
+            initializationVector : TestDataGenerator.randomBytes(16),
+            key                  : TestDataGenerator.randomBytes(32),
+            keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+              keyId            : await Encryption.getKeyId(memberRuleSet.$keyAgreement!.publicKeyJwk),
+              publicKey        : memberRuleSet.$keyAgreement!.publicKeyJwk,
+              derivationScheme : KeyDerivationScheme.ProtocolPath,
+            }],
+          },
+          protocol     : protocolDefinition.protocol,
+          protocolPath : ENCRYPTION_CONTROL_DELIVERY_PATH,
+          recipient    : bob.did,
+          schema       : 'https://identity.foundation/dwn/json-schemas/encryption/delivery.json',
+          signer       : Jws.createSigner(alice),
+          tags         : {
+            protocol           : protocolDefinition.protocol,
+            rolePath           : 'member',
+            contextId          : '',
+            keyId              : audience.keyId,
+            recipientAuthority : 'roleCreatorRole',
+            roleRef            : 'admin',
+          },
+        });
+
+        const reply = await dwn.processMessage(alice.did, delivery.message, { dataStream: DataStream.fromBytes(deliveryData) });
+
+        expect(reply.status.code).toBe(400);
+        expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateDeliveryRecipientUnauthorized);
+      });
+
+      it('should reject author-delegated audience control writes when the grant does not cover the role path', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-author-delegate-rejected.xyz',
+          published : false,
+          types     : {
+            member  : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+            message : { schema: 'http://message-schema', dataFormats: ['text/plain'] },
+          },
+          structure: {
+            member  : { $role: true },
+            message : {},
+          },
+        };
+        const encryptedProtocolDefinition = await Protocols.deriveAndInjectPublicEncryptionKeys(
+          protocolDefinition, alice.keyId, alice.encryptionKeyPair.privateJwk
+        );
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author             : alice,
+          protocolDefinition : encryptedProtocolDefinition,
+        });
+        expect((await dwn.processMessage(alice.did, protocolConfig.message)).status.code).toBe(202);
+
+        const grant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : bob,
+          delegated : true,
+          scope     : {
+            interface    : DwnInterfaceName.Records,
+            method       : DwnMethodName.Write,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'message',
+          },
+        });
+        expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+        const roleRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audiencePublicKeyJwk = alice.encryptionKeyPair.publicJwk;
+        const audienceKeyId = await Encryption.getKeyId(audiencePublicKeyJwk);
+        const sealKeyId = await Encryption.getKeyId(roleRuleSet.$keyAgreement!.publicKeyJwk);
+        const dataBytes = Encoder.objectToBytes({
+          protocol         : protocolDefinition.protocol,
+          rolePath         : 'member',
+          contextId        : '',
+          keyId            : audienceKeyId,
+          publicKeyJwk     : audiencePublicKeyJwk,
+          sealedPrivateKey : {
+            algorithm          : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+            derivationScheme   : 'seal',
+            keyId              : sealKeyId,
+            ephemeralPublicKey : alice.encryptionKeyPair.publicJwk,
+            encryptedKey       : Encoder.bytesToBase64Url(TestDataGenerator.randomBytes(32)),
+          },
+        });
+        const audience = await RecordsWrite.create({
+          data           : dataBytes,
+          dataFormat     : 'application/json',
+          delegatedGrant : grant.dataEncodedMessage,
+          protocol       : protocolDefinition.protocol,
+          protocolPath   : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          schema         : 'https://identity.foundation/dwn/json-schemas/encryption/audience.json',
+          signer         : Jws.createSigner(bob),
+          tags           : {
+            protocol  : protocolDefinition.protocol,
+            rolePath  : 'member',
+            contextId : '',
+            keyId     : audienceKeyId,
+          },
+        });
+
+        const reply = await dwn.processMessage(alice.did, audience.message, { dataStream: DataStream.fromBytes(dataBytes) });
+
+        expect(reply.status.code).toBe(401);
+        expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateAudienceWriterUnauthorized);
+      });
+
+      it('should accept audience control records from authorized non-tenant role creators', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+
+        const anyoneProtocol: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-audience-anyone-writer.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['create'] }],
+            },
+          },
+        };
+        const encryptedAnyoneProtocol = await installEncryptedProtocol(alice, anyoneProtocol);
+        const anyoneRoleRuleSet = encryptedAnyoneProtocol.structure.member as ProtocolRuleSet;
+        const anyoneAudience = await createAudienceControlWrite({
+          author      : bob,
+          protocol    : anyoneProtocol.protocol,
+          rolePath    : 'member',
+          roleRuleSet : anyoneRoleRuleSet,
+        });
+
+        expect(
+          (await dwn.processMessage(alice.did, anyoneAudience.recordsWrite.message, {
+            dataStream: DataStream.fromBytes(anyoneAudience.dataBytes),
+          })).status.code
+        ).toBe(202);
+
+        const roleProtocol: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-audience-role-writer.xyz',
+          published : false,
+          types     : {
+            admin  : { schema: 'http://admin-schema', dataFormats: ['application/json'] },
+            member : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            admin  : { $role: true },
+            member : {
+              $role    : true,
+              $actions : [{ role: 'admin', can: ['create'] }],
+            },
+          },
+        };
+        const encryptedRoleProtocol = await installEncryptedProtocol(alice, roleProtocol);
+        const memberRoleRuleSet = encryptedRoleProtocol.structure.member as ProtocolRuleSet;
+        const adminRole = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('bob is an admin'),
+          dataFormat   : 'application/json',
+          protocol     : roleProtocol.protocol,
+          protocolPath : 'admin',
+          recipient    : bob.did,
+          schema       : 'http://admin-schema',
+        });
+        expect((await dwn.processMessage(alice.did, adminRole.message, { dataStream: adminRole.dataStream })).status.code).toBe(202);
+
+        const roleAudience = await createAudienceControlWrite({
+          author       : bob,
+          protocol     : roleProtocol.protocol,
+          protocolRole : 'admin',
+          rolePath     : 'member',
+          roleRuleSet  : memberRoleRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, roleAudience.recordsWrite.message, {
+            dataStream: DataStream.fromBytes(roleAudience.dataBytes),
+          })).status.code
+        ).toBe(202);
+
+        const grantProtocol: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-audience-delegated-writer.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedGrantProtocol = await installEncryptedProtocol(alice, grantProtocol);
+        const grantRoleRuleSet = encryptedGrantProtocol.structure.member as ProtocolRuleSet;
+        const grant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : carol,
+          delegated : true,
+          scope     : {
+            interface    : DwnInterfaceName.Records,
+            method       : DwnMethodName.Write,
+            protocol     : grantProtocol.protocol,
+            protocolPath : 'member',
+          },
+        });
+        expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+        const delegatedAudience = await createAudienceControlWrite({
+          author         : alice,
+          delegatedGrant : grant.dataEncodedMessage,
+          protocol       : grantProtocol.protocol,
+          rolePath       : 'member',
+          roleRuleSet    : grantRoleRuleSet,
+          signer         : carol,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, delegatedAudience.recordsWrite.message, {
+            dataStream: DataStream.fromBytes(delegatedAudience.dataBytes),
+          })).status.code
+        ).toBe(202);
+
+        const directGrant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : bob,
+          scope     : {
+            interface    : DwnInterfaceName.Records,
+            method       : DwnMethodName.Write,
+            protocol     : grantProtocol.protocol,
+            protocolPath : 'member',
+          },
+        });
+        expect((await dwn.processMessage(alice.did, directGrant.message, { dataStream: directGrant.dataStream })).status.code).toBe(202);
+
+        const directGrantAudience = await createAudienceControlWrite({
+          author            : bob,
+          permissionGrantId : directGrant.message.recordId,
+          protocol          : grantProtocol.protocol,
+          rolePath          : 'member',
+          roleRuleSet       : grantRoleRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, directGrantAudience.recordsWrite.message, {
+            dataStream: DataStream.fromBytes(directGrantAudience.dataBytes),
+          })).status.code
+        ).toBe(202);
+      });
+
+      it('should enforce publication conditions on delegated audience control writes', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-delegated-publication-condition.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const roleRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const grant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : bob,
+          delegated : true,
+          scope     : {
+            interface    : DwnInterfaceName.Records,
+            method       : DwnMethodName.Write,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'member',
+          },
+          conditions: {
+            publication: PermissionConditionPublication.Required,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+        const audience = await createAudienceControlWrite({
+          author         : alice,
+          delegatedGrant : grant.dataEncodedMessage,
+          protocol       : protocolDefinition.protocol,
+          published      : false,
+          rolePath       : 'member',
+          roleRuleSet,
+          signer         : bob,
+        });
+        const reply = await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) });
+
+        expect(reply.status.code).toBe(401);
+        expect(reply.status.detail).toContain(DwnErrorCode.RecordsGrantAuthorizationConditionPublicationRequired);
+      });
+
+      it('should reject malformed audience control records with typed validation errors', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-audience-malformed-payload.xyz',
+          published : false,
+          types     : {
+            chat   : { schema: 'http://chat-schema', dataFormats: ['application/json'] },
+            member : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            chat: {
+              member: { $role: true },
+            },
+            member: { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const rootRoleRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const nestedRoleRuleSet = (encryptedProtocolDefinition.structure.chat as ProtocolRuleSet).member as ProtocolRuleSet;
+
+        const payloadMismatch = await createAudienceControlWrite({
+          author           : alice,
+          payloadOverrides : { rolePath: 'other' },
+          protocol         : protocolDefinition.protocol,
+          rolePath         : 'member',
+          roleRuleSet      : rootRoleRuleSet,
+        });
+        const payloadMismatchReply = await dwn.processMessage(
+          alice.did,
+          payloadMismatch.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(payloadMismatch.dataBytes) }
+        );
+        expect(payloadMismatchReply.status.code).toBe(400);
+        expect(payloadMismatchReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateAudienceTagsMismatch);
+
+        const keyMismatch = await createAudienceControlWrite({
+          author           : alice,
+          payloadOverrides : { publicKeyJwk: bob.encryptionKeyPair.publicJwk },
+          protocol         : protocolDefinition.protocol,
+          rolePath         : 'member',
+          roleRuleSet      : rootRoleRuleSet,
+        });
+        const keyMismatchReply = await dwn.processMessage(
+          alice.did,
+          keyMismatch.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(keyMismatch.dataBytes) }
+        );
+        expect(keyMismatchReply.status.code).toBe(400);
+        expect(keyMismatchReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateAudienceKeyIdMismatch);
+
+        const rootWithContext = await createAudienceControlWrite({
+          author      : alice,
+          contextId   : 'root-context',
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : rootRoleRuleSet,
+        });
+        const rootWithContextReply = await dwn.processMessage(
+          alice.did,
+          rootWithContext.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(rootWithContext.dataBytes) }
+        );
+        expect(rootWithContextReply.status.code).toBe(400);
+        expect(rootWithContextReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateAudienceContextIdInvalid);
+
+        const nestedWithoutContext = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'chat/member',
+          roleRuleSet : nestedRoleRuleSet,
+        });
+        const nestedWithoutContextReply = await dwn.processMessage(
+          alice.did,
+          nestedWithoutContext.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(nestedWithoutContext.dataBytes) }
+        );
+        expect(nestedWithoutContextReply.status.code).toBe(400);
+        expect(nestedWithoutContextReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateAudienceContextIdInvalid);
+
+        const protocolTagMismatch = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : rootRoleRuleSet,
+          tags        : { protocol: 'http://mismatched-control-tag.xyz' },
+        });
+        const protocolTagMismatchReply = await dwn.processMessage(
+          alice.did,
+          protocolTagMismatch.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(protocolTagMismatch.dataBytes) }
+        );
+        expect(protocolTagMismatchReply.status.code).toBe(400);
+        expect(protocolTagMismatchReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateAudienceTagsMismatch);
+      });
+
+      it('should reject audience control records for role paths without key agreement material', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-role-without-keyagreement.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+        expect((await dwn.processMessage(alice.did, protocolConfig.message)).status.code).toBe(202);
+
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : protocolDefinition.structure.member as ProtocolRuleSet,
+          sealKeyId   : await Encryption.getKeyId(alice.encryptionKeyPair.publicJwk),
+        });
+        const reply = await dwn.processMessage(
+          alice.did,
+          audience.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(audience.dataBytes) }
+        );
+
+        expect(reply.status.code).toBe(400);
+        expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateAudienceRolePathInvalid);
+      });
+
+      it('should reject oversized inline audience control records', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-oversized-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const roleRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author           : alice,
+          payloadOverrides : { filler: 'x'.repeat(DwnConstant.maxDataSizeAllowedToBeEncoded) },
+          protocol         : protocolDefinition.protocol,
+          rolePath         : 'member',
+          roleRuleSet,
+        });
+
+        const reply = await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) });
+
+        expect(reply.status.code).toBe(400);
+        expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateUnexpectedRecord);
+      });
+
+      it('should accept delivery control records for each supported recipient authority', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-delivery-authorities.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['create'] }],
+            },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const memberRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : memberRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) })).status.code
+        ).toBe(202);
+
+        const memberRole = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('bob is a member'),
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'member',
+          recipient    : bob.did,
+          schema       : 'http://member-schema',
+        });
+        expect((await dwn.processMessage(alice.did, memberRole.message, { dataStream: memberRole.dataStream })).status.code).toBe(202);
+
+        const roleHolderDelivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          rolePath           : 'member',
+          roleRuleSet        : memberRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, roleHolderDelivery.recordsWrite.message, {
+            dataStream: DataStream.fromBytes(roleHolderDelivery.dataBytes),
+          })).status.code
+        ).toBe(202);
+
+        const grant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : carol,
+          scope     : {
+            interface    : DwnInterfaceName.Records,
+            method       : DwnMethodName.Write,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'member',
+          },
+        });
+        expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+        const grantDelivery = await createDeliveryControlWrite({
+          author             : alice,
+          grantId            : grant.message.recordId,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : carol.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleCreatorGrant,
+          rolePath           : 'member',
+          roleRuleSet        : memberRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, grantDelivery.recordsWrite.message, {
+            dataStream: DataStream.fromBytes(grantDelivery.dataBytes),
+          })).status.code
+        ).toBe(202);
+
+        const anyoneDelivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : carol.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleCreatorAnyone,
+          rolePath           : 'member',
+          roleRuleSet        : memberRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, anyoneDelivery.recordsWrite.message, {
+            dataStream: DataStream.fromBytes(anyoneDelivery.dataBytes),
+          })).status.code
+        ).toBe(202);
+      });
+
+      it('should reject malformed delivery control records with typed validation errors', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-delivery-malformed.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const memberRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : memberRuleSet,
+        });
+        expect(
+          (await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) })).status.code
+        ).toBe(202);
+
+        const unencryptedData = Encoder.objectToBytes({ protocol: protocolDefinition.protocol });
+        const unencryptedDelivery = await RecordsWrite.create({
+          data         : unencryptedData,
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : ENCRYPTION_CONTROL_DELIVERY_PATH,
+          recipient    : bob.did,
+          schema       : 'https://identity.foundation/dwn/json-schemas/encryption/delivery.json',
+          signer       : Jws.createSigner(alice),
+          tags         : {
+            protocol           : protocolDefinition.protocol,
+            rolePath           : 'member',
+            contextId          : '',
+            keyId              : audience.keyId,
+            recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          },
+        });
+        const unencryptedReply = await dwn.processMessage(
+          alice.did,
+          unencryptedDelivery.message,
+          { dataStream: DataStream.fromBytes(unencryptedData) }
+        );
+        expect(unencryptedReply.status.code).toBe(400);
+        expect(unencryptedReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateUnexpectedRecord);
+
+        const noRecipientData = Encoder.objectToBytes({ protocol: protocolDefinition.protocol });
+        const noRecipientDelivery = await RecordsWrite.create({
+          data            : noRecipientData,
+          dataFormat      : 'application/json',
+          encryptionInput : {
+            initializationVector : TestDataGenerator.randomBytes(16),
+            key                  : TestDataGenerator.randomBytes(32),
+            keyEncryptionInputs  : [{
+              algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+              keyId            : await Encryption.getKeyId(memberRuleSet.$keyAgreement!.publicKeyJwk),
+              publicKey        : memberRuleSet.$keyAgreement!.publicKeyJwk,
+              derivationScheme : KeyDerivationScheme.ProtocolPath,
+            }],
+          },
+          protocol     : protocolDefinition.protocol,
+          protocolPath : ENCRYPTION_CONTROL_DELIVERY_PATH,
+          schema       : 'https://identity.foundation/dwn/json-schemas/encryption/delivery.json',
+          signer       : Jws.createSigner(alice),
+          tags         : {
+            protocol           : protocolDefinition.protocol,
+            rolePath           : 'member',
+            contextId          : '',
+            keyId              : audience.keyId,
+            recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          },
+        });
+        const noRecipientReply = await dwn.processMessage(
+          alice.did,
+          noRecipientDelivery.message,
+          { dataStream: DataStream.fromBytes(noRecipientData) }
+        );
+        expect(noRecipientReply.status.code).toBe(400);
+        expect(noRecipientReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateDeliveryRecipientMissing);
+
+        const invalidAuthorityDelivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : 'unknown',
+          rolePath           : 'member',
+          roleRuleSet        : memberRuleSet,
+        });
+        const invalidAuthorityReply = await dwn.processMessage(
+          alice.did,
+          invalidAuthorityDelivery.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(invalidAuthorityDelivery.dataBytes) }
+        );
+        expect(invalidAuthorityReply.status.code).toBe(400);
+        expect(invalidAuthorityReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateDeliveryRecipientAuthorityInvalid);
+
+        const unauthorizedRoleHolderDelivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          rolePath           : 'member',
+          roleRuleSet        : memberRuleSet,
+        });
+        const unauthorizedRoleHolderReply = await dwn.processMessage(
+          alice.did,
+          unauthorizedRoleHolderDelivery.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(unauthorizedRoleHolderDelivery.dataBytes) }
+        );
+        expect(unauthorizedRoleHolderReply.status.code).toBe(400);
+        expect(unauthorizedRoleHolderReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateDeliveryRecipientUnauthorized);
+
+        const missingGrantDelivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleCreatorGrant,
+          rolePath           : 'member',
+          roleRuleSet        : memberRuleSet,
+        });
+        const missingGrantReply = await dwn.processMessage(
+          alice.did,
+          missingGrantDelivery.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(missingGrantDelivery.dataBytes) }
+        );
+        expect(missingGrantReply.status.code).toBe(400);
+        expect(missingGrantReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateDeliveryRecipientUnauthorized);
+
+        const missingRoleRefDelivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleCreatorRole,
+          rolePath           : 'member',
+          roleRuleSet        : memberRuleSet,
+        });
+        const missingRoleRefReply = await dwn.processMessage(
+          alice.did,
+          missingRoleRefDelivery.recordsWrite.message,
+          { dataStream: DataStream.fromBytes(missingRoleRefDelivery.dataBytes) }
+        );
+        expect(missingRoleRefReply.status.code).toBe(400);
+        expect(missingRoleRefReply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateDeliveryRecipientUnauthorized);
       });
 
       it('should not treat lookalike encryption control paths as reserved paths', async () => {


### PR DESCRIPTION
## Summary
- Adds source-protocol encryption control validation for reserved audience and delivery paths.
- Enforces role-audience control writer authorization, payload/tag/key binding, delivery recipient authority, and audience existence checks through the DWN write path.
- Extends handler coverage for positive and negative control-record admission, including delegated/direct grant writers, malformed payloads, missing key agreement, oversized inline records, delivery recipient failures, and grant publication conditions.

## Test plan
- [x] `bun run --filter @enbox/dwn-sdk-js build`
- [x] `bun run --filter @enbox/dwn-sdk-js lint`
- [x] `bun run --filter @enbox/dwn-sdk-js test:node`
- [x] `bun run test:node:coverage` from `packages/dwn-sdk-js`
- [x] `bun run --filter @enbox/agent build`
- [x] `bun run lint`
- [x] `bunx changeset status`
- [ ] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node` from `packages/agent` (attempted locally; failed because no DWN server was reachable on `http://localhost:3000` for server-dependent tests)

## Notes
- Part of #1100.
- This PR adds the validation/admission slice only. Producers, sync/read surfaces, rotation, and active-set selection remain follow-up workstreams.
