### PR TITLE
chore(deps): replace Temporal polyfill

### DIFF
--- a/.changeset/replace-temporal-polyfill.md
+++ b/.changeset/replace-temporal-polyfill.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+chore: replace Temporal polyfill usage with native timestamp utilities.

--- a/bun.lock
+++ b/bun.lock
@@ -234,7 +234,6 @@
         "@enbox/crypto": "workspace:*",
         "@enbox/dids": "workspace:*",
         "@ipld/dag-cbor": "10.0.1",
-        "@js-temporal/polyfill": "0.4.4",
         "@noble/curves": "2.2.0",
         "ajv": "8.18.0",
         "interface-blockstore": "7.0.1",
@@ -802,8 +801,6 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@js-temporal/polyfill": ["@js-temporal/polyfill@0.4.4", "", { "dependencies": { "jsbi": "^4.3.0", "tslib": "^2.4.1" } }, "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg=="],
 
     "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
 
@@ -1830,8 +1827,6 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
-
-    "jsbi": ["jsbi@4.3.2", "", {}, "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 

--- a/packages/dwn-sdk-js/package.json
+++ b/packages/dwn-sdk-js/package.json
@@ -68,7 +68,6 @@
     "@enbox/crypto": "workspace:*",
     "@enbox/dids": "workspace:*",
     "@ipld/dag-cbor": "10.0.1",
-    "@js-temporal/polyfill": "0.4.4",
     "@noble/curves": "2.2.0",
     "ajv": "8.18.0",
     "interface-blockstore": "7.0.1",

--- a/packages/dwn-sdk-js/src/utils/time.ts
+++ b/packages/dwn-sdk-js/src/utils/time.ts
@@ -1,6 +1,23 @@
 import { sleep } from '@enbox/common';
-import { Temporal } from '@js-temporal/polyfill';
 import { DwnError, DwnErrorCode } from '../core/dwn-error.js';
+
+type ParsedTimestamp = {
+  epochMilliseconds: number;
+  microsecond: number;
+};
+
+type TimestampOptions = {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  minute?: number;
+  second?: number;
+  millisecond?: number;
+  microsecond?: number;
+};
+
+const timestampRegex = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{6})Z$/;
 
 /**
  * Time related utilities.
@@ -19,10 +36,9 @@ export class Time {
 
   /**
    * Returns an UTC ISO-8601 timestamp with microsecond precision accepted by DWN.
-   * using @js-temporal/polyfill
    */
   public static getCurrentTimestamp(): string {
-    return Temporal.Now.instant().toString({ smallestUnit: 'microseconds' });
+    return Time.formatUtcTimestamp(Date.now(), 0);
   }
 
   /**
@@ -30,21 +46,21 @@ export class Time {
    * @param options - Options for creating the timestamp.
    * @returns string
    */
