### PR TITLE
chore(deps): split LevelStore out of common hot path

### DIFF
--- a/.changeset/split-level-store.md
+++ b/.changeset/split-level-store.md
@@ -1,0 +1,6 @@
+---
+"@enbox/common": patch
+"@enbox/agent": patch
+---
+
+chore: move the Level-backed common store behind a dedicated optional subpath.

--- a/bun.lock
+++ b/bun.lock
@@ -147,7 +147,6 @@
       "version": "0.1.1",
       "dependencies": {
         "@isaacs/ttlcache": "1.4.1",
-        "level": "8.0.1",
         "multiformats": "14.0.3",
       },
       "devDependencies": {
@@ -162,6 +161,14 @@
         "typescript": "5.9.3",
         "vitest": "4.0.18",
       },
+      "peerDependencies": {
+        "abstract-level": "1.0.4",
+        "level": "8.0.1",
+      },
+      "optionalPeers": [
+        "abstract-level",
+        "level",
+      ],
     },
     "packages/crypto": {
       "name": "@enbox/crypto",

--- a/packages/agent/src/enbox-user-agent.ts
+++ b/packages/agent/src/enbox-user-agent.ts
@@ -20,7 +20,7 @@ import { DwnIdentityStore } from './store-identity.js';
 import { DwnKeyStore } from './store-key.js';
 import { EnboxRpcClient } from '@enbox/dwn-clients';
 import { HdIdentityVault } from './hd-identity-vault.js';
-import { LevelStore } from '@enbox/common';
+import { LevelStore } from '@enbox/common/level-store';
 import { LocalKeyManager } from './local-key-manager.js';
 import { SyncEngineLevel } from './sync-engine-level.js';
 import { DidDht, DidJwk } from '@enbox/dids';

--- a/packages/agent/src/test-harness.ts
+++ b/packages/agent/src/test-harness.ts
@@ -6,9 +6,10 @@ import type { KeyValueStore } from '@enbox/common';
 import type { Dwn, EventLog } from '@enbox/dwn-sdk-js';
 
 import { Level } from 'level';
+import { LevelStore } from '@enbox/common/level-store';
+import { MemoryStore } from '@enbox/common';
 import { DataStoreLevel, DurableEventLog, EventEmitterWakePublisher, MessageStoreLevel, ResumableTaskStoreLevel } from '@enbox/dwn-sdk-js';
 import { DidDht, DidJwk, DidResolverCacheMemory } from '@enbox/dids';
-import { LevelStore, MemoryStore } from '@enbox/common';
 
 import { AgentCryptoApi } from './crypto-api.js';
 import { AgentDidApi } from './did-api.js';

--- a/packages/agent/tests/hd-identity-vault.spec.ts
+++ b/packages/agent/tests/hd-identity-vault.spec.ts
@@ -1,11 +1,10 @@
+import type { IdentityVaultBackup } from '../src/types/identity-vault.js';
 import type { KeyValueStore } from '@enbox/common';
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { LevelStore, MemoryStore } from '@enbox/common';
-
-import type { IdentityVaultBackup } from '../src/types/identity-vault.js';
-
 import { HdIdentityVault } from '../src/hd-identity-vault.js';
+import { LevelStore } from '@enbox/common/level-store';
+import { MemoryStore } from '@enbox/common';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 describe('HdIdentityVault', () => {
   ['MemoryStore', 'LevelStore'].forEach((vaultStoreType) => {

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -26,16 +26,24 @@ const hex = Convert.uint8Array(bytes).toHex();
 const b64 = Convert.hex(hex).toBase64Url();
 ```
 
-### `LevelStore` / `MemoryStore`
+### `MemoryStore`
 
-Implementations of the `KeyValueStore<K, V>` interface — LevelDB-backed (persistent) and Map-backed (in-memory).
+Map-backed implementation of the `KeyValueStore<K, V>` interface.
 
 ```typescript
-import { LevelStore, MemoryStore } from '@enbox/common';
+import { MemoryStore } from '@enbox/common';
+
+const ephemeral = new MemoryStore();
+```
+
+### `LevelStore`
+
+LevelDB-backed implementation of the `KeyValueStore<K, V>` interface. It lives behind a dedicated subpath so default `@enbox/common` imports do not require LevelDB.
+
+```typescript
+import { LevelStore } from '@enbox/common/level-store';
 
 const persistent = new LevelStore({ location: './data' });
-const ephemeral = new MemoryStore();
-
 await persistent.set('key', 'value');
 const value = await persistent.get('key');
 ```

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -53,6 +53,10 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js"
+    },
+    "./level-store": {
+      "types": "./dist/types/level-store.d.ts",
+      "import": "./dist/esm/level-store.js"
     }
   },
   "react-native": "./dist/esm/index.js",
@@ -73,8 +77,19 @@
   },
   "dependencies": {
     "@isaacs/ttlcache": "1.4.1",
-    "level": "8.0.1",
     "multiformats": "14.0.3"
+  },
+  "peerDependencies": {
+    "abstract-level": "1.0.4",
+    "level": "8.0.1"
+  },
+  "peerDependenciesMeta": {
+    "abstract-level": {
+      "optional": true
+    },
+    "level": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "22.19.15",

--- a/packages/common/src/level-store.ts
+++ b/packages/common/src/level-store.ts
@@ -1,0 +1,47 @@
+import type { AbstractLevel } from 'abstract-level';
+import type { KeyValueStore } from './types.js';
+
+import { Level } from 'level';
+
+export type LevelStoreOptions<K = string, V = any> = {
+  db?: AbstractLevel<string | Buffer | Uint8Array, K, V>;
+  location?: string;
+};
+
+export class LevelStore<K = string, V = any> implements KeyValueStore<K, V> {
+  private readonly store: AbstractLevel<string | Buffer | Uint8Array, K, V>;
+
+  public constructor({ db, location = 'DATASTORE' }: LevelStoreOptions<K, V> = {}) {
+    this.store = db ?? new Level<K, V>(location);
+  }
+
+  public async open(): Promise<void> {
+    await this.store.open();
+  }
+
+  public async clear(): Promise<void> {
+    await this.store.clear();
+  }
+
+  public async close(): Promise<void> {
+    await this.store.close();
+  }
+
+  public async delete(key: K): Promise<void> {
+    await this.store.del(key);
+  }
+
+  public async get(key: K): Promise<V | undefined> {
+    try {
+      return await this.store.get(key);
+    } catch (error: any) {
+      // Don't throw when a key wasn't found.
+      if (error.notFound) { return undefined; }
+      throw error;
+    }
+  }
+
+  public async set(key: K, value: V): Promise<void> {
+    await this.store.put(key, value);
+  }
+}

--- a/packages/common/src/stores.ts
+++ b/packages/common/src/stores.ts
@@ -1,49 +1,4 @@
-import type { AbstractLevel } from 'abstract-level';
-
-import { Level } from 'level';
-
 import type { KeyValueStore } from './types.js';
-
-export class LevelStore<K = string, V = any> implements KeyValueStore<K, V> {
-  private readonly store: AbstractLevel<string | Buffer | Uint8Array, K, V>;
-
-  constructor({ db, location = 'DATASTORE' }: {
-    db?: AbstractLevel<string | Buffer | Uint8Array, K, V>;
-    location?: string;
-  } = {}) {
-    this.store = db ?? new Level<K, V>(location);
-  }
-
-  async open(): Promise<void> {
-    await this.store.open();
-  }
-
-  async clear(): Promise<void> {
-    await this.store.clear();
-  }
-
-  async close(): Promise<void> {
-    await this.store.close();
-  }
-
-  async delete(key: K): Promise<void> {
-    await this.store.del(key);
-  }
-
-  async get(key: K): Promise<V | undefined> {
-    try {
-      return await this.store.get(key);
-    } catch (error: any) {
-      // Don't throw when a key wasn't found.
-      if (error.notFound) {return undefined;}
-      throw error;
-    }
-  }
-
-  async set(key: K, value: V): Promise<void> {
-    await this.store.put(key, value);
-  }
-}
 
 /**
  * The `MemoryStore` class is an implementation of
@@ -75,21 +30,21 @@ export class MemoryStore<K, V> implements KeyValueStore<K, V> {
    *
    * @returns A Promise that resolves when the operation is complete.
    */
-  async clear(): Promise<void> {
+  public async clear(): Promise<void> {
     this.store.clear();
   }
 
   /**
    * This operation is no-op for `MemoryStore`.
    */
-  async open(): Promise<void> {
+  public async open(): Promise<void> {
     /** no-op */
   }
 
   /**
    * This operation is no-op for `MemoryStore`.
    */
-  async close(): Promise<void> {
+  public async close(): Promise<void> {
     /** no-op */
   }
 
@@ -99,7 +54,7 @@ export class MemoryStore<K, V> implements KeyValueStore<K, V> {
    * @param id - The key of the entry to delete.
    * @returns A Promise that resolves to a boolean indicating whether the entry was successfully deleted.
    */
-  async delete(id: K): Promise<boolean> {
+  public async delete(id: K): Promise<boolean> {
     return this.store.delete(id);
   }
 
@@ -109,7 +64,7 @@ export class MemoryStore<K, V> implements KeyValueStore<K, V> {
    * @param id - The key of the entry to retrieve.
    * @returns A Promise that resolves to the value of the entry, or `undefined` if the entry does not exist.
    */
-  async get(id: K): Promise<V | undefined> {
+  public async get(id: K): Promise<V | undefined> {
     return this.store.get(id);
   }
 
@@ -119,7 +74,7 @@ export class MemoryStore<K, V> implements KeyValueStore<K, V> {
    * @param id - The key to check for the existence of.
    * @returns A Promise that resolves to a boolean indicating whether an element with the specified key exists or not.
    */
-  async has(id: K): Promise<boolean> {
+  public async has(id: K): Promise<boolean> {
     return this.store.has(id);
   }
 
@@ -128,7 +83,7 @@ export class MemoryStore<K, V> implements KeyValueStore<K, V> {
    *
    * @returns A Promise that resolves to an array of all values in the store.
    */
-  async list(): Promise<V[]> {
+  public async list(): Promise<V[]> {
     return Array.from(this.store.values());
   }
 
@@ -139,7 +94,7 @@ export class MemoryStore<K, V> implements KeyValueStore<K, V> {
    * @param key - The new value for the entry.
    * @returns A Promise that resolves when the operation is complete.
    */
-  async set(id: K, key: V): Promise<void> {
+  public async set(id: K, key: V): Promise<void> {
     this.store.set(id, key);
   }
 }

--- a/packages/common/tests/stores.test.ts
+++ b/packages/common/tests/stores.test.ts
@@ -2,7 +2,8 @@ import { Level } from 'level';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
-import { LevelStore, MemoryStore } from '../src/stores.js';
+import { LevelStore } from '../src/level-store.js';
+import { MemoryStore } from '../src/stores.js';
 
 describe('LevelStore', () => {
   let levelStore: LevelStore<string, string>;


### PR DESCRIPTION
Summary
- Move `LevelStore` from the default `@enbox/common` export into `@enbox/common/level-store`.
- Make `level` and `abstract-level` optional peers for `@enbox/common`, while keeping them as dev deps for tests/builds.
- Update agent disk-store call sites and tests to import the Level-backed store explicitly.
- Document the new import path and add a changeset.

Dependency impact
- `@enbox/common` default runtime deps: `level` removed from direct dependencies.
- `level@8.0.1` lockfile closure: 16 packages now avoided by default `@enbox/common` consumers unless they explicitly import/use the Level subpath.
- Default common browser bundle scan has no LevelDB-related package names.
- Exact-version scan: no `^` or `~` ranges in repo `package.json` files.

Test plan
- [x] `bun run --filter @enbox/common build`
- [x] `bun run --filter @enbox/common test:node` (235 pass)
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun test tests/hd-identity-vault.spec.ts --timeout 10000` from `packages/agent` (76 pass)
- [x] `bun run dev:ensure`
- [x] `bun run test:node` from `packages/agent` (first run exposed dev-server reachability failure; retry with foreground DWN server passed: 1272 pass, 4 skip, 0 fail)

Closes #1131
