### PR TITLE
fix(dwn-sdk-js): treat Messages as control record transport

### DIFF
--- a/.changeset/messages-control-transport.md
+++ b/.changeset/messages-control-transport.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+fix: treat Messages surfaces as encrypted control-record transport

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -1,8 +1,8 @@
 import type { GenericMessage } from '../types/message-types.js';
+import type { RecordsPermissionScope } from '../types/permission-types.js';
 import type { RecordsWrite } from '../interfaces/records-write.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
 import type { EncryptionControlAudiencePayload, EncryptionControlDeliveryTags, RoleAudienceKeyId } from '../types/encryption-types.js';
-import type { MessagesPermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
 import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
 import type { RecordsCountMessage, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsSubscribeMessage, RecordsWriteMessage, RecordsWriteTags } from '../types/records-types.js';
 
@@ -52,10 +52,8 @@ type ControlFilterMessage =
 type ControlFilterInput<T extends RecordsWriteMessage> = {
   tenant: string;
   incomingMessage: ControlFilterMessage;
-  permissionGrants?: PermissionGrant[];
   requester: string | undefined;
   recordsWriteMessages: T[];
-  visibilityCache?: Map<string, boolean>;
   validationStateReader: ValidationStateReader;
 };
 
@@ -83,12 +81,10 @@ export class EncryptionControl {
     for (const recordsWrite of input.recordsWriteMessages) {
       const visible = await EncryptionControl.isVisibleControlRecord({
         incomingMessage       : input.incomingMessage,
-        permissionGrants      : input.permissionGrants,
         recordsWriteMessage   : recordsWrite,
         requester             : input.requester,
         tenant                : input.tenant,
         validationStateReader : input.validationStateReader,
-        visibilityCache       : input.visibilityCache,
       });
 
       if (visible) {
@@ -119,7 +115,6 @@ export class EncryptionControl {
   public static async canRead(input: {
     tenant: string;
     incomingMessage: ControlReadMessage;
-    permissionGrants?: PermissionGrant[];
     requester: string | undefined;
     recordsWriteMessage: RecordsWriteMessage;
     validationStateReader: ValidationStateReader;
@@ -152,7 +147,6 @@ export class EncryptionControl {
       tenant,
       actorDid              : requester,
       incomingMessage       : input.incomingMessage,
-      permissionGrants      : input.permissionGrants,
       tags,
       validationStateReader : input.validationStateReader,
     });
@@ -712,14 +706,13 @@ export class EncryptionControl {
     tenant: string;
     actorDid: string;
     incomingMessage: ControlReadMessage;
-    permissionGrants?: PermissionGrant[];
     tags: RoleAudienceKeyId;
     validationStateReader: ValidationStateReader;
   }): Promise<boolean> {
     const {
-      tenant, actorDid, incomingMessage, permissionGrants, tags, validationStateReader
+      tenant, actorDid, incomingMessage, tags, validationStateReader
     } = input;
-    const grants = permissionGrants ?? await EncryptionControl.getInvokedReadGrants({
+    const grants = await EncryptionControl.getInvokedReadGrants({
       tenant,
       actorDid,
       incomingMessage,
@@ -782,9 +775,8 @@ export class EncryptionControl {
   }
 
   private static grantCoversAudienceEnumeration(grant: PermissionGrant, tags: RoleAudienceKeyId): boolean {
-    const scope = grant.scope as MessagesPermissionScope | RecordsPermissionScope;
-    const interfaceIsEligible = scope.interface === DwnInterfaceName.Records || scope.interface === DwnInterfaceName.Messages;
-    if (!interfaceIsEligible || scope.method !== DwnMethodName.Read) {
+    const scope = grant.scope as RecordsPermissionScope;
+    if (scope.interface !== DwnInterfaceName.Records || scope.method !== DwnMethodName.Read) {
       return false;
     }
 
@@ -961,48 +953,13 @@ export class EncryptionControl {
   }
 
   private static async resolveVisibleControlRecord<T extends RecordsWriteMessage>(input: ControlRecordVisibilityInput<T>): Promise<boolean> {
-    const cacheKey = EncryptionControl.visibilityCacheKey(input.requester, input.incomingMessage, input.recordsWriteMessage);
-    if (cacheKey !== undefined) {
-      const visible = input.visibilityCache?.get(cacheKey);
-      if (visible !== undefined) {
-        return visible;
-      }
-    }
-
-    const visible = await EncryptionControl.canRead({
+    return EncryptionControl.canRead({
       tenant                : input.tenant,
       incomingMessage       : input.incomingMessage,
-      permissionGrants      : input.permissionGrants,
       requester             : input.requester,
       recordsWriteMessage   : input.recordsWriteMessage,
       validationStateReader : input.validationStateReader,
     });
-
-    if (cacheKey !== undefined) {
-      input.visibilityCache?.set(cacheKey, visible);
-    }
-
-    return visible;
-  }
-
-  private static visibilityCacheKey(
-    requester: string | undefined,
-    incomingMessage: ControlFilterMessage,
-    recordsWriteMessage: RecordsWriteMessage,
-  ): string | undefined {
-    if (EncryptionControl.getRecordType(recordsWriteMessage) !== 'audience') {
-      return undefined;
-    }
-
-    const tags = EncryptionControl.getRoleAudienceKeyId(recordsWriteMessage, 'audience');
-    return [
-      requester ?? '',
-      incomingMessage.descriptor.messageTimestamp,
-      tags.protocol,
-      tags.rolePath,
-      tags.contextId,
-      tags.keyId,
-    ].join('\u001f');
   }
 
   private static exactAudienceFilterMatchesRecord(filter: RecordsFilter, tags: RoleAudienceKeyId, recordId: string): boolean {

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -1,8 +1,8 @@
+import type { GenericMessage } from '../types/message-types.js';
 import type { RecordsWrite } from '../interfaces/records-write.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
 import type { EncryptionControlAudiencePayload, EncryptionControlDeliveryTags, RoleAudienceKeyId } from '../types/encryption-types.js';
 import type { MessagesPermissionScope, RecordsPermissionScope } from '../types/permission-types.js';
-import type { MessagesQueryMessage, MessagesReadMessage, MessagesSubscribeMessage } from '../types/messages-types.js';
 import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
 import type { RecordsCountMessage, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsSubscribeMessage, RecordsWriteMessage, RecordsWriteTags } from '../types/records-types.js';
 
@@ -39,17 +39,12 @@ type ExactAudienceFilterTuple = Omit<RoleAudienceKeyId, 'keyId'> & {
 };
 
 type ControlReadMessage =
-  | MessagesQueryMessage
-  | MessagesReadMessage
-  | MessagesSubscribeMessage
   | RecordsCountMessage
   | RecordsReadMessage
   | RecordsQueryMessage
   | RecordsSubscribeMessage;
 
 type ControlFilterMessage =
-  | MessagesQueryMessage
-  | MessagesSubscribeMessage
   | RecordsCountMessage
   | RecordsQueryMessage
   | RecordsSubscribeMessage;
@@ -74,7 +69,7 @@ export class EncryptionControl {
   }
 
   public static getRequester(
-    message: ControlReadMessage,
+    message: GenericMessage,
   ): string | undefined {
     return Message.isSignedByAuthorDelegate(message) ? Message.getSigner(message) : Message.getAuthor(message);
   }

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -1,4 +1,3 @@
-import type { GenericMessage } from '../types/message-types.js';
 import type { RecordsPermissionScope } from '../types/permission-types.js';
 import type { RecordsWrite } from '../interfaces/records-write.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
@@ -64,12 +63,6 @@ type ControlRecordVisibilityInput<T extends RecordsWriteMessage> = Omit<ControlF
 export class EncryptionControl {
   public static isControlMessage(message: RecordsWriteMessage): boolean {
     return isEncryptionControlPath(message.descriptor.protocolPath);
-  }
-
-  public static getRequester(
-    message: GenericMessage,
-  ): string | undefined {
-    return Message.isSignedByAuthorDelegate(message) ? Message.getSigner(message) : Message.getAuthor(message);
   }
 
   public static isExactAudienceFilter(filter: RecordsFilter): boolean {
@@ -943,23 +936,19 @@ export class EncryptionControl {
     }
 
     try {
-      return await EncryptionControl.resolveVisibleControlRecord(input);
+      return await EncryptionControl.canRead({
+        tenant                : input.tenant,
+        incomingMessage       : input.incomingMessage,
+        requester             : input.requester,
+        recordsWriteMessage   : input.recordsWriteMessage,
+        validationStateReader : input.validationStateReader,
+      });
     } catch (error) {
       if (error instanceof DwnError) {
         return false;
       }
       throw error;
     }
-  }
-
-  private static async resolveVisibleControlRecord<T extends RecordsWriteMessage>(input: ControlRecordVisibilityInput<T>): Promise<boolean> {
-    return EncryptionControl.canRead({
-      tenant                : input.tenant,
-      incomingMessage       : input.incomingMessage,
-      requester             : input.requester,
-      recordsWriteMessage   : input.recordsWriteMessage,
-      validationStateReader : input.validationStateReader,
-    });
   }
 
   private static exactAudienceFilterMatchesRecord(filter: RecordsFilter, tags: RoleAudienceKeyId, recordId: string): boolean {

--- a/packages/dwn-sdk-js/src/core/message.ts
+++ b/packages/dwn-sdk-js/src/core/message.ts
@@ -50,6 +50,13 @@ export class Message {
   }
 
   /**
+   * Gets the DID whose authority is being exercised by the request.
+   */
+  public static getRequester(message: GenericMessage): string | undefined {
+    return Message.isSignedByAuthorDelegate(message) ? Message.getSigner(message) : Message.getAuthor(message);
+  }
+
+  /**
    * Validates the given message against the corresponding JSON schema.
    * @throws {Error} if fails validation.
    */

--- a/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
@@ -8,7 +8,6 @@ import type { DataEncodedRecordsWriteMessage, RecordsDeleteMessage, RecordsWrite
 import type { MessagesQueryMessage, MessagesReadMessage, MessagesSubscribeMessage } from '../types/messages-types.js';
 
 import { DwnInterfaceName } from '../enums/dwn-interface-method.js';
-import { EncryptionControl } from './encryption-control.js';
 import { EncryptionProtocol } from '../protocols/encryption.js';
 import { GrantAuthorization } from './grant-authorization.js';
 import { Jws } from '../utils/jws.js';
@@ -111,7 +110,7 @@ export class MessagesGrantAuthorization {
     const {
       tenant, incomingMessage, validationStateReader, failureCode
     } = input;
-    const requester = EncryptionControl.getRequester(incomingMessage);
+    const requester = Message.getRequester(incomingMessage);
     if (Message.getAuthor(incomingMessage) === tenant && requester === tenant) {
       return undefined;
     }

--- a/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
+++ b/packages/dwn-sdk-js/src/core/messages-grant-authorization.ts
@@ -59,39 +59,6 @@ export class MessagesGrantAuthorization {
       validationStateReader
     });
 
-    const controlRecordsWrite = await MessagesGrantAuthorization.getControlRecordsWrite(
-      expectedGrantor,
-      messageToRead,
-      validationStateReader
-    );
-    if (controlRecordsWrite !== undefined) {
-      if (!MessagesGrantAuthorization.someScopeMatches(
-        permissionGrants.map(permissionGrant => permissionGrant.scope as MessagesPermissionScope),
-        MessagesGrantAuthorization.getControlScopeTarget(controlRecordsWrite)
-      )) {
-        throw new DwnError(DwnErrorCode.MessagesReadVerifyScopeFailed, 'record message failed scope authorization');
-      }
-
-      try {
-        if (await EncryptionControl.canRead({
-          tenant                : expectedGrantor,
-          incomingMessage       : messagesReadMessage,
-          permissionGrants      : permissionGrants,
-          requester             : expectedGrantee,
-          recordsWriteMessage   : controlRecordsWrite,
-          validationStateReader : validationStateReader,
-        })) {
-          return;
-        }
-      } catch (error) {
-        if (!(error instanceof DwnError)) {
-          throw error;
-        }
-      }
-
-      throw new DwnError(DwnErrorCode.MessagesReadVerifyScopeFailed, 'record message failed scope authorization');
-    }
-
     for (const permissionGrant of permissionGrants) {
       const scope = permissionGrant.scope as MessagesPermissionScope;
       if (await MessagesGrantAuthorization.isScopeAuthorized({
@@ -192,18 +159,6 @@ export class MessagesGrantAuthorization {
 
   private static someScopeMatches(scopes: MessagesPermissionScope[], target: ProtocolScope): boolean {
     return scopes.some(scope => PermissionScopeMatcher.matches(scope, target));
-  }
-
-  private static getControlScopeTarget(recordsWriteMessage: RecordsWriteMessage): ProtocolScope {
-    const rolePath = recordsWriteMessage.descriptor.tags?.rolePath;
-    if (typeof rolePath === 'string') {
-      return {
-        protocol     : recordsWriteMessage.descriptor.protocol,
-        protocolPath : rolePath,
-      };
-    }
-
-    return { protocol: recordsWriteMessage.descriptor.protocol };
   }
 
   private static hasUnscopedGrant(scopes: MessagesPermissionScope[]): boolean {
@@ -343,23 +298,6 @@ export class MessagesGrantAuthorization {
     }
 
     return PermissionScopeMatcher.matches(incomingScope, MessagesGrantAuthorization.getRecordsScopeTarget(recordsWriteMessage));
-  }
-
-  private static async getControlRecordsWrite(
-    tenant: string,
-    messageToGet: GenericMessage,
-    validationStateReader: ValidationStateReader,
-  ): Promise<RecordsWriteMessage | undefined> {
-    if (messageToGet.descriptor.interface !== DwnInterfaceName.Records) {
-      return undefined;
-    }
-
-    const recordsWriteMessage = await MessagesGrantAuthorization.getAssociatedRecordsWrite(
-      tenant,
-      messageToGet as RecordsWriteMessage | RecordsDeleteMessage,
-      validationStateReader
-    );
-    return EncryptionControl.isControlMessage(recordsWriteMessage) ? recordsWriteMessage : undefined;
   }
 
   private static async isPermissionRecordScopeAuthorized(

--- a/packages/dwn-sdk-js/src/handlers/messages-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-query.ts
@@ -1,26 +1,18 @@
-import type { PermissionGrant } from '../protocols/permission-grant.js';
-import type { EventLogEntry, EventLogReadResult, ProgressGapInfo, ProgressToken, ReplicationFeedReader } from '../types/subscriptions.js';
+import type { EventLogEntry, ProgressGapInfo, ReplicationFeedReader } from '../types/subscriptions.js';
 import type { Filter, KeyValues } from '../types/query-types.js';
 import type { HandlerDependencies, MethodHandler } from '../types/method-handler.js';
 import type { MessagesFilter, MessagesQueryMessage, MessagesQueryReply, MessagesQueryReplyEntry } from '../types/messages-types.js';
 
 import { authenticate } from '../core/auth.js';
-import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { Messages } from '../utils/messages.js';
 import { MessagesGrantAuthorization } from '../core/messages-grant-authorization.js';
 import { MessagesQuery } from '../interfaces/messages-query.js';
-import { Records } from '../utils/records.js';
 import { Replication } from '../utils/replication.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
-type MessagesQueryAuthorization =
-  | { kind: 'owner' }
-  | { kind: 'nonOwner'; permissionGrants: PermissionGrant[]; requester: string };
-
 export class MessagesQueryHandler implements MethodHandler {
-  private static readonly projectedFingerprintPageLimit = 256;
 
   constructor(private readonly deps: HandlerDependencies) { }
 
@@ -32,10 +24,9 @@ export class MessagesQueryHandler implements MethodHandler {
       return messageReplyFromError(e, 400);
     }
 
-    let authorization: MessagesQueryAuthorization;
     try {
       await authenticate(message.authorization, this.deps.didResolver);
-      authorization = await this.authorizeMessagesQuery(tenant, messagesQuery);
+      await this.authorizeMessagesQuery(tenant, messagesQuery);
     } catch (e) {
       return messageReplyFromError(e, 401);
     }
@@ -52,11 +43,7 @@ export class MessagesQueryHandler implements MethodHandler {
 
     try {
       const filters = MessagesQueryHandler.convertFilters(message.descriptor.filters, this.deps);
-      const result = await this.logReadVisibleEvents({
-        tenant,
-        messagesQuery,
-        authorization,
-        replicationFeedReader,
+      const result = await replicationFeedReader.logRead(tenant, {
         cursor : message.descriptor.cursor,
         filters,
         limit  : message.descriptor.limit,
@@ -71,14 +58,7 @@ export class MessagesQueryHandler implements MethodHandler {
 
       const fingerprintScopes = MessagesQueryHandler.computeFingerprintScopes(message.descriptor.filters);
       if (fingerprintScopes !== undefined) {
-        reply.fingerprint = await this.computeVisibleFingerprint({
-          tenant,
-          messagesQuery,
-          authorization,
-          replicationFeedReader,
-          filters,
-          fingerprintScopes,
-        });
+        reply.fingerprint = await replicationFeedReader.fingerprint(tenant, fingerprintScopes);
       }
 
       return reply;
@@ -98,130 +78,13 @@ export class MessagesQueryHandler implements MethodHandler {
   private async authorizeMessagesQuery(
     tenant: string,
     messagesQuery: MessagesQuery,
-  ): Promise<MessagesQueryAuthorization> {
-    const grantSet = await MessagesGrantAuthorization.authorizeQueryOrSubscribeInvocation({
+  ): Promise<void> {
+    await MessagesGrantAuthorization.authorizeQueryOrSubscribeInvocation({
       tenant                : tenant,
       incomingMessage       : messagesQuery.message,
       validationStateReader : this.deps.validationStateReader,
       failureCode           : DwnErrorCode.MessagesQueryAuthorizationFailed,
     });
-    if (grantSet === undefined) {
-      return { kind: 'owner' };
-    }
-
-    return { kind: 'nonOwner', ...grantSet };
-  }
-
-  private async logReadVisibleEvents(input: {
-    tenant: string;
-    messagesQuery: MessagesQuery;
-    authorization: MessagesQueryAuthorization;
-    replicationFeedReader: ReplicationFeedReader;
-    cursor?: ProgressToken;
-    filters?: Filter[];
-    limit?: number;
-  }): Promise<EventLogReadResult> {
-    const {
-      tenant, messagesQuery, authorization, replicationFeedReader, cursor, filters, limit
-    } = input;
-    if (authorization.kind === 'owner') {
-      return replicationFeedReader.logRead(tenant, { cursor, filters, limit });
-    }
-
-    const visibilityCache = new Map<string, boolean>();
-    if (limit === undefined || limit <= 0) {
-      const result = await replicationFeedReader.logRead(tenant, { cursor, filters, limit });
-      return {
-        ...result,
-        events: await this.filterVisibleControlEvents(tenant, messagesQuery, authorization, result.events, visibilityCache),
-      };
-    }
-
-    const visibleEvents: EventLogEntry[] = [];
-    let nextCursor = cursor;
-    let drained = false;
-    do {
-      const result = await replicationFeedReader.logRead(tenant, {
-        cursor : nextCursor,
-        filters,
-        limit  : limit - visibleEvents.length,
-      });
-      // Keeps visible-page pagination stable until #1100 moves control visibility into indexed store filters.
-      const filteredEvents = await this.filterVisibleControlEvents(tenant, messagesQuery, authorization, result.events, visibilityCache);
-      visibleEvents.push(...filteredEvents);
-      nextCursor = result.cursor;
-      drained = result.drained;
-      if (result.events.length === 0) {
-        break;
-      }
-    } while (visibleEvents.length < limit && !drained && nextCursor !== undefined);
-
-    return { events: visibleEvents, cursor: nextCursor, drained };
-  }
-
-  private async computeVisibleFingerprint(input: {
-    tenant: string;
-    messagesQuery: MessagesQuery;
-    authorization: MessagesQueryAuthorization;
-    replicationFeedReader: ReplicationFeedReader;
-    filters?: Filter[];
-    fingerprintScopes: string[];
-  }): Promise<string> {
-    const {
-      tenant, messagesQuery, authorization, replicationFeedReader, filters, fingerprintScopes
-    } = input;
-    if (authorization.kind === 'owner') {
-      return replicationFeedReader.fingerprint(tenant, fingerprintScopes);
-    }
-
-    let cursor: ProgressToken | undefined;
-    let drained = false;
-    let fingerprint = Replication.emptyFingerprint();
-    const visibilityCache = new Map<string, boolean>();
-
-    do {
-      const result = await replicationFeedReader.logRead(tenant, {
-        cursor,
-        filters,
-        limit: MessagesQueryHandler.projectedFingerprintPageLimit,
-      });
-      const visibleEvents = await this.filterVisibleControlEvents(tenant, messagesQuery, authorization, result.events, visibilityCache);
-      for (const event of visibleEvents) {
-        const messageCid = event.messageCid ?? await Message.getCid(event.event.message);
-        fingerprint = Replication.xorFingerprint(fingerprint, await Replication.hashMessageCid(messageCid));
-      }
-
-      cursor = result.cursor;
-      drained = result.drained;
-      if (result.events.length === 0) {
-        break;
-      }
-    } while (!drained && cursor !== undefined);
-
-    return Replication.fingerprintToHex(fingerprint);
-  }
-
-  private async filterVisibleControlEvents(
-    tenant: string,
-    messagesQuery: MessagesQuery,
-    authorization: Extract<MessagesQueryAuthorization, { kind: 'nonOwner' }>,
-    events: EventLogEntry[],
-    visibilityCache?: Map<string, boolean>,
-  ): Promise<EventLogEntry[]> {
-    const recordsWriteMessages = events
-      .map(event => event.event.message)
-      .filter(Records.isRecordsWrite);
-    const visibleRecordsWrites = new Set(await EncryptionControl.filterVisibleControlRecords({
-      tenant,
-      incomingMessage       : messagesQuery.message,
-      permissionGrants      : authorization.permissionGrants,
-      requester             : authorization.requester,
-      recordsWriteMessages,
-      visibilityCache,
-      validationStateReader : this.deps.validationStateReader,
-    }));
-
-    return events.filter(event => !Records.isRecordsWrite(event.event.message) || visibleRecordsWrites.has(event.event.message));
   }
 
   private static asReplicationFeedReader(candidate: unknown): ReplicationFeedReader | undefined {

--- a/packages/dwn-sdk-js/src/handlers/messages-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-read.ts
@@ -6,7 +6,6 @@ import type { MessagesReadMessage, MessagesReadReply, MessagesReadReplyEntry } f
 import { authenticate } from '../core/auth.js';
 import { DataStream } from '../utils/data-stream.js';
 import { Encoder } from '../utils/encoder.js';
-import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { MessagesGrantAuthorization } from '../core/messages-grant-authorization.js';
@@ -81,7 +80,7 @@ export class MessagesReadHandler implements MethodHandler {
     deps: HandlerDependencies
   ): Promise<void> {
 
-    const requester = EncryptionControl.getRequester(messagesRead.message);
+    const requester = Message.getRequester(messagesRead.message);
     if (messagesRead.author === tenant && requester === tenant) {
       // If the author is the tenant, no further authorization is needed
       return;

--- a/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
@@ -4,13 +4,11 @@ import type { HandlerDependencies, MethodHandler } from '../types/method-handler
 import type { MessagesSubscribeMessage, MessagesSubscribeReply } from '../types/messages-types.js';
 
 import { authenticate } from '../core/auth.js';
-import { EncryptionControl } from '../core/encryption-control.js';
 import { Message } from '../core/message.js';
 import { messageReplyFromError } from '../core/message-reply.js';
 import { Messages } from '../utils/messages.js';
 import { MessagesGrantAuthorization } from '../core/messages-grant-authorization.js';
 import { MessagesSubscribe } from '../interfaces/messages-subscribe.js';
-import { Records } from '../utils/records.js';
 import { Time } from '../utils/time.js';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
 
@@ -29,8 +27,7 @@ type GuardedSubscriptionHandler = {
 };
 
 type DeliveryStepDwnErrorOutcome =
-  | { kind: 'hidden' }
-  | { kind: 'terminal'; code: DwnErrorCode; detail: string };
+  { kind: 'terminal'; code: DwnErrorCode; detail: string };
 
 type DeliveryStepResult<T> =
   | { kind: 'ok'; value: T }
@@ -76,7 +73,6 @@ export class MessagesSubscribeHandler implements MethodHandler {
       deps: this.deps,
       messagesSubscribe,
       subscriptionHandler,
-      tenant,
     });
 
     const { filters, cursor: eventLogCursor } = message.descriptor;
@@ -134,9 +130,8 @@ export class MessagesSubscribeHandler implements MethodHandler {
     deps: HandlerDependencies;
     messagesSubscribe: MessagesSubscribe;
     subscriptionHandler: SubscriptionListener;
-    tenant: string;
   }): GuardedSubscriptionHandler {
-    const { authorization, deps, messagesSubscribe, subscriptionHandler, tenant } = input;
+    const { authorization, deps, messagesSubscribe, subscriptionHandler } = input;
     if (authorization.kind === 'owner') {
       return {
         listener        : subscriptionHandler,
@@ -180,10 +175,6 @@ export class MessagesSubscribeHandler implements MethodHandler {
         return true;
       }
 
-      if (result.kind === 'hidden') {
-        return false;
-      }
-
       emitTerminalDeliveryError(cursor, result.code, result.detail);
       closeSubscription();
       return false;
@@ -214,24 +205,6 @@ export class MessagesSubscribeHandler implements MethodHandler {
         },
       });
       if (!applyDeliveryStepResult(authorizationResult, subMessage.cursor)) {
-        return;
-      }
-
-      const visibilityResult = await MessagesSubscribeHandler.evaluateDeliveryStep({
-        step: async (): Promise<boolean> => MessagesSubscribeHandler.canDeliverEvent({
-          tenant,
-          authorization,
-          deps,
-          messagesSubscribe,
-          subMessage,
-        }),
-        dwnErrorOutcome: { kind: 'hidden' },
-      });
-      if (!applyDeliveryStepResult(visibilityResult, subMessage.cursor)) {
-        return;
-      }
-
-      if (!visibilityResult.value) {
         return;
       }
 
@@ -291,29 +264,5 @@ export class MessagesSubscribeHandler implements MethodHandler {
         detail : 'subscription delivery failed',
       };
     }
-  }
-
-  private static async canDeliverEvent(input: {
-    tenant: string;
-    authorization: Extract<MessagesSubscribeAuthorization, { kind: 'delegate' }>;
-    deps: HandlerDependencies;
-    messagesSubscribe: MessagesSubscribe;
-    subMessage: SubscriptionEvent;
-  }): Promise<boolean> {
-    const { authorization, deps, messagesSubscribe, subMessage, tenant } = input;
-    const { message } = subMessage.event;
-    if (!Records.isRecordsWrite(message) || !EncryptionControl.isControlMessage(message)) {
-      return true;
-    }
-
-    const visibleRecordsWrites = await EncryptionControl.filterVisibleControlRecords({
-      tenant,
-      incomingMessage       : messagesSubscribe.message,
-      permissionGrants      : authorization.permissionGrants,
-      requester             : authorization.expectedGrantee,
-      recordsWriteMessages  : [message],
-      validationStateReader : deps.validationStateReader,
-    });
-    return visibleRecordsWrites.length === 1;
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/messages-subscribe.ts
@@ -26,13 +26,6 @@ type GuardedSubscriptionHandler = {
   setSubscription(subscription: EventSubscription): Promise<void>;
 };
 
-type DeliveryStepDwnErrorOutcome =
-  { kind: 'terminal'; code: DwnErrorCode; detail: string };
-
-type DeliveryStepResult<T> =
-  | { kind: 'ok'; value: T }
-  | DeliveryStepDwnErrorOutcome;
-
 export class MessagesSubscribeHandler implements MethodHandler {
 
   constructor(private readonly deps: HandlerDependencies) {}
@@ -167,19 +160,6 @@ export class MessagesSubscribeHandler implements MethodHandler {
       });
     };
 
-    const applyDeliveryStepResult = <T>(
-      result: DeliveryStepResult<T>,
-      cursor: SubscriptionEvent['cursor']
-    ): result is { kind: 'ok'; value: T } => {
-      if (result.kind === 'ok') {
-        return true;
-      }
-
-      emitTerminalDeliveryError(cursor, result.code, result.detail);
-      closeSubscription();
-      return false;
-    };
-
     // Deliberately do not cache delivery authorization here. Subscribe-open
     // authorization validates static grant shape and filter scope; this per-event
     // check revalidates dynamic grant state so expiry or revocation stops delivery
@@ -187,24 +167,30 @@ export class MessagesSubscribeHandler implements MethodHandler {
     // split static and dynamic checks explicitly and document any bounded staleness
     // introduced by caching revocation lookups.
     const authorizeAndDeliverEvent = async (subMessage: SubscriptionEvent): Promise<void> => {
-      const authorizationResult = await MessagesSubscribeHandler.evaluateDeliveryStep({
-        step: async (): Promise<void> => {
-          await MessagesGrantAuthorization.authorizeSubscribeDelivery({
-            messagesSubscribeMessage : messagesSubscribe.message,
-            expectedGrantor          : authorization.expectedGrantor,
-            expectedGrantee          : authorization.expectedGrantee,
-            permissionGrants         : authorization.permissionGrants,
-            validationStateReader    : deps.validationStateReader,
-            deliveryTimestamp        : Time.getCurrentTimestamp(),
-          });
-        },
-        dwnErrorOutcome: {
-          kind   : 'terminal',
-          code   : DwnErrorCode.MessagesSubscribeDeliveryAuthorizationFailed,
-          detail : 'subscription authorization failed during delivery',
-        },
-      });
-      if (!applyDeliveryStepResult(authorizationResult, subMessage.cursor)) {
+      try {
+        await MessagesGrantAuthorization.authorizeSubscribeDelivery({
+          messagesSubscribeMessage : messagesSubscribe.message,
+          expectedGrantor          : authorization.expectedGrantor,
+          expectedGrantee          : authorization.expectedGrantee,
+          permissionGrants         : authorization.permissionGrants,
+          validationStateReader    : deps.validationStateReader,
+          deliveryTimestamp        : Time.getCurrentTimestamp(),
+        });
+      } catch (error) {
+        if (error instanceof DwnError) {
+          emitTerminalDeliveryError(
+            subMessage.cursor,
+            DwnErrorCode.MessagesSubscribeDeliveryAuthorizationFailed,
+            'subscription authorization failed during delivery',
+          );
+        } else {
+          emitTerminalDeliveryError(
+            subMessage.cursor,
+            DwnErrorCode.MessagesSubscribeDeliveryFailed,
+            'subscription delivery failed',
+          );
+        }
+        closeSubscription();
         return;
       }
 
@@ -245,24 +231,5 @@ export class MessagesSubscribeHandler implements MethodHandler {
         }
       },
     };
-  }
-
-  private static async evaluateDeliveryStep<T>(input: {
-    dwnErrorOutcome: DeliveryStepDwnErrorOutcome;
-    step: () => Promise<T>;
-  }): Promise<DeliveryStepResult<T>> {
-    try {
-      return { kind: 'ok', value: await input.step() };
-    } catch (error) {
-      if (error instanceof DwnError) {
-        return input.dwnErrorOutcome;
-      }
-
-      return {
-        kind   : 'terminal',
-        code   : DwnErrorCode.MessagesSubscribeDeliveryFailed,
-        detail : 'subscription delivery failed',
-      };
-    }
   }
 }

--- a/packages/dwn-sdk-js/src/handlers/records-count.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-count.ts
@@ -29,7 +29,7 @@ export class RecordsCountHandler implements MethodHandler {
     }
 
     let count: number;
-    const requester = EncryptionControl.getRequester(recordsCount.message);
+    const requester = Message.getRequester(recordsCount.message);
 
     // if this is an anonymous count and the filter supports published records, count only published records
     if (Records.filterIncludesPublishedRecords(recordsCount.message.descriptor.filter) && recordsCount.author === undefined) {

--- a/packages/dwn-sdk-js/src/handlers/records-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-query.ts
@@ -34,7 +34,7 @@ export class RecordsQueryHandler implements MethodHandler {
 
     let recordsWrites: RecordsQueryReplyEntry[];
     let cursor: PaginationCursor | undefined;
-    const requester = EncryptionControl.getRequester(recordsQuery.message);
+    const requester = Message.getRequester(recordsQuery.message);
     // if this is an anonymous query and the filter supports published records, query only published records
     if (Records.filterIncludesPublishedRecords(recordsQuery.message.descriptor.filter) && recordsQuery.author === undefined) {
       const results = await this.fetchPublishedRecords(tenant, recordsQuery, requester);

--- a/packages/dwn-sdk-js/src/handlers/records-read.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-read.ts
@@ -189,7 +189,7 @@ export class RecordsReadHandler implements MethodHandler {
       await EncryptionControl.authorizeRead({
         tenant,
         incomingMessage       : recordsRead.message,
-        requester             : EncryptionControl.getRequester(recordsRead.message),
+        requester             : Message.getRequester(recordsRead.message),
         recordsWriteMessage   : matchedRecordsWrite.message,
         validationStateReader : deps.validationStateReader,
       });

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -53,7 +53,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
 
     let eventFilters: Filter[] = [];
     let queryFilters: Filter[] = [];
-    const requester = EncryptionControl.getRequester(recordsSubscribe.message);
+    const requester = Message.getRequester(recordsSubscribe.message);
 
     // if this is an anonymous subscribe and the filter supports published records, subscribe to only published records
     if (Records.filterIncludesPublishedRecords(recordsSubscribe.message.descriptor.filter) && recordsSubscribe.author === undefined) {
@@ -200,7 +200,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
     tenant: string;
   }): ProjectedRecordsSubscriptionHandler {
     const { deps, recordsSubscribe, subscriptionHandler, tenant } = input;
-    const requester = EncryptionControl.getRequester(recordsSubscribe.message);
+    const requester = Message.getRequester(recordsSubscribe.message);
     let subscription: EventSubscription | undefined;
     let closeRequested = false;
     let terminalErrorEmitted = false;

--- a/packages/dwn-sdk-js/tests/core/message.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/message.spec.ts
@@ -98,6 +98,43 @@ describe('Message', () => {
     });
   });
 
+  describe('getRequester()', () => {
+    it('should return the signer for delegated messages and author for direct messages', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const deviceX = await TestDataGenerator.generatePersona();
+      const scope: PermissionScope = {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Write,
+        protocol  : 'https://example.com/protocol/test',
+      };
+      const delegatedGrant = await PermissionsProtocol.createGrant({
+        delegated   : true,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 100 }),
+        grantedTo   : deviceX.did,
+        scope,
+        signer      : Jws.createSigner(alice),
+      });
+      const delegatedWrite = await RecordsWrite.create({
+        signer         : Jws.createSigner(deviceX),
+        delegatedGrant : delegatedGrant.dataEncodedMessage,
+        protocol       : 'https://example.com/protocol/test',
+        protocolPath   : 'test/path',
+        dataFormat     : 'application/json',
+        data           : TestDataGenerator.randomBytes(32),
+      });
+      const directWrite = await TestDataGenerator.generateRecordsWrite({ author: alice });
+      const unsignedRead = await RecordsRead.create({
+        filter: {
+          recordId: await TestDataGenerator.randomCborSha256Cid()
+        }
+      });
+
+      expect(Message.getRequester(delegatedWrite.message)).toBe(deviceX.did);
+      expect(Message.getRequester(directWrite.message)).toBe(alice.did);
+      expect(Message.getRequester(unsignedRead.message)).toBeUndefined();
+    });
+  });
+
   describe('toJSON()', () => {
     it('should return the message passed in to the constructor', async () => {
       // create a message without `authorization`

--- a/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
@@ -25,15 +25,6 @@ function getFeedReader(messageStore: MessageStore): ReplicationFeedReader | unde
   }
 }
 
-async function fingerprintFromCids(messageCids: string[]): Promise<string> {
-  let fingerprint = Replication.emptyFingerprint();
-  for (const messageCid of messageCids) {
-    fingerprint = Replication.xorFingerprint(fingerprint, await Replication.hashMessageCid(messageCid));
-  }
-
-  return Replication.fingerprintToHex(fingerprint);
-}
-
 export function testMessagesQueryHandler(): void {
   describe('MessagesQueryHandler.handle()', () => {
     let didResolver: DidResolver;
@@ -341,7 +332,7 @@ export function testMessagesQueryHandler(): void {
       ].sort());
     });
 
-    it('filters hidden delivery control events without shrinking limited MessagesQuery pages', async () => {
+    it('transports delivery control events and accumulator fingerprints for delegated MessagesQuery', async () => {
       const feedReader = getFeedReader(messageStore);
       if (feedReader === undefined) {
         return;
@@ -424,10 +415,10 @@ export function testMessagesQueryHandler(): void {
         cidsOnly           : true,
       });
       const reply = await dwn.processMessage(alice.did, query);
+      const deliveryCid = await Message.getCid(delivery.recordsWrite.message);
 
       expect(reply.status.code).toBe(200);
-      expect(reply.entries?.map(entry => entry.messageCid)).toEqual([await Message.getCid(record.message)]);
-      expect(reply.entries?.map(entry => entry.messageCid)).not.toContain(await Message.getCid(delivery.recordsWrite.message));
+      expect(reply.entries?.map(entry => entry.messageCid)).toEqual([deliveryCid]);
 
       const { message: fullQuery } = await TestDataGenerator.generateMessagesQuery({
         author             : carol,
@@ -446,9 +437,17 @@ export function testMessagesQueryHandler(): void {
       expect(fullReply.status.code).toBe(200);
       expect(fullReply.drained).toBe(true);
       expect(fullReplyCids).toContain(await Message.getCid(audience.recordsWrite.message));
-      expect(fullReplyCids).not.toContain(await Message.getCid(delivery.recordsWrite.message));
-      expect(fullReply.fingerprint).toBe(await fingerprintFromCids(fullReplyCids));
-      expect(fullReply.fingerprint).not.toBe(rawFingerprint);
+      expect(fullReplyCids).toContain(deliveryCid);
+      expect(fullReply.fingerprint).toBe(rawFingerprint);
+
+      const { message: ownerQuery } = await TestDataGenerator.generateMessagesQuery({
+        author   : alice,
+        filters  : [{ protocol: protocolDefinition.protocol }],
+        cidsOnly : true,
+      });
+      const ownerReply = await dwn.processMessage(alice.did, ownerQuery);
+      expect(ownerReply.status.code).toBe(200);
+      expect(fullReply.fingerprint).toBe(ownerReply.fingerprint);
     });
 
     it('rejects unfiltered delegated queries with a protocol-scoped grant', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
@@ -25,6 +25,15 @@ function getFeedReader(messageStore: MessageStore): ReplicationFeedReader | unde
   }
 }
 
+async function fingerprintFromCids(messageCids: string[]): Promise<string> {
+  let fingerprint = Replication.emptyFingerprint();
+  for (const messageCid of messageCids) {
+    fingerprint = Replication.xorFingerprint(fingerprint, await Replication.hashMessageCid(messageCid));
+  }
+
+  return Replication.fingerprintToHex(fingerprint);
+}
+
 export function testMessagesQueryHandler(): void {
   describe('MessagesQueryHandler.handle()', () => {
     let didResolver: DidResolver;
@@ -438,6 +447,7 @@ export function testMessagesQueryHandler(): void {
       expect(fullReply.drained).toBe(true);
       expect(fullReplyCids).toContain(await Message.getCid(audience.recordsWrite.message));
       expect(fullReplyCids).toContain(deliveryCid);
+      expect(fullReply.fingerprint).toBe(await fingerprintFromCids(fullReplyCids));
       expect(fullReply.fingerprint).toBe(rawFingerprint);
 
       const { message: ownerQuery } = await TestDataGenerator.generateMessagesQuery({

--- a/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
@@ -346,7 +346,7 @@ export function testMessagesReadHandler(): void {
     });
 
     describe('with a grant', () => {
-      it('enforces delivery control visibility for MessagesRead grants', async () => {
+      it('transports delivery control records for MessagesRead grants', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
         const bob = await TestDataGenerator.generateDidKeyPersona();
         const carol = await TestDataGenerator.generateDidKeyPersona();
@@ -443,8 +443,8 @@ export function testMessagesReadHandler(): void {
           permissionGrantIds : [carolGrant.message.recordId],
         });
         const carolReply = await dwn.processMessage(alice.did, carolRead.message);
-        expect(carolReply.status.code).toBe(401);
-        expect(carolReply.status.detail).toContain(DwnErrorCode.MessagesReadVerifyScopeFailed);
+        expect(carolReply.status.code).toBe(200);
+        expect(carolReply.entry?.messageCid).toBe(deliveryCid);
       });
 
       it('returns a 401 if grant has different DWN interface scope', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -11,7 +11,6 @@ import sinon from 'sinon';
 import { Dwn } from '../../src/dwn.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Encoder } from '../../src/utils/encoder.js';
-import { EncryptionControl } from '../../src/core/encryption-control.js';
 import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import { Jws } from '../../src/utils/jws.js';
 import { Message } from '../../src/core/message.js';
@@ -434,7 +433,7 @@ export function testMessagesSubscribeHandler(): void {
           });
         });
 
-        it('filters delivery control events that are not addressed to the subscriber', async () => {
+        it('delivers control record envelopes to delegated MessagesSubscribe streams', async () => {
           const alice = await TestDataGenerator.generateDidKeyPersona();
           const bob = await TestDataGenerator.generateDidKeyPersona();
           const carol = await TestDataGenerator.generateDidKeyPersona();
@@ -524,25 +523,9 @@ export function testMessagesSubscribeHandler(): void {
 
           await Poller.pollUntilSuccessOrTimeout(async () => {
             expect(messageCids).toContain(recordCid);
+            expect(messageCids).toContain(deliveryCid);
           });
-          expect(messageCids).not.toContain(deliveryCid);
-
-          sinon.stub(EncryptionControl, 'filterVisibleControlRecords').rejects(new Error('visibility check failed'));
-          const failedDelivery = await createDeliveryControlWrite({
-            author             : alice,
-            keyId              : audience.keyId,
-            protocol           : protocolDefinition.protocol,
-            recipient          : bob.did,
-            recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleHolder,
-            rolePath           : 'member',
-            roleRuleSet,
-          });
-          await processControlWrite(dwn, alice.did, failedDelivery);
-
-          await Poller.pollUntilSuccessOrTimeout(async () => {
-            const errorMessage = received.find(msg => msg.type === 'error');
-            expect(errorMessage?.error.code).toBe(DwnErrorCode.MessagesSubscribeDeliveryFailed);
-          });
+          expect(received.every(msg => msg.type !== 'error')).toBe(true);
         });
 
         it('rejects subscribe of messages with mismatching interface grant scope', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -946,6 +946,7 @@ export function testMessagesSubscribeHandler(): void {
             });
             await Time.minimalSleep();
             expect(received.filter(msg => msg.type === 'error').length).toBe(1);
+            expect(received.find(msg => msg.type === 'error')?.error.code).toBe(DwnErrorCode.MessagesSubscribeDeliveryFailed);
             expect(received.filter(msg => msg.type === 'event').length).toBe(0);
           });
 


### PR DESCRIPTION
Summary
- Remove Messages-surface encryption-control visibility filtering so MessagesRead/Query/Subscribe transport in-scope encrypted control envelopes.
- Keep Records-surface control visibility enforcement unchanged.
- Update Messages handler tests to assert delegated transport of audience and delivery control records plus matching accumulator fingerprints.

Test plan
- [x] bun run --filter @enbox/dwn-sdk-js lint
- [x] bun run lint
- [x] bun run --filter @enbox/dwn-sdk-js build
- [x] packages/dwn-sdk-js: GREP="MessagesQueryHandler.handle|MessagesReadHandler.handle|MessagesSubscribe.handle" bun run test:node-grep
- [x] packages/dwn-sdk-js: GREP="RecordsReadHandler.handle|RecordsQueryHandler.handle|RecordsCountHandler.handle|RecordsSubscribe.handle" bun run test:node-grep
- [x] packages/dwn-sdk-js: bun run test:node
- [x] packages/agent: bun test tests/sync-feed-convergence.spec.ts
- [x] packages/agent: bun test tests/sync-engine-level.spec.ts
- [x] packages/agent: bun run test:node with local DWN server rate limits disabled

Notes
- Messages grants authorize source-protocol control records by their literal `$encryption/*` transport path. Product connect flows issue protocol-scoped Messages grants, so rolePath-scoped control-message reads are intentionally not a product path.
- The default local server rate limits caused full-suite live-sync flakes via RateLimitExceeded. Rerunning with DWN_RATE_LIMIT_REQUESTS_PER_SECOND=0 and DWN_RATE_LIMIT_TENANT_REQUESTS_PER_SECOND=0 passed the full agent suite.