-  public static createTimestamp(options: {
-    year?: number, month?: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number, microsecond?: number
-  }): string {
-    const { year, month, day, hour, minute, second, millisecond, microsecond } = options;
-    return Temporal.ZonedDateTime.from({
-      timeZone: 'UTC',
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond
-    }).toInstant().toString({ smallestUnit: 'microseconds' });
+  public static createTimestamp(options: TimestampOptions): string {
+    const year = Time.constrainInteger(Time.requireTimestampField(options.year, 'year'), 0, 9999);
+    const month = Time.constrainInteger(Time.requireTimestampField(options.month, 'month'), 1, 12);
+    const day = Time.constrainInteger(Time.requireTimestampField(options.day, 'day'), 1, Time.daysInUtcMonth(year, month));
+    const hour = Time.constrainInteger(options.hour ?? 0, 0, 23);
+    const minute = Time.constrainInteger(options.minute ?? 0, 0, 59);
+    const second = Time.constrainInteger(options.second ?? 0, 0, 59);
+    const millisecond = Time.constrainInteger(options.millisecond ?? 0, 0, 999);
+    const microsecond = Time.constrainInteger(options.microsecond ?? 0, 0, 999);
+    const date = new Date(0);
+    date.setUTCHours(0, 0, 0, 0);
+    date.setUTCFullYear(year, month - 1, day);
+    date.setUTCHours(hour, minute, second, millisecond);
+
+    return Time.formatUtcTimestamp(date.getTime(), microsecond);
   }
 
   /**
@@ -52,22 +68,124 @@ export class Time {
    * @param offset Negative number means offset into the past.
    */
   public static createOffsetTimestamp(offset: { seconds: number }, timestamp?: string): string {
-    const timestampInstant = timestamp ? Temporal.Instant.from(timestamp) : Temporal.Now.instant();
-    const offsetDuration = Temporal.Duration.from(offset);
-    const offsetInstant = timestampInstant.add(offsetDuration);
-    return offsetInstant.toString({ smallestUnit: 'microseconds' });
+    const parsedTimestamp = timestamp !== undefined ? Time.parseTimestamp(timestamp) : { epochMilliseconds: Date.now(), microsecond: 0 };
+    if (parsedTimestamp === undefined) {
+      throw new DwnError(DwnErrorCode.TimestampInvalid, `Invalid timestamp: ${timestamp}`);
+    }
+
+    const offsetSeconds = Time.requireWholeNumber(offset.seconds, 'seconds');
+    return Time.formatUtcTimestamp(parsedTimestamp.epochMilliseconds + (offsetSeconds * 1000), parsedTimestamp.microsecond);
   }
 
   /**
-   * Validates that the provided timestamp is a valid number
+   * Validates that the provided timestamp is a DWN-compatible UTC timestamp.
    * @param timestamp the timestamp to validate
-   * @throws DwnError if timestamp is not a valid number
+   * @throws DwnError if timestamp is invalid
    */
   public static validateTimestamp(timestamp: string): void {
-    try {
-      Temporal.Instant.from(timestamp);
-    } catch {
+    if (Time.parseTimestamp(timestamp) === undefined) {
       throw new DwnError(DwnErrorCode.TimestampInvalid, `Invalid timestamp: ${timestamp}`);
     }
+  }
+
+  private static constrainInteger(value: number, min: number, max: number): number {
+    if (!Number.isFinite(value)) {
+      throw new RangeError('timestamp field must be finite');
+    }
+
+    const integer = Math.trunc(value);
+    return Math.min(Math.max(integer, min), max);
+  }
+
+  private static daysInUtcMonth(year: number, month: number): number {
+    const date = new Date(0);
+    date.setUTCHours(0, 0, 0, 0);
+    date.setUTCFullYear(year, month, 0);
+
+    return date.getUTCDate();
+  }
+
+  private static formatUtcTimestamp(epochMilliseconds: number, microsecond: number): string {
+    if (!Number.isFinite(epochMilliseconds)) {
+      throw new RangeError('timestamp is outside the supported Date range');
+    }
+
+    const date = new Date(epochMilliseconds);
+    const year = date.getUTCFullYear();
+    if (year < 0 || year > 9999) {
+      throw new RangeError('timestamp year must be between 0000 and 9999');
+    }
+
+    const fraction = String((date.getUTCMilliseconds() * 1000) + microsecond).padStart(6, '0');
+    return `${Time.pad(year, 4)}-${Time.pad(date.getUTCMonth() + 1, 2)}-${Time.pad(date.getUTCDate(), 2)}` +
+      `T${Time.pad(date.getUTCHours(), 2)}:${Time.pad(date.getUTCMinutes(), 2)}:${Time.pad(date.getUTCSeconds(), 2)}.${fraction}Z`;
+  }
+
+  private static pad(value: number, length: number): string {
+    return String(value).padStart(length, '0');
+  }
+
+  private static parseTimestamp(timestamp: string): ParsedTimestamp | undefined {
+    const match = timestampRegex.exec(timestamp);
+    if (match === null) {
+      return undefined;
+    }
+
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const hour = Number(match[4]);
+    const minute = Number(match[5]);
+    const second = Number(match[6]);
+    const fraction = match[7];
+    const millisecond = Number(fraction.slice(0, 3));
+    const microsecond = Number(fraction.slice(3));
+    const isLeapSecond = hour === 23 && minute === 59 && second === 60;
+
+    if (
+      month < 1 ||
+      month > 12 ||
+      day < 1 ||
+      day > Time.daysInUtcMonth(year, month) ||
+      hour > 23 ||
+      minute > 59 ||
+      (second > 59 && !isLeapSecond)
+    ) {
+      return undefined;
+    }
+
+    const date = new Date(0);
+    date.setUTCHours(0, 0, 0, 0);
+    date.setUTCFullYear(year, month - 1, day);
+    date.setUTCHours(hour, minute, isLeapSecond ? 59 : second, millisecond);
+
+    if (
+      date.getUTCFullYear() !== year ||
+      date.getUTCMonth() !== month - 1 ||
+      date.getUTCDate() !== day ||
+      date.getUTCHours() !== hour ||
+      date.getUTCMinutes() !== minute ||
+      date.getUTCSeconds() !== (isLeapSecond ? 59 : second)
+    ) {
+      return undefined;
+    }
+
+    return { epochMilliseconds: date.getTime(), microsecond };
+  }
+
+  private static requireTimestampField(value: number | undefined, fieldName: string): number {
+    if (value === undefined) {
+      throw new TypeError(`required property '${fieldName}' missing or undefined`);
+    }
+
+    return value;
+  }
+
+  private static requireWholeNumber(value: number, fieldName: string): number {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      throw new RangeError(`${fieldName} must be a finite integer`);
+    }
+
+    return value;
   }
 }

