### PR TITLE
chore(deps): upgrade Kysely

### DIFF
--- a/.changeset/upgrade-kysely-patch.md
+++ b/.changeset/upgrade-kysely-patch.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-server": patch
+"@enbox/dwn-sql-store": patch
+---
+
+chore: upgrade Kysely to a patched pinned version.

--- a/bun.lock
+++ b/bun.lock
@@ -285,7 +285,7 @@
         "@enbox/dwn-sql-store": "workspace:*",
         "@simplewebauthn/server": "13.2.3",
         "jose": "6.1.3",
-        "kysely": "0.28.14",
+        "kysely": "0.28.17",
         "loglevel": "1.8.1",
         "prom-client": "14.2.0",
       },
@@ -345,7 +345,7 @@
         "interface-blockstore": "7.0.1",
         "ipfs-unixfs-exporter": "16.0.2",
         "ipfs-unixfs-importer": "17.0.1",
-        "kysely": "0.28.14",
+        "kysely": "0.28.17",
         "multiformats": "14.0.3",
       },
       "devDependencies": {
@@ -1861,7 +1861,7 @@
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
-    "kysely": ["kysely@0.28.14", "", {}, "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA=="],
+    "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
 
     "level": ["level@8.0.1", "", { "dependencies": { "abstract-level": "^1.0.4", "browser-level": "^1.0.1", "classic-level": "^1.2.0" } }, "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ=="],
 

--- a/packages/dwn-server/package.json
+++ b/packages/dwn-server/package.json
@@ -41,7 +41,7 @@
     "@enbox/dwn-sql-store": "workspace:*",
     "@simplewebauthn/server": "13.2.3",
     "jose": "6.1.3",
-    "kysely": "0.28.14",
+    "kysely": "0.28.17",
     "loglevel": "1.8.1",
     "prom-client": "14.2.0"
   },

--- a/packages/dwn-sql-store/package.json
+++ b/packages/dwn-sql-store/package.json
@@ -34,7 +34,7 @@
     "interface-blockstore": "7.0.1",
     "ipfs-unixfs-exporter": "16.0.2",
     "ipfs-unixfs-importer": "17.0.1",
-    "kysely": "0.28.14",
+    "kysely": "0.28.17",
     "multiformats": "14.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- Pin Kysely to 0.28.17 in @enbox/dwn-server and @enbox/dwn-sql-store.
- Update bun.lock for the patched Kysely release.
- Add a patch changeset for the affected packages.
- Confirm the Kysely audit advisory is cleared; unrelated audit findings remain.

Closes #1134

## Test plan
- [x] bun run build
- [x] ./scripts/dev.sh infra
- [x] bun run --filter @enbox/dwn-sql-store test
- [x] bun run --filter @enbox/dwn-server test:node
- [x] bun run lint
- [x] bunx changeset status
- [x] bun audit --production (Kysely finding no longer present; unrelated findings remain)
- [x] rg scan confirms no package.json ^/~ version ranges
- [x] git diff --check