### PR TITLE
feat(dwn-sdk-js): authorize encryption control reads

### DIFF
--- a/.changeset/clean-control-read-auth.md
+++ b/.changeset/clean-control-read-auth.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Authorize source-protocol encryption control records for read, query, and subscribe operations.

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -20,6 +20,7 @@ export enum DwnErrorCode {
   ComputeCidCodecNotSupported = 'ComputeCidCodecNotSupported',
   ComputeCidMultihashNotSupported = 'ComputeCidMultihashNotSupported',
   Ed25519InvalidJwk = 'Ed25519InvalidJwk',
+  EncryptionControlReadUnauthorized = 'EncryptionControlReadUnauthorized',
   EncryptionControlValidateAudienceActiveSetCapExceeded = 'EncryptionControlValidateAudienceActiveSetCapExceeded',
   EncryptionControlValidateAudienceContextIdInvalid = 'EncryptionControlValidateAudienceContextIdInvalid',
   EncryptionControlValidateAudienceKeyIdMismatch = 'EncryptionControlValidateAudienceKeyIdMismatch',

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -37,13 +37,15 @@ type ExactAudienceFilterTuple = Omit<RoleAudienceKeyId, 'keyId'> & {
   keyId?: string;
 };
 
+type ControlReadMessage = RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+
 export class EncryptionControl {
   public static isControlMessage(message: RecordsWriteMessage): boolean {
     return isEncryptionControlPath(message.descriptor.protocolPath);
   }
 
   public static getRequester(
-    message: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage,
+    message: ControlReadMessage,
   ): string | undefined {
     return Message.isSignedByAuthorDelegate(message) ? Message.getSigner(message) : Message.getAuthor(message);
   }
@@ -88,7 +90,7 @@ export class EncryptionControl {
 
   public static async authorizeRead(input: {
     tenant: string;
-    incomingMessage: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    incomingMessage: ControlReadMessage;
     requester: string | undefined;
     recordsWriteMessage: RecordsWriteMessage;
     validationStateReader: ValidationStateReader;
@@ -105,7 +107,7 @@ export class EncryptionControl {
 
   public static async canRead(input: {
     tenant: string;
-    incomingMessage: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    incomingMessage: ControlReadMessage;
     requester: string | undefined;
     recordsWriteMessage: RecordsWriteMessage;
     validationStateReader: ValidationStateReader;
@@ -696,7 +698,7 @@ export class EncryptionControl {
   private static async canEnumerateAudience(input: {
     tenant: string;
     actorDid: string;
-    incomingMessage: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    incomingMessage: ControlReadMessage;
     tags: RoleAudienceKeyId;
     validationStateReader: ValidationStateReader;
   }): Promise<boolean> {
@@ -737,7 +739,7 @@ export class EncryptionControl {
   private static async getInvokedReadGrant(input: {
     tenant: string;
     actorDid: string;
-    incomingMessage: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    incomingMessage: ControlReadMessage;
     validationStateReader: ValidationStateReader;
   }): Promise<PermissionGrant | undefined> {
     if (Message.isSignedByAuthorDelegate(input.incomingMessage)) {

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -3,7 +3,7 @@ import type { RecordsWrite } from '../interfaces/records-write.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
 import type { EncryptionControlAudiencePayload, EncryptionControlDeliveryTags, RoleAudienceKeyId } from '../types/encryption-types.js';
 import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
-import type { RecordsWriteMessage, RecordsWriteTags } from '../types/records-types.js';
+import type { RecordsCountMessage, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsSubscribeMessage, RecordsWriteMessage, RecordsWriteTags } from '../types/records-types.js';
 
 import { checkActor } from './protocol-authorization-action.js';
 import { DwnConstant } from './dwn-constant.js';
@@ -33,9 +33,74 @@ type EffectiveControlActor = {
   grant?: PermissionGrant;
 };
 
+type ExactAudienceFilterTuple = Omit<RoleAudienceKeyId, 'keyId'> & {
+  keyId?: string;
+};
+
 export class EncryptionControl {
   public static isControlMessage(message: RecordsWriteMessage): boolean {
     return isEncryptionControlPath(message.descriptor.protocolPath);
+  }
+
+  public static isExactAudienceFilter(filter: RecordsFilter): boolean {
+    return EncryptionControl.getExactAudienceFilterTuple(filter) !== undefined;
+  }
+
+  public static async authorizeRead(input: {
+    tenant: string;
+    incomingMessage: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    requester: string | undefined;
+    recordsWriteMessage: RecordsWriteMessage;
+    validationStateReader: ValidationStateReader;
+  }): Promise<void> {
+    if (await EncryptionControl.canRead(input)) {
+      return;
+    }
+
+    throw new DwnError(
+      DwnErrorCode.EncryptionControlReadUnauthorized,
+      'requester is not authorized to read the encryption control record.'
+    );
+  }
+
+  public static async canRead(input: {
+    tenant: string;
+    incomingMessage: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    requester: string | undefined;
+    recordsWriteMessage: RecordsWriteMessage;
+    validationStateReader: ValidationStateReader;
+  }): Promise<boolean> {
+    const { requester, recordsWriteMessage, tenant } = input;
+    if (!EncryptionControl.isControlMessage(recordsWriteMessage)) {
+      return true;
+    }
+
+    if (requester === tenant) {
+      return true;
+    }
+
+    if (requester === undefined) {
+      return false;
+    }
+
+    const recordType = EncryptionControl.getRecordType(recordsWriteMessage);
+    if (recordType === 'delivery') {
+      return requester === recordsWriteMessage.descriptor.recipient ||
+        requester === Message.getAuthor(recordsWriteMessage);
+    }
+
+    const tags = EncryptionControl.getRoleAudienceKeyId(recordsWriteMessage, 'audience');
+    if (EncryptionControl.exactAudienceFilterMatchesRecord(input.incomingMessage.descriptor.filter, tags, recordsWriteMessage.recordId)) {
+      return true;
+    }
+
+    return EncryptionControl.canEnumerateAudience({
+      tenant,
+      actorDid              : requester,
+      incomingMessage       : input.incomingMessage,
+      tags,
+      validationStateReader : input.validationStateReader,
+    });
   }
 
   public static async authorizeWrite(
@@ -389,30 +454,55 @@ export class EncryptionControl {
     message: RecordsWriteMessage;
   }): Promise<void> {
     const { tenant, actor, tags, protocolDefinition, ruleSet, validationStateReader, message } = input;
-    if (actor.did === tenant) {
+    const signaturePayload = Jws.decodePlainObjectPayload(message.authorization.signature);
+    if (await EncryptionControl.actorCanCreateRole({
+      tenant,
+      actor,
+      tags,
+      protocolDefinition,
+      ruleSet,
+      validationStateReader,
+      invokedRole: signaturePayload.protocolRole,
+    })) {
       return;
+    }
+
+    throw new DwnError(
+      DwnErrorCode.EncryptionControlValidateAudienceWriterUnauthorized,
+      'control records must be written by a DID authorized to create the referenced role.'
+    );
+  }
+
+  private static async actorCanCreateRole(input: {
+    tenant: string;
+    actor: EffectiveControlActor;
+    tags: RoleAudienceKeyId;
+    protocolDefinition: ProtocolDefinition;
+    ruleSet: ProtocolRuleSet;
+    validationStateReader: ValidationStateReader;
+    invokedRole: string | undefined;
+  }): Promise<boolean> {
+    const { tenant, actor, tags, protocolDefinition, ruleSet, validationStateReader, invokedRole } = input;
+    if (actor.did === tenant) {
+      return true;
     }
 
     if (actor.did === undefined) {
-      throw new DwnError(
-        DwnErrorCode.EncryptionControlValidateAudienceWriterUnauthorized,
-        'control records must be written by a DID authorized to create the referenced role.'
-      );
+      return false;
     }
 
     if (actor.grant !== undefined && EncryptionControl.grantCoversRoleCreate(actor.grant, tags)) {
-      return;
+      return true;
     }
 
     const recordChain = await EncryptionControl.constructRoleParentChain(tenant, tags, validationStateReader);
-    const signaturePayload = Jws.decodePlainObjectPayload(message.authorization.signature);
     for (const actionRule of ruleSet.$actions ?? []) {
       if (!actionRule.can.includes(ProtocolAction.Create)) {
         continue;
       }
 
       if (actionRule.who === ProtocolActor.Anyone) {
-        return;
+        return true;
       }
 
       if (await EncryptionControl.roleRuleAllowsActor(
@@ -422,20 +512,17 @@ export class EncryptionControl {
         tags,
         protocolDefinition,
         validationStateReader,
-        signaturePayload.protocolRole,
+        invokedRole,
       )) {
-        return;
+        return true;
       }
 
       if (await checkActor(actor.did, actionRule, recordChain, protocolDefinition)) {
-        return;
+        return true;
       }
     }
 
-    throw new DwnError(
-      DwnErrorCode.EncryptionControlValidateAudienceWriterUnauthorized,
-      'control records must be written by a DID authorized to create the referenced role.'
-    );
+    return false;
   }
 
   private static async verifyDeliveryRecipientAuthority(input: {
@@ -570,6 +657,107 @@ export class EncryptionControl {
     });
   }
 
+  private static async canEnumerateAudience(input: {
+    tenant: string;
+    actorDid: string;
+    incomingMessage: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    tags: RoleAudienceKeyId;
+    validationStateReader: ValidationStateReader;
+  }): Promise<boolean> {
+    const {
+      tenant, actorDid, incomingMessage, tags, validationStateReader
+    } = input;
+    const grant = await EncryptionControl.getInvokedReadGrant({
+      tenant,
+      actorDid,
+      incomingMessage,
+      validationStateReader,
+    });
+    if (grant !== undefined && EncryptionControl.grantCoversAudienceEnumeration(grant, tags)) {
+      return true;
+    }
+
+    const { protocolDefinition, ruleSet } = await EncryptionControl.getRoleAudienceDefinition({
+      tenant,
+      tags,
+      messageTimestamp: incomingMessage.descriptor.messageTimestamp,
+      validationStateReader,
+    });
+    const invokedRole = incomingMessage.authorization === undefined
+      ? undefined
+      : Jws.decodePlainObjectPayload(incomingMessage.authorization.signature).protocolRole;
+
+    return EncryptionControl.actorCanCreateRole({
+      tenant,
+      actor: { did: actorDid },
+      tags,
+      protocolDefinition,
+      ruleSet,
+      validationStateReader,
+      invokedRole,
+    });
+  }
+
+  private static async getInvokedReadGrant(input: {
+    tenant: string;
+    actorDid: string;
+    incomingMessage: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    validationStateReader: ValidationStateReader;
+  }): Promise<PermissionGrant | undefined> {
+    const grantId = input.incomingMessage.descriptor.permissionGrantId;
+    if (grantId === undefined) {
+      return undefined;
+    }
+
+    const grant = await input.validationStateReader.fetchGrant(input.tenant, grantId);
+    await GrantAuthorization.performBaseValidation({
+      incomingMessage       : input.incomingMessage,
+      expectedGrantor       : input.tenant,
+      expectedGrantee       : input.actorDid,
+      permissionGrant       : grant,
+      validationStateReader : input.validationStateReader,
+    });
+    return grant;
+  }
+
+  private static grantCoversAudienceEnumeration(grant: PermissionGrant, tags: RoleAudienceKeyId): boolean {
+    const scope = grant.scope as RecordsPermissionScope;
+    if (scope.interface !== DwnInterfaceName.Records || scope.method !== DwnMethodName.Read) {
+      return false;
+    }
+
+    return PermissionScopeMatcher.matches(scope, {
+      protocol     : tags.protocol,
+      protocolPath : tags.rolePath,
+    });
+  }
+
+  private static async getRoleAudienceDefinition(input: {
+    tenant: string;
+    tags: RoleAudienceKeyId;
+    messageTimestamp: string;
+    validationStateReader: ValidationStateReader;
+  }): Promise<RoleAudienceDefinition> {
+    const { tenant, tags, messageTimestamp, validationStateReader } = input;
+    EncryptionControl.verifyRoleAudienceContext(tags.rolePath, tags.contextId);
+
+    const protocolDefinition = await validationStateReader.fetchProtocolDefinition(
+      tenant,
+      tags.protocol,
+      messageTimestamp,
+    );
+    const ruleSet = getRuleSetAtPath(tags.rolePath, protocolDefinition.structure);
+
+    if (ruleSet?.$role !== true || ruleSet.$keyAgreement === undefined) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateAudienceRolePathInvalid,
+        `role audience path '${tags.rolePath}' must be a role path with $keyAgreement.`
+      );
+    }
+
+    return { protocolDefinition, ruleSet };
+  }
+
   private static verifyGrantConditions(message: RecordsWriteMessage, grant: PermissionGrant): void {
     if (grant.conditions?.publication === PermissionConditionPublication.Required && message.descriptor.published !== true) {
       throw new DwnError(
@@ -693,6 +881,47 @@ export class EncryptionControl {
 
   private static getRecordType(message: RecordsWriteMessage): 'audience' | 'delivery' {
     return message.descriptor.protocolPath === ENCRYPTION_CONTROL_DELIVERY_PATH ? 'delivery' : 'audience';
+  }
+
+  private static exactAudienceFilterMatchesRecord(filter: RecordsFilter, tags: RoleAudienceKeyId, recordId: string): boolean {
+    if (filter.recordId === recordId) {
+      return true;
+    }
+
+    const tuple = EncryptionControl.getExactAudienceFilterTuple(filter);
+    if (tuple === undefined) {
+      return false;
+    }
+
+    return tuple.protocol === tags.protocol &&
+      tuple.rolePath === tags.rolePath &&
+      tuple.contextId === tags.contextId &&
+      (tuple.keyId === undefined || tuple.keyId === tags.keyId);
+  }
+
+  private static getExactAudienceFilterTuple(filter: RecordsFilter): ExactAudienceFilterTuple | undefined {
+    if (filter.protocol === undefined || filter.protocolPath !== ENCRYPTION_CONTROL_AUDIENCE_PATH) {
+      return undefined;
+    }
+
+    const protocol = EncryptionControl.getExactFilterTag(filter, 'protocol');
+    const rolePath = EncryptionControl.getExactFilterTag(filter, 'rolePath');
+    const contextId = EncryptionControl.getExactFilterTag(filter, 'contextId');
+    if (protocol !== filter.protocol || rolePath === undefined || contextId === undefined) {
+      return undefined;
+    }
+
+    const keyId = EncryptionControl.getExactFilterTag(filter, 'keyId');
+    if (keyId === undefined) {
+      return { protocol, rolePath, contextId };
+    }
+
+    return { protocol, rolePath, contextId, keyId };
+  }
+
+  private static getExactFilterTag(filter: RecordsFilter, tag: string): string | undefined {
+    const value = filter.tags?.[tag];
+    return typeof value === 'string' ? value : undefined;
   }
 
   private static getRequiredStringTag(message: RecordsWriteMessage, tag: string, recordType: 'audience' | 'delivery'): string {

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -713,7 +713,7 @@ export class EncryptionControl {
       return true;
     }
 
-    const { protocolDefinition, ruleSet } = await EncryptionControl.getRoleAudienceDefinition({
+    const { protocolDefinition, ruleSet } = await EncryptionControl.resolveRoleAudienceDefinition({
       tenant,
       tags,
       messageTimestamp: incomingMessage.descriptor.messageTimestamp,
@@ -796,15 +796,6 @@ export class EncryptionControl {
     }
 
     return { protocolDefinition, ruleSet };
-  }
-
-  private static async getRoleAudienceDefinition(input: {
-    tenant: string;
-    tags: RoleAudienceKeyId;
-    messageTimestamp: string;
-    validationStateReader: ValidationStateReader;
-  }): Promise<RoleAudienceDefinition> {
-    return EncryptionControl.resolveRoleAudienceDefinition(input);
   }
 
   private static verifyGrantConditions(message: RecordsWriteMessage, grant: PermissionGrant): void {

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -42,8 +42,48 @@ export class EncryptionControl {
     return isEncryptionControlPath(message.descriptor.protocolPath);
   }
 
+  public static getRequester(
+    message: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage,
+  ): string | undefined {
+    return Message.isSignedByAuthorDelegate(message) ? Message.getSigner(message) : Message.getAuthor(message);
+  }
+
   public static isExactAudienceFilter(filter: RecordsFilter): boolean {
     return EncryptionControl.getExactAudienceFilterTuple(filter) !== undefined;
+  }
+
+  public static async filterVisibleControlRecords<T extends RecordsWriteMessage>(input: {
+    tenant: string;
+    incomingMessage: RecordsCountMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    requester: string | undefined;
+    recordsWriteMessages: T[];
+    validationStateReader: ValidationStateReader;
+  }): Promise<T[]> {
+    const visibleRecordsWrites: T[] = [];
+    for (const recordsWrite of input.recordsWriteMessages) {
+      if (!EncryptionControl.isControlMessage(recordsWrite)) {
+        visibleRecordsWrites.push(recordsWrite);
+        continue;
+      }
+
+      try {
+        if (await EncryptionControl.canRead({
+          tenant                : input.tenant,
+          incomingMessage       : input.incomingMessage,
+          requester             : input.requester,
+          recordsWriteMessage   : recordsWrite,
+          validationStateReader : input.validationStateReader,
+        })) {
+          visibleRecordsWrites.push(recordsWrite);
+        }
+      } catch (error) {
+        if (!(error instanceof DwnError)) {
+          throw error;
+        }
+      }
+    }
+
+    return visibleRecordsWrites;
   }
 
   public static async authorizeRead(input: {
@@ -324,6 +364,13 @@ export class EncryptionControl {
   }
 
   private static verifyInlineControlRecord(message: RecordsWriteMessage): void {
+    if (message.descriptor.published === true) {
+      throw new DwnError(
+        DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
+        'encryption control records must not be published.'
+      );
+    }
+
     if (message.descriptor.dataSize > DwnConstant.maxDataSizeAllowedToBeEncoded) {
       throw new DwnError(
         DwnErrorCode.EncryptionControlValidateUnexpectedRecord,
@@ -351,8 +398,6 @@ export class EncryptionControl {
     validationStateReader: ValidationStateReader,
     recordType: 'audience' | 'delivery',
   ): Promise<RoleAudienceDefinition> {
-    EncryptionControl.verifyRoleAudienceContext(tags.rolePath, tags.contextId);
-
     if (tags.protocol !== message.descriptor.protocol) {
       const errorCode = recordType === 'audience'
         ? DwnErrorCode.EncryptionControlValidateAudienceTagsMismatch
@@ -363,21 +408,12 @@ export class EncryptionControl {
       );
     }
 
-    const protocolDefinition = await validationStateReader.fetchProtocolDefinition(
+    return EncryptionControl.resolveRoleAudienceDefinition({
       tenant,
-      tags.protocol,
-      message.descriptor.messageTimestamp,
-    );
-    const ruleSet = getRuleSetAtPath(tags.rolePath, protocolDefinition.structure);
-
-    if (ruleSet?.$role !== true || ruleSet.$keyAgreement === undefined) {
-      throw new DwnError(
-        DwnErrorCode.EncryptionControlValidateAudienceRolePathInvalid,
-        `role audience path '${tags.rolePath}' must be a role path with $keyAgreement.`
-      );
-    }
-
-    return { protocolDefinition, ruleSet };
+      tags,
+      messageTimestamp: message.descriptor.messageTimestamp,
+      validationStateReader,
+    });
   }
 
   private static verifyRoleAudienceContext(rolePath: string, contextId: string): void {
@@ -704,6 +740,10 @@ export class EncryptionControl {
     incomingMessage: RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
     validationStateReader: ValidationStateReader;
   }): Promise<PermissionGrant | undefined> {
+    if (Message.isSignedByAuthorDelegate(input.incomingMessage)) {
+      return PermissionGrant.parse(input.incomingMessage.authorization!.authorDelegatedGrant!);
+    }
+
     const grantId = input.incomingMessage.descriptor.permissionGrantId;
     if (grantId === undefined) {
       return undefined;
@@ -732,7 +772,7 @@ export class EncryptionControl {
     });
   }
 
-  private static async getRoleAudienceDefinition(input: {
+  private static async resolveRoleAudienceDefinition(input: {
     tenant: string;
     tags: RoleAudienceKeyId;
     messageTimestamp: string;
@@ -756,6 +796,15 @@ export class EncryptionControl {
     }
 
     return { protocolDefinition, ruleSet };
+  }
+
+  private static async getRoleAudienceDefinition(input: {
+    tenant: string;
+    tags: RoleAudienceKeyId;
+    messageTimestamp: string;
+    validationStateReader: ValidationStateReader;
+  }): Promise<RoleAudienceDefinition> {
+    return EncryptionControl.resolveRoleAudienceDefinition(input);
   }
 
   private static verifyGrantConditions(message: RecordsWriteMessage, grant: PermissionGrant): void {

--- a/packages/dwn-sdk-js/src/handlers/records-count.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-count.ts
@@ -1,15 +1,17 @@
 import type { Filter } from '../types/query-types.js';
 import type { HandlerDependencies, MethodHandler } from '../types/method-handler.js';
-import type { RecordsCountMessage, RecordsCountReply } from '../types/records-types.js';
+import type { RecordsCountMessage, RecordsCountReply, RecordsWriteMessage } from '../types/records-types.js';
 
 import { authenticate } from '../core/auth.js';
-import { countRecordsWithRecordLimitOccupancy } from '../utils/record-limit-occupancy.js';
+import { EncryptionControl } from '../core/encryption-control.js';
+import { isEncryptionControlPath } from '../core/constants.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
 import { Records } from '../utils/records.js';
 import { RecordsCount } from '../interfaces/records-count.js';
 import { RecordsGrantAuthorization } from '../core/records-grant-authorization.js';
+import { countRecordsWithRecordLimitOccupancy, queryRecordsWithRecordLimitOccupancy } from '../utils/record-limit-occupancy.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 
 export class RecordsCountHandler implements MethodHandler {
@@ -82,6 +84,10 @@ export class RecordsCountHandler implements MethodHandler {
     }
 
     if (Records.filterIncludesUnpublishedRecords(filter)) {
+      if (EncryptionControl.isExactAudienceFilter(filter)) {
+        filters.push(RecordsCountHandler.buildUnpublishedControlRecordsFilter(recordsCount));
+      }
+
       if (Records.shouldBuildUnpublishedAuthorFilter(filter, recordsCount.author!)) {
         filters.push(RecordsCountHandler.buildUnpublishedRecordsByCountAuthorFilter(recordsCount));
       }
@@ -99,7 +105,7 @@ export class RecordsCountHandler implements MethodHandler {
       }
     }
 
-    return this.countProjectedRecords(tenant, recordsCount, filters);
+    return this.countProjectedRecordsAsNonOwner(tenant, recordsCount, filters);
   }
 
   /**
@@ -118,6 +124,22 @@ export class RecordsCountHandler implements MethodHandler {
       filters,
       messageTimestamp      : recordsCount.message.descriptor.messageTimestamp,
     });
+  }
+
+  private async countProjectedRecordsAsNonOwner(tenant: string, recordsCount: RecordsCount, filters: Filter[]): Promise<number> {
+    if (!RecordsCountHandler.filtersMayIncludeControlRecords(filters)) {
+      return this.countProjectedRecords(tenant, recordsCount, filters);
+    }
+
+    const { messages } = await queryRecordsWithRecordLimitOccupancy({
+      messageStore          : this.deps.messageStore,
+      validationStateReader : this.deps.validationStateReader,
+      tenant,
+      filters,
+      messageTimestamp      : recordsCount.message.descriptor.messageTimestamp,
+    });
+    const visibleMessages = await this.filterControlRecordsForNonOwner(tenant, recordsCount, messages);
+    return visibleMessages.length;
   }
 
   private static buildPublishedRecordsFilter(recordsCount: RecordsCount): Filter {
@@ -174,6 +196,17 @@ export class RecordsCountHandler implements MethodHandler {
     };
   }
 
+  private static buildUnpublishedControlRecordsFilter(recordsCount: RecordsCount): Filter {
+    const { filter } = recordsCount.message.descriptor;
+    return {
+      ...Records.convertFilter(filter),
+      interface         : DwnInterfaceName.Records,
+      method            : DwnMethodName.Write,
+      isLatestBaseState : true,
+      published         : false,
+    };
+  }
+
   /**
    * Creates a filter for only unpublished records where the author is the same as the count author.
    */
@@ -187,6 +220,13 @@ export class RecordsCountHandler implements MethodHandler {
       isLatestBaseState : true,
       published         : false
     };
+  }
+
+  private static filtersMayIncludeControlRecords(filters: Filter[]): boolean {
+    return filters.some((filter): boolean => {
+      const protocolPath = filter.protocolPath;
+      return typeof protocolPath !== 'string' || isEncryptionControlPath(protocolPath);
+    });
   }
 
   /**
@@ -221,5 +261,31 @@ export class RecordsCountHandler implements MethodHandler {
     if (Records.shouldProtocolAuthorize(recordsCount.signaturePayload!)) {
       await ProtocolAuthorization.authorizeQueryOrSubscribe(tenant, recordsCount, deps.validationStateReader);
     }
+  }
+
+  private async filterControlRecordsForNonOwner(
+    tenant: string,
+    recordsCount: RecordsCount,
+    recordsWrites: RecordsWriteMessage[],
+  ): Promise<RecordsWriteMessage[]> {
+    const visibleRecordsWrites: RecordsWriteMessage[] = [];
+    for (const recordsWrite of recordsWrites) {
+      if (!EncryptionControl.isControlMessage(recordsWrite)) {
+        visibleRecordsWrites.push(recordsWrite);
+        continue;
+      }
+
+      if (await EncryptionControl.canRead({
+        tenant,
+        incomingMessage       : recordsCount.message,
+        requester             : recordsCount.author,
+        recordsWriteMessage   : recordsWrite,
+        validationStateReader : this.deps.validationStateReader,
+      })) {
+        visibleRecordsWrites.push(recordsWrite);
+      }
+    }
+
+    return visibleRecordsWrites;
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-count.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-count.ts
@@ -1,10 +1,9 @@
 import type { Filter } from '../types/query-types.js';
 import type { HandlerDependencies, MethodHandler } from '../types/method-handler.js';
-import type { RecordsCountMessage, RecordsCountReply, RecordsWriteMessage } from '../types/records-types.js';
+import type { RecordsCountMessage, RecordsCountReply } from '../types/records-types.js';
 
 import { authenticate } from '../core/auth.js';
 import { EncryptionControl } from '../core/encryption-control.js';
-import { isEncryptionControlPath } from '../core/constants.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
@@ -30,10 +29,11 @@ export class RecordsCountHandler implements MethodHandler {
     }
 
     let count: number;
+    const requester = EncryptionControl.getRequester(recordsCount.message);
 
     // if this is an anonymous count and the filter supports published records, count only published records
     if (Records.filterIncludesPublishedRecords(recordsCount.message.descriptor.filter) && recordsCount.author === undefined) {
-      count = await this.countPublishedRecords(tenant, recordsCount);
+      count = await this.countPublishedRecords(tenant, recordsCount, requester);
     } else {
       // authentication and authorization
       try {
@@ -44,10 +44,12 @@ export class RecordsCountHandler implements MethodHandler {
         return messageReplyFromError(e, 401);
       }
 
-      if (recordsCount.author === tenant) {
+      if (recordsCount.author === tenant && requester === tenant) {
         count = await this.countRecordsAsOwner(tenant, recordsCount);
+      } else if (recordsCount.author === tenant) {
+        count = await this.countRecordsAsOwnerDelegate(tenant, recordsCount, requester);
       } else {
-        count = await this.countRecordsAsNonOwner(tenant, recordsCount);
+        count = await this.countRecordsAsNonOwner(tenant, recordsCount, requester);
       }
     }
 
@@ -72,10 +74,30 @@ export class RecordsCountHandler implements MethodHandler {
     return this.countProjectedRecords(tenant, recordsCount, [countFilter]);
   }
 
+  private async countRecordsAsOwnerDelegate(
+    tenant: string,
+    recordsCount: RecordsCount,
+    requester: string | undefined,
+  ): Promise<number> {
+    const { filter } = recordsCount.message.descriptor;
+    const countFilter = {
+      ...Records.convertFilter(filter),
+      interface         : DwnInterfaceName.Records,
+      method            : DwnMethodName.Write,
+      isLatestBaseState : true
+    };
+
+    return this.countProjectedRecordsForRequester(tenant, recordsCount, requester, [countFilter]);
+  }
+
   /**
    * Counts records as a non-owner, applying the same filter logic as RecordsQuery.
    */
-  private async countRecordsAsNonOwner(tenant: string, recordsCount: RecordsCount): Promise<number> {
+  private async countRecordsAsNonOwner(
+    tenant: string,
+    recordsCount: RecordsCount,
+    requester: string | undefined,
+  ): Promise<number> {
     const { filter } = recordsCount.message.descriptor;
     const filters: Filter[] = [];
 
@@ -85,7 +107,7 @@ export class RecordsCountHandler implements MethodHandler {
 
     if (Records.filterIncludesUnpublishedRecords(filter)) {
       if (EncryptionControl.isExactAudienceFilter(filter)) {
-        filters.push(RecordsCountHandler.buildUnpublishedControlRecordsFilter(recordsCount));
+        filters.push(Records.buildUnpublishedControlRecordsFilter(filter));
       }
 
       if (Records.shouldBuildUnpublishedAuthorFilter(filter, recordsCount.author!)) {
@@ -105,15 +127,19 @@ export class RecordsCountHandler implements MethodHandler {
       }
     }
 
-    return this.countProjectedRecordsAsNonOwner(tenant, recordsCount, filters);
+    return this.countProjectedRecordsForRequester(tenant, recordsCount, requester, filters);
   }
 
   /**
    * Counts only published records.
    */
-  private async countPublishedRecords(tenant: string, recordsCount: RecordsCount): Promise<number> {
+  private async countPublishedRecords(
+    tenant: string,
+    recordsCount: RecordsCount,
+    requester: string | undefined,
+  ): Promise<number> {
     const filter = RecordsCountHandler.buildPublishedRecordsFilter(recordsCount);
-    return this.countProjectedRecords(tenant, recordsCount, [filter]);
+    return this.countProjectedRecordsForRequester(tenant, recordsCount, requester, [filter]);
   }
 
   private async countProjectedRecords(tenant: string, recordsCount: RecordsCount, filters: Filter[]): Promise<number> {
@@ -126,20 +152,38 @@ export class RecordsCountHandler implements MethodHandler {
     });
   }
 
-  private async countProjectedRecordsAsNonOwner(tenant: string, recordsCount: RecordsCount, filters: Filter[]): Promise<number> {
-    if (!RecordsCountHandler.filtersMayIncludeControlRecords(filters)) {
+  private async countProjectedRecordsForRequester(
+    tenant: string,
+    recordsCount: RecordsCount,
+    requester: string | undefined,
+    filters: Filter[],
+  ): Promise<number> {
+    const controlFilters = Records.buildControlRecordsFilters(filters);
+    if (controlFilters.length === 0) {
       return this.countProjectedRecords(tenant, recordsCount, filters);
+    }
+
+    const totalCount = await this.countProjectedRecords(tenant, recordsCount, filters);
+    const controlCount = await this.countProjectedRecords(tenant, recordsCount, controlFilters);
+    if (controlCount === 0) {
+      return totalCount;
     }
 
     const { messages } = await queryRecordsWithRecordLimitOccupancy({
       messageStore          : this.deps.messageStore,
       validationStateReader : this.deps.validationStateReader,
       tenant,
-      filters,
+      filters               : controlFilters,
       messageTimestamp      : recordsCount.message.descriptor.messageTimestamp,
     });
-    const visibleMessages = await this.filterControlRecordsForNonOwner(tenant, recordsCount, messages);
-    return visibleMessages.length;
+    const visibleMessages = await EncryptionControl.filterVisibleControlRecords({
+      tenant,
+      incomingMessage       : recordsCount.message,
+      requester,
+      recordsWriteMessages  : messages,
+      validationStateReader : this.deps.validationStateReader,
+    });
+    return totalCount - controlCount + visibleMessages.length;
   }
 
   private static buildPublishedRecordsFilter(recordsCount: RecordsCount): Filter {
@@ -196,17 +240,6 @@ export class RecordsCountHandler implements MethodHandler {
     };
   }
 
-  private static buildUnpublishedControlRecordsFilter(recordsCount: RecordsCount): Filter {
-    const { filter } = recordsCount.message.descriptor;
-    return {
-      ...Records.convertFilter(filter),
-      interface         : DwnInterfaceName.Records,
-      method            : DwnMethodName.Write,
-      isLatestBaseState : true,
-      published         : false,
-    };
-  }
-
   /**
    * Creates a filter for only unpublished records where the author is the same as the count author.
    */
@@ -220,13 +253,6 @@ export class RecordsCountHandler implements MethodHandler {
       isLatestBaseState : true,
       published         : false
     };
-  }
-
-  private static filtersMayIncludeControlRecords(filters: Filter[]): boolean {
-    return filters.some((filter): boolean => {
-      const protocolPath = filter.protocolPath;
-      return typeof protocolPath !== 'string' || isEncryptionControlPath(protocolPath);
-    });
   }
 
   /**
@@ -263,29 +289,4 @@ export class RecordsCountHandler implements MethodHandler {
     }
   }
 
-  private async filterControlRecordsForNonOwner(
-    tenant: string,
-    recordsCount: RecordsCount,
-    recordsWrites: RecordsWriteMessage[],
-  ): Promise<RecordsWriteMessage[]> {
-    const visibleRecordsWrites: RecordsWriteMessage[] = [];
-    for (const recordsWrite of recordsWrites) {
-      if (!EncryptionControl.isControlMessage(recordsWrite)) {
-        visibleRecordsWrites.push(recordsWrite);
-        continue;
-      }
-
-      if (await EncryptionControl.canRead({
-        tenant,
-        incomingMessage       : recordsCount.message,
-        requester             : recordsCount.author,
-        recordsWriteMessage   : recordsWrite,
-        validationStateReader : this.deps.validationStateReader,
-      })) {
-        visibleRecordsWrites.push(recordsWrite);
-      }
-    }
-
-    return visibleRecordsWrites;
-  }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-query.ts
@@ -289,6 +289,7 @@ export class RecordsQueryHandler implements MethodHandler {
     const visibleMessages: RecordsQueryReplyEntry[] = [];
     let cursor = pagination.cursor;
     let nextCursor: PaginationCursor | undefined;
+    // Keeps visible-page pagination stable until #1100 moves control visibility into indexed store filters.
     do {
       const remainingLimit = pagination.limit - visibleMessages.length;
       const result = await queryRecordsWithRecordLimitOccupancy({

--- a/packages/dwn-sdk-js/src/handlers/records-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-query.ts
@@ -34,9 +34,10 @@ export class RecordsQueryHandler implements MethodHandler {
 
     let recordsWrites: RecordsQueryReplyEntry[];
     let cursor: PaginationCursor | undefined;
+    const requester = EncryptionControl.getRequester(recordsQuery.message);
     // if this is an anonymous query and the filter supports published records, query only published records
     if (Records.filterIncludesPublishedRecords(recordsQuery.message.descriptor.filter) && recordsQuery.author === undefined) {
-      const results = await this.fetchPublishedRecords(tenant, recordsQuery);
+      const results = await this.fetchPublishedRecords(tenant, recordsQuery, requester);
       recordsWrites = results.messages as RecordsQueryReplyEntry[];
       cursor = results.cursor;
     } else {
@@ -50,16 +51,14 @@ export class RecordsQueryHandler implements MethodHandler {
       }
 
       if (recordsQuery.author === tenant) {
-        const results = await this.fetchRecordsAsOwner(tenant, recordsQuery);
+        const results = requester === tenant
+          ? await this.fetchRecordsAsOwner(tenant, recordsQuery)
+          : await this.fetchRecordsAsOwnerDelegate(tenant, recordsQuery, requester);
         recordsWrites = results.messages as RecordsQueryReplyEntry[];
         cursor = results.cursor;
       } else {
-        const results = await this.fetchRecordsAsNonOwner(tenant, recordsQuery);
-        recordsWrites = await this.filterControlRecordsForNonOwner(
-          tenant,
-          recordsQuery,
-          results.messages as RecordsQueryReplyEntry[],
-        );
+        const results = await this.fetchRecordsAsNonOwner(tenant, recordsQuery, requester);
+        recordsWrites = results.messages as RecordsQueryReplyEntry[];
         cursor = results.cursor;
       }
     }
@@ -138,6 +137,30 @@ export class RecordsQueryHandler implements MethodHandler {
     });
   }
 
+  private async fetchRecordsAsOwnerDelegate(
+    tenant: string,
+    recordsQuery: RecordsQuery,
+    requester: string | undefined,
+  ): Promise<{ messages: GenericMessage[], cursor?: PaginationCursor }> {
+    const { dateSort, filter, pagination } = recordsQuery.message.descriptor;
+    const queryFilter = {
+      ...Records.convertFilter(filter, dateSort),
+      interface         : DwnInterfaceName.Records,
+      method            : DwnMethodName.Write,
+      isLatestBaseState : true
+    };
+
+    const messageSort = this.convertDateSort(dateSort);
+    return this.queryRecordsWithVisibleControlFiltering({
+      tenant,
+      recordsQuery,
+      requester,
+      filters: [queryFilter],
+      messageSort,
+      pagination,
+    });
+  }
+
   /**
    * Fetches the records as a non-owner.
    *
@@ -158,7 +181,9 @@ export class RecordsQueryHandler implements MethodHandler {
    *
    */
   private async fetchRecordsAsNonOwner(
-    tenant: string, recordsQuery: RecordsQuery
+    tenant: string,
+    recordsQuery: RecordsQuery,
+    requester: string | undefined,
   ): Promise<{ messages: GenericMessage[], cursor?: PaginationCursor }> {
     const { dateSort, pagination, filter } = recordsQuery.message.descriptor;
     const filters = [];
@@ -168,7 +193,7 @@ export class RecordsQueryHandler implements MethodHandler {
 
     if (Records.filterIncludesUnpublishedRecords(filter)) {
       if (EncryptionControl.isExactAudienceFilter(filter)) {
-        filters.push(RecordsQueryHandler.buildUnpublishedControlRecordsFilter(recordsQuery));
+        filters.push(Records.buildUnpublishedControlRecordsFilter(filter, dateSort));
       }
 
       if (Records.shouldBuildUnpublishedAuthorFilter(filter, recordsQuery.author!)) {
@@ -189,14 +214,13 @@ export class RecordsQueryHandler implements MethodHandler {
     }
 
     const messageSort = this.convertDateSort(dateSort);
-    return queryRecordsWithRecordLimitOccupancy({
-      messageStore          : this.deps.messageStore,
-      validationStateReader : this.deps.validationStateReader,
+    return this.queryRecordsWithVisibleControlFiltering({
       tenant,
+      recordsQuery,
+      requester,
       filters,
       messageSort,
       pagination,
-      messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
     });
   }
 
@@ -204,20 +228,90 @@ export class RecordsQueryHandler implements MethodHandler {
    * Fetches only published records.
    */
   private async fetchPublishedRecords(
-    tenant: string, recordsQuery: RecordsQuery
+    tenant: string,
+    recordsQuery: RecordsQuery,
+    requester: string | undefined,
   ): Promise<{ messages: GenericMessage[], cursor?: PaginationCursor }> {
     const { dateSort, pagination } = recordsQuery.message.descriptor;
     const filter = RecordsQueryHandler.buildPublishedRecordsFilter(recordsQuery);
     const messageSort = this.convertDateSort(dateSort);
-    return queryRecordsWithRecordLimitOccupancy({
-      messageStore          : this.deps.messageStore,
-      validationStateReader : this.deps.validationStateReader,
+    return this.queryRecordsWithVisibleControlFiltering({
       tenant,
-      filters               : [filter],
+      recordsQuery,
+      requester,
+      filters: [filter],
       messageSort,
       pagination,
-      messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
     });
+  }
+
+  private async queryRecordsWithVisibleControlFiltering(input: {
+    tenant: string;
+    recordsQuery: RecordsQuery;
+    requester: string | undefined;
+    filters: Filter[];
+    messageSort: MessageSort;
+    pagination?: { cursor?: PaginationCursor; limit?: number };
+  }): Promise<{ messages: RecordsQueryReplyEntry[], cursor?: PaginationCursor }> {
+    const {
+      tenant, recordsQuery, requester, filters, messageSort, pagination
+    } = input;
+    const controlFilters = Records.buildControlRecordsFilters(filters);
+    if (controlFilters.length === 0) {
+      const result = await queryRecordsWithRecordLimitOccupancy({
+        messageStore          : this.deps.messageStore,
+        validationStateReader : this.deps.validationStateReader,
+        tenant,
+        filters,
+        messageSort,
+        pagination,
+        messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
+      });
+      return { messages: result.messages as RecordsQueryReplyEntry[], cursor: result.cursor };
+    }
+
+    if (pagination?.limit === undefined || pagination.limit <= 0) {
+      const result = await queryRecordsWithRecordLimitOccupancy({
+        messageStore          : this.deps.messageStore,
+        validationStateReader : this.deps.validationStateReader,
+        tenant,
+        filters,
+        messageSort,
+        pagination,
+        messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
+      });
+      return {
+        messages : await this.filterControlRecordsForRequester(tenant, recordsQuery, requester, result.messages as RecordsQueryReplyEntry[]),
+        cursor   : result.cursor,
+      };
+    }
+
+    const visibleMessages: RecordsQueryReplyEntry[] = [];
+    let cursor = pagination.cursor;
+    let nextCursor: PaginationCursor | undefined;
+    do {
+      const remainingLimit = pagination.limit - visibleMessages.length;
+      const result = await queryRecordsWithRecordLimitOccupancy({
+        messageStore          : this.deps.messageStore,
+        validationStateReader : this.deps.validationStateReader,
+        tenant,
+        filters,
+        messageSort,
+        pagination            : { ...pagination, cursor, limit: remainingLimit },
+        messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
+      });
+      const filteredMessages = await this.filterControlRecordsForRequester(
+        tenant,
+        recordsQuery,
+        requester,
+        result.messages as RecordsQueryReplyEntry[],
+      );
+      visibleMessages.push(...filteredMessages);
+      nextCursor = result.cursor;
+      cursor = result.cursor;
+    } while (visibleMessages.length < pagination.limit && cursor !== undefined);
+
+    return { messages: visibleMessages, cursor: nextCursor };
   }
 
   private static buildPublishedRecordsFilter(recordsQuery: RecordsQuery): Filter {
@@ -277,17 +371,6 @@ export class RecordsQueryHandler implements MethodHandler {
     };
   }
 
-  private static buildUnpublishedControlRecordsFilter(recordsQuery: RecordsQuery): Filter {
-    const { dateSort, filter } = recordsQuery.message.descriptor;
-    return {
-      ...Records.convertFilter(filter, dateSort),
-      interface         : DwnInterfaceName.Records,
-      method            : DwnMethodName.Write,
-      isLatestBaseState : true,
-      published         : false,
-    };
-  }
-
   /**
    * Creates a filter for only unpublished records where the author is the same as the query author.
    */
@@ -338,29 +421,18 @@ export class RecordsQueryHandler implements MethodHandler {
     }
   }
 
-  private async filterControlRecordsForNonOwner(
+  private async filterControlRecordsForRequester(
     tenant: string,
     recordsQuery: RecordsQuery,
+    requester: string | undefined,
     recordsWrites: RecordsQueryReplyEntry[],
   ): Promise<RecordsQueryReplyEntry[]> {
-    const visibleRecordsWrites: RecordsQueryReplyEntry[] = [];
-    for (const recordsWrite of recordsWrites) {
-      if (!EncryptionControl.isControlMessage(recordsWrite)) {
-        visibleRecordsWrites.push(recordsWrite);
-        continue;
-      }
-
-      if (await EncryptionControl.canRead({
-        tenant,
-        incomingMessage       : recordsQuery.message,
-        requester             : recordsQuery.author,
-        recordsWriteMessage   : recordsWrite,
-        validationStateReader : this.deps.validationStateReader,
-      })) {
-        visibleRecordsWrites.push(recordsWrite);
-      }
-    }
-
-    return visibleRecordsWrites;
+    return EncryptionControl.filterVisibleControlRecords({
+      tenant,
+      incomingMessage       : recordsQuery.message,
+      requester,
+      recordsWriteMessages  : recordsWrites,
+      validationStateReader : this.deps.validationStateReader,
+    });
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-query.ts
@@ -5,6 +5,7 @@ import type { RecordsQueryMessage, RecordsQueryReply, RecordsQueryReplyEntry } f
 
 import { authenticate } from '../core/auth.js';
 import { DateSort } from '../types/records-types.js';
+import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
@@ -54,7 +55,11 @@ export class RecordsQueryHandler implements MethodHandler {
         cursor = results.cursor;
       } else {
         const results = await this.fetchRecordsAsNonOwner(tenant, recordsQuery);
-        recordsWrites = results.messages as RecordsQueryReplyEntry[];
+        recordsWrites = await this.filterControlRecordsForNonOwner(
+          tenant,
+          recordsQuery,
+          results.messages as RecordsQueryReplyEntry[],
+        );
         cursor = results.cursor;
       }
     }
@@ -162,6 +167,10 @@ export class RecordsQueryHandler implements MethodHandler {
     }
 
     if (Records.filterIncludesUnpublishedRecords(filter)) {
+      if (EncryptionControl.isExactAudienceFilter(filter)) {
+        filters.push(RecordsQueryHandler.buildUnpublishedControlRecordsFilter(recordsQuery));
+      }
+
       if (Records.shouldBuildUnpublishedAuthorFilter(filter, recordsQuery.author!)) {
         filters.push(RecordsQueryHandler.buildUnpublishedRecordsByQueryAuthorFilter(recordsQuery));
       }
@@ -268,6 +277,17 @@ export class RecordsQueryHandler implements MethodHandler {
     };
   }
 
+  private static buildUnpublishedControlRecordsFilter(recordsQuery: RecordsQuery): Filter {
+    const { dateSort, filter } = recordsQuery.message.descriptor;
+    return {
+      ...Records.convertFilter(filter, dateSort),
+      interface         : DwnInterfaceName.Records,
+      method            : DwnMethodName.Write,
+      isLatestBaseState : true,
+      published         : false,
+    };
+  }
+
   /**
    * Creates a filter for only unpublished records where the author is the same as the query author.
    */
@@ -316,5 +336,31 @@ export class RecordsQueryHandler implements MethodHandler {
     if (Records.shouldProtocolAuthorize(recordsQuery.signaturePayload!)) {
       await ProtocolAuthorization.authorizeQueryOrSubscribe(tenant, recordsQuery, deps.validationStateReader);
     }
+  }
+
+  private async filterControlRecordsForNonOwner(
+    tenant: string,
+    recordsQuery: RecordsQuery,
+    recordsWrites: RecordsQueryReplyEntry[],
+  ): Promise<RecordsQueryReplyEntry[]> {
+    const visibleRecordsWrites: RecordsQueryReplyEntry[] = [];
+    for (const recordsWrite of recordsWrites) {
+      if (!EncryptionControl.isControlMessage(recordsWrite)) {
+        visibleRecordsWrites.push(recordsWrite);
+        continue;
+      }
+
+      if (await EncryptionControl.canRead({
+        tenant,
+        incomingMessage       : recordsQuery.message,
+        requester             : recordsQuery.author,
+        recordsWriteMessage   : recordsWrite,
+        validationStateReader : this.deps.validationStateReader,
+      })) {
+        visibleRecordsWrites.push(recordsWrite);
+      }
+    }
+
+    return visibleRecordsWrites;
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -5,6 +5,7 @@ import type { RecordsDeleteMessage, RecordsQueryReplyEntry, RecordsReadMessage, 
 import { authenticate } from '../core/auth.js';
 import { DataStream } from '../utils/data-stream.js';
 import { Encoder } from '../utils/encoder.js';
+import { EncryptionControl } from '../core/encryption-control.js';
 import { isRecordLimitOccupant } from '../utils/record-limit-occupancy.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
@@ -195,6 +196,14 @@ export class RecordsReadHandler implements MethodHandler {
     ) {
       // The recipient or author of a message may always read it
       return;
+    } else if (EncryptionControl.isControlMessage(matchedRecordsWrite.message)) {
+      await EncryptionControl.authorizeRead({
+        tenant,
+        incomingMessage       : recordsRead.message,
+        requester             : recordsRead.author,
+        recordsWriteMessage   : matchedRecordsWrite.message,
+        validationStateReader : deps.validationStateReader,
+      });
     } else if (recordsRead.author !== undefined && Message.getPermissionGrantId(recordsRead.signaturePayload!) !== undefined) {
       const permissionGrantId = Message.getPermissionGrantId(recordsRead.signaturePayload!)!;
       const permissionGrant = await deps.validationStateReader.fetchGrant(tenant, permissionGrantId);

--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -185,8 +185,16 @@ export class RecordsReadHandler implements MethodHandler {
 
     const { descriptor } = matchedRecordsWrite.message;
 
-    // if author is the same as the target tenant, we can directly grant access
-    if (recordsRead.author === tenant) {
+    if (EncryptionControl.isControlMessage(matchedRecordsWrite.message)) {
+      await EncryptionControl.authorizeRead({
+        tenant,
+        incomingMessage       : recordsRead.message,
+        requester             : EncryptionControl.getRequester(recordsRead.message),
+        recordsWriteMessage   : matchedRecordsWrite.message,
+        validationStateReader : deps.validationStateReader,
+      });
+    } else if (recordsRead.author === tenant) {
+      // if author is the same as the target tenant, we can directly grant access
       return;
     } else if (descriptor.published === true) {
       // authentication is not required for published data
@@ -196,14 +204,6 @@ export class RecordsReadHandler implements MethodHandler {
     ) {
       // The recipient or author of a message may always read it
       return;
-    } else if (EncryptionControl.isControlMessage(matchedRecordsWrite.message)) {
-      await EncryptionControl.authorizeRead({
-        tenant,
-        incomingMessage       : recordsRead.message,
-        requester             : recordsRead.author,
-        recordsWriteMessage   : matchedRecordsWrite.message,
-        validationStateReader : deps.validationStateReader,
-      });
     } else if (recordsRead.author !== undefined && Message.getPermissionGrantId(recordsRead.signaturePayload!) !== undefined) {
       const permissionGrantId = Message.getPermissionGrantId(recordsRead.signaturePayload!)!;
       const permissionGrant = await deps.validationStateReader.fetchGrant(tenant, permissionGrantId);

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -572,6 +572,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
     const visibleMessages: RecordsQueryReplyEntry[] = [];
     let cursor = pagination.cursor;
     let nextCursor: PaginationCursor | undefined;
+    // Keeps visible-page pagination stable until #1100 moves control visibility into indexed store filters.
     do {
       const remainingLimit = pagination.limit - visibleMessages.length;
       const result = await queryRecordsWithRecordLimitOccupancy({

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -6,6 +6,7 @@ import type { RecordsQueryReplyEntry, RecordsSubscribeMessage, RecordsSubscribeR
 
 import { authenticate } from '../core/auth.js';
 import { DateSort } from '../types/records-types.js';
+import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { ProtocolAuthorization } from '../core/protocol-authorization.js';
@@ -139,7 +140,11 @@ export class RecordsSubscribeHandler implements MethodHandler {
         pagination,
         messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
       });
-      entries = queryResult.messages;
+      entries = await this.filterControlRecordsForNonOwner(
+        tenant,
+        recordsSubscribe,
+        queryResult.messages,
+      );
       paginationCursor = queryResult.cursor;
 
       // attach initialWrite for non-initial writes
@@ -230,6 +235,16 @@ export class RecordsSubscribeHandler implements MethodHandler {
     const deliverProjectedEvent = async (subscriptionEvent: SubscriptionEvent): Promise<void> => {
       const { message } = subscriptionEvent.event;
       if (Records.isRecordsWrite(message)) {
+        if (!await EncryptionControl.canRead({
+          tenant,
+          incomingMessage       : recordsSubscribe.message,
+          requester             : recordsSubscribe.author,
+          recordsWriteMessage   : message,
+          validationStateReader : deps.validationStateReader,
+        })) {
+          return;
+        }
+
         let isOccupant: boolean;
         try {
           isOccupant = await isRecordLimitOccupant({
@@ -315,6 +330,15 @@ export class RecordsSubscribeHandler implements MethodHandler {
     }
 
     if (Records.filterIncludesUnpublishedRecords(filter)) {
+      if (EncryptionControl.isExactAudienceFilter(filter)) {
+        filters.push({
+          ...Records.convertFilter(filter),
+          interface : DwnInterfaceName.Records,
+          method    : [DwnMethodName.Write, DwnMethodName.Delete],
+          published : false,
+        });
+      }
+
       if (Records.shouldBuildUnpublishedAuthorFilter(filter, recordsSubscribe.author!)) {
         filters.push({
           ...Records.convertFilter(filter),
@@ -397,6 +421,16 @@ export class RecordsSubscribeHandler implements MethodHandler {
     }
 
     if (Records.filterIncludesUnpublishedRecords(filter)) {
+      if (EncryptionControl.isExactAudienceFilter(filter)) {
+        filters.push({
+          ...Records.convertFilter(filter, dateSort),
+          interface         : DwnInterfaceName.Records,
+          method            : DwnMethodName.Write,
+          isLatestBaseState : true,
+          published         : false,
+        });
+      }
+
       if (Records.shouldBuildUnpublishedAuthorFilter(filter, recordsSubscribe.author!)) {
         filters.push({
           ...Records.convertFilter(filter, dateSort),
@@ -488,5 +522,35 @@ export class RecordsSubscribeHandler implements MethodHandler {
     if (Records.shouldProtocolAuthorize(recordsSubscribe.signaturePayload!)) {
       await ProtocolAuthorization.authorizeQueryOrSubscribe(tenant, recordsSubscribe, deps.validationStateReader);
     }
+  }
+
+  private async filterControlRecordsForNonOwner(
+    tenant: string,
+    recordsSubscribe: RecordsSubscribe,
+    recordsWrites: RecordsQueryReplyEntry[],
+  ): Promise<RecordsQueryReplyEntry[]> {
+    if (recordsSubscribe.author === tenant) {
+      return recordsWrites;
+    }
+
+    const visibleRecordsWrites: RecordsQueryReplyEntry[] = [];
+    for (const recordsWrite of recordsWrites) {
+      if (!EncryptionControl.isControlMessage(recordsWrite)) {
+        visibleRecordsWrites.push(recordsWrite);
+        continue;
+      }
+
+      if (await EncryptionControl.canRead({
+        tenant,
+        incomingMessage       : recordsSubscribe.message,
+        requester             : recordsSubscribe.author,
+        recordsWriteMessage   : recordsWrite,
+        validationStateReader : this.deps.validationStateReader,
+      })) {
+        visibleRecordsWrites.push(recordsWrite);
+      }
+    }
+
+    return visibleRecordsWrites;
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -53,6 +53,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
 
     let eventFilters: Filter[] = [];
     let queryFilters: Filter[] = [];
+    const requester = EncryptionControl.getRequester(recordsSubscribe.message);
 
     // if this is an anonymous subscribe and the filter supports published records, subscribe to only published records
     if (Records.filterIncludesPublishedRecords(recordsSubscribe.message.descriptor.filter) && recordsSubscribe.author === undefined) {
@@ -131,20 +132,15 @@ export class RecordsSubscribeHandler implements MethodHandler {
     try {
       const { dateSort, pagination } = recordsSubscribe.message.descriptor;
       const messageSort = RecordsSubscribeHandler.convertDateSort(dateSort);
-      const queryResult = await queryRecordsWithRecordLimitOccupancy({
-        messageStore          : this.deps.messageStore,
-        validationStateReader : this.deps.validationStateReader,
-        tenant,
-        filters               : queryFilters,
-        messageSort,
-        pagination,
-        messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
-      });
-      entries = await this.filterControlRecordsForNonOwner(
+      const queryResult = await this.queryRecordsWithVisibleControlFiltering(
         tenant,
         recordsSubscribe,
-        queryResult.messages,
+        requester,
+        queryFilters,
+        messageSort,
+        pagination,
       );
+      entries = queryResult.messages;
       paginationCursor = queryResult.cursor;
 
       // attach initialWrite for non-initial writes
@@ -204,6 +200,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
     tenant: string;
   }): ProjectedRecordsSubscriptionHandler {
     const { deps, recordsSubscribe, subscriptionHandler, tenant } = input;
+    const requester = EncryptionControl.getRequester(recordsSubscribe.message);
     let subscription: EventSubscription | undefined;
     let closeRequested = false;
     let terminalErrorEmitted = false;
@@ -235,13 +232,14 @@ export class RecordsSubscribeHandler implements MethodHandler {
     const deliverProjectedEvent = async (subscriptionEvent: SubscriptionEvent): Promise<void> => {
       const { message } = subscriptionEvent.event;
       if (Records.isRecordsWrite(message)) {
-        if (!await EncryptionControl.canRead({
+        const visibleMessages = await EncryptionControl.filterVisibleControlRecords({
           tenant,
           incomingMessage       : recordsSubscribe.message,
-          requester             : recordsSubscribe.author,
-          recordsWriteMessage   : message,
+          requester,
+          recordsWriteMessages  : [message],
           validationStateReader : deps.validationStateReader,
-        })) {
+        });
+        if (visibleMessages.length === 0) {
           return;
         }
 
@@ -422,13 +420,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
 
     if (Records.filterIncludesUnpublishedRecords(filter)) {
       if (EncryptionControl.isExactAudienceFilter(filter)) {
-        filters.push({
-          ...Records.convertFilter(filter, dateSort),
-          interface         : DwnInterfaceName.Records,
-          method            : DwnMethodName.Write,
-          isLatestBaseState : true,
-          published         : false,
-        });
+        filters.push(Records.buildUnpublishedControlRecordsFilter(filter, dateSort));
       }
 
       if (Records.shouldBuildUnpublishedAuthorFilter(filter, recordsSubscribe.author!)) {
@@ -527,30 +519,81 @@ export class RecordsSubscribeHandler implements MethodHandler {
   private async filterControlRecordsForNonOwner(
     tenant: string,
     recordsSubscribe: RecordsSubscribe,
+    requester: string | undefined,
     recordsWrites: RecordsQueryReplyEntry[],
   ): Promise<RecordsQueryReplyEntry[]> {
-    if (recordsSubscribe.author === tenant) {
-      return recordsWrites;
-    }
+    return EncryptionControl.filterVisibleControlRecords({
+      tenant,
+      incomingMessage       : recordsSubscribe.message,
+      requester,
+      recordsWriteMessages  : recordsWrites,
+      validationStateReader : this.deps.validationStateReader,
+    });
+  }
 
-    const visibleRecordsWrites: RecordsQueryReplyEntry[] = [];
-    for (const recordsWrite of recordsWrites) {
-      if (!EncryptionControl.isControlMessage(recordsWrite)) {
-        visibleRecordsWrites.push(recordsWrite);
-        continue;
-      }
-
-      if (await EncryptionControl.canRead({
-        tenant,
-        incomingMessage       : recordsSubscribe.message,
-        requester             : recordsSubscribe.author,
-        recordsWriteMessage   : recordsWrite,
+  private async queryRecordsWithVisibleControlFiltering(
+    tenant: string,
+    recordsSubscribe: RecordsSubscribe,
+    requester: string | undefined,
+    filters: Filter[],
+    messageSort: MessageSort,
+    pagination: { cursor?: PaginationCursor; limit?: number } | undefined,
+  ): Promise<{ messages: RecordsQueryReplyEntry[], cursor?: PaginationCursor }> {
+    const controlFilters = Records.buildControlRecordsFilters(filters);
+    if (controlFilters.length === 0) {
+      const result = await queryRecordsWithRecordLimitOccupancy({
+        messageStore          : this.deps.messageStore,
         validationStateReader : this.deps.validationStateReader,
-      })) {
-        visibleRecordsWrites.push(recordsWrite);
-      }
+        tenant,
+        filters,
+        messageSort,
+        pagination,
+        messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
+      });
+      return { messages: result.messages, cursor: result.cursor };
     }
 
-    return visibleRecordsWrites;
+    if (pagination?.limit === undefined || pagination.limit <= 0) {
+      const result = await queryRecordsWithRecordLimitOccupancy({
+        messageStore          : this.deps.messageStore,
+        validationStateReader : this.deps.validationStateReader,
+        tenant,
+        filters,
+        messageSort,
+        pagination,
+        messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
+      });
+      return {
+        messages : await this.filterControlRecordsForNonOwner(tenant, recordsSubscribe, requester, result.messages),
+        cursor   : result.cursor,
+      };
+    }
+
+    const visibleMessages: RecordsQueryReplyEntry[] = [];
+    let cursor = pagination.cursor;
+    let nextCursor: PaginationCursor | undefined;
+    do {
+      const remainingLimit = pagination.limit - visibleMessages.length;
+      const result = await queryRecordsWithRecordLimitOccupancy({
+        messageStore          : this.deps.messageStore,
+        validationStateReader : this.deps.validationStateReader,
+        tenant,
+        filters,
+        messageSort,
+        pagination            : { ...pagination, cursor, limit: remainingLimit },
+        messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
+      });
+      const filteredMessages = await this.filterControlRecordsForNonOwner(
+        tenant,
+        recordsSubscribe,
+        requester,
+        result.messages,
+      );
+      visibleMessages.push(...filteredMessages);
+      nextCursor = result.cursor;
+      cursor = result.cursor;
+    } while (visibleMessages.length < pagination.limit && cursor !== undefined);
+
+    return { messages: visibleMessages, cursor: nextCursor };
   }
 }

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -12,6 +12,7 @@ import { DataStream } from './data-stream.js';
 import { DateSort } from '../types/records-types.js';
 import { Encoder } from './encoder.js';
 import { FilterUtility } from './filter.js';
+import { isEncryptionControlPath } from '../core/constants.js';
 import { Jws } from './jws.js';
 import { Message } from '../core/message.js';
 import { PermissionGrant } from '../protocols/permission-grant.js';
@@ -331,6 +332,10 @@ export class Records {
   ): void {
     const { contextId, protocolPath } = filter;
     if (!protocolPath?.includes('/')) {
+      return;
+    }
+
+    if (isEncryptionControlPath(protocolPath)) {
       return;
     }
 

--- a/packages/dwn-sdk-js/src/utils/records.ts
+++ b/packages/dwn-sdk-js/src/utils/records.ts
@@ -12,7 +12,6 @@ import { DataStream } from './data-stream.js';
 import { DateSort } from '../types/records-types.js';
 import { Encoder } from './encoder.js';
 import { FilterUtility } from './filter.js';
-import { isEncryptionControlPath } from '../core/constants.js';
 import { Jws } from './jws.js';
 import { Message } from '../core/message.js';
 import { PermissionGrant } from '../protocols/permission-grant.js';
@@ -22,6 +21,7 @@ import { X25519 } from '@enbox/crypto';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
 import { Encryption, ROLE_AUDIENCE_DERIVATION_SCHEME } from './encryption.js';
+import { ENCRYPTION_CONTROL_PATHS, isEncryptionControlPath } from '../core/constants.js';
 import { HdKey, KeyDerivationScheme } from './hd-key.js';
 import { normalizeProtocolUrl, normalizeSchemaUrl } from './url.js';
 
@@ -445,6 +445,35 @@ export class Records {
     }
 
     return filterCopy;
+  }
+
+  public static buildUnpublishedControlRecordsFilter(filter: RecordsFilter, dateSort?: DateSort): Filter {
+    return {
+      ...Records.convertFilter(filter, dateSort),
+      interface         : DwnInterfaceName.Records,
+      method            : DwnMethodName.Write,
+      isLatestBaseState : true,
+      published         : false,
+    };
+  }
+
+  public static buildControlRecordsFilters(filters: Filter[]): Filter[] {
+    const controlFilters: Filter[] = [];
+    for (const filter of filters) {
+      const protocolPath = filter.protocolPath;
+      if (typeof protocolPath === 'string') {
+        if (isEncryptionControlPath(protocolPath)) {
+          controlFilters.push(filter);
+        }
+        continue;
+      }
+
+      for (const controlPath of ENCRYPTION_CONTROL_PATHS) {
+        controlFilters.push({ ...filter, protocolPath: controlPath });
+      }
+    }
+
+    return controlFilters;
   }
 
   /**

--- a/packages/dwn-sdk-js/tests/handlers/records-count.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-count.spec.ts
@@ -1,22 +1,27 @@
 import type { DidResolver } from '@enbox/dids';
 import type { EventLog } from '../../src/types/subscriptions.js';
-import type { DataStore, MessageStore, ProtocolDefinition, ResumableTaskStore } from '../../src/index.js';
+import type { DataStore, MessageStore, ProtocolDefinition, ProtocolRuleSet, ResumableTaskStore } from '../../src/index.js';
 
 import sinon from 'sinon';
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { DataStream } from '../../src/utils/data-stream.js';
+import { Encoder } from '../../src/utils/encoder.js';
+import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
 import { Jws } from '../../src/utils/jws.js';
 import { PermissionsProtocol } from '../../src/protocols/permissions.js';
+import { RecordsCount } from '../../src/interfaces/records-count.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Time } from '../../src/index.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
 
 export function testRecordsCountHandler(): void {
   describe('RecordsCountHandler.handle()', () => {
@@ -192,6 +197,118 @@ export function testRecordsCountHandler(): void {
 
         expect(reply.status.code).toBe(200);
         expect(reply.count).toBe(1);
+      });
+
+      it('should count exact-tuple audience control records without broad enumeration', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-count-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : encryptedDefinition.structure.member as ProtocolRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        const exactCount = await RecordsCount.create({
+          filter: {
+            protocol     : protocolDefinition.protocol,
+            protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+            tags         : {
+              protocol  : protocolDefinition.protocol,
+              rolePath  : 'member',
+              contextId : '',
+            },
+          },
+          signer: Jws.createSigner(bob),
+        });
+        const exactReply = await dwn.processMessage(alice.did, exactCount.message);
+        expect(exactReply.status.code).toBe(200);
+        expect(exactReply.count).toBe(1);
+
+        const broadCount = await RecordsCount.create({
+          filter : { protocol: protocolDefinition.protocol },
+          signer : Jws.createSigner(bob),
+        });
+        const broadReply = await dwn.processMessage(alice.did, broadCount.message);
+        expect(broadReply.status.code).toBe(200);
+        expect(broadReply.count).toBe(0);
+      });
+
+      it('should count delivery control records only for the recipient', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-count-delivery.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        const roleRecord = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('bob is a member'),
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'member',
+          recipient    : bob.did,
+          schema       : 'http://member-schema',
+        });
+        expect((await dwn.processMessage(alice.did, roleRecord.message, { dataStream: roleRecord.dataStream })).status.code).toBe(202);
+
+        const delivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          rolePath           : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, delivery);
+
+        const bobCount = await RecordsCount.create({
+          filter : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          signer : Jws.createSigner(bob),
+        });
+        const bobReply = await dwn.processMessage(alice.did, bobCount.message);
+        expect(bobReply.status.code).toBe(200);
+        expect(bobReply.count).toBe(1);
+
+        const carolCount = await RecordsCount.create({
+          filter : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          signer : Jws.createSigner(carol),
+        });
+        const carolReply = await dwn.processMessage(alice.did, carolCount.message);
+        expect(carolReply.status.code).toBe(200);
+        expect(carolReply.count).toBe(0);
       });
 
       it('should count unpublished records authorized by permissionGrantId', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-count.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-count.spec.ts
@@ -247,6 +247,58 @@ export function testRecordsCountHandler(): void {
         expect(broadReply.count).toBe(0);
       });
 
+      it('should hide stale audience control records from delegated broad counts', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-count-stale-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : encryptedDefinition.structure.member as ProtocolRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        await installEncryptedProtocol(dwn, alice, {
+          ...protocolDefinition,
+          structure: {
+            member: {},
+          },
+        });
+
+        const grant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : bob,
+          delegated : true,
+          scope     : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+        const count = await RecordsCount.create({
+          delegatedGrant : grant.dataEncodedMessage,
+          filter         : { protocol: protocolDefinition.protocol },
+          signer         : Jws.createSigner(bob),
+        });
+        const reply = await dwn.processMessage(alice.did, count.message);
+        expect(reply.status.code).toBe(200);
+        expect(reply.count).toBe(0);
+      });
+
       it('should count delivery control records only for the recipient', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
         const bob = await TestDataGenerator.generateDidKeyPersona();
@@ -309,6 +361,27 @@ export function testRecordsCountHandler(): void {
         const carolReply = await dwn.processMessage(alice.did, carolCount.message);
         expect(carolReply.status.code).toBe(200);
         expect(carolReply.count).toBe(0);
+
+        const carolGrant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : carol,
+          delegated : true,
+          scope     : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, carolGrant.message, { dataStream: carolGrant.dataStream })).status.code).toBe(202);
+
+        const delegatedCarolCount = await RecordsCount.create({
+          delegatedGrant : carolGrant.dataEncodedMessage,
+          filter         : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          signer         : Jws.createSigner(carol),
+        });
+        const delegatedCarolReply = await dwn.processMessage(alice.did, delegatedCarolCount.message);
+        expect(delegatedCarolReply.status.code).toBe(200);
+        expect(delegatedCarolReply.count).toBe(0);
       });
 
       it('should count unpublished records authorized by permissionGrantId', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
@@ -1,5 +1,5 @@
 import type { DidResolver } from '@enbox/dids';
-import type { DataStore, EventLog, GenericMessage, MessageStore, ProtocolDefinition, RecordsWriteMessage, ResumableTaskStore } from '../../src/index.js';
+import type { DataStore, EventLog, GenericMessage, MessageStore, ProtocolDefinition, ProtocolRuleSet, RecordsWriteMessage, ResumableTaskStore } from '../../src/index.js';
 import type { RecordsQueryReply, RecordsQueryReplyEntry, RecordsWriteDescriptor } from '../../src/types/records-types.js';
 
 import sinon from 'sinon';
@@ -17,6 +17,7 @@ import { DateSort } from '../../src/types/records-types.js';
 import { DwnConstant } from '../../src/core/dwn-constant.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Encoder } from '../../src/utils/encoder.js';
+import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import { Jws } from '../../src/utils/jws.js';
 import { Message } from '../../src/core/message.js';
 import { PermissionsProtocol } from '../../src/protocols/permissions.js';
@@ -27,9 +28,11 @@ import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { CoreProtocolRegistry, DataStoreLevel, Dwn, MessageStoreLevel, ProtocolsConfigure, RecordsWrite, Time } from '../../src/index.js';
+import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { defaultTestProtocolDefinition, TestDataGenerator } from '../utils/test-data-generator.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
 
@@ -161,6 +164,162 @@ export function testRecordsQueryHandler(): void {
 
         expect(reply2.status.code).toBe(200);
         expect(reply2.entries?.length).toBe(1); // only 1 entry should match the query
+      });
+
+      it('should allow exact-tuple audience control queries without broad enumeration', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-query-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : encryptedDefinition.structure.member as ProtocolRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        const exactQuery = await RecordsQuery.create({
+          filter: {
+            protocol     : protocolDefinition.protocol,
+            protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+            tags         : {
+              protocol  : protocolDefinition.protocol,
+              rolePath  : 'member',
+              contextId : '',
+            },
+          },
+          signer: Jws.createSigner(bob),
+        });
+        const exactReply = await dwn.processMessage(alice.did, exactQuery.message);
+        expect(exactReply.status.code).toBe(200);
+        expect(exactReply.entries?.map(entry => entry.recordId)).toEqual([audience.recordsWrite.message.recordId]);
+
+        const broadQuery = await RecordsQuery.create({
+          filter : { protocol: protocolDefinition.protocol },
+          signer : Jws.createSigner(bob),
+        });
+        const broadReply = await dwn.processMessage(alice.did, broadQuery.message);
+        expect(broadReply.status.code).toBe(200);
+        expect(broadReply.entries?.map(entry => entry.recordId)).not.toContain(audience.recordsWrite.message.recordId);
+      });
+
+      it('should allow grant-backed audience control enumeration', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-query-grant-enumeration.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : encryptedDefinition.structure.member as ProtocolRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        const grant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : bob,
+          scope     : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+        const query = await RecordsQuery.create({
+          filter            : { protocol: protocolDefinition.protocol },
+          permissionGrantId : grant.message.recordId,
+          signer            : Jws.createSigner(bob),
+        });
+        const reply = await dwn.processMessage(alice.did, query.message);
+        expect(reply.status.code).toBe(200);
+        expect(reply.entries?.map(entry => entry.recordId)).toContain(audience.recordsWrite.message.recordId);
+      });
+
+      it('should return delivery control records only to the recipient', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-query-delivery.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        const roleRecord = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('bob is a member'),
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'member',
+          recipient    : bob.did,
+          schema       : 'http://member-schema',
+        });
+        expect((await dwn.processMessage(alice.did, roleRecord.message, { dataStream: roleRecord.dataStream })).status.code).toBe(202);
+
+        const delivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          rolePath           : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, delivery);
+
+        const bobQuery = await RecordsQuery.create({
+          filter : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          signer : Jws.createSigner(bob),
+        });
+        const bobReply = await dwn.processMessage(alice.did, bobQuery.message);
+        expect(bobReply.status.code).toBe(200);
+        expect(bobReply.entries?.map(entry => entry.recordId)).toContain(delivery.recordsWrite.message.recordId);
+
+        const carolQuery = await RecordsQuery.create({
+          filter : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          signer : Jws.createSigner(carol),
+        });
+        const carolReply = await dwn.processMessage(alice.did, carolQuery.message);
+        expect(carolReply.status.code).toBe(200);
+        expect(carolReply.entries?.map(entry => entry.recordId)).not.toContain(delivery.recordsWrite.message.recordId);
       });
 
       it('should return `encodedData` if data size is within the spec threshold', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
@@ -258,6 +258,58 @@ export function testRecordsQueryHandler(): void {
         expect(reply.entries?.map(entry => entry.recordId)).toContain(audience.recordsWrite.message.recordId);
       });
 
+      it('should hide stale audience control records from delegated broad queries', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-query-stale-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : encryptedDefinition.structure.member as ProtocolRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        await installEncryptedProtocol(dwn, alice, {
+          ...protocolDefinition,
+          structure: {
+            member: {},
+          },
+        });
+
+        const grant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : bob,
+          delegated : true,
+          scope     : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+        const query = await RecordsQuery.create({
+          delegatedGrant : grant.dataEncodedMessage,
+          filter         : { protocol: protocolDefinition.protocol },
+          signer         : Jws.createSigner(bob),
+        });
+        const reply = await dwn.processMessage(alice.did, query.message);
+        expect(reply.status.code).toBe(200);
+        expect(reply.entries?.map(entry => entry.recordId)).not.toContain(audience.recordsWrite.message.recordId);
+      });
+
       it('should return delivery control records only to the recipient', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
         const bob = await TestDataGenerator.generateDidKeyPersona();
@@ -320,6 +372,60 @@ export function testRecordsQueryHandler(): void {
         const carolReply = await dwn.processMessage(alice.did, carolQuery.message);
         expect(carolReply.status.code).toBe(200);
         expect(carolReply.entries?.map(entry => entry.recordId)).not.toContain(delivery.recordsWrite.message.recordId);
+
+        const carolGrant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : carol,
+          delegated : true,
+          scope     : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, carolGrant.message, { dataStream: carolGrant.dataStream })).status.code).toBe(202);
+
+        const delegatedCarolQuery = await RecordsQuery.create({
+          delegatedGrant : carolGrant.dataEncodedMessage,
+          filter         : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          signer         : Jws.createSigner(carol),
+        });
+        const delegatedCarolReply = await dwn.processMessage(alice.did, delegatedCarolQuery.message);
+        expect(delegatedCarolReply.status.code).toBe(200);
+        expect(delegatedCarolReply.entries?.map(entry => entry.recordId)).not.toContain(delivery.recordsWrite.message.recordId);
+
+        const carolRoleRecord = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('carol is a member'),
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'member',
+          recipient    : carol.did,
+          schema       : 'http://member-schema',
+        });
+        expect((await dwn.processMessage(alice.did, carolRoleRecord.message, { dataStream: carolRoleRecord.dataStream })).status.code).toBe(202);
+
+        const carolDelivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : carol.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          rolePath           : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, carolDelivery);
+
+        const pagedDelegatedCarolQuery = await RecordsQuery.create({
+          dateSort       : DateSort.CreatedAscending,
+          delegatedGrant : carolGrant.dataEncodedMessage,
+          filter         : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          pagination     : { limit: 1 },
+          signer         : Jws.createSigner(carol),
+        });
+        const pagedDelegatedCarolReply = await dwn.processMessage(alice.did, pagedDelegatedCarolQuery.message);
+        expect(pagedDelegatedCarolReply.status.code).toBe(200);
+        expect(pagedDelegatedCarolReply.entries?.map(entry => entry.recordId)).toEqual([carolDelivery.recordsWrite.message.recordId]);
       });
 
       it('should return `encodedData` if data size is within the spec threshold', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
@@ -223,6 +223,26 @@ export function testRecordsReadHandler(): void {
         });
         const carolReply = await dwn.processMessage(alice.did, carolRead.message);
         expect(carolReply.status.code).toBe(401);
+
+        const carolGrant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : carol,
+          delegated : true,
+          scope     : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, carolGrant.message, { dataStream: carolGrant.dataStream })).status.code).toBe(202);
+
+        const delegatedCarolRead = await RecordsRead.create({
+          delegatedGrant : carolGrant.dataEncodedMessage,
+          filter         : { recordId: delivery.recordsWrite.message.recordId },
+          signer         : Jws.createSigner(carol),
+        });
+        const delegatedCarolReply = await dwn.processMessage(alice.did, delegatedCarolRead.message);
+        expect(delegatedCarolReply.status.code).toBe(401);
       });
 
       it('should allow reading of data that is published without `authorization`', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
@@ -2,7 +2,7 @@ import type { DerivedPrivateJwk } from '../../src/utils/hd-key.js';
 import type { DidResolver } from '@enbox/dids';
 import type { EncryptionInput } from '../../src/interfaces/records-write.js';
 import type { EventLog } from '../../src/types/subscriptions.js';
-import type { DataStore, MessageStore, ProtocolDefinition, ProtocolsConfigureMessage, ResumableTaskStore } from '../../src/index.js';
+import type { DataStore, MessageStore, ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage, ResumableTaskStore } from '../../src/index.js';
 
 import emailProtocolDefinition from '../vectors/protocol-definitions/email.json' with { type: 'json' };
 import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
@@ -15,6 +15,8 @@ import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread
 import { ArrayUtility } from '../../src/utils/array.js';
 import { authenticate } from '../../src/core/auth.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { Encoder } from '../../src/utils/encoder.js';
+import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import { HdKey } from '../../src/utils/hd-key.js';
 import { KeyDerivationScheme } from '../../src/utils/hd-key.js';
 import { RecordsReadHandler } from '../../src/handlers/records-read.js';
@@ -24,6 +26,7 @@ import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm } from '../../src/utils/encryption.js';
+import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { DataStoreLevel, DwnConstant, MessageStoreLevel, PermissionsProtocol, Time } from '../../src/index.js';
 import { DataStream, DateSort, Dwn, Jws, Protocols, ProtocolsConfigure, ProtocolsQuery, Records, RecordsDelete, RecordsRead , RecordsWrite } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
@@ -119,6 +122,107 @@ export function testRecordsReadHandler(): void {
 
         const readReply = await dwn.processMessage(alice.did, recordsRead.message);
         expect(readReply.status.code).toBe(401);
+      });
+
+      it('should allow authenticated exact-record reads of audience control records', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-read-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet : encryptedDefinition.structure.member as ProtocolRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        const recordsRead = await RecordsRead.create({
+          filter : { recordId: audience.recordsWrite.message.recordId },
+          signer : Jws.createSigner(bob),
+        });
+        const readReply = await dwn.processMessage(alice.did, recordsRead.message);
+        expect(readReply.status.code).toBe(200);
+        expect(readReply.entry?.recordsWrite?.recordId).toBe(audience.recordsWrite.message.recordId);
+
+        const anonymousRead = await RecordsRead.create({
+          filter: { recordId: audience.recordsWrite.message.recordId },
+        });
+        const anonymousReply = await dwn.processMessage(alice.did, anonymousRead.message);
+        expect(anonymousReply.status.code).toBe(401);
+      });
+
+      it('should only allow delivery control reads by the recipient or writer', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-read-delivery.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        const roleRecord = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('bob is a member'),
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'member',
+          recipient    : bob.did,
+          schema       : 'http://member-schema',
+        });
+        expect((await dwn.processMessage(alice.did, roleRecord.message, { dataStream: roleRecord.dataStream })).status.code).toBe(202);
+
+        const delivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          rolePath           : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, delivery);
+
+        const bobRead = await RecordsRead.create({
+          filter : { recordId: delivery.recordsWrite.message.recordId },
+          signer : Jws.createSigner(bob),
+        });
+        const bobReply = await dwn.processMessage(alice.did, bobRead.message);
+        expect(bobReply.status.code).toBe(200);
+        expect(bobReply.entry?.recordsWrite?.recordId).toBe(delivery.recordsWrite.message.recordId);
+
+        const carolRead = await RecordsRead.create({
+          filter : { recordId: delivery.recordsWrite.message.recordId },
+          signer : Jws.createSigner(carol),
+        });
+        const carolReply = await dwn.processMessage(alice.did, carolRead.message);
+        expect(carolReply.status.code).toBe(401);
       });
 
       it('should allow reading of data that is published without `authorization`', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
@@ -359,6 +359,19 @@ export function testRecordsSubscribeHandler(): void {
 
         const bobEvents: RecordEvent[] = [];
         const carolEvents: RecordEvent[] = [];
+        const delegatedCarolEvents: RecordEvent[] = [];
+        const carolGrant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : carol,
+          delegated : true,
+          scope     : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, carolGrant.message, { dataStream: carolGrant.dataStream })).status.code).toBe(202);
+
         const bobSubscribe = await RecordsSubscribe.create({
           filter : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
           signer : Jws.createSigner(bob),
@@ -366,6 +379,11 @@ export function testRecordsSubscribeHandler(): void {
         const carolSubscribe = await RecordsSubscribe.create({
           filter : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
           signer : Jws.createSigner(carol),
+        });
+        const delegatedCarolSubscribe = await RecordsSubscribe.create({
+          delegatedGrant : carolGrant.dataEncodedMessage,
+          filter         : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          signer         : Jws.createSigner(carol),
         });
         const bobReply = await dwn.processMessage(alice.did, bobSubscribe.message, {
           subscriptionHandler: (msg): void => {
@@ -381,8 +399,16 @@ export function testRecordsSubscribeHandler(): void {
             }
           },
         });
+        const delegatedCarolReply = await dwn.processMessage(alice.did, delegatedCarolSubscribe.message, {
+          subscriptionHandler: (msg): void => {
+            if (msg.type === 'event') {
+              delegatedCarolEvents.push(msg.event as RecordEvent);
+            }
+          },
+        });
         expect(bobReply.status.code).toBe(200);
         expect(carolReply.status.code).toBe(200);
+        expect(delegatedCarolReply.status.code).toBe(200);
 
         const delivery = await createDeliveryControlWrite({
           author             : alice,
@@ -400,6 +426,8 @@ export function testRecordsSubscribeHandler(): void {
         });
         await sleep(200);
         expect(carolEvents.map(event => (event.message as RecordsWriteMessage).recordId)).not.toContain(delivery.recordsWrite.message.recordId);
+        const delegatedCarolRecordIds = delegatedCarolEvents.map(event => (event.message as RecordsWriteMessage).recordId);
+        expect(delegatedCarolRecordIds).not.toContain(delivery.recordsWrite.message.recordId);
       });
 
       describe('cursor-based subscriptions', () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
@@ -1,5 +1,5 @@
 import type { DidResolver } from '@enbox/dids';
-import type { DataStore, MessageStore, ProtocolDefinition, RecordsDeleteMessage, RecordsWriteMessage, ResumableTaskStore } from '../../src/index.js';
+import type { DataStore, MessageStore, ProtocolDefinition, ProtocolRuleSet, RecordsDeleteMessage, RecordsWriteMessage, ResumableTaskStore } from '../../src/index.js';
 import type { EventLog, SubscriptionListener, SubscriptionMessage } from '../../src/types/subscriptions.js';
 import type { RecordEvent, RecordsFilter } from '../../src/types/records-types.js';
 
@@ -12,6 +12,8 @@ import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend
 import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 
 import { DataStream } from '../../src/utils/data-stream.js';
+import { Encoder } from '../../src/utils/encoder.js';
+import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import { Jws } from '../../src/utils/jws.js';
 import { Message } from '../../src/core/message.js';
 import { PermissionsProtocol } from '../../src/protocols/permissions.js';
@@ -22,8 +24,10 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
+import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DurableEventLog, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, MessageStoreLevel, Time } from '../../src/index.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
 
@@ -256,6 +260,146 @@ export function testRecordsSubscribeHandler(): void {
           expect(receivedEvents.length).toBe(1);
           expect((receivedEvents[0].message as RecordsWriteMessage).recordId).toBe(write2.message.recordId);
         });
+      });
+
+      it('should authorize exact-tuple audience control subscriptions for snapshots and live events', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-subscribe-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+        const initialAudience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, initialAudience);
+
+        const receivedEvents: RecordEvent[] = [];
+        const subscriptionHandler: SubscriptionListener = (msg): void => {
+          if (msg.type === 'event') {
+            receivedEvents.push(msg.event as RecordEvent);
+          }
+        };
+        const recordsSubscribe = await RecordsSubscribe.create({
+          filter: {
+            protocol     : protocolDefinition.protocol,
+            protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+            tags         : {
+              protocol  : protocolDefinition.protocol,
+              rolePath  : 'member',
+              contextId : '',
+            },
+          },
+          signer: Jws.createSigner(bob),
+        });
+        const subReply = await dwn.processMessage(alice.did, recordsSubscribe.message, { subscriptionHandler });
+        expect(subReply.status.code).toBe(200);
+        expect(subReply.entries?.map(entry => entry.recordId)).toEqual([initialAudience.recordsWrite.message.recordId]);
+
+        const liveAudience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, liveAudience);
+
+        await Poller.pollUntilSuccessOrTimeout(async () => {
+          expect(receivedEvents.map(event => (event.message as RecordsWriteMessage).recordId)).toContain(liveAudience.recordsWrite.message.recordId);
+        });
+      });
+
+      it('should deliver live delivery control events only to the recipient', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-subscribe-delivery.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        const roleRecord = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('bob is a member'),
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'member',
+          recipient    : bob.did,
+          schema       : 'http://member-schema',
+        });
+        expect((await dwn.processMessage(alice.did, roleRecord.message, { dataStream: roleRecord.dataStream })).status.code).toBe(202);
+
+        const bobEvents: RecordEvent[] = [];
+        const carolEvents: RecordEvent[] = [];
+        const bobSubscribe = await RecordsSubscribe.create({
+          filter : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          signer : Jws.createSigner(bob),
+        });
+        const carolSubscribe = await RecordsSubscribe.create({
+          filter : { protocol: protocolDefinition.protocol, protocolPath: ENCRYPTION_CONTROL_DELIVERY_PATH },
+          signer : Jws.createSigner(carol),
+        });
+        const bobReply = await dwn.processMessage(alice.did, bobSubscribe.message, {
+          subscriptionHandler: (msg): void => {
+            if (msg.type === 'event') {
+              bobEvents.push(msg.event as RecordEvent);
+            }
+          },
+        });
+        const carolReply = await dwn.processMessage(alice.did, carolSubscribe.message, {
+          subscriptionHandler: (msg): void => {
+            if (msg.type === 'event') {
+              carolEvents.push(msg.event as RecordEvent);
+            }
+          },
+        });
+        expect(bobReply.status.code).toBe(200);
+        expect(carolReply.status.code).toBe(200);
+
+        const delivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          rolePath           : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, delivery);
+
+        await Poller.pollUntilSuccessOrTimeout(async () => {
+          expect(bobEvents.map(event => (event.message as RecordsWriteMessage).recordId)).toContain(delivery.recordsWrite.message.recordId);
+        });
+        await sleep(200);
+        expect(carolEvents.map(event => (event.message as RecordsWriteMessage).recordId)).not.toContain(delivery.recordsWrite.message.recordId);
       });
 
       describe('cursor-based subscriptions', () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -297,6 +297,33 @@ export function testRecordsWriteHandler(): void {
         expect(reply.status.code).toBe(202);
       });
 
+      it('should reject published encryption control records', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-published-rejected.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: { $role: true },
+          },
+        };
+        const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+        const audience = await createAudienceControlWrite({
+          author      : alice,
+          protocol    : protocolDefinition.protocol,
+          published   : true,
+          rolePath    : 'member',
+          roleRuleSet : encryptedProtocolDefinition.structure.member as ProtocolRuleSet,
+        });
+
+        const reply = await dwn.processMessage(alice.did, audience.recordsWrite.message, { dataStream: DataStream.fromBytes(audience.dataBytes) });
+        expect(reply.status.code).toBe(400);
+        expect(reply.status.detail).toContain(DwnErrorCode.EncryptionControlValidateUnexpectedRecord);
+      });
+
       it('should reject dataless and update attempts for immutable audience control records', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 

--- a/packages/dwn-sdk-js/tests/utils/encryption-control-test-utils.ts
+++ b/packages/dwn-sdk-js/tests/utils/encryption-control-test-utils.ts
@@ -1,0 +1,166 @@
+import type { Persona } from './test-data-generator.js';
+import type { DataEncodedRecordsWriteMessage, Dwn, ProtocolDefinition, ProtocolRuleSet } from '../../src/index.js';
+
+import { expect } from 'bun:test';
+
+import { DataStream } from '../../src/utils/data-stream.js';
+import { Encoder } from '../../src/utils/encoder.js';
+import { Jws } from '../../src/utils/jws.js';
+import { KeyDerivationScheme } from '../../src/utils/hd-key.js';
+import { TestDataGenerator } from './test-data-generator.js';
+import { Encryption, KeyAgreementAlgorithm } from '../../src/utils/encryption.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
+import { Protocols, RecordsWrite } from '../../src/index.js';
+
+export type AudienceControlWrite = {
+  dataBytes: Uint8Array;
+  keyId: string;
+  payload: Record<string, unknown>;
+  recordsWrite: RecordsWrite;
+};
+
+export async function installEncryptedProtocol(
+  dwn: Dwn,
+  author: Persona,
+  protocolDefinition: ProtocolDefinition,
+): Promise<ProtocolDefinition> {
+  const encryptedProtocolDefinition = await Protocols.deriveAndInjectPublicEncryptionKeys(
+    protocolDefinition, author.keyId, author.encryptionKeyPair.privateJwk
+  );
+  const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+    author,
+    protocolDefinition: encryptedProtocolDefinition,
+  });
+  expect((await dwn.processMessage(author.did, protocolConfig.message)).status.code).toBe(202);
+
+  return encryptedProtocolDefinition;
+}
+
+export async function createAudienceControlWrite(input: {
+  author: Persona;
+  contextId?: string;
+  delegatedGrant?: DataEncodedRecordsWriteMessage;
+  payloadOverrides?: Record<string, unknown>;
+  permissionGrantId?: string;
+  protocol: string;
+  protocolRole?: string;
+  published?: boolean;
+  rolePath: string;
+  roleRuleSet: ProtocolRuleSet;
+  sealKeyId?: string;
+  signer?: Persona;
+  tags?: Record<string, string>;
+}): Promise<AudienceControlWrite> {
+  const audiencePublicKeyJwk = input.author.encryptionKeyPair.publicJwk;
+  const audienceKeyId = await Encryption.getKeyId(audiencePublicKeyJwk);
+  const sealKeyId = input.sealKeyId ?? await Encryption.getKeyId(input.roleRuleSet.$keyAgreement!.publicKeyJwk);
+  const payload = {
+    protocol         : input.protocol,
+    rolePath         : input.rolePath,
+    contextId        : input.contextId ?? '',
+    keyId            : audienceKeyId,
+    publicKeyJwk     : audiencePublicKeyJwk,
+    sealedPrivateKey : {
+      algorithm          : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+      derivationScheme   : 'seal',
+      keyId              : sealKeyId,
+      ephemeralPublicKey : input.author.encryptionKeyPair.publicJwk,
+      encryptedKey       : Encoder.bytesToBase64Url(TestDataGenerator.randomBytes(32)),
+    },
+    ...input.payloadOverrides,
+  };
+  const dataBytes = Encoder.objectToBytes(payload);
+  const recordsWrite = await RecordsWrite.create({
+    data              : dataBytes,
+    dataFormat        : 'application/json',
+    delegatedGrant    : input.delegatedGrant,
+    permissionGrantId : input.permissionGrantId,
+    protocol          : input.protocol,
+    protocolPath      : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+    protocolRole      : input.protocolRole,
+    published         : input.published,
+    schema            : 'https://identity.foundation/dwn/json-schemas/encryption/audience.json',
+    signer            : Jws.createSigner(input.signer ?? input.author),
+    tags              : {
+      protocol  : input.protocol,
+      rolePath  : input.rolePath,
+      contextId : input.contextId ?? '',
+      keyId     : audienceKeyId,
+      ...input.tags,
+    },
+  });
+
+  return {
+    dataBytes,
+    keyId: audienceKeyId,
+    payload,
+    recordsWrite,
+  };
+}
+
+export async function createDeliveryControlWrite(input: {
+  author: Persona;
+  contextId?: string;
+  grantId?: string;
+  keyId: string;
+  protocol: string;
+  recipient: string;
+  recipientAuthority: string;
+  rolePath: string;
+  roleRef?: string;
+  roleRuleSet: ProtocolRuleSet;
+}): Promise<{ dataBytes: Uint8Array; recordsWrite: RecordsWrite }> {
+  const tags: Record<string, string> = {
+    protocol           : input.protocol,
+    rolePath           : input.rolePath,
+    contextId          : input.contextId ?? '',
+    keyId              : input.keyId,
+    recipientAuthority : input.recipientAuthority,
+  };
+  if (input.grantId !== undefined) {
+    tags.grantId = input.grantId;
+  }
+  if (input.roleRef !== undefined) {
+    tags.roleRef = input.roleRef;
+  }
+
+  const dataBytes = Encoder.objectToBytes({
+    protocol  : input.protocol,
+    rolePath  : input.rolePath,
+    contextId : input.contextId ?? '',
+    keyId     : input.keyId,
+  });
+  const recordsWrite = await RecordsWrite.create({
+    data            : dataBytes,
+    dataFormat      : 'application/json',
+    encryptionInput : {
+      initializationVector : TestDataGenerator.randomBytes(16),
+      key                  : TestDataGenerator.randomBytes(32),
+      keyEncryptionInputs  : [{
+        algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+        keyId            : await Encryption.getKeyId(input.roleRuleSet.$keyAgreement!.publicKeyJwk),
+        publicKey        : input.roleRuleSet.$keyAgreement!.publicKeyJwk,
+        derivationScheme : KeyDerivationScheme.ProtocolPath,
+      }],
+    },
+    protocol     : input.protocol,
+    protocolPath : ENCRYPTION_CONTROL_DELIVERY_PATH,
+    recipient    : input.recipient,
+    schema       : 'https://identity.foundation/dwn/json-schemas/encryption/delivery.json',
+    signer       : Jws.createSigner(input.author),
+    tags,
+  });
+
+  return { dataBytes, recordsWrite };
+}
+
+export async function processControlWrite(
+  dwn: Dwn,
+  tenant: string,
+  controlWrite: { dataBytes: Uint8Array; recordsWrite: RecordsWrite },
+): Promise<void> {
+  const reply = await dwn.processMessage(tenant, controlWrite.recordsWrite.message, {
+    dataStream: DataStream.fromBytes(controlWrite.dataBytes),
+  });
+  expect(reply.status.code).toBe(202);
+}


### PR DESCRIPTION
## Summary
- add centralized read authorization for source-protocol encryption control records
- wire RecordsRead, RecordsQuery, RecordsCount, and RecordsSubscribe to enforce audience and delivery control visibility for direct, delegated, and anonymous access
- harden control visibility around stale records, published-control rejection, indexed counts, and paginated query/subscribe snapshots
- add handler-level coverage for exact audience lookup, grant-backed audience enumeration, delivery recipient visibility, delegated access, stale records, published rejection, and pagination after filtering

## Test plan
- [x] bun run lint
- [x] bun run --filter @enbox/dwn-sdk-js build
- [x] bun run --filter @enbox/dwn-sdk-js test:node
- [x] bun run --filter @enbox/agent build
- [x] bun run test:node from packages/agent with local Pkarr + local DWN server on :3000; server rate limits disabled for the full local run