--- a/packages/dwn-sdk-js/src/utils/time.ts
+++ b/packages/dwn-sdk-js/src/utils/time.ts
@@ -68,7 +68,7 @@ export class Time {
    * @param offset Negative number means offset into the past.
    */
   public static createOffsetTimestamp(offset: { seconds: number }, timestamp?: string): string {
-    const parsedTimestamp = timestamp !== undefined ? Time.parseTimestamp(timestamp) : { epochMilliseconds: Date.now(), microsecond: 0 };
+    const parsedTimestamp = timestamp === undefined ? { epochMilliseconds: Date.now(), microsecond: 0 } : Time.parseTimestamp(timestamp);
     if (parsedTimestamp === undefined) {
       throw new DwnError(DwnErrorCode.TimestampInvalid, `Invalid timestamp: ${timestamp}`);
     }

--- a/packages/dwn-sdk-js/tests/features/protocol-composition.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/protocol-composition.spec.ts
@@ -2148,7 +2148,7 @@ export function testProtocolComposition(): void {
     });
 
     // =========================================================================
-    // Temporal correctness — incoming timestamp for cross-protocol lookups
+    // Timestamp correctness — incoming timestamp for cross-protocol lookups
     // =========================================================================
 
     describe('temporal correctness — incoming message timestamp', () => {

--- a/packages/dwn-sdk-js/tests/fuzz/time.fuzz.spec.ts
+++ b/packages/dwn-sdk-js/tests/fuzz/time.fuzz.spec.ts
@@ -30,12 +30,14 @@ describe('Time — fuzz', () => {
       fc.assert(
         fc.property(
           fc.record({
-            year   : fc.integer({ min: 1, max: 9999 }),
-            month  : fc.integer({ min: 1, max: 12 }),
-            day    : fc.integer({ min: 1, max: 28 }), // 28 is always valid
-            hour   : fc.integer({ min: 0, max: 23 }),
-            minute : fc.integer({ min: 0, max: 59 }),
-            second : fc.integer({ min: 0, max: 59 }),
+            year        : fc.integer({ min: 1, max: 9999 }),
+            month       : fc.integer({ min: 1, max: 12 }),
+            day         : fc.integer({ min: 1, max: 28 }), // 28 is always valid
+            hour        : fc.integer({ min: 0, max: 23 }),
+            minute      : fc.integer({ min: 0, max: 59 }),
+            second      : fc.integer({ min: 0, max: 59 }),
+            millisecond : fc.integer({ min: 0, max: 999 }),
+            microsecond : fc.integer({ min: 0, max: 999 }),
           }),
           (opts) => {
             const timestamp = Time.createTimestamp(opts);
@@ -51,16 +53,18 @@ describe('Time — fuzz', () => {
   describe('createTimestamp — format consistency', () => {
     it('should always produce ISO-8601 timestamps ending with Z (UTC) and microsecond precision', () => {
       // Pattern: YYYY-MM-DDTHH:MM:SS.xxxxxxZ
-      const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+      const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/;
       fc.assert(
         fc.property(
           fc.record({
-            year   : fc.integer({ min: 1, max: 9999 }),
-            month  : fc.integer({ min: 1, max: 12 }),
-            day    : fc.integer({ min: 1, max: 28 }),
-            hour   : fc.integer({ min: 0, max: 23 }),
-            minute : fc.integer({ min: 0, max: 59 }),
-            second : fc.integer({ min: 0, max: 59 }),
+            year        : fc.integer({ min: 1, max: 9999 }),
+            month       : fc.integer({ min: 1, max: 12 }),
+            day         : fc.integer({ min: 1, max: 28 }),
+            hour        : fc.integer({ min: 0, max: 23 }),
+            minute      : fc.integer({ min: 0, max: 59 }),
+            second      : fc.integer({ min: 0, max: 59 }),
+            millisecond : fc.integer({ min: 0, max: 999 }),
+            microsecond : fc.integer({ min: 0, max: 999 }),
           }),
           (opts) => {
             const timestamp = Time.createTimestamp(opts);
@@ -77,12 +81,14 @@ describe('Time — fuzz', () => {
       fc.assert(
         fc.property(
           fc.record({
-            year   : fc.integer({ min: 100, max: 9000 }),
-            month  : fc.integer({ min: 1, max: 12 }),
-            day    : fc.integer({ min: 1, max: 28 }),
-            hour   : fc.integer({ min: 0, max: 23 }),
-            minute : fc.integer({ min: 0, max: 59 }),
-            second : fc.integer({ min: 0, max: 59 }),
+            year        : fc.integer({ min: 100, max: 9000 }),
+            month       : fc.integer({ min: 1, max: 12 }),
+            day         : fc.integer({ min: 1, max: 28 }),
+            hour        : fc.integer({ min: 0, max: 23 }),
+            minute      : fc.integer({ min: 0, max: 59 }),
+            second      : fc.integer({ min: 0, max: 59 }),
+            millisecond : fc.integer({ min: 0, max: 999 }),
+            microsecond : fc.integer({ min: 0, max: 999 }),
           }),
           fc.integer({ min: 1, max: 86400 }),
           (opts, offsetSeconds) => {

--- a/packages/dwn-sdk-js/tests/store/index-level.spec.ts
+++ b/packages/dwn-sdk-js/tests/store/index-level.spec.ts
@@ -8,8 +8,8 @@ import { DwnErrorCode } from '../../src/index.js';
 import { IndexLevel } from '../../src/store/index-level.js';
 import { lexicographicalCompare } from '../../src/utils/string.js';
 import { SortDirection } from '../../src/types/query-types.js';
-import { Temporal } from '@js-temporal/polyfill';
 import { TestDataGenerator } from '../utils/test-data-generator.js';
+import { Time } from '../../src/utils/time.js';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
@@ -585,7 +585,7 @@ describe('IndexLevel', () => {
           const id = uuid();
           const doc = {
             id,
-            dateCreated: Temporal.PlainDateTime.from({ year: 2023, month: 1, day: 15 + i }).toString({ smallestUnit: 'microseconds' })
+            dateCreated: Time.createTimestamp({ year: 2023, month: 1, day: 15 + i })
           };
 
           await testIndex.put(tenant, id, doc);
@@ -593,7 +593,7 @@ describe('IndexLevel', () => {
 
         const filters = [{
           dateCreated: {
-            gte: Temporal.PlainDateTime.from({ year: 2023, month: 1, day: 15 }).toString({ smallestUnit: 'microseconds' })
+            gte: Time.createTimestamp({ year: 2023, month: 1, day: 15 })
           }
         }];
         const entries = await testIndex.query(tenant, filters, { sortProperty: 'id' });

--- a/packages/dwn-sdk-js/tests/utils/time.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/time.spec.ts
@@ -12,6 +12,9 @@ describe('time', () => {
         '2022-01-36T90:20:30.405060Z', // invalid hour
         '2022-01-36T25:99:30.405060Z', // invalid minute
         '2022-14-18T10:30:00.123456Z', // invalid month
+        '2022-04-29T10:30:00.123Z', // must use microsecond precision
+        '2022-04-29T10:30:00.123456789Z', // must use microsecond precision
+        '2022-04-29T10:30:00.123456+00:00', // must use UTC Z suffix
       ];
       invalidTimestamps.forEach((timestamp) => {
         it(`should throw an exception if an invalid timestamp is passed: ${timestamp}`, () => {
@@ -23,6 +26,7 @@ describe('time', () => {
     describe('valid timestamps', () => {
       it('should pass if a valid timestamp is passed', () => {
         expect(() => Time.validateTimestamp('2022-04-29T10:30:00.123456Z')).not.toThrow();
+        expect(() => Time.validateTimestamp('2022-04-29T23:59:60.123456Z')).not.toThrow();
         expect(() => Time.validateTimestamp(TestDataGenerator.randomTimestamp())).not.toThrow();
       });
     });
@@ -41,6 +45,21 @@ describe('time', () => {
         microsecond : 456
       });
       expect(timestamp).toBe('2022-04-29T10:30:00.123456Z');
+    });
+
+    it('should constrain out-of-range fields without rolling into the next unit', () => {
+      const timestamp = Time.createTimestamp({
+        year        : 2023,
+        month       : 2,
+        day         : 29,
+        hour        : 24,
+        minute      : 60,
+        second      : 60,
+        millisecond : 1000,
+        microsecond : 1000,
+      });
+
+      expect(timestamp).toBe('2023-02-28T23:59:59.999999Z');
     });
 
     for (let i = 0; i < 5; i++) {
@@ -66,6 +85,19 @@ describe('time', () => {
       const offsetTimestamp = Time.createOffsetTimestamp({ seconds: 60 * 60 * 24 * 365 }, baseTimestamp);
 
       expect(offsetTimestamp).toBe('2001-04-29T10:30:00.123456Z');
+    });
+
+    it('should preserve microseconds across day and year boundaries', () => {
+      const baseTimestamp = '2023-12-31T23:59:59.123456Z';
+
+      expect(Time.createOffsetTimestamp({ seconds: 2 }, baseTimestamp)).toBe('2024-01-01T00:00:01.123456Z');
+      expect(Time.createOffsetTimestamp({ seconds: -86_400 }, baseTimestamp)).toBe('2023-12-30T23:59:59.123456Z');
+    });
+
+    it('should preserve leap second offset behavior', () => {
+      const baseTimestamp = '2022-04-29T23:59:60.123456Z';
+
+      expect(Time.createOffsetTimestamp({ seconds: 1 }, baseTimestamp)).toBe('2022-04-30T00:00:00.123456Z');
     });
   });
 });

--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -70,7 +70,6 @@ export default defineConfig({
 
       // --- Dual-format packages (CJS default, ESM via exports) ---
       // Pre-bundling these avoids edge cases where Vite picks the CJS entry.
-      '@js-temporal/polyfill',
       '@noble/ciphers/aes.js',
       '@noble/ciphers/chacha.js',
       '@noble/ciphers/crypto.js',


### PR DESCRIPTION
## Summary
- Replace @js-temporal/polyfill usage in dwn-sdk-js time utilities with native Date-based UTC formatting/parsing.
- Preserve DWN microsecond timestamp output, ordering behavior, constrained timestamp creation, and leap-second validation compatibility.
- Remove @js-temporal/polyfill and jsbi from bun.lock and remove the browser prebundle hint.
- Add regression/fuzz coverage for strict timestamp format, invalid relaxed forms, offset boundaries, and IndexLevel range ordering.

Closes #1128

## Test plan
- [x] bun test packages/dwn-sdk-js/tests/fuzz/time.fuzz.spec.ts
- [x] bun test packages/dwn-sdk-js/tests/utils/time.spec.ts
- [x] bun test packages/dwn-sdk-js/tests/store/index-level.spec.ts
- [x] bun run --filter @enbox/dwn-sdk-js build
- [x] bun run --filter @enbox/dwn-sdk-js test:node
- [x] bun run lint
- [x] bun run --filter @enbox/dwn-clients build && bun run --filter @enbox/agent build
- [x] bunx changeset status
- [x] rg scan confirms no package.json ^/~ version ranges
- [x] rg scan confirms no @js-temporal/polyfill/jsbi/Temporal references remain outside built artifacts
- [x] git diff --check
- [ ] bun run test:node from packages/agent (local dev DWN server died during the run; 1174 pass, 4 skip, 65 remote-DWN failures with http://localhost:3000 unreachable; dev:status showed DWN server DOWN and .dev/dwn-server.log had normal startup plus /info, no crash stack)