### PR TITLE
chore(deps): replace ttlcache dependency

### DIFF
--- a/.changeset/local-ttl-cache.md
+++ b/.changeset/local-ttl-cache.md
@@ -2,4 +2,4 @@
 "@enbox/common": patch
 ---
 
-chore: replace ttlcache dependency with a local in-memory TTL cache
+chore: replace ttlcache dependency with a local in-memory TTL cache tailored to Enbox's used API surface. Disposal callbacks are accepted through constructor options.

--- a/.changeset/local-ttl-cache.md
+++ b/.changeset/local-ttl-cache.md
@@ -1,0 +1,5 @@
+---
+"@enbox/common": patch
+---
+
+chore: replace ttlcache dependency with a local in-memory TTL cache

--- a/bun.lock
+++ b/bun.lock
@@ -149,7 +149,6 @@
       "name": "@enbox/common",
       "version": "0.1.1",
       "dependencies": {
-        "@isaacs/ttlcache": "1.4.1",
         "multiformats": "14.0.3",
       },
       "devDependencies": {
@@ -826,8 +825,6 @@
     "@ipld/dag-pb": ["@ipld/dag-pb@4.1.7", "", { "dependencies": { "multiformats": "^14.0.0" } }, "sha512-/i/13trFihjWfDyXlylRwhuYjtzYjvOFw0vlRjYGnZuv7d7MOgA2lV/vRuL5RfeUajM03aZfFLdq4S7cTbbTRg=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
-    "@isaacs/ttlcache": ["@isaacs/ttlcache@1.4.1", "", {}, "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA=="],
 
     "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
 

--- a/packages/agent/vitest.browser.config.ts
+++ b/packages/agent/vitest.browser.config.ts
@@ -44,9 +44,6 @@ export default defineConfig({
       'abstract-level',
       'level',
       'ms',
-      // @isaacs/ttlcache — CJS; transitive dep via @enbox/crypto -> @enbox/common.
-      // Use Vite's nested-dep `>` syntax to resolve through workspace symlinks.
-      '@enbox/crypto > @enbox/common > @isaacs/ttlcache',
     ],
     holdUntilCrawlEnd: true,
   },

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -50,7 +50,9 @@ const value = await persistent.get('key');
 
 ### `TtlCache`
 
-Time-to-live in-memory cache with bounded size support.
+Time-to-live in-memory cache with bounded size support. Expired entries are removed by an unref'd background timer and
+are also checked on `get()` / `has()`, so stale values are not returned if the timer has not fired yet. `cancelTimer()`
+only stops the background timer; lazy expiry checks still run on access.
 
 ### `Stream`
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -50,7 +50,7 @@ const value = await persistent.get('key');
 
 ### `TtlCache`
 
-Time-to-live in-memory cache (re-export of `@isaacs/ttlcache`).
+Time-to-live in-memory cache with bounded size support.
 
 ### `Stream`
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -52,7 +52,8 @@ const value = await persistent.get('key');
 
 Time-to-live in-memory cache with bounded size support. Expired entries are removed by an unref'd background timer and
 are also checked on `get()` / `has()`, so stale values are not returned if the timer has not fired yet. `cancelTimer()`
-only stops the background timer; lazy expiry checks still run on access.
+only stops the background timer; lazy expiry checks still run on access. Disposal callbacks are provided with the
+constructor's `dispose` option.
 
 ### `Stream`
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -76,7 +76,6 @@
     "bun": ">=1.0.0"
   },
   "dependencies": {
-    "@isaacs/ttlcache": "1.4.1",
     "multiformats": "14.0.3"
   },
   "peerDependencies": {

--- a/packages/common/src/cache.ts
+++ b/packages/common/src/cache.ts
@@ -4,6 +4,12 @@ type TtlCacheEntry<V> = {
   value: V;
 };
 
+type TtlCacheTimer = ReturnType<typeof setTimeout>;
+
+function now(): number {
+  return performance.now();
+}
+
 function isPositiveIntegerOrInfinity(value: number): boolean {
   return value === Infinity || (Number.isInteger(value) && value > 0 && Number.isFinite(value));
 }
@@ -20,6 +26,13 @@ function assertTtl(ttl: number | undefined): asserts ttl is number {
   }
 }
 
+function unrefTimer(timer: TtlCacheTimer): void {
+  if (typeof timer === 'object' && timer !== null && 'unref' in timer) {
+    const { unref } = timer as { unref?: () => void };
+    unref?.();
+  }
+}
+
 const entryCompare = <K, V>([, left]: [K, TtlCacheEntry<V>], [, right]: [K, TtlCacheEntry<V>]): number => {
   if (left.expiresAt !== right.expiresAt) {
     return left.expiresAt - right.expiresAt;
@@ -30,9 +43,11 @@ const entryCompare = <K, V>([, left]: [K, TtlCacheEntry<V>], [, right]: [K, TtlC
 
 /**
  * Small in-memory TTL cache tailored to the cache API used by Enbox.
+ *
+ * Expired entries are purged by an unref'd background timer and are also checked on access. `cancelTimer()` only stops
+ * the background timer; `get()` and `has()` still remove stale entries.
  */
 export class TtlCache<K, V> implements Iterable<[K, V]> {
-  public checkAgeOnGet: boolean;
   public max: number;
   public noDisposeOnSet: boolean;
   public noUpdateTTL: boolean;
@@ -42,10 +57,11 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
   private readonly _data = new Map<K, TtlCacheEntry<V>>();
   private readonly _dispose?: TtlCache.Disposer<K, V>;
   private _sequence = 0;
+  private _timer?: TtlCacheTimer;
+  private _timerExpiresAt = Infinity;
 
   public constructor(options: TtlCache.Options<K, V> = {}) {
     const {
-      checkAgeOnGet = false,
       dispose,
       max = Infinity,
       noDisposeOnSet = false,
@@ -64,7 +80,6 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
       throw new TypeError('dispose must be function if set');
     }
 
-    this.checkAgeOnGet = checkAgeOnGet;
     this.max = max;
     this.noDisposeOnSet = noDisposeOnSet;
     this.noUpdateTTL = noUpdateTTL;
@@ -74,10 +89,9 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
   }
 
   /**
-   * Total live entries currently stored in the cache.
+   * Total entries currently held in the cache.
    */
   public get size(): number {
-    this.purgeStale();
     return this._data.size;
   }
 
@@ -99,12 +113,15 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
     const current = this._data.get(key);
     const expiresAt = current !== undefined && noUpdateTTL ? current.expiresAt : this._expirationFromTtl(ttl);
     const sequence = current !== undefined && noUpdateTTL ? current.sequence : ++this._sequence;
+    const shouldDispose = current !== undefined && current.value !== value && !noDisposeOnSet;
 
-    if (current !== undefined && current.value !== value && !noDisposeOnSet) {
+    this._data.set(key, { expiresAt, sequence, value });
+    this._scheduleTimer(expiresAt);
+
+    if (shouldDispose) {
       this._dispose?.(current.value, key, 'set');
     }
 
-    this._data.set(key, { expiresAt, sequence, value });
     this._purgeToCapacity();
 
     return this;
@@ -132,6 +149,7 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
       assertTtl(ttl);
       entry.expiresAt = this._expirationFromTtl(ttl);
       entry.sequence = ++this._sequence;
+      this._scheduleTimer(entry.expiresAt);
     }
 
     return entry.value as unknown as T;
@@ -168,6 +186,7 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
   public clear(): void {
     const entries = [...this._data.entries()];
     this._data.clear();
+    this.cancelTimer();
 
     for (const [key, entry] of entries) {
       this._dispose?.(entry.value, key, 'delete');
@@ -178,16 +197,7 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
    * Remove expired entries.
    */
   public purgeStale(): boolean {
-    let purged = false;
-
-    for (const [key, entry] of this._data.entries()) {
-      if (this._isExpired(entry)) {
-        this._delete(key, 'stale');
-        purged = true;
-      }
-    }
-
-    return purged;
+    return this._purgeStale(this._timer !== undefined);
   }
 
   /**
@@ -204,7 +214,7 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
       return Infinity;
     }
 
-    const remainingTtl = Math.ceil(entry.expiresAt - Date.now());
+    const remainingTtl = Math.ceil(entry.expiresAt - now());
 
     if (remainingTtl <= 0) {
       this._delete(key, 'stale');
@@ -233,6 +243,7 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
 
     entry.expiresAt = this._expirationFromTtl(ttl);
     entry.sequence = ++this._sequence;
+    this._scheduleTimer(entry.expiresAt);
   }
 
   /**
@@ -265,10 +276,14 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
   }
 
   /**
-   * Provided for compatibility with the previous TTL cache package. No background timer exists, so this trims expired entries.
+   * Cancel the background purge timer. Lazy expiry checks still run on access.
    */
   public cancelTimer(): void {
-    this.purgeStale();
+    if (this._timer !== undefined) {
+      clearTimeout(this._timer);
+      this._timer = undefined;
+      this._timerExpiresAt = Infinity;
+    }
   }
 
   public [Symbol.iterator](): Iterator<[K, V]> {
@@ -276,20 +291,50 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
   }
 
   private _expirationFromTtl(ttl: number): number {
-    return ttl === Infinity ? Infinity : Date.now() + ttl;
+    return ttl === Infinity ? Infinity : now() + ttl;
   }
 
   private _isExpired(entry: TtlCacheEntry<V>): boolean {
-    return entry.expiresAt !== Infinity && Date.now() >= entry.expiresAt;
+    return entry.expiresAt !== Infinity && now() >= entry.expiresAt;
   }
 
   private _purgeToCapacity(): void {
+    if (this.max === Infinity || this._data.size <= this.max) {
+      return;
+    }
+
     this.purgeStale();
 
-    while (this._data.size > this.max) {
-      const [key] = this._sortedEntries()[0];
+    if (this._data.size <= this.max) {
+      return;
+    }
+
+    const entries = this._sortedEntries();
+
+    for (const [key] of entries) {
+      if (this._data.size <= this.max) {
+        return;
+      }
+
       this._delete(key, 'evict');
     }
+  }
+
+  private _purgeStale(scheduleNextTimer: boolean): boolean {
+    let purged = false;
+
+    for (const [key, entry] of this._data.entries()) {
+      if (this._isExpired(entry)) {
+        this._delete(key, 'stale');
+        purged = true;
+      }
+    }
+
+    if (purged && scheduleNextTimer) {
+      this._rescheduleTimer();
+    }
+
+    return purged;
   }
 
   private _sortedEntries(): [K, TtlCacheEntry<V>][] {
@@ -304,9 +349,55 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
     }
 
     this._data.delete(key);
+
+    if (this._data.size === 0) {
+      this.cancelTimer();
+    }
+
     this._dispose?.(entry.value, key, reason);
 
     return true;
+  }
+
+  private _scheduleTimer(expiresAt: number): void {
+    if (expiresAt === Infinity || expiresAt >= this._timerExpiresAt) {
+      return;
+    }
+
+    this.cancelTimer();
+
+    const delay = Math.max(0, Math.ceil(expiresAt - now()));
+    const timer = setTimeout((): void => {
+      this._timer = undefined;
+      this._timerExpiresAt = Infinity;
+      const purged = this._purgeStale(true);
+
+      if (!purged) {
+        this._scheduleNextTimer();
+      }
+    }, delay);
+
+    unrefTimer(timer);
+
+    this._timer = timer;
+    this._timerExpiresAt = expiresAt;
+  }
+
+  private _scheduleNextTimer(): void {
+    let nextExpiration = Infinity;
+
+    for (const entry of this._data.values()) {
+      if (entry.expiresAt < nextExpiration) {
+        nextExpiration = entry.expiresAt;
+      }
+    }
+
+    this._scheduleTimer(nextExpiration);
+  }
+
+  private _rescheduleTimer(): void {
+    this.cancelTimer();
+    this._scheduleNextTimer();
   }
 }
 
@@ -321,7 +412,6 @@ export namespace TtlCache {
   };
 
   export type Options<K, V> = TTLOptions & {
-    checkAgeOnGet?: boolean;
     dispose?: Disposer<K, V>;
     max?: number;
     noDisposeOnSet?: boolean;
@@ -335,7 +425,6 @@ export namespace TtlCache {
   };
 
   export type GetOptions = {
-    checkAgeOnGet?: boolean;
     ttl?: number;
     updateAgeOnGet?: boolean;
   };

--- a/packages/common/src/cache.ts
+++ b/packages/common/src/cache.ts
@@ -28,8 +28,8 @@ function assertTtl(ttl: number | undefined): asserts ttl is number {
 
 function unrefTimer(timer: TtlCacheTimer): void {
   if (typeof timer === 'object' && timer !== null && 'unref' in timer) {
-    const { unref } = timer as { unref?: () => void };
-    unref?.();
+    const unrefableTimer = timer as TtlCacheTimer & { unref?: () => void };
+    unrefableTimer.unref?.();
   }
 }
 

--- a/packages/common/src/cache.ts
+++ b/packages/common/src/cache.ts
@@ -180,7 +180,7 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
   public purgeStale(): boolean {
     let purged = false;
 
-    for (const [key, entry] of [...this._data.entries()]) {
+    for (const [key, entry] of this._data.entries()) {
       if (this._isExpired(entry)) {
         this._delete(key, 'stale');
         purged = true;
@@ -265,9 +265,10 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
   }
 
   /**
-   * Provided for compatibility with the previous TTL cache package.
+   * Provided for compatibility with the previous TTL cache package. No background timer exists, so this trims expired entries.
    */
   public cancelTimer(): void {
+    this.purgeStale();
   }
 
   public [Symbol.iterator](): Iterator<[K, V]> {

--- a/packages/common/src/cache.ts
+++ b/packages/common/src/cache.ts
@@ -4,6 +4,11 @@ type TtlCacheEntry<V> = {
   value: V;
 };
 
+type TtlCacheEvictionCandidate<K, V> = {
+  entry: TtlCacheEntry<V>;
+  key: K;
+};
+
 type TtlCachePurgeState = {
   purgedStale: boolean;
 };
@@ -311,8 +316,8 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
     return ttl === Infinity ? Infinity : now() + ttl;
   }
 
-  private _isExpired(entry: TtlCacheEntry<V>): boolean {
-    return entry.expiresAt !== Infinity && now() >= entry.expiresAt;
+  private _isExpired(entry: TtlCacheEntry<V>, currentTime: number = now()): boolean {
+    return entry.expiresAt !== Infinity && currentTime >= entry.expiresAt;
   }
 
   private _purgeToCapacity(): void {
@@ -325,13 +330,17 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
 
     try {
       while (this._data.size > this.max) {
-        const evictKey = this._purgeStaleAndSelectEviction(purgeState);
+        const evictCandidate = this._purgeStaleAndSelectEviction(purgeState);
 
-        if (this._data.size <= this.max || evictKey === undefined) {
+        if (this._data.size <= this.max || evictCandidate === undefined) {
           return;
         }
 
-        this._delete(evictKey, 'evict');
+        if (this._data.get(evictCandidate.key) !== evictCandidate.entry) {
+          continue;
+        }
+
+        this._delete(evictCandidate.key, 'evict');
       }
     } finally {
       if (purgeState.purgedStale && hadTimer) {
@@ -341,12 +350,13 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
     }
   }
 
-  private _purgeStaleAndSelectEviction(purgeState: TtlCachePurgeState): K | undefined {
+  private _purgeStaleAndSelectEviction(purgeState: TtlCachePurgeState): TtlCacheEvictionCandidate<K, V> | undefined {
+    const currentTime = now();
     let evictKey: K | undefined;
     let evictEntry: TtlCacheEntry<V> | undefined;
 
     for (const [key, entry] of this._data.entries()) {
-      if (this._isExpired(entry)) {
+      if (this._isExpired(entry, currentTime)) {
         purgeState.purgedStale = true;
         this._delete(key, 'stale');
         continue;
@@ -358,7 +368,11 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
       }
     }
 
-    return evictKey;
+    if (evictKey === undefined || evictEntry === undefined) {
+      return undefined;
+    }
+
+    return { entry: evictEntry, key: evictKey };
   }
 
   private _isEarlierEntry(entry: TtlCacheEntry<V>, selectedEntry: TtlCacheEntry<V> | undefined): boolean {

--- a/packages/common/src/cache.ts
+++ b/packages/common/src/cache.ts
@@ -6,7 +6,9 @@ type TtlCacheEntry<V> = {
 
 type TtlCacheEvictionCandidate<K, V> = {
   entry: TtlCacheEntry<V>;
+  expiresAt: number;
   key: K;
+  sequence: number;
 };
 
 type TtlCachePurgeState = {
@@ -336,7 +338,13 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
           return;
         }
 
-        if (this._data.get(evictCandidate.key) !== evictCandidate.entry) {
+        const currentEntry = this._data.get(evictCandidate.key);
+
+        if (
+          currentEntry !== evictCandidate.entry ||
+          currentEntry.expiresAt !== evictCandidate.expiresAt ||
+          currentEntry.sequence !== evictCandidate.sequence
+        ) {
           continue;
         }
 
@@ -354,6 +362,8 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
     const currentTime = now();
     let evictKey: K | undefined;
     let evictEntry: TtlCacheEntry<V> | undefined;
+    let evictExpiresAt: number | undefined;
+    let evictSequence: number | undefined;
 
     for (const [key, entry] of this._data.entries()) {
       if (this._isExpired(entry, currentTime)) {
@@ -362,36 +372,39 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
         continue;
       }
 
-      if (this._isEarlierEntry(entry, evictEntry)) {
+      if (this._isEarlierEntry(entry, evictExpiresAt, evictSequence)) {
         evictKey = key;
         evictEntry = entry;
+        evictExpiresAt = entry.expiresAt;
+        evictSequence = entry.sequence;
       }
     }
 
-    if (evictKey === undefined || evictEntry === undefined) {
+    if (evictKey === undefined || evictEntry === undefined || evictExpiresAt === undefined || evictSequence === undefined) {
       return undefined;
     }
 
-    return { entry: evictEntry, key: evictKey };
+    return { entry: evictEntry, expiresAt: evictExpiresAt, key: evictKey, sequence: evictSequence };
   }
 
-  private _isEarlierEntry(entry: TtlCacheEntry<V>, selectedEntry: TtlCacheEntry<V> | undefined): boolean {
-    if (selectedEntry === undefined) {
+  private _isEarlierEntry(entry: TtlCacheEntry<V>, selectedExpiresAt: number | undefined, selectedSequence: number | undefined): boolean {
+    if (selectedExpiresAt === undefined || selectedSequence === undefined) {
       return true;
     }
 
-    if (entry.expiresAt !== selectedEntry.expiresAt) {
-      return entry.expiresAt < selectedEntry.expiresAt;
+    if (entry.expiresAt !== selectedExpiresAt) {
+      return entry.expiresAt < selectedExpiresAt;
     }
 
-    return entry.sequence < selectedEntry.sequence;
+    return entry.sequence < selectedSequence;
   }
 
   private _purgeStale(): boolean {
+    const currentTime = now();
     let purged = false;
 
     for (const [key, entry] of this._data.entries()) {
-      if (this._isExpired(entry)) {
+      if (this._isExpired(entry, currentTime)) {
         this._delete(key, 'stale');
         purged = true;
       }

--- a/packages/common/src/cache.ts
+++ b/packages/common/src/cache.ts
@@ -1,2 +1,341 @@
-import TTLCache from '@isaacs/ttlcache';
-export { TTLCache as TtlCache };
+type TtlCacheEntry<V> = {
+  expiresAt: number;
+  sequence: number;
+  value: V;
+};
+
+function isPositiveIntegerOrInfinity(value: number): boolean {
+  return value === Infinity || (Number.isInteger(value) && value > 0 && Number.isFinite(value));
+}
+
+function assertPositiveIntegerOrInfinity(value: number, name: string): void {
+  if (!isPositiveIntegerOrInfinity(value)) {
+    throw new TypeError(`${name} must be positive integer or Infinity`);
+  }
+}
+
+function assertTtl(ttl: number | undefined): asserts ttl is number {
+  if (ttl === undefined || !isPositiveIntegerOrInfinity(ttl)) {
+    throw new TypeError('ttl must be positive integer or Infinity');
+  }
+}
+
+const entryCompare = <K, V>([, left]: [K, TtlCacheEntry<V>], [, right]: [K, TtlCacheEntry<V>]): number => {
+  if (left.expiresAt !== right.expiresAt) {
+    return left.expiresAt - right.expiresAt;
+  }
+
+  return left.sequence - right.sequence;
+};
+
+/**
+ * Small in-memory TTL cache tailored to the cache API used by Enbox.
+ */
+export class TtlCache<K, V> implements Iterable<[K, V]> {
+  public checkAgeOnGet: boolean;
+  public max: number;
+  public noDisposeOnSet: boolean;
+  public noUpdateTTL: boolean;
+  public ttl?: number;
+  public updateAgeOnGet: boolean;
+
+  private readonly _data = new Map<K, TtlCacheEntry<V>>();
+  private readonly _dispose?: TtlCache.Disposer<K, V>;
+  private _sequence = 0;
+
+  public constructor(options: TtlCache.Options<K, V> = {}) {
+    const {
+      checkAgeOnGet = false,
+      dispose,
+      max = Infinity,
+      noDisposeOnSet = false,
+      noUpdateTTL = false,
+      ttl,
+      updateAgeOnGet = false,
+    } = options;
+
+    if (ttl !== undefined) {
+      assertPositiveIntegerOrInfinity(ttl, 'ttl');
+    }
+
+    assertPositiveIntegerOrInfinity(max, 'max');
+
+    if (dispose !== undefined && typeof dispose !== 'function') {
+      throw new TypeError('dispose must be function if set');
+    }
+
+    this.checkAgeOnGet = checkAgeOnGet;
+    this.max = max;
+    this.noDisposeOnSet = noDisposeOnSet;
+    this.noUpdateTTL = noUpdateTTL;
+    this.ttl = ttl;
+    this.updateAgeOnGet = updateAgeOnGet;
+    this._dispose = dispose;
+  }
+
+  /**
+   * Total live entries currently stored in the cache.
+   */
+  public get size(): number {
+    this.purgeStale();
+    return this._data.size;
+  }
+
+  /**
+   * Store a value and assign the configured TTL.
+   */
+  public set(key: K, value: V, options: TtlCache.SetOptions = {}): this {
+    const ttl = options.ttl ?? this.ttl;
+    assertTtl(ttl);
+
+    const existing = this._data.get(key);
+    const noUpdateTTL = options.noUpdateTTL ?? this.noUpdateTTL;
+    const noDisposeOnSet = options.noDisposeOnSet ?? this.noDisposeOnSet;
+
+    if (existing !== undefined && this._isExpired(existing)) {
+      this._delete(key, 'stale');
+    }
+
+    const current = this._data.get(key);
+    const expiresAt = current !== undefined && noUpdateTTL ? current.expiresAt : this._expirationFromTtl(ttl);
+    const sequence = current !== undefined && noUpdateTTL ? current.sequence : ++this._sequence;
+
+    if (current !== undefined && current.value !== value && !noDisposeOnSet) {
+      this._dispose?.(current.value, key, 'set');
+    }
+
+    this._data.set(key, { expiresAt, sequence, value });
+    this._purgeToCapacity();
+
+    return this;
+  }
+
+  /**
+   * Retrieve a cached value, optionally extending the entry age.
+   */
+  public get<T = V>(key: K, options: TtlCache.GetOptions = {}): T | undefined {
+    const entry = this._data.get(key);
+
+    if (entry === undefined) {
+      return undefined;
+    }
+
+    if (this._isExpired(entry)) {
+      this._delete(key, 'stale');
+      return undefined;
+    }
+
+    const updateAgeOnGet = options.updateAgeOnGet ?? this.updateAgeOnGet;
+
+    if (updateAgeOnGet) {
+      const ttl = options.ttl ?? this.ttl;
+      assertTtl(ttl);
+      entry.expiresAt = this._expirationFromTtl(ttl);
+      entry.sequence = ++this._sequence;
+    }
+
+    return entry.value as unknown as T;
+  }
+
+  /**
+   * Check whether a live value exists for the given key.
+   */
+  public has(key: K): boolean {
+    const entry = this._data.get(key);
+
+    if (entry === undefined) {
+      return false;
+    }
+
+    if (this._isExpired(entry)) {
+      this._delete(key, 'stale');
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Delete a cache entry.
+   */
+  public delete(key: K): boolean {
+    return this._delete(key, 'delete');
+  }
+
+  /**
+   * Clear all cache entries.
+   */
+  public clear(): void {
+    const entries = [...this._data.entries()];
+    this._data.clear();
+
+    for (const [key, entry] of entries) {
+      this._dispose?.(entry.value, key, 'delete');
+    }
+  }
+
+  /**
+   * Remove expired entries.
+   */
+  public purgeStale(): boolean {
+    let purged = false;
+
+    for (const [key, entry] of [...this._data.entries()]) {
+      if (this._isExpired(entry)) {
+        this._delete(key, 'stale');
+        purged = true;
+      }
+    }
+
+    return purged;
+  }
+
+  /**
+   * Return the remaining TTL for a live entry.
+   */
+  public getRemainingTTL(key: K): number {
+    const entry = this._data.get(key);
+
+    if (entry === undefined) {
+      return 0;
+    }
+
+    if (entry.expiresAt === Infinity) {
+      return Infinity;
+    }
+
+    const remainingTtl = Math.ceil(entry.expiresAt - Date.now());
+
+    if (remainingTtl <= 0) {
+      this._delete(key, 'stale');
+      return 0;
+    }
+
+    return remainingTtl;
+  }
+
+  /**
+   * Set a new TTL for an existing entry.
+   */
+  public setTTL(key: K, ttl: number | undefined = this.ttl): void {
+    assertTtl(ttl);
+
+    const entry = this._data.get(key);
+
+    if (entry === undefined) {
+      return;
+    }
+
+    if (this._isExpired(entry)) {
+      this._delete(key, 'stale');
+      return;
+    }
+
+    entry.expiresAt = this._expirationFromTtl(ttl);
+    entry.sequence = ++this._sequence;
+  }
+
+  /**
+   * Iterate over live entries from soonest to latest expiration.
+   */
+  public *entries(): Generator<[K, V]> {
+    this.purgeStale();
+
+    for (const [key, entry] of this._sortedEntries()) {
+      yield [key, entry.value];
+    }
+  }
+
+  /**
+   * Iterate over live keys from soonest to latest expiration.
+   */
+  public *keys(): Generator<K> {
+    for (const [key] of this.entries()) {
+      yield key;
+    }
+  }
+
+  /**
+   * Iterate over live values from soonest to latest expiration.
+   */
+  public *values(): Generator<V> {
+    for (const [, value] of this.entries()) {
+      yield value;
+    }
+  }
+
+  /**
+   * Provided for compatibility with the previous TTL cache package.
+   */
+  public cancelTimer(): void {
+  }
+
+  public [Symbol.iterator](): Iterator<[K, V]> {
+    return this.entries();
+  }
+
+  private _expirationFromTtl(ttl: number): number {
+    return ttl === Infinity ? Infinity : Date.now() + ttl;
+  }
+
+  private _isExpired(entry: TtlCacheEntry<V>): boolean {
+    return entry.expiresAt !== Infinity && Date.now() >= entry.expiresAt;
+  }
+
+  private _purgeToCapacity(): void {
+    this.purgeStale();
+
+    while (this._data.size > this.max) {
+      const [key] = this._sortedEntries()[0];
+      this._delete(key, 'evict');
+    }
+  }
+
+  private _sortedEntries(): [K, TtlCacheEntry<V>][] {
+    return [...this._data.entries()].sort(entryCompare);
+  }
+
+  private _delete(key: K, reason: TtlCache.DisposeReason): boolean {
+    const entry = this._data.get(key);
+
+    if (entry === undefined) {
+      return false;
+    }
+
+    this._data.delete(key);
+    this._dispose?.(entry.value, key, reason);
+
+    return true;
+  }
+}
+
+export namespace TtlCache {
+  export type DisposeReason = 'evict' | 'set' | 'delete' | 'stale';
+
+  export type Disposer<K, V> = (value: V, key: K, reason: DisposeReason) => void;
+
+  export type TTLOptions = {
+    noUpdateTTL?: boolean;
+    ttl?: number;
+  };
+
+  export type Options<K, V> = TTLOptions & {
+    checkAgeOnGet?: boolean;
+    dispose?: Disposer<K, V>;
+    max?: number;
+    noDisposeOnSet?: boolean;
+    updateAgeOnGet?: boolean;
+  };
+
+  export type SetOptions = {
+    noDisposeOnSet?: boolean;
+    noUpdateTTL?: boolean;
+    ttl?: number;
+  };
+
+  export type GetOptions = {
+    checkAgeOnGet?: boolean;
+    ttl?: number;
+    updateAgeOnGet?: boolean;
+  };
+}

--- a/packages/common/src/cache.ts
+++ b/packages/common/src/cache.ts
@@ -4,6 +4,10 @@ type TtlCacheEntry<V> = {
   value: V;
 };
 
+type TtlCachePurgeState = {
+  purgedStale: boolean;
+};
+
 type TtlCacheTimer = ReturnType<typeof setTimeout>;
 
 const MAX_TIMER_DELAY = 2_147_483_647;
@@ -317,45 +321,56 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
     }
 
     const hadTimer = this._timer !== undefined;
-    let purgedStale = false;
+    const purgeState = { purgedStale: false };
 
     try {
       while (this._data.size > this.max) {
-        let evictKey: K | undefined;
-        let evictEntry: TtlCacheEntry<V> | undefined;
+        const evictKey = this._purgeStaleAndSelectEviction(purgeState);
 
-        for (const [key, entry] of this._data.entries()) {
-          if (this._isExpired(entry)) {
-            purgedStale = true;
-            this._delete(key, 'stale');
-
-            if (this._data.size <= this.max) {
-              return;
-            }
-
-            continue;
-          }
-
-          if (evictEntry === undefined || entry.expiresAt < evictEntry.expiresAt || (
-            entry.expiresAt === evictEntry.expiresAt && entry.sequence < evictEntry.sequence
-          )) {
-            evictKey = key;
-            evictEntry = entry;
-          }
-        }
-
-        if (evictKey === undefined) {
+        if (this._data.size <= this.max || evictKey === undefined) {
           return;
         }
 
         this._delete(evictKey, 'evict');
       }
     } finally {
-      if (purgedStale && hadTimer) {
+      if (purgeState.purgedStale && hadTimer) {
         this.cancelTimer();
         this._scheduleNextTimer();
       }
     }
+  }
+
+  private _purgeStaleAndSelectEviction(purgeState: TtlCachePurgeState): K | undefined {
+    let evictKey: K | undefined;
+    let evictEntry: TtlCacheEntry<V> | undefined;
+
+    for (const [key, entry] of this._data.entries()) {
+      if (this._isExpired(entry)) {
+        purgeState.purgedStale = true;
+        this._delete(key, 'stale');
+        continue;
+      }
+
+      if (this._isEarlierEntry(entry, evictEntry)) {
+        evictKey = key;
+        evictEntry = entry;
+      }
+    }
+
+    return evictKey;
+  }
+
+  private _isEarlierEntry(entry: TtlCacheEntry<V>, selectedEntry: TtlCacheEntry<V> | undefined): boolean {
+    if (selectedEntry === undefined) {
+      return true;
+    }
+
+    if (entry.expiresAt !== selectedEntry.expiresAt) {
+      return entry.expiresAt < selectedEntry.expiresAt;
+    }
+
+    return entry.sequence < selectedEntry.sequence;
   }
 
   private _purgeStale(): boolean {

--- a/packages/common/src/cache.ts
+++ b/packages/common/src/cache.ts
@@ -6,6 +6,8 @@ type TtlCacheEntry<V> = {
 
 type TtlCacheTimer = ReturnType<typeof setTimeout>;
 
+const MAX_TIMER_DELAY = 2_147_483_647;
+
 function now(): number {
   return performance.now();
 }
@@ -146,10 +148,13 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
 
     if (updateAgeOnGet) {
       const ttl = options.ttl ?? this.ttl;
-      assertTtl(ttl);
-      entry.expiresAt = this._expirationFromTtl(ttl);
-      entry.sequence = ++this._sequence;
-      this._scheduleTimer(entry.expiresAt);
+
+      if (ttl !== undefined) {
+        assertTtl(ttl);
+        entry.expiresAt = this._expirationFromTtl(ttl);
+        entry.sequence = ++this._sequence;
+        this._scheduleTimer(entry.expiresAt);
+      }
     }
 
     return entry.value as unknown as T;
@@ -197,7 +202,15 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
    * Remove expired entries.
    */
   public purgeStale(): boolean {
-    return this._purgeStale(this._timer !== undefined);
+    const hadTimer = this._timer !== undefined;
+    const purged = this._purgeStale();
+
+    if (purged && hadTimer) {
+      this.cancelTimer();
+      this._scheduleNextTimer();
+    }
+
+    return purged;
   }
 
   /**
@@ -303,24 +316,49 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
       return;
     }
 
-    this.purgeStale();
+    const hadTimer = this._timer !== undefined;
+    let purgedStale = false;
 
-    if (this._data.size <= this.max) {
-      return;
-    }
+    try {
+      while (this._data.size > this.max) {
+        let evictKey: K | undefined;
+        let evictEntry: TtlCacheEntry<V> | undefined;
 
-    const entries = this._sortedEntries();
+        for (const [key, entry] of this._data.entries()) {
+          if (this._isExpired(entry)) {
+            purgedStale = true;
+            this._delete(key, 'stale');
 
-    for (const [key] of entries) {
-      if (this._data.size <= this.max) {
-        return;
+            if (this._data.size <= this.max) {
+              return;
+            }
+
+            continue;
+          }
+
+          if (evictEntry === undefined || entry.expiresAt < evictEntry.expiresAt || (
+            entry.expiresAt === evictEntry.expiresAt && entry.sequence < evictEntry.sequence
+          )) {
+            evictKey = key;
+            evictEntry = entry;
+          }
+        }
+
+        if (evictKey === undefined) {
+          return;
+        }
+
+        this._delete(evictKey, 'evict');
       }
-
-      this._delete(key, 'evict');
+    } finally {
+      if (purgedStale && hadTimer) {
+        this.cancelTimer();
+        this._scheduleNextTimer();
+      }
     }
   }
 
-  private _purgeStale(scheduleNextTimer: boolean): boolean {
+  private _purgeStale(): boolean {
     let purged = false;
 
     for (const [key, entry] of this._data.entries()) {
@@ -328,10 +366,6 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
         this._delete(key, 'stale');
         purged = true;
       }
-    }
-
-    if (purged && scheduleNextTimer) {
-      this._rescheduleTimer();
     }
 
     return purged;
@@ -366,13 +400,14 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
 
     this.cancelTimer();
 
-    const delay = Math.max(0, Math.ceil(expiresAt - now()));
+    const delay = Math.min(MAX_TIMER_DELAY, Math.max(0, Math.ceil(expiresAt - now())));
     const timer = setTimeout((): void => {
       this._timer = undefined;
       this._timerExpiresAt = Infinity;
-      const purged = this._purgeStale(true);
 
-      if (!purged) {
+      try {
+        this._purgeStale();
+      } finally {
         this._scheduleNextTimer();
       }
     }, delay);
@@ -393,11 +428,6 @@ export class TtlCache<K, V> implements Iterable<[K, V]> {
     }
 
     this._scheduleTimer(nextExpiration);
-  }
-
-  private _rescheduleTimer(): void {
-    this.cancelTimer();
-    this._scheduleNextTimer();
   }
 }
 

--- a/packages/common/tests/cache.test.ts
+++ b/packages/common/tests/cache.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'bun:test';
 import { sleep } from '../src/time.js';
 import { TtlCache } from '../src/cache.js';
 
+const MAX_TIMER_DELAY = 2_147_483_647;
+
 describe('TtlCache', () => {
   it('should store and retrieve string values', () => {
     const cache = new TtlCache({ max: 10000, ttl: 1000 });
@@ -39,20 +41,29 @@ describe('TtlCache', () => {
   });
 
   it('should renew ttl when updateAgeOnGet is enabled per read', async () => {
-    const cache = new TtlCache({ ttl: 250 });
+    const cache = new TtlCache({ ttl: 600 });
     cache.set('key', 'value');
 
-    await sleep(75);
+    await sleep(150);
     const remainingBeforeGet = cache.getRemainingTTL('key');
 
     expect(cache.get('key', { updateAgeOnGet: true })).toBe('value');
     expect(cache.getRemainingTTL('key')).toBeGreaterThan(remainingBeforeGet);
 
-    await sleep(125);
+    await sleep(500);
     expect(cache.get('key')).toBe('value');
 
-    await sleep(175);
+    await sleep(225);
     expect(cache.get('key')).toBeUndefined();
+  });
+
+  it('should leave the existing expiry unchanged when updateAgeOnGet has no ttl to apply', () => {
+    const cache = new TtlCache<string, string>({ updateAgeOnGet: true });
+    cache.set('key', 'value', { ttl: 1000 });
+    const remainingBeforeGet = cache.getRemainingTTL('key');
+
+    expect(cache.get('key')).toBe('value');
+    expect(cache.getRemainingTTL('key')).toBeLessThanOrEqual(remainingBeforeGet);
   });
 
   it('should evict the soonest expiring entry when max is exceeded', () => {
@@ -100,15 +111,15 @@ describe('TtlCache', () => {
   });
 
   it('should update ttl for an existing entry', async () => {
-    const cache = new TtlCache({ ttl: 20 });
+    const cache = new TtlCache({ ttl: 100 });
     cache.set('key', 'value');
-    cache.setTTL('key', 80);
+    cache.setTTL('key', 400);
 
-    await sleep(35);
+    await sleep(125);
     expect(cache.get('key')).toBe('value');
 
-    cache.setTTL('key', 10);
-    await sleep(20);
+    cache.setTTL('key', 50);
+    await sleep(125);
 
     expect(cache.get('key')).toBeUndefined();
   });
@@ -152,6 +163,25 @@ describe('TtlCache', () => {
     expect(disposed).toEqual(['key:value:stale']);
   });
 
+  it('should re-arm the background timer for the next stale entry', async () => {
+    const disposed: string[] = [];
+    const cache = new TtlCache<string, string>({
+      dispose : (value, key, reason): void => { disposed.push(`${key}:${value}:${reason}`); },
+      ttl     : 1000,
+    });
+
+    cache.set('first', 'a', { ttl: 25 });
+    cache.set('second', 'b', { ttl: 75 });
+
+    await sleep(200);
+
+    expect(cache.size).toBe(0);
+    expect(disposed).toEqual([
+      'first:a:stale',
+      'second:b:stale',
+    ]);
+  });
+
   it('should call timer unref with the timer as receiver', () => {
     const originalSetTimeout = globalThis.setTimeout;
     const originalClearTimeout = globalThis.clearTimeout;
@@ -178,6 +208,73 @@ describe('TtlCache', () => {
     }
   });
 
+  it('should clamp background timer delays to the runtime timeout ceiling', () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const delays: number[] = [];
+
+    globalThis.setTimeout = ((_handler: TimerHandler, timeout?: number): ReturnType<typeof setTimeout> => {
+      delays.push(timeout ?? 0);
+      return { unref(): void {} } as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = ((_timer?: ReturnType<typeof setTimeout>): void => undefined) as typeof clearTimeout;
+
+    try {
+      const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+      const cache = new TtlCache({ ttl: thirtyDays });
+      cache.set('key', 'value');
+
+      expect(delays).toEqual([MAX_TIMER_DELAY]);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+
+  it('should re-arm the background timer before an async dispose error escapes', () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const handlers: TimerHandler[] = [];
+    const delays: number[] = [];
+
+    globalThis.setTimeout = ((handler: TimerHandler, timeout?: number): ReturnType<typeof setTimeout> => {
+      handlers.push(handler);
+      delays.push(timeout ?? 0);
+      return { unref(): void {} } as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = ((_timer?: ReturnType<typeof setTimeout>): void => undefined) as typeof clearTimeout;
+
+    try {
+      const cache = new TtlCache<string, string>({
+        dispose: (_value, key): void => {
+          if (key === 'first') {
+            throw new Error('dispose failed');
+          }
+        },
+        ttl: 1000,
+      });
+
+      cache.set('first', 'a');
+      cache.set('second', 'b');
+
+      const cacheInternals = cache as unknown as { _data: Map<string, { expiresAt: number }> };
+      cacheInternals._data.get('first')!.expiresAt = performance.now() - 1;
+
+      expect(() => {
+        const handler = handlers[0];
+
+        if (typeof handler === 'function') {
+          handler();
+        }
+      }).toThrow('dispose failed');
+      expect(cache.get('second')).toBe('b');
+      expect(delays.length).toBe(2);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+
   it('should cancel the background timer without synchronously purging stale entries', async () => {
     const disposed: string[] = [];
     const cache = new TtlCache<string, string>({
@@ -190,6 +287,8 @@ describe('TtlCache', () => {
     cache.cancelTimer();
 
     await sleep(125);
+
+    cache.cancelTimer();
 
     expect(cache.size).toBe(1);
     expect(disposed).toEqual([]);
@@ -272,18 +371,19 @@ describe('TtlCache', () => {
   });
 
   it('should preserve an existing ttl when noUpdateTTL is used', async () => {
-    const cache = new TtlCache<string, string>({ ttl: 250 });
+    const cache = new TtlCache<string, string>({ ttl: 1000 });
     cache.set('key', 'first');
 
-    await sleep(75);
+    await sleep(150);
     const remainingBeforeSet = cache.getRemainingTTL('key');
     cache.set('key', 'second', { noUpdateTTL: true });
     const remainingAfterSet = cache.getRemainingTTL('key');
 
+    expect(remainingBeforeSet).toBeGreaterThan(0);
     expect(remainingAfterSet).toBeLessThanOrEqual(remainingBeforeSet);
     expect(cache.get('key')).toBe('second');
 
-    await sleep(remainingAfterSet + 75);
+    await sleep(remainingAfterSet + 150);
     expect(cache.get('key')).toBeUndefined();
   });
 

--- a/packages/common/tests/cache.test.ts
+++ b/packages/common/tests/cache.test.ts
@@ -393,6 +393,38 @@ describe('TtlCache', () => {
     ]);
   });
 
+  it('should not evict an entry re-aged in place by a stale dispose callback during capacity pruning', () => {
+    const disposed: string[] = [];
+    const cache = new TtlCache<string, string>({
+      dispose: (value, key, reason): void => {
+        disposed.push(`${key}:${value}:${reason}`);
+
+        if (key === 'stale' && reason === 'stale') {
+          cache.setTTL('candidate', 1000);
+        }
+      },
+      max : Infinity,
+      ttl : 1000,
+    });
+
+    cache.set('candidate', 'old', { ttl: 100 });
+    cache.set('survivor', 'live', { ttl: 200 });
+    cache.set('stale', 'expired', { ttl: 1 });
+    busyWait(5);
+
+    cache.max = 2;
+    cache.set('trigger', 'new', { ttl: 300 });
+
+    expect(cache.get('candidate')).toBe('old');
+    expect(cache.get('trigger')).toBe('new');
+    expect(cache.get('survivor')).toBeUndefined();
+    expect(cache.size).toBe(2);
+    expect(disposed).toEqual([
+      'stale:expired:stale',
+      'survivor:live:evict',
+    ]);
+  });
+
   it('should store an overwritten value before calling dispose', () => {
     let observedValue: string | undefined;
     const cache = new TtlCache<string, string>({

--- a/packages/common/tests/cache.test.ts
+++ b/packages/common/tests/cache.test.ts
@@ -152,6 +152,32 @@ describe('TtlCache', () => {
     expect(disposed).toEqual(['key:value:stale']);
   });
 
+  it('should call timer unref with the timer as receiver', () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const timer = {
+      refed: true,
+      unref(): void {
+        this.refed = false;
+      },
+    };
+
+    globalThis.setTimeout = ((_handler: TimerHandler, _timeout?: number): ReturnType<typeof setTimeout> => {
+      return timer as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = ((_timer?: ReturnType<typeof setTimeout>): void => undefined) as typeof clearTimeout;
+
+    try {
+      const cache = new TtlCache({ ttl: 25 });
+      cache.set('key', 'value');
+
+      expect(timer.refed).toBe(false);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+
   it('should cancel the background timer without synchronously purging stale entries', async () => {
     const disposed: string[] = [];
     const cache = new TtlCache<string, string>({

--- a/packages/common/tests/cache.test.ts
+++ b/packages/common/tests/cache.test.ts
@@ -134,6 +134,17 @@ describe('TtlCache', () => {
     expect(cache.getRemainingTTL('key')).toBe(Infinity);
   });
 
+  it('should keep cancelTimer compatibility and purge stale entries', async () => {
+    const cache = new TtlCache({ ttl: 10 });
+    cache.set('key', 'value');
+
+    await sleep(25);
+
+    cache.cancelTimer();
+
+    expect(cache.size).toBe(0);
+  });
+
   it('should call dispose with the reason entries are removed', async () => {
     const disposed: string[] = [];
     const cache = new TtlCache<string, string>({

--- a/packages/common/tests/cache.test.ts
+++ b/packages/common/tests/cache.test.ts
@@ -39,16 +39,19 @@ describe('TtlCache', () => {
   });
 
   it('should renew ttl when updateAgeOnGet is enabled per read', async () => {
-    const cache = new TtlCache({ ttl: 40 });
+    const cache = new TtlCache({ ttl: 250 });
     cache.set('key', 'value');
 
-    await sleep(25);
-    expect(cache.get('key', { updateAgeOnGet: true })).toBe('value');
+    await sleep(75);
+    const remainingBeforeGet = cache.getRemainingTTL('key');
 
-    await sleep(25);
+    expect(cache.get('key', { updateAgeOnGet: true })).toBe('value');
+    expect(cache.getRemainingTTL('key')).toBeGreaterThan(remainingBeforeGet);
+
+    await sleep(125);
     expect(cache.get('key')).toBe('value');
 
-    await sleep(30);
+    await sleep(175);
     expect(cache.get('key')).toBeUndefined();
   });
 
@@ -134,15 +137,39 @@ describe('TtlCache', () => {
     expect(cache.getRemainingTTL('key')).toBe(Infinity);
   });
 
-  it('should keep cancelTimer compatibility and purge stale entries', async () => {
-    const cache = new TtlCache({ ttl: 10 });
+  it('should proactively purge stale entries on their ttl', async () => {
+    const disposed: string[] = [];
+    const cache = new TtlCache<string, string>({
+      dispose : (value, key, reason): void => { disposed.push(`${key}:${value}:${reason}`); },
+      ttl     : 25,
+    });
+
     cache.set('key', 'value');
 
-    await sleep(25);
+    await sleep(125);
+
+    expect(cache.size).toBe(0);
+    expect(disposed).toEqual(['key:value:stale']);
+  });
+
+  it('should cancel the background timer without synchronously purging stale entries', async () => {
+    const disposed: string[] = [];
+    const cache = new TtlCache<string, string>({
+      dispose : (value, key, reason): void => { disposed.push(`${key}:${value}:${reason}`); },
+      ttl     : 25,
+    });
+
+    cache.set('key', 'value');
 
     cache.cancelTimer();
 
+    await sleep(125);
+
+    expect(cache.size).toBe(1);
+    expect(disposed).toEqual([]);
+    expect(cache.get('key')).toBeUndefined();
     expect(cache.size).toBe(0);
+    expect(disposed).toEqual(['key:value:stale']);
   });
 
   it('should call dispose with the reason entries are removed', async () => {
@@ -188,14 +215,49 @@ describe('TtlCache', () => {
     expect(disposed).toEqual(['key:second:set']);
   });
 
+  it('should store an overwritten value before calling dispose', () => {
+    let observedValue: string | undefined;
+    const cache = new TtlCache<string, string>({
+      dispose: (_value, key, reason): void => {
+        if (reason === 'set') {
+          observedValue = cache.get(key);
+        }
+      },
+      ttl: 1000,
+    });
+
+    cache.set('key', 'old');
+    cache.set('key', 'new');
+
+    expect(observedValue).toBe('new');
+    expect(cache.get('key')).toBe('new');
+  });
+
+  it('should keep an overwritten value when dispose throws', () => {
+    const cache = new TtlCache<string, string>({
+      dispose : (): void => { throw new Error('dispose failed'); },
+      ttl     : Infinity,
+    });
+
+    cache.set('key', 'old');
+
+    expect(() => cache.set('key', 'new')).toThrow('dispose failed');
+    expect(cache.get('key')).toBe('new');
+  });
+
   it('should preserve an existing ttl when noUpdateTTL is used', async () => {
-    const cache = new TtlCache<string, string>({ ttl: 30 });
+    const cache = new TtlCache<string, string>({ ttl: 250 });
     cache.set('key', 'first');
 
-    await sleep(15);
+    await sleep(75);
+    const remainingBeforeSet = cache.getRemainingTTL('key');
     cache.set('key', 'second', { noUpdateTTL: true });
-    await sleep(25);
+    const remainingAfterSet = cache.getRemainingTTL('key');
 
+    expect(remainingAfterSet).toBeLessThanOrEqual(remainingBeforeSet);
+    expect(cache.get('key')).toBe('second');
+
+    await sleep(remainingAfterSet + 75);
     expect(cache.get('key')).toBeUndefined();
   });
 

--- a/packages/common/tests/cache.test.ts
+++ b/packages/common/tests/cache.test.ts
@@ -5,6 +5,15 @@ import { TtlCache } from '../src/cache.js';
 
 const MAX_TIMER_DELAY = 2_147_483_647;
 
+function busyWait(duration: number): void {
+  const deadline = performance.now() + duration;
+  let currentTime = performance.now();
+
+  while (currentTime < deadline) {
+    currentTime = performance.now();
+  }
+}
+
 describe('TtlCache', () => {
   it('should store and retrieve string values', () => {
     const cache = new TtlCache({ max: 10000, ttl: 1000 });
@@ -41,25 +50,28 @@ describe('TtlCache', () => {
   });
 
   it('should renew ttl when updateAgeOnGet is enabled per read', async () => {
-    const cache = new TtlCache({ ttl: 600 });
+    const cache = new TtlCache({ ttl: 1200 });
     cache.set('key', 'value');
 
-    await sleep(150);
+    await sleep(300);
     const remainingBeforeGet = cache.getRemainingTTL('key');
 
     expect(cache.get('key', { updateAgeOnGet: true })).toBe('value');
     expect(cache.getRemainingTTL('key')).toBeGreaterThan(remainingBeforeGet);
 
-    await sleep(500);
+    await sleep(1000);
     expect(cache.get('key')).toBe('value');
 
-    await sleep(225);
+    await sleep(350);
     expect(cache.get('key')).toBeUndefined();
   });
 
-  it('should leave the existing expiry unchanged when updateAgeOnGet has no ttl to apply', () => {
+  it('should leave the existing expiry unchanged when updateAgeOnGet has no ttl to apply', async () => {
     const cache = new TtlCache<string, string>({ updateAgeOnGet: true });
     cache.set('key', 'value', { ttl: 1000 });
+
+    await sleep(150);
+
     const remainingBeforeGet = cache.getRemainingTTL('key');
 
     expect(cache.get('key')).toBe('value');
@@ -173,7 +185,12 @@ describe('TtlCache', () => {
     cache.set('first', 'a', { ttl: 25 });
     cache.set('second', 'b', { ttl: 75 });
 
-    await sleep(200);
+    await sleep(50);
+
+    expect(cache.size).toBe(1);
+    expect(disposed).toEqual(['first:a:stale']);
+
+    await sleep(150);
 
     expect(cache.size).toBe(0);
     expect(disposed).toEqual([
@@ -254,12 +271,12 @@ describe('TtlCache', () => {
         ttl: 1000,
       });
 
-      cache.set('first', 'a');
+      cache.set('first', 'a', { ttl: 1 });
       cache.set('second', 'b');
 
-      const cacheInternals = cache as unknown as { _data: Map<string, { expiresAt: number }> };
-      cacheInternals._data.get('first')!.expiresAt = performance.now() - 1;
+      busyWait(5);
 
+      const delayCountBeforeHandler = delays.length;
       expect(() => {
         const handler = handlers[0];
 
@@ -268,7 +285,7 @@ describe('TtlCache', () => {
         }
       }).toThrow('dispose failed');
       expect(cache.get('second')).toBe('b');
-      expect(delays).toHaveLength(2);
+      expect(delays).toHaveLength(delayCountBeforeHandler + 1);
     } finally {
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;
@@ -338,6 +355,42 @@ describe('TtlCache', () => {
     cache.set('key', 'third', { noDisposeOnSet: false });
 
     expect(disposed).toEqual(['key:second:set']);
+  });
+
+  it('should not evict an entry refreshed by a stale dispose callback during capacity pruning', () => {
+    const disposed: string[] = [];
+    const cache = new TtlCache<string, string>({
+      dispose: (value, key, reason): void => {
+        disposed.push(`${key}:${value}:${reason}`);
+
+        if (key === 'stale' && reason === 'stale') {
+          const previousMax = cache.max;
+          cache.max = Infinity;
+          cache.set('candidate', 'refreshed', { ttl: 1000 });
+          cache.max = previousMax;
+        }
+      },
+      max : Infinity,
+      ttl : 1000,
+    });
+
+    cache.set('candidate', 'old', { ttl: 100 });
+    cache.set('survivor', 'live', { ttl: 200 });
+    cache.set('stale', 'expired', { ttl: 1 });
+    busyWait(5);
+
+    cache.max = 2;
+    cache.set('trigger', 'new', { ttl: 300 });
+
+    expect(cache.get('candidate')).toBe('refreshed');
+    expect(cache.get('trigger')).toBe('new');
+    expect(cache.get('survivor')).toBeUndefined();
+    expect(cache.size).toBe(2);
+    expect(disposed).toEqual([
+      'stale:expired:stale',
+      'candidate:old:set',
+      'survivor:live:evict',
+    ]);
   });
 
   it('should store an overwritten value before calling dispose', () => {

--- a/packages/common/tests/cache.test.ts
+++ b/packages/common/tests/cache.test.ts
@@ -268,7 +268,7 @@ describe('TtlCache', () => {
         }
       }).toThrow('dispose failed');
       expect(cache.get('second')).toBe('b');
-      expect(delays.length).toBe(2);
+      expect(delays).toHaveLength(2);
     } finally {
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;

--- a/packages/common/tests/cache.test.ts
+++ b/packages/common/tests/cache.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 
+import { sleep } from '../src/time.js';
 import { TtlCache } from '../src/cache.js';
 
-describe('TTLCache', function () {
-  it('should store and retrieve string values', function () {
+describe('TtlCache', () => {
+  it('should store and retrieve string values', () => {
     const cache = new TtlCache({ max: 10000, ttl: 1000 });
     cache.set('key1', 'value1');
 
@@ -14,7 +15,7 @@ describe('TTLCache', function () {
     expect(cache.get('key1')).toBe('value1');
   });
 
-  it('should store and retrieve object values', function () {
+  it('should store and retrieve object values', () => {
     const cache = new TtlCache({ max: 10000, ttl: 1000 });
     const value = { prop: 'value' };
     cache.set('key2', value);
@@ -24,5 +25,174 @@ describe('TTLCache', function () {
 
     expect(cache.has('key2')).toBe(true);
     expect(cache.get('key2')).toEqual(value);
+  });
+
+  it('should expire entries after their ttl', async () => {
+    const cache = new TtlCache({ ttl: 10 });
+    cache.set('key', 'value');
+
+    await sleep(25);
+
+    expect(cache.has('key')).toBe(false);
+    expect(cache.get('key')).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it('should renew ttl when updateAgeOnGet is enabled per read', async () => {
+    const cache = new TtlCache({ ttl: 40 });
+    cache.set('key', 'value');
+
+    await sleep(25);
+    expect(cache.get('key', { updateAgeOnGet: true })).toBe('value');
+
+    await sleep(25);
+    expect(cache.get('key')).toBe('value');
+
+    await sleep(30);
+    expect(cache.get('key')).toBeUndefined();
+  });
+
+  it('should evict the soonest expiring entry when max is exceeded', () => {
+    const cache = new TtlCache<string, string>({ max: 2, ttl: 1000 });
+
+    cache.set('first', 'a', { ttl: 100 });
+    cache.set('second', 'b', { ttl: 300 });
+    cache.set('third', 'c', { ttl: 500 });
+
+    expect(cache.has('first')).toBe(false);
+    expect(cache.get('second')).toBe('b');
+    expect(cache.get('third')).toBe('c');
+    expect(cache.size).toBe(2);
+  });
+
+  it('should delete and clear entries', () => {
+    const cache = new TtlCache({ ttl: 1000 });
+    cache.set('first', 'a');
+    cache.set('second', 'b');
+
+    expect(cache.delete('first')).toBe(true);
+    expect(cache.delete('missing')).toBe(false);
+    expect(cache.has('first')).toBe(false);
+
+    cache.clear();
+
+    expect(cache.has('second')).toBe(false);
+    expect(cache.size).toBe(0);
+  });
+
+  it('should iterate live entries from soonest to latest expiration', () => {
+    const cache = new TtlCache<string, string>({ ttl: 1000 });
+    cache.set('third', 'c', { ttl: 300 });
+    cache.set('first', 'a', { ttl: 100 });
+    cache.set('second', 'b', { ttl: 200 });
+
+    expect([...cache.keys()]).toEqual(['first', 'second', 'third']);
+    expect([...cache.values()]).toEqual(['a', 'b', 'c']);
+    expect([...cache.entries()]).toEqual([
+      ['first', 'a'],
+      ['second', 'b'],
+      ['third', 'c'],
+    ]);
+    expect([...cache]).toEqual([...cache.entries()]);
+  });
+
+  it('should update ttl for an existing entry', async () => {
+    const cache = new TtlCache({ ttl: 20 });
+    cache.set('key', 'value');
+    cache.setTTL('key', 80);
+
+    await sleep(35);
+    expect(cache.get('key')).toBe('value');
+
+    cache.setTTL('key', 10);
+    await sleep(20);
+
+    expect(cache.get('key')).toBeUndefined();
+  });
+
+  it('should return remaining ttl for live and missing entries', async () => {
+    const cache = new TtlCache({ ttl: 40 });
+    cache.set('key', 'value');
+
+    const remainingTtl = cache.getRemainingTTL('key');
+    expect(remainingTtl).toBeGreaterThan(0);
+    expect(remainingTtl).toBeLessThanOrEqual(40);
+
+    await sleep(55);
+
+    expect(cache.getRemainingTTL('key')).toBe(0);
+    expect(cache.getRemainingTTL('missing')).toBe(0);
+  });
+
+  it('should support entries that never expire', async () => {
+    const cache = new TtlCache({ ttl: Infinity });
+    cache.set('key', 'value');
+
+    await sleep(5);
+
+    expect(cache.get('key')).toBe('value');
+    expect(cache.getRemainingTTL('key')).toBe(Infinity);
+  });
+
+  it('should call dispose with the reason entries are removed', async () => {
+    const disposed: string[] = [];
+    const cache = new TtlCache<string, string>({
+      dispose : (value, key, reason): void => { disposed.push(`${key}:${value}:${reason}`); },
+      max     : 2,
+      ttl     : 1000,
+    });
+
+    cache.set('set', 'old');
+    cache.set('set', 'new');
+    cache.set('delete', 'value');
+    cache.delete('delete');
+    cache.set('stale', 'value', { ttl: 10 });
+
+    await sleep(25);
+
+    cache.purgeStale();
+    cache.set('first', 'a', { ttl: 100 });
+    cache.set('second', 'b', { ttl: 200 });
+
+    expect(disposed).toEqual([
+      'set:old:set',
+      'delete:value:delete',
+      'stale:value:stale',
+      'first:a:evict',
+    ]);
+  });
+
+  it('should honor noDisposeOnSet', () => {
+    const disposed: string[] = [];
+    const cache = new TtlCache<string, string>({
+      dispose        : (value, key, reason): void => { disposed.push(`${key}:${value}:${reason}`); },
+      noDisposeOnSet : true,
+      ttl            : 1000,
+    });
+
+    cache.set('key', 'first');
+    cache.set('key', 'second');
+    cache.set('key', 'third', { noDisposeOnSet: false });
+
+    expect(disposed).toEqual(['key:second:set']);
+  });
+
+  it('should preserve an existing ttl when noUpdateTTL is used', async () => {
+    const cache = new TtlCache<string, string>({ ttl: 30 });
+    cache.set('key', 'first');
+
+    await sleep(15);
+    cache.set('key', 'second', { noUpdateTTL: true });
+    await sleep(25);
+
+    expect(cache.get('key')).toBeUndefined();
+  });
+
+  it('should reject invalid ttl and max values', () => {
+    expect(() => new TtlCache({ ttl: 0 })).toThrow('ttl must be positive integer or Infinity');
+    expect(() => new TtlCache({ ttl: 1.5 })).toThrow('ttl must be positive integer or Infinity');
+    expect(() => new TtlCache({ max: 0 })).toThrow('max must be positive integer or Infinity');
+    expect(() => new TtlCache().set('key', 'value')).toThrow('ttl must be positive integer or Infinity');
+    expect(() => new TtlCache({ ttl: 100 }).set('key', 'value', { ttl: -1 })).toThrow('ttl must be positive integer or Infinity');
   });
 });

--- a/packages/dwn-clients/tests/dwn-server-info-cache.spec.ts
+++ b/packages/dwn-clients/tests/dwn-server-info-cache.spec.ts
@@ -87,9 +87,7 @@ describe('DwnServerInfoCache', () => {
     });
 
     it('returns undefined after ttl', async function () {
-      // NOTE: tried very hard to use sinon.useFakeTimers() but couldn't get it to work with `TtlCache` implementation in `DwnServerInfoCacheMemory`.
-      // I sanity added a setInterval here, and it obeys the fake time ticks and its callback
-      // is fired, but the `TtlCache` just ignores the fake timer ticks.
+      // TtlCache uses a monotonic clock for TTL arithmetic, so keep this as a real-time sleep.
       cache = new DwnServerInfoCacheMemory({ ttl: '100ms' });
 
       const key = 'some-key1';

--- a/packages/dwn-sdk-js/vitest.browser.config.ts
+++ b/packages/dwn-sdk-js/vitest.browser.config.ts
@@ -64,10 +64,6 @@ export default defineConfig({
       'ipfs-unixfs-importer',
       'ipfs-unixfs-exporter',
 
-      // @isaacs/ttlcache — CJS; via @enbox/crypto -> @enbox/common.
-      // Use Vite's nested-dep `>` syntax to resolve through workspace symlinks.
-      '@enbox/crypto > @enbox/common > @isaacs/ttlcache',
-
       // --- Dual-format packages (CJS default, ESM via exports) ---
       // Pre-bundling these avoids edge cases where Vite picks the CJS entry.
       '@noble/ciphers/aes.js',


### PR DESCRIPTION
## Summary

- Closes #1147.
- Replaces the `@isaacs/ttlcache` re-export in `@enbox/common` with a local `TtlCache` implementation.
- Removes `@isaacs/ttlcache` from `@enbox/common`, `bun.lock`, and browser optimizer include lists.
- Adds cache coverage for expiry, max eviction, TTL renewal, disposal, iteration, validation, and no-update/no-dispose options.

## Test plan

- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run --filter @enbox/common test:node`
- [x] `bun run --filter @enbox/common test:node:coverage`
- [x] `BROWSER=chromium bun run --filter @enbox/common test:browser`
- [x] `BROWSER=chromium bun run --filter @enbox/dwn-sdk-js test:browser`
- [x] `BROWSER=chromium bun run --filter @enbox/agent test:browser`
- [x] `bun test tests/resolver/resolver-cache-memory.test.ts` from `packages/dids`
- [x] `bun test tests/dwn-server-info-cache.spec.ts` from `packages/dwn-clients`
- [x] `bun test tests/dwn-protocol-cache.spec.ts` from `packages/agent`
- [x] `bun run dev:ensure`
- [x] `bun run test:node` from `packages/agent` (one local DWN rate-limit failure; targeted rerun passed)
- [x] `bun test tests/sync-engine-level.spec.ts -t "synchronizes records for 1 identity from remote DWN to local DWN"` from `packages/agent`