### PR TITLE
chore(deps): replace ms duration parsing

### DIFF
--- a/.changeset/remove-ms-duration-parser.md
+++ b/.changeset/remove-ms-duration-parser.md
@@ -1,0 +1,8 @@
+---
+"@enbox/common": patch
+"@enbox/agent": patch
+"@enbox/dids": patch
+"@enbox/dwn-clients": patch
+---
+
+chore: replace direct ms usage with a shared duration parser.

--- a/bun.lock
+++ b/bun.lock
@@ -62,10 +62,8 @@
         "@scure/bip39": "2.2.0",
         "abstract-level": "1.0.4",
         "level": "8.0.1",
-        "ms": "2.1.3",
       },
       "devDependencies": {
-        "@types/ms": "0.7.34",
         "@types/node": "22.19.15",
         "@types/sinon": "17.0.3",
         "@typescript-eslint/eslint-plugin": "8.32.1",
@@ -197,11 +195,9 @@
         "abstract-level": "1.0.4",
         "bencode": "4.0.0",
         "level": "8.0.1",
-        "ms": "2.1.3",
       },
       "devDependencies": {
         "@types/bencode": "2.0.4",
-        "@types/ms": "0.7.34",
         "@types/node": "22.19.15",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
@@ -220,10 +216,8 @@
         "@enbox/common": "workspace:*",
         "@enbox/crypto": "workspace:*",
         "@enbox/dwn-sdk-js": "workspace:*",
-        "ms": "2.1.3",
       },
       "devDependencies": {
-        "@types/ms": "0.7.34",
         "@types/node": "22.19.15",
         "@types/sinon": "17.0.3",
         "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -80,11 +80,9 @@
     "@noble/curves": "2.2.0",
     "@noble/hashes": "2.2.0",
     "abstract-level": "1.0.4",
-    "level": "8.0.1",
-    "ms": "2.1.3"
+    "level": "8.0.1"
   },
   "devDependencies": {
-    "@types/ms": "0.7.34",
     "@types/node": "22.19.15",
     "@types/sinon": "17.0.3",
     "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/packages/agent/src/store-data.ts
+++ b/packages/agent/src/store-data.ts
@@ -1,13 +1,11 @@
 import type { Jwk } from '@enbox/crypto';
-
-import ms from 'ms';
-import { Convert, Stream, TtlCache } from '@enbox/common';
-
-import type { DwnMessageParams } from './types/dwn.js';
-import type { EnboxPlatformAgent } from './types/agent.js';
 import type { ProtocolDefinition, RecordsReadReplyEntry } from '@enbox/dwn-sdk-js';
 
 import { Protocols } from '@enbox/dwn-sdk-js';
+import { Convert, parseDurationInMilliseconds, Stream, TtlCache } from '@enbox/common';
+
+import type { DwnMessageParams } from './types/dwn.js';
+import type { EnboxPlatformAgent } from './types/agent.js';
 
 import { DwnInterface } from './types/dwn.js';
 import { getDataStoreTenant, TENANT_SEPARATOR } from './utils-internal.js';
@@ -54,7 +52,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
      *
      * Up to 100 entries are retained for 15 minutes.
      */
-  protected _cache = new TtlCache<string, TStoreObject>({ ttl: ms('15 minutes'), max: 100 });
+  protected _cache = new TtlCache<string, TStoreObject>({ ttl: parseDurationInMilliseconds('15 minutes'), max: 100 });
 
   /**
    * Index for mappings from Store Identifier to DWN record ID.
@@ -63,7 +61,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
    * Up to 1,000 entries are retained for 21 days.
    * NOTE: The maximum number for the ttl is 2^31 - 1 milliseconds (24.8 days), setting to 21 days to be safe.
    */
-  protected _index = new TtlCache<string, string>({ ttl: ms('21 days'), max: 1000 });
+  protected _index = new TtlCache<string, string>({ ttl: parseDurationInMilliseconds('21 days'), max: 1000 });
 
   /**
    * Cache of tenant DIDs that have been initialized with the protocol.
@@ -76,7 +74,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
    * together — otherwise `initialize()` could return early while the
    * encryption state is stale.
    */
-  protected _protocolInitializedCache: TtlCache<string, boolean> = new TtlCache({ ttl: ms('1 hour'), max: 1000 });
+  protected _protocolInitializedCache: TtlCache<string, boolean> = new TtlCache({ ttl: parseDurationInMilliseconds('1 hour'), max: 1000 });
 
   /**
    * The protocol assigned to this storage instance.
@@ -93,7 +91,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
    * Uses the same 1-hour TTL as `_protocolInitializedCache` so both
    * caches expire and re-derive together. See comment above.
    */
-  private readonly _tenantEncryptionActive: TtlCache<string, boolean> = new TtlCache({ ttl: ms('1 hour'), max: 1000 });
+  private readonly _tenantEncryptionActive: TtlCache<string, boolean> = new TtlCache({ ttl: parseDurationInMilliseconds('1 hour'), max: 1000 });
 
   /** Cached result of the `encryptionRequired` check on the protocol definition.
    *  Computed lazily on first access — the definition is immutable after assignment. */

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -3,11 +3,9 @@ import type { AbstractLevel } from 'abstract-level';
 import type { DwnSubscriptionHandler, ResubscribeFactory } from '@enbox/dwn-clients';
 import type { GenericMessage, MessageEvent, MessagesFilter, MessagesQueryReply, MessagesQueryReplyEntry, MessagesSubscribeReply, ProgressToken, ProtocolDefinition, RecordsQueryReply, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
-import ms from 'ms';
-
 import { Level } from 'level';
-import { sleep } from '@enbox/common';
 import { DwnInterfaceName, DwnMethodName, Encoder, Message } from '@enbox/dwn-sdk-js';
+import { parseDurationInMilliseconds, sleep } from '@enbox/common';
 
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
@@ -1130,7 +1128,7 @@ export class SyncEngineLevel implements SyncEngine {
   public async startSync(params: StartSyncParams): Promise<void> {
     const mode = params.mode ?? 'poll';
     const intervalStr = params.interval ?? (mode === 'live' ? '5m' : '2m');
-    const intervalMilliseconds = ms(intervalStr);
+    const intervalMilliseconds = parseDurationInMilliseconds(intervalStr);
 
     // Tear down previous mode if there are active live resources.
     if (this._liveSubscriptions.length > 0 || this._localSubscriptions.length > 0) {

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -354,7 +354,7 @@ export type StartSyncParams = {
 
   /**
    * The interval at which the sync operation should be performed.
-   * Accepts any value recognised by `ms()`, e.g. `'30s'`, `'2m'`, `'10m'`.
+   * Accepts duration strings such as `'30s'`, `'2m'`, `'10m'`, or `'1 hour'`.
    *
    * In `'live'` mode this controls the frequency of the durable feed settle check.
    * In `'poll'` mode this controls the polling frequency.

--- a/packages/common/src/time.ts
+++ b/packages/common/src/time.ts
@@ -11,6 +11,40 @@ export type TimedOptions = {
   log?: (message: string) => void;
 };
 
+const durationUnitMultipliers = new Map<string, number>([
+  ['ms', 1],
+  ['msec', 1],
+  ['msecs', 1],
+  ['millisecond', 1],
+  ['milliseconds', 1],
+  ['s', 1000],
+  ['sec', 1000],
+  ['secs', 1000],
+  ['second', 1000],
+  ['seconds', 1000],
+  ['m', 60 * 1000],
+  ['min', 60 * 1000],
+  ['mins', 60 * 1000],
+  ['minute', 60 * 1000],
+  ['minutes', 60 * 1000],
+  ['h', 60 * 60 * 1000],
+  ['hr', 60 * 60 * 1000],
+  ['hrs', 60 * 60 * 1000],
+  ['hour', 60 * 60 * 1000],
+  ['hours', 60 * 60 * 1000],
+  ['d', 24 * 60 * 60 * 1000],
+  ['day', 24 * 60 * 60 * 1000],
+  ['days', 24 * 60 * 60 * 1000],
+  ['w', 7 * 24 * 60 * 60 * 1000],
+  ['week', 7 * 24 * 60 * 60 * 1000],
+  ['weeks', 7 * 24 * 60 * 60 * 1000],
+  ['y', 365.25 * 24 * 60 * 60 * 1000],
+  ['yr', 365.25 * 24 * 60 * 60 * 1000],
+  ['yrs', 365.25 * 24 * 60 * 60 * 1000],
+  ['year', 365.25 * 24 * 60 * 60 * 1000],
+  ['years', 365.25 * 24 * 60 * 60 * 1000],
+]);
+
 /**
  * Returns a high-resolution monotonic timestamp in milliseconds.
  *
@@ -24,6 +58,36 @@ export function nowMs(): number {
   }
 
   return Date.now();
+}
+
+/**
+ * Parses a human-readable duration string into milliseconds.
+ *
+ * Accepted units: milliseconds (`ms`), seconds (`s`), minutes (`m`), hours (`h`),
+ * days (`d`), weeks (`w`), and years (`y`), including their common long-form
+ * aliases such as `minutes` and `hours`. A bare numeric string is treated as
+ * milliseconds.
+ *
+ * @throws Error if the input is empty, negative, non-finite, or uses an unknown unit.
+ */
+export function parseDurationInMilliseconds(duration: string): number {
+  const match = /^((?:\d+|\d*\.\d+))\s*([a-zA-Z]+)?$/.exec(duration.trim());
+  if (match === null) {
+    throw new Error(`Invalid duration: '${duration}'`);
+  }
+
+  const durationUnit = match[2]?.toLowerCase() ?? 'ms';
+  const multiplier = durationUnitMultipliers.get(durationUnit);
+  if (multiplier === undefined) {
+    throw new Error(`Invalid duration unit: '${durationUnit}'`);
+  }
+
+  const durationInMilliseconds = Number(match[1]) * multiplier;
+  if (!Number.isFinite(durationInMilliseconds)) {
+    throw new Error(`Invalid duration: '${duration}'`);
+  }
+
+  return durationInMilliseconds;
 }
 
 /**

--- a/packages/common/tests/time.test.ts
+++ b/packages/common/tests/time.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it } from 'bun:test';
 
-import { nowMs, sleep, timed } from '../src/time.js';
+import { nowMs, parseDurationInMilliseconds, sleep, timed } from '../src/time.js';
+
+describe('parseDurationInMilliseconds', () => {
+  it('parses existing default duration strings', () => {
+    expect(parseDurationInMilliseconds('15m')).toBe(15 * 60 * 1000);
+    expect(parseDurationInMilliseconds('15 minutes')).toBe(15 * 60 * 1000);
+    expect(parseDurationInMilliseconds('21 days')).toBe(21 * 24 * 60 * 60 * 1000);
+    expect(parseDurationInMilliseconds('1 hour')).toBe(60 * 60 * 1000);
+    expect(parseDurationInMilliseconds('2m')).toBe(2 * 60 * 1000);
+    expect(parseDurationInMilliseconds('5m')).toBe(5 * 60 * 1000);
+  });
+
+  it('parses supported short and long units', () => {
+    expect(parseDurationInMilliseconds('250')).toBe(250);
+    expect(parseDurationInMilliseconds('250ms')).toBe(250);
+    expect(parseDurationInMilliseconds('30s')).toBe(30 * 1000);
+    expect(parseDurationInMilliseconds('1.5 hours')).toBe(90 * 60 * 1000);
+    expect(parseDurationInMilliseconds('2 weeks')).toBe(14 * 24 * 60 * 60 * 1000);
+    expect(parseDurationInMilliseconds('1 year')).toBe(365.25 * 24 * 60 * 60 * 1000);
+  });
+
+  it('rejects invalid duration strings', () => {
+    expect(() => parseDurationInMilliseconds('')).toThrow('Invalid duration');
+    expect(() => parseDurationInMilliseconds('-1s')).toThrow('Invalid duration');
+    expect(() => parseDurationInMilliseconds('1 month')).toThrow('Invalid duration unit');
+    expect(() => parseDurationInMilliseconds('abc')).toThrow('Invalid duration');
+    expect(() => parseDurationInMilliseconds('1 second later')).toThrow('Invalid duration');
+  });
+});
 
 describe('sleep', () => {
   it('returns a Promise that resolves after at least the given duration', async () => {

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -82,12 +82,10 @@
     "@enbox/crypto": "workspace:*",
     "abstract-level": "1.0.4",
     "bencode": "4.0.0",
-    "level": "8.0.1",
-    "ms": "2.1.3"
+    "level": "8.0.1"
   },
   "devDependencies": {
     "@types/bencode": "2.0.4",
-    "@types/ms": "0.7.34",
     "@types/node": "22.19.15",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",

--- a/packages/dids/src/resolver/resolver-cache-level.ts
+++ b/packages/dids/src/resolver/resolver-cache-level.ts
@@ -1,7 +1,7 @@
 import type { AbstractLevel } from 'abstract-level';
 
 import { Level } from 'level';
-import ms from 'ms';
+import { parseDurationInMilliseconds } from '@enbox/common';
 
 import type { DidResolutionResult } from '../types/did-core.js';
 import type { DidResolverCache } from '../types/did-resolution.js';
@@ -84,7 +84,7 @@ export class DidResolverCacheLevel implements DidResolverCache {
     ttl = '15m'
   }: DidResolverCacheLevelParams = {}) {
     this.cache = db ?? new Level<string, string>(location);
-    this.ttl = ms(ttl);
+    this.ttl = parseDurationInMilliseconds(ttl);
   }
 
   /**

--- a/packages/dids/src/resolver/resolver-cache-memory.ts
+++ b/packages/dids/src/resolver/resolver-cache-memory.ts
@@ -1,5 +1,4 @@
-import ms from 'ms';
-import { TtlCache } from '@enbox/common';
+import { parseDurationInMilliseconds, TtlCache } from '@enbox/common';
 
 import type { DidResolutionResult } from '../types/did-core.js';
 import type { DidResolverCache } from '../types/did-resolution.js';
@@ -23,7 +22,7 @@ export class DidResolverCacheMemory implements DidResolverCache {
   private readonly cache: TtlCache<string, DidResolutionResult>;
 
   constructor({ ttl = '15m' }: DidResolverCacheMemoryParams = {}) {
-    this.cache = new TtlCache({ ttl: ms(ttl) });
+    this.cache = new TtlCache({ ttl: parseDurationInMilliseconds(ttl) });
   }
 
   /**

--- a/packages/dwn-clients/package.json
+++ b/packages/dwn-clients/package.json
@@ -48,11 +48,9 @@
   "dependencies": {
     "@enbox/common": "workspace:*",
     "@enbox/crypto": "workspace:*",
-    "@enbox/dwn-sdk-js": "workspace:*",
-    "ms": "2.1.3"
+    "@enbox/dwn-sdk-js": "workspace:*"
   },
   "devDependencies": {
-    "@types/ms": "0.7.34",
     "@types/node": "22.19.15",
     "@types/sinon": "17.0.3",
     "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/packages/dwn-clients/src/dwn-server-info-cache-memory.ts
+++ b/packages/dwn-clients/src/dwn-server-info-cache-memory.ts
@@ -1,6 +1,4 @@
-
-import ms from 'ms';
-import { TtlCache } from '@enbox/common';
+import { parseDurationInMilliseconds, TtlCache } from '@enbox/common';
 
 import type { DwnServerInfoCache, ServerInfo } from './server-info-types.js';
 
@@ -23,7 +21,7 @@ export class DwnServerInfoCacheMemory implements DwnServerInfoCache {
   private readonly cache: TtlCache<string, ServerInfo>;
 
   constructor({ ttl = '15m' }: DwnServerInfoCacheMemoryParams= {}) {
-    this.cache = new TtlCache({ ttl: ms(ttl) });
+    this.cache = new TtlCache({ ttl: parseDurationInMilliseconds(ttl) });
   }
 
   /**


### PR DESCRIPTION
Summary
- Add a shared parseDurationInMilliseconds helper in @enbox/common.
- Replace direct ms usage in agent, dids, and dwn-clients.
- Remove direct ms and @types/ms package entries and add parser coverage.

Closes #1126

Test plan
- [x] bun run --filter @enbox/common test:node
- [x] bun run --filter @enbox/common build
- [x] bun run --filter @enbox/common lint
- [x] bun run lint
- [x] bun run build
- [x] bun run dev:ensure
- [x] bun run --filter @enbox/dids test:node
- [x] bun run --filter @enbox/dwn-clients test:node
- [x] bun run --filter @enbox/agent test:node
- [x] rg -n "from 'ms'|from \\\"ms\\\"|require\\(['\\\"]ms['\\\"]\\)|\\bms\\(" . --glob "!node_modules/**" --glob "!dist/**" --glob "!coverage/**"\n- [x] rg -n "\\\"[^\\\"]+\\\"\\s*:\\s*\\\"[\\^~]" --glob package.json .\n\nNote: dev:ensure started a server that exited after readiness on this machine, so dwn-clients and agent were verified with the DWN server held open directly in a foreground session.