### PR TITLE
feat(encryption): expand grantKey role coverage

### DIFF
--- a/.changeset/grantkey-role-coverage.md
+++ b/.changeset/grantkey-role-coverage.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+---
+
+feat: expand durable grantKey coverage for role-path encryption keys

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -1461,21 +1461,27 @@ async function getGrantKeyDeliveryScopes(
   };
 
   if (grant.scope.method === DwnMethodName.Read) {
+    if (grant.scope.protocolPath === undefined) {
+      addScope({
+        scheme   : KeyDerivationScheme.ProtocolPath,
+        protocol : grant.scope.protocol,
+      });
+      return [...deliveredScopes.values()];
+    }
+
     addScope({
-      scheme   : KeyDerivationScheme.ProtocolPath,
-      protocol : grant.scope.protocol,
-      ...(grant.scope.protocolPath !== undefined ? { protocolPath: grant.scope.protocolPath } : {}),
+      scheme       : KeyDerivationScheme.ProtocolPath,
+      protocol     : grant.scope.protocol,
+      protocolPath : grant.scope.protocolPath,
     });
 
-    if (grant.scope.protocolPath !== undefined) {
-      const protocolDefinition = await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grant.scope.protocol, protocolDefinitions);
-      for (const rolePath of getReadRolePathsForScope(protocolDefinition, grant.scope.protocolPath)) {
-        addScope({
-          scheme       : KeyDerivationScheme.ProtocolPath,
-          protocol     : grant.scope.protocol,
-          protocolPath : rolePath,
-        });
-      }
+    const protocolDefinition = await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grant.scope.protocol, protocolDefinitions);
+    for (const rolePath of getReadRolePathsForScope(protocolDefinition, grant.scope.protocolPath)) {
+      addScope({
+        scheme       : KeyDerivationScheme.ProtocolPath,
+        protocol     : grant.scope.protocol,
+        protocolPath : rolePath,
+      });
     }
   }
 

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -3,11 +3,12 @@ import type {
   DerivedPrivateJwk,
   EncryptionInput,
   EncryptionKeyDeriver,
+  GrantKeyEligibleRecordsScope,
+  GrantKeyProtocolPathScope,
   KeyDecrypter,
   KeyDecrypterDerivationScheme,
   PermissionGrant,
   ProtocolDefinition,
-  ProtocolRuleSet,
   RecordsQueryReply,
   RecordsReadReply,
   RecordsWriteMessage,
@@ -26,18 +27,18 @@ import {
   Cid,
   ContentEncryptionAlgorithm,
   DataStream,
-  DwnInterfaceName,
   DwnMethodName,
   PermissionGrant as DwnPermissionGrant,
   Encoder,
   Encryption,
   EncryptionProtocol,
-  getRuleSetAtPath,
+  getGrantKeyDeliveryScopes,
+  grantKeyScopeCoversDeliveredScope,
   HdKey,
+  isGrantKeyEligibleRecordsScope,
   KeyAgreementAlgorithm,
   KeyDerivationScheme,
   Message,
-  parseCrossProtocolRef,
   Records,
   ROLE_AUDIENCE_DERIVATION_SCHEME,
   Time,
@@ -63,12 +64,6 @@ export type AudienceDecryptionKeyCache = {
   set?(key: string, value: AudienceDecryptionKeyEntry): void;
 };
 
-type GrantKeyScope = {
-  scheme: typeof KeyDerivationScheme.ProtocolPath;
-  protocol: string;
-  protocolPath?: string;
-};
-
 type X25519KeyMaterialBase = {
   algorithm: typeof KeyAgreementAlgorithm.X25519HkdfSha256A256Kw;
   derivationScheme: string;
@@ -88,7 +83,7 @@ type X25519RoleAudienceKeyMaterial = X25519KeyMaterialBase & {
 
 type GrantKeyPayload = {
   grantId: string;
-  scope: GrantKeyScope;
+  scope: GrantKeyProtocolPathScope;
   keyMaterial: X25519ProtocolPathKeyMaterial;
 };
 
@@ -1370,33 +1365,23 @@ function getRoleAudienceContextId(
 }
 
 function isGrantKeyEligibleGrant(grant: PermissionGrant): grant is PermissionGrant & {
-  scope: PermissionGrant['scope'] & {
-    interface: typeof DwnInterfaceName.Records;
-    method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
-    protocol: string;
-    protocolPath?: string;
-  };
+  scope: GrantKeyEligibleRecordsScope;
 } {
-  return grant.scope.interface === DwnInterfaceName.Records &&
-    (grant.scope.method === DwnMethodName.Read || grant.scope.method === DwnMethodName.Write) &&
-    'protocol' in grant.scope &&
-    typeof grant.scope.protocol === 'string' &&
-    !('contextId' in grant.scope && grant.scope.contextId !== undefined);
+  return isGrantKeyEligibleRecordsScope(grant.scope);
 }
 
 async function buildGrantKeyPayloads(
   agent: EnboxPlatformAgent,
   ownerDid: string,
   grant: PermissionGrant & {
-    scope: PermissionGrant['scope'] & {
-      method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
-      protocol: string;
-      protocolPath?: string;
-    };
+    scope: GrantKeyEligibleRecordsScope;
   },
   protocolDefinitions: Map<string, ProtocolDefinition>,
 ): Promise<GrantKeyPayload[]> {
-  const scopes = await getGrantKeyDeliveryScopes(agent, ownerDid, grant, protocolDefinitions);
+  const protocolDefinition = grant.scope.method === DwnMethodName.Read && grant.scope.protocolPath === undefined
+    ? undefined
+    : await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grant.scope.protocol, protocolDefinitions);
+  const scopes = getGrantKeyDeliveryScopes(grant.scope, protocolDefinition);
   if (scopes.length === 0) {
     return [];
   }
@@ -1414,7 +1399,7 @@ async function buildGrantKeyPayload(
   agent: EnboxPlatformAgent,
   keyUri: string,
   grantId: string,
-  scope: GrantKeyScope,
+  scope: GrantKeyProtocolPathScope,
 ): Promise<GrantKeyPayload> {
   const derivationPath = getScopeDerivationPath(scope.protocol, scope.protocolPath);
   const privateKeyBytes = await agent.keyManager.derivePrivateKeyBytes({
@@ -1443,62 +1428,6 @@ async function buildGrantKeyPayload(
   };
 }
 
-async function getGrantKeyDeliveryScopes(
-  agent: EnboxPlatformAgent,
-  ownerDid: string,
-  grant: PermissionGrant & {
-    scope: PermissionGrant['scope'] & {
-      method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
-      protocol: string;
-      protocolPath?: string;
-    };
-  },
-  protocolDefinitions: Map<string, ProtocolDefinition>,
-): Promise<GrantKeyScope[]> {
-  const deliveredScopes = new Map<string, GrantKeyScope>();
-  const addScope = (scope: GrantKeyScope): void => {
-    deliveredScopes.set(getGrantKeyScopeCacheKey(scope), scope);
-  };
-
-  if (grant.scope.method === DwnMethodName.Read) {
-    if (grant.scope.protocolPath === undefined) {
-      addScope({
-        scheme   : KeyDerivationScheme.ProtocolPath,
-        protocol : grant.scope.protocol,
-      });
-      return [...deliveredScopes.values()];
-    }
-
-    addScope({
-      scheme       : KeyDerivationScheme.ProtocolPath,
-      protocol     : grant.scope.protocol,
-      protocolPath : grant.scope.protocolPath,
-    });
-
-    const protocolDefinition = await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grant.scope.protocol, protocolDefinitions);
-    for (const rolePath of getReadRolePathsForScope(protocolDefinition, grant.scope.protocolPath)) {
-      addScope({
-        scheme       : KeyDerivationScheme.ProtocolPath,
-        protocol     : grant.scope.protocol,
-        protocolPath : rolePath,
-      });
-    }
-  }
-
-  if (grant.scope.method === DwnMethodName.Write) {
-    const protocolDefinition = await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grant.scope.protocol, protocolDefinitions);
-    for (const rolePath of getRolePathsCoveredByScope(protocolDefinition, grant.scope.protocolPath)) {
-      addScope({
-        scheme       : KeyDerivationScheme.ProtocolPath,
-        protocol     : grant.scope.protocol,
-        protocolPath : rolePath,
-      });
-    }
-  }
-
-  return [...deliveredScopes.values()];
-}
-
 async function getGrantKeyProtocolDefinition(
   agent: EnboxPlatformAgent,
   authorDid: string,
@@ -1524,75 +1453,6 @@ async function getGrantKeyProtocolDefinition(
 
   protocolDefinitions.set(protocol, definition);
   return definition;
-}
-
-function getReadRolePathsForScope(protocolDefinition: ProtocolDefinition, scopeProtocolPath: string): string[] {
-  const scopedRuleSet = getRuleSetAtPath(scopeProtocolPath, protocolDefinition.structure);
-  if (scopedRuleSet === undefined) {
-    return [];
-  }
-
-  return [...collectReadRolePaths(protocolDefinition, scopedRuleSet)];
-}
-
-function collectReadRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet): Set<string> {
-  const rolePaths = new Set<string>();
-
-  for (const actionRule of ruleSet.$actions ?? []) {
-    if (!actionRule.can.includes('read') || actionRule.role === undefined || parseCrossProtocolRef(actionRule.role) !== undefined) {
-      continue;
-    }
-
-    if (isLocalRolePath(protocolDefinition, actionRule.role)) {
-      rolePaths.add(actionRule.role);
-    }
-  }
-
-  for (const [key, value] of Object.entries(ruleSet)) {
-    if (key.startsWith('$')) {
-      continue;
-    }
-    for (const rolePath of collectReadRolePaths(protocolDefinition, value as ProtocolRuleSet)) {
-      rolePaths.add(rolePath);
-    }
-  }
-
-  return rolePaths;
-}
-
-function getRolePathsCoveredByScope(protocolDefinition: ProtocolDefinition, scopeProtocolPath?: string): string[] {
-  return collectRolePaths(protocolDefinition, protocolDefinition.structure as ProtocolRuleSet)
-    .filter((rolePath) => scopeProtocolPath === undefined || isBoundaryAwareSubtree(scopeProtocolPath, rolePath));
-}
-
-function collectRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet, parentPath?: string): string[] {
-  const rolePaths: string[] = [];
-
-  for (const [key, value] of Object.entries(ruleSet)) {
-    if (key.startsWith('$')) {
-      continue;
-    }
-
-    const protocolPath = parentPath === undefined ? key : `${parentPath}/${key}`;
-    const childRuleSet = value as ProtocolRuleSet;
-    if (isLocalRolePath(protocolDefinition, protocolPath)) {
-      rolePaths.push(protocolPath);
-    }
-    rolePaths.push(...collectRolePaths(protocolDefinition, childRuleSet, protocolPath));
-  }
-
-  return rolePaths;
-}
-
-function isLocalRolePath(protocolDefinition: ProtocolDefinition, protocolPath: string): boolean {
-  const ruleSet = getRuleSetAtPath(protocolPath, protocolDefinition.structure);
-  return ruleSet?.$role === true && ruleSet.$keyAgreement !== undefined;
-}
-
-function getGrantKeyScopeCacheKey(scope: GrantKeyScope): string {
-  return scope.protocolPath === undefined
-    ? `${scope.protocol}~protocol`
-    : `${scope.protocol}~protocolPath~${scope.protocolPath}`;
 }
 
 async function derivePublicKeyFromPrivateKey(
@@ -1881,43 +1741,26 @@ async function grantScopeCoversPayload(
     return false;
   }
 
-  if (grant.scope.protocol !== payload.scope.protocol) {
-    return false;
-  }
-
-  if (grant.scope.method === DwnMethodName.Read && grant.scope.protocolPath === undefined) {
+  if (grantKeyScopeCoversDeliveredScope({
+    grantScope     : grant.scope,
+    deliveredScope : payload.scope,
+  })) {
     return true;
   }
 
-  if (grant.scope.method === DwnMethodName.Read) {
-    const grantProtocolPath = grant.scope.protocolPath;
-    if (grantProtocolPath === undefined) {
-      return false;
-    }
-
-    if (payload.scope.protocolPath !== undefined &&
-        isBoundaryAwareSubtree(grantProtocolPath, payload.scope.protocolPath)) {
-      return true;
-    }
-
-    if (payload.scope.protocolPath === undefined) {
-      return false;
-    }
-
-    const protocolDefinition = await getGrantKeyProtocolDefinition(agent, requesterDid, ownerDid, grant.scope.protocol, new Map());
-    return getReadRolePathsForScope(protocolDefinition, grantProtocolPath).includes(payload.scope.protocolPath);
-  }
-
-  if (payload.scope.protocolPath === undefined ||
-      (grant.scope.protocolPath !== undefined && !isBoundaryAwareSubtree(grant.scope.protocolPath, payload.scope.protocolPath))) {
+  if (payload.scope.protocolPath === undefined) {
     return false;
   }
 
   const protocolDefinition = await getGrantKeyProtocolDefinition(agent, requesterDid, ownerDid, grant.scope.protocol, new Map());
-  return isLocalRolePath(protocolDefinition, payload.scope.protocolPath);
+  return grantKeyScopeCoversDeliveredScope({
+    grantScope     : grant.scope,
+    deliveredScope : payload.scope,
+    protocolDefinition,
+  });
 }
 
-function scopeCoversRecord(scope: GrantKeyScope, protocol: string, protocolPath: string | undefined): boolean {
+function scopeCoversRecord(scope: GrantKeyProtocolPathScope, protocol: string, protocolPath: string | undefined): boolean {
   if (scope.protocol !== protocol) {
     return false;
   }

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -1378,10 +1378,18 @@ async function buildGrantKeyPayloads(
   },
   protocolDefinitions: Map<string, ProtocolDefinition>,
 ): Promise<GrantKeyPayload[]> {
-  const protocolDefinition = grant.scope.method === DwnMethodName.Read && grant.scope.protocolPath === undefined
-    ? undefined
-    : await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grant.scope.protocol, protocolDefinitions);
-  const scopes = getGrantKeyDeliveryScopes(grant.scope, protocolDefinition);
+  const grantScope = grant.scope;
+  let scopes: GrantKeyProtocolPathScope[];
+  if (grantScope.method === DwnMethodName.Read) {
+    const protocolDefinition = grantScope.protocolPath === undefined
+      ? undefined
+      : await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grantScope.protocol, protocolDefinitions);
+    scopes = getGrantKeyDeliveryScopes(grantScope, protocolDefinition);
+  } else {
+    const protocolDefinition = await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grantScope.protocol, protocolDefinitions);
+    scopes = getGrantKeyDeliveryScopes(grantScope, protocolDefinition);
+  }
+
   if (scopes.length === 0) {
     return [];
   }

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -6,6 +6,8 @@ import type {
   KeyDecrypter,
   KeyDecrypterDerivationScheme,
   PermissionGrant,
+  ProtocolDefinition,
+  ProtocolRuleSet,
   RecordsQueryReply,
   RecordsReadReply,
   RecordsWriteMessage,
@@ -30,10 +32,12 @@ import {
   Encoder,
   Encryption,
   EncryptionProtocol,
+  getRuleSetAtPath,
   HdKey,
   KeyAgreementAlgorithm,
   KeyDerivationScheme,
   Message,
+  parseCrossProtocolRef,
   Records,
   ROLE_AUDIENCE_DERIVATION_SCHEME,
   Time,
@@ -389,8 +393,17 @@ export async function createGrantKeyRecordsForGrants(params: {
   granteeDid: string;
   granteeRootPrivateKey: PrivateKeyJwk;
   grantMessages: DataEncodedRecordsWriteMessage[];
+  protocolDefinitions?: ProtocolDefinition[];
 }): Promise<DataEncodedRecordsWriteMessage[]> {
   const grantKeyRecords: DataEncodedRecordsWriteMessage[] = [];
+  const protocolDefinitions = new Map(
+    (params.protocolDefinitions ?? []).map((definition) => [definition.protocol, definition])
+  );
+  const granteeGrantKeyPublicKey = await derivePublicKeyFromPrivateKey(
+    params.granteeRootPrivateKey,
+    GRANT_KEY_DERIVATION_PATH,
+  );
+  const granteeGrantKeyKeyId = await Encryption.getKeyId(granteeGrantKeyPublicKey);
 
   for (const grantMessage of params.grantMessages) {
     const grant = DwnPermissionGrant.parse(grantMessage);
@@ -398,61 +411,58 @@ export async function createGrantKeyRecordsForGrants(params: {
       continue;
     }
 
-    const payload = await buildGrantKeyPayload(params.agent, params.ownerDid, grant);
-    const payloadBytes = Encoder.objectToBytes(payload);
-    const contentEncryptionAlgorithm = ContentEncryptionAlgorithm.A256CTR;
-    const dataEncryptionKey = crypto.getRandomValues(new Uint8Array(32));
-    const dataEncryptionIV = crypto.getRandomValues(new Uint8Array(ivLength(contentEncryptionAlgorithm)));
-    const granteeGrantKeyPublicKey = await derivePublicKeyFromPrivateKey(
-      params.granteeRootPrivateKey,
-      GRANT_KEY_DERIVATION_PATH,
-    );
-    const granteeGrantKeyKeyId = await Encryption.getKeyId(granteeGrantKeyPublicKey);
-    const encryptionInput = buildEncryptionInput(
-      dataEncryptionKey,
-      dataEncryptionIV,
-      granteeGrantKeyKeyId,
-      granteeGrantKeyPublicKey,
-      KeyDerivationScheme.ProtocolPath,
-    );
-    const { encryptedBytes, dataCid, dataSize } = await encryptAndComputeCid(
-      payloadBytes,
-      dataEncryptionKey,
-      dataEncryptionIV,
-      contentEncryptionAlgorithm,
-    );
+    const payloads = await buildGrantKeyPayloads(params.agent, params.ownerDid, grant, protocolDefinitions);
+    for (const payload of payloads) {
+      const payloadBytes = Encoder.objectToBytes(payload);
+      const contentEncryptionAlgorithm = ContentEncryptionAlgorithm.A256CTR;
+      const dataEncryptionKey = crypto.getRandomValues(new Uint8Array(32));
+      const dataEncryptionIV = crypto.getRandomValues(new Uint8Array(ivLength(contentEncryptionAlgorithm)));
+      const encryptionInput = buildEncryptionInput(
+        dataEncryptionKey,
+        dataEncryptionIV,
+        granteeGrantKeyKeyId,
+        granteeGrantKeyPublicKey,
+        KeyDerivationScheme.ProtocolPath,
+      );
+      const { encryptedBytes, dataCid, dataSize } = await encryptAndComputeCid(
+        payloadBytes,
+        dataEncryptionKey,
+        dataEncryptionIV,
+        contentEncryptionAlgorithm,
+      );
 
-    const { reply, message } = await params.agent.processDwnRequest({
-      author        : params.ownerDid,
-      target        : params.ownerDid,
-      messageType   : DwnInterface.RecordsWrite,
-      messageParams : {
-        recipient    : params.granteeDid,
-        protocol     : EncryptionProtocol.uri,
-        protocolPath : EncryptionProtocol.grantKeyPath,
-        schema       : EncryptionProtocol.definition.types.grantKey.schema,
-        dataFormat   : 'application/json',
-        dataCid,
-        dataSize,
-        encryptionInput,
-        tags         : {
-          grantId  : grant.id,
-          protocol : grant.scope.protocol,
-          ...(grant.scope.protocolPath ? { protocolPath: grant.scope.protocolPath } : {}),
-          keyId    : payload.keyMaterial.keyId,
+      const { reply, message } = await params.agent.processDwnRequest({
+        author        : params.ownerDid,
+        target        : params.ownerDid,
+        messageType   : DwnInterface.RecordsWrite,
+        messageParams : {
+          recipient    : params.granteeDid,
+          protocol     : EncryptionProtocol.uri,
+          protocolPath : EncryptionProtocol.grantKeyPath,
+          schema       : EncryptionProtocol.definition.types.grantKey.schema,
+          dataFormat   : 'application/json',
+          dataCid,
+          dataSize,
+          encryptionInput,
+          tags         : {
+            grantId  : grant.id,
+            protocol : payload.scope.protocol,
+            ...(payload.scope.protocolPath ? { protocolPath: payload.scope.protocolPath } : {}),
+            keyId    : payload.keyMaterial.keyId,
+          },
         },
-      },
-      dataStream: DataStream.fromBytes(encryptedBytes),
-    });
+        dataStream: DataStream.fromBytes(encryptedBytes),
+      });
 
-    if (reply.status.code !== 202 && reply.status.code !== 409) {
-      throw new Error(`AgentDwnApi: Failed to create grantKey record: ${reply.status.detail}`);
+      if (reply.status.code !== 202 && reply.status.code !== 409) {
+        throw new Error(`AgentDwnApi: Failed to create grantKey record: ${reply.status.detail}`);
+      }
+
+      grantKeyRecords.push({
+        ...message!,
+        encodedData: Encoder.bytesToBase64Url(encryptedBytes),
+      } as DataEncodedRecordsWriteMessage);
     }
-
-    grantKeyRecords.push({
-      ...message!,
-      encodedData: Encoder.bytesToBase64Url(encryptedBytes),
-    } as DataEncodedRecordsWriteMessage);
   }
 
   return grantKeyRecords;
@@ -1362,30 +1372,51 @@ function getRoleAudienceContextId(
 function isGrantKeyEligibleGrant(grant: PermissionGrant): grant is PermissionGrant & {
   scope: PermissionGrant['scope'] & {
     interface: typeof DwnInterfaceName.Records;
-    method: typeof DwnMethodName.Read;
+    method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
     protocol: string;
     protocolPath?: string;
   };
 } {
   return grant.scope.interface === DwnInterfaceName.Records &&
-    grant.scope.method === DwnMethodName.Read &&
+    (grant.scope.method === DwnMethodName.Read || grant.scope.method === DwnMethodName.Write) &&
     'protocol' in grant.scope &&
     typeof grant.scope.protocol === 'string' &&
     !('contextId' in grant.scope && grant.scope.contextId !== undefined);
 }
 
-async function buildGrantKeyPayload(
+async function buildGrantKeyPayloads(
   agent: EnboxPlatformAgent,
   ownerDid: string,
   grant: PermissionGrant & {
     scope: PermissionGrant['scope'] & {
+      method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
       protocol: string;
       protocolPath?: string;
     };
   },
-): Promise<GrantKeyPayload> {
+  protocolDefinitions: Map<string, ProtocolDefinition>,
+): Promise<GrantKeyPayload[]> {
+  const scopes = await getGrantKeyDeliveryScopes(agent, ownerDid, grant, protocolDefinitions);
+  if (scopes.length === 0) {
+    return [];
+  }
+
   const { keyUri } = await getEncryptionKeyInfo(agent, ownerDid);
-  const derivationPath = getScopeDerivationPath(grant.scope.protocol, grant.scope.protocolPath);
+  const payloads: GrantKeyPayload[] = [];
+  for (const scope of scopes) {
+    payloads.push(await buildGrantKeyPayload(agent, keyUri, grant.id, scope));
+  }
+
+  return payloads;
+}
+
+async function buildGrantKeyPayload(
+  agent: EnboxPlatformAgent,
+  keyUri: string,
+  grantId: string,
+  scope: GrantKeyScope,
+): Promise<GrantKeyPayload> {
+  const derivationPath = getScopeDerivationPath(scope.protocol, scope.protocolPath);
   const privateKeyBytes = await agent.keyManager.derivePrivateKeyBytes({
     keyUri,
     derivationPath,
@@ -1395,11 +1426,11 @@ async function buildGrantKeyPayload(
   const keyId = await Encryption.getKeyId(publicKeyJwk);
 
   return {
-    grantId : grant.id,
-    scope   : {
+    grantId,
+    scope: {
       scheme   : KeyDerivationScheme.ProtocolPath,
-      protocol : grant.scope.protocol,
-      ...(grant.scope.protocolPath ? { protocolPath: grant.scope.protocolPath } : {}),
+      protocol : scope.protocol,
+      ...(scope.protocolPath ? { protocolPath: scope.protocolPath } : {}),
     },
     keyMaterial: {
       algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
@@ -1410,6 +1441,152 @@ async function buildGrantKeyPayload(
       publicKeyJwk,
     },
   };
+}
+
+async function getGrantKeyDeliveryScopes(
+  agent: EnboxPlatformAgent,
+  ownerDid: string,
+  grant: PermissionGrant & {
+    scope: PermissionGrant['scope'] & {
+      method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
+      protocol: string;
+      protocolPath?: string;
+    };
+  },
+  protocolDefinitions: Map<string, ProtocolDefinition>,
+): Promise<GrantKeyScope[]> {
+  const deliveredScopes = new Map<string, GrantKeyScope>();
+  const addScope = (scope: GrantKeyScope): void => {
+    deliveredScopes.set(getGrantKeyScopeCacheKey(scope), scope);
+  };
+
+  if (grant.scope.method === DwnMethodName.Read) {
+    addScope({
+      scheme   : KeyDerivationScheme.ProtocolPath,
+      protocol : grant.scope.protocol,
+      ...(grant.scope.protocolPath !== undefined ? { protocolPath: grant.scope.protocolPath } : {}),
+    });
+
+    if (grant.scope.protocolPath !== undefined) {
+      const protocolDefinition = await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grant.scope.protocol, protocolDefinitions);
+      for (const rolePath of getReadRolePathsForScope(protocolDefinition, grant.scope.protocolPath)) {
+        addScope({
+          scheme       : KeyDerivationScheme.ProtocolPath,
+          protocol     : grant.scope.protocol,
+          protocolPath : rolePath,
+        });
+      }
+    }
+  }
+
+  if (grant.scope.method === DwnMethodName.Write) {
+    const protocolDefinition = await getGrantKeyProtocolDefinition(agent, ownerDid, ownerDid, grant.scope.protocol, protocolDefinitions);
+    for (const rolePath of getRolePathsCoveredByScope(protocolDefinition, grant.scope.protocolPath)) {
+      addScope({
+        scheme       : KeyDerivationScheme.ProtocolPath,
+        protocol     : grant.scope.protocol,
+        protocolPath : rolePath,
+      });
+    }
+  }
+
+  return [...deliveredScopes.values()];
+}
+
+async function getGrantKeyProtocolDefinition(
+  agent: EnboxPlatformAgent,
+  authorDid: string,
+  targetDid: string,
+  protocol: string,
+  protocolDefinitions: Map<string, ProtocolDefinition>,
+): Promise<ProtocolDefinition> {
+  const cachedDefinition = protocolDefinitions.get(protocol);
+  if (cachedDefinition !== undefined) {
+    return cachedDefinition;
+  }
+
+  const { reply } = await agent.processDwnRequest({
+    author        : authorDid,
+    target        : targetDid,
+    messageType   : DwnInterface.ProtocolsQuery,
+    messageParams : { filter: { protocol } },
+  });
+  const definition = reply.entries?.[0]?.descriptor.definition;
+  if (reply.status.code !== 200 || definition === undefined) {
+    throw new Error(`AgentDwnApi: unable to resolve protocol definition '${protocol}' for grantKey coverage.`);
+  }
+
+  protocolDefinitions.set(protocol, definition);
+  return definition;
+}
+
+function getReadRolePathsForScope(protocolDefinition: ProtocolDefinition, scopeProtocolPath: string): string[] {
+  const scopedRuleSet = getRuleSetAtPath(scopeProtocolPath, protocolDefinition.structure);
+  if (scopedRuleSet === undefined) {
+    return [];
+  }
+
+  return [...collectReadRolePaths(protocolDefinition, scopedRuleSet)];
+}
+
+function collectReadRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet): Set<string> {
+  const rolePaths = new Set<string>();
+
+  for (const actionRule of ruleSet.$actions ?? []) {
+    if (!actionRule.can.includes('read') || actionRule.role === undefined || parseCrossProtocolRef(actionRule.role) !== undefined) {
+      continue;
+    }
+
+    if (isLocalRolePath(protocolDefinition, actionRule.role)) {
+      rolePaths.add(actionRule.role);
+    }
+  }
+
+  for (const [key, value] of Object.entries(ruleSet)) {
+    if (key.startsWith('$')) {
+      continue;
+    }
+    for (const rolePath of collectReadRolePaths(protocolDefinition, value as ProtocolRuleSet)) {
+      rolePaths.add(rolePath);
+    }
+  }
+
+  return rolePaths;
+}
+
+function getRolePathsCoveredByScope(protocolDefinition: ProtocolDefinition, scopeProtocolPath?: string): string[] {
+  return collectRolePaths(protocolDefinition, protocolDefinition.structure as ProtocolRuleSet)
+    .filter((rolePath) => scopeProtocolPath === undefined || isBoundaryAwareSubtree(scopeProtocolPath, rolePath));
+}
+
+function collectRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet, parentPath?: string): string[] {
+  const rolePaths: string[] = [];
+
+  for (const [key, value] of Object.entries(ruleSet)) {
+    if (key.startsWith('$')) {
+      continue;
+    }
+
+    const protocolPath = parentPath === undefined ? key : `${parentPath}/${key}`;
+    const childRuleSet = value as ProtocolRuleSet;
+    if (isLocalRolePath(protocolDefinition, protocolPath)) {
+      rolePaths.push(protocolPath);
+    }
+    rolePaths.push(...collectRolePaths(protocolDefinition, childRuleSet, protocolPath));
+  }
+
+  return rolePaths;
+}
+
+function isLocalRolePath(protocolDefinition: ProtocolDefinition, protocolPath: string): boolean {
+  const ruleSet = getRuleSetAtPath(protocolPath, protocolDefinition.structure);
+  return ruleSet?.$role === true && ruleSet.$keyAgreement !== undefined;
+}
+
+function getGrantKeyScopeCacheKey(scope: GrantKeyScope): string {
+  return scope.protocolPath === undefined
+    ? `${scope.protocol}~protocol`
+    : `${scope.protocol}~protocolPath~${scope.protocolPath}`;
 }
 
 async function derivePublicKeyFromPrivateKey(
@@ -1535,6 +1712,7 @@ async function resolveGrantKeyRecords(params: {
       await verifyPermissionGrantActive(params.agent, params.granteeDid, params.grantorDid, grant);
 
       await verifyGrantKeyPayload({
+        agent        : params.agent,
         payload,
         grant,
         grantKeyMessage,
@@ -1639,6 +1817,7 @@ async function verifyPermissionGrantActive(
 }
 
 async function verifyGrantKeyPayload(params: {
+  agent: EnboxPlatformAgent;
   payload: GrantKeyPayload;
   grant: PermissionGrant;
   grantKeyMessage: RecordsWriteMessage;
@@ -1662,7 +1841,7 @@ async function verifyGrantKeyPayload(params: {
   if (grant.id !== payload.grantId ||
       grant.grantor !== params.grantorDid ||
       grant.grantee !== params.granteeDid ||
-      !grantScopeCoversPayload(grant, payload)) {
+      !await grantScopeCoversPayload(params.agent, params.granteeDid, params.grantorDid, grant, payload)) {
     throw new Error('grantKey payload is not covered by the referenced grant.');
   }
 
@@ -1685,7 +1864,13 @@ async function verifyGrantKeyPayload(params: {
   }
 }
 
-function grantScopeCoversPayload(grant: PermissionGrant, payload: GrantKeyPayload): boolean {
+async function grantScopeCoversPayload(
+  agent: EnboxPlatformAgent,
+  requesterDid: string,
+  ownerDid: string,
+  grant: PermissionGrant,
+  payload: GrantKeyPayload,
+): Promise<boolean> {
   if (!isGrantKeyEligibleGrant(grant)) {
     return false;
   }
@@ -1694,12 +1879,36 @@ function grantScopeCoversPayload(grant: PermissionGrant, payload: GrantKeyPayloa
     return false;
   }
 
-  if (grant.scope.protocolPath === undefined) {
+  if (grant.scope.method === DwnMethodName.Read && grant.scope.protocolPath === undefined) {
     return true;
   }
 
-  return payload.scope.protocolPath !== undefined &&
-    isBoundaryAwareSubtree(grant.scope.protocolPath, payload.scope.protocolPath);
+  if (grant.scope.method === DwnMethodName.Read) {
+    const grantProtocolPath = grant.scope.protocolPath;
+    if (grantProtocolPath === undefined) {
+      return false;
+    }
+
+    if (payload.scope.protocolPath !== undefined &&
+        isBoundaryAwareSubtree(grantProtocolPath, payload.scope.protocolPath)) {
+      return true;
+    }
+
+    if (payload.scope.protocolPath === undefined) {
+      return false;
+    }
+
+    const protocolDefinition = await getGrantKeyProtocolDefinition(agent, requesterDid, ownerDid, grant.scope.protocol, new Map());
+    return getReadRolePathsForScope(protocolDefinition, grantProtocolPath).includes(payload.scope.protocolPath);
+  }
+
+  if (payload.scope.protocolPath === undefined ||
+      (grant.scope.protocolPath !== undefined && !isBoundaryAwareSubtree(grant.scope.protocolPath, payload.scope.protocolPath))) {
+    return false;
+  }
+
+  const protocolDefinition = await getGrantKeyProtocolDefinition(agent, requesterDid, ownerDid, grant.scope.protocol, new Map());
+  return isLocalRolePath(protocolDefinition, payload.scope.protocolPath);
 }
 
 function scopeCoversRecord(scope: GrantKeyScope, protocol: string, protocolPath: string | undefined): boolean {

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -1392,6 +1392,7 @@ async function submitConnectResponse(
                 granteeDid            : delegateBearerDid.uri,
                 granteeRootPrivateKey : delegateX25519PrivateKey as PrivateKeyJwk,
                 grantMessages         : grants,
+                protocolDefinitions   : [protocolDefinition],
               });
               durableGrantKeyRecords.push(...grantKeyRecords);
             }

--- a/packages/agent/tests/dwn-encryption.spec.ts
+++ b/packages/agent/tests/dwn-encryption.spec.ts
@@ -1,5 +1,5 @@
 import type { AudienceEpochPayload } from '../src/dwn-encryption.js';
-import type { DerivedPrivateJwk, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
+import type { DerivedPrivateJwk, ProtocolDefinition, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 
 import sinon from 'sinon';
 
@@ -547,17 +547,17 @@ describe('dwn-encryption', () => {
   });
 
   describe('createGrantKeyRecordsForGrants', () => {
-    it('should skip grants that cannot carry durable encrypted read access', async () => {
+    it('should skip grants that cannot carry durable encrypted access', async () => {
       const grantor = await TestDataGenerator.generatePersona({ did: 'did:example:alice' });
       const grantee = await TestDataGenerator.generatePersona({ did: 'did:example:delegate' });
-      const writeGrant = await TestDataGenerator.generateGrantCreate({
+      const deleteGrant = await TestDataGenerator.generateGrantCreate({
         author      : grantor,
         grantedTo   : grantee,
         delegated   : true,
         dateExpires : '2040-06-25T16:09:16.693356Z',
         scope       : {
           interface : DwnInterfaceName.Records,
-          method    : DwnMethodName.Write,
+          method    : DwnMethodName.Delete,
           protocol  : 'https://proto.example.com',
         },
       });
@@ -584,7 +584,6 @@ describe('dwn-encryption', () => {
           protocol  : 'https://proto.example.com',
         },
       });
-      // Role-path Write grant coverage belongs to the encryption-control workstream.
       const processDwnRequest = sinon.stub().rejects(new Error('ineligible grants should not write records'));
 
       const records = await createGrantKeyRecordsForGrants({
@@ -592,11 +591,98 @@ describe('dwn-encryption', () => {
         ownerDid              : grantor.did,
         granteeDid            : grantee.did,
         granteeRootPrivateKey : await X25519.generateKey(),
-        grantMessages         : [writeGrant.dataEncodedMessage, contextReadGrant.dataEncodedMessage, messagesReadGrant.dataEncodedMessage],
+        grantMessages         : [deleteGrant.dataEncodedMessage, contextReadGrant.dataEncodedMessage, messagesReadGrant.dataEncodedMessage],
       });
 
       expect(records).toHaveLength(0);
       expect(processDwnRequest.called).toBe(false);
+    });
+
+    it('should create grantKey records for read scope keys and referenced local role keys', async () => {
+      const grantor = await TestDataGenerator.generatePersona({ did: 'did:example:alice' });
+      const grantee = await TestDataGenerator.generatePersona({ did: 'did:example:delegate' });
+      const ownerPrivateKey = await X25519.generateKey();
+      const protocolDefinition = await createGrantKeyCoverageProtocolDefinition('https://proto.example.com');
+      const readGrant = await TestDataGenerator.generateGrantCreate({
+        author      : grantor,
+        grantedTo   : grantee,
+        delegated   : true,
+        dateExpires : '2040-06-25T16:09:16.693356Z',
+        scope       : {
+          interface    : DwnInterfaceName.Records,
+          method       : DwnMethodName.Read,
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'chat/message',
+        },
+      });
+      const processDwnRequest = sinon.stub().callsFake(async (request: any): Promise<any> => ({
+        message: {
+          recordId   : `grant-key-${processDwnRequest.callCount}`,
+          descriptor : {
+            ...request.messageParams,
+            messageTimestamp: Time.getCurrentTimestamp(),
+          },
+        },
+        reply: { status: { code: 202, detail: 'Accepted' } },
+      }));
+      const mockAgent = await createGrantKeyProducerAgent(grantor.did, ownerPrivateKey, processDwnRequest);
+
+      const records = await createGrantKeyRecordsForGrants({
+        agent                 : mockAgent,
+        ownerDid              : grantor.did,
+        granteeDid            : grantee.did,
+        granteeRootPrivateKey : await X25519.generateKey(),
+        grantMessages         : [readGrant.dataEncodedMessage],
+        protocolDefinitions   : [protocolDefinition],
+      });
+
+      expect(records).toHaveLength(2);
+      expect(records.map((record) => record.descriptor.tags?.protocolPath).sort()).toEqual(['chat/member', 'chat/message']);
+      expect(processDwnRequest.callCount).toBe(2);
+      expect(processDwnRequest.getCalls().every((call) => call.args[0].messageType === DwnInterface.RecordsWrite)).toBe(true);
+    });
+
+    it('should create grantKey records for role paths covered by write grants', async () => {
+      const grantor = await TestDataGenerator.generatePersona({ did: 'did:example:alice' });
+      const grantee = await TestDataGenerator.generatePersona({ did: 'did:example:delegate' });
+      const ownerPrivateKey = await X25519.generateKey();
+      const protocolDefinition = await createGrantKeyCoverageProtocolDefinition('https://proto.example.com');
+      const writeGrant = await TestDataGenerator.generateGrantCreate({
+        author      : grantor,
+        grantedTo   : grantee,
+        delegated   : true,
+        dateExpires : '2040-06-25T16:09:16.693356Z',
+        scope       : {
+          interface    : DwnInterfaceName.Records,
+          method       : DwnMethodName.Write,
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'chat',
+        },
+      });
+      const processDwnRequest = sinon.stub().callsFake(async (request: any): Promise<any> => ({
+        message: {
+          recordId   : `grant-key-${processDwnRequest.callCount}`,
+          descriptor : {
+            ...request.messageParams,
+            messageTimestamp: Time.getCurrentTimestamp(),
+          },
+        },
+        reply: { status: { code: 202, detail: 'Accepted' } },
+      }));
+      const mockAgent = await createGrantKeyProducerAgent(grantor.did, ownerPrivateKey, processDwnRequest);
+
+      const records = await createGrantKeyRecordsForGrants({
+        agent                 : mockAgent,
+        ownerDid              : grantor.did,
+        granteeDid            : grantee.did,
+        granteeRootPrivateKey : await X25519.generateKey(),
+        grantMessages         : [writeGrant.dataEncodedMessage],
+        protocolDefinitions   : [protocolDefinition],
+      });
+
+      expect(records).toHaveLength(2);
+      expect(records.map((record) => record.descriptor.tags?.protocolPath).sort()).toEqual(['chat/admin', 'chat/member']);
+      expect(processDwnRequest.callCount).toBe(2);
     });
   });
 
@@ -630,6 +716,7 @@ describe('dwn-encryption', () => {
       recordProtocolPath = 'message',
       includeEncodedData = true,
       grantRevoked = false,
+      protocolDefinition,
       mutatePayload,
       mutateRecordTags,
     }: {
@@ -639,6 +726,7 @@ describe('dwn-encryption', () => {
       recordProtocolPath?: string;
       includeEncodedData?: boolean;
       grantRevoked?: boolean;
+      protocolDefinition?: ProtocolDefinition;
       mutatePayload?: (payload: any) => void;
       mutateRecordTags?: (tags: Record<string, string>) => void;
     } = {}): Promise<{
@@ -742,6 +830,16 @@ describe('dwn-encryption', () => {
           },
         },
       });
+      nextCallIndex++;
+      if (protocolDefinition !== undefined) {
+        processDwnRequest.onCall(nextCallIndex).resolves({
+          reply: {
+            status  : { code: 200, detail: 'OK' },
+            entries : [{ descriptor: { definition: protocolDefinition } }],
+          },
+        });
+        nextCallIndex++;
+      }
       const mockAgent = {
         did: {
           resolve: sinon.stub().resolves({
@@ -1210,6 +1308,32 @@ describe('dwn-encryption', () => {
       })).toBe(true);
     });
 
+    it('should hydrate a read-grant role-path durable grantKey referenced by a covered read rule', async () => {
+      const protocolDefinition = await createGrantKeyCoverageProtocolDefinition('https://proto.example.com');
+      const { mockAgent, delegateCache, recordsWrite } = await makeGrantKeyResolverFixture({
+        grantScopeProtocolPath   : 'chat/message',
+        payloadScopeProtocolPath : 'chat/member',
+        protocolDefinition,
+        recordProtocolPath       : 'chat/member',
+      });
+
+      const result = await resolveKeyDecrypter(
+        mockAgent, 'did:example:delegate', recordsWrite, 'did:example:alice',
+        delegateCache,
+        'did:example:delegate',
+      );
+
+      expect(result.derivationScheme).toBe(KeyDerivationScheme.ProtocolPath);
+      expect(delegateCache.set.calledOnce).toBe(true);
+      expect(mockAgent.processDwnRequest.callCount).toBe(3);
+      expect(mockAgent.processDwnRequest.thirdCall.args[0]).toMatchObject({
+        author        : 'did:example:delegate',
+        target        : 'did:example:alice',
+        messageType   : DwnInterface.ProtocolsQuery,
+        messageParams : { filter: { protocol: 'https://proto.example.com' } },
+      });
+    });
+
     it('should read durable grantKey data when the query entry omits encodedData', async () => {
       const { mockAgent, delegateCache, grantKeyRecordId, recordsWrite } = await makeGrantKeyResolverFixture({
         includeEncodedData: false,
@@ -1412,3 +1536,66 @@ describe('dwn-encryption', () => {
     });
   });
 });
+
+async function createGrantKeyCoverageProtocolDefinition(protocol: string): Promise<ProtocolDefinition> {
+  const rolePublicKey = await X25519.getPublicKey({ key: await X25519.generateKey() });
+  return {
+    published : true,
+    protocol,
+    types     : {
+      admin   : { dataFormats: ['application/json'] },
+      chat    : { dataFormats: ['application/json'] },
+      member  : { dataFormats: ['application/json'] },
+      message : { dataFormats: ['application/json'], encryptionRequired: true },
+    },
+    structure: {
+      chat: {
+        admin: {
+          $keyAgreement : { publicKeyJwk: rolePublicKey },
+          $role         : true,
+        },
+        member: {
+          $keyAgreement : { publicKeyJwk: rolePublicKey },
+          $role         : true,
+        },
+        message: {
+          $actions      : [{ can: ['read'], role: 'chat/member' }],
+          $keyAgreement : { publicKeyJwk: rolePublicKey },
+        },
+      },
+    },
+  };
+}
+
+async function createGrantKeyProducerAgent(
+  ownerDid: string,
+  ownerPrivateKey: Awaited<ReturnType<typeof X25519.generateKey>>,
+  processDwnRequest: sinon.SinonStub,
+): Promise<any> {
+  const ownerPublicKey = await X25519.getPublicKey({ key: ownerPrivateKey });
+  const ownerPrivateKeyBytes = await X25519.privateKeyToBytes({ privateKey: ownerPrivateKey });
+  return {
+    did: {
+      resolve: sinon.stub().resolves({
+        didDocument: {
+          id                 : ownerDid,
+          keyAgreement       : ['#enc'],
+          verificationMethod : [{
+            controller   : ownerDid,
+            id           : `${ownerDid}#enc`,
+            publicKeyJwk : ownerPublicKey,
+            type         : 'JsonWebKey2020',
+          }],
+        },
+        didResolutionMetadata: {},
+      }),
+    },
+    keyManager: {
+      derivePrivateKeyBytes: sinon.stub().callsFake(async ({ derivationPath }: { derivationPath: string[] }): Promise<Uint8Array> => {
+        return HdKey.derivePrivateKeyBytes(ownerPrivateKeyBytes, derivationPath);
+      }),
+      getKeyUri: sinon.stub().resolves('owner-key-uri'),
+    },
+    processDwnRequest,
+  };
+}

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -39,7 +39,7 @@ export type { DataStore, DataStorePutResult, DataStoreGetResult } from './types/
 export type { ResumableTaskStore, ManagedResumableTask } from './types/resumable-task-store.js';
 export { DataStream } from './utils/data-stream.js';
 export { getGrantKeyDeliveryScopes, grantKeyScopeCoversDeliveredScope, isGrantKeyEligibleRecordsScope, isGrantKeyRecordsScope } from './utils/grant-key-coverage.js';
-export type { GrantKeyEligibleRecordsScope, GrantKeyProtocolPathScope, GrantKeyRecordsScope } from './utils/grant-key-coverage.js';
+export type { GrantKeyEligibleRecordsScope, GrantKeyProtocolPathScope, GrantKeyReadRecordsScope, GrantKeyRecordsScope, GrantKeyWriteRecordsScope } from './utils/grant-key-coverage.js';
 export { HdKey, KeyDerivationScheme } from './utils/hd-key.js';
 export type { DerivedPrivateJwk } from './utils/hd-key.js';
 export { Dwn } from './dwn.js';

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -38,6 +38,8 @@ export type { RecordsQueryOptions } from './interfaces/records-query.js';
 export type { DataStore, DataStorePutResult, DataStoreGetResult } from './types/data-store.js';
 export type { ResumableTaskStore, ManagedResumableTask } from './types/resumable-task-store.js';
 export { DataStream } from './utils/data-stream.js';
+export { getGrantKeyDeliveryScopes, grantKeyScopeCoversDeliveredScope, isGrantKeyEligibleRecordsScope, isGrantKeyRecordsScope } from './utils/grant-key-coverage.js';
+export type { GrantKeyEligibleRecordsScope, GrantKeyProtocolPathScope, GrantKeyRecordsScope } from './utils/grant-key-coverage.js';
 export { HdKey, KeyDerivationScheme } from './utils/hd-key.js';
 export type { DerivedPrivateJwk } from './utils/hd-key.js';
 export { Dwn } from './dwn.js';

--- a/packages/dwn-sdk-js/src/protocols/encryption.ts
+++ b/packages/dwn-sdk-js/src/protocols/encryption.ts
@@ -19,8 +19,8 @@ import { Message } from '../core/message.js';
 import { Records } from '../utils/records.js';
 import { validateJsonSchema } from '../schema-validator.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
-import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 import { getRuleSetAtPath, isCrossProtocolRef, parseCrossProtocolRef } from '../utils/protocols.js';
+import { grantKeyScopeCoversDeliveredScope, isGrantKeyEligibleRecordsScope, isGrantKeyRecordsScope } from '../utils/grant-key-coverage.js';
 import { ProtocolAction, ProtocolActor } from '../types/protocols-types.js';
 
 type AudienceTags = {
@@ -422,14 +422,14 @@ export class EncryptionProtocol implements CoreProtocol {
   }): Promise<void> {
     const { grantScope, protocol, protocolPath } = params;
 
-    if (!EncryptionProtocol.isGrantKeyEligibleRecordsScope(grantScope)) {
+    if (!isGrantKeyRecordsScope(grantScope)) {
       throw new DwnError(
         DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
         'grantKey must reference a Records.Read or Records.Write permission grant.'
       );
     }
 
-    if (grantScope.contextId !== undefined) {
+    if (!isGrantKeyEligibleRecordsScope(grantScope)) {
       throw new DwnError(
         DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
         'grantKey must not reference a context-scoped permission grant.'
@@ -443,59 +443,16 @@ export class EncryptionProtocol implements CoreProtocol {
       );
     }
 
-    if (await EncryptionProtocol.grantScopeCoversDeliveredPath({ ...params, grantScope })) {
+    const deliveredScope = { protocol, protocolPath };
+    if (grantKeyScopeCoversDeliveredScope({ grantScope, deliveredScope })) {
       return;
     }
 
-    throw new DwnError(
-      DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
-      `grantKey protocolPath ${protocolPath ?? '<protocol>'} is outside the permission grant scope.`
-    );
-  }
-
-  private static async grantScopeCoversDeliveredPath(params: {
-    tenant: string;
-    message: RecordsWriteMessage;
-    grantScope: PermissionScope & {
-      interface: typeof DwnInterfaceName.Records;
-      method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
-      protocol: string;
-      protocolPath?: string;
-      contextId?: string;
-    };
-    protocol: string;
-    protocolPath: string | undefined;
-    validationStateReader: ValidationStateReader;
-  }): Promise<boolean> {
-    const { grantScope, protocolPath } = params;
-
-    if (grantScope.method === DwnMethodName.Read) {
-      if (grantScope.protocolPath === undefined) {
-        return true;
-      }
-
-      if (protocolPath !== undefined && EncryptionProtocol.isBoundaryAwareSubtree(grantScope.protocolPath, protocolPath)) {
-        return true;
-      }
-
-      if (protocolPath === undefined) {
-        return false;
-      }
-
-      const protocolDefinition = await params.validationStateReader.fetchProtocolDefinition(
-        params.tenant,
-        params.protocol,
-        params.message.descriptor.messageTimestamp,
-      );
-      return EncryptionProtocol.readScopeReferencesRolePath(protocolDefinition, grantScope.protocolPath, protocolPath);
-    }
-
     if (protocolPath === undefined) {
-      return false;
-    }
-
-    if (grantScope.protocolPath !== undefined && !EncryptionProtocol.isBoundaryAwareSubtree(grantScope.protocolPath, protocolPath)) {
-      return false;
+      throw new DwnError(
+        DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
+        `grantKey protocolPath ${protocolPath ?? '<protocol>'} is outside the permission grant scope.`
+      );
     }
 
     const protocolDefinition = await params.validationStateReader.fetchProtocolDefinition(
@@ -503,68 +460,14 @@ export class EncryptionProtocol implements CoreProtocol {
       params.protocol,
       params.message.descriptor.messageTimestamp,
     );
-    return EncryptionProtocol.isLocalRolePath(protocolDefinition, protocolPath);
-  }
-
-  private static isGrantKeyEligibleRecordsScope(scope: PermissionScope): scope is PermissionScope & {
-    interface: typeof DwnInterfaceName.Records;
-    method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
-    protocol: string;
-    protocolPath?: string;
-    contextId?: string;
-  } {
-    return scope.interface === DwnInterfaceName.Records &&
-      (scope.method === DwnMethodName.Read || scope.method === DwnMethodName.Write) &&
-      'protocol' in scope &&
-      typeof scope.protocol === 'string';
-  }
-
-  private static readScopeReferencesRolePath(
-    protocolDefinition: ProtocolDefinition,
-    scopeProtocolPath: string,
-    rolePath: string,
-  ): boolean {
-    const scopedRuleSet = getRuleSetAtPath(scopeProtocolPath, protocolDefinition.structure);
-    if (scopedRuleSet === undefined || !EncryptionProtocol.isLocalRolePath(protocolDefinition, rolePath)) {
-      return false;
+    if (grantKeyScopeCoversDeliveredScope({ grantScope, deliveredScope, protocolDefinition })) {
+      return;
     }
 
-    const referencedRoles = EncryptionProtocol.collectReadRolePaths(protocolDefinition, scopedRuleSet);
-    return referencedRoles.has(rolePath);
-  }
-
-  private static collectReadRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet): Set<string> {
-    const rolePaths = new Set<string>();
-
-    for (const actionRule of ruleSet.$actions ?? []) {
-      if (!actionRule.can.includes(ProtocolAction.Read) || actionRule.role === undefined || parseCrossProtocolRef(actionRule.role) !== undefined) {
-        continue;
-      }
-
-      if (EncryptionProtocol.isLocalRolePath(protocolDefinition, actionRule.role)) {
-        rolePaths.add(actionRule.role);
-      }
-    }
-
-    for (const [key, value] of Object.entries(ruleSet)) {
-      if (key.startsWith('$')) {
-        continue;
-      }
-      for (const rolePath of EncryptionProtocol.collectReadRolePaths(protocolDefinition, value as ProtocolRuleSet)) {
-        rolePaths.add(rolePath);
-      }
-    }
-
-    return rolePaths;
-  }
-
-  private static isLocalRolePath(protocolDefinition: ProtocolDefinition, protocolPath: string): boolean {
-    const ruleSet = getRuleSetAtPath(protocolPath, protocolDefinition.structure);
-    return ruleSet?.$role === true && ruleSet.$keyAgreement !== undefined;
-  }
-
-  private static isBoundaryAwareSubtree(scopePath: string, candidatePath: string): boolean {
-    return candidatePath === scopePath || candidatePath.startsWith(scopePath + '/');
+    throw new DwnError(
+      DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
+      `grantKey protocolPath ${protocolPath ?? '<protocol>'} is outside the permission grant scope.`
+    );
   }
 
   private static async verifyRoleAudienceDefinition(

--- a/packages/dwn-sdk-js/src/protocols/encryption.ts
+++ b/packages/dwn-sdk-js/src/protocols/encryption.ts
@@ -40,9 +40,6 @@ export class EncryptionProtocol implements CoreProtocol {
   public static readonly audienceEpochPath = 'audienceEpoch';
   public static readonly audienceKeyPath = 'audienceKey';
   public static readonly grantKeyPath = 'grantKey';
-  private static readonly grantKeyScopeMethodsByInterface: Record<string, DwnMethodName | undefined> = {
-    [DwnInterfaceName.Records]: DwnMethodName.Read,
-  };
 
   public static readonly definition: ProtocolDefinition = {
     published : true,
@@ -255,7 +252,14 @@ export class EncryptionProtocol implements CoreProtocol {
     await EncryptionProtocol.verifyGrantActive(tenant, message, grant, validationStateReader);
     EncryptionProtocol.verifyGrantKeyAuthor(message, grant);
     EncryptionProtocol.verifyGrantKeyRecipient(message, grant);
-    EncryptionProtocol.verifyGrantKeyScope(grant.scope, protocol, protocolPath);
+    await EncryptionProtocol.verifyGrantKeyScope({
+      tenant,
+      message,
+      grantScope: grant.scope,
+      protocol,
+      protocolPath,
+      validationStateReader,
+    });
   }
 
   private static verifyEncryptedDelivery(message: RecordsWriteMessage): void {
@@ -408,35 +412,155 @@ export class EncryptionProtocol implements CoreProtocol {
     );
   }
 
-  private static verifyGrantKeyScope(grantScope: PermissionScope, protocol: string, protocolPath: string | undefined): void {
-    if (!EncryptionProtocol.isReadScope(grantScope)) {
+  private static async verifyGrantKeyScope(params: {
+    tenant: string;
+    message: RecordsWriteMessage;
+    grantScope: PermissionScope;
+    protocol: string;
+    protocolPath: string | undefined;
+    validationStateReader: ValidationStateReader;
+  }): Promise<void> {
+    const { grantScope, protocol, protocolPath } = params;
+
+    if (!EncryptionProtocol.isGrantKeyEligibleRecordsScope(grantScope)) {
       throw new DwnError(
         DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
-        'grantKey must reference a Records.Read permission grant.'
+        'grantKey must reference a Records.Read or Records.Write permission grant.'
       );
     }
 
-    if ('protocol' in grantScope && grantScope.protocol !== undefined && grantScope.protocol !== protocol) {
+    if (grantScope.contextId !== undefined) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
+        'grantKey must not reference a context-scoped permission grant.'
+      );
+    }
+
+    if (grantScope.protocol !== protocol) {
       throw new DwnError(
         DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
         `grantKey protocol ${protocol} is outside the permission grant scope.`
       );
     }
 
-    if (!('protocolPath' in grantScope) || grantScope.protocolPath === undefined) {
+    if (await EncryptionProtocol.grantScopeCoversDeliveredPath({ ...params, grantScope })) {
       return;
     }
 
-    if (protocolPath === undefined || !EncryptionProtocol.isBoundaryAwareSubtree(grantScope.protocolPath, protocolPath)) {
-      throw new DwnError(
-        DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
-        `grantKey protocolPath ${protocolPath ?? '<protocol>'} is outside the permission grant scope.`
-      );
-    }
+    throw new DwnError(
+      DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch,
+      `grantKey protocolPath ${protocolPath ?? '<protocol>'} is outside the permission grant scope.`
+    );
   }
 
-  private static isReadScope(scope: PermissionScope): boolean {
-    return Object.is(EncryptionProtocol.grantKeyScopeMethodsByInterface[scope.interface], scope.method);
+  private static async grantScopeCoversDeliveredPath(params: {
+    tenant: string;
+    message: RecordsWriteMessage;
+    grantScope: PermissionScope & {
+      interface: typeof DwnInterfaceName.Records;
+      method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
+      protocol: string;
+      protocolPath?: string;
+      contextId?: string;
+    };
+    protocol: string;
+    protocolPath: string | undefined;
+    validationStateReader: ValidationStateReader;
+  }): Promise<boolean> {
+    const { grantScope, protocolPath } = params;
+
+    if (grantScope.method === DwnMethodName.Read) {
+      if (grantScope.protocolPath === undefined) {
+        return true;
+      }
+
+      if (protocolPath !== undefined && EncryptionProtocol.isBoundaryAwareSubtree(grantScope.protocolPath, protocolPath)) {
+        return true;
+      }
+
+      if (protocolPath === undefined) {
+        return false;
+      }
+
+      const protocolDefinition = await params.validationStateReader.fetchProtocolDefinition(
+        params.tenant,
+        params.protocol,
+        params.message.descriptor.messageTimestamp,
+      );
+      return EncryptionProtocol.readScopeReferencesRolePath(protocolDefinition, grantScope.protocolPath, protocolPath);
+    }
+
+    if (protocolPath === undefined) {
+      return false;
+    }
+
+    if (grantScope.protocolPath !== undefined && !EncryptionProtocol.isBoundaryAwareSubtree(grantScope.protocolPath, protocolPath)) {
+      return false;
+    }
+
+    const protocolDefinition = await params.validationStateReader.fetchProtocolDefinition(
+      params.tenant,
+      params.protocol,
+      params.message.descriptor.messageTimestamp,
+    );
+    return EncryptionProtocol.isLocalRolePath(protocolDefinition, protocolPath);
+  }
+
+  private static isGrantKeyEligibleRecordsScope(scope: PermissionScope): scope is PermissionScope & {
+    interface: typeof DwnInterfaceName.Records;
+    method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
+    protocol: string;
+    protocolPath?: string;
+    contextId?: string;
+  } {
+    return scope.interface === DwnInterfaceName.Records &&
+      (scope.method === DwnMethodName.Read || scope.method === DwnMethodName.Write) &&
+      'protocol' in scope &&
+      typeof scope.protocol === 'string';
+  }
+
+  private static readScopeReferencesRolePath(
+    protocolDefinition: ProtocolDefinition,
+    scopeProtocolPath: string,
+    rolePath: string,
+  ): boolean {
+    const scopedRuleSet = getRuleSetAtPath(scopeProtocolPath, protocolDefinition.structure);
+    if (scopedRuleSet === undefined || !EncryptionProtocol.isLocalRolePath(protocolDefinition, rolePath)) {
+      return false;
+    }
+
+    const referencedRoles = EncryptionProtocol.collectReadRolePaths(protocolDefinition, scopedRuleSet);
+    return referencedRoles.has(rolePath);
+  }
+
+  private static collectReadRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet): Set<string> {
+    const rolePaths = new Set<string>();
+
+    for (const actionRule of ruleSet.$actions ?? []) {
+      if (!actionRule.can.includes(ProtocolAction.Read) || actionRule.role === undefined || parseCrossProtocolRef(actionRule.role) !== undefined) {
+        continue;
+      }
+
+      if (EncryptionProtocol.isLocalRolePath(protocolDefinition, actionRule.role)) {
+        rolePaths.add(actionRule.role);
+      }
+    }
+
+    for (const [key, value] of Object.entries(ruleSet)) {
+      if (key.startsWith('$')) {
+        continue;
+      }
+      for (const rolePath of EncryptionProtocol.collectReadRolePaths(protocolDefinition, value as ProtocolRuleSet)) {
+        rolePaths.add(rolePath);
+      }
+    }
+
+    return rolePaths;
+  }
+
+  private static isLocalRolePath(protocolDefinition: ProtocolDefinition, protocolPath: string): boolean {
+    const ruleSet = getRuleSetAtPath(protocolPath, protocolDefinition.structure);
+    return ruleSet?.$role === true && ruleSet.$keyAgreement !== undefined;
   }
 
   private static isBoundaryAwareSubtree(scopePath: string, candidatePath: string): boolean {

--- a/packages/dwn-sdk-js/src/utils/grant-key-coverage.ts
+++ b/packages/dwn-sdk-js/src/utils/grant-key-coverage.ts
@@ -1,0 +1,205 @@
+import type { PermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
+import type { ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
+
+import { KeyDerivationScheme } from './hd-key.js';
+import { ProtocolAction } from '../types/protocols-types.js';
+import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
+import { getRuleSetAtPath, parseCrossProtocolRef } from './protocols.js';
+
+export type GrantKeyRecordsScope = RecordsPermissionScope & {
+  interface: typeof DwnInterfaceName.Records;
+  method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
+  protocol: string;
+};
+
+export type GrantKeyEligibleRecordsScope = GrantKeyRecordsScope & {
+  contextId?: undefined;
+};
+
+export type GrantKeyProtocolPathScope = {
+  scheme: typeof KeyDerivationScheme.ProtocolPath;
+  protocol: string;
+  protocolPath?: string;
+};
+
+export function isGrantKeyRecordsScope(scope: PermissionScope): scope is GrantKeyRecordsScope {
+  return scope.interface === DwnInterfaceName.Records &&
+    (scope.method === DwnMethodName.Read || scope.method === DwnMethodName.Write) &&
+    'protocol' in scope &&
+    typeof scope.protocol === 'string';
+}
+
+export function isGrantKeyEligibleRecordsScope(scope: PermissionScope): scope is GrantKeyEligibleRecordsScope {
+  return isGrantKeyRecordsScope(scope) &&
+    !('contextId' in scope && scope.contextId !== undefined);
+}
+
+export function getGrantKeyDeliveryScopes(
+  grantScope: GrantKeyEligibleRecordsScope,
+  protocolDefinition?: ProtocolDefinition,
+): GrantKeyProtocolPathScope[] {
+  const deliveredScopes = new Map<string, GrantKeyProtocolPathScope>();
+  const addScope = (scope: GrantKeyProtocolPathScope): void => {
+    deliveredScopes.set(getGrantKeyScopeCacheKey(scope), scope);
+  };
+
+  if (grantScope.method === DwnMethodName.Read) {
+    if (grantScope.protocolPath === undefined) {
+      addScope({
+        scheme   : KeyDerivationScheme.ProtocolPath,
+        protocol : grantScope.protocol,
+      });
+      return [...deliveredScopes.values()];
+    }
+
+    addScope({
+      scheme       : KeyDerivationScheme.ProtocolPath,
+      protocol     : grantScope.protocol,
+      protocolPath : grantScope.protocolPath,
+    });
+
+    if (protocolDefinition !== undefined) {
+      for (const rolePath of getGrantKeyReadRolePathsForScope(protocolDefinition, grantScope.protocolPath)) {
+        addScope({
+          scheme       : KeyDerivationScheme.ProtocolPath,
+          protocol     : grantScope.protocol,
+          protocolPath : rolePath,
+        });
+      }
+    }
+  }
+
+  if (grantScope.method === DwnMethodName.Write && protocolDefinition !== undefined) {
+    for (const rolePath of getGrantKeyRolePathsCoveredByScope(protocolDefinition, grantScope.protocolPath)) {
+      addScope({
+        scheme       : KeyDerivationScheme.ProtocolPath,
+        protocol     : grantScope.protocol,
+        protocolPath : rolePath,
+      });
+    }
+  }
+
+  return [...deliveredScopes.values()];
+}
+
+export function grantKeyScopeCoversDeliveredScope(input: {
+  grantScope: GrantKeyEligibleRecordsScope;
+  deliveredScope: Pick<GrantKeyProtocolPathScope, 'protocol' | 'protocolPath'>;
+  protocolDefinition?: ProtocolDefinition;
+}): boolean {
+  const { grantScope, deliveredScope, protocolDefinition } = input;
+  if (grantScope.protocol !== deliveredScope.protocol) {
+    return false;
+  }
+
+  if (grantScope.method === DwnMethodName.Read) {
+    if (grantScope.protocolPath === undefined) {
+      return true;
+    }
+
+    if (deliveredScope.protocolPath !== undefined && isBoundaryAwareSubtree(grantScope.protocolPath, deliveredScope.protocolPath)) {
+      return true;
+    }
+
+    if (deliveredScope.protocolPath === undefined || protocolDefinition === undefined) {
+      return false;
+    }
+
+    return grantKeyReadScopeReferencesRolePath(protocolDefinition, grantScope.protocolPath, deliveredScope.protocolPath);
+  }
+
+  if (deliveredScope.protocolPath === undefined) {
+    return false;
+  }
+
+  if (grantScope.protocolPath !== undefined && !isBoundaryAwareSubtree(grantScope.protocolPath, deliveredScope.protocolPath)) {
+    return false;
+  }
+
+  return protocolDefinition !== undefined && isGrantKeyLocalRolePath(protocolDefinition, deliveredScope.protocolPath);
+}
+
+function getGrantKeyReadRolePathsForScope(protocolDefinition: ProtocolDefinition, scopeProtocolPath: string): string[] {
+  const scopedRuleSet = getRuleSetAtPath(scopeProtocolPath, protocolDefinition.structure);
+  if (scopedRuleSet === undefined) {
+    return [];
+  }
+
+  return [...collectReadRolePaths(protocolDefinition, scopedRuleSet)];
+}
+
+function grantKeyReadScopeReferencesRolePath(
+  protocolDefinition: ProtocolDefinition,
+  scopeProtocolPath: string,
+  rolePath: string,
+): boolean {
+  if (!isGrantKeyLocalRolePath(protocolDefinition, rolePath)) {
+    return false;
+  }
+
+  return getGrantKeyReadRolePathsForScope(protocolDefinition, scopeProtocolPath).includes(rolePath);
+}
+
+function collectReadRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet): Set<string> {
+  const rolePaths = new Set<string>();
+
+  for (const actionRule of ruleSet.$actions ?? []) {
+    if (!actionRule.can.includes(ProtocolAction.Read) || actionRule.role === undefined || parseCrossProtocolRef(actionRule.role) !== undefined) {
+      continue;
+    }
+
+    if (isGrantKeyLocalRolePath(protocolDefinition, actionRule.role)) {
+      rolePaths.add(actionRule.role);
+    }
+  }
+
+  for (const [key, value] of Object.entries(ruleSet)) {
+    if (key.startsWith('$')) {
+      continue;
+    }
+    for (const rolePath of collectReadRolePaths(protocolDefinition, value as ProtocolRuleSet)) {
+      rolePaths.add(rolePath);
+    }
+  }
+
+  return rolePaths;
+}
+
+function getGrantKeyRolePathsCoveredByScope(protocolDefinition: ProtocolDefinition, scopeProtocolPath?: string): string[] {
+  return collectRolePaths(protocolDefinition, protocolDefinition.structure as ProtocolRuleSet)
+    .filter((rolePath) => scopeProtocolPath === undefined || isBoundaryAwareSubtree(scopeProtocolPath, rolePath));
+}
+
+function collectRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet, parentPath?: string): string[] {
+  const rolePaths: string[] = [];
+
+  for (const [key, value] of Object.entries(ruleSet)) {
+    if (key.startsWith('$')) {
+      continue;
+    }
+
+    const protocolPath = parentPath === undefined ? key : `${parentPath}/${key}`;
+    const childRuleSet = value as ProtocolRuleSet;
+    if (isGrantKeyLocalRolePath(protocolDefinition, protocolPath)) {
+      rolePaths.push(protocolPath);
+    }
+    rolePaths.push(...collectRolePaths(protocolDefinition, childRuleSet, protocolPath));
+  }
+
+  return rolePaths;
+}
+
+function isGrantKeyLocalRolePath(protocolDefinition: ProtocolDefinition, protocolPath: string): boolean {
+  const ruleSet = getRuleSetAtPath(protocolPath, protocolDefinition.structure);
+  return ruleSet?.$role === true && ruleSet.$keyAgreement !== undefined;
+}
+
+function isBoundaryAwareSubtree(scopePath: string, candidatePath: string): boolean {
+  return candidatePath === scopePath || candidatePath.startsWith(scopePath + '/');
+}
+
+function getGrantKeyScopeCacheKey(scope: GrantKeyProtocolPathScope): string {
+  return scope.protocolPath === undefined
+    ? `${scope.protocol}~protocol`
+    : `${scope.protocol}~protocolPath~${scope.protocolPath}`;
+}

--- a/packages/dwn-sdk-js/src/utils/grant-key-coverage.ts
+++ b/packages/dwn-sdk-js/src/utils/grant-key-coverage.ts
@@ -22,11 +22,41 @@ export type GrantKeyProtocolPathScope = {
   protocolPath?: string;
 };
 
+type GrantKeyDeliveryScopeBuilder = (
+  grantScope: GrantKeyEligibleRecordsScope,
+  protocolDefinition?: ProtocolDefinition,
+) => GrantKeyProtocolPathScope[];
+
+type GrantKeyCoveragePredicate = (
+  input: {
+    grantScope: GrantKeyEligibleRecordsScope;
+    deliveredScope: Pick<GrantKeyProtocolPathScope, 'protocol' | 'protocolPath'>;
+    protocolDefinition?: ProtocolDefinition;
+  },
+) => boolean;
+
+const grantKeyRecordsMethods = new Set<string>([
+  DwnMethodName.Read,
+  DwnMethodName.Write,
+]);
+
+const grantKeyDeliveryScopeBuilders: Record<GrantKeyRecordsScope['method'], GrantKeyDeliveryScopeBuilder> = {
+  [DwnMethodName.Read]  : getReadGrantKeyDeliveryScopes,
+  [DwnMethodName.Write] : getWriteGrantKeyDeliveryScopes,
+};
+
+const grantKeyCoveragePredicates: Record<GrantKeyRecordsScope['method'], GrantKeyCoveragePredicate> = {
+  [DwnMethodName.Read]  : readGrantKeyScopeCoversDeliveredScope,
+  [DwnMethodName.Write] : writeGrantKeyScopeCoversDeliveredScope,
+};
+
 export function isGrantKeyRecordsScope(scope: PermissionScope): scope is GrantKeyRecordsScope {
-  return scope.interface === DwnInterfaceName.Records &&
-    (scope.method === DwnMethodName.Read || scope.method === DwnMethodName.Write) &&
-    'protocol' in scope &&
-    typeof scope.protocol === 'string';
+  const maybeProtocol = (scope as { protocol?: unknown }).protocol;
+  return [
+    scope.interface === DwnInterfaceName.Records,
+    grantKeyRecordsMethods.has(scope.method),
+    typeof maybeProtocol === 'string',
+  ].every(Boolean);
 }
 
 export function isGrantKeyEligibleRecordsScope(scope: PermissionScope): scope is GrantKeyEligibleRecordsScope {
@@ -38,48 +68,7 @@ export function getGrantKeyDeliveryScopes(
   grantScope: GrantKeyEligibleRecordsScope,
   protocolDefinition?: ProtocolDefinition,
 ): GrantKeyProtocolPathScope[] {
-  const deliveredScopes = new Map<string, GrantKeyProtocolPathScope>();
-  const addScope = (scope: GrantKeyProtocolPathScope): void => {
-    deliveredScopes.set(getGrantKeyScopeCacheKey(scope), scope);
-  };
-
-  if (grantScope.method === DwnMethodName.Read) {
-    if (grantScope.protocolPath === undefined) {
-      addScope({
-        scheme   : KeyDerivationScheme.ProtocolPath,
-        protocol : grantScope.protocol,
-      });
-      return [...deliveredScopes.values()];
-    }
-
-    addScope({
-      scheme       : KeyDerivationScheme.ProtocolPath,
-      protocol     : grantScope.protocol,
-      protocolPath : grantScope.protocolPath,
-    });
-
-    if (protocolDefinition !== undefined) {
-      for (const rolePath of getGrantKeyReadRolePathsForScope(protocolDefinition, grantScope.protocolPath)) {
-        addScope({
-          scheme       : KeyDerivationScheme.ProtocolPath,
-          protocol     : grantScope.protocol,
-          protocolPath : rolePath,
-        });
-      }
-    }
-  }
-
-  if (grantScope.method === DwnMethodName.Write && protocolDefinition !== undefined) {
-    for (const rolePath of getGrantKeyRolePathsCoveredByScope(protocolDefinition, grantScope.protocolPath)) {
-      addScope({
-        scheme       : KeyDerivationScheme.ProtocolPath,
-        protocol     : grantScope.protocol,
-        protocolPath : rolePath,
-      });
-    }
-  }
-
-  return [...deliveredScopes.values()];
+  return uniqueGrantKeyScopes(grantKeyDeliveryScopeBuilders[grantScope.method](grantScope, protocolDefinition));
 }
 
 export function grantKeyScopeCoversDeliveredScope(input: {
@@ -92,31 +81,111 @@ export function grantKeyScopeCoversDeliveredScope(input: {
     return false;
   }
 
-  if (grantScope.method === DwnMethodName.Read) {
-    if (grantScope.protocolPath === undefined) {
-      return true;
-    }
+  return grantKeyCoveragePredicates[grantScope.method]({ grantScope, deliveredScope, protocolDefinition });
+}
 
-    if (deliveredScope.protocolPath !== undefined && isBoundaryAwareSubtree(grantScope.protocolPath, deliveredScope.protocolPath)) {
-      return true;
-    }
-
-    if (deliveredScope.protocolPath === undefined || protocolDefinition === undefined) {
-      return false;
-    }
-
-    return grantKeyReadScopeReferencesRolePath(protocolDefinition, grantScope.protocolPath, deliveredScope.protocolPath);
+function getReadGrantKeyDeliveryScopes(
+  grantScope: GrantKeyEligibleRecordsScope,
+  protocolDefinition?: ProtocolDefinition,
+): GrantKeyProtocolPathScope[] {
+  if (grantScope.protocolPath === undefined) {
+    return [createProtocolGrantKeyScope(grantScope.protocol)];
   }
 
-  if (deliveredScope.protocolPath === undefined) {
+  const scopes = [
+    createProtocolPathGrantKeyScope(grantScope.protocol, grantScope.protocolPath),
+  ];
+
+  if (protocolDefinition === undefined) {
+    return scopes;
+  }
+
+  for (const rolePath of getGrantKeyReadRolePathsForScope(protocolDefinition, grantScope.protocolPath)) {
+    scopes.push(createProtocolPathGrantKeyScope(grantScope.protocol, rolePath));
+  }
+
+  return scopes;
+}
+
+function getWriteGrantKeyDeliveryScopes(
+  grantScope: GrantKeyEligibleRecordsScope,
+  protocolDefinition?: ProtocolDefinition,
+): GrantKeyProtocolPathScope[] {
+  if (protocolDefinition === undefined) {
+    return [];
+  }
+
+  return getGrantKeyRolePathsCoveredByScope(protocolDefinition, grantScope.protocolPath)
+    .map((rolePath) => createProtocolPathGrantKeyScope(grantScope.protocol, rolePath));
+}
+
+function createProtocolGrantKeyScope(protocol: string): GrantKeyProtocolPathScope {
+  return {
+    scheme: KeyDerivationScheme.ProtocolPath,
+    protocol,
+  };
+}
+
+function createProtocolPathGrantKeyScope(protocol: string, protocolPath: string): GrantKeyProtocolPathScope {
+  return {
+    scheme: KeyDerivationScheme.ProtocolPath,
+    protocol,
+    protocolPath,
+  };
+}
+
+function readGrantKeyScopeCoversDeliveredScope(input: {
+  grantScope: GrantKeyEligibleRecordsScope;
+  deliveredScope: Pick<GrantKeyProtocolPathScope, 'protocol' | 'protocolPath'>;
+  protocolDefinition?: ProtocolDefinition;
+}): boolean {
+  const { grantScope, deliveredScope, protocolDefinition } = input;
+  const grantProtocolPath = grantScope.protocolPath;
+  if (grantProtocolPath === undefined) {
+    return true;
+  }
+
+  const deliveredProtocolPath = deliveredScope.protocolPath;
+  if (deliveredProtocolPath === undefined) {
     return false;
   }
 
-  if (grantScope.protocolPath !== undefined && !isBoundaryAwareSubtree(grantScope.protocolPath, deliveredScope.protocolPath)) {
+  if (isBoundaryAwareSubtree(grantProtocolPath, deliveredProtocolPath)) {
+    return true;
+  }
+
+  if (protocolDefinition === undefined) {
     return false;
   }
 
-  return protocolDefinition !== undefined && isGrantKeyLocalRolePath(protocolDefinition, deliveredScope.protocolPath);
+  return grantKeyReadScopeReferencesRolePath(protocolDefinition, grantProtocolPath, deliveredProtocolPath);
+}
+
+function writeGrantKeyScopeCoversDeliveredScope(input: {
+  grantScope: GrantKeyEligibleRecordsScope;
+  deliveredScope: Pick<GrantKeyProtocolPathScope, 'protocol' | 'protocolPath'>;
+  protocolDefinition?: ProtocolDefinition;
+}): boolean {
+  const { grantScope, deliveredScope, protocolDefinition } = input;
+  const deliveredProtocolPath = deliveredScope.protocolPath;
+  if (deliveredProtocolPath === undefined) {
+    return false;
+  }
+
+  if (protocolDefinition === undefined) {
+    return false;
+  }
+
+  if (!isGrantKeyLocalRolePath(protocolDefinition, deliveredProtocolPath)) {
+    return false;
+  }
+
+  const grantProtocolPath = grantScope.protocolPath;
+  if (grantProtocolPath === undefined) {
+    return true;
+  }
+
+  return isBoundaryAwareSubtree(grantProtocolPath, deliveredProtocolPath);
 }
 
 function getGrantKeyReadRolePathsForScope(protocolDefinition: ProtocolDefinition, scopeProtocolPath: string): string[] {
@@ -170,7 +239,7 @@ function getGrantKeyRolePathsCoveredByScope(protocolDefinition: ProtocolDefiniti
     .filter((rolePath) => scopeProtocolPath === undefined || isBoundaryAwareSubtree(scopeProtocolPath, rolePath));
 }
 
-function collectRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet, parentPath?: string): string[] {
+function collectRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: ProtocolRuleSet, parentPath: string[] = []): string[] {
   const rolePaths: string[] = [];
 
   for (const [key, value] of Object.entries(ruleSet)) {
@@ -178,12 +247,13 @@ function collectRolePaths(protocolDefinition: ProtocolDefinition, ruleSet: Proto
       continue;
     }
 
-    const protocolPath = parentPath === undefined ? key : `${parentPath}/${key}`;
+    const path = [...parentPath, key];
+    const protocolPath = path.join('/');
     const childRuleSet = value as ProtocolRuleSet;
     if (isGrantKeyLocalRolePath(protocolDefinition, protocolPath)) {
       rolePaths.push(protocolPath);
     }
-    rolePaths.push(...collectRolePaths(protocolDefinition, childRuleSet, protocolPath));
+    rolePaths.push(...collectRolePaths(protocolDefinition, childRuleSet, path));
   }
 
   return rolePaths;
@@ -195,11 +265,18 @@ function isGrantKeyLocalRolePath(protocolDefinition: ProtocolDefinition, protoco
 }
 
 function isBoundaryAwareSubtree(scopePath: string, candidatePath: string): boolean {
-  return candidatePath === scopePath || candidatePath.startsWith(scopePath + '/');
+  return `${candidatePath}/`.startsWith(`${scopePath}/`);
 }
 
 function getGrantKeyScopeCacheKey(scope: GrantKeyProtocolPathScope): string {
-  return scope.protocolPath === undefined
-    ? `${scope.protocol}~protocol`
-    : `${scope.protocol}~protocolPath~${scope.protocolPath}`;
+  return JSON.stringify([scope.protocol, scope.protocolPath]);
+}
+
+function uniqueGrantKeyScopes(scopes: GrantKeyProtocolPathScope[]): GrantKeyProtocolPathScope[] {
+  const deliveredScopes = new Map<string, GrantKeyProtocolPathScope>();
+  for (const scope of scopes) {
+    deliveredScopes.set(getGrantKeyScopeCacheKey(scope), scope);
+  }
+
+  return [...deliveredScopes.values()];
 }

--- a/packages/dwn-sdk-js/src/utils/grant-key-coverage.ts
+++ b/packages/dwn-sdk-js/src/utils/grant-key-coverage.ts
@@ -6,15 +6,26 @@ import { ProtocolAction } from '../types/protocols-types.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 import { getRuleSetAtPath, parseCrossProtocolRef } from './protocols.js';
 
-export type GrantKeyRecordsScope = RecordsPermissionScope & {
+type GrantKeyRecordsScopeBase = RecordsPermissionScope & {
   interface: typeof DwnInterfaceName.Records;
-  method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
   protocol: string;
 };
 
-export type GrantKeyEligibleRecordsScope = GrantKeyRecordsScope & {
-  contextId?: undefined;
+export type GrantKeyRecordsScope = GrantKeyRecordsScopeBase & {
+  method: typeof DwnMethodName.Read | typeof DwnMethodName.Write;
 };
+
+export type GrantKeyReadRecordsScope = GrantKeyRecordsScopeBase & {
+  contextId?: undefined;
+  method: typeof DwnMethodName.Read;
+};
+
+export type GrantKeyWriteRecordsScope = GrantKeyRecordsScopeBase & {
+  contextId?: undefined;
+  method: typeof DwnMethodName.Write;
+};
+
+export type GrantKeyEligibleRecordsScope = GrantKeyReadRecordsScope | GrantKeyWriteRecordsScope;
 
 export type GrantKeyProtocolPathScope = {
   scheme: typeof KeyDerivationScheme.ProtocolPath;
@@ -65,6 +76,16 @@ export function isGrantKeyEligibleRecordsScope(scope: PermissionScope): scope is
 }
 
 export function getGrantKeyDeliveryScopes(
+  grantScope: GrantKeyReadRecordsScope,
+  protocolDefinition?: ProtocolDefinition,
+): GrantKeyProtocolPathScope[];
+
+export function getGrantKeyDeliveryScopes(
+  grantScope: GrantKeyWriteRecordsScope,
+  protocolDefinition: ProtocolDefinition,
+): GrantKeyProtocolPathScope[];
+
+export function getGrantKeyDeliveryScopes(
   grantScope: GrantKeyEligibleRecordsScope,
   protocolDefinition?: ProtocolDefinition,
 ): GrantKeyProtocolPathScope[] {
@@ -112,7 +133,7 @@ function getWriteGrantKeyDeliveryScopes(
   protocolDefinition?: ProtocolDefinition,
 ): GrantKeyProtocolPathScope[] {
   if (protocolDefinition === undefined) {
-    return [];
+    throw new Error('getGrantKeyDeliveryScopes: write grants require a protocol definition.');
   }
 
   return getGrantKeyRolePathsCoveredByScope(protocolDefinition, grantScope.protocolPath)

--- a/packages/dwn-sdk-js/tests/protocols/encryption.spec.ts
+++ b/packages/dwn-sdk-js/tests/protocols/encryption.spec.ts
@@ -509,6 +509,147 @@ describe('EncryptionProtocol', () => {
       await encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant }));
     });
 
+    it('should accept read-grant grantKey records for referenced role paths outside the read subtree', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const bob = await TestDataGenerator.generatePersona();
+      const rolePublicKey = (await TestDataGenerator.generatePersona()).encryptionKeyPair.publicJwk;
+      const protocol = 'https://example.com/protocol';
+      const protocolDefinition = createGrantKeyCoverageProtocolDefinition(protocol, rolePublicKey);
+      const grant = createGrant({
+        grantor      : alice.did,
+        grantee      : bob.did,
+        id           : 'grant1',
+        protocol,
+        protocolPath : 'chat/message',
+      });
+      const message = await createGrantKeyMessage({
+        grant,
+        protocol,
+        protocolPath : 'chat/member',
+        recipient    : bob.did,
+        signer       : Jws.createSigner(alice),
+      });
+
+      const encryptionProtocol = new EncryptionProtocol();
+
+      await encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant, protocolDefinition }));
+    });
+
+    it('should reject read-grant grantKey records for unreferenced role paths outside the read subtree', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const bob = await TestDataGenerator.generatePersona();
+      const rolePublicKey = (await TestDataGenerator.generatePersona()).encryptionKeyPair.publicJwk;
+      const protocol = 'https://example.com/protocol';
+      const protocolDefinition = createGrantKeyCoverageProtocolDefinition(protocol, rolePublicKey);
+      const grant = createGrant({
+        grantor      : alice.did,
+        grantee      : bob.did,
+        id           : 'grant1',
+        protocol,
+        protocolPath : 'chat/message',
+      });
+      const message = await createGrantKeyMessage({
+        grant,
+        protocol,
+        protocolPath : 'chat/admin',
+        recipient    : bob.did,
+        signer       : Jws.createSigner(alice),
+      });
+
+      const encryptionProtocol = new EncryptionProtocol();
+
+      await expect(
+        encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant, protocolDefinition }))
+      ).rejects.toThrow(DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch);
+    });
+
+    it('should reject read-grant grantKey records for cross-protocol role references', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const bob = await TestDataGenerator.generatePersona();
+      const rolePublicKey = (await TestDataGenerator.generatePersona()).encryptionKeyPair.publicJwk;
+      const protocol = 'https://example.com/protocol';
+      const protocolDefinition = createGrantKeyCoverageProtocolDefinition(protocol, rolePublicKey, {
+        messageRole : 'contacts:member',
+        uses        : { contacts: 'https://example.com/contacts' },
+      });
+      const grant = createGrant({
+        grantor      : alice.did,
+        grantee      : bob.did,
+        id           : 'grant1',
+        protocol,
+        protocolPath : 'chat/message',
+      });
+      const message = await createGrantKeyMessage({
+        grant,
+        protocol,
+        protocolPath : 'chat/member',
+        recipient    : bob.did,
+        signer       : Jws.createSigner(alice),
+      });
+
+      const encryptionProtocol = new EncryptionProtocol();
+
+      await expect(
+        encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant, protocolDefinition }))
+      ).rejects.toThrow(DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch);
+    });
+
+    it('should accept write-grant grantKey records for covered role paths', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const bob = await TestDataGenerator.generatePersona();
+      const rolePublicKey = (await TestDataGenerator.generatePersona()).encryptionKeyPair.publicJwk;
+      const protocol = 'https://example.com/protocol';
+      const protocolDefinition = createGrantKeyCoverageProtocolDefinition(protocol, rolePublicKey);
+      const grant = createGrant({
+        grantor      : alice.did,
+        grantee      : bob.did,
+        id           : 'grant1',
+        method       : DwnMethodName.Write,
+        protocol,
+        protocolPath : 'chat',
+      });
+      const message = await createGrantKeyMessage({
+        grant,
+        protocol,
+        protocolPath : 'chat/member',
+        recipient    : bob.did,
+        signer       : Jws.createSigner(alice),
+      });
+
+      const encryptionProtocol = new EncryptionProtocol();
+
+      await encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant, protocolDefinition }));
+    });
+
+    it('should reject write-grant grantKey records for covered non-role paths', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const bob = await TestDataGenerator.generatePersona();
+      const rolePublicKey = (await TestDataGenerator.generatePersona()).encryptionKeyPair.publicJwk;
+      const protocol = 'https://example.com/protocol';
+      const protocolDefinition = createGrantKeyCoverageProtocolDefinition(protocol, rolePublicKey);
+      const grant = createGrant({
+        grantor      : alice.did,
+        grantee      : bob.did,
+        id           : 'grant1',
+        method       : DwnMethodName.Write,
+        protocol,
+        protocolPath : 'chat',
+      });
+      const message = await createGrantKeyMessage({
+        grant,
+        protocol,
+        protocolPath : 'chat/message',
+        recipient    : bob.did,
+        signer       : Jws.createSigner(alice),
+      });
+
+      const encryptionProtocol = new EncryptionProtocol();
+
+      await expect(
+        encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant, protocolDefinition }))
+      ).rejects.toThrow(DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch);
+    });
+
     it('should reject grantKey records covered only by a Messages read grant', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const bob = await TestDataGenerator.generatePersona();
@@ -537,7 +678,9 @@ describe('EncryptionProtocol', () => {
     it('should reject protocol-scoped grantKey records for protocolPath-scoped read grants', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const bob = await TestDataGenerator.generatePersona();
+      const rolePublicKey = (await TestDataGenerator.generatePersona()).encryptionKeyPair.publicJwk;
       const protocol = 'https://example.com/protocol';
+      const protocolDefinition = createGrantKeyCoverageProtocolDefinition(protocol, rolePublicKey);
       const grant = createGrant({
         grantor      : alice.did,
         grantee      : bob.did,
@@ -555,7 +698,7 @@ describe('EncryptionProtocol', () => {
       const encryptionProtocol = new EncryptionProtocol();
 
       await expect(
-        encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant }))
+        encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant, protocolDefinition }))
       ).rejects.toThrow(DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch);
     });
 
@@ -585,7 +728,9 @@ describe('EncryptionProtocol', () => {
     it('should reject grantKey records outside the grant protocolPath subtree', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const bob = await TestDataGenerator.generatePersona();
+      const rolePublicKey = (await TestDataGenerator.generatePersona()).encryptionKeyPair.publicJwk;
       const protocol = 'https://example.com/protocol';
+      const protocolDefinition = createGrantKeyCoverageProtocolDefinition(protocol, rolePublicKey);
       const grant = createGrant({
         grantor      : alice.did,
         grantee      : bob.did,
@@ -604,7 +749,7 @@ describe('EncryptionProtocol', () => {
       const encryptionProtocol = new EncryptionProtocol();
 
       await expect(
-        encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant }))
+        encryptionProtocol.preProcessWrite('did:example:tenant', message, createValidationStateReader({ grant, protocolDefinition }))
       ).rejects.toThrow(DwnErrorCode.EncryptionProtocolValidateGrantKeyGrantScopeMismatch);
     });
 
@@ -789,15 +934,15 @@ describe('EncryptionProtocol', () => {
       ).rejects.toThrow(DwnErrorCode.EncryptionProtocolValidateEncryptedDeliveryMissingEncryption);
     });
 
-    it('should reject grantKey records for non-read permission grants', async () => {
+    it('should reject grantKey records for context-scoped permission grants', async () => {
       const alice = await TestDataGenerator.generatePersona();
       const bob = await TestDataGenerator.generatePersona();
       const protocol = 'https://example.com/protocol';
       const grant = createGrant({
-        grantor : alice.did,
-        grantee : bob.did,
-        id      : 'grant1',
-        method  : DwnMethodName.Write,
+        contextId : 'context1',
+        grantor   : alice.did,
+        grantee   : bob.did,
+        id        : 'grant1',
         protocol,
       });
       const message = await createGrantKeyMessage({
@@ -959,6 +1104,7 @@ function createGrant(input: {
   protocol: string;
   interface?: DwnInterfaceName.Records | DwnInterfaceName.Messages;
   protocolPath?: string;
+  contextId?: string;
   method?: DwnMethodName;
   dateExpires?: string;
   dateGranted?: string;
@@ -977,6 +1123,7 @@ function createGrant(input: {
       interface    : input.interface ?? DwnInterfaceName.Records,
       method       : input.method ?? DwnMethodName.Read,
       protocol     : input.protocol,
+      contextId    : input.contextId,
       protocolPath : input.protocolPath,
     },
   } as PermissionGrant;
@@ -1041,6 +1188,43 @@ function createRoleProtocolDefinition(
       },
     },
   } as ProtocolDefinition;
+}
+
+function createGrantKeyCoverageProtocolDefinition(
+  protocol: string,
+  publicKeyJwk: PublicKeyJwk,
+  options: {
+    messageRole?: string;
+    uses?: Record<string, string>;
+  } = {},
+): ProtocolDefinition {
+  return {
+    published : true,
+    protocol,
+    uses      : options.uses,
+    types     : {
+      admin   : { dataFormats: ['application/json'] },
+      chat    : { dataFormats: ['application/json'] },
+      member  : { dataFormats: ['application/json'] },
+      message : { dataFormats: ['application/json'], encryptionRequired: true },
+    },
+    structure: {
+      chat: {
+        admin: {
+          $keyAgreement : { publicKeyJwk },
+          $role         : true,
+        },
+        member: {
+          $keyAgreement : { publicKeyJwk },
+          $role         : true,
+        },
+        message: {
+          $actions      : [{ can: ['read'], role: options.messageRole ?? 'chat/member' }],
+          $keyAgreement : { publicKeyJwk },
+        },
+      },
+    },
+  };
 }
 
 async function createAudienceEpochMessage(input: {

--- a/packages/dwn-sdk-js/tests/utils/grant-key-coverage.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/grant-key-coverage.spec.ts
@@ -47,6 +47,11 @@ describe('GrantKeyCoverage', () => {
         interface : DwnInterfaceName.Protocols,
         method    : DwnMethodName.Query,
       })).toBe(false);
+
+      expect(isGrantKeyRecordsScope({
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Read,
+      } as PermissionScope)).toBe(false);
     });
   });
 
@@ -61,6 +66,11 @@ describe('GrantKeyCoverage', () => {
 
       expect(isGrantKeyEligibleRecordsScope(contextScopedGrant)).toBe(false);
       expect(isGrantKeyEligibleRecordsScope(recordsReadScope())).toBe(true);
+      expect(isGrantKeyEligibleRecordsScope({
+        interface : DwnInterfaceName.Messages,
+        method    : DwnMethodName.Read,
+        protocol,
+      })).toBe(false);
     });
   });
 
@@ -85,6 +95,25 @@ describe('GrantKeyCoverage', () => {
       ]);
     });
 
+    it('should deliver only the read-subtree key when no protocol definition is supplied', () => {
+      const scopes = getGrantKeyDeliveryScopes(recordsReadScope({ protocolPath: 'chat/message' }));
+
+      expect(scopeKeys(scopes)).toEqual([
+        'chat/message',
+      ]);
+    });
+
+    it('should deliver only the read-subtree key when the scoped path is not configured', () => {
+      const scopes = getGrantKeyDeliveryScopes(
+        recordsReadScope({ protocolPath: 'chat/missing' }),
+        grantKeyProtocolDefinition(),
+      );
+
+      expect(scopeKeys(scopes)).toEqual([
+        'chat/missing',
+      ]);
+    });
+
     it('should deliver covered local role keys for write grants', () => {
       const scopes = getGrantKeyDeliveryScopes(
         recordsWriteScope({ protocolPath: 'chat/message' }),
@@ -93,6 +122,20 @@ describe('GrantKeyCoverage', () => {
 
       expect(scopeKeys(scopes)).toEqual([
         'chat/message/moderator',
+      ]);
+    });
+
+    it('should deliver all local role keys for protocol-scoped write grants', () => {
+      const scopes = getGrantKeyDeliveryScopes(
+        recordsWriteScope(),
+        grantKeyProtocolDefinition(),
+      );
+
+      expect(scopeKeys(scopes)).toEqual([
+        'chat/admin',
+        'chat/member',
+        'chat/message/moderator',
+        'chat/unreferenced',
       ]);
     });
 
@@ -168,6 +211,14 @@ describe('GrantKeyCoverage', () => {
       expect(grantKeyScopeCoversDeliveredScope({
         grantScope         : recordsWriteScope({ protocolPath: 'chat/message' }),
         deliveredScope     : { protocol, protocolPath: 'chat/message/moderator' },
+        protocolDefinition : grantKeyProtocolDefinition(),
+      })).toBe(true);
+    });
+
+    it('should allow protocol-scoped write grants to cover local role paths', () => {
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope         : recordsWriteScope(),
+        deliveredScope     : { protocol, protocolPath: 'chat/member' },
         protocolDefinition : grantKeyProtocolDefinition(),
       })).toBe(true);
     });

--- a/packages/dwn-sdk-js/tests/utils/grant-key-coverage.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/grant-key-coverage.spec.ts
@@ -1,6 +1,6 @@
-import type { GrantKeyEligibleRecordsScope } from '../../src/utils/grant-key-coverage.js';
 import type { PermissionScope } from '../../src/types/permission-types.js';
 import type { PublicKeyJwk } from '../../src/types/jose-types.js';
+import type { GrantKeyEligibleRecordsScope, GrantKeyProtocolPathScope } from '../../src/utils/grant-key-coverage.js';
 import type { ProtocolDefinition, ProtocolRuleSet } from '../../src/types/protocols-types.js';
 
 import { describe, expect, it } from 'bun:test';
@@ -139,8 +139,13 @@ describe('GrantKeyCoverage', () => {
       ]);
     });
 
-    it('should return no write-grant delivery scopes without a protocol definition', () => {
-      expect(getGrantKeyDeliveryScopes(recordsWriteScope())).toEqual([]);
+    it('should reject write-grant delivery scope generation without a protocol definition', () => {
+      const getDeliveryScopes = getGrantKeyDeliveryScopes as (
+        grantScope: GrantKeyEligibleRecordsScope,
+        protocolDefinition?: ProtocolDefinition,
+      ) => GrantKeyProtocolPathScope[];
+
+      expect(() => getDeliveryScopes(recordsWriteScope())).toThrow('write grants require a protocol definition');
     });
   });
 

--- a/packages/dwn-sdk-js/tests/utils/grant-key-coverage.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/grant-key-coverage.spec.ts
@@ -1,0 +1,277 @@
+import type { GrantKeyEligibleRecordsScope } from '../../src/utils/grant-key-coverage.js';
+import type { PermissionScope } from '../../src/types/permission-types.js';
+import type { PublicKeyJwk } from '../../src/types/jose-types.js';
+import type { ProtocolDefinition, ProtocolRuleSet } from '../../src/types/protocols-types.js';
+
+import { describe, expect, it } from 'bun:test';
+
+import { KeyDerivationScheme } from '../../src/utils/hd-key.js';
+import { ProtocolAction } from '../../src/types/protocols-types.js';
+import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
+import {
+  getGrantKeyDeliveryScopes,
+  grantKeyScopeCoversDeliveredScope,
+  isGrantKeyEligibleRecordsScope,
+  isGrantKeyRecordsScope,
+} from '../../src/utils/grant-key-coverage.js';
+
+const protocol = 'https://example.com/chat';
+const otherProtocol = 'https://example.com/other';
+const publicKeyJwk: PublicKeyJwk = {
+  crv : 'X25519',
+  kty : 'OKP',
+  x   : 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+};
+
+describe('GrantKeyCoverage', () => {
+  describe('isGrantKeyRecordsScope()', () => {
+    it('should identify Records read and write scopes with a protocol', () => {
+      expect(isGrantKeyRecordsScope(recordsReadScope())).toBe(true);
+      expect(isGrantKeyRecordsScope(recordsWriteScope())).toBe(true);
+    });
+
+    it('should reject non-Records scopes, Records delete scopes, and scopes without a protocol', () => {
+      expect(isGrantKeyRecordsScope({
+        interface : DwnInterfaceName.Messages,
+        method    : DwnMethodName.Read,
+        protocol,
+      })).toBe(false);
+
+      expect(isGrantKeyRecordsScope({
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Delete,
+        protocol,
+      })).toBe(false);
+
+      expect(isGrantKeyRecordsScope({
+        interface : DwnInterfaceName.Protocols,
+        method    : DwnMethodName.Query,
+      })).toBe(false);
+    });
+  });
+
+  describe('isGrantKeyEligibleRecordsScope()', () => {
+    it('should reject context-scoped Records grants', () => {
+      const contextScopedGrant: PermissionScope = {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Read,
+        protocol,
+        contextId : 'context-1',
+      };
+
+      expect(isGrantKeyEligibleRecordsScope(contextScopedGrant)).toBe(false);
+      expect(isGrantKeyEligibleRecordsScope(recordsReadScope())).toBe(true);
+    });
+  });
+
+  describe('getGrantKeyDeliveryScopes()', () => {
+    it('should deliver the protocol root key for protocol-scoped read grants', () => {
+      expect(getGrantKeyDeliveryScopes(recordsReadScope())).toEqual([{
+        scheme: KeyDerivationScheme.ProtocolPath,
+        protocol,
+      }]);
+    });
+
+    it('should deliver read-subtree and referenced local role keys for path-scoped read grants', () => {
+      const scopes = getGrantKeyDeliveryScopes(
+        recordsReadScope({ protocolPath: 'chat/message' }),
+        grantKeyProtocolDefinition(),
+      );
+
+      expect(scopeKeys(scopes)).toEqual([
+        'chat/admin',
+        'chat/member',
+        'chat/message',
+      ]);
+    });
+
+    it('should deliver covered local role keys for write grants', () => {
+      const scopes = getGrantKeyDeliveryScopes(
+        recordsWriteScope({ protocolPath: 'chat/message' }),
+        grantKeyProtocolDefinition(),
+      );
+
+      expect(scopeKeys(scopes)).toEqual([
+        'chat/message/moderator',
+      ]);
+    });
+
+    it('should return no write-grant delivery scopes without a protocol definition', () => {
+      expect(getGrantKeyDeliveryScopes(recordsWriteScope())).toEqual([]);
+    });
+  });
+
+  describe('grantKeyScopeCoversDeliveredScope()', () => {
+    it('should allow protocol-scoped read grants to cover any key in the same protocol', () => {
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope     : recordsReadScope(),
+        deliveredScope : { protocol },
+      })).toBe(true);
+
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope     : recordsReadScope(),
+        deliveredScope : { protocol, protocolPath: 'chat/message/reply' },
+      })).toBe(true);
+    });
+
+    it('should reject delivered keys outside the grant protocol', () => {
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope     : recordsReadScope(),
+        deliveredScope : { protocol: otherProtocol, protocolPath: 'chat/message' },
+      })).toBe(false);
+    });
+
+    it('should allow path-scoped read grants to cover their subtree', () => {
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope     : recordsReadScope({ protocolPath: 'chat/message' }),
+        deliveredScope : { protocol, protocolPath: 'chat/message/reply' },
+      })).toBe(true);
+    });
+
+    it('should reject protocol root keys and sibling paths for path-scoped read grants', () => {
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope     : recordsReadScope({ protocolPath: 'chat/message' }),
+        deliveredScope : { protocol },
+      })).toBe(false);
+
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope     : recordsReadScope({ protocolPath: 'chat/message' }),
+        deliveredScope : { protocol, protocolPath: 'chat/message-extra' },
+      })).toBe(false);
+    });
+
+    it('should allow path-scoped read grants to cover referenced local role paths', () => {
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope         : recordsReadScope({ protocolPath: 'chat/message' }),
+        deliveredScope     : { protocol, protocolPath: 'chat/member' },
+        protocolDefinition : grantKeyProtocolDefinition(),
+      })).toBe(true);
+    });
+
+    it('should reject unreferenced, unkeyed, and cross-protocol role paths for path-scoped read grants', () => {
+      const definition = grantKeyProtocolDefinition();
+
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope         : recordsReadScope({ protocolPath: 'chat/message' }),
+        deliveredScope     : { protocol, protocolPath: 'chat/unreferenced' },
+        protocolDefinition : definition,
+      })).toBe(false);
+
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope         : recordsReadScope({ protocolPath: 'chat/message' }),
+        deliveredScope     : { protocol, protocolPath: 'chat/guest' },
+        protocolDefinition : definition,
+      })).toBe(false);
+    });
+
+    it('should allow write grants to cover local role paths in scope', () => {
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope         : recordsWriteScope({ protocolPath: 'chat/message' }),
+        deliveredScope     : { protocol, protocolPath: 'chat/message/moderator' },
+        protocolDefinition : grantKeyProtocolDefinition(),
+      })).toBe(true);
+    });
+
+    it('should reject protocol root keys, non-role paths, and sibling role paths for write grants', () => {
+      const definition = grantKeyProtocolDefinition();
+      const grantScope = recordsWriteScope({ protocolPath: 'chat/message' });
+
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope,
+        deliveredScope: { protocol },
+      })).toBe(false);
+
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope,
+        deliveredScope     : { protocol, protocolPath: 'chat/message/reply' },
+        protocolDefinition : definition,
+      })).toBe(false);
+
+      expect(grantKeyScopeCoversDeliveredScope({
+        grantScope,
+        deliveredScope     : { protocol, protocolPath: 'chat/member' },
+        protocolDefinition : definition,
+      })).toBe(false);
+    });
+  });
+});
+
+function recordsReadScope(
+  overrides: { protocolPath?: string } = {},
+): GrantKeyEligibleRecordsScope & { method: typeof DwnMethodName.Read } {
+  return {
+    interface : DwnInterfaceName.Records,
+    method    : DwnMethodName.Read,
+    protocol,
+    ...overrides,
+  };
+}
+
+function recordsWriteScope(
+  overrides: { protocolPath?: string } = {},
+): GrantKeyEligibleRecordsScope & { method: typeof DwnMethodName.Write } {
+  return {
+    interface : DwnInterfaceName.Records,
+    method    : DwnMethodName.Write,
+    protocol,
+    ...overrides,
+  };
+}
+
+function grantKeyProtocolDefinition(): ProtocolDefinition {
+  return {
+    protocol,
+    published : true,
+    uses      : { external: otherProtocol },
+    types     : {
+      admin        : {},
+      chat         : {},
+      guest        : {},
+      member       : {},
+      message      : {},
+      messageExtra : {},
+      moderator    : {},
+      reply        : {},
+      unreferenced : {},
+    },
+    structure: {
+      chat: {
+        admin   : roleRuleSet(),
+        guest   : { $role: true },
+        member  : roleRuleSet(),
+        message : {
+          $actions: [
+            { role: 'chat/member', can: [ProtocolAction.Read] },
+            { role: 'chat/guest', can: [ProtocolAction.Read] },
+            { role: 'external:member', can: [ProtocolAction.Read] },
+          ],
+          moderator : roleRuleSet(),
+          reply     : {
+            $actions: [
+              { role: 'chat/admin', can: [ProtocolAction.Read] },
+            ],
+          },
+        },
+        messageExtra: {
+          $actions: [
+            { role: 'chat/admin', can: [ProtocolAction.Read] },
+          ],
+        },
+        unreferenced: roleRuleSet(),
+      },
+    },
+  };
+}
+
+function roleRuleSet(): ProtocolRuleSet {
+  return {
+    $keyAgreement : { publicKeyJwk },
+    $role         : true,
+  };
+}
+
+function scopeKeys(scopes: { protocolPath?: string }[]): string[] {
+  return scopes
+    .map((scope) => scope.protocolPath ?? '<protocol>')
+    .sort();
+}


### PR DESCRIPTION
Summary
- Expands EncryptionProtocol grantKey validation so Records.Read grants can carry referenced same-protocol role-path keys and Records.Write grants can carry covered role-path keys only.
- Mirrors the same predicate in agent grantKey production and hydration.
- Passes installed protocol definitions through connect-time grantKey production and adds positive/negative coverage.

Test plan
- [x] bun run build
- [x] bun run lint
- [x] bun test packages/dwn-sdk-js/tests/protocols/encryption.spec.ts
- [x] bun test packages/agent/tests/dwn-encryption.spec.ts
- [x] bunx changeset status
- [ ] cd packages/agent && export DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 && bun run test:node (local run fails because no DWN server is listening at http://localhost:3000)