### PR TITLE
feat(dwn-sdk-js): admit source role audience entries

### DIFF
--- a/.changeset/role-audience-admission.md
+++ b/.changeset/role-audience-admission.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+---
+
+feat: admit source-protocol role-audience encryption entries

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -27,6 +27,7 @@ import {
   Encryption,
   EncryptionProtocol,
   EventEmitterWakePublisher,
+  getRoleAudienceContextId,
   getRuleSetAtPath,
   KeyAgreementAlgorithm,
   KeyDerivationScheme,
@@ -787,7 +788,7 @@ export class AgentDwnApi {
       return;
     }
 
-    const contextId = this.getRoleAudienceContextIdForRecord(recordsWrite, descriptor.protocolPath);
+    const contextId = getRoleAudienceContextId(descriptor.protocolPath, recordsWrite.contextId);
     if (contextId === undefined) {
       throw new Error(`AgentDwnApi: Unable to determine role audience context for '${descriptor.protocolPath}'.`);
     }
@@ -878,51 +879,8 @@ export class AgentDwnApi {
       return undefined;
     }
 
-    const contextId = this.getRoleAudienceContextIdForWrite(role, parentContextId);
+    const contextId = getRoleAudienceContextId(role, parentContextId);
     return contextId === undefined ? undefined : { protocol, role, contextId };
-  }
-
-  private getRoleAudienceContextIdForRecord(
-    recordsWrite: RecordsWriteMessage,
-    rolePath: string,
-  ): string | undefined {
-    const parentDepth = rolePath.split('/').length - 1;
-    if (parentDepth === 0) {
-      return '';
-    }
-
-    const contextId = recordsWrite.contextId;
-    if (typeof contextId !== 'string') {
-      return undefined;
-    }
-
-    const contextSegments = contextId.split('/');
-    if (contextSegments.length < parentDepth) {
-      return undefined;
-    }
-
-    return contextSegments.slice(0, parentDepth).join('/');
-  }
-
-  private getRoleAudienceContextIdForWrite(
-    rolePath: string,
-    parentContextId: string | undefined,
-  ): string | undefined {
-    const parentDepth = rolePath.split('/').length - 1;
-    if (parentDepth === 0) {
-      return '';
-    }
-
-    if (parentContextId === undefined) {
-      return undefined;
-    }
-
-    const contextSegments = parentContextId.split('/');
-    if (contextSegments.length < parentDepth) {
-      return undefined;
-    }
-
-    return contextSegments.slice(0, parentDepth).join('/');
   }
 
   private async getOrCreateAudienceKey(params: {

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -33,6 +33,7 @@ import {
   Encryption,
   EncryptionProtocol,
   getGrantKeyDeliveryScopes,
+  getRoleAudienceContextId,
   grantKeyScopeCoversDeliveredScope,
   HdKey,
   isGrantKeyEligibleRecordsScope,
@@ -797,7 +798,7 @@ async function resolveRoleAudienceDecrypter(params: {
   } => entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME);
 
   for (const entry of roleAudienceEntries) {
-    const contextId = getRoleAudienceContextId(params.recordsWrite, entry.role);
+    const contextId = getRoleAudienceContextId(entry.role, params.recordsWrite.contextId);
     if (contextId === undefined) {
       continue;
     }
@@ -1342,27 +1343,6 @@ function getAudienceDecryptionKeyCacheKey(input: {
   ]))}`;
 }
 
-function getRoleAudienceContextId(
-  recordsWrite: RecordsWriteMessage,
-  rolePath: string,
-): string | undefined {
-  const parentDepth = rolePath.split('/').length - 1;
-  if (parentDepth === 0) {
-    return '';
-  }
-
-  const contextId = recordsWrite.contextId;
-  if (typeof contextId !== 'string') {
-    return undefined;
-  }
-
-  const contextSegments = contextId.split('/');
-  if (contextSegments.length < parentDepth) {
-    return undefined;
-  }
-
-  return contextSegments.slice(0, parentDepth).join('/');
-}
 
 function isGrantKeyEligibleGrant(grant: PermissionGrant): grant is PermissionGrant & {
   scope: GrantKeyEligibleRecordsScope;

--- a/packages/agent/src/sync-admission-order.ts
+++ b/packages/agent/src/sync-admission-order.ts
@@ -6,6 +6,7 @@ import {
   DwnMethodName,
   ENCRYPTION_CONTROL_AUDIENCE_PATH,
   EncryptionProtocol,
+  getRoleAudienceContextId,
   isCrossProtocolRef,
   Jws,
   Message,
@@ -290,24 +291,6 @@ function getInvokedRoleKey(
   }
 
   return getRoleKey(roleProtocol, roleProtocolPath, recipient, getRoleContextPrefix(roleProtocolPath, contextId));
-}
-
-function getRoleAudienceContextId(rolePath: string, contextId?: string): string | undefined {
-  const roleSegments = rolePath.split('/').length - 1;
-  if (roleSegments === 0) {
-    return '';
-  }
-
-  if (contextId === undefined) {
-    return undefined;
-  }
-
-  const contextSegments = contextId.split('/');
-  if (contextSegments.length < roleSegments) {
-    return undefined;
-  }
-
-  return contextSegments.slice(0, roleSegments).join('/');
 }
 
 function getSourceAudienceKeysFromEncryption(message: GenericMessage): string[] {

--- a/packages/agent/src/sync-admission-order.ts
+++ b/packages/agent/src/sync-admission-order.ts
@@ -1,7 +1,18 @@
 import type { GenericMessage, GenericSignaturePayload, ProtocolDefinition } from '@enbox/dwn-sdk-js';
 
 import { getInvokedPermissionGrantIds } from './sync-permission-grants.js';
-import { DwnInterfaceName, DwnMethodName, EncryptionProtocol, isCrossProtocolRef, Jws, Message, parseCrossProtocolRef, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+import {
+  DwnInterfaceName,
+  DwnMethodName,
+  ENCRYPTION_CONTROL_AUDIENCE_PATH,
+  EncryptionProtocol,
+  isCrossProtocolRef,
+  Jws,
+  Message,
+  parseCrossProtocolRef,
+  PermissionsProtocol,
+  ROLE_AUDIENCE_DERIVATION_SCHEME,
+} from '@enbox/dwn-sdk-js';
 
 type DescriptorWithRecordId = GenericMessage['descriptor'] & {
   recordId?: string;
@@ -28,6 +39,13 @@ type AudienceTags = {
   keyId: string;
 };
 
+type SourceAudienceTags = {
+  protocol: string;
+  contextId: string;
+  rolePath: string;
+  keyId: string;
+};
+
 type MessageDependencyGraph<T> = {
   sorted: T[];
   dependencies: Map<T, T[]>;
@@ -41,6 +59,7 @@ type DependencyIndexes<T> = {
   grantIndex: Map<string, number>;
   roleIndex: Map<string, number>;
   audienceEpochIndex: Map<string, number>;
+  sourceAudienceIndex: Map<string, number>;
 };
 
 type DependencyEdges = {
@@ -143,6 +162,15 @@ function getAudienceEpochKey(message: GenericMessage): string | undefined {
     : `${tags.protocol}|${tags.contextId}|${tags.role}|${tags.epoch}|${tags.keyId}`;
 }
 
+function getSourceAudienceKeyFromTags(tags: SourceAudienceTags): string {
+  return `${tags.protocol}|${tags.rolePath}|${tags.contextId}|${tags.keyId}`;
+}
+
+function getSourceAudienceKey(message: GenericMessage): string | undefined {
+  const tags = getSourceAudienceTags(message);
+  return tags === undefined ? undefined : getSourceAudienceKeyFromTags(tags);
+}
+
 function getAudienceRoleKey(message: GenericMessage): string | undefined {
   const tags = getAudienceTags(message);
   const recipient = (message.descriptor as RecordsDescriptor).recipient;
@@ -176,6 +204,30 @@ function getAudienceTags(message: GenericMessage): AudienceTags | undefined {
   }
 
   return { protocol, contextId, role, epoch, keyId };
+}
+
+function getSourceAudienceTags(message: GenericMessage): SourceAudienceTags | undefined {
+  const { descriptor } = message;
+  if (!isRecordsWriteDescriptor(descriptor) || descriptor.protocolPath !== ENCRYPTION_CONTROL_AUDIENCE_PATH) {
+    return undefined;
+  }
+
+  const tags = descriptor.tags;
+  if (!isRecordObject(tags)) {
+    return undefined;
+  }
+
+  const { protocol, contextId, rolePath, keyId } = tags;
+  if (
+    typeof protocol !== 'string' ||
+    typeof contextId !== 'string' ||
+    typeof rolePath !== 'string' ||
+    typeof keyId !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return { protocol, contextId, rolePath, keyId };
 }
 
 function getStringTag(message: GenericMessage, tag: string): string | undefined {
@@ -240,6 +292,61 @@ function getInvokedRoleKey(
   return getRoleKey(roleProtocol, roleProtocolPath, recipient, getRoleContextPrefix(roleProtocolPath, contextId));
 }
 
+function getRoleAudienceContextId(rolePath: string, contextId?: string): string | undefined {
+  const roleSegments = rolePath.split('/').length - 1;
+  if (roleSegments === 0) {
+    return '';
+  }
+
+  if (contextId === undefined) {
+    return undefined;
+  }
+
+  const contextSegments = contextId.split('/');
+  if (contextSegments.length < roleSegments) {
+    return undefined;
+  }
+
+  return contextSegments.slice(0, roleSegments).join('/');
+}
+
+function getSourceAudienceKeysFromEncryption(message: GenericMessage): string[] {
+  const keyEncryption = (message as {
+    encryption?: {
+      keyEncryption?: Record<string, unknown>[];
+    };
+  }).encryption?.keyEncryption;
+  if (!Array.isArray(keyEncryption)) {
+    return [];
+  }
+
+  const keys: string[] = [];
+  for (const entry of keyEncryption) {
+    if (
+      entry.derivationScheme !== ROLE_AUDIENCE_DERIVATION_SCHEME ||
+      typeof entry.protocol !== 'string' ||
+      typeof entry.rolePath !== 'string' ||
+      typeof entry.keyId !== 'string'
+    ) {
+      continue;
+    }
+
+    const contextId = getRoleAudienceContextId(entry.rolePath, getContextId(message));
+    if (contextId === undefined) {
+      continue;
+    }
+
+    keys.push(getSourceAudienceKeyFromTags({
+      protocol : entry.protocol,
+      rolePath : entry.rolePath,
+      contextId,
+      keyId    : entry.keyId,
+    }));
+  }
+
+  return keys;
+}
+
 /**
  * Builds a dependency graph from the fetched messages and returns them in
  * dependency order so that dependencies are processed before dependents.
@@ -286,6 +393,7 @@ function buildDependencyIndexes<T extends { message: GenericMessage }>(messages:
     grantIndex                    : new Map(),
     roleIndex                     : new Map(),
     audienceEpochIndex            : new Map(),
+    sourceAudienceIndex           : new Map(),
   };
 
   for (let i = 0; i < messages.length; i++) {
@@ -332,6 +440,11 @@ function indexRecordsWrite<T>(message: GenericMessage, index: number, indexes: D
   const audienceEpochKey = getAudienceEpochKey(message);
   if (desc.protocol === EncryptionProtocol.uri && desc.protocolPath === EncryptionProtocol.audienceEpochPath && audienceEpochKey !== undefined) {
     indexes.audienceEpochIndex.set(audienceEpochKey, index);
+  }
+
+  const sourceAudienceKey = getSourceAudienceKey(message);
+  if (sourceAudienceKey !== undefined) {
+    indexes.sourceAudienceIndex.set(sourceAudienceKey, index);
   }
 
   const roleKey = getRoleRecordKey(message);
@@ -402,6 +515,7 @@ function addDependencyEdgesForMessage<T>(
   addDeleteEdge(index, desc, indexes, addEdge);
   addPermissionGrantEdges(index, message, indexes, addEdge);
   addEncryptionProtocolEdges(index, message, indexes, addEdge);
+  addSourceAudienceEdges(index, message, indexes, addEdge);
   addRoleEdge(index, message, indexes, addEdge);
 }
 
@@ -551,6 +665,20 @@ function addRoleEdge<T>(
   const roleIndex = roleKey === undefined ? undefined : indexes.roleIndex.get(roleKey);
   if (roleIndex !== undefined) {
     addEdge(roleIndex, index);
+  }
+}
+
+function addSourceAudienceEdges<T>(
+  index: number,
+  message: GenericMessage,
+  indexes: DependencyIndexes<T>,
+  addEdge: AddDependencyEdge,
+): void {
+  for (const audienceKey of getSourceAudienceKeysFromEncryption(message)) {
+    const audienceIndex = indexes.sourceAudienceIndex.get(audienceKey);
+    if (audienceIndex !== undefined) {
+      addEdge(audienceIndex, index);
+    }
   }
 }
 

--- a/packages/agent/src/sync-admit-closure.ts
+++ b/packages/agent/src/sync-admit-closure.ts
@@ -2,6 +2,7 @@ import type {
   DependencyRef,
   GenericMessage,
   MessagesQueryReply,
+  ProgressToken,
   ProtocolsConfigureMessage,
   ProtocolsQueryReply,
   RecordsQueryReply,
@@ -443,25 +444,34 @@ class AdmitClosureContext {
   }
 
   private async fetchEncryptionControlRecord(ref: Extract<DependencyRef, { type: 'EncryptionControl' }>): Promise<SyncMessageEntry[]> {
-    const reply = await queryRemoteMessageFeed({
-      did                : this.deps.did,
-      dwnUrl             : this.deps.dwnUrl,
-      delegateDid        : this.deps.delegateDid,
-      permissionGrantIds : this.deps.permissionGrantIds,
-      filters            : [{ protocol: ref.protocol }],
-      agent              : this.deps.agent,
-    });
-    if (reply.status.code !== 200 || reply.entries === undefined) {
-      return [];
-    }
-
     const entries: SyncMessageEntry[] = [];
-    for (const entry of reply.entries) {
-      if (!matchesEncryptionControlDependency(entry.message, ref)) {
-        continue;
+    let cursor: ProgressToken | undefined;
+    for (;;) {
+      const reply = await queryRemoteMessageFeed({
+        did                : this.deps.did,
+        dwnUrl             : this.deps.dwnUrl,
+        delegateDid        : this.deps.delegateDid,
+        permissionGrantIds : this.deps.permissionGrantIds,
+        filters            : [{ protocol: ref.protocol, protocolPathPrefix: ref.protocolPath }],
+        cursor,
+        agent              : this.deps.agent,
+      });
+      if (reply.status.code !== 200 || reply.entries === undefined) {
+        return [];
       }
 
-      entries.push(this.entryFromMessageFeedEntry(entry));
+      for (const entry of reply.entries) {
+        if (!matchesEncryptionControlDependency(entry.message, ref)) {
+          continue;
+        }
+
+        entries.push(this.entryFromMessageFeedEntry(entry));
+      }
+
+      if (entries.length > 0 || reply.drained === true || reply.cursor === undefined) {
+        break;
+      }
+      cursor = reply.cursor;
     }
 
     const dedupedEntries = await dedupeEntries(entries);

--- a/packages/agent/src/sync-admit-closure.ts
+++ b/packages/agent/src/sync-admit-closure.ts
@@ -31,6 +31,7 @@ import {
   dependencyKey,
   hasTerminalDependency,
   isTenantProtocolConfig,
+  matchesEncryptionControlDependency,
   matchesEncryptionProtocolDependency,
   missingDependencyDetail,
   newestProtocolConfig,
@@ -317,6 +318,8 @@ class AdmitClosureContext {
         return this.fetchRoleRecord(ref);
       case 'Grant':
         return this.fetchGrantRecord(ref.permissionGrantId);
+      case 'EncryptionControl':
+        return this.fetchEncryptionControlRecord(ref);
       case 'EncryptionProtocol':
         return this.fetchEncryptionProtocolRecord(ref);
       case 'RecordData':
@@ -428,6 +431,33 @@ class AdmitClosureContext {
     const entries: SyncMessageEntry[] = [];
     for (const entry of reply.entries) {
       if (!matchesEncryptionProtocolDependency(entry.message, ref)) {
+        continue;
+      }
+
+      entries.push(this.entryFromMessageFeedEntry(entry));
+    }
+
+    const dedupedEntries = await dedupeEntries(entries);
+    await this.rememberEntries(dedupedEntries);
+    return dedupedEntries;
+  }
+
+  private async fetchEncryptionControlRecord(ref: Extract<DependencyRef, { type: 'EncryptionControl' }>): Promise<SyncMessageEntry[]> {
+    const reply = await queryRemoteMessageFeed({
+      did                : this.deps.did,
+      dwnUrl             : this.deps.dwnUrl,
+      delegateDid        : this.deps.delegateDid,
+      permissionGrantIds : this.deps.permissionGrantIds,
+      filters            : [{ protocol: ref.protocol }],
+      agent              : this.deps.agent,
+    });
+    if (reply.status.code !== 200 || reply.entries === undefined) {
+      return [];
+    }
+
+    const entries: SyncMessageEntry[] = [];
+    for (const entry of reply.entries) {
+      if (!matchesEncryptionControlDependency(entry.message, ref)) {
         continue;
       }
 

--- a/packages/agent/src/sync-fetch-helpers.ts
+++ b/packages/agent/src/sync-fetch-helpers.ts
@@ -92,37 +92,35 @@ export function matchesEncryptionProtocolDependency(
   message: GenericMessage | undefined,
   ref: Extract<DependencyRef, { type: 'EncryptionProtocol' }>,
 ): boolean {
-  if (message === undefined || message.descriptor.interface !== DwnInterfaceName.Records) {
-    return false;
-  }
-
-  const descriptor = message.descriptor as Record<string, unknown>;
-  if (descriptor.protocol !== EncryptionProtocol.uri || descriptor.protocolPath !== ref.protocolPath) {
-    return false;
-  }
-
-  if (ref.recipient !== undefined && descriptor.recipient !== ref.recipient) {
-    return false;
-  }
-
-  const tags = descriptor.tags;
-  if (!isRecordObject(tags)) {
-    return ref.tags === undefined;
-  }
-
-  for (const [key, value] of Object.entries(ref.tags ?? {})) {
-    if (tags[key] !== value) {
-      return false;
-    }
-  }
-
-  return true;
+  return matchesRecordsDependency(message, {
+    protocol     : EncryptionProtocol.uri,
+    protocolPath : ref.protocolPath,
+    recipient    : ref.recipient,
+    tags         : ref.tags,
+  });
 }
 
 /** Predicate matching the exact source-protocol encryption control record named by a dependency ref. */
 export function matchesEncryptionControlDependency(
   message: GenericMessage | undefined,
   ref: Extract<DependencyRef, { type: 'EncryptionControl' }>,
+): boolean {
+  return matchesRecordsDependency(message, {
+    protocol     : ref.protocol,
+    protocolPath : ref.protocolPath,
+    recipient    : ref.recipient,
+    tags         : ref.tags,
+  });
+}
+
+function matchesRecordsDependency(
+  message: GenericMessage | undefined,
+  ref: {
+    protocol: string;
+    protocolPath: string;
+    recipient?: string;
+    tags?: Record<string, string | number>;
+  },
 ): boolean {
   if (message === undefined || message.descriptor.interface !== DwnInterfaceName.Records) {
     return false;

--- a/packages/agent/src/sync-fetch-helpers.ts
+++ b/packages/agent/src/sync-fetch-helpers.ts
@@ -119,6 +119,38 @@ export function matchesEncryptionProtocolDependency(
   return true;
 }
 
+/** Predicate matching the exact source-protocol encryption control record named by a dependency ref. */
+export function matchesEncryptionControlDependency(
+  message: GenericMessage | undefined,
+  ref: Extract<DependencyRef, { type: 'EncryptionControl' }>,
+): boolean {
+  if (message === undefined || message.descriptor.interface !== DwnInterfaceName.Records) {
+    return false;
+  }
+
+  const descriptor = message.descriptor as Record<string, unknown>;
+  if (descriptor.protocol !== ref.protocol || descriptor.protocolPath !== ref.protocolPath) {
+    return false;
+  }
+
+  if (ref.recipient !== undefined && descriptor.recipient !== ref.recipient) {
+    return false;
+  }
+
+  const tags = descriptor.tags;
+  if (!isRecordObject(tags)) {
+    return ref.tags === undefined;
+  }
+
+  for (const [key, value] of Object.entries(ref.tags ?? {})) {
+    if (tags[key] !== value) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function isRecordObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -872,27 +872,36 @@ class RemoteApplyPushContext {
   }
 
   private async fetchEncryptionControlRecord(ref: Extract<DependencyRef, { type: 'EncryptionControl' }>): Promise<FetchDependencyResult> {
-    const reply = await queryLocalMessageFeed({
-      did                : this.deps.did,
-      delegateDid        : this.deps.delegateDid,
-      permissionGrantIds : this.deps.permissionGrantIds,
-      filters            : [{ protocol: ref.protocol }],
-      agent              : this.deps.agent,
-    });
-    if (reply.status.code !== 200 || reply.entries === undefined) {
-      return {
-        kind   : 'failed',
-        detail : `local encryption control feed query failed for ${ref.protocol}: ${reply.status.code} ${reply.status.detail ?? ''}`,
-      };
-    }
-
     const entries: SyncMessageEntry[] = [];
-    for (const entry of reply.entries) {
-      if (!matchesEncryptionControlDependency(entry.message, ref)) {
-        continue;
+    let cursor: ProgressToken | undefined;
+    for (;;) {
+      const reply = await queryLocalMessageFeed({
+        did                : this.deps.did,
+        delegateDid        : this.deps.delegateDid,
+        permissionGrantIds : this.deps.permissionGrantIds,
+        filters            : [{ protocol: ref.protocol, protocolPathPrefix: ref.protocolPath }],
+        cursor,
+        agent              : this.deps.agent,
+      });
+      if (reply.status.code !== 200 || reply.entries === undefined) {
+        return {
+          kind   : 'failed',
+          detail : `local encryption control feed query failed for ${ref.protocol}: ${reply.status.code} ${reply.status.detail ?? ''}`,
+        };
       }
 
-      entries.push(await this.entryForMessageFeedEntry(entry));
+      for (const entry of reply.entries) {
+        if (!matchesEncryptionControlDependency(entry.message, ref)) {
+          continue;
+        }
+
+        entries.push(await this.entryForMessageFeedEntry(entry));
+      }
+
+      if (entries.length > 0 || reply.drained === true || reply.cursor === undefined) {
+        break;
+      }
+      cursor = reply.cursor;
     }
 
     await this.rememberEntries(entries);

--- a/packages/agent/src/sync-messages.ts
+++ b/packages/agent/src/sync-messages.ts
@@ -32,6 +32,7 @@ import {
   dependencyKey,
   hasTerminalDependency,
   isTenantProtocolConfig,
+  matchesEncryptionControlDependency,
   matchesEncryptionProtocolDependency,
   missingDependencyDetail,
   newestProtocolConfig,
@@ -720,6 +721,8 @@ class RemoteApplyPushContext {
         return this.fetchRecordsByRecordId(ref.permissionGrantId);
       case 'RecordData':
         return this.fetchRecordData(ref);
+      case 'EncryptionControl':
+        return this.fetchEncryptionControlRecord(ref);
       case 'EncryptionProtocol':
         return this.fetchEncryptionProtocolRecord(ref);
       default:
@@ -858,6 +861,34 @@ class RemoteApplyPushContext {
     const entries: SyncMessageEntry[] = [];
     for (const entry of reply.entries) {
       if (!matchesEncryptionProtocolDependency(entry.message, ref)) {
+        continue;
+      }
+
+      entries.push(await this.entryForMessageFeedEntry(entry));
+    }
+
+    await this.rememberEntries(entries);
+    return { kind: 'fetched', entries };
+  }
+
+  private async fetchEncryptionControlRecord(ref: Extract<DependencyRef, { type: 'EncryptionControl' }>): Promise<FetchDependencyResult> {
+    const reply = await queryLocalMessageFeed({
+      did                : this.deps.did,
+      delegateDid        : this.deps.delegateDid,
+      permissionGrantIds : this.deps.permissionGrantIds,
+      filters            : [{ protocol: ref.protocol }],
+      agent              : this.deps.agent,
+    });
+    if (reply.status.code !== 200 || reply.entries === undefined) {
+      return {
+        kind   : 'failed',
+        detail : `local encryption control feed query failed for ${ref.protocol}: ${reply.status.code} ${reply.status.detail ?? ''}`,
+      };
+    }
+
+    const entries: SyncMessageEntry[] = [];
+    for (const entry of reply.entries) {
+      if (!matchesEncryptionControlDependency(entry.message, ref)) {
         continue;
       }
 

--- a/packages/agent/tests/sync-admission-order.spec.ts
+++ b/packages/agent/tests/sync-admission-order.spec.ts
@@ -1,7 +1,14 @@
 import type { GenericMessage } from '@enbox/dwn-sdk-js';
 
 import { describe, expect, it } from 'bun:test';
-import { DwnInterfaceName, DwnMethodName, EncryptionProtocol, PermissionsProtocol } from '@enbox/dwn-sdk-js';
+import {
+  DwnInterfaceName,
+  DwnMethodName,
+  ENCRYPTION_CONTROL_AUDIENCE_PATH,
+  EncryptionProtocol,
+  PermissionsProtocol,
+  ROLE_AUDIENCE_DERIVATION_SCHEME,
+} from '@enbox/dwn-sdk-js';
 
 import { orderMessagesForAdmission } from '../src/sync-admission-order.js';
 
@@ -371,6 +378,51 @@ describe('orderMessagesForAdmission', () => {
 
     expect(result.indexOf(audienceEpoch)).toBeLessThan(result.indexOf(audienceKey));
     expect(result.indexOf(role)).toBeLessThan(result.indexOf(audienceKey));
+  });
+
+  it('should place source-protocol audience records before encrypted records that reference them', () => {
+    const protocol = 'https://example.com/source-audience-ordering';
+    const audience: SortEntry = {
+      message: {
+        ...makeMessage({
+          protocol,
+          protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          tags         : {
+            protocol,
+            contextId : 'thread-1',
+            rolePath  : 'thread/member',
+            keyId     : 'key-1',
+          },
+        }),
+        recordId  : 'audience-record',
+        contextId : 'audience-record',
+      } as unknown as GenericMessage,
+    };
+    const encryptedRecord: SortEntry = {
+      message: {
+        ...makeMessage({
+          protocol,
+          protocolPath     : 'thread/message',
+          parentId         : 'thread-1',
+          dateCreated      : '2024-01-01T00:00:00.000000Z',
+          messageTimestamp : '2024-01-01T00:00:00.000000Z',
+        }),
+        contextId  : 'thread-1/message-1',
+        encryption : {
+          keyEncryption: [{
+            derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+            protocol,
+            rolePath         : 'thread/member',
+            keyId            : 'key-1',
+          }],
+        },
+        recordId: 'message-1',
+      } as unknown as GenericMessage,
+    };
+
+    const result = orderMessagesForAdmission([encryptedRecord, audience]);
+
+    expect(result.indexOf(audience)).toBeLessThan(result.indexOf(encryptedRecord));
   });
 
   it('should place permission grants before grantKey records', () => {

--- a/packages/agent/tests/sync-admit-closure.spec.ts
+++ b/packages/agent/tests/sync-admit-closure.spec.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
 import { afterEach, describe, expect, it } from 'bun:test';
-import { DwnErrorCode, Encoder, EncryptionProtocol, Message, TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { DwnErrorCode, Encoder, ENCRYPTION_CONTROL_AUDIENCE_PATH, EncryptionProtocol, Message, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
 import { admitClosure } from '../src/sync-admit-closure.js';
 import { DwnInterface } from '../src/types/dwn.js';
@@ -474,6 +474,70 @@ describe('admitClosure', () => {
       },
     });
     expect(agent.dwn.applyReplicatedMessage.secondCall.args[1]).toEqual(audienceEpoch.message);
+  });
+
+  it('fetches encryption control dependencies from the source protocol feed', async () => {
+    const protocol = 'https://example.com/protocol-control';
+    const root = await TestDataGenerator.generateRecordsWrite({ protocol });
+    const tags = {
+      protocol,
+      contextId : 'root-context',
+      rolePath  : 'thread/member',
+      keyId     : 'key-id',
+    };
+    const audience = await TestDataGenerator.generateRecordsWrite({
+      protocol,
+      protocolPath: ENCRYPTION_CONTROL_AUDIENCE_PATH,
+      tags,
+    });
+    const rootCid = await Message.getCid(root.message);
+    const audienceCid = await Message.getCid(audience.message);
+    const agent = createMockAgent();
+
+    agent.rpc.sendDwnRequest.resolves({
+      status  : { code: 200 },
+      entries : [{
+        seq               : '1',
+        messageCid        : audienceCid,
+        isLatestBaseState : true,
+        protocol,
+        message           : audience.message,
+        encodedData       : Encoder.bytesToBase64Url(audience.dataBytes!),
+      }],
+    });
+    agent.dwn.applyReplicatedMessage
+      .onFirstCall().resolves({
+        kind    : 'Incomplete',
+        missing : [{
+          type         : 'EncryptionControl',
+          protocol,
+          protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          tags,
+        }],
+      })
+      .onSecondCall().resolves({ kind: 'Applied' })
+      .onThirdCall().resolves({ kind: 'Applied' });
+
+    const outcome = await admitClosure(rootCid, {
+      did                : 'did:example:alice',
+      dwnUrl             : 'https://dwn.example.com',
+      delegateDid        : 'did:example:delegate',
+      permissionGrantIds : ['messages-query-grant'],
+      agent,
+      prefetched         : [{ message: root.message }],
+    });
+
+    expect(outcome).toEqual({ kind: 'admitted', appliedCids: [audienceCid, rootCid] });
+    expect(agent.processDwnRequest.firstCall.args[0]).toMatchObject({
+      author        : 'did:example:alice',
+      granteeDid    : 'did:example:delegate',
+      messageType   : DwnInterface.MessagesQuery,
+      messageParams : {
+        filters            : [{ protocol }],
+        permissionGrantIds : ['messages-query-grant'],
+      },
+    });
+    expect(agent.dwn.applyReplicatedMessage.secondCall.args[1]).toEqual(audience.message);
   });
 
   it('fetches record data with RecordsRead and retries with the data stream', async () => {

--- a/packages/agent/tests/sync-admit-closure.spec.ts
+++ b/packages/agent/tests/sync-admit-closure.spec.ts
@@ -493,18 +493,31 @@ describe('admitClosure', () => {
     const rootCid = await Message.getCid(root.message);
     const audienceCid = await Message.getCid(audience.message);
     const agent = createMockAgent();
+    const cursor = {
+      streamId : 'control-feed',
+      epoch    : 'epoch-1',
+      position : '1',
+    };
 
-    agent.rpc.sendDwnRequest.resolves({
-      status  : { code: 200 },
-      entries : [{
-        seq               : '1',
-        messageCid        : audienceCid,
-        isLatestBaseState : true,
-        protocol,
-        message           : audience.message,
-        encodedData       : Encoder.bytesToBase64Url(audience.dataBytes!),
-      }],
-    });
+    agent.rpc.sendDwnRequest
+      .onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [],
+        cursor,
+        drained : false,
+      })
+      .onSecondCall().resolves({
+        status  : { code: 200 },
+        entries : [{
+          seq               : '1',
+          messageCid        : audienceCid,
+          isLatestBaseState : true,
+          protocol,
+          message           : audience.message,
+          encodedData       : Encoder.bytesToBase64Url(audience.dataBytes!),
+        }],
+        drained: true,
+      });
     agent.dwn.applyReplicatedMessage
       .onFirstCall().resolves({
         kind    : 'Incomplete',
@@ -533,9 +546,12 @@ describe('admitClosure', () => {
       granteeDid    : 'did:example:delegate',
       messageType   : DwnInterface.MessagesQuery,
       messageParams : {
-        filters            : [{ protocol }],
+        filters            : [{ protocol, protocolPathPrefix: ENCRYPTION_CONTROL_AUDIENCE_PATH }],
         permissionGrantIds : ['messages-query-grant'],
       },
+    });
+    expect(agent.processDwnRequest.secondCall.args[0]).toMatchObject({
+      messageParams: { cursor },
     });
     expect(agent.dwn.applyReplicatedMessage.secondCall.args[1]).toEqual(audience.message);
   });

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -930,7 +930,7 @@ describe('sync-messages', () => {
 
       expect(result).toEqual({ succeeded: [rootCid], failed: [] });
       expect(processRequestStub.withArgs(sinon.match({
-        messageParams : sinon.match({ filters: [{ protocol }] }),
+        messageParams : sinon.match({ filters: [{ protocol, protocolPathPrefix: ENCRYPTION_CONTROL_AUDIENCE_PATH }] }),
         messageType   : DwnInterface.MessagesQuery,
       })).calledOnce).toBe(true);
       expect(await Promise.all(applyStub.getCalls().map(async (call): Promise<string> =>

--- a/packages/agent/tests/sync-messages.spec.ts
+++ b/packages/agent/tests/sync-messages.spec.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import { afterEach, describe, expect, it } from 'bun:test';
 import { DwnRpcError, JsonRpcErrorCodes } from '@enbox/dwn-clients';
-import { EncryptionProtocol, Message, TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH, EncryptionProtocol, Message, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
 import { DwnInterface } from '../src/types/dwn.js';
 import {
@@ -879,6 +879,62 @@ describe('sync-messages', () => {
       })).calledOnce).toBe(true);
       expect(await Promise.all(applyStub.getCalls().map(async (call): Promise<string> =>
         Message.getCid(call.args[0].message)))).toEqual([rootCid, audienceEpochCid, rootCid]);
+    });
+
+    it('should fetch an encryption control dependency from the source protocol feed', async () => {
+      const protocol = 'https://example.com/encrypted-control-push';
+      const root = await TestDataGenerator.generateRecordsWrite({ protocol });
+      const tags = {
+        protocol,
+        contextId : 'thread-record',
+        rolePath  : 'thread/member',
+        keyId     : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      };
+      const audience = await TestDataGenerator.generateRecordsWrite({
+        author       : root.author,
+        protocol,
+        protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+        tags,
+      });
+      const rootCid = await Message.getCid(root.message);
+      const audienceCid = await Message.getCid(audience.message);
+      const { agent, applyStub, processRequestStub } = createLocalAgentFixture({
+        messagesByCid      : new Map([[rootCid, { message: root.message }]]),
+        messageFeedEntries : [{
+          isLatestBaseState : true,
+          message           : audience.message,
+          messageCid        : audienceCid,
+          protocol,
+        }],
+        applyResults: [
+          {
+            kind    : 'Incomplete',
+            missing : [{
+              type         : 'EncryptionControl',
+              protocol,
+              protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+              tags,
+            }],
+          },
+          { kind: 'Applied' },
+          { kind: 'Applied' },
+        ],
+      });
+
+      const result = await pushMessages({
+        did         : root.author.did,
+        dwnUrl      : 'https://dwn.example.com',
+        messageCids : [rootCid],
+        agent,
+      });
+
+      expect(result).toEqual({ succeeded: [rootCid], failed: [] });
+      expect(processRequestStub.withArgs(sinon.match({
+        messageParams : sinon.match({ filters: [{ protocol }] }),
+        messageType   : DwnInterface.MessagesQuery,
+      })).calledOnce).toBe(true);
+      expect(await Promise.all(applyStub.getCalls().map(async (call): Promise<string> =>
+        Message.getCid(call.args[0].message)))).toEqual([rootCid, audienceCid, rootCid]);
     });
 
     it('should query a missing role dependency with contextPrefix', async () => {

--- a/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-unidentified.json
+++ b/packages/dwn-sdk-js/json-schemas/interface-methods/records-write-unidentified.json
@@ -110,6 +110,67 @@
                   "protocol": {
                     "type": "string"
                   },
+                  "rolePath": {
+                    "type": "string"
+                  },
+                  "ephemeralPublicKey": {
+                    "allOf": [
+                      {
+                        "$ref": "https://identity.foundation/dwn/json-schemas/public-jwk.json"
+                      }
+                    ],
+                    "type": "object",
+                    "required": [
+                      "kty",
+                      "crv",
+                      "x"
+                    ],
+                    "properties": {
+                      "kty": {
+                        "const": "OKP"
+                      },
+                      "crv": {
+                        "const": "X25519"
+                      },
+                      "x": {
+                        "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
+                      }
+                    }
+                  },
+                  "encryptedKey": {
+                    "$ref": "https://identity.foundation/dwn/json-schemas/defs.json#/$defs/base64url"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "algorithm",
+                  "keyId",
+                  "derivationScheme",
+                  "protocol",
+                  "rolePath",
+                  "ephemeralPublicKey",
+                  "encryptedKey"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "algorithm": {
+                    "type": "string",
+                    "enum": [
+                      "X25519-HKDF-SHA256+A256KW"
+                    ]
+                  },
+                  "keyId": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]{43}$"
+                  },
+                  "derivationScheme": {
+                    "const": "roleAudience"
+                  },
+                  "protocol": {
+                    "type": "string"
+                  },
                   "role": {
                     "type": "string"
                   },

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -369,26 +369,32 @@ async function validateSourceRoleAudienceEntry(
   inboundMessage: RecordsWriteMessage,
   validationStateReader: ValidationStateReader,
 ): Promise<RoleAudienceEntryValidationResult> {
-  const matchingEntry = inboundMessage.encryption!.keyEncryption.find((entry): entry is SourceRoleAudienceKeyEncryption =>
+  const matchingEntries = inboundMessage.encryption!.keyEncryption.filter((entry): entry is SourceRoleAudienceKeyEncryption =>
     entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
     entry.protocol === roleAudience.protocol &&
     'rolePath' in entry &&
     entry.rolePath === roleAudience.rolePath
   );
 
-  if (matchingEntry === undefined) {
+  if (matchingEntries.length === 0) {
     return { hasAudience: false, hasEntry: false };
   }
 
-  const matchingAudienceRecords = await validationStateReader.queryAudienceRecords({
-    tenant,
-    protocol  : roleAudience.protocol,
-    contextId : roleAudience.contextId,
-    rolePath  : roleAudience.rolePath,
-    keyId     : matchingEntry.keyId,
-  });
+  for (const matchingEntry of matchingEntries) {
+    const matchingAudienceRecords = await validationStateReader.queryAudienceRecords({
+      tenant,
+      protocol  : roleAudience.protocol,
+      contextId : roleAudience.contextId,
+      rolePath  : roleAudience.rolePath,
+      keyId     : matchingEntry.keyId,
+    });
 
-  return { hasAudience: matchingAudienceRecords.length > 0, hasEntry: true };
+    if (matchingAudienceRecords.length > 0) {
+      return { hasAudience: true, hasEntry: true };
+    }
+  }
+
+  return { hasAudience: false, hasEntry: true };
 }
 
 async function validateLegacyRoleAudienceEntry(
@@ -397,7 +403,7 @@ async function validateLegacyRoleAudienceEntry(
   inboundMessage: RecordsWriteMessage,
   validationStateReader: ValidationStateReader,
 ): Promise<RoleAudienceEntryValidationResult> {
-  const matchingLegacyEntry = inboundMessage.encryption!.keyEncryption.find((entry): entry is LegacyRoleAudienceKeyEncryption =>
+  const matchingLegacyEntries = inboundMessage.encryption!.keyEncryption.filter((entry): entry is LegacyRoleAudienceKeyEncryption =>
     entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
     entry.protocol === roleAudience.protocol &&
     'role' in entry &&
@@ -405,20 +411,26 @@ async function validateLegacyRoleAudienceEntry(
     'epoch' in entry
   );
 
-  if (matchingLegacyEntry === undefined) {
+  if (matchingLegacyEntries.length === 0) {
     return { hasAudience: false, hasEntry: false };
   }
 
-  const matchingEpochs = await validationStateReader.queryAudienceEpochs({
-    tenant,
-    protocol  : roleAudience.protocol,
-    contextId : roleAudience.contextId,
-    role      : roleAudience.rolePath,
-    epoch     : matchingLegacyEntry.epoch,
-    keyId     : matchingLegacyEntry.keyId,
-  });
+  for (const matchingLegacyEntry of matchingLegacyEntries) {
+    const matchingEpochs = await validationStateReader.queryAudienceEpochs({
+      tenant,
+      protocol  : roleAudience.protocol,
+      contextId : roleAudience.contextId,
+      role      : roleAudience.rolePath,
+      epoch     : matchingLegacyEntry.epoch,
+      keyId     : matchingLegacyEntry.keyId,
+    });
 
-  return { hasAudience: matchingEpochs.length > 0, hasEntry: true };
+    if (matchingEpochs.length > 0) {
+      return { hasAudience: true, hasEntry: true };
+    }
+  }
+
+  return { hasAudience: false, hasEntry: true };
 }
 
 function resolveRoleAudience(

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -9,7 +9,7 @@ import { Records } from '../utils/records.js';
 import { validateProtocolTags } from '../utils/protocol-tags.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { Encryption, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../utils/encryption.js';
-import { getRuleSetAtPath, getTypeName, parseCrossProtocolRef } from '../utils/protocols.js';
+import { getRoleAudienceContextId, getRuleSetAtPath, getTypeName, parseCrossProtocolRef } from '../utils/protocols.js';
 import { ProtocolAction, ProtocolRecordLimitStrategy } from '../types/protocols-types.js';
 
 type ResolvedRoleAudience = {
@@ -452,30 +452,8 @@ function resolveRoleAudience(
     return undefined;
   }
 
-  const contextId = getRoleAudienceContextId(inboundMessage, rolePath);
+  const contextId = getRoleAudienceContextId(rolePath, inboundMessage.contextId);
   return contextId === undefined ? undefined : { protocol, rolePath, contextId };
-}
-
-function getRoleAudienceContextId(
-  inboundMessage: RecordsWriteMessage,
-  rolePath: string,
-): string | undefined {
-  const parentDepth = rolePath.split('/').length - 1;
-  if (parentDepth === 0) {
-    return '';
-  }
-
-  const contextId = inboundMessage.contextId;
-  if (typeof contextId !== 'string') {
-    return undefined;
-  }
-
-  const contextSegments = contextId.split('/');
-  if (contextSegments.length < parentDepth) {
-    return undefined;
-  }
-
-  return contextSegments.slice(0, parentDepth).join('/');
 }
 
 /**

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -1,7 +1,7 @@
 import type { RecordsWrite } from '../interfaces/records-write.js';
 import type { RecordsWriteMessage } from '../types/records-types.js';
-import type { RoleAudienceKeyEncryption } from '../utils/encryption.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
+import type { LegacyRoleAudienceKeyEncryption, SourceRoleAudienceKeyEncryption } from '../utils/encryption.js';
 import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet, ProtocolType, ProtocolTypes } from '../types/protocols-types.js';
 
 import { KeyDerivationScheme } from '../utils/hd-key.js';
@@ -319,34 +319,61 @@ async function verifyRoleAudienceEncryptionIfNeeded(
       continue;
     }
 
-    const matchingEntry = inboundMessage.encryption!.keyEncryption.find((entry): entry is RoleAudienceKeyEncryption =>
+    const matchingEntry = inboundMessage.encryption!.keyEncryption.find((entry): entry is SourceRoleAudienceKeyEncryption =>
       entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
       entry.protocol === roleAudience.protocol &&
-      entry.role === roleAudience.role
+      'rolePath' in entry &&
+      entry.rolePath === roleAudience.rolePath
     );
 
-    if (matchingEntry === undefined) {
+    if (matchingEntry !== undefined) {
+      const matchingAudienceRecords = await validationStateReader.queryAudienceRecords({
+        tenant,
+        protocol  : roleAudience.protocol,
+        contextId : roleAudience.contextId,
+        rolePath  : roleAudience.rolePath,
+        keyId     : matchingEntry.keyId,
+      });
+
+      if (matchingAudienceRecords.length > 0) {
+        continue;
+      }
+    }
+
+    const matchingLegacyEntry = inboundMessage.encryption!.keyEncryption.find((entry): entry is LegacyRoleAudienceKeyEncryption =>
+      entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
+      entry.protocol === roleAudience.protocol &&
+      'role' in entry &&
+      entry.role === roleAudience.rolePath &&
+      'epoch' in entry
+    );
+
+    if (matchingEntry === undefined && matchingLegacyEntry === undefined) {
       throw new DwnError(
         DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEntryMissing,
-        `encrypted record is missing a roleAudience keyEncryption entry for role '${roleAudience.role}'`
+        `encrypted record is missing a roleAudience keyEncryption entry for role '${roleAudience.rolePath}'`
       );
     }
 
-    const matchingEpochs = await validationStateReader.queryAudienceEpochs({
-      tenant,
-      protocol  : roleAudience.protocol,
-      contextId : roleAudience.contextId,
-      role      : roleAudience.role,
-      epoch     : matchingEntry.epoch,
-      keyId     : matchingEntry.keyId,
-    });
+    if (matchingLegacyEntry !== undefined) {
+      const matchingEpochs = await validationStateReader.queryAudienceEpochs({
+        tenant,
+        protocol  : roleAudience.protocol,
+        contextId : roleAudience.contextId,
+        role      : roleAudience.rolePath,
+        epoch     : matchingLegacyEntry.epoch,
+        keyId     : matchingLegacyEntry.keyId,
+      });
 
-    if (matchingEpochs.length === 0) {
-      throw new DwnError(
-        DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing,
-        `encrypted record references a missing audienceEpoch for role '${roleAudience.role}'`
-      );
+      if (matchingEpochs.length > 0) {
+        continue;
+      }
     }
+
+    throw new DwnError(
+      DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing,
+      `encrypted record references a missing audience for role '${roleAudience.rolePath}'`
+    );
   }
 }
 
@@ -354,7 +381,7 @@ function resolveRoleAudience(
   actionRule: ProtocolActionRule,
   inboundMessage: RecordsWriteMessage,
   protocolDefinition: ProtocolDefinition,
-): { protocol: string; role: string; contextId: string } | undefined {
+): { protocol: string; rolePath: string; contextId: string } | undefined {
   const roleRef = actionRule.role;
   if (roleRef === undefined) {
     return undefined;
@@ -364,13 +391,13 @@ function resolveRoleAudience(
   const protocol = parsed === undefined
     ? inboundMessage.descriptor.protocol
     : protocolDefinition.uses?.[parsed.alias];
-  const role = parsed === undefined ? roleRef : parsed.protocolPath;
+  const rolePath = parsed === undefined ? roleRef : parsed.protocolPath;
   if (protocol === undefined) {
     return undefined;
   }
 
-  const contextId = getRoleAudienceContextId(inboundMessage, role);
-  return contextId === undefined ? undefined : { protocol, role, contextId };
+  const contextId = getRoleAudienceContextId(inboundMessage, rolePath);
+  return contextId === undefined ? undefined : { protocol, rolePath, contextId };
 }
 
 function getRoleAudienceContextId(

--- a/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
+++ b/packages/dwn-sdk-js/src/core/protocol-authorization-validation.ts
@@ -12,6 +12,17 @@ import { Encryption, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../utils/encryption
 import { getRuleSetAtPath, getTypeName, parseCrossProtocolRef } from '../utils/protocols.js';
 import { ProtocolAction, ProtocolRecordLimitStrategy } from '../types/protocols-types.js';
 
+type ResolvedRoleAudience = {
+  contextId: string;
+  protocol: string;
+  rolePath: string;
+};
+
+type RoleAudienceEntryValidationResult = {
+  hasAudience: boolean;
+  hasEntry: boolean;
+};
+
 /**
  * Verifies the `protocolPath` declared in the given message matches the path of actual record chain.
  * For cross-protocol composition, the parent record may belong to a different protocol (resolved via `$ref` in the composing protocol).
@@ -319,69 +330,102 @@ async function verifyRoleAudienceEncryptionIfNeeded(
       continue;
     }
 
-    const matchingEntry = inboundMessage.encryption!.keyEncryption.find((entry): entry is SourceRoleAudienceKeyEncryption =>
-      entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
-      entry.protocol === roleAudience.protocol &&
-      'rolePath' in entry &&
-      entry.rolePath === roleAudience.rolePath
-    );
+    await verifyResolvedRoleAudienceEncryption(tenant, inboundMessage, roleAudience, validationStateReader);
+  }
+}
 
-    if (matchingEntry !== undefined) {
-      const matchingAudienceRecords = await validationStateReader.queryAudienceRecords({
-        tenant,
-        protocol  : roleAudience.protocol,
-        contextId : roleAudience.contextId,
-        rolePath  : roleAudience.rolePath,
-        keyId     : matchingEntry.keyId,
-      });
+async function verifyResolvedRoleAudienceEncryption(
+  tenant: string,
+  inboundMessage: RecordsWriteMessage,
+  roleAudience: ResolvedRoleAudience,
+  validationStateReader: ValidationStateReader,
+): Promise<void> {
+  const sourceEntryValidation = await validateSourceRoleAudienceEntry(tenant, roleAudience, inboundMessage, validationStateReader);
+  if (sourceEntryValidation.hasAudience) {
+    return;
+  }
 
-      if (matchingAudienceRecords.length > 0) {
-        continue;
-      }
-    }
+  const legacyEntryValidation = await validateLegacyRoleAudienceEntry(tenant, roleAudience, inboundMessage, validationStateReader);
+  if (legacyEntryValidation.hasAudience) {
+    return;
+  }
 
-    const matchingLegacyEntry = inboundMessage.encryption!.keyEncryption.find((entry): entry is LegacyRoleAudienceKeyEncryption =>
-      entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
-      entry.protocol === roleAudience.protocol &&
-      'role' in entry &&
-      entry.role === roleAudience.rolePath &&
-      'epoch' in entry
-    );
-
-    if (matchingEntry === undefined && matchingLegacyEntry === undefined) {
-      throw new DwnError(
-        DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEntryMissing,
-        `encrypted record is missing a roleAudience keyEncryption entry for role '${roleAudience.rolePath}'`
-      );
-    }
-
-    if (matchingLegacyEntry !== undefined) {
-      const matchingEpochs = await validationStateReader.queryAudienceEpochs({
-        tenant,
-        protocol  : roleAudience.protocol,
-        contextId : roleAudience.contextId,
-        role      : roleAudience.rolePath,
-        epoch     : matchingLegacyEntry.epoch,
-        keyId     : matchingLegacyEntry.keyId,
-      });
-
-      if (matchingEpochs.length > 0) {
-        continue;
-      }
-    }
-
+  if (!sourceEntryValidation.hasEntry && !legacyEntryValidation.hasEntry) {
     throw new DwnError(
-      DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing,
-      `encrypted record references a missing audience for role '${roleAudience.rolePath}'`
+      DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEntryMissing,
+      `encrypted record is missing a roleAudience keyEncryption entry for role '${roleAudience.rolePath}'`
     );
   }
+
+  throw new DwnError(
+    DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing,
+    `encrypted record references a missing audience for role '${roleAudience.rolePath}'`
+  );
+}
+
+async function validateSourceRoleAudienceEntry(
+  tenant: string,
+  roleAudience: ResolvedRoleAudience,
+  inboundMessage: RecordsWriteMessage,
+  validationStateReader: ValidationStateReader,
+): Promise<RoleAudienceEntryValidationResult> {
+  const matchingEntry = inboundMessage.encryption!.keyEncryption.find((entry): entry is SourceRoleAudienceKeyEncryption =>
+    entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
+    entry.protocol === roleAudience.protocol &&
+    'rolePath' in entry &&
+    entry.rolePath === roleAudience.rolePath
+  );
+
+  if (matchingEntry === undefined) {
+    return { hasAudience: false, hasEntry: false };
+  }
+
+  const matchingAudienceRecords = await validationStateReader.queryAudienceRecords({
+    tenant,
+    protocol  : roleAudience.protocol,
+    contextId : roleAudience.contextId,
+    rolePath  : roleAudience.rolePath,
+    keyId     : matchingEntry.keyId,
+  });
+
+  return { hasAudience: matchingAudienceRecords.length > 0, hasEntry: true };
+}
+
+async function validateLegacyRoleAudienceEntry(
+  tenant: string,
+  roleAudience: ResolvedRoleAudience,
+  inboundMessage: RecordsWriteMessage,
+  validationStateReader: ValidationStateReader,
+): Promise<RoleAudienceEntryValidationResult> {
+  const matchingLegacyEntry = inboundMessage.encryption!.keyEncryption.find((entry): entry is LegacyRoleAudienceKeyEncryption =>
+    entry.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
+    entry.protocol === roleAudience.protocol &&
+    'role' in entry &&
+    entry.role === roleAudience.rolePath &&
+    'epoch' in entry
+  );
+
+  if (matchingLegacyEntry === undefined) {
+    return { hasAudience: false, hasEntry: false };
+  }
+
+  const matchingEpochs = await validationStateReader.queryAudienceEpochs({
+    tenant,
+    protocol  : roleAudience.protocol,
+    contextId : roleAudience.contextId,
+    role      : roleAudience.rolePath,
+    epoch     : matchingLegacyEntry.epoch,
+    keyId     : matchingLegacyEntry.keyId,
+  });
+
+  return { hasAudience: matchingEpochs.length > 0, hasEntry: true };
 }
 
 function resolveRoleAudience(
   actionRule: ProtocolActionRule,
   inboundMessage: RecordsWriteMessage,
   protocolDefinition: ProtocolDefinition,
-): { protocol: string; rolePath: string; contextId: string } | undefined {
+): ResolvedRoleAudience | undefined {
   const roleRef = actionRule.role;
   if (roleRef === undefined) {
     return undefined;

--- a/packages/dwn-sdk-js/src/core/replication-apply.ts
+++ b/packages/dwn-sdk-js/src/core/replication-apply.ts
@@ -1,3 +1,4 @@
+import type { EncryptionControlPath } from './constants.js';
 import type { GenericMessage } from '../types/message-types.js';
 import type { ProgressToken } from '../types/subscriptions.js';
 import type { ProtocolDefinition } from '../types/protocols-types.js';
@@ -5,6 +6,7 @@ import type { ValidationStateReader } from '../types/validation-state-reader.js'
 
 import { DwnErrorCode } from './dwn-error.js';
 import { Encoder } from '../utils/encoder.js';
+import { ENCRYPTION_CONTROL_AUDIENCE_PATH } from './constants.js';
 import { EncryptionProtocol } from '../protocols/encryption.js';
 import { Message } from './message.js';
 import { ROLE_AUDIENCE_DERIVATION_SCHEME } from '../utils/encryption.js';
@@ -60,6 +62,15 @@ export type DependencyRef =
   | {
       type: 'EncryptionProtocol';
       protocolPath: 'audienceEpoch' | 'audienceKey' | 'grantKey';
+      tags?: Record<string, string | number>;
+      recipient?: string;
+      messageCid?: string;
+      terminal?: boolean;
+    }
+  | {
+      type: 'EncryptionControl';
+      protocol: string;
+      protocolPath: EncryptionControlPath;
       tags?: Record<string, string | number>;
       recipient?: string;
       messageCid?: string;
@@ -202,7 +213,7 @@ function dependencyRefsFromStatus(
   case DwnErrorCode.EncryptionProtocolValidateAudienceEpochMissing:
     return toRefList(encryptionProtocolDependencyFromMessage(message, EncryptionProtocol.audienceEpochPath));
   case DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing:
-    return toRefList(encryptionProtocolDependencyFromRoleAudienceEntry(message, detail));
+    return toRefList(encryptionAudienceDependencyFromRoleAudienceEntry(message, detail));
   case DwnErrorCode.EncryptionProtocolValidateAudienceKeyRoleRecordMissing:
     return toRefList(roleDependencyFromEncryptionAudienceRecipient(message));
   case DwnErrorCode.RecordsWriteMissingDataInPrevious:
@@ -429,10 +440,10 @@ function encryptionProtocolDependencyFromMessage(
     : { type: 'EncryptionProtocol', protocolPath, tags };
 }
 
-function encryptionProtocolDependencyFromRoleAudienceEntry(
+function encryptionAudienceDependencyFromRoleAudienceEntry(
   message: GenericMessage,
   detail: string,
-): DependencyRef | undefined {
+): Extract<DependencyRef, { type: 'EncryptionControl' | 'EncryptionProtocol' }> | undefined {
   const descriptor = message.descriptor as Record<string, unknown>;
   const messageContextId = (message as { contextId?: unknown }).contextId;
   const contextId = typeof messageContextId === 'string' ? messageContextId : descriptor.contextId;
@@ -446,6 +457,33 @@ function encryptionProtocolDependencyFromRoleAudienceEntry(
   }
 
   const missingRole = /role '([^']+)'/.exec(detail)?.[1];
+  const sourceEntry = keyEncryption.find((candidate): boolean =>
+    candidate.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
+    typeof candidate.protocol === 'string' &&
+    typeof candidate.rolePath === 'string' &&
+    (missingRole === undefined || candidate.rolePath === missingRole) &&
+    typeof candidate.keyId === 'string'
+  );
+  if (sourceEntry !== undefined) {
+    const rolePath = sourceEntry.rolePath as string;
+    const audienceContextId = roleAudienceContextId(rolePath, contextId);
+    if (audienceContextId === undefined) {
+      return undefined;
+    }
+
+    return {
+      type         : 'EncryptionControl',
+      protocol     : sourceEntry.protocol as string,
+      protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+      tags         : {
+        protocol  : sourceEntry.protocol as string,
+        rolePath,
+        contextId : audienceContextId,
+        keyId     : sourceEntry.keyId as string,
+      },
+    };
+  }
+
   const entry = keyEncryption.find((candidate): boolean =>
     candidate.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
     typeof candidate.protocol === 'string' &&

--- a/packages/dwn-sdk-js/src/core/replication-apply.ts
+++ b/packages/dwn-sdk-js/src/core/replication-apply.ts
@@ -11,7 +11,7 @@ import { EncryptionProtocol } from '../protocols/encryption.js';
 import { Message } from './message.js';
 import { ROLE_AUDIENCE_DERIVATION_SCHEME } from '../utils/encryption.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
-import { isCrossProtocolRef, parseCrossProtocolRef } from '../utils/protocols.js';
+import { getRoleAudienceContextId, isCrossProtocolRef, parseCrossProtocolRef } from '../utils/protocols.js';
 
 export type ReplicationApplyOptions = {
   dataStream?: ReadableStream<Uint8Array>;
@@ -467,7 +467,7 @@ function encryptionAudienceDependenciesFromRoleAudienceEntries(
   );
   for (const sourceEntry of sourceEntries) {
     const rolePath = sourceEntry.rolePath as string;
-    const audienceContextId = roleAudienceContextId(rolePath, contextId);
+    const audienceContextId = getRoleAudienceContextId(rolePath, contextId);
     if (audienceContextId === undefined) {
       continue;
     }
@@ -495,7 +495,7 @@ function encryptionAudienceDependenciesFromRoleAudienceEntries(
   );
   for (const entry of legacyEntries) {
     const role = entry.role as string;
-    const audienceContextId = roleAudienceContextId(role, contextId);
+    const audienceContextId = getRoleAudienceContextId(role, contextId);
     if (audienceContextId === undefined) {
       continue;
     }
@@ -616,20 +616,6 @@ function roleContextPrefix(rolePath: string, contextId: string): string | undefi
   }
 
   return contextId.split('/').slice(0, roleSegments).join('/');
-}
-
-function roleAudienceContextId(rolePath: string, contextId: string): string | undefined {
-  const roleSegments = rolePath.split('/').length - 1;
-  if (roleSegments === 0) {
-    return '';
-  }
-
-  const contextSegments = contextId.split('/');
-  if (contextSegments.length < roleSegments) {
-    return undefined;
-  }
-
-  return contextSegments.slice(0, roleSegments).join('/');
 }
 
 function isRecordObject(value: unknown): value is Record<string, unknown> {

--- a/packages/dwn-sdk-js/src/core/replication-apply.ts
+++ b/packages/dwn-sdk-js/src/core/replication-apply.ts
@@ -213,7 +213,7 @@ function dependencyRefsFromStatus(
   case DwnErrorCode.EncryptionProtocolValidateAudienceEpochMissing:
     return toRefList(encryptionProtocolDependencyFromMessage(message, EncryptionProtocol.audienceEpochPath));
   case DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing:
-    return toRefList(encryptionAudienceDependencyFromRoleAudienceEntry(message, detail));
+    return encryptionAudienceDependenciesFromRoleAudienceEntries(message, detail);
   case DwnErrorCode.EncryptionProtocolValidateAudienceKeyRoleRecordMissing:
     return toRefList(roleDependencyFromEncryptionAudienceRecipient(message));
   case DwnErrorCode.RecordsWriteMissingDataInPrevious:
@@ -440,10 +440,10 @@ function encryptionProtocolDependencyFromMessage(
     : { type: 'EncryptionProtocol', protocolPath, tags };
 }
 
-function encryptionAudienceDependencyFromRoleAudienceEntry(
+function encryptionAudienceDependenciesFromRoleAudienceEntries(
   message: GenericMessage,
   detail: string,
-): Extract<DependencyRef, { type: 'EncryptionControl' | 'EncryptionProtocol' }> | undefined {
+): Extract<DependencyRef, { type: 'EncryptionControl' | 'EncryptionProtocol' }>[] {
   const descriptor = message.descriptor as Record<string, unknown>;
   const messageContextId = (message as { contextId?: unknown }).contextId;
   const contextId = typeof messageContextId === 'string' ? messageContextId : descriptor.contextId;
@@ -453,25 +453,26 @@ function encryptionAudienceDependencyFromRoleAudienceEntry(
     };
   }).encryption?.keyEncryption;
   if (typeof contextId !== 'string' || !Array.isArray(keyEncryption)) {
-    return undefined;
+    return [];
   }
 
   const missingRole = /role '([^']+)'/.exec(detail)?.[1];
-  const sourceEntry = keyEncryption.find((candidate): boolean =>
+  const refs: Extract<DependencyRef, { type: 'EncryptionControl' | 'EncryptionProtocol' }>[] = [];
+  const sourceEntries = keyEncryption.filter((candidate): boolean =>
     candidate.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
     typeof candidate.protocol === 'string' &&
     typeof candidate.rolePath === 'string' &&
     (missingRole === undefined || candidate.rolePath === missingRole) &&
     typeof candidate.keyId === 'string'
   );
-  if (sourceEntry !== undefined) {
+  for (const sourceEntry of sourceEntries) {
     const rolePath = sourceEntry.rolePath as string;
     const audienceContextId = roleAudienceContextId(rolePath, contextId);
     if (audienceContextId === undefined) {
-      return undefined;
+      continue;
     }
 
-    return {
+    refs.push({
       type         : 'EncryptionControl',
       protocol     : sourceEntry.protocol as string,
       protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
@@ -481,10 +482,10 @@ function encryptionAudienceDependencyFromRoleAudienceEntry(
         contextId : audienceContextId,
         keyId     : sourceEntry.keyId as string,
       },
-    };
+    });
   }
 
-  const entry = keyEncryption.find((candidate): boolean =>
+  const legacyEntries = keyEncryption.filter((candidate): boolean =>
     candidate.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME &&
     typeof candidate.protocol === 'string' &&
     typeof candidate.role === 'string' &&
@@ -492,27 +493,27 @@ function encryptionAudienceDependencyFromRoleAudienceEntry(
     typeof candidate.epoch === 'number' &&
     typeof candidate.keyId === 'string'
   );
-  if (entry === undefined) {
-    return undefined;
+  for (const entry of legacyEntries) {
+    const role = entry.role as string;
+    const audienceContextId = roleAudienceContextId(role, contextId);
+    if (audienceContextId === undefined) {
+      continue;
+    }
+
+    refs.push({
+      type         : 'EncryptionProtocol',
+      protocolPath : EncryptionProtocol.audienceEpochPath,
+      tags         : {
+        protocol  : entry.protocol as string,
+        contextId : audienceContextId,
+        role,
+        epoch     : entry.epoch as number,
+        keyId     : entry.keyId as string,
+      },
+    });
   }
 
-  const role = entry.role as string;
-  const audienceContextId = roleAudienceContextId(role, contextId);
-  if (audienceContextId === undefined) {
-    return undefined;
-  }
-
-  return {
-    type         : 'EncryptionProtocol',
-    protocolPath : EncryptionProtocol.audienceEpochPath,
-    tags         : {
-      protocol  : entry.protocol as string,
-      contextId : audienceContextId,
-      role,
-      epoch     : entry.epoch as number,
-      keyId     : entry.keyId as string,
-    },
-  };
+  return refs;
 }
 
 function roleDependencyFromEncryptionAudienceRecipient(message: GenericMessage): DependencyRef | undefined {

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -85,7 +85,7 @@ export { PermissionScopeMatcher } from './utils/permission-scope.js';
 export type { ProtocolScope } from './utils/permission-scope.js';
 export { PrivateKeySigner } from './utils/private-key-signer.js';
 export type { PrivateKeySignerOptions } from './utils/private-key-signer.js';
-export { Protocols, parseCrossProtocolRef, isCrossProtocolRef, getRuleSetAtPath } from './utils/protocols.js';
+export { Protocols, parseCrossProtocolRef, isCrossProtocolRef, getRoleAudienceContextId, getRuleSetAtPath } from './utils/protocols.js';
 export type { CrossProtocolRef } from './utils/protocols.js';
 export { ProtocolsConfigure } from './interfaces/protocols-configure.js';
 export type { ProtocolsConfigureOptions } from './interfaces/protocols-configure.js';

--- a/packages/dwn-sdk-js/src/utils/encryption.ts
+++ b/packages/dwn-sdk-js/src/utils/encryption.ts
@@ -46,12 +46,20 @@ export type ProtocolPathKeyEncryption = X25519KeyEncryptionBase & {
   derivationScheme: KeyDerivationScheme.ProtocolPath;
 };
 
-export type RoleAudienceKeyEncryption = X25519KeyEncryptionBase & {
+export type SourceRoleAudienceKeyEncryption = X25519KeyEncryptionBase & {
+  derivationScheme: typeof ROLE_AUDIENCE_DERIVATION_SCHEME;
+  protocol: string;
+  rolePath: string;
+};
+
+export type LegacyRoleAudienceKeyEncryption = X25519KeyEncryptionBase & {
   derivationScheme: typeof ROLE_AUDIENCE_DERIVATION_SCHEME;
   protocol: string;
   role: string;
   epoch: number;
 };
+
+export type RoleAudienceKeyEncryption = SourceRoleAudienceKeyEncryption | LegacyRoleAudienceKeyEncryption;
 
 export type X25519KeyEncryption = ProtocolPathKeyEncryption | RoleAudienceKeyEncryption;
 
@@ -71,12 +79,20 @@ export type ProtocolPathKeyEncryptionInput = X25519KeyEncryptionInputBase & {
   derivationScheme: KeyDerivationScheme.ProtocolPath;
 };
 
-export type RoleAudienceKeyEncryptionInput = X25519KeyEncryptionInputBase & {
+export type SourceRoleAudienceKeyEncryptionInput = X25519KeyEncryptionInputBase & {
+  derivationScheme: typeof ROLE_AUDIENCE_DERIVATION_SCHEME;
+  protocol: string;
+  rolePath: string;
+};
+
+export type LegacyRoleAudienceKeyEncryptionInput = X25519KeyEncryptionInputBase & {
   derivationScheme: typeof ROLE_AUDIENCE_DERIVATION_SCHEME;
   protocol: string;
   role: string;
   epoch: number;
 };
+
+export type RoleAudienceKeyEncryptionInput = SourceRoleAudienceKeyEncryptionInput | LegacyRoleAudienceKeyEncryptionInput;
 
 export type X25519KeyEncryptionInput = ProtocolPathKeyEncryptionInput | RoleAudienceKeyEncryptionInput;
 
@@ -265,13 +281,20 @@ export class Encryption {
       };
     }
 
-    return {
-      ...common,
-      derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
-      epoch            : keyInput.epoch,
-      protocol         : keyInput.protocol,
-      role             : keyInput.role,
-    };
+    return 'rolePath' in keyInput
+      ? {
+        ...common,
+        derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+        protocol         : keyInput.protocol,
+        rolePath         : keyInput.rolePath,
+      }
+      : {
+        ...common,
+        derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+        epoch            : keyInput.epoch,
+        protocol         : keyInput.protocol,
+        role             : keyInput.role,
+      };
   }
 
   private static validateKeyEncryptionEntry(entry: X25519KeyEncryption): void {
@@ -312,6 +335,16 @@ export class Encryption {
 
   private static getKekInfo(keyEncryption: X25519KeyEncryptionInput | X25519KeyEncryption): string {
     if (keyEncryption.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME) {
+      if ('rolePath' in keyEncryption) {
+        return JSON.stringify([
+          KEK_INFO_PREFIX,
+          ROLE_AUDIENCE_DERIVATION_SCHEME,
+          keyEncryption.protocol,
+          keyEncryption.rolePath,
+          keyEncryption.keyId,
+        ]);
+      }
+
       return JSON.stringify([
         KEK_INFO_PREFIX,
         ROLE_AUDIENCE_DERIVATION_SCHEME,

--- a/packages/dwn-sdk-js/src/utils/protocols.ts
+++ b/packages/dwn-sdk-js/src/utils/protocols.ts
@@ -53,6 +53,29 @@ export function getTypeName(protocolPath: string): string {
 }
 
 /**
+ * Computes the role-audience context id for a role path relative to a source record context id.
+ * Root-level role audiences use the empty string; nested role audiences use the ancestor
+ * context prefix at the same depth as the role parent.
+ */
+export function getRoleAudienceContextId(rolePath: string, contextId?: string): string | undefined {
+  const roleParentDepth = rolePath.split('/').length - 1;
+  if (roleParentDepth === 0) {
+    return '';
+  }
+
+  if (contextId === undefined) {
+    return undefined;
+  }
+
+  const contextSegments = contextId.split('/');
+  if (contextSegments.length < roleParentDepth) {
+    return undefined;
+  }
+
+  return contextSegments.slice(0, roleParentDepth).join('/');
+}
+
+/**
  * Gets the rule set at a given protocol path within a protocol definition's structure tree.
  * Returns `undefined` if the path does not exist.
  */

--- a/packages/dwn-sdk-js/tests/core/replication-apply.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/replication-apply.spec.ts
@@ -390,15 +390,36 @@ describe('replicationApplyResultFromReply', () => {
     message.encryption = {
       algorithm            : 'A256CTR',
       initializationVector : 'iv',
-      keyEncryption        : [{
-        algorithm          : 'X25519-HKDF-SHA256+A256KW',
-        derivationScheme   : ROLE_AUDIENCE_DERIVATION_SCHEME,
-        encryptedKey       : 'encrypted-key',
-        ephemeralPublicKey : { kty: 'OKP', crv: 'X25519', x: 'x' },
-        keyId              : 'abc',
-        protocol,
-        rolePath,
-      }],
+      keyEncryption        : [
+        {
+          algorithm          : 'X25519-HKDF-SHA256+A256KW',
+          derivationScheme   : ROLE_AUDIENCE_DERIVATION_SCHEME,
+          encryptedKey       : 'encrypted-key-1',
+          ephemeralPublicKey : { kty: 'OKP', crv: 'X25519', x: 'x' },
+          keyId              : 'abc',
+          protocol,
+          rolePath,
+        },
+        {
+          algorithm          : 'X25519-HKDF-SHA256+A256KW',
+          derivationScheme   : ROLE_AUDIENCE_DERIVATION_SCHEME,
+          encryptedKey       : 'encrypted-key-2',
+          ephemeralPublicKey : { kty: 'OKP', crv: 'X25519', x: 'x' },
+          keyId              : 'def',
+          protocol,
+          rolePath,
+        },
+        {
+          algorithm          : 'X25519-HKDF-SHA256+A256KW',
+          derivationScheme   : ROLE_AUDIENCE_DERIVATION_SCHEME,
+          encryptedKey       : 'legacy-encrypted-key',
+          ephemeralPublicKey : { kty: 'OKP', crv: 'X25519', x: 'x' },
+          epoch              : 3,
+          keyId              : 'legacy',
+          protocol,
+          role               : rolePath,
+        },
+      ],
     } as any;
 
     const detail = `${DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing}: ` +
@@ -411,17 +432,41 @@ describe('replicationApplyResultFromReply', () => {
       },
     })).toEqual({
       kind    : 'Incomplete',
-      missing : [{
-        type         : 'EncryptionControl',
-        protocol,
-        protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
-        tags         : {
+      missing : [
+        {
+          type         : 'EncryptionControl',
           protocol,
-          contextId : 'thread-record',
-          rolePath,
-          keyId     : 'abc',
+          protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          tags         : {
+            protocol,
+            contextId : 'thread-record',
+            rolePath,
+            keyId     : 'abc',
+          },
         },
-      }],
+        {
+          type         : 'EncryptionControl',
+          protocol,
+          protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          tags         : {
+            protocol,
+            contextId : 'thread-record',
+            rolePath,
+            keyId     : 'def',
+          },
+        },
+        {
+          type         : 'EncryptionProtocol',
+          protocolPath : EncryptionProtocol.audienceEpochPath,
+          tags         : {
+            protocol,
+            contextId : 'thread-record',
+            role      : rolePath,
+            epoch     : 3,
+            keyId     : 'legacy',
+          },
+        },
+      ],
     });
   });
 

--- a/packages/dwn-sdk-js/tests/core/replication-apply.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/replication-apply.spec.ts
@@ -3,7 +3,7 @@ import type { ProtocolDefinition } from '../../src/index.js';
 import { describe, expect, it } from 'bun:test';
 
 import { TestDataGenerator } from '../utils/test-data-generator.js';
-import { DwnErrorCode, EncryptionProtocol, replicationApplyResultFromReply, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/index.js';
+import { DwnErrorCode, ENCRYPTION_CONTROL_AUDIENCE_PATH, EncryptionProtocol, replicationApplyResultFromReply, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/index.js';
 
 describe('replicationApplyResultFromReply', () => {
   it('classifies successful and idempotent replies', async () => {
@@ -379,9 +379,9 @@ describe('replicationApplyResultFromReply', () => {
     });
   });
 
-  it('classifies roleAudience audienceEpoch dependencies from encrypted application records', async () => {
+  it('classifies roleAudience audience dependencies from encrypted application records', async () => {
     const protocol = 'https://example.com/encrypted-chat';
-    const role = 'thread/member';
+    const rolePath = 'thread/member';
     const { message } = await TestDataGenerator.generateRecordsWrite({
       protocol,
       protocolPath: 'thread/chat',
@@ -395,15 +395,14 @@ describe('replicationApplyResultFromReply', () => {
         derivationScheme   : ROLE_AUDIENCE_DERIVATION_SCHEME,
         encryptedKey       : 'encrypted-key',
         ephemeralPublicKey : { kty: 'OKP', crv: 'X25519', x: 'x' },
-        epoch              : 3,
         keyId              : 'abc',
         protocol,
-        role,
+        rolePath,
       }],
     } as any;
 
     const detail = `${DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing}: ` +
-      `encrypted record references a missing audienceEpoch for role '${role}'`;
+      `encrypted record references a missing audience for role '${rolePath}'`;
 
     expect(replicationApplyResultFromReply(message, {
       status: {
@@ -413,13 +412,13 @@ describe('replicationApplyResultFromReply', () => {
     })).toEqual({
       kind    : 'Incomplete',
       missing : [{
-        type         : 'EncryptionProtocol',
-        protocolPath : EncryptionProtocol.audienceEpochPath,
+        type         : 'EncryptionControl',
+        protocol,
+        protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
         tags         : {
           protocol,
           contextId : 'thread-record',
-          role,
-          epoch     : 3,
+          rolePath,
           keyId     : 'abc',
         },
       }],

--- a/packages/dwn-sdk-js/tests/fuzz/protocols-utils.fuzz.spec.ts
+++ b/packages/dwn-sdk-js/tests/fuzz/protocols-utils.fuzz.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 
 import fc from 'fast-check';
 
-import { getTypeName, isCrossProtocolRef, parseCrossProtocolRef } from '../../src/utils/protocols.js';
+import { getRoleAudienceContextId, getTypeName, isCrossProtocolRef, parseCrossProtocolRef } from '../../src/utils/protocols.js';
 
 const numRuns = Number(process.env.FAST_CHECK_NUM_RUNS) || 100;
 
@@ -71,6 +71,23 @@ describe('Protocol utility functions — fuzz', () => {
         ),
         { numRuns }
       );
+    });
+  });
+
+  describe('getRoleAudienceContextId', () => {
+    it('should return an empty context id for a root role path', () => {
+      expect(getRoleAudienceContextId('member')).toBe('');
+      expect(getRoleAudienceContextId('member', 'thread/message')).toBe('');
+    });
+
+    it('should return the ancestor context prefix at the role parent depth', () => {
+      expect(getRoleAudienceContextId('thread/member', 'thread-record/message-record')).toBe('thread-record');
+      expect(getRoleAudienceContextId('thread/message/member', 'thread-record/message-record/reply-record')).toBe('thread-record/message-record');
+    });
+
+    it('should return undefined when a nested role path has no covering context id', () => {
+      expect(getRoleAudienceContextId('thread/member')).toBeUndefined();
+      expect(getRoleAudienceContextId('thread/message/member', 'thread-record')).toBeUndefined();
     });
   });
 });

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -46,7 +46,7 @@ import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { Time } from '../../src/utils/time.js';
 import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/utils/encryption.js';
-import { CoreProtocolRegistry, DataStoreLevel, DwnConstant, DwnInterfaceName, DwnMethodName, EncryptionProtocol, KeyDerivationScheme, MessageStoreLevel, PermissionsProtocol, Protocols, RecordsDelete, RecordsQuery } from '../../src/index.js';
+import { CoreProtocolRegistry, DataStoreLevel, DwnConstant, DwnInterfaceName, DwnMethodName, KeyDerivationScheme, MessageStoreLevel, PermissionsProtocol, Protocols, RecordsDelete, RecordsQuery } from '../../src/index.js';
 import { defaultTestProtocolDefinition, TestDataGenerator } from '../utils/test-data-generator.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnError, DwnErrorCode } from '../../src/core/dwn-error.js';
@@ -4098,7 +4098,99 @@ export function testRecordsWriteHandler(): void {
           expect(writeReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEntryMissing);
         });
 
-        it('should accept an encrypted role-readable RecordsWrite with a matching audienceEpoch', async () => {
+        it('should reject an encrypted role-readable RecordsWrite whose roleAudience entry references a missing audience record', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://role-audience-record-required.xyz',
+            published : false,
+            types     : {
+              thread      : { schema: 'http://thread-schema', dataFormats: ['application/json'] },
+              participant : { schema: 'http://participant-schema', dataFormats: ['application/json'] },
+              chat        : { schema: 'http://chat-schema', dataFormats: ['text/plain'], encryptionRequired: true },
+            },
+            structure: {
+              thread: {
+                participant : { $role: true },
+                chat        : {
+                  $actions: [
+                    { role: 'thread/participant', can: ['read'] },
+                  ],
+                },
+              },
+            },
+          };
+
+          const encryptedProtocolDefinition = await Protocols.deriveAndInjectPublicEncryptionKeys(
+            protocolDefinition, alice.keyId, alice.encryptionKeyPair.privateJwk
+          );
+
+          const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : encryptedProtocolDefinition,
+          });
+          expect((await dwn.processMessage(alice.did, protocolConfig.message)).status.code).toBe(202);
+
+          const thread = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'thread',
+            schema       : 'http://thread-schema',
+            dataFormat   : 'application/json',
+            data         : Encoder.stringToBytes('{"title":"secret"}'),
+          });
+          expect((await dwn.processMessage(alice.did, thread.message, { dataStream: thread.dataStream })).status.code).toBe(202);
+
+          const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+          const dataEncryptionInitializationVector = TestDataGenerator.randomBytes(16);
+          const encryptedData = await Encryption.encrypt(
+            ContentEncryptionAlgorithm.A256CTR,
+            dataEncryptionKey,
+            dataEncryptionInitializationVector,
+            Encoder.stringToBytes('encrypted chat'),
+          );
+          const threadRuleSet = encryptedProtocolDefinition.structure.thread;
+          const chatRuleSet = threadRuleSet.chat as ProtocolRuleSet;
+          const protocolPathPublicKey = chatRuleSet.$keyAgreement!.publicKeyJwk;
+          const audiencePublicKey = alice.encryptionKeyPair.publicJwk;
+          const encryptionInput: EncryptionInput = {
+            initializationVector : dataEncryptionInitializationVector,
+            key                  : dataEncryptionKey,
+            keyEncryptionInputs  : [
+              {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                keyId            : await Encryption.getKeyId(protocolPathPublicKey),
+                publicKey        : protocolPathPublicKey,
+                derivationScheme : KeyDerivationScheme.ProtocolPath,
+              },
+              {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                keyId            : await Encryption.getKeyId(audiencePublicKey),
+                publicKey        : audiencePublicKey,
+                derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+                protocol         : protocolDefinition.protocol,
+                rolePath         : 'thread/participant',
+              },
+            ],
+          };
+
+          const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+            author          : alice,
+            protocol        : protocolDefinition.protocol,
+            protocolPath    : 'thread/chat',
+            parentContextId : thread.message.contextId,
+            schema          : 'http://chat-schema',
+            dataFormat      : 'text/plain',
+            data            : encryptedData,
+            encryptionInput,
+          });
+
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: recordsWrite.dataStream });
+          expect(writeReply.status.code).toBe(400);
+          expect(writeReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing);
+        });
+
+        it('should accept an encrypted role-readable RecordsWrite with a matching audience record', async () => {
           const alice = await TestDataGenerator.generateDidKeyPersona();
 
           const protocolDefinition: ProtocolDefinition = {
@@ -4141,38 +4233,20 @@ export function testRecordsWriteHandler(): void {
           });
           expect((await dwn.processMessage(alice.did, thread.message, { dataStream: thread.dataStream })).status.code).toBe(202);
 
-          const role = 'thread/participant';
+          const rolePath = 'thread/participant';
           const threadRuleSet = encryptedProtocolDefinition.structure.thread;
           const participantRuleSet = threadRuleSet.participant as ProtocolRuleSet;
-          const rolePublicKey = participantRuleSet.$keyAgreement!.publicKeyJwk;
-          const roleKeyId = await Encryption.getKeyId(rolePublicKey);
-          const audienceEpochData = Encoder.objectToBytes({
-            protocol     : protocolDefinition.protocol,
-            contextId    : thread.message.contextId,
-            role,
-            epoch        : 1,
-            keyId        : roleKeyId,
-            publicKeyJwk : rolePublicKey,
-          });
-          const audienceEpoch = await RecordsWrite.create({
-            data         : audienceEpochData,
-            dataFormat   : 'application/json',
-            protocol     : EncryptionProtocol.uri,
-            protocolPath : EncryptionProtocol.audienceEpochPath,
-            schema       : EncryptionProtocol.definition.types.audienceEpoch.schema,
-            signer       : Jws.createSigner(alice),
-            tags         : {
-              protocol  : protocolDefinition.protocol,
-              contextId : thread.message.contextId!,
-              role,
-              epoch     : 1,
-              keyId     : roleKeyId,
-            },
+          const audience = await createAudienceControlWrite({
+            author      : alice,
+            contextId   : thread.message.contextId,
+            protocol    : protocolDefinition.protocol,
+            rolePath,
+            roleRuleSet : participantRuleSet,
           });
           expect((await dwn.processMessage(
             alice.did,
-            audienceEpoch.message,
-            { dataStream: DataStream.fromBytes(audienceEpochData) }
+            audience.recordsWrite.message,
+            { dataStream: DataStream.fromBytes(audience.dataBytes) }
           )).status.code).toBe(202);
 
           const data = Encoder.stringToBytes('encrypted chat');
@@ -4195,12 +4269,11 @@ export function testRecordsWriteHandler(): void {
               },
               {
                 algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
-                keyId            : roleKeyId,
-                publicKey        : rolePublicKey,
+                keyId            : audience.keyId,
+                publicKey        : alice.encryptionKeyPair.publicJwk,
                 derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
                 protocol         : protocolDefinition.protocol,
-                role,
-                epoch            : 1,
+                rolePath,
               },
             ],
           };

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -46,7 +46,7 @@ import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { Time } from '../../src/utils/time.js';
 import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/utils/encryption.js';
-import { CoreProtocolRegistry, DataStoreLevel, DwnConstant, DwnInterfaceName, DwnMethodName, KeyDerivationScheme, MessageStoreLevel, PermissionsProtocol, Protocols, RecordsDelete, RecordsQuery } from '../../src/index.js';
+import { CoreProtocolRegistry, DataStoreLevel, DwnConstant, DwnInterfaceName, DwnMethodName, EncryptionProtocol, KeyDerivationScheme, MessageStoreLevel, PermissionsProtocol, Protocols, RecordsDelete, RecordsQuery } from '../../src/index.js';
 import { defaultTestProtocolDefinition, TestDataGenerator } from '../utils/test-data-generator.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnError, DwnErrorCode } from '../../src/core/dwn-error.js';
@@ -4188,6 +4188,351 @@ export function testRecordsWriteHandler(): void {
           const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: recordsWrite.dataStream });
           expect(writeReply.status.code).toBe(400);
           expect(writeReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing);
+        });
+
+        it('should accept an encrypted role-readable RecordsWrite when any source roleAudience entry matches an accepted audience record', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://role-audience-second-entry-accepted.xyz',
+            published : false,
+            types     : {
+              thread      : { schema: 'http://thread-schema', dataFormats: ['application/json'] },
+              participant : { schema: 'http://participant-schema', dataFormats: ['application/json'] },
+              chat        : { schema: 'http://chat-schema', dataFormats: ['text/plain'], encryptionRequired: true },
+            },
+            structure: {
+              thread: {
+                participant : { $role: true },
+                chat        : {
+                  $actions: [
+                    { role: 'thread/participant', can: ['read'] },
+                  ],
+                },
+              },
+            },
+          };
+
+          const encryptedProtocolDefinition = await Protocols.deriveAndInjectPublicEncryptionKeys(
+            protocolDefinition, alice.keyId, alice.encryptionKeyPair.privateJwk
+          );
+
+          const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : encryptedProtocolDefinition,
+          });
+          expect((await dwn.processMessage(alice.did, protocolConfig.message)).status.code).toBe(202);
+
+          const thread = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'thread',
+            schema       : 'http://thread-schema',
+            dataFormat   : 'application/json',
+            data         : Encoder.stringToBytes('{"title":"secret"}'),
+          });
+          expect((await dwn.processMessage(alice.did, thread.message, { dataStream: thread.dataStream })).status.code).toBe(202);
+
+          const rolePath = 'thread/participant';
+          const threadRuleSet = encryptedProtocolDefinition.structure.thread;
+          const participantRuleSet = threadRuleSet.participant as ProtocolRuleSet;
+          const audience = await createAudienceControlWrite({
+            author      : alice,
+            contextId   : thread.message.contextId,
+            protocol    : protocolDefinition.protocol,
+            rolePath,
+            roleRuleSet : participantRuleSet,
+          });
+          expect((await dwn.processMessage(
+            alice.did,
+            audience.recordsWrite.message,
+            { dataStream: DataStream.fromBytes(audience.dataBytes) }
+          )).status.code).toBe(202);
+
+          const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+          const dataEncryptionInitializationVector = TestDataGenerator.randomBytes(16);
+          const encryptedData = await Encryption.encrypt(
+            ContentEncryptionAlgorithm.A256CTR,
+            dataEncryptionKey,
+            dataEncryptionInitializationVector,
+            Encoder.stringToBytes('encrypted chat'),
+          );
+          const chatRuleSet = threadRuleSet.chat as ProtocolRuleSet;
+          const protocolPathPublicKey = chatRuleSet.$keyAgreement!.publicKeyJwk;
+          const encryptionInput: EncryptionInput = {
+            initializationVector : dataEncryptionInitializationVector,
+            key                  : dataEncryptionKey,
+            keyEncryptionInputs  : [
+              {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                keyId            : await Encryption.getKeyId(protocolPathPublicKey),
+                publicKey        : protocolPathPublicKey,
+                derivationScheme : KeyDerivationScheme.ProtocolPath,
+              },
+              {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                keyId            : await Encryption.getKeyId(bob.encryptionKeyPair.publicJwk),
+                publicKey        : bob.encryptionKeyPair.publicJwk,
+                derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+                protocol         : protocolDefinition.protocol,
+                rolePath,
+              },
+              {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                keyId            : audience.keyId,
+                publicKey        : alice.encryptionKeyPair.publicJwk,
+                derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+                protocol         : protocolDefinition.protocol,
+                rolePath,
+              },
+            ],
+          };
+
+          const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+            author          : alice,
+            protocol        : protocolDefinition.protocol,
+            protocolPath    : 'thread/chat',
+            parentContextId : thread.message.contextId,
+            schema          : 'http://chat-schema',
+            dataFormat      : 'text/plain',
+            data            : encryptedData,
+            encryptionInput,
+          });
+
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: recordsWrite.dataStream });
+          expect(writeReply.status.code).toBe(202);
+        });
+
+        it('should reject an encrypted role-readable RecordsWrite when the roleAudience keyId does not match the audience record', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://role-audience-key-id-bound.xyz',
+            published : false,
+            types     : {
+              thread      : { schema: 'http://thread-schema', dataFormats: ['application/json'] },
+              participant : { schema: 'http://participant-schema', dataFormats: ['application/json'] },
+              chat        : { schema: 'http://chat-schema', dataFormats: ['text/plain'], encryptionRequired: true },
+            },
+            structure: {
+              thread: {
+                participant : { $role: true },
+                chat        : {
+                  $actions: [
+                    { role: 'thread/participant', can: ['read'] },
+                  ],
+                },
+              },
+            },
+          };
+
+          const encryptedProtocolDefinition = await Protocols.deriveAndInjectPublicEncryptionKeys(
+            protocolDefinition, alice.keyId, alice.encryptionKeyPair.privateJwk
+          );
+
+          const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : encryptedProtocolDefinition,
+          });
+          expect((await dwn.processMessage(alice.did, protocolConfig.message)).status.code).toBe(202);
+
+          const thread = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'thread',
+            schema       : 'http://thread-schema',
+            dataFormat   : 'application/json',
+            data         : Encoder.stringToBytes('{"title":"secret"}'),
+          });
+          expect((await dwn.processMessage(alice.did, thread.message, { dataStream: thread.dataStream })).status.code).toBe(202);
+
+          const rolePath = 'thread/participant';
+          const threadRuleSet = encryptedProtocolDefinition.structure.thread;
+          const participantRuleSet = threadRuleSet.participant as ProtocolRuleSet;
+          const audience = await createAudienceControlWrite({
+            author      : alice,
+            contextId   : thread.message.contextId,
+            protocol    : protocolDefinition.protocol,
+            rolePath,
+            roleRuleSet : participantRuleSet,
+          });
+          expect((await dwn.processMessage(
+            alice.did,
+            audience.recordsWrite.message,
+            { dataStream: DataStream.fromBytes(audience.dataBytes) }
+          )).status.code).toBe(202);
+
+          const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+          const dataEncryptionInitializationVector = TestDataGenerator.randomBytes(16);
+          const encryptedData = await Encryption.encrypt(
+            ContentEncryptionAlgorithm.A256CTR,
+            dataEncryptionKey,
+            dataEncryptionInitializationVector,
+            Encoder.stringToBytes('encrypted chat'),
+          );
+          const chatRuleSet = threadRuleSet.chat as ProtocolRuleSet;
+          const protocolPathPublicKey = chatRuleSet.$keyAgreement!.publicKeyJwk;
+          const encryptionInput: EncryptionInput = {
+            initializationVector : dataEncryptionInitializationVector,
+            key                  : dataEncryptionKey,
+            keyEncryptionInputs  : [
+              {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                keyId            : await Encryption.getKeyId(protocolPathPublicKey),
+                publicKey        : protocolPathPublicKey,
+                derivationScheme : KeyDerivationScheme.ProtocolPath,
+              },
+              {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                keyId            : await Encryption.getKeyId(bob.encryptionKeyPair.publicJwk),
+                publicKey        : bob.encryptionKeyPair.publicJwk,
+                derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+                protocol         : protocolDefinition.protocol,
+                rolePath,
+              },
+            ],
+          };
+
+          const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+            author          : alice,
+            protocol        : protocolDefinition.protocol,
+            protocolPath    : 'thread/chat',
+            parentContextId : thread.message.contextId,
+            schema          : 'http://chat-schema',
+            dataFormat      : 'text/plain',
+            data            : encryptedData,
+            encryptionInput,
+          });
+
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: recordsWrite.dataStream });
+          expect(writeReply.status.code).toBe(400);
+          expect(writeReply.status.detail).toContain(DwnErrorCode.ProtocolAuthorizationEncryptionRoleAudienceEpochMissing);
+        });
+
+        it('should accept legacy epoch-shaped roleAudience entries during the staged migration', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://role-audience-legacy-entry-accepted.xyz',
+            published : false,
+            types     : {
+              thread      : { schema: 'http://thread-schema', dataFormats: ['application/json'] },
+              participant : { schema: 'http://participant-schema', dataFormats: ['application/json'] },
+              chat        : { schema: 'http://chat-schema', dataFormats: ['text/plain'], encryptionRequired: true },
+            },
+            structure: {
+              thread: {
+                participant : { $role: true },
+                chat        : {
+                  $actions: [
+                    { role: 'thread/participant', can: ['read'] },
+                  ],
+                },
+              },
+            },
+          };
+
+          const encryptedProtocolDefinition = await Protocols.deriveAndInjectPublicEncryptionKeys(
+            protocolDefinition, alice.keyId, alice.encryptionKeyPair.privateJwk
+          );
+
+          const protocolConfig = await TestDataGenerator.generateProtocolsConfigure({
+            author             : alice,
+            protocolDefinition : encryptedProtocolDefinition,
+          });
+          expect((await dwn.processMessage(alice.did, protocolConfig.message)).status.code).toBe(202);
+
+          const thread = await TestDataGenerator.generateRecordsWrite({
+            author       : alice,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'thread',
+            schema       : 'http://thread-schema',
+            dataFormat   : 'application/json',
+            data         : Encoder.stringToBytes('{"title":"secret"}'),
+          });
+          expect((await dwn.processMessage(alice.did, thread.message, { dataStream: thread.dataStream })).status.code).toBe(202);
+
+          const role = 'thread/participant';
+          const threadRuleSet = encryptedProtocolDefinition.structure.thread;
+          const participantRuleSet = threadRuleSet.participant as ProtocolRuleSet;
+          const rolePublicKey = participantRuleSet.$keyAgreement!.publicKeyJwk;
+          const roleKeyId = await Encryption.getKeyId(rolePublicKey);
+          const audienceEpochData = Encoder.objectToBytes({
+            protocol     : protocolDefinition.protocol,
+            contextId    : thread.message.contextId,
+            role,
+            epoch        : 1,
+            keyId        : roleKeyId,
+            publicKeyJwk : rolePublicKey,
+          });
+          const audienceEpoch = await RecordsWrite.create({
+            data         : audienceEpochData,
+            dataFormat   : 'application/json',
+            protocol     : EncryptionProtocol.uri,
+            protocolPath : EncryptionProtocol.audienceEpochPath,
+            schema       : EncryptionProtocol.definition.types.audienceEpoch.schema,
+            signer       : Jws.createSigner(alice),
+            tags         : {
+              protocol  : protocolDefinition.protocol,
+              contextId : thread.message.contextId!,
+              role,
+              epoch     : 1,
+              keyId     : roleKeyId,
+            },
+          });
+          expect((await dwn.processMessage(
+            alice.did,
+            audienceEpoch.message,
+            { dataStream: DataStream.fromBytes(audienceEpochData) }
+          )).status.code).toBe(202);
+
+          const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+          const dataEncryptionInitializationVector = TestDataGenerator.randomBytes(16);
+          const encryptedData = await Encryption.encrypt(
+            ContentEncryptionAlgorithm.A256CTR,
+            dataEncryptionKey,
+            dataEncryptionInitializationVector,
+            Encoder.stringToBytes('encrypted chat'),
+          );
+          const chatRuleSet = threadRuleSet.chat as ProtocolRuleSet;
+          const protocolPathPublicKey = chatRuleSet.$keyAgreement!.publicKeyJwk;
+          const encryptionInput: EncryptionInput = {
+            initializationVector : dataEncryptionInitializationVector,
+            key                  : dataEncryptionKey,
+            keyEncryptionInputs  : [
+              {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                keyId            : await Encryption.getKeyId(protocolPathPublicKey),
+                publicKey        : protocolPathPublicKey,
+                derivationScheme : KeyDerivationScheme.ProtocolPath,
+              },
+              {
+                algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                keyId            : roleKeyId,
+                publicKey        : rolePublicKey,
+                derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+                protocol         : protocolDefinition.protocol,
+                role,
+                epoch            : 1,
+              },
+            ],
+          };
+
+          const recordsWrite = await TestDataGenerator.generateRecordsWrite({
+            author          : alice,
+            protocol        : protocolDefinition.protocol,
+            protocolPath    : 'thread/chat',
+            parentContextId : thread.message.contextId,
+            schema          : 'http://chat-schema',
+            dataFormat      : 'text/plain',
+            data            : encryptedData,
+            encryptionInput,
+          });
+
+          const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: recordsWrite.dataStream });
+          expect(writeReply.status.code).toBe(202);
         });
 
         it('should accept an encrypted role-readable RecordsWrite with a matching audience record', async () => {

--- a/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
@@ -416,11 +416,10 @@ describe('RecordsWrite', () => {
           keyEncryptionInputs  : [{
             algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
             derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
-            epoch            : 1,
             keyId            : await Encryption.getKeyId(publicKey),
             protocol         : 'https://example.com/protocol',
             publicKey,
-            role             : 'thread/member',
+            rolePath         : 'thread/member',
           }],
         },
         protocol     : 'https://example.com/protocol',
@@ -432,9 +431,10 @@ describe('RecordsWrite', () => {
 
       const keyEncryption = recordsWrite.message.encryption!.keyEncryption[0];
       expect(keyEncryption.derivationScheme).toBe(ROLE_AUDIENCE_DERIVATION_SCHEME);
-      expect('epoch' in keyEncryption && keyEncryption.epoch).toBe(1);
       expect('protocol' in keyEncryption && keyEncryption.protocol).toBe('https://example.com/protocol');
-      expect('role' in keyEncryption && keyEncryption.role).toBe('thread/member');
+      expect('rolePath' in keyEncryption && keyEncryption.rolePath).toBe('thread/member');
+      expect('epoch' in keyEncryption).toBe(false);
+      expect('role' in keyEncryption).toBe(false);
     });
   });
 

--- a/packages/dwn-sdk-js/tests/utils/encryption.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/encryption.spec.ts
@@ -186,7 +186,6 @@ describe('Encryption', () => {
       const baseKeyInput = {
         algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
         derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
-        epoch            : 1,
         keyId,
         publicKey        : recipientPublicKey,
       } as const;
@@ -197,7 +196,7 @@ describe('Encryption', () => {
         keyInput: {
           ...baseKeyInput,
           protocol : 'https://example.com/a|b',
-          role     : 'c',
+          rolePath : 'c',
         },
       });
       const wrappedKey2 = await Encryption.wrapKey({
@@ -206,7 +205,7 @@ describe('Encryption', () => {
         keyInput: {
           ...baseKeyInput,
           protocol : 'https://example.com/a',
-          role     : 'b|c',
+          rolePath : 'b|c',
         },
       });
 
@@ -217,14 +216,14 @@ describe('Encryption', () => {
         encryptedKey       : Encoder.bytesToBase64Url(wrappedKey1.encryptedKey),
         ephemeralPublicKey : wrappedKey1.ephemeralPublicKey,
         protocol           : 'https://example.com/a|b',
-        role               : 'c',
+        rolePath           : 'c',
       });
       const unwrapped2 = await Encryption.unwrapKey(recipientPrivateKey, {
         ...baseKeyInput,
         encryptedKey       : Encoder.bytesToBase64Url(wrappedKey2.encryptedKey),
         ephemeralPublicKey : wrappedKey2.ephemeralPublicKey,
         protocol           : 'https://example.com/a',
-        role               : 'b|c',
+        rolePath           : 'b|c',
       });
 
       expect(ArrayUtility.byteArraysEqual(unwrapped1, cek)).toBe(true);


### PR DESCRIPTION
## Summary
- Adds source-protocol `roleAudience` key-encryption entries keyed by `protocol` + `rolePath`, while keeping the legacy epoch-shaped entries during the staged agent migration.
- Validates encrypted role-readable application writes against any accepted source-protocol `$encryption/audience` record for the required role audience.
- Emits all candidate audience dependency refs and narrows/paginates source-protocol control-record repair so sync closure can recover missing audience records.
- Orders in-batch source audience records before encrypted application records that reference them.

## Test plan
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test:node` from `packages/dwn-sdk-js`
- [x] `bun test tests/sync-admission-order.spec.ts tests/sync-admit-closure.spec.ts tests/sync-messages.spec.ts` from `packages/agent`
- [ ] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node` from `packages/agent` (attempted locally before this update; 1176 passed, 65 failed because the local DWN server at `http://localhost:3000` was not reachable)

## Notes
This is an admission and sync-dependency substrate slice. It does not claim the agent role-audience producer rewrite is complete.

During the staged dual-shape migration, a valid legacy epoch-shaped entry can admit a mixed envelope even if a source-shaped entry is unanchored. Client decryption still verifies usable key material, and this migration allowance goes away when the legacy epoch shape is removed.
