### PR TITLE
fix(ci): remove version-PR CI dispatch that races the pull_request run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      release_pr_number:
-        description: "Version packages PR number that requested this CI run"
-        required: false
-        type: string
   workflow_call:
 
 permissions:
@@ -18,8 +12,8 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.release_pr_number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event.inputs.release_pr_number != '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
       pull-requests: write
       id-token: write
@@ -97,16 +96,3 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # bun publish reads the npm token from bunfig or NPM_CONFIG_TOKEN
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Dispatch CI for version PR
-        if: steps.changesets.outputs.pullRequestNumber != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_BRANCH: changeset-release/${{ github.ref_name }}
-          RELEASE_PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
-        run: |
-          echo "Dispatching CI for version PR #${RELEASE_PR_NUMBER} on ${RELEASE_BRANCH}"
-          gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/dispatches" \
-            --method POST \
-            -f ref="${RELEASE_BRANCH}" \
-            -f "inputs[release_pr_number]=${RELEASE_PR_NUMBER}"


### PR DESCRIPTION
## Summary

- Every merge to `main` fired two CI runs for the version PR — a `pull_request` (synchronize) run and a `workflow_dispatch` run from `release.yml` (added in #1067) — both landing in the same concurrency group with `cancel-in-progress: true`.
- Group-entry order between the two is effectively random; when the dispatch entered second (~1/3 of merges), it cancelled the `pull_request` run that carries the required **CI Passed** check, leaving the version PR red until a manual re-run. The dispatch never added coverage the `pull_request` run didn't already provide.
- Removes the `Dispatch CI for version PR` step and its `actions: write` permission from `release.yml`, and the `workflow_dispatch` trigger plus both `release_pr_number` concurrency-group references from `ci.yml` — restoring the single-run flow that worked reliably before #1067.

Fixes #1104.

## Test plan

- [x] `bunx js-yaml` parses both `ci.yml` and `release.yml`
- [x] `actionlint` clean on both files for this change (one pre-existing, unrelated finding on the untouched `create-github-app-token@v3` step reproduces identically on `main` — out of scope here)
- [x] `grep -rn release_pr_number .github/` → no matches
- [x] `bun run lint` — passes
- [x] `bun run build` — passes
- [ ] Post-merge: next 2-3 `changeset-release/main` updates each produce exactly one `event=pull_request`, `attempt=1`, `conclusion=success` CI run (no `workflow_dispatch` runs), verified with:
  ```bash
  gh api 'repos/enboxorg/enbox/actions/runs?branch=changeset-release%2Fmain&per_page=10' \
    --jq '.workflow_runs[] | "\(.created_at) \(.name) \(.event) attempt=\(.run_attempt) \(.conclusion)"'
  ```
