### PR TITLE
fix(dwn-sdk-js): enforce messages control visibility

### DIFF
--- a/.changeset/messages-control-visibility.md
+++ b/.changeset/messages-control-visibility.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+fix: enforce encryption control record visibility on Messages read and feed surfaces

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -58,7 +58,16 @@ export enum DwnErrorCode {
   MessagesGrantAuthorizationSubscribeProtocolMismatch = 'MessagesGrantAuthorizationSubscribeProtocolMismatch',
   MessagesGrantAuthorizationUnfilteredSubscribeProtocolScope = 'MessagesGrantAuthorizationUnfilteredSubscribeProtocolScope',
   MessagesSubscribeAuthorizationFailed = 'MessagesSubscribeAuthorizationFailed',
+  /**
+   * Terminal subscription delivery error indicating the invoked grant no longer authorizes delivery.
+   * Subscribers should not resubscribe with the same grant.
+   */
   MessagesSubscribeDeliveryAuthorizationFailed = 'MessagesSubscribeDeliveryAuthorizationFailed',
+  /**
+   * Terminal subscription delivery error for non-authorization delivery failures.
+   * Subscribers may resubscribe from their last cursor.
+   */
+  MessagesSubscribeDeliveryFailed = 'MessagesSubscribeDeliveryFailed',
   MessagesSubscribeEventLogUnimplemented = 'MessagesSubscribeEventLogUnimplemented',
   GeneralJwsVerifierGetPublicKeyNotFound = 'GeneralJwsVerifierGetPublicKeyNotFound',
   GeneralJwsVerifierInvalidSignature = 'GeneralJwsVerifierInvalidSignature',

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -1,3 +1,4 @@
+import type { MessagesPermissionScope } from '../types/permission-types.js';
 import type { RecordsPermissionScope } from '../types/permission-types.js';
 import type { RecordsWrite } from '../interfaces/records-write.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
@@ -72,8 +73,10 @@ export class EncryptionControl {
   public static async filterVisibleControlRecords<T extends RecordsWriteMessage>(input: {
     tenant: string;
     incomingMessage: ControlFilterMessage;
+    permissionGrants?: PermissionGrant[];
     requester: string | undefined;
     recordsWriteMessages: T[];
+    visibilityCache?: Map<string, boolean>;
     validationStateReader: ValidationStateReader;
   }): Promise<T[]> {
     const visibleRecordsWrites: T[] = [];
@@ -84,13 +87,23 @@ export class EncryptionControl {
       }
 
       try {
-        if (await EncryptionControl.canRead({
-          tenant                : input.tenant,
-          incomingMessage       : input.incomingMessage,
-          requester             : input.requester,
-          recordsWriteMessage   : recordsWrite,
-          validationStateReader : input.validationStateReader,
-        })) {
+        const cacheKey = EncryptionControl.visibilityCacheKey(input.requester, input.incomingMessage, recordsWrite);
+        let visible = cacheKey === undefined ? undefined : input.visibilityCache?.get(cacheKey);
+        if (visible === undefined) {
+          visible = await EncryptionControl.canRead({
+            tenant                : input.tenant,
+            incomingMessage       : input.incomingMessage,
+            permissionGrants      : input.permissionGrants,
+            requester             : input.requester,
+            recordsWriteMessage   : recordsWrite,
+            validationStateReader : input.validationStateReader,
+          });
+          if (cacheKey !== undefined) {
+            input.visibilityCache?.set(cacheKey, visible);
+          }
+        }
+
+        if (visible) {
           visibleRecordsWrites.push(recordsWrite);
         }
       } catch (error) {
@@ -123,6 +136,7 @@ export class EncryptionControl {
   public static async canRead(input: {
     tenant: string;
     incomingMessage: ControlReadMessage;
+    permissionGrants?: PermissionGrant[];
     requester: string | undefined;
     recordsWriteMessage: RecordsWriteMessage;
     validationStateReader: ValidationStateReader;
@@ -155,6 +169,7 @@ export class EncryptionControl {
       tenant,
       actorDid              : requester,
       incomingMessage       : input.incomingMessage,
+      permissionGrants      : input.permissionGrants,
       tags,
       validationStateReader : input.validationStateReader,
     });
@@ -714,19 +729,20 @@ export class EncryptionControl {
     tenant: string;
     actorDid: string;
     incomingMessage: ControlReadMessage;
+    permissionGrants?: PermissionGrant[];
     tags: RoleAudienceKeyId;
     validationStateReader: ValidationStateReader;
   }): Promise<boolean> {
     const {
-      tenant, actorDid, incomingMessage, tags, validationStateReader
+      tenant, actorDid, incomingMessage, permissionGrants, tags, validationStateReader
     } = input;
-    const grant = await EncryptionControl.getInvokedReadGrant({
+    const grants = permissionGrants ?? await EncryptionControl.getInvokedReadGrants({
       tenant,
       actorDid,
       incomingMessage,
       validationStateReader,
     });
-    if (grant !== undefined && EncryptionControl.grantCoversAudienceEnumeration(grant, tags)) {
+    if (grants.some(grant => EncryptionControl.grantCoversAudienceEnumeration(grant, tags))) {
       return true;
     }
 
@@ -751,24 +767,24 @@ export class EncryptionControl {
     });
   }
 
-  private static async getInvokedReadGrant(input: {
+  private static async getInvokedReadGrants(input: {
     tenant: string;
     actorDid: string;
     incomingMessage: ControlReadMessage;
     validationStateReader: ValidationStateReader;
-  }): Promise<PermissionGrant | undefined> {
+  }): Promise<PermissionGrant[]> {
     if (Message.isSignedByAuthorDelegate(input.incomingMessage)) {
-      return PermissionGrant.parse(input.incomingMessage.authorization!.authorDelegatedGrant!);
+      return [PermissionGrant.parse(input.incomingMessage.authorization!.authorDelegatedGrant!)];
     }
 
     const { descriptor } = input.incomingMessage;
     if (!('permissionGrantId' in descriptor)) {
-      return undefined;
+      return [];
     }
 
     const grantId = descriptor.permissionGrantId;
     if (grantId === undefined) {
-      return undefined;
+      return [];
     }
 
     const grant = await input.validationStateReader.fetchGrant(input.tenant, grantId);
@@ -779,19 +795,26 @@ export class EncryptionControl {
       permissionGrant       : grant,
       validationStateReader : input.validationStateReader,
     });
-    return grant;
+    return [grant];
   }
 
   private static grantCoversAudienceEnumeration(grant: PermissionGrant, tags: RoleAudienceKeyId): boolean {
-    const scope = grant.scope as RecordsPermissionScope;
-    if (scope.interface !== DwnInterfaceName.Records || scope.method !== DwnMethodName.Read) {
-      return false;
+    const scope = grant.scope as MessagesPermissionScope | RecordsPermissionScope;
+    if (scope.interface === DwnInterfaceName.Records && scope.method === DwnMethodName.Read) {
+      return PermissionScopeMatcher.matches(scope, {
+        protocol     : tags.protocol,
+        protocolPath : tags.rolePath,
+      });
     }
 
-    return PermissionScopeMatcher.matches(scope, {
-      protocol     : tags.protocol,
-      protocolPath : tags.rolePath,
-    });
+    if (scope.interface === DwnInterfaceName.Messages && scope.method === DwnMethodName.Read) {
+      return PermissionScopeMatcher.matches(scope, {
+        protocol     : tags.protocol,
+        protocolPath : tags.rolePath,
+      });
+    }
+
+    return false;
   }
 
   private static async resolveRoleAudienceDefinition(input: {
@@ -943,6 +966,26 @@ export class EncryptionControl {
 
   private static getRecordType(message: RecordsWriteMessage): 'audience' | 'delivery' {
     return message.descriptor.protocolPath === ENCRYPTION_CONTROL_DELIVERY_PATH ? 'delivery' : 'audience';
+  }
+
+  private static visibilityCacheKey(
+    requester: string | undefined,
+    incomingMessage: ControlFilterMessage,
+    recordsWriteMessage: RecordsWriteMessage,
+  ): string | undefined {
+    if (EncryptionControl.getRecordType(recordsWriteMessage) !== 'audience') {
+      return undefined;
+    }
+
+    const tags = EncryptionControl.getRoleAudienceKeyId(recordsWriteMessage, 'audience');
+    return [
+      requester ?? '',
+      incomingMessage.descriptor.messageTimestamp,
+      tags.protocol,
+      tags.rolePath,
+      tags.contextId,
+      tags.keyId,
+    ].join('\u001f');
   }
 
   private static exactAudienceFilterMatchesRecord(filter: RecordsFilter, tags: RoleAudienceKeyId, recordId: string): boolean {

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -800,21 +800,15 @@ export class EncryptionControl {
 
   private static grantCoversAudienceEnumeration(grant: PermissionGrant, tags: RoleAudienceKeyId): boolean {
     const scope = grant.scope as MessagesPermissionScope | RecordsPermissionScope;
-    if (scope.interface === DwnInterfaceName.Records && scope.method === DwnMethodName.Read) {
-      return PermissionScopeMatcher.matches(scope, {
-        protocol     : tags.protocol,
-        protocolPath : tags.rolePath,
-      });
+    const interfaceIsEligible = scope.interface === DwnInterfaceName.Records || scope.interface === DwnInterfaceName.Messages;
+    if (!interfaceIsEligible || scope.method !== DwnMethodName.Read) {
+      return false;
     }
 
-    if (scope.interface === DwnInterfaceName.Messages && scope.method === DwnMethodName.Read) {
-      return PermissionScopeMatcher.matches(scope, {
-        protocol     : tags.protocol,
-        protocolPath : tags.rolePath,
-      });
-    }
-
-    return false;
+    return PermissionScopeMatcher.matches(scope, {
+      protocol     : tags.protocol,
+      protocolPath : tags.rolePath,
+    });
   }
 
   private static async resolveRoleAudienceDefinition(input: {

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -1,8 +1,7 @@
-import type { MessagesPermissionScope } from '../types/permission-types.js';
-import type { RecordsPermissionScope } from '../types/permission-types.js';
 import type { RecordsWrite } from '../interfaces/records-write.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
 import type { EncryptionControlAudiencePayload, EncryptionControlDeliveryTags, RoleAudienceKeyId } from '../types/encryption-types.js';
+import type { MessagesPermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
 import type { MessagesQueryMessage, MessagesReadMessage, MessagesSubscribeMessage } from '../types/messages-types.js';
 import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
 import type { RecordsCountMessage, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsSubscribeMessage, RecordsWriteMessage, RecordsWriteTags } from '../types/records-types.js';
@@ -55,6 +54,20 @@ type ControlFilterMessage =
   | RecordsQueryMessage
   | RecordsSubscribeMessage;
 
+type ControlFilterInput<T extends RecordsWriteMessage> = {
+  tenant: string;
+  incomingMessage: ControlFilterMessage;
+  permissionGrants?: PermissionGrant[];
+  requester: string | undefined;
+  recordsWriteMessages: T[];
+  visibilityCache?: Map<string, boolean>;
+  validationStateReader: ValidationStateReader;
+};
+
+type ControlRecordVisibilityInput<T extends RecordsWriteMessage> = Omit<ControlFilterInput<T>, 'recordsWriteMessages'> & {
+  recordsWriteMessage: T;
+};
+
 export class EncryptionControl {
   public static isControlMessage(message: RecordsWriteMessage): boolean {
     return isEncryptionControlPath(message.descriptor.protocolPath);
@@ -70,46 +83,21 @@ export class EncryptionControl {
     return EncryptionControl.getExactAudienceFilterTuple(filter) !== undefined;
   }
 
-  public static async filterVisibleControlRecords<T extends RecordsWriteMessage>(input: {
-    tenant: string;
-    incomingMessage: ControlFilterMessage;
-    permissionGrants?: PermissionGrant[];
-    requester: string | undefined;
-    recordsWriteMessages: T[];
-    visibilityCache?: Map<string, boolean>;
-    validationStateReader: ValidationStateReader;
-  }): Promise<T[]> {
+  public static async filterVisibleControlRecords<T extends RecordsWriteMessage>(input: ControlFilterInput<T>): Promise<T[]> {
     const visibleRecordsWrites: T[] = [];
     for (const recordsWrite of input.recordsWriteMessages) {
-      if (!EncryptionControl.isControlMessage(recordsWrite)) {
+      const visible = await EncryptionControl.isVisibleControlRecord({
+        incomingMessage       : input.incomingMessage,
+        permissionGrants      : input.permissionGrants,
+        recordsWriteMessage   : recordsWrite,
+        requester             : input.requester,
+        tenant                : input.tenant,
+        validationStateReader : input.validationStateReader,
+        visibilityCache       : input.visibilityCache,
+      });
+
+      if (visible) {
         visibleRecordsWrites.push(recordsWrite);
-        continue;
-      }
-
-      try {
-        const cacheKey = EncryptionControl.visibilityCacheKey(input.requester, input.incomingMessage, recordsWrite);
-        let visible = cacheKey === undefined ? undefined : input.visibilityCache?.get(cacheKey);
-        if (visible === undefined) {
-          visible = await EncryptionControl.canRead({
-            tenant                : input.tenant,
-            incomingMessage       : input.incomingMessage,
-            permissionGrants      : input.permissionGrants,
-            requester             : input.requester,
-            recordsWriteMessage   : recordsWrite,
-            validationStateReader : input.validationStateReader,
-          });
-          if (cacheKey !== undefined) {
-            input.visibilityCache?.set(cacheKey, visible);
-          }
-        }
-
-        if (visible) {
-          visibleRecordsWrites.push(recordsWrite);
-        }
-      } catch (error) {
-        if (!(error instanceof DwnError)) {
-          throw error;
-        }
       }
     }
 
@@ -800,21 +788,15 @@ export class EncryptionControl {
 
   private static grantCoversAudienceEnumeration(grant: PermissionGrant, tags: RoleAudienceKeyId): boolean {
     const scope = grant.scope as MessagesPermissionScope | RecordsPermissionScope;
-    if (scope.interface === DwnInterfaceName.Records && scope.method === DwnMethodName.Read) {
-      return PermissionScopeMatcher.matches(scope, {
-        protocol     : tags.protocol,
-        protocolPath : tags.rolePath,
-      });
+    const interfaceIsEligible = scope.interface === DwnInterfaceName.Records || scope.interface === DwnInterfaceName.Messages;
+    if (!interfaceIsEligible || scope.method !== DwnMethodName.Read) {
+      return false;
     }
 
-    if (scope.interface === DwnInterfaceName.Messages && scope.method === DwnMethodName.Read) {
-      return PermissionScopeMatcher.matches(scope, {
-        protocol     : tags.protocol,
-        protocolPath : tags.rolePath,
-      });
-    }
-
-    return false;
+    return PermissionScopeMatcher.matches(scope, {
+      protocol     : tags.protocol,
+      protocolPath : tags.rolePath,
+    });
   }
 
   private static async resolveRoleAudienceDefinition(input: {
@@ -966,6 +948,46 @@ export class EncryptionControl {
 
   private static getRecordType(message: RecordsWriteMessage): 'audience' | 'delivery' {
     return message.descriptor.protocolPath === ENCRYPTION_CONTROL_DELIVERY_PATH ? 'delivery' : 'audience';
+  }
+
+  private static async isVisibleControlRecord<T extends RecordsWriteMessage>(input: ControlRecordVisibilityInput<T>): Promise<boolean> {
+    if (!EncryptionControl.isControlMessage(input.recordsWriteMessage)) {
+      return true;
+    }
+
+    try {
+      return await EncryptionControl.resolveVisibleControlRecord(input);
+    } catch (error) {
+      if (error instanceof DwnError) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private static async resolveVisibleControlRecord<T extends RecordsWriteMessage>(input: ControlRecordVisibilityInput<T>): Promise<boolean> {
+    const cacheKey = EncryptionControl.visibilityCacheKey(input.requester, input.incomingMessage, input.recordsWriteMessage);
+    if (cacheKey !== undefined) {
+      const visible = input.visibilityCache?.get(cacheKey);
+      if (visible !== undefined) {
+        return visible;
+      }
+    }
+
+    const visible = await EncryptionControl.canRead({
+      tenant                : input.tenant,
+      incomingMessage       : input.incomingMessage,
+      permissionGrants      : input.permissionGrants,
+      requester             : input.requester,
+      recordsWriteMessage   : input.recordsWriteMessage,
+      validationStateReader : input.validationStateReader,
+    });
+
+    if (cacheKey !== undefined) {
+      input.visibilityCache?.set(cacheKey, visible);
+    }
+
+    return visible;
   }
 
   private static visibilityCacheKey(

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -2,6 +2,7 @@ import type { RecordsPermissionScope } from '../types/permission-types.js';
 import type { RecordsWrite } from '../interfaces/records-write.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
 import type { EncryptionControlAudiencePayload, EncryptionControlDeliveryTags, RoleAudienceKeyId } from '../types/encryption-types.js';
+import type { MessagesQueryMessage, MessagesReadMessage, MessagesSubscribeMessage } from '../types/messages-types.js';
 import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
 import type { RecordsCountMessage, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsSubscribeMessage, RecordsWriteMessage, RecordsWriteTags } from '../types/records-types.js';
 
@@ -37,7 +38,21 @@ type ExactAudienceFilterTuple = Omit<RoleAudienceKeyId, 'keyId'> & {
   keyId?: string;
 };
 
-type ControlReadMessage = RecordsCountMessage | RecordsReadMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+type ControlReadMessage =
+  | MessagesQueryMessage
+  | MessagesReadMessage
+  | MessagesSubscribeMessage
+  | RecordsCountMessage
+  | RecordsReadMessage
+  | RecordsQueryMessage
+  | RecordsSubscribeMessage;
+
+type ControlFilterMessage =
+  | MessagesQueryMessage
+  | MessagesSubscribeMessage
+  | RecordsCountMessage
+  | RecordsQueryMessage
+  | RecordsSubscribeMessage;
 
 export class EncryptionControl {
   public static isControlMessage(message: RecordsWriteMessage): boolean {
@@ -56,7 +71,7 @@ export class EncryptionControl {
 
   public static async filterVisibleControlRecords<T extends RecordsWriteMessage>(input: {
     tenant: string;
-    incomingMessage: RecordsCountMessage | RecordsQueryMessage | RecordsSubscribeMessage;
+    incomingMessage: ControlFilterMessage;
     requester: string | undefined;
     recordsWriteMessages: T[];
     validationStateReader: ValidationStateReader;
@@ -132,7 +147,7 @@ export class EncryptionControl {
     }
 
     const tags = EncryptionControl.getRoleAudienceKeyId(recordsWriteMessage, 'audience');
-    if (EncryptionControl.exactAudienceFilterMatchesRecord(input.incomingMessage.descriptor.filter, tags, recordsWriteMessage.recordId)) {
+    if (EncryptionControl.exactAudienceRequestMatchesRecord(input.incomingMessage, tags, recordsWriteMessage.recordId)) {
       return true;
     }
 
@@ -746,7 +761,12 @@ export class EncryptionControl {
       return PermissionGrant.parse(input.incomingMessage.authorization!.authorDelegatedGrant!);
     }
 
-    const grantId = input.incomingMessage.descriptor.permissionGrantId;
+    const { descriptor } = input.incomingMessage;
+    if (!('permissionGrantId' in descriptor)) {
+      return undefined;
+    }
+
+    const grantId = descriptor.permissionGrantId;
     if (grantId === undefined) {
       return undefined;
     }
@@ -959,6 +979,19 @@ export class EncryptionControl {
     }
 
     return { protocol, rolePath, contextId, keyId };
+  }
+
+  private static exactAudienceRequestMatchesRecord(
+    incomingMessage: ControlReadMessage,
+    tags: RoleAudienceKeyId,
+    recordId: string,
+  ): boolean {
+    const { descriptor } = incomingMessage;
+    if ('filter' in descriptor) {
+      return EncryptionControl.exactAudienceFilterMatchesRecord(descriptor.filter, tags, recordId);
+    }
+
+    return false;
   }
 
   private static getExactFilterTag(filter: RecordsFilter, tag: string): string | undefined {

--- a/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
@@ -11,10 +11,17 @@ import { DwnInterfaceName } from '../enums/dwn-interface-method.js';
 import { EncryptionControl } from './encryption-control.js';
 import { EncryptionProtocol } from '../protocols/encryption.js';
 import { GrantAuthorization } from './grant-authorization.js';
+import { Jws } from '../utils/jws.js';
+import { Message } from './message.js';
 import { PermissionScopeMatcher } from '../utils/permission-scope.js';
 import { PermissionsProtocol } from '../protocols/permissions.js';
 import { Records } from '../utils/records.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
+
+export type MessagesQueryOrSubscribeGrantSet = {
+  permissionGrants: PermissionGrant[];
+  requester: string;
+};
 
 export class MessagesGrantAuthorization {
 
@@ -52,15 +59,46 @@ export class MessagesGrantAuthorization {
       validationStateReader
     });
 
+    const controlRecordsWrite = await MessagesGrantAuthorization.getControlRecordsWrite(
+      expectedGrantor,
+      messageToRead,
+      validationStateReader
+    );
+    if (controlRecordsWrite !== undefined) {
+      if (!MessagesGrantAuthorization.someScopeMatches(
+        permissionGrants.map(permissionGrant => permissionGrant.scope as MessagesPermissionScope),
+        MessagesGrantAuthorization.getControlScopeTarget(controlRecordsWrite)
+      )) {
+        throw new DwnError(DwnErrorCode.MessagesReadVerifyScopeFailed, 'record message failed scope authorization');
+      }
+
+      try {
+        if (await EncryptionControl.canRead({
+          tenant                : expectedGrantor,
+          incomingMessage       : messagesReadMessage,
+          permissionGrants      : permissionGrants,
+          requester             : expectedGrantee,
+          recordsWriteMessage   : controlRecordsWrite,
+          validationStateReader : validationStateReader,
+        })) {
+          return;
+        }
+      } catch (error) {
+        if (!(error instanceof DwnError)) {
+          throw error;
+        }
+      }
+
+      throw new DwnError(DwnErrorCode.MessagesReadVerifyScopeFailed, 'record message failed scope authorization');
+    }
+
     for (const permissionGrant of permissionGrants) {
       const scope = permissionGrant.scope as MessagesPermissionScope;
       if (await MessagesGrantAuthorization.isScopeAuthorized({
-        tenant          : expectedGrantor,
-        incomingMessage : messagesReadMessage,
-        messageToGet    : messageToRead,
-        incomingScope   : scope,
-        requester       : expectedGrantee,
-        validationStateReader,
+        tenant                : expectedGrantor,
+        messageToGet          : messageToRead,
+        incomingScope         : scope,
+        validationStateReader : validationStateReader,
       })) {
         return;
       }
@@ -97,6 +135,36 @@ export class MessagesGrantAuthorization {
     MessagesGrantAuthorization.authorizeFilterScope(incomingMessage, scopes);
   }
 
+  public static async authorizeQueryOrSubscribeInvocation(input: {
+    tenant: string;
+    incomingMessage: MessagesQueryMessage | MessagesSubscribeMessage;
+    validationStateReader: ValidationStateReader;
+    failureCode: DwnErrorCode;
+  }): Promise<MessagesQueryOrSubscribeGrantSet | undefined> {
+    const {
+      tenant, incomingMessage, validationStateReader, failureCode
+    } = input;
+    const requester = EncryptionControl.getRequester(incomingMessage);
+    if (Message.getAuthor(incomingMessage) === tenant && requester === tenant) {
+      return undefined;
+    }
+
+    const permissionGrantIds = Message.getPermissionGrantIds(Jws.decodePlainObjectPayload(incomingMessage.authorization.signature));
+    if (requester !== undefined && permissionGrantIds.length > 0) {
+      const permissionGrants = await MessagesGrantAuthorization.fetchPermissionGrants(tenant, validationStateReader, permissionGrantIds);
+      await MessagesGrantAuthorization.authorizeQueryOrSubscribe({
+        incomingMessage       : incomingMessage,
+        expectedGrantor       : tenant,
+        expectedGrantee       : requester,
+        permissionGrants      : permissionGrants,
+        validationStateReader : validationStateReader,
+      });
+      return { permissionGrants, requester };
+    }
+
+    throw new DwnError(failureCode, 'message failed authorization');
+  }
+
   private static authorizeFilterScope(
     messagesMessage: MessagesQueryMessage | MessagesSubscribeMessage,
     scopes: MessagesPermissionScope[]
@@ -124,6 +192,18 @@ export class MessagesGrantAuthorization {
 
   private static someScopeMatches(scopes: MessagesPermissionScope[], target: ProtocolScope): boolean {
     return scopes.some(scope => PermissionScopeMatcher.matches(scope, target));
+  }
+
+  private static getControlScopeTarget(recordsWriteMessage: RecordsWriteMessage): ProtocolScope {
+    const rolePath = recordsWriteMessage.descriptor.tags?.rolePath;
+    if (typeof rolePath === 'string') {
+      return {
+        protocol     : recordsWriteMessage.descriptor.protocol,
+        protocolPath : rolePath,
+      };
+    }
+
+    return { protocol: recordsWriteMessage.descriptor.protocol };
   }
 
   private static hasUnscopedGrant(scopes: MessagesPermissionScope[]): boolean {
@@ -202,23 +282,19 @@ export class MessagesGrantAuthorization {
   private static async isScopeAuthorized(
     input: {
       tenant: string;
-      incomingMessage: MessagesReadMessage;
       messageToGet: GenericMessage;
       incomingScope: MessagesPermissionScope;
-      requester: string;
       validationStateReader: ValidationStateReader;
     },
   ): Promise<boolean> {
     const {
-      tenant, incomingMessage, messageToGet, incomingScope, requester, validationStateReader
+      tenant, messageToGet, incomingScope, validationStateReader
     } = input;
     if (messageToGet.descriptor.interface === DwnInterfaceName.Records) {
       return MessagesGrantAuthorization.isRecordsMessageScopeAuthorized(
         tenant,
-        incomingMessage,
         messageToGet as RecordsWriteMessage | RecordsDeleteMessage,
         incomingScope,
-        requester,
         validationStateReader
       );
     }
@@ -239,10 +315,8 @@ export class MessagesGrantAuthorization {
 
   private static async isRecordsMessageScopeAuthorized(
     tenant: string,
-    incomingMessage: MessagesReadMessage,
     recordsMessage: RecordsWriteMessage | RecordsDeleteMessage,
     incomingScope: MessagesPermissionScope,
-    requester: string,
     validationStateReader: ValidationStateReader,
   ): Promise<boolean> {
     const recordsWriteMessage = await MessagesGrantAuthorization.getAssociatedRecordsWrite(
@@ -250,22 +324,6 @@ export class MessagesGrantAuthorization {
       recordsMessage,
       validationStateReader
     );
-
-    const isScopedToRecordProtocol = incomingScope.protocol === undefined ||
-      PermissionScopeMatcher.matches(incomingScope, { protocol: recordsWriteMessage.descriptor.protocol });
-    if (EncryptionControl.isControlMessage(recordsWriteMessage)) {
-      if (!isScopedToRecordProtocol) {
-        return false;
-      }
-
-      return EncryptionControl.canRead({
-        tenant,
-        incomingMessage,
-        requester,
-        recordsWriteMessage,
-        validationStateReader,
-      });
-    }
 
     if (incomingScope.protocol === undefined) {
       return true;
@@ -285,6 +343,23 @@ export class MessagesGrantAuthorization {
     }
 
     return PermissionScopeMatcher.matches(incomingScope, MessagesGrantAuthorization.getRecordsScopeTarget(recordsWriteMessage));
+  }
+
+  private static async getControlRecordsWrite(
+    tenant: string,
+    messageToGet: GenericMessage,
+    validationStateReader: ValidationStateReader,
+  ): Promise<RecordsWriteMessage | undefined> {
+    if (messageToGet.descriptor.interface !== DwnInterfaceName.Records) {
+      return undefined;
+    }
+
+    const recordsWriteMessage = await MessagesGrantAuthorization.getAssociatedRecordsWrite(
+      tenant,
+      messageToGet as RecordsWriteMessage | RecordsDeleteMessage,
+      validationStateReader
+    );
+    return EncryptionControl.isControlMessage(recordsWriteMessage) ? recordsWriteMessage : undefined;
   }
 
   private static async isPermissionRecordScopeAuthorized(

--- a/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
@@ -8,6 +8,7 @@ import type { DataEncodedRecordsWriteMessage, RecordsDeleteMessage, RecordsWrite
 import type { MessagesQueryMessage, MessagesReadMessage, MessagesSubscribeMessage } from '../types/messages-types.js';
 
 import { DwnInterfaceName } from '../enums/dwn-interface-method.js';
+import { EncryptionControl } from './encryption-control.js';
 import { EncryptionProtocol } from '../protocols/encryption.js';
 import { GrantAuthorization } from './grant-authorization.js';
 import { PermissionScopeMatcher } from '../utils/permission-scope.js';
@@ -53,7 +54,14 @@ export class MessagesGrantAuthorization {
 
     for (const permissionGrant of permissionGrants) {
       const scope = permissionGrant.scope as MessagesPermissionScope;
-      if (await MessagesGrantAuthorization.isScopeAuthorized(expectedGrantor, messageToRead, scope, validationStateReader)) {
+      if (await MessagesGrantAuthorization.isScopeAuthorized({
+        tenant          : expectedGrantor,
+        incomingMessage : messagesReadMessage,
+        messageToGet    : messageToRead,
+        incomingScope   : scope,
+        requester       : expectedGrantee,
+        validationStateReader,
+      })) {
         return;
       }
     }
@@ -192,22 +200,31 @@ export class MessagesGrantAuthorization {
    * Determines whether the given record is inside a grant scope.
    */
   private static async isScopeAuthorized(
-    tenant: string,
-    messageToGet: GenericMessage,
-    incomingScope: MessagesPermissionScope,
-    validationStateReader: ValidationStateReader,
+    input: {
+      tenant: string;
+      incomingMessage: MessagesReadMessage;
+      messageToGet: GenericMessage;
+      incomingScope: MessagesPermissionScope;
+      requester: string;
+      validationStateReader: ValidationStateReader;
+    },
   ): Promise<boolean> {
-    if (incomingScope.protocol === undefined) {
-      return true;
-    }
-
+    const {
+      tenant, incomingMessage, messageToGet, incomingScope, requester, validationStateReader
+    } = input;
     if (messageToGet.descriptor.interface === DwnInterfaceName.Records) {
       return MessagesGrantAuthorization.isRecordsMessageScopeAuthorized(
         tenant,
+        incomingMessage,
         messageToGet as RecordsWriteMessage | RecordsDeleteMessage,
         incomingScope,
+        requester,
         validationStateReader
       );
+    }
+
+    if (incomingScope.protocol === undefined) {
+      return true;
     }
 
     if (messageToGet.descriptor.interface === DwnInterfaceName.Protocols) {
@@ -222,8 +239,10 @@ export class MessagesGrantAuthorization {
 
   private static async isRecordsMessageScopeAuthorized(
     tenant: string,
+    incomingMessage: MessagesReadMessage,
     recordsMessage: RecordsWriteMessage | RecordsDeleteMessage,
     incomingScope: MessagesPermissionScope,
+    requester: string,
     validationStateReader: ValidationStateReader,
   ): Promise<boolean> {
     const recordsWriteMessage = await MessagesGrantAuthorization.getAssociatedRecordsWrite(
@@ -231,6 +250,26 @@ export class MessagesGrantAuthorization {
       recordsMessage,
       validationStateReader
     );
+
+    const isScopedToRecordProtocol = incomingScope.protocol === undefined ||
+      PermissionScopeMatcher.matches(incomingScope, { protocol: recordsWriteMessage.descriptor.protocol });
+    if (EncryptionControl.isControlMessage(recordsWriteMessage)) {
+      if (!isScopedToRecordProtocol) {
+        return false;
+      }
+
+      return EncryptionControl.canRead({
+        tenant,
+        incomingMessage,
+        requester,
+        recordsWriteMessage,
+        validationStateReader,
+      });
+    }
+
+    if (incomingScope.protocol === undefined) {
+      return true;
+    }
 
     if (recordsWriteMessage.descriptor.protocol === PermissionsProtocol.uri) {
       return MessagesGrantAuthorization.isPermissionRecordScopeAuthorized(

--- a/packages/dwn-sdk-js/src/handlers/messages-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-query.ts
@@ -1,16 +1,22 @@
-import type { EventLogEntry, ProgressGapInfo, ReplicationFeedReader } from '../types/subscriptions.js';
+import type { EventLogEntry, EventLogReadResult, ProgressGapInfo, ProgressToken, ReplicationFeedReader } from '../types/subscriptions.js';
 import type { Filter, KeyValues } from '../types/query-types.js';
 import type { HandlerDependencies, MethodHandler } from '../types/method-handler.js';
 import type { MessagesFilter, MessagesQueryMessage, MessagesQueryReply, MessagesQueryReplyEntry } from '../types/messages-types.js';
 
 import { authenticate } from '../core/auth.js';
+import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { Messages } from '../utils/messages.js';
 import { MessagesGrantAuthorization } from '../core/messages-grant-authorization.js';
 import { MessagesQuery } from '../interfaces/messages-query.js';
+import { Records } from '../utils/records.js';
 import { Replication } from '../utils/replication.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
+
+type MessagesQueryAuthorization =
+  | { kind: 'owner' }
+  | { kind: 'nonOwner'; requester: string };
 
 export class MessagesQueryHandler implements MethodHandler {
 
@@ -24,9 +30,10 @@ export class MessagesQueryHandler implements MethodHandler {
       return messageReplyFromError(e, 400);
     }
 
+    let authorization: MessagesQueryAuthorization;
     try {
       await authenticate(message.authorization, this.deps.didResolver);
-      await this.authorizeMessagesQuery(tenant, messagesQuery);
+      authorization = await this.authorizeMessagesQuery(tenant, messagesQuery);
     } catch (e) {
       return messageReplyFromError(e, 401);
     }
@@ -43,7 +50,11 @@ export class MessagesQueryHandler implements MethodHandler {
 
     try {
       const filters = MessagesQueryHandler.convertFilters(message.descriptor.filters, this.deps);
-      const result = await replicationFeedReader.logRead(tenant, {
+      const result = await this.logReadVisibleEvents({
+        tenant,
+        messagesQuery,
+        authorization,
+        replicationFeedReader,
         cursor : message.descriptor.cursor,
         filters,
         limit  : message.descriptor.limit,
@@ -78,13 +89,14 @@ export class MessagesQueryHandler implements MethodHandler {
   private async authorizeMessagesQuery(
     tenant: string,
     messagesQuery: MessagesQuery,
-  ): Promise<void> {
-    if (messagesQuery.author === tenant) {
-      return;
+  ): Promise<MessagesQueryAuthorization> {
+    const requester = EncryptionControl.getRequester(messagesQuery.message);
+    if (messagesQuery.author === tenant && requester === tenant) {
+      return { kind: 'owner' };
     }
 
     const permissionGrantIds = Message.getPermissionGrantIds(messagesQuery.signaturePayload!);
-    if (messagesQuery.author !== undefined && permissionGrantIds.length > 0) {
+    if (requester !== undefined && permissionGrantIds.length > 0) {
       const permissionGrants = await MessagesGrantAuthorization.fetchPermissionGrants(
         tenant,
         this.deps.validationStateReader,
@@ -93,14 +105,95 @@ export class MessagesQueryHandler implements MethodHandler {
       await MessagesGrantAuthorization.authorizeQueryOrSubscribe({
         incomingMessage       : messagesQuery.message,
         expectedGrantor       : tenant,
-        expectedGrantee       : messagesQuery.author,
+        expectedGrantee       : requester,
         permissionGrants,
         validationStateReader : this.deps.validationStateReader
       });
-      return;
+      return { kind: 'nonOwner', requester };
     }
 
     throw new DwnError(DwnErrorCode.MessagesQueryAuthorizationFailed, 'message failed authorization');
+  }
+
+  private async logReadVisibleEvents(input: {
+    tenant: string;
+    messagesQuery: MessagesQuery;
+    authorization: MessagesQueryAuthorization;
+    replicationFeedReader: ReplicationFeedReader;
+    cursor?: ProgressToken;
+    filters?: Filter[];
+    limit?: number;
+  }): Promise<EventLogReadResult> {
+    const {
+      tenant, messagesQuery, authorization, replicationFeedReader, cursor, filters, limit
+    } = input;
+    if (authorization.kind === 'owner') {
+      return replicationFeedReader.logRead(tenant, { cursor, filters, limit });
+    }
+
+    if (limit === undefined || limit <= 0) {
+      const result = await replicationFeedReader.logRead(tenant, { cursor, filters, limit });
+      return {
+        ...result,
+        events: await this.filterVisibleControlEvents(tenant, messagesQuery, authorization.requester, result.events),
+      };
+    }
+
+    const visibleEvents: EventLogEntry[] = [];
+    let nextCursor = cursor;
+    let resultCursor: ProgressToken | undefined;
+    let drained = false;
+    do {
+      const result = await replicationFeedReader.logRead(tenant, {
+        cursor : nextCursor,
+        filters,
+        limit  : limit - visibleEvents.length,
+      });
+      const filteredEvents = await this.filterVisibleControlEvents(tenant, messagesQuery, authorization.requester, result.events);
+      visibleEvents.push(...filteredEvents);
+      resultCursor = result.cursor;
+      nextCursor = result.cursor;
+      drained = result.drained;
+      if (result.events.length === 0) {
+        break;
+      }
+    } while (visibleEvents.length < limit && !drained && nextCursor !== undefined);
+
+    return { events: visibleEvents, cursor: resultCursor, drained };
+  }
+
+  private async filterVisibleControlEvents(
+    tenant: string,
+    messagesQuery: MessagesQuery,
+    requester: string,
+    events: EventLogEntry[],
+  ): Promise<EventLogEntry[]> {
+    const visibleEvents: EventLogEntry[] = [];
+    for (const event of events) {
+      const { message } = event.event;
+      if (!Records.isRecordsWrite(message) || !EncryptionControl.isControlMessage(message)) {
+        visibleEvents.push(event);
+        continue;
+      }
+
+      try {
+        if (await EncryptionControl.canRead({
+          tenant,
+          incomingMessage       : messagesQuery.message,
+          requester,
+          recordsWriteMessage   : message,
+          validationStateReader : this.deps.validationStateReader,
+        })) {
+          visibleEvents.push(event);
+        }
+      } catch (error) {
+        if (!(error instanceof DwnError)) {
+          throw error;
+        }
+      }
+    }
+
+    return visibleEvents;
   }
 
   private static asReplicationFeedReader(candidate: unknown): ReplicationFeedReader | undefined {

--- a/packages/dwn-sdk-js/src/handlers/messages-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-query.ts
@@ -1,3 +1,4 @@
+import type { PermissionGrant } from '../protocols/permission-grant.js';
 import type { EventLogEntry, EventLogReadResult, ProgressGapInfo, ProgressToken, ReplicationFeedReader } from '../types/subscriptions.js';
 import type { Filter, KeyValues } from '../types/query-types.js';
 import type { HandlerDependencies, MethodHandler } from '../types/method-handler.js';
@@ -16,9 +17,10 @@ import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
 type MessagesQueryAuthorization =
   | { kind: 'owner' }
-  | { kind: 'nonOwner'; requester: string };
+  | { kind: 'nonOwner'; permissionGrants: PermissionGrant[]; requester: string };
 
 export class MessagesQueryHandler implements MethodHandler {
+  private static readonly ProjectedFingerprintPageLimit = 256;
 
   constructor(private readonly deps: HandlerDependencies) { }
 
@@ -69,7 +71,14 @@ export class MessagesQueryHandler implements MethodHandler {
 
       const fingerprintScopes = MessagesQueryHandler.computeFingerprintScopes(message.descriptor.filters);
       if (fingerprintScopes !== undefined) {
-        reply.fingerprint = await replicationFeedReader.fingerprint(tenant, fingerprintScopes);
+        reply.fingerprint = await this.computeVisibleFingerprint({
+          tenant,
+          messagesQuery,
+          authorization,
+          replicationFeedReader,
+          filters,
+          fingerprintScopes,
+        });
       }
 
       return reply;
@@ -90,29 +99,17 @@ export class MessagesQueryHandler implements MethodHandler {
     tenant: string,
     messagesQuery: MessagesQuery,
   ): Promise<MessagesQueryAuthorization> {
-    const requester = EncryptionControl.getRequester(messagesQuery.message);
-    if (messagesQuery.author === tenant && requester === tenant) {
+    const grantSet = await MessagesGrantAuthorization.authorizeQueryOrSubscribeInvocation({
+      tenant                : tenant,
+      incomingMessage       : messagesQuery.message,
+      validationStateReader : this.deps.validationStateReader,
+      failureCode           : DwnErrorCode.MessagesQueryAuthorizationFailed,
+    });
+    if (grantSet === undefined) {
       return { kind: 'owner' };
     }
 
-    const permissionGrantIds = Message.getPermissionGrantIds(messagesQuery.signaturePayload!);
-    if (requester !== undefined && permissionGrantIds.length > 0) {
-      const permissionGrants = await MessagesGrantAuthorization.fetchPermissionGrants(
-        tenant,
-        this.deps.validationStateReader,
-        permissionGrantIds
-      );
-      await MessagesGrantAuthorization.authorizeQueryOrSubscribe({
-        incomingMessage       : messagesQuery.message,
-        expectedGrantor       : tenant,
-        expectedGrantee       : requester,
-        permissionGrants,
-        validationStateReader : this.deps.validationStateReader
-      });
-      return { kind: 'nonOwner', requester };
-    }
-
-    throw new DwnError(DwnErrorCode.MessagesQueryAuthorizationFailed, 'message failed authorization');
+    return { kind: 'nonOwner', ...grantSet };
   }
 
   private async logReadVisibleEvents(input: {
@@ -131,17 +128,17 @@ export class MessagesQueryHandler implements MethodHandler {
       return replicationFeedReader.logRead(tenant, { cursor, filters, limit });
     }
 
+    const visibilityCache = new Map<string, boolean>();
     if (limit === undefined || limit <= 0) {
       const result = await replicationFeedReader.logRead(tenant, { cursor, filters, limit });
       return {
         ...result,
-        events: await this.filterVisibleControlEvents(tenant, messagesQuery, authorization.requester, result.events),
+        events: await this.filterVisibleControlEvents(tenant, messagesQuery, authorization, result.events, visibilityCache),
       };
     }
 
     const visibleEvents: EventLogEntry[] = [];
     let nextCursor = cursor;
-    let resultCursor: ProgressToken | undefined;
     let drained = false;
     do {
       const result = await replicationFeedReader.logRead(tenant, {
@@ -149,9 +146,9 @@ export class MessagesQueryHandler implements MethodHandler {
         filters,
         limit  : limit - visibleEvents.length,
       });
-      const filteredEvents = await this.filterVisibleControlEvents(tenant, messagesQuery, authorization.requester, result.events);
+      // Keeps visible-page pagination stable until #1100 moves control visibility into indexed store filters.
+      const filteredEvents = await this.filterVisibleControlEvents(tenant, messagesQuery, authorization, result.events, visibilityCache);
       visibleEvents.push(...filteredEvents);
-      resultCursor = result.cursor;
       nextCursor = result.cursor;
       drained = result.drained;
       if (result.events.length === 0) {
@@ -159,41 +156,72 @@ export class MessagesQueryHandler implements MethodHandler {
       }
     } while (visibleEvents.length < limit && !drained && nextCursor !== undefined);
 
-    return { events: visibleEvents, cursor: resultCursor, drained };
+    return { events: visibleEvents, cursor: nextCursor, drained };
+  }
+
+  private async computeVisibleFingerprint(input: {
+    tenant: string;
+    messagesQuery: MessagesQuery;
+    authorization: MessagesQueryAuthorization;
+    replicationFeedReader: ReplicationFeedReader;
+    filters?: Filter[];
+    fingerprintScopes: string[];
+  }): Promise<string> {
+    const {
+      tenant, messagesQuery, authorization, replicationFeedReader, filters, fingerprintScopes
+    } = input;
+    if (authorization.kind === 'owner') {
+      return replicationFeedReader.fingerprint(tenant, fingerprintScopes);
+    }
+
+    let cursor: ProgressToken | undefined;
+    let drained = false;
+    let fingerprint = Replication.emptyFingerprint();
+    const visibilityCache = new Map<string, boolean>();
+
+    do {
+      const result = await replicationFeedReader.logRead(tenant, {
+        cursor,
+        filters,
+        limit: MessagesQueryHandler.ProjectedFingerprintPageLimit,
+      });
+      const visibleEvents = await this.filterVisibleControlEvents(tenant, messagesQuery, authorization, result.events, visibilityCache);
+      for (const event of visibleEvents) {
+        const messageCid = event.messageCid ?? await Message.getCid(event.event.message);
+        fingerprint = Replication.xorFingerprint(fingerprint, await Replication.hashMessageCid(messageCid));
+      }
+
+      cursor = result.cursor;
+      drained = result.drained;
+      if (result.events.length === 0) {
+        break;
+      }
+    } while (!drained && cursor !== undefined);
+
+    return Replication.fingerprintToHex(fingerprint);
   }
 
   private async filterVisibleControlEvents(
     tenant: string,
     messagesQuery: MessagesQuery,
-    requester: string,
+    authorization: Extract<MessagesQueryAuthorization, { kind: 'nonOwner' }>,
     events: EventLogEntry[],
+    visibilityCache?: Map<string, boolean>,
   ): Promise<EventLogEntry[]> {
-    const visibleEvents: EventLogEntry[] = [];
-    for (const event of events) {
-      const { message } = event.event;
-      if (!Records.isRecordsWrite(message) || !EncryptionControl.isControlMessage(message)) {
-        visibleEvents.push(event);
-        continue;
-      }
+    const recordsWriteMessages = events
+      .map(event => event.event.message)
+      .filter(Records.isRecordsWrite);
+    const visibleRecordsWrites = new Set(await EncryptionControl.filterVisibleControlRecords({
+      tenant,
+      incomingMessage       : messagesQuery.message,
+      permissionGrants      : authorization.permissionGrants,
+      requester             : authorization.requester,
+      recordsWriteMessages,
+      visibilityCache,
+      validationStateReader : this.deps.validationStateReader,
+    }));
 
-      try {
-        if (await EncryptionControl.canRead({
-          tenant,
-          incomingMessage       : messagesQuery.message,
-          requester,
-          recordsWriteMessage   : message,
-          validationStateReader : this.deps.validationStateReader,
-        })) {
-          visibleEvents.push(event);
-        }
-      } catch (error) {
-        if (!(error instanceof DwnError)) {
-          throw error;
-        }
-      }
-    }
-
-    return visibleEvents;
+    return events.filter(event => !Records.isRecordsWrite(event.event.message) || visibleRecordsWrites.has(event.event.message));
   }
 
   private static asReplicationFeedReader(candidate: unknown): ReplicationFeedReader | undefined {

--- a/packages/dwn-sdk-js/src/handlers/messages-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-query.ts
@@ -20,7 +20,7 @@ type MessagesQueryAuthorization =
   | { kind: 'nonOwner'; permissionGrants: PermissionGrant[]; requester: string };
 
 export class MessagesQueryHandler implements MethodHandler {
-  private static readonly ProjectedFingerprintPageLimit = 256;
+  private static readonly projectedFingerprintPageLimit = 256;
 
   constructor(private readonly deps: HandlerDependencies) { }
 
@@ -183,7 +183,7 @@ export class MessagesQueryHandler implements MethodHandler {
       const result = await replicationFeedReader.logRead(tenant, {
         cursor,
         filters,
-        limit: MessagesQueryHandler.ProjectedFingerprintPageLimit,
+        limit: MessagesQueryHandler.projectedFingerprintPageLimit,
       });
       const visibleEvents = await this.filterVisibleControlEvents(tenant, messagesQuery, authorization, result.events, visibilityCache);
       for (const event of visibleEvents) {

--- a/packages/dwn-sdk-js/src/handlers/messages-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-read.ts
@@ -6,6 +6,7 @@ import type { MessagesReadMessage, MessagesReadReply, MessagesReadReplyEntry } f
 import { authenticate } from '../core/auth.js';
 import { DataStream } from '../utils/data-stream.js';
 import { Encoder } from '../utils/encoder.js';
+import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { MessagesGrantAuthorization } from '../core/messages-grant-authorization.js';
@@ -80,19 +81,20 @@ export class MessagesReadHandler implements MethodHandler {
     deps: HandlerDependencies
   ): Promise<void> {
 
-    if (messagesRead.author === tenant) {
+    const requester = EncryptionControl.getRequester(messagesRead.message);
+    if (messagesRead.author === tenant && requester === tenant) {
       // If the author is the tenant, no further authorization is needed
       return;
     }
 
     const permissionGrantIds = Message.getPermissionGrantIds(messagesRead.signaturePayload!);
-    if (messagesRead.author !== undefined && permissionGrantIds.length > 0) {
+    if (requester !== undefined && permissionGrantIds.length > 0) {
       const permissionGrants = await MessagesGrantAuthorization.fetchPermissionGrants(tenant, deps.validationStateReader, permissionGrantIds);
       await MessagesGrantAuthorization.authorizeMessagesRead({
         messagesReadMessage   : messagesRead.message,
         messageToRead         : matchedMessage,
         expectedGrantor       : tenant,
-        expectedGrantee       : messagesRead.author,
+        expectedGrantee       : requester,
         permissionGrants,
         validationStateReader : deps.validationStateReader
       });

--- a/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
@@ -103,30 +103,22 @@ export class MessagesSubscribeHandler implements MethodHandler {
     messagesSubscribe: MessagesSubscribe,
     deps: HandlerDependencies
   ): Promise<MessagesSubscribeAuthorization> {
-    const requester = EncryptionControl.getRequester(messagesSubscribe.message);
-    if (messagesSubscribe.author === tenant && requester === tenant) {
+    const grantSet = await MessagesGrantAuthorization.authorizeQueryOrSubscribeInvocation({
+      tenant                : tenant,
+      incomingMessage       : messagesSubscribe.message,
+      validationStateReader : deps.validationStateReader,
+      failureCode           : DwnErrorCode.MessagesSubscribeAuthorizationFailed,
+    });
+    if (grantSet === undefined) {
       return { kind: 'owner' };
     }
 
-    const permissionGrantIds = Message.getPermissionGrantIds(messagesSubscribe.signaturePayload!);
-    if (requester !== undefined && permissionGrantIds.length > 0) {
-      const permissionGrants = await MessagesGrantAuthorization.fetchPermissionGrants(tenant, deps.validationStateReader, permissionGrantIds);
-      await MessagesGrantAuthorization.authorizeQueryOrSubscribe({
-        incomingMessage       : messagesSubscribe.message,
-        expectedGrantor       : tenant,
-        expectedGrantee       : requester,
-        permissionGrants,
-        validationStateReader : deps.validationStateReader
-      });
-      return {
-        kind            : 'delegate',
-        expectedGrantor : tenant,
-        expectedGrantee : requester,
-        permissionGrants,
-      };
-    } else {
-      throw new DwnError(DwnErrorCode.MessagesSubscribeAuthorizationFailed, 'message failed authorization');
-    }
+    return {
+      kind             : 'delegate',
+      expectedGrantor  : tenant,
+      expectedGrantee  : grantSet.requester,
+      permissionGrants : grantSet.permissionGrants,
+    };
   }
 
   private static createAuthorizationGuard(input: {
@@ -194,13 +186,21 @@ export class MessagesSubscribeHandler implements MethodHandler {
         return;
       }
 
-      const visible = await MessagesSubscribeHandler.canDeliverEvent({
-        tenant,
-        authorization,
-        deps,
-        messagesSubscribe,
-        subMessage,
-      });
+      let visible: boolean;
+      try {
+        visible = await MessagesSubscribeHandler.canDeliverEvent({
+          tenant,
+          authorization,
+          deps,
+          messagesSubscribe,
+          subMessage,
+        });
+      } catch {
+        emitTerminalAuthorizationError(subMessage.cursor);
+        closeSubscription();
+        return;
+      }
+
       if (!visible) {
         return;
       }
@@ -257,20 +257,14 @@ export class MessagesSubscribeHandler implements MethodHandler {
       return true;
     }
 
-    try {
-      return await EncryptionControl.canRead({
-        tenant,
-        incomingMessage       : messagesSubscribe.message,
-        requester             : authorization.expectedGrantee,
-        recordsWriteMessage   : message,
-        validationStateReader : deps.validationStateReader,
-      });
-    } catch (error) {
-      if (!(error instanceof DwnError)) {
-        throw error;
-      }
-
-      return false;
-    }
+    const visibleRecordsWrites = await EncryptionControl.filterVisibleControlRecords({
+      tenant,
+      incomingMessage       : messagesSubscribe.message,
+      permissionGrants      : authorization.permissionGrants,
+      requester             : authorization.expectedGrantee,
+      recordsWriteMessages  : [message],
+      validationStateReader : deps.validationStateReader,
+    });
+    return visibleRecordsWrites.length === 1;
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
@@ -28,6 +28,14 @@ type GuardedSubscriptionHandler = {
   setSubscription(subscription: EventSubscription): Promise<void>;
 };
 
+type DeliveryStepDwnErrorOutcome =
+  | { kind: 'hidden' }
+  | { kind: 'terminal'; code: DwnErrorCode; detail: string };
+
+type DeliveryStepResult<T> =
+  | { kind: 'ok'; value: T }
+  | DeliveryStepDwnErrorOutcome;
+
 export class MessagesSubscribeHandler implements MethodHandler {
 
   constructor(private readonly deps: HandlerDependencies) {}
@@ -149,7 +157,7 @@ export class MessagesSubscribeHandler implements MethodHandler {
       Promise.resolve(subscription?.close()).catch(() => {});
     };
 
-    const emitTerminalAuthorizationError = (cursor: SubscriptionEvent['cursor']): void => {
+    const emitTerminalDeliveryError = (cursor: SubscriptionEvent['cursor'], code: DwnErrorCode, detail: string): void => {
       if (terminalErrorEmitted) {
         return;
       }
@@ -158,10 +166,27 @@ export class MessagesSubscribeHandler implements MethodHandler {
         type  : 'error',
         cursor,
         error : {
-          code   : DwnErrorCode.MessagesSubscribeDeliveryAuthorizationFailed,
-          detail : 'subscription authorization failed during delivery',
+          code,
+          detail,
         },
       });
+    };
+
+    const applyDeliveryStepResult = <T>(
+      result: DeliveryStepResult<T>,
+      cursor: SubscriptionEvent['cursor']
+    ): result is { kind: 'ok'; value: T } => {
+      if (result.kind === 'ok') {
+        return true;
+      }
+
+      if (result.kind === 'hidden') {
+        return false;
+      }
+
+      emitTerminalDeliveryError(cursor, result.code, result.detail);
+      closeSubscription();
+      return false;
     };
 
     // Deliberately do not cache delivery authorization here. Subscribe-open
@@ -171,37 +196,42 @@ export class MessagesSubscribeHandler implements MethodHandler {
     // split static and dynamic checks explicitly and document any bounded staleness
     // introduced by caching revocation lookups.
     const authorizeAndDeliverEvent = async (subMessage: SubscriptionEvent): Promise<void> => {
-      try {
-        await MessagesGrantAuthorization.authorizeSubscribeDelivery({
-          messagesSubscribeMessage : messagesSubscribe.message,
-          expectedGrantor          : authorization.expectedGrantor,
-          expectedGrantee          : authorization.expectedGrantee,
-          permissionGrants         : authorization.permissionGrants,
-          validationStateReader    : deps.validationStateReader,
-          deliveryTimestamp        : Time.getCurrentTimestamp(),
-        });
-      } catch {
-        emitTerminalAuthorizationError(subMessage.cursor);
-        closeSubscription();
+      const authorizationResult = await MessagesSubscribeHandler.evaluateDeliveryStep({
+        step: async (): Promise<void> => {
+          await MessagesGrantAuthorization.authorizeSubscribeDelivery({
+            messagesSubscribeMessage : messagesSubscribe.message,
+            expectedGrantor          : authorization.expectedGrantor,
+            expectedGrantee          : authorization.expectedGrantee,
+            permissionGrants         : authorization.permissionGrants,
+            validationStateReader    : deps.validationStateReader,
+            deliveryTimestamp        : Time.getCurrentTimestamp(),
+          });
+        },
+        dwnErrorOutcome: {
+          kind   : 'terminal',
+          code   : DwnErrorCode.MessagesSubscribeDeliveryAuthorizationFailed,
+          detail : 'subscription authorization failed during delivery',
+        },
+      });
+      if (!applyDeliveryStepResult(authorizationResult, subMessage.cursor)) {
         return;
       }
 
-      let visible: boolean;
-      try {
-        visible = await MessagesSubscribeHandler.canDeliverEvent({
+      const visibilityResult = await MessagesSubscribeHandler.evaluateDeliveryStep({
+        step: async (): Promise<boolean> => MessagesSubscribeHandler.canDeliverEvent({
           tenant,
           authorization,
           deps,
           messagesSubscribe,
           subMessage,
-        });
-      } catch {
-        emitTerminalAuthorizationError(subMessage.cursor);
-        closeSubscription();
+        }),
+        dwnErrorOutcome: { kind: 'hidden' },
+      });
+      if (!applyDeliveryStepResult(visibilityResult, subMessage.cursor)) {
         return;
       }
 
-      if (!visible) {
+      if (!visibilityResult.value) {
         return;
       }
 
@@ -242,6 +272,25 @@ export class MessagesSubscribeHandler implements MethodHandler {
         }
       },
     };
+  }
+
+  private static async evaluateDeliveryStep<T>(input: {
+    dwnErrorOutcome: DeliveryStepDwnErrorOutcome;
+    step: () => Promise<T>;
+  }): Promise<DeliveryStepResult<T>> {
+    try {
+      return { kind: 'ok', value: await input.step() };
+    } catch (error) {
+      if (error instanceof DwnError) {
+        return input.dwnErrorOutcome;
+      }
+
+      return {
+        kind   : 'terminal',
+        code   : DwnErrorCode.MessagesSubscribeDeliveryFailed,
+        detail : 'subscription delivery failed',
+      };
+    }
   }
 
   private static async canDeliverEvent(input: {

--- a/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
@@ -4,11 +4,13 @@ import type { HandlerDependencies, MethodHandler } from '../types/method-handler
 import type { MessagesSubscribeMessage, MessagesSubscribeReply } from '../types/messages-types.js';
 
 import { authenticate } from '../core/auth.js';
+import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { Messages } from '../utils/messages.js';
 import { MessagesGrantAuthorization } from '../core/messages-grant-authorization.js';
 import { MessagesSubscribe } from '../interfaces/messages-subscribe.js';
+import { Records } from '../utils/records.js';
 import { Time } from '../utils/time.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
@@ -63,9 +65,10 @@ export class MessagesSubscribeHandler implements MethodHandler {
 
     const guardedHandler = MessagesSubscribeHandler.createAuthorizationGuard({
       authorization,
+      deps: this.deps,
       messagesSubscribe,
-      validationStateReader: this.deps.validationStateReader,
       subscriptionHandler,
+      tenant,
     });
 
     const { filters, cursor: eventLogCursor } = message.descriptor;
@@ -100,25 +103,25 @@ export class MessagesSubscribeHandler implements MethodHandler {
     messagesSubscribe: MessagesSubscribe,
     deps: HandlerDependencies
   ): Promise<MessagesSubscribeAuthorization> {
-    // if `MessagesSubscribe` author is the same as the target tenant, we can directly grant access
-    if (messagesSubscribe.author === tenant) {
+    const requester = EncryptionControl.getRequester(messagesSubscribe.message);
+    if (messagesSubscribe.author === tenant && requester === tenant) {
       return { kind: 'owner' };
     }
 
     const permissionGrantIds = Message.getPermissionGrantIds(messagesSubscribe.signaturePayload!);
-    if (messagesSubscribe.author !== undefined && permissionGrantIds.length > 0) {
+    if (requester !== undefined && permissionGrantIds.length > 0) {
       const permissionGrants = await MessagesGrantAuthorization.fetchPermissionGrants(tenant, deps.validationStateReader, permissionGrantIds);
       await MessagesGrantAuthorization.authorizeQueryOrSubscribe({
         incomingMessage       : messagesSubscribe.message,
         expectedGrantor       : tenant,
-        expectedGrantee       : messagesSubscribe.author,
+        expectedGrantee       : requester,
         permissionGrants,
         validationStateReader : deps.validationStateReader
       });
       return {
         kind            : 'delegate',
         expectedGrantor : tenant,
-        expectedGrantee : messagesSubscribe.author,
+        expectedGrantee : requester,
         permissionGrants,
       };
     } else {
@@ -128,11 +131,12 @@ export class MessagesSubscribeHandler implements MethodHandler {
 
   private static createAuthorizationGuard(input: {
     authorization: MessagesSubscribeAuthorization;
+    deps: HandlerDependencies;
     messagesSubscribe: MessagesSubscribe;
-    validationStateReader: HandlerDependencies['validationStateReader'];
     subscriptionHandler: SubscriptionListener;
+    tenant: string;
   }): GuardedSubscriptionHandler {
-    const { authorization, messagesSubscribe, validationStateReader, subscriptionHandler } = input;
+    const { authorization, deps, messagesSubscribe, subscriptionHandler, tenant } = input;
     if (authorization.kind === 'owner') {
       return {
         listener        : subscriptionHandler,
@@ -181,12 +185,23 @@ export class MessagesSubscribeHandler implements MethodHandler {
           expectedGrantor          : authorization.expectedGrantor,
           expectedGrantee          : authorization.expectedGrantee,
           permissionGrants         : authorization.permissionGrants,
-          validationStateReader,
+          validationStateReader    : deps.validationStateReader,
           deliveryTimestamp        : Time.getCurrentTimestamp(),
         });
       } catch {
         emitTerminalAuthorizationError(subMessage.cursor);
         closeSubscription();
+        return;
+      }
+
+      const visible = await MessagesSubscribeHandler.canDeliverEvent({
+        tenant,
+        authorization,
+        deps,
+        messagesSubscribe,
+        subMessage,
+      });
+      if (!visible) {
         return;
       }
 
@@ -227,5 +242,35 @@ export class MessagesSubscribeHandler implements MethodHandler {
         }
       },
     };
+  }
+
+  private static async canDeliverEvent(input: {
+    tenant: string;
+    authorization: Extract<MessagesSubscribeAuthorization, { kind: 'delegate' }>;
+    deps: HandlerDependencies;
+    messagesSubscribe: MessagesSubscribe;
+    subMessage: SubscriptionEvent;
+  }): Promise<boolean> {
+    const { authorization, deps, messagesSubscribe, subMessage, tenant } = input;
+    const { message } = subMessage.event;
+    if (!Records.isRecordsWrite(message) || !EncryptionControl.isControlMessage(message)) {
+      return true;
+    }
+
+    try {
+      return await EncryptionControl.canRead({
+        tenant,
+        incomingMessage       : messagesSubscribe.message,
+        requester             : authorization.expectedGrantee,
+        recordsWriteMessage   : message,
+        validationStateReader : deps.validationStateReader,
+      });
+    } catch (error) {
+      if (!(error instanceof DwnError)) {
+        throw error;
+      }
+
+      return false;
+    }
   }
 }

--- a/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
@@ -25,6 +25,15 @@ function getFeedReader(messageStore: MessageStore): ReplicationFeedReader | unde
   }
 }
 
+async function fingerprintFromCids(messageCids: string[]): Promise<string> {
+  let fingerprint = Replication.emptyFingerprint();
+  for (const messageCid of messageCids) {
+    fingerprint = Replication.xorFingerprint(fingerprint, await Replication.hashMessageCid(messageCid));
+  }
+
+  return Replication.fingerprintToHex(fingerprint);
+}
+
 export function testMessagesQueryHandler(): void {
   describe('MessagesQueryHandler.handle()', () => {
     let didResolver: DidResolver;
@@ -419,6 +428,27 @@ export function testMessagesQueryHandler(): void {
       expect(reply.status.code).toBe(200);
       expect(reply.entries?.map(entry => entry.messageCid)).toEqual([await Message.getCid(record.message)]);
       expect(reply.entries?.map(entry => entry.messageCid)).not.toContain(await Message.getCid(delivery.recordsWrite.message));
+
+      const { message: fullQuery } = await TestDataGenerator.generateMessagesQuery({
+        author             : carol,
+        filters            : [{ protocol: protocolDefinition.protocol }],
+        permissionGrantIds : [grant.message.recordId],
+        cidsOnly           : true,
+      });
+      const fullReply = await dwn.processMessage(alice.did, fullQuery);
+      const fullReplyCids = fullReply.entries!.map(entry => entry.messageCid);
+      const rawFingerprint = await feedReader.fingerprint(alice.did, [
+        Replication.protocolDomain(protocolDefinition.protocol),
+        Replication.permissionDomain(protocolDefinition.protocol),
+        Replication.encryptionDomain(protocolDefinition.protocol),
+      ]);
+
+      expect(fullReply.status.code).toBe(200);
+      expect(fullReply.drained).toBe(true);
+      expect(fullReplyCids).toContain(await Message.getCid(audience.recordsWrite.message));
+      expect(fullReplyCids).not.toContain(await Message.getCid(delivery.recordsWrite.message));
+      expect(fullReply.fingerprint).toBe(await fingerprintFromCids(fullReplyCids));
+      expect(fullReply.fingerprint).not.toBe(rawFingerprint);
     });
 
     it('rejects unfiltered delegated queries with a protocol-scoped grant', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
@@ -1,14 +1,16 @@
 import type { DidResolver } from '@enbox/dids';
-import type { DataStore, MessageStore, ProtocolDefinition, ReplicationFeedReader, ResumableTaskStore } from '../../src/index.js';
+import type { DataStore, MessageStore, ProtocolDefinition, ProtocolRuleSet, ReplicationFeedReader, ResumableTaskStore } from '../../src/index.js';
 
 import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 
+import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import { Message } from '../../src/core/message.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestStores } from '../test-stores.js';
+import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, EncryptionProtocol, PermissionsProtocol, Replication } from '../../src/index.js';
 
 function getFeedReader(messageStore: MessageStore): ReplicationFeedReader | undefined {
@@ -328,6 +330,95 @@ export function testMessagesQueryHandler(): void {
         await Message.getCid(grant.message),
         await Message.getCid(record.message),
       ].sort());
+    });
+
+    it('filters hidden delivery control events without shrinking limited MessagesQuery pages', async () => {
+      const feedReader = getFeedReader(messageStore);
+      if (feedReader === undefined) {
+        return;
+      }
+
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const bob = await TestDataGenerator.generateDidKeyPersona();
+      const carol = await TestDataGenerator.generateDidKeyPersona();
+
+      const protocolDefinition: ProtocolDefinition = {
+        protocol  : 'http://messages-query-control-pagination.xyz',
+        published : false,
+        types     : {
+          member : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          post   : { schema: 'http://post-schema', dataFormats: ['application/json'] },
+        },
+        structure: {
+          member : { $role: true },
+          post   : {},
+        },
+      };
+      const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+      const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+      const audience = await createAudienceControlWrite({
+        author   : alice,
+        protocol : protocolDefinition.protocol,
+        rolePath : 'member',
+        roleRuleSet,
+      });
+      await processControlWrite(dwn, alice.did, audience);
+
+      const roleRecord = await TestDataGenerator.generateRecordsWrite({
+        author       : alice,
+        data         : Encoder.stringToBytes('bob is a member'),
+        dataFormat   : 'application/json',
+        protocol     : protocolDefinition.protocol,
+        protocolPath : 'member',
+        recipient    : bob.did,
+        schema       : 'http://member-schema',
+      });
+      expect((await dwn.processMessage(alice.did, roleRecord.message, { dataStream: roleRecord.dataStream })).status.code).toBe(202);
+
+      const grant = await TestDataGenerator.generateGrantCreate({
+        author    : alice,
+        grantedTo : carol,
+        scope     : {
+          interface : DwnInterfaceName.Messages,
+          method    : DwnMethodName.Read,
+          protocol  : protocolDefinition.protocol,
+        },
+      });
+      expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+      const setupCursor = (await feedReader.logRead(alice.did)).cursor;
+      const delivery = await createDeliveryControlWrite({
+        author             : alice,
+        keyId              : audience.keyId,
+        protocol           : protocolDefinition.protocol,
+        recipient          : bob.did,
+        recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+        rolePath           : 'member',
+        roleRuleSet,
+      });
+      await processControlWrite(dwn, alice.did, delivery);
+
+      const record = await TestDataGenerator.generateRecordsWrite({
+        author       : alice,
+        protocol     : protocolDefinition.protocol,
+        protocolPath : 'post',
+        schema       : 'http://post-schema',
+      });
+      expect((await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream })).status.code).toBe(202);
+
+      const { message: query } = await TestDataGenerator.generateMessagesQuery({
+        author             : carol,
+        filters            : [{ protocol: protocolDefinition.protocol }],
+        permissionGrantIds : [grant.message.recordId],
+        cursor             : setupCursor,
+        limit              : 1,
+        cidsOnly           : true,
+      });
+      const reply = await dwn.processMessage(alice.did, query);
+
+      expect(reply.status.code).toBe(200);
+      expect(reply.entries?.map(entry => entry.messageCid)).toEqual([await Message.getCid(record.message)]);
+      expect(reply.entries?.map(entry => entry.messageCid)).not.toContain(await Message.getCid(delivery.recordsWrite.message));
     });
 
     it('rejects unfiltered delegated queries with a protocol-scoped grant', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
@@ -418,6 +418,16 @@ export function testMessagesReadHandler(): void {
         });
         expect((await dwn.processMessage(alice.did, carolGrant.message, { dataStream: carolGrant.dataStream })).status.code).toBe(202);
 
+        const audienceCid = await Message.getCid(audience.recordsWrite.message);
+        const carolAudienceRead = await TestDataGenerator.generateMessagesRead({
+          author             : carol,
+          messageCid         : audienceCid,
+          permissionGrantIds : [carolGrant.message.recordId],
+        });
+        const carolAudienceReply = await dwn.processMessage(alice.did, carolAudienceRead.message);
+        expect(carolAudienceReply.status.code).toBe(200);
+        expect(carolAudienceReply.entry?.messageCid).toBe(audienceCid);
+
         const bobRead = await TestDataGenerator.generateMessagesRead({
           author             : bob,
           messageCid         : deliveryCid,

--- a/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
@@ -4,9 +4,13 @@ import type {
   DataStore,
   MessagesReadReply,
   MessageStore,
+  ProtocolDefinition,
+  ProtocolRuleSet,
   ResumableTaskStore,
 } from '../../src/index.js';
 
+import { Encoder } from '../../src/utils/encoder.js';
+import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
 import { GeneralJwsVerifier } from '../../src/jose/jws/general/verifier.js';
 import { Message } from '../../src/core/message.js';
@@ -16,6 +20,7 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { DataStream, Dwn, DwnConstant, DwnErrorCode, DwnInterfaceName, DwnMethodName, Jws, PermissionGrant, PermissionsProtocol, Time } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 
@@ -341,6 +346,97 @@ export function testMessagesReadHandler(): void {
     });
 
     describe('with a grant', () => {
+      it('enforces delivery control visibility for MessagesRead grants', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://messages-read-control-delivery.xyz',
+          published : false,
+          types     : {
+            member : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+            post   : { schema: 'http://post-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member : { $role: true },
+            post   : {},
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+        const audience = await createAudienceControlWrite({
+          author   : alice,
+          protocol : protocolDefinition.protocol,
+          rolePath : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, audience);
+
+        const roleRecord = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          data         : Encoder.stringToBytes('bob is a member'),
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'member',
+          recipient    : bob.did,
+          schema       : 'http://member-schema',
+        });
+        expect((await dwn.processMessage(alice.did, roleRecord.message, { dataStream: roleRecord.dataStream })).status.code).toBe(202);
+
+        const delivery = await createDeliveryControlWrite({
+          author             : alice,
+          keyId              : audience.keyId,
+          protocol           : protocolDefinition.protocol,
+          recipient          : bob.did,
+          recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+          rolePath           : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, delivery);
+        const deliveryCid = await Message.getCid(delivery.recordsWrite.message);
+
+        const bobGrant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : bob,
+          scope     : {
+            interface : DwnInterfaceName.Messages,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, bobGrant.message, { dataStream: bobGrant.dataStream })).status.code).toBe(202);
+
+        const carolGrant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : carol,
+          scope     : {
+            interface : DwnInterfaceName.Messages,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, carolGrant.message, { dataStream: carolGrant.dataStream })).status.code).toBe(202);
+
+        const bobRead = await TestDataGenerator.generateMessagesRead({
+          author             : bob,
+          messageCid         : deliveryCid,
+          permissionGrantIds : [bobGrant.message.recordId],
+        });
+        const bobReply = await dwn.processMessage(alice.did, bobRead.message);
+        expect(bobReply.status.code).toBe(200);
+        expect(bobReply.entry?.messageCid).toBe(deliveryCid);
+
+        const carolRead = await TestDataGenerator.generateMessagesRead({
+          author             : carol,
+          messageCid         : deliveryCid,
+          permissionGrantIds : [carolGrant.message.recordId],
+        });
+        const carolReply = await dwn.processMessage(alice.did, carolRead.message);
+        expect(carolReply.status.code).toBe(401);
+        expect(carolReply.status.detail).toContain(DwnErrorCode.MessagesReadVerifyScopeFailed);
+      });
+
       it('returns a 401 if grant has different DWN interface scope', async () => {
         // scenario: Alice grants Bob access to RecordsWrite, then Bob tries to invoke the grant with MessagesRead
 

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -541,7 +541,7 @@ export function testMessagesSubscribeHandler(): void {
 
           await Poller.pollUntilSuccessOrTimeout(async () => {
             const errorMessage = received.find(msg => msg.type === 'error');
-            expect(errorMessage?.error.code).toBe(DwnErrorCode.MessagesSubscribeDeliveryAuthorizationFailed);
+            expect(errorMessage?.error.code).toBe(DwnErrorCode.MessagesSubscribeDeliveryFailed);
           });
         });
 

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -11,6 +11,7 @@ import sinon from 'sinon';
 import { Dwn } from '../../src/dwn.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Encoder } from '../../src/utils/encoder.js';
+import { EncryptionControl } from '../../src/core/encryption-control.js';
 import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import { Jws } from '../../src/utils/jws.js';
 import { Message } from '../../src/core/message.js';
@@ -483,7 +484,9 @@ export function testMessagesSubscribeHandler(): void {
           expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
 
           const messageCids: string[] = [];
+          const received: SubscriptionMessage[] = [];
           const handler = async (msg: SubscriptionMessage): Promise<void> => {
+            received.push(msg);
             if (msg.type !== 'event') {
               return;
             }
@@ -523,6 +526,23 @@ export function testMessagesSubscribeHandler(): void {
             expect(messageCids).toContain(recordCid);
           });
           expect(messageCids).not.toContain(deliveryCid);
+
+          sinon.stub(EncryptionControl, 'filterVisibleControlRecords').rejects(new Error('visibility check failed'));
+          const failedDelivery = await createDeliveryControlWrite({
+            author             : alice,
+            keyId              : audience.keyId,
+            protocol           : protocolDefinition.protocol,
+            recipient          : bob.did,
+            recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+            rolePath           : 'member',
+            roleRuleSet,
+          });
+          await processControlWrite(dwn, alice.did, failedDelivery);
+
+          await Poller.pollUntilSuccessOrTimeout(async () => {
+            const errorMessage = received.find(msg => msg.type === 'error');
+            expect(errorMessage?.error.code).toBe(DwnErrorCode.MessagesSubscribeDeliveryAuthorizationFailed);
+          });
         });
 
         it('rejects subscribe of messages with mismatching interface grant scope', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -1,5 +1,5 @@
 import type { DidResolver } from '@enbox/dids';
-import type { DataStore, MessageStore, ProtocolDefinition, ResumableTaskStore } from '../../src/index.js';
+import type { DataStore, MessageStore, ProtocolDefinition, ProtocolRuleSet, ResumableTaskStore } from '../../src/index.js';
 import type { EventLog, SubscriptionMessage } from '../../src/types/subscriptions.js';
 import type { GenerateGrantCreateOutput, GenerateRecordsWriteOutput, Persona } from '../utils/test-data-generator.js';
 
@@ -10,6 +10,8 @@ import sinon from 'sinon';
 
 import { Dwn } from '../../src/dwn.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
+import { Encoder } from '../../src/utils/encoder.js';
+import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import { Jws } from '../../src/utils/jws.js';
 import { Message } from '../../src/core/message.js';
 import { MessagesGrantAuthorization } from '../../src/core/messages-grant-authorization.js';
@@ -19,6 +21,7 @@ import { Poller } from '../utils/poller.js';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
+import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { DataStream, DwnInterfaceName, DwnMethodName, PermissionGrant, PermissionsProtocol, Time } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 
@@ -428,6 +431,98 @@ export function testMessagesSubscribeHandler(): void {
           await Poller.pollUntilSuccessOrTimeout(async () => {
             expect(messageCids.length).toBeGreaterThanOrEqual(1);
           });
+        });
+
+        it('filters delivery control events that are not addressed to the subscriber', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+          const carol = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://messages-subscribe-control-delivery.xyz',
+            published : false,
+            types     : {
+              member : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+              post   : { schema: 'http://post-schema', dataFormats: ['application/json'] },
+            },
+            structure: {
+              member : { $role: true },
+              post   : {},
+            },
+          };
+          const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+          const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+          const audience = await createAudienceControlWrite({
+            author   : alice,
+            protocol : protocolDefinition.protocol,
+            rolePath : 'member',
+            roleRuleSet,
+          });
+          await processControlWrite(dwn, alice.did, audience);
+
+          const roleRecord = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            data         : Encoder.stringToBytes('bob is a member'),
+            dataFormat   : 'application/json',
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'member',
+            recipient    : bob.did,
+            schema       : 'http://member-schema',
+          });
+          expect((await dwn.processMessage(alice.did, roleRecord.message, { dataStream: roleRecord.dataStream })).status.code).toBe(202);
+
+          const grant = await TestDataGenerator.generateGrantCreate({
+            author    : alice,
+            grantedTo : carol,
+            scope     : {
+              interface : DwnInterfaceName.Messages,
+              method    : DwnMethodName.Read,
+              protocol  : protocolDefinition.protocol,
+            },
+          });
+          expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+          const messageCids: string[] = [];
+          const handler = async (msg: SubscriptionMessage): Promise<void> => {
+            if (msg.type !== 'event') {
+              return;
+            }
+
+            messageCids.push(await Message.getCid(msg.event.message));
+          };
+          const { message: subscribeMessage } = await TestDataGenerator.generateMessagesSubscribe({
+            author             : carol,
+            filters            : [{ protocol: protocolDefinition.protocol }],
+            permissionGrantIds : [grant.message.recordId],
+          });
+          const subscribeReply = await dwn.processMessage(alice.did, subscribeMessage, { subscriptionHandler: handler });
+          expect(subscribeReply.status.code).toBe(200);
+
+          const delivery = await createDeliveryControlWrite({
+            author             : alice,
+            keyId              : audience.keyId,
+            protocol           : protocolDefinition.protocol,
+            recipient          : bob.did,
+            recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
+            rolePath           : 'member',
+            roleRuleSet,
+          });
+          await processControlWrite(dwn, alice.did, delivery);
+
+          const record = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'post',
+            schema       : 'http://post-schema',
+          });
+          expect((await dwn.processMessage(alice.did, record.message, { dataStream: record.dataStream })).status.code).toBe(202);
+          const recordCid = await Message.getCid(record.message);
+          const deliveryCid = await Message.getCid(delivery.recordsWrite.message);
+
+          await Poller.pollUntilSuccessOrTimeout(async () => {
+            expect(messageCids).toContain(recordCid);
+          });
+          expect(messageCids).not.toContain(deliveryCid);
         });
 
         it('rejects subscribe of messages with mismatching interface grant scope', async () => {


### PR DESCRIPTION
## Summary
- routes MessagesRead authorization for source-protocol encryption control records through EncryptionControl visibility checks with the invoked grant set
- filters hidden encryption control events from non-owner MessagesQuery and MessagesSubscribe feeds, including audience records covered by Messages grants
- returns non-owner MessagesQuery fingerprints over the visible projection instead of the full raw feed
- distinguishes terminal subscribe authorization loss from retryable delivery infrastructure failures
- keeps Records and Messages audience-enumeration grant coverage on one shared predicate branch

## Test plan
- [x] bun run lint
- [x] bun run --filter @enbox/dwn-sdk-js build
- [x] GREP="delivery control visibility|hidden delivery|filters delivery" bun run test:node-grep from packages/dwn-sdk-js
- [x] bun run test:node from packages/dwn-sdk-js
- [x] bunx changeset status
- [ ] DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node from packages/agent (not run locally; no DWN server is listening on http://localhost:3000)
