### PR TITLE
chore(deps): inline BEP44 signing encoder

### DIFF
--- a/.changeset/inline-bep44-bencode.md
+++ b/.changeset/inline-bep44-bencode.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dids": patch
+---
+
+chore: inline BEP44 signing byte encoding.

--- a/bun.lock
+++ b/bun.lock
@@ -193,11 +193,9 @@
         "@enbox/common": "workspace:*",
         "@enbox/crypto": "workspace:*",
         "abstract-level": "1.0.4",
-        "bencode": "4.0.0",
         "level": "8.0.1",
       },
       "devDependencies": {
-        "@types/bencode": "2.0.4",
         "@types/node": "22.19.15",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
@@ -1201,8 +1199,6 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.1", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "postcss": "^8.5.6", "tailwindcss": "4.2.1" } }, "sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw=="],
 
-    "@types/bencode": ["@types/bencode@2.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-sirDu3HUSG7jZMlhTDvCzSFiPR4lkUYBQA75CoMi6DEf2alFZWJWtHgfjBbb9PachPZhPMB1IlH09deyMNBipQ=="],
-
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -1347,13 +1343,9 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
-
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
-
-    "bencode": ["bencode@4.0.0", "", { "dependencies": { "uint8-util": "^2.2.2" } }, "sha512-AERXw18df0pF3ziGOCyUjqKZBVNH8HV3lBxnx5w0qtgMIk4a1wb9BkcCQbkp9Zstfrn/dzRwl7MmUHHocX3sRQ=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
@@ -2527,8 +2519,6 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "uint8-util": ["uint8-util@2.2.6", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-r+ZjS8CzPhtPF771ROOadUoqC40OVdiMKBI8lTfJQWb4W7+73sMBwMYmai/uvNcmZ7tBJJyZSad03yMWIt3RQg=="],
-
     "uint8-varint": ["uint8-varint@3.0.0", "", { "dependencies": { "uint8arraylist": "^3.0.1", "uint8arrays": "^6.1.0" } }, "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q=="],
 
     "uint8arraylist": ["uint8arraylist@3.0.2", "", { "dependencies": { "uint8arrays": "^6.0.0" } }, "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ=="],
@@ -2697,8 +2687,6 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@types/bencode/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
-
     "@types/pg/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "@types/pg/pg-types": ["pg-types@4.1.0", "", { "dependencies": { "pg-int8": "1.0.1", "pg-numeric": "1.0.2", "postgres-array": "~3.0.1", "postgres-bytea": "~3.0.0", "postgres-date": "~2.1.0", "postgres-interval": "^3.0.0", "postgres-range": "^1.1.1" } }, "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg=="],
@@ -2860,8 +2848,6 @@
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
-    "@types/bencode/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@types/pg-cursor/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -81,11 +81,9 @@
     "@enbox/common": "workspace:*",
     "@enbox/crypto": "workspace:*",
     "abstract-level": "1.0.4",
-    "bencode": "4.0.0",
     "level": "8.0.1"
   },
   "devDependencies": {
-    "@types/bencode": "2.0.4",
     "@types/node": "22.19.15",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",

--- a/packages/dids/src/methods/did-dht-pkarr.ts
+++ b/packages/dids/src/methods/did-dht-pkarr.ts
@@ -3,11 +3,31 @@ import type { Signer } from '@enbox/crypto';
 
 import type { Bep44Message } from './did-dht-types.js';
 
-import bencode from 'bencode';
 import { Ed25519 } from '@enbox/crypto';
 import { Convert, fetchPublicUrl, PublicUrlValidationError } from '@enbox/common';
 import { DidError, DidErrorCode } from '../did-error.js';
 import { decode as dnsPacketDecode, encode as dnsPacketEncode } from '@dnsquery/dns-packet';
+
+const textEncoder = new TextEncoder();
+
+/**
+ * Encodes the BEP44 signing payload for a mutable item.
+ *
+ * BEP44 signs the dictionary body for `{ seq, v }`, without the surrounding `d` and `e` dictionary
+ * delimiters. For DID DHT records that body is always:
+ * `3:seqi<sequenceNumber>e1:v<valueLength>:<valueBytes>`.
+ */
+export function encodeBep44SigningPayload({ sequenceNumber, value }: {
+  sequenceNumber: number;
+  value: Uint8Array;
+}): Uint8Array {
+  const prefix = textEncoder.encode(`3:seqi${sequenceNumber}e1:v${value.length}:`);
+  const encodedPayload = new Uint8Array(prefix.length + value.length);
+  encodedPayload.set(prefix);
+  encodedPayload.set(value, prefix.length);
+
+  return encodedPayload;
+}
 
 /**
  * Constructs a Pkarr URL from public key bytes and a gateway URI.
@@ -181,15 +201,15 @@ export async function createBep44PutMessage({ dnsPacket, publicKeyBytes, signer 
   // Encode the DNS packet into a byte array containing a UDP payload.
   const encodedDnsPacket = dnsPacketEncode(dnsPacket);
 
-  // Encode the sequence and DNS byte array to bencode format.
-  const bencodedData = bencode.encode({ seq: sequenceNumber, v: encodedDnsPacket }).subarray(1, -1);
+  // Encode the sequence and DNS byte array to the BEP44 signing payload.
+  const signingPayload = encodeBep44SigningPayload({ sequenceNumber, value: encodedDnsPacket });
 
-  if (bencodedData.length > 1000) {
-    throw new DidError(DidErrorCode.InvalidDidDocumentLength, `DNS packet exceeds the 1000 byte maximum size: ${bencodedData.length} bytes`);
+  if (signingPayload.length > 1000) {
+    throw new DidError(DidErrorCode.InvalidDidDocumentLength, `DNS packet exceeds the 1000 byte maximum size: ${signingPayload.length} bytes`);
   }
 
-  // Sign the BEP44 message. Wrap in Uint8Array since bencode returns Buffer.
-  const signature = await signer.sign({ data: new Uint8Array(bencodedData) });
+  // Sign the BEP44 message.
+  const signature = await signer.sign({ data: signingPayload });
 
   return { k: publicKeyBytes, seq: sequenceNumber, sig: signature, v: encodedDnsPacket };
 }
@@ -207,14 +227,14 @@ export async function parseBep44GetMessage({ bep44Message }: {
   // Convert the public key byte array to JWK format.
   const publicKey = await Ed25519.bytesToPublicKey({ publicKeyBytes: bep44Message.k });
 
-  // Encode the sequence and DNS byte array to bencode format.
-  const bencodedData = bencode.encode({ seq: bep44Message.seq, v: bep44Message.v }).subarray(1, -1);
+  // Encode the sequence and DNS byte array to the BEP44 signing payload.
+  const signingPayload = encodeBep44SigningPayload({ sequenceNumber: bep44Message.seq, value: bep44Message.v });
 
   // Verify the signature of the BEP44 message.
   const isValid = await Ed25519.verify({
     key       : publicKey,
     signature : bep44Message.sig,
-    data      : new Uint8Array(bencodedData)
+    data      : signingPayload
   });
 
   if (!isValid) {

--- a/packages/dids/src/methods/did-dht-types.ts
+++ b/packages/dids/src/methods/did-dht-types.ts
@@ -27,7 +27,7 @@ export interface Bep44Message {
 
   /**
    * The signature of the message, ensuring the authenticity and integrity of the data. It's
-   * computed over the bencoded sequence number and value.
+   * computed over the BEP44 encoded sequence number and value.
    */
   sig: Uint8Array;
 

--- a/packages/dids/tests/methods/did-dht.test.ts
+++ b/packages/dids/tests/methods/did-dht.test.ts
@@ -1,9 +1,12 @@
-import type { Answer } from '@dnsquery/dns-packet';
 import type { DidDocument } from '../../src/index.js';
 import type { PortableDid } from '../../src/types/portable-did.js';
+import type { Signer } from '@enbox/crypto';
+import type { Answer, Packet } from '@dnsquery/dns-packet';
 
 import { Convert } from '@enbox/common';
 import { DidErrorCode } from '../../src/did-error.js';
+import { Ed25519 } from '@enbox/crypto';
+import { encodeBep44SigningPayload } from '../../src/methods/did-dht-pkarr.js';
 import officialTestVector1 from '../fixtures/test-vectors/did-dht/vector-1.json' with { type: 'json' };
 import officialTestVector2 from '../fixtures/test-vectors/did-dht/vector-2.json' with { type: 'json' };
 import officialTestVector3 from '../fixtures/test-vectors/did-dht/vector-3.json' with { type: 'json' };
@@ -65,6 +68,21 @@ const fetchOkResponse = (response?: any): {
   ok          : true,
   arrayBuffer : async (): Promise<any> => Promise.resolve(response)
 });
+
+const testTextEncoder = new TextEncoder();
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const length = parts.reduce((total, part) => total + part.length, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+
+  return result;
+}
 
 describe('DidDht', () => {
   pinPublicGatewayDefault();
@@ -1520,6 +1538,91 @@ describe('DidDhtUtils', () => {
     const newDid = (await DidDht.create()).document.id;
 
     await expect(DidDhtUtils.validatePreviousDidProof({ newDid, previousDidProof })).rejects.toThrow(DidErrorCode.InvalidPreviousDidProof);
+  });
+
+  describe('BEP44 signing payloads', () => {
+    it('encodes sequence and value vectors without dictionary delimiters', () => {
+      const vectors = [
+        {
+          sequenceNumber : 0,
+          value          : new Uint8Array(),
+          expected       : testTextEncoder.encode('3:seqi0e1:v0:'),
+        },
+        {
+          sequenceNumber : 42,
+          value          : new Uint8Array([0, 97, 255]),
+          expected       : concatBytes(testTextEncoder.encode('3:seqi42e1:v3:'), new Uint8Array([0, 97, 255])),
+        },
+        {
+          sequenceNumber : 1_700_000_000,
+          value          : testTextEncoder.encode('hello'),
+          expected       : testTextEncoder.encode('3:seqi1700000000e1:v5:hello'),
+        }
+      ];
+
+      for (const vector of vectors) {
+        const payload = encodeBep44SigningPayload({
+          sequenceNumber : vector.sequenceNumber,
+          value          : vector.value,
+        });
+
+        expect(Array.from(payload)).toEqual(Array.from(vector.expected));
+      }
+    });
+
+    it('signs and verifies DNS packets using the BEP44 signing payload', async () => {
+      const privateKey = await Ed25519.generateKey();
+      const publicKey = await Ed25519.getPublicKey({ key: privateKey });
+      const publicKeyBytes = await Ed25519.publicKeyToBytes({ publicKey });
+      let signedPayload: Uint8Array | undefined;
+
+      const signer: Signer = {
+        async sign({ data }): Promise<Uint8Array> {
+          signedPayload = data;
+          return Ed25519.sign({ key: privateKey, data });
+        },
+        async verify({ data, signature }): Promise<boolean> {
+          return Ed25519.verify({ key: publicKey, data, signature });
+        }
+      };
+
+      const dnsPacket: Packet = {
+        id      : 0,
+        type    : 'response',
+        flags   : 1024,
+        answers : [
+          {
+            type : 'TXT',
+            name : '_did.example.',
+            ttl  : 7200,
+            data : 'id=0',
+          }
+        ]
+      };
+
+      const bep44Message = await DidDhtUtils.createBep44PutMessage({
+        dnsPacket,
+        publicKeyBytes,
+        signer,
+      });
+      const expectedPayload = encodeBep44SigningPayload({
+        sequenceNumber : bep44Message.seq,
+        value          : bep44Message.v,
+      });
+
+      expect(Array.from(signedPayload!)).toEqual(Array.from(expectedPayload));
+
+      const parsedPacket = await DidDhtUtils.parseBep44GetMessage({ bep44Message });
+      expect(parsedPacket.answers).toHaveLength(1);
+
+      const tamperedMessage = {
+        ...bep44Message,
+        v: new Uint8Array(bep44Message.v),
+      };
+      tamperedMessage.v[0] ^= 0xff;
+
+      await expect(DidDhtUtils.parseBep44GetMessage({ bep44Message: tamperedMessage })).rejects.toThrow(DidErrorCode.InvalidSignature);
+    });
   });
 });
 


### PR DESCRIPTION
Summary
- Remove the direct bencode and @types/bencode dependencies from @enbox/dids.
- Replace the dependency call with a local BEP44 signing payload encoder for { seq, v }.
- Add known byte-vector coverage plus a real Ed25519 create/parse signature round trip.

Test plan
- [x] bun run --filter @enbox/dids lint
- [x] bun run --filter @enbox/common build && bun run --filter @enbox/crypto build && bun run --filter @enbox/dids build
- [x] bun run dev:ensure
- [x] bun run --filter @enbox/dids test:node
- [x] bun run lint
- [x] bun run --filter @enbox/agent build
- [x] bunx changeset status
- [x] rg scan confirmed no package.json ^/~ version ranges
- [x] rg scan confirmed no bencode/@types-bencode package or source references
- [ ] bun run test:node from packages/agent - failed locally twice because the dev DWN server dropped during the suite. Both runs reached 1174 pass / 4 skip / 65 fail, with failures reporting http://localhost:3000 unreachable; dev:ensure and /info succeeded immediately before the rerun, and dev:status showed the DWN server DOWN after the run.

Closes #1127