### PR TITLE
chore(deps): lazy-load WebAuthn server

### DIFF
--- a/.changeset/lazy-webauthn-server.md
+++ b/.changeset/lazy-webauthn-server.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-server": patch
+---
+
+chore: make WebAuthn admin passkey support use an optional peer dependency

--- a/bun.lock
+++ b/bun.lock
@@ -281,7 +281,6 @@
         "@enbox/dwn-clients": "workspace:*",
         "@enbox/dwn-sdk-js": "workspace:*",
         "@enbox/dwn-sql-store": "workspace:*",
-        "@simplewebauthn/server": "13.2.3",
         "jose": "6.1.3",
         "kysely": "0.28.17",
         "loglevel": "1.8.1",
@@ -289,6 +288,7 @@
       },
       "devDependencies": {
         "@nats-io/transport-node": "3.3.1",
+        "@simplewebauthn/server": "13.2.3",
         "@types/bun": "1.3.14",
         "@types/node": "22.19.15",
         "@types/sinon": "17.0.3",
@@ -311,12 +311,14 @@
       },
       "peerDependencies": {
         "@nats-io/transport-node": "3.3.1",
+        "@simplewebauthn/server": "13.2.3",
         "mysql2": "3.22.5",
         "pg": "8.11.2",
         "pg-cursor": "2.10.2",
       },
       "optionalPeers": [
         "@nats-io/transport-node",
+        "@simplewebauthn/server",
         "mysql2",
         "pg",
         "pg-cursor",

--- a/packages/dwn-server/package.json
+++ b/packages/dwn-server/package.json
@@ -39,7 +39,6 @@
     "@enbox/dwn-clients": "workspace:*",
     "@enbox/dwn-sdk-js": "workspace:*",
     "@enbox/dwn-sql-store": "workspace:*",
-    "@simplewebauthn/server": "13.2.3",
     "jose": "6.1.3",
     "kysely": "0.28.17",
     "loglevel": "1.8.1",
@@ -50,12 +49,16 @@
   },
   "peerDependencies": {
     "@nats-io/transport-node": "3.3.1",
+    "@simplewebauthn/server": "13.2.3",
     "mysql2": "3.22.5",
     "pg": "8.11.2",
     "pg-cursor": "2.10.2"
   },
   "peerDependenciesMeta": {
     "@nats-io/transport-node": {
+      "optional": true
+    },
+    "@simplewebauthn/server": {
       "optional": true
     },
     "mysql2": {
@@ -70,6 +73,7 @@
   },
   "devDependencies": {
     "@nats-io/transport-node": "3.3.1",
+    "@simplewebauthn/server": "13.2.3",
     "@types/bun": "1.3.14",
     "@types/node": "22.19.15",
     "@types/sinon": "17.0.3",

--- a/packages/dwn-server/src/admin/admin-api.ts
+++ b/packages/dwn-server/src/admin/admin-api.ts
@@ -1,3 +1,4 @@
+import type * as SimpleWebAuthnServer from '@simplewebauthn/server';
 import type { ActivityLog } from './activity-log.js';
 import type { AdminPasskeyStore } from './admin-passkey-store.js';
 import type { AdminSessionManager } from './admin-session.js';
@@ -25,15 +26,8 @@ import type {
   TenantQuotaInput,
   TenantQuotaStatus,
 } from './types.js';
-import type { AuthenticationResponseJSON, RegistrationResponseJSON } from '@simplewebauthn/server';
 
 import log from 'loglevel';
-import {
-  generateAuthenticationOptions,
-  generateRegistrationOptions,
-  verifyAuthenticationResponse,
-  verifyRegistrationResponse,
-} from '@simplewebauthn/server';
 
 import { validateAdminAuth } from './admin-auth.js';
 import {
@@ -44,6 +38,11 @@ import {
   websocketSubscriptions,
 } from '../metrics.js';
 
+type WebAuthnServerModule = typeof SimpleWebAuthnServer;
+type WebAuthnServerLoader = () => Promise<WebAuthnServerModule>;
+
+const defaultWebAuthnServerLoader: WebAuthnServerLoader = async (): Promise<WebAuthnServerModule> => import('@simplewebauthn/server');
+
 /** Parses a string to an integer, returning `defaultValue` when the input is null or non-numeric. */
 function parseIntOrDefault(value: string | null, defaultValue: number): number {
   if (value === null) {
@@ -51,6 +50,29 @@ function parseIntOrDefault(value: string | null, defaultValue: number): number {
   }
   const parsed = parseInt(value, 10);
   return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+/** Returns `true` when the optional WebAuthn server package itself is missing. */
+function isMissingWebAuthnServerDependency(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message;
+  return (
+    message.includes('Cannot find package @simplewebauthn/server') ||
+    message.includes('Cannot find package \'@simplewebauthn/server\'') ||
+    message.includes('Cannot find module @simplewebauthn/server') ||
+    message.includes('Cannot find module \'@simplewebauthn/server\'')
+  );
+}
+
+/** Builds the response returned when passkey routes are used without the optional WebAuthn dependency installed. */
+function webAuthnServerUnavailableResponse(): Response {
+  return Response.json(
+    { error: 'Admin passkey support requires optional dependency @simplewebauthn/server. Install it to use passkey admin authentication.' },
+    { status: 501 },
+  );
 }
 
 /**
@@ -71,6 +93,7 @@ export class AdminApi {
   #webhookManager: WebhookManager | undefined;
   #passkeyStore: AdminPasskeyStore | undefined;
   #sessionManager: AdminSessionManager | undefined;
+  #webAuthnServerLoader: WebAuthnServerLoader = defaultWebAuthnServerLoader;
   /** In-memory challenge store: maps challenge → expiry timestamp. */
   readonly #challenges: Map<string, number> = new Map();
   /** Challenge TTL: 60 seconds. */
@@ -104,6 +127,7 @@ export class AdminApi {
     webhookManager? : WebhookManager;
     passkeyStore? : AdminPasskeyStore;
     sessionManager? : AdminSessionManager;
+    webAuthnServerLoader? : WebAuthnServerLoader;
     packageInfo? : { version?: string };
   }): AdminApi {
     const api = new AdminApi();
@@ -120,6 +144,7 @@ export class AdminApi {
     api.#webhookManager = options.webhookManager;
     api.#passkeyStore = options.passkeyStore;
     api.#sessionManager = options.sessionManager;
+    api.#webAuthnServerLoader = options.webAuthnServerLoader ?? defaultWebAuthnServerLoader;
     api.#packageInfo = options.packageInfo ?? {};
     return api;
   }
@@ -1324,6 +1349,11 @@ export class AdminApi {
       );
     }
 
+    const webAuthn = await this.#getWebAuthnServer();
+    if (webAuthn instanceof Response) {
+      return webAuthn;
+    }
+
     let body: { name?: string };
     try {
       body = await req.json() as { name?: string };
@@ -1341,7 +1371,7 @@ export class AdminApi {
       transports : JSON.parse(cred.transports) as AuthenticatorTransport[],
     }));
 
-    const options = await generateRegistrationOptions({
+    const options = await webAuthn.generateRegistrationOptions({
       rpName,
       rpID                   : rpId,
       userName               : 'admin',
@@ -1372,7 +1402,12 @@ export class AdminApi {
       );
     }
 
-    let body: { credential: RegistrationResponseJSON; name?: string };
+    const webAuthn = await this.#getWebAuthnServer();
+    if (webAuthn instanceof Response) {
+      return webAuthn;
+    }
+
+    let body: { credential: SimpleWebAuthnServer.RegistrationResponseJSON; name?: string };
     try {
       body = await req.json() as typeof body;
     } catch {
@@ -1388,7 +1423,7 @@ export class AdminApi {
 
     let verification;
     try {
-      verification = await verifyRegistrationResponse({
+      verification = await webAuthn.verifyRegistrationResponse({
         response          : body.credential,
         expectedChallenge : (challenge: string): boolean => this.#consumeChallenge(challenge),
         expectedOrigin,
@@ -1432,6 +1467,11 @@ export class AdminApi {
       return Response.json({ error: 'Passkeys are not enabled.' }, { status: 501 });
     }
 
+    const webAuthn = await this.#getWebAuthnServer();
+    if (webAuthn instanceof Response) {
+      return webAuthn;
+    }
+
     const existing = await this.#passkeyStore.list();
     if (existing.length === 0) {
       return Response.json({ error: 'No passkeys registered.' }, { status: 404 });
@@ -1444,7 +1484,7 @@ export class AdminApi {
       transports : JSON.parse(cred.transports) as AuthenticatorTransport[],
     }));
 
-    const options = await generateAuthenticationOptions({
+    const options = await webAuthn.generateAuthenticationOptions({
       rpID             : rpId,
       allowCredentials,
       userVerification : 'preferred',
@@ -1468,7 +1508,12 @@ export class AdminApi {
       return Response.json({ error: 'Passkeys are not enabled.' }, { status: 501 });
     }
 
-    let body: { credential: AuthenticationResponseJSON };
+    const webAuthn = await this.#getWebAuthnServer();
+    if (webAuthn instanceof Response) {
+      return webAuthn;
+    }
+
+    let body: { credential: SimpleWebAuthnServer.AuthenticationResponseJSON };
     try {
       body = await req.json() as typeof body;
     } catch {
@@ -1490,7 +1535,7 @@ export class AdminApi {
 
     let verification;
     try {
-      verification = await verifyAuthenticationResponse({
+      verification = await webAuthn.verifyAuthenticationResponse({
         response          : body.credential,
         expectedChallenge : (challenge: string): boolean => this.#consumeChallenge(challenge),
         expectedOrigin,
@@ -1585,6 +1630,21 @@ export class AdminApi {
       return new URL(this.#config.baseUrl).hostname;
     } catch {
       return 'localhost';
+    }
+  }
+
+  /**
+   * Loads the optional WebAuthn server implementation when passkey operations need it.
+   */
+  async #getWebAuthnServer(): Promise<WebAuthnServerModule | Response> {
+    try {
+      return await this.#webAuthnServerLoader();
+    } catch (error) {
+      if (isMissingWebAuthnServerDependency(error)) {
+        return webAuthnServerUnavailableResponse();
+      }
+
+      throw error;
     }
   }
 

--- a/packages/dwn-server/tests/admin/admin-api.test.ts
+++ b/packages/dwn-server/tests/admin/admin-api.test.ts
@@ -3126,7 +3126,15 @@ describe('Passkey routes — unit coverage', () => {
     lastUsedAt : '2025-02-01T12:00:00.000Z',
   };
 
-  async function createApiWithPasskeys(): Promise<{
+  function createMissingWebAuthnServerLoader(): () => Promise<never> {
+    return async (): Promise<never> => {
+      throw Object.assign(new Error('Cannot find package @simplewebauthn/server'), { code: 'ERR_MODULE_NOT_FOUND' });
+    };
+  }
+
+  async function createApiWithPasskeys(options: {
+    webAuthnServerLoader?: () => Promise<never>;
+  } = {}): Promise<{
     api: InstanceType<typeof AdminApi>;
     store: InstanceType<typeof AdminPasskeyStore>;
     sessionManager: InstanceType<typeof AdminSessionManager>;
@@ -3142,6 +3150,7 @@ describe('Passkey routes — unit coverage', () => {
       dwn          : {} as any,
       passkeyStore : store,
       sessionManager,
+      ...options,
     });
 
     return { api, store, sessionManager };
@@ -3201,6 +3210,23 @@ describe('Passkey routes — unit coverage', () => {
     expect(body.excludeCredentials).toBeDefined();
     expect(body.excludeCredentials.length).toBe(1);
     expect(body.excludeCredentials[0].id).toBe('cred-test-1');
+
+    await store.close();
+    sessionManager.destroy();
+  });
+
+  it('should return 501 for register options when the WebAuthn dependency is unavailable', async () => {
+    const { api, store, sessionManager } = await createApiWithPasskeys({
+      webAuthnServerLoader: createMissingWebAuthnServerLoader(),
+    });
+
+    const res = await routeReq(api, '/passkeys/register/options', 'POST', {
+      headers : { 'content-type': 'application/json' },
+      body    : JSON.stringify({ name: 'Another Key' }),
+    });
+    expect(res.status).toBe(501);
+    const body = await res.json();
+    expect(body.error).toContain('@simplewebauthn/server');
 
     await store.close();
     sessionManager.destroy();
@@ -3328,6 +3354,23 @@ describe('Passkey routes — unit coverage', () => {
     expect(body.allowCredentials).toBeDefined();
     expect(body.allowCredentials.length).toBe(1);
     expect(body.allowCredentials[0].id).toBe('cred-test-1');
+
+    await store.close();
+    sessionManager.destroy();
+  });
+
+  it('should return 501 for login options when the WebAuthn dependency is unavailable', async () => {
+    const { api, store, sessionManager } = await createApiWithPasskeys({
+      webAuthnServerLoader: createMissingWebAuthnServerLoader(),
+    });
+
+    const req = new Request('http://localhost/admin/api/passkeys/login/options', {
+      method: 'POST',
+    });
+    const res = await api.route(req, new URL(req.url), '/admin/api/passkeys/login/options', 'POST');
+    expect(res.status).toBe(501);
+    const body = await res.json();
+    expect(body.error).toContain('@simplewebauthn/server');
 
     await store.close();
     sessionManager.destroy();


### PR DESCRIPTION
Summary
- Move @simplewebauthn/server out of required dwn-server runtime dependencies into an exact-pinned optional peer/dev dependency.
- Lazy-load WebAuthn server helpers only from passkey registration/login handlers.
- Return a clear 501 response when passkey handlers need WebAuthn support but the optional package is not installed.
- Add passkey route coverage for the missing optional dependency path.

Test plan
- [x] bun run build
- [x] bun run lint
- [x] bun run --filter @enbox/dwn-server build
- [x] bun test packages/dwn-server/tests/admin/admin-api.test.ts -t "WebAuthn dependency is unavailable"
- [x] bun run --filter @enbox/dwn-server test:node
- [x] bunx changeset status
- [x] rg "\"[^\"]+\"\\s*:\\s*\"[~^]" -g package.json .

Closes #1132