### PR TITLE
fix(dwn-sdk): project current audience keys

### DIFF
--- a/.changeset/current-audience-projection.md
+++ b/.changeset/current-audience-projection.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-sdk-js": patch
+---
+
+Project audience control enumeration to the deterministic current key per role-audience tuple.

--- a/packages/dwn-sdk-js/src/core/dwn-error.ts
+++ b/packages/dwn-sdk-js/src/core/dwn-error.ts
@@ -21,7 +21,6 @@ export enum DwnErrorCode {
   ComputeCidMultihashNotSupported = 'ComputeCidMultihashNotSupported',
   Ed25519InvalidJwk = 'Ed25519InvalidJwk',
   EncryptionControlReadUnauthorized = 'EncryptionControlReadUnauthorized',
-  EncryptionControlValidateAudienceActiveSetCapExceeded = 'EncryptionControlValidateAudienceActiveSetCapExceeded',
   EncryptionControlValidateAudienceContextIdInvalid = 'EncryptionControlValidateAudienceContextIdInvalid',
   EncryptionControlValidateAudienceKeyIdMismatch = 'EncryptionControlValidateAudienceKeyIdMismatch',
   EncryptionControlValidateAudienceMissingRequiredTag = 'EncryptionControlValidateAudienceMissingRequiredTag',

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -1,7 +1,9 @@
+import type { MessageStore } from '../types/message-store.js';
 import type { RecordsPermissionScope } from '../types/permission-types.js';
 import type { RecordsWrite } from '../interfaces/records-write.js';
 import type { ValidationStateReader } from '../types/validation-state-reader.js';
 import type { EncryptionControlAudiencePayload, EncryptionControlDeliveryTags, RoleAudienceKeyId } from '../types/encryption-types.js';
+import type { Filter, PaginationCursor } from '../types/query-types.js';
 import type { ProtocolActionRule, ProtocolDefinition, ProtocolRuleSet } from '../types/protocols-types.js';
 import type { RecordsCountMessage, RecordsFilter, RecordsQueryMessage, RecordsReadMessage, RecordsSubscribeMessage, RecordsWriteMessage, RecordsWriteTags } from '../types/records-types.js';
 
@@ -12,10 +14,14 @@ import { Encryption } from '../utils/encryption.js';
 import { EncryptionControlDeliveryRecipientAuthority } from '../types/encryption-types.js';
 import { GrantAuthorization } from './grant-authorization.js';
 import { Jws } from '../utils/jws.js';
+import { lexicographicalCompare } from '../utils/string.js';
 import { Message } from './message.js';
 import { PermissionConditionPublication } from '../types/permission-types.js';
 import { PermissionGrant } from '../protocols/permission-grant.js';
 import { PermissionScopeMatcher } from '../utils/permission-scope.js';
+import { Records } from '../utils/records.js';
+import { selectOccupantRecordIds } from '../utils/record-limit-occupancy.js';
+import { SortDirection } from '../types/query-types.js';
 import { validateJsonSchema } from '../schema-validator.js';
 import { DwnError, DwnErrorCode } from './dwn-error.js';
 import { DwnInterfaceName, DwnMethodName } from '../enums/dwn-interface-method.js';
@@ -36,6 +42,8 @@ type EffectiveControlActor = {
 type ExactAudienceFilterTuple = Omit<RoleAudienceKeyId, 'keyId'> & {
   keyId?: string;
 };
+
+type AudienceTuple = Omit<RoleAudienceKeyId, 'keyId'>;
 
 type ControlReadMessage =
   | RecordsCountMessage
@@ -65,8 +73,117 @@ export class EncryptionControl {
     return isEncryptionControlPath(message.descriptor.protocolPath);
   }
 
+  public static isAudienceControlMessage(message: RecordsWriteMessage): boolean {
+    return message.descriptor.protocolPath === ENCRYPTION_CONTROL_AUDIENCE_PATH;
+  }
+
   public static isExactAudienceFilter(filter: RecordsFilter): boolean {
     return EncryptionControl.getExactAudienceFilterTuple(filter) !== undefined;
+  }
+
+  public static buildAudienceRecordFilters(filters: Filter[]): Filter[] {
+    const audienceFilters: Filter[] = [];
+    for (const filter of filters) {
+      const protocolPath = filter.protocolPath;
+      if (protocolPath === undefined) {
+        audienceFilters.push({ ...filter, protocolPath: ENCRYPTION_CONTROL_AUDIENCE_PATH });
+        continue;
+      }
+
+      if (typeof protocolPath === 'string') {
+        if (protocolPath === ENCRYPTION_CONTROL_AUDIENCE_PATH) {
+          audienceFilters.push(filter);
+        }
+        continue;
+      }
+
+      if (Array.isArray(protocolPath) && protocolPath.includes(ENCRYPTION_CONTROL_AUDIENCE_PATH)) {
+        audienceFilters.push({ ...filter, protocolPath: ENCRYPTION_CONTROL_AUDIENCE_PATH });
+      }
+    }
+
+    return audienceFilters;
+  }
+
+  /**
+   * Resolves the current audience record for a role-audience tuple.
+   *
+   * Current-key projection orders stored audience records by:
+   * tenant-authored actual signer first, then oldest `dateCreated`, then `recordId` ascending.
+   */
+  public static async resolveCurrentAudienceRecord(input: {
+    messageStore: MessageStore;
+    tenant: string;
+    protocol: string;
+    rolePath: string;
+    contextId: string;
+  }): Promise<RecordsWriteMessage | undefined> {
+    const records = await EncryptionControl.queryStoredAudienceRecordsForTuple(input);
+    const currentRecordIds = selectOccupantRecordIds({
+      records,
+      max            : 1,
+      getScopeKey    : (record): string => EncryptionControl.getAudienceTupleKey(EncryptionControl.getRoleAudienceKeyId(record, 'audience')),
+      compareRecords : (left, right): number => EncryptionControl.compareAudienceProjectionCandidates(input.tenant, left, right),
+    });
+    const currentRecordId = currentRecordIds.values().next().value as string | undefined;
+    return records.find((record): boolean => record.recordId === currentRecordId);
+  }
+
+  public static async projectCurrentAudienceRecords<T extends RecordsWriteMessage>(input: {
+    messageStore: MessageStore;
+    tenant: string;
+    recordsWriteMessages: T[];
+    bypassFilters?: Filter[];
+    currentAudienceRecordIdCache?: Map<string, string | undefined>;
+  }): Promise<T[]> {
+    const currentRecordIds = new Set<string>();
+    const tupleKeys = new Set<string>();
+
+    for (const record of input.recordsWriteMessages) {
+      if (!EncryptionControl.shouldProjectAudienceRecord(record, input.bypassFilters ?? [])) {
+        continue;
+      }
+
+      const tags = EncryptionControl.getRoleAudienceKeyId(record, 'audience');
+      tupleKeys.add(EncryptionControl.getAudienceTupleKey(tags));
+    }
+
+    for (const tupleKey of tupleKeys) {
+      const tuple = EncryptionControl.parseAudienceTupleKey(tupleKey);
+      const currentRecordId = await EncryptionControl.resolveCurrentAudienceRecordId({
+        ...tuple,
+        currentAudienceRecordIdCache : input.currentAudienceRecordIdCache,
+        messageStore                 : input.messageStore,
+        tenant                       : input.tenant,
+      });
+      if (currentRecordId !== undefined) {
+        currentRecordIds.add(currentRecordId);
+      }
+    }
+
+    return input.recordsWriteMessages.filter((record): boolean =>
+      !EncryptionControl.shouldProjectAudienceRecord(record, input.bypassFilters ?? []) ||
+      currentRecordIds.has(record.recordId)
+    );
+  }
+
+  public static async projectCurrentAudienceRecordPage<T extends RecordsWriteMessage>(input: {
+    messageStore: MessageStore;
+    tenant: string;
+    filters: Filter[];
+    result: { messages: T[], cursor?: PaginationCursor };
+    currentAudienceRecordIdCache?: Map<string, string | undefined>;
+  }): Promise<{ messages: T[], cursor?: PaginationCursor }> {
+    return {
+      messages: await EncryptionControl.projectCurrentAudienceRecords({
+        currentAudienceRecordIdCache : input.currentAudienceRecordIdCache,
+        messageStore                 : input.messageStore,
+        tenant                       : input.tenant,
+        recordsWriteMessages         : input.result.messages,
+        bypassFilters                : input.filters,
+      }),
+      cursor: input.result.cursor,
+    };
   }
 
   public static async filterVisibleControlRecords<T extends RecordsWriteMessage>(input: ControlFilterInput<T>): Promise<T[]> {
@@ -999,6 +1116,93 @@ export class EncryptionControl {
   private static getExactFilterTag(filter: RecordsFilter, tag: string): string | undefined {
     const value = filter.tags?.[tag];
     return typeof value === 'string' ? value : undefined;
+  }
+
+  private static async queryStoredAudienceRecordsForTuple(input: {
+    messageStore: MessageStore;
+    tenant: string;
+    protocol: string;
+    rolePath: string;
+    contextId: string;
+  }): Promise<RecordsWriteMessage[]> {
+    const filter: Filter = {
+      interface         : DwnInterfaceName.Records,
+      method            : DwnMethodName.Write,
+      isLatestBaseState : true,
+      protocol          : input.protocol,
+      protocolPath      : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+      'tag.protocol'    : input.protocol,
+      'tag.rolePath'    : input.rolePath,
+      'tag.contextId'   : input.contextId,
+    };
+    const { messages } = await input.messageStore.query(input.tenant, [filter], { dateCreated: SortDirection.Ascending });
+    return messages.filter(Records.isRecordsWrite);
+  }
+
+  private static async resolveCurrentAudienceRecordId(input: {
+    messageStore: MessageStore;
+    tenant: string;
+    protocol: string;
+    rolePath: string;
+    contextId: string;
+    currentAudienceRecordIdCache?: Map<string, string | undefined>;
+  }): Promise<string | undefined> {
+    const tupleKey = EncryptionControl.getAudienceTupleKey(input);
+    if (input.currentAudienceRecordIdCache?.has(tupleKey) === true) {
+      return input.currentAudienceRecordIdCache.get(tupleKey);
+    }
+
+    const current = await EncryptionControl.resolveCurrentAudienceRecord(input);
+    const currentRecordId = current?.recordId;
+    input.currentAudienceRecordIdCache?.set(tupleKey, currentRecordId);
+    return currentRecordId;
+  }
+
+  private static shouldProjectAudienceRecord(message: RecordsWriteMessage, bypassFilters: Filter[]): boolean {
+    return EncryptionControl.isAudienceControlMessage(message) &&
+      !bypassFilters.some((filter): boolean => EncryptionControl.audienceProjectionBypassFilterMatchesRecord(filter, message));
+  }
+
+  private static audienceProjectionBypassFilterMatchesRecord(filter: Filter, message: RecordsWriteMessage): boolean {
+    if (filter.recordId === message.recordId) {
+      return true;
+    }
+
+    const tags = EncryptionControl.getRoleAudienceKeyId(message, 'audience');
+    return filter.protocol === tags.protocol &&
+      filter.protocolPath === ENCRYPTION_CONTROL_AUDIENCE_PATH &&
+      filter['tag.protocol'] === tags.protocol &&
+      filter['tag.rolePath'] === tags.rolePath &&
+      filter['tag.contextId'] === tags.contextId &&
+      filter['tag.keyId'] === tags.keyId;
+  }
+
+  private static getAudienceTupleKey(input: AudienceTuple): string {
+    return JSON.stringify([input.protocol, input.rolePath, input.contextId]);
+  }
+
+  private static parseAudienceTupleKey(key: string): AudienceTuple {
+    const [protocol, rolePath, contextId] = JSON.parse(key) as string[];
+    return { protocol, rolePath, contextId };
+  }
+
+  private static compareAudienceProjectionCandidates(
+    tenant: string,
+    left: RecordsWriteMessage,
+    right: RecordsWriteMessage,
+  ): number {
+    const leftIsTenantSigned = Message.getSigner(left) === tenant;
+    const rightIsTenantSigned = Message.getSigner(right) === tenant;
+    if (leftIsTenantSigned !== rightIsTenantSigned) {
+      return leftIsTenantSigned ? -1 : 1;
+    }
+
+    const dateComparison = lexicographicalCompare(left.descriptor.dateCreated, right.descriptor.dateCreated);
+    if (dateComparison !== 0) {
+      return dateComparison;
+    }
+
+    return lexicographicalCompare(left.recordId, right.recordId);
   }
 
   private static getRequiredStringTag(message: RecordsWriteMessage, tag: string, recordType: 'audience' | 'delivery'): string {

--- a/packages/dwn-sdk-js/src/handlers/records-count.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-count.ts
@@ -143,13 +143,33 @@ export class RecordsCountHandler implements MethodHandler {
   }
 
   private async countProjectedRecords(tenant: string, recordsCount: RecordsCount, filters: Filter[]): Promise<number> {
-    return countRecordsWithRecordLimitOccupancy({
+    const totalCount = await countRecordsWithRecordLimitOccupancy({
       messageStore          : this.deps.messageStore,
       validationStateReader : this.deps.validationStateReader,
       tenant,
       filters,
       messageTimestamp      : recordsCount.message.descriptor.messageTimestamp,
     });
+
+    const audienceFilters = EncryptionControl.buildAudienceRecordFilters(filters);
+    if (audienceFilters.length === 0) {
+      return totalCount;
+    }
+
+    const storedAudienceCount = await this.deps.messageStore.count(tenant, audienceFilters);
+    if (storedAudienceCount === 0) {
+      return totalCount;
+    }
+
+    const { messages } = await this.deps.messageStore.query(tenant, audienceFilters);
+    const projectedAudienceMessages = await EncryptionControl.projectCurrentAudienceRecords({
+      messageStore         : this.deps.messageStore,
+      tenant,
+      recordsWriteMessages : messages.filter(Records.isRecordsWrite),
+      bypassFilters        : audienceFilters,
+    });
+
+    return totalCount - storedAudienceCount + projectedAudienceMessages.length;
   }
 
   private async countProjectedRecordsForRequester(
@@ -176,11 +196,17 @@ export class RecordsCountHandler implements MethodHandler {
       filters               : controlFilters,
       messageTimestamp      : recordsCount.message.descriptor.messageTimestamp,
     });
+    const projectedMessages = await EncryptionControl.projectCurrentAudienceRecords({
+      messageStore         : this.deps.messageStore,
+      tenant,
+      recordsWriteMessages : messages,
+      bypassFilters        : controlFilters,
+    });
     const visibleMessages = await EncryptionControl.filterVisibleControlRecords({
       tenant,
       incomingMessage       : recordsCount.message,
       requester,
-      recordsWriteMessages  : messages,
+      recordsWriteMessages  : projectedMessages,
       validationStateReader : this.deps.validationStateReader,
     });
     return totalCount - controlCount + visibleMessages.length;

--- a/packages/dwn-sdk-js/src/handlers/records-query.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-query.ts
@@ -126,14 +126,13 @@ export class RecordsQueryHandler implements MethodHandler {
     };
 
     const messageSort = this.convertDateSort(dateSort);
-    return queryRecordsWithRecordLimitOccupancy({
-      messageStore          : this.deps.messageStore,
-      validationStateReader : this.deps.validationStateReader,
+    return this.queryRecordsWithVisibleControlFiltering({
       tenant,
-      filters               : [queryFilter],
+      recordsQuery,
+      requester : tenant,
+      filters   : [queryFilter],
       messageSort,
       pagination,
-      messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
     });
   }
 
@@ -257,6 +256,7 @@ export class RecordsQueryHandler implements MethodHandler {
       tenant, recordsQuery, requester, filters, messageSort, pagination
     } = input;
     const controlFilters = Records.buildControlRecordsFilters(filters);
+    const currentAudienceRecordIdCache = new Map<string, string | undefined>();
     if (controlFilters.length === 0) {
       const result = await queryRecordsWithRecordLimitOccupancy({
         messageStore          : this.deps.messageStore,
@@ -267,7 +267,16 @@ export class RecordsQueryHandler implements MethodHandler {
         pagination,
         messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
       });
-      return { messages: result.messages as RecordsQueryReplyEntry[], cursor: result.cursor };
+      return EncryptionControl.projectCurrentAudienceRecordPage({
+        messageStore : this.deps.messageStore,
+        tenant,
+        filters,
+        currentAudienceRecordIdCache,
+        result       : {
+          messages : result.messages as RecordsQueryReplyEntry[],
+          cursor   : result.cursor,
+        },
+      });
     }
 
     if (pagination?.limit === undefined || pagination.limit <= 0) {
@@ -280,9 +289,19 @@ export class RecordsQueryHandler implements MethodHandler {
         pagination,
         messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
       });
+      const projectedResult = await EncryptionControl.projectCurrentAudienceRecordPage({
+        messageStore : this.deps.messageStore,
+        tenant,
+        filters,
+        currentAudienceRecordIdCache,
+        result       : {
+          messages : result.messages as RecordsQueryReplyEntry[],
+          cursor   : result.cursor,
+        },
+      });
       return {
-        messages : await this.filterControlRecordsForRequester(tenant, recordsQuery, requester, result.messages as RecordsQueryReplyEntry[]),
-        cursor   : result.cursor,
+        messages : await this.filterControlRecordsForRequester(tenant, recordsQuery, requester, projectedResult.messages),
+        cursor   : projectedResult.cursor,
       };
     }
 
@@ -301,15 +320,25 @@ export class RecordsQueryHandler implements MethodHandler {
         pagination            : { ...pagination, cursor, limit: remainingLimit },
         messageTimestamp      : recordsQuery.message.descriptor.messageTimestamp,
       });
+      const projectedResult = await EncryptionControl.projectCurrentAudienceRecordPage({
+        messageStore : this.deps.messageStore,
+        tenant,
+        filters,
+        currentAudienceRecordIdCache,
+        result       : {
+          messages : result.messages as RecordsQueryReplyEntry[],
+          cursor   : result.cursor,
+        },
+      });
       const filteredMessages = await this.filterControlRecordsForRequester(
         tenant,
         recordsQuery,
         requester,
-        result.messages as RecordsQueryReplyEntry[],
+        projectedResult.messages,
       );
       visibleMessages.push(...filteredMessages);
-      nextCursor = result.cursor;
-      cursor = result.cursor;
+      nextCursor = projectedResult.cursor;
+      cursor = projectedResult.cursor;
     } while (visibleMessages.length < pagination.limit && cursor !== undefined);
 
     return { messages: visibleMessages, cursor: nextCursor };

--- a/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
+++ b/packages/dwn-sdk-js/src/handlers/records-subscribe.ts
@@ -84,6 +84,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
     const { cursor: eventLogCursor } = recordsSubscribe.message.descriptor;
     const projectedSubscriptionHandler = RecordsSubscribeHandler.createRecordLimitOccupancyGuard({
       deps: this.deps,
+      eventFilters,
       recordsSubscribe,
       subscriptionHandler,
       tenant,
@@ -195,11 +196,12 @@ export class RecordsSubscribeHandler implements MethodHandler {
 
   private static createRecordLimitOccupancyGuard(input: {
     deps: HandlerDependencies;
+    eventFilters: Filter[];
     recordsSubscribe: RecordsSubscribe;
     subscriptionHandler: SubscriptionListener;
     tenant: string;
   }): ProjectedRecordsSubscriptionHandler {
-    const { deps, recordsSubscribe, subscriptionHandler, tenant } = input;
+    const { deps, eventFilters, recordsSubscribe, subscriptionHandler, tenant } = input;
     const requester = Message.getRequester(recordsSubscribe.message);
     let subscription: EventSubscription | undefined;
     let closeRequested = false;
@@ -240,6 +242,16 @@ export class RecordsSubscribeHandler implements MethodHandler {
           validationStateReader : deps.validationStateReader,
         });
         if (visibleMessages.length === 0) {
+          return;
+        }
+
+        const projectedMessages = await EncryptionControl.projectCurrentAudienceRecords({
+          messageStore         : deps.messageStore,
+          tenant,
+          recordsWriteMessages : [message],
+          bypassFilters        : eventFilters,
+        });
+        if (projectedMessages.length === 0) {
           return;
         }
 
@@ -540,6 +552,7 @@ export class RecordsSubscribeHandler implements MethodHandler {
     pagination: { cursor?: PaginationCursor; limit?: number } | undefined,
   ): Promise<{ messages: RecordsQueryReplyEntry[], cursor?: PaginationCursor }> {
     const controlFilters = Records.buildControlRecordsFilters(filters);
+    const currentAudienceRecordIdCache = new Map<string, string | undefined>();
     if (controlFilters.length === 0) {
       const result = await queryRecordsWithRecordLimitOccupancy({
         messageStore          : this.deps.messageStore,
@@ -550,7 +563,13 @@ export class RecordsSubscribeHandler implements MethodHandler {
         pagination,
         messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
       });
-      return { messages: result.messages, cursor: result.cursor };
+      return EncryptionControl.projectCurrentAudienceRecordPage({
+        messageStore: this.deps.messageStore,
+        tenant,
+        filters,
+        currentAudienceRecordIdCache,
+        result,
+      });
     }
 
     if (pagination?.limit === undefined || pagination.limit <= 0) {
@@ -563,9 +582,16 @@ export class RecordsSubscribeHandler implements MethodHandler {
         pagination,
         messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
       });
+      const projectedResult = await EncryptionControl.projectCurrentAudienceRecordPage({
+        messageStore: this.deps.messageStore,
+        tenant,
+        filters,
+        currentAudienceRecordIdCache,
+        result,
+      });
       return {
-        messages : await this.filterControlRecordsForNonOwner(tenant, recordsSubscribe, requester, result.messages),
-        cursor   : result.cursor,
+        messages : await this.filterControlRecordsForNonOwner(tenant, recordsSubscribe, requester, projectedResult.messages),
+        cursor   : projectedResult.cursor,
       };
     }
 
@@ -584,17 +610,25 @@ export class RecordsSubscribeHandler implements MethodHandler {
         pagination            : { ...pagination, cursor, limit: remainingLimit },
         messageTimestamp      : recordsSubscribe.message.descriptor.messageTimestamp,
       });
+      const projectedResult = await EncryptionControl.projectCurrentAudienceRecordPage({
+        messageStore: this.deps.messageStore,
+        tenant,
+        filters,
+        currentAudienceRecordIdCache,
+        result,
+      });
       const filteredMessages = await this.filterControlRecordsForNonOwner(
         tenant,
         recordsSubscribe,
         requester,
-        result.messages,
+        projectedResult.messages,
       );
       visibleMessages.push(...filteredMessages);
-      nextCursor = result.cursor;
-      cursor = result.cursor;
+      nextCursor = projectedResult.cursor;
+      cursor = projectedResult.cursor;
     } while (visibleMessages.length < pagination.limit && cursor !== undefined);
 
     return { messages: visibleMessages, cursor: nextCursor };
   }
+
 }

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -16,6 +16,7 @@ export type { DataEncodedRecordsWriteMessage, RecordsCountDescriptor, RecordsCou
 export type { GeneralJws, SignatureEntry } from './types/jws-types.js';
 export { authenticate } from './core/auth.js';
 export { CoreProtocolRegistry } from './core/core-protocol.js';
+export { EncryptionControl } from './core/encryption-control.js';
 export {
   ENCRYPTION_CONTROL_AUDIENCE_PATH,
   ENCRYPTION_CONTROL_DELIVERY_PATH,

--- a/packages/dwn-sdk-js/src/utils/record-limit-occupancy.ts
+++ b/packages/dwn-sdk-js/src/utils/record-limit-occupancy.ts
@@ -37,6 +37,13 @@ type RecordLimitFilterResolution = {
   projectedFilters: Filter[];
 };
 
+type OccupancyProjectionInput<T extends RecordsWriteMessage> = {
+  records: T[];
+  max: number;
+  getScopeKey(record: T): string;
+  compareRecords(left: T, right: T): number;
+};
+
 /**
  * Queries records with bounded `$recordLimit` occupancy projection when every limited filter targets one concrete scope.
  *
@@ -285,11 +292,12 @@ async function findOccupantRecordIds(input: {
     ...boundaryCandidates,
   ];
 
-  return new Set(
-    rankedCandidates
-      .slice(0, input.recordLimit.max)
-      .map((message): string => message.recordId)
-  );
+  return selectOccupantRecordIds({
+    records        : rankedCandidates,
+    max            : input.recordLimit.max,
+    getScopeKey    : (): string => '',
+    compareRecords : compareRecordLimitCandidates,
+  });
 }
 
 function buildRecordLimitScopeFilter(scope: RecordLimitScope): Filter {
@@ -374,4 +382,25 @@ function compareRecordLimitCandidates(left: RecordsWriteMessage, right: RecordsW
   }
 
   return lexicographicalCompare(left.recordId, right.recordId);
+}
+
+export function selectOccupantRecordIds<T extends RecordsWriteMessage>(input: OccupancyProjectionInput<T>): Set<string> {
+  const occupants = new Set<string>();
+  const groups = new Map<string, T[]>();
+
+  for (const record of input.records) {
+    const scopeKey = input.getScopeKey(record);
+    const group = groups.get(scopeKey) ?? [];
+    group.push(record);
+    groups.set(scopeKey, group);
+  }
+
+  for (const group of groups.values()) {
+    group.sort(input.compareRecords);
+    for (const record of group.slice(0, input.max)) {
+      occupants.add(record.recordId);
+    }
+  }
+
+  return occupants;
 }

--- a/packages/dwn-sdk-js/tests/core/encryption-control.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/encryption-control.spec.ts
@@ -1,4 +1,4 @@
-import type { RecordsReadMessage, RecordsWriteMessage, ValidationStateReader } from '../../src/index.js';
+import type { MessageStore, RecordsReadMessage, RecordsWriteMessage, ValidationStateReader } from '../../src/index.js';
 
 import { describe, expect, it } from 'bun:test';
 
@@ -34,6 +34,46 @@ describe('EncryptionControl', () => {
       expect(result).toBe(true);
     });
   });
+
+  describe('projectCurrentAudienceRecords()', () => {
+    it('should reuse current audience resolution results from a caller-provided cache', async () => {
+      const current = makeAudienceRecordsWriteMessage({
+        dateCreated : '2026-01-01T00:00:00.000000Z',
+        keyId       : 'current',
+        recordId    : 'current-record',
+      });
+      const loser = makeAudienceRecordsWriteMessage({
+        dateCreated : '2026-01-01T00:00:01.000000Z',
+        keyId       : 'loser',
+        recordId    : 'loser-record',
+      });
+      let queryCount = 0;
+      const messageStore = {
+        query: async (): Promise<{ messages: RecordsWriteMessage[] }> => {
+          queryCount++;
+          return { messages: [current, loser] };
+        },
+      } as unknown as MessageStore;
+      const currentAudienceRecordIdCache = new Map<string, string | undefined>();
+
+      const loserProjection = await EncryptionControl.projectCurrentAudienceRecords({
+        currentAudienceRecordIdCache,
+        messageStore,
+        tenant,
+        recordsWriteMessages: [loser],
+      });
+      expect(loserProjection).toEqual([]);
+
+      const currentProjection = await EncryptionControl.projectCurrentAudienceRecords({
+        currentAudienceRecordIdCache,
+        messageStore,
+        tenant,
+        recordsWriteMessages: [current],
+      });
+      expect(currentProjection.map(record => record.recordId)).toEqual(['current-record']);
+      expect(queryCount).toBe(1);
+    });
+  });
 });
 
 function makeIncomingMessage(): RecordsReadMessage {
@@ -51,4 +91,27 @@ function makeRecordsWriteMessage(options: { protocolPath: string }): RecordsWrit
       protocolPath: options.protocolPath,
     },
   } as RecordsWriteMessage;
+}
+
+function makeAudienceRecordsWriteMessage(options: {
+  dateCreated: string;
+  keyId: string;
+  recordId: string;
+}): RecordsWriteMessage {
+  return {
+    descriptor: {
+      interface    : DwnInterfaceName.Records,
+      method       : DwnMethodName.Write,
+      protocol     : 'http://example.com/protocol',
+      protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+      dateCreated  : options.dateCreated,
+      tags         : {
+        contextId : '',
+        keyId     : options.keyId,
+        protocol  : 'http://example.com/protocol',
+        rolePath  : 'member',
+      },
+    },
+    recordId: options.recordId,
+  } as unknown as RecordsWriteMessage;
 }

--- a/packages/dwn-sdk-js/tests/handlers/records-count.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-count.spec.ts
@@ -101,6 +101,47 @@ export function testRecordsCountHandler(): void {
         expect(reply.count).toBe(3);
       });
 
+      it('should keep broad protocol counts on the indexed count path when no audience records exist', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-count-indexed-broad.xyz',
+          published : false,
+          types     : {
+            message: { schema: 'http://message-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            message: {
+              $actions: [{ who: 'anyone', can: ['create', 'read'] }],
+            },
+          },
+        };
+        const protocolConfigure = await TestDataGenerator.generateProtocolsConfigure({
+          author: alice,
+          protocolDefinition,
+        });
+        expect((await dwn.processMessage(alice.did, protocolConfigure.message)).status.code).toBe(202);
+
+        const write = await TestDataGenerator.generateRecordsWrite({
+          author       : alice,
+          dataFormat   : 'application/json',
+          protocol     : protocolDefinition.protocol,
+          protocolPath : 'message',
+          schema       : 'http://message-schema',
+        });
+        expect((await dwn.processMessage(alice.did, write.message, { dataStream: write.dataStream })).status.code).toBe(202);
+
+        const querySpy = sinon.spy(messageStore, 'query');
+        const count = await RecordsCount.create({
+          filter : { protocol: protocolDefinition.protocol },
+          signer : Jws.createSigner(alice),
+        });
+        const reply = await dwn.processMessage(alice.did, count.message);
+
+        expect(reply.status.code).toBe(200);
+        expect(reply.count).toBe(1);
+        expect(querySpy.called).toBe(false);
+      });
+
       it('should allow anonymous count of published records', async () => {
         const alice = await TestDataGenerator.generatePersona();
         TestStubGenerator.stubDidResolver(didResolver, [alice]);
@@ -245,6 +286,179 @@ export function testRecordsCountHandler(): void {
         const broadReply = await dwn.processMessage(alice.did, broadCount.message);
         expect(broadReply.status.code).toBe(200);
         expect(broadReply.count).toBe(0);
+      });
+
+      it('should count only the current audience record during tuple enumeration', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-count-current-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['create'] }],
+            },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+        const nonTenantAudience = await createAudienceControlWrite({
+          author      : bob,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 1 }),
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, nonTenantAudience);
+
+        const otherNonTenantAudience = await createAudienceControlWrite({
+          author      : carol,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 2 }),
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, otherNonTenantAudience);
+
+        const tenantAudience = await createAudienceControlWrite({
+          author      : alice,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 3 }),
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, tenantAudience);
+
+        const tupleCount = await RecordsCount.create({
+          filter: {
+            protocol     : protocolDefinition.protocol,
+            protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+            tags         : {
+              protocol  : protocolDefinition.protocol,
+              rolePath  : 'member',
+              contextId : '',
+            },
+          },
+          signer: Jws.createSigner(alice),
+        });
+        const tupleReply = await dwn.processMessage(alice.did, tupleCount.message);
+        expect(tupleReply.status.code).toBe(200);
+        expect(tupleReply.count).toBe(1);
+
+        const exactLoserCount = await RecordsCount.create({
+          filter: {
+            protocol     : protocolDefinition.protocol,
+            protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+            tags         : {
+              protocol  : protocolDefinition.protocol,
+              rolePath  : 'member',
+              contextId : '',
+              keyId     : nonTenantAudience.keyId,
+            },
+          },
+          signer: Jws.createSigner(bob),
+        });
+        const exactLoserReply = await dwn.processMessage(alice.did, exactLoserCount.message);
+        expect(exactLoserReply.status.code).toBe(200);
+        expect(exactLoserReply.count).toBe(1);
+
+        const protocolReadGrant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : bob,
+          delegated : true,
+          scope     : {
+            interface : DwnInterfaceName.Records,
+            method    : DwnMethodName.Read,
+            protocol  : protocolDefinition.protocol,
+          },
+        });
+        expect((await dwn.processMessage(alice.did, protocolReadGrant.message, { dataStream: protocolReadGrant.dataStream })).status.code).toBe(202);
+
+        const delegatedProtocolCount = await RecordsCount.create({
+          delegatedGrant : protocolReadGrant.dataEncodedMessage,
+          filter         : { protocol: protocolDefinition.protocol },
+          signer         : Jws.createSigner(bob),
+        });
+        const delegatedProtocolReply = await dwn.processMessage(alice.did, delegatedProtocolCount.message);
+        expect(delegatedProtocolReply.status.code).toBe(200);
+        expect(delegatedProtocolReply.count).toBe(1);
+      });
+
+      it('should not count a current audience record that does not match an enumeration filter', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-count-current-range-filter.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['create'] }],
+            },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+        const loserDateCreated = Time.createOffsetTimestamp({ seconds: 2 });
+        const currentAudience = await createAudienceControlWrite({
+          author      : alice,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 1 }),
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, currentAudience);
+
+        const loserAudience = await createAudienceControlWrite({
+          author      : bob,
+          dateCreated : loserDateCreated,
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, loserAudience);
+
+        const rangeFilter = {
+          protocol     : protocolDefinition.protocol,
+          protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          dateCreated  : { from: loserDateCreated },
+          tags         : {
+            protocol  : protocolDefinition.protocol,
+            rolePath  : 'member',
+            contextId : '',
+          },
+        };
+        const rangeCount = await RecordsCount.create({
+          filter : rangeFilter,
+          signer : Jws.createSigner(alice),
+        });
+        const rangeReply = await dwn.processMessage(alice.did, rangeCount.message);
+        expect(rangeReply.status.code).toBe(200);
+        expect(rangeReply.count).toBe(0);
+
+        const exactLoserCount = await RecordsCount.create({
+          filter: {
+            ...rangeFilter,
+            tags: {
+              ...rangeFilter.tags,
+              keyId: loserAudience.keyId,
+            },
+          },
+          signer: Jws.createSigner(alice),
+        });
+        const exactLoserReply = await dwn.processMessage(alice.did, exactLoserCount.message);
+        expect(exactLoserReply.status.code).toBe(200);
+        expect(exactLoserReply.count).toBe(1);
       });
 
       it('should hide stale audience control records from delegated broad counts', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
@@ -1,5 +1,6 @@
+import type { AudienceControlWrite } from '../utils/encryption-control-test-utils.js';
 import type { DidResolver } from '@enbox/dids';
-import type { DataStore, EventLog, GenericMessage, MessageStore, ProtocolDefinition, ProtocolRuleSet, RecordsWriteMessage, ResumableTaskStore } from '../../src/index.js';
+import type { DataEncodedRecordsWriteMessage, DataStore, EventLog, GenericMessage, MessageStore, Persona, ProtocolDefinition, ProtocolRuleSet, RecordsWriteMessage, ResumableTaskStore } from '../../src/index.js';
 import type { RecordsQueryReply, RecordsQueryReplyEntry, RecordsWriteDescriptor } from '../../src/types/records-types.js';
 
 import sinon from 'sinon';
@@ -17,12 +18,14 @@ import { DateSort } from '../../src/types/records-types.js';
 import { DwnConstant } from '../../src/core/dwn-constant.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
 import { Encoder } from '../../src/utils/encoder.js';
+import { Encryption } from '../../src/utils/encryption.js';
 import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
 import { Jws } from '../../src/utils/jws.js';
 import { Message } from '../../src/core/message.js';
 import { PermissionsProtocol } from '../../src/protocols/permissions.js';
 import { RecordsQuery } from '../../src/interfaces/records-query.js';
 import { RecordsQueryHandler } from '../../src/handlers/records-query.js';
+import { RecordsRead } from '../../src/interfaces/records-read.js';
 import { RecordsWriteHandler } from '../../src/handlers/records-write.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
@@ -77,6 +80,88 @@ export function testRecordsQueryHandler(): void {
       afterAll(async () => {
         await dwn.close();
       });
+
+      async function installAudienceProjectionProtocol(
+        author: Persona,
+        protocol: string,
+      ): Promise<{
+        protocolDefinition: ProtocolDefinition;
+        encryptedDefinition: ProtocolDefinition;
+        roleRuleSet: ProtocolRuleSet;
+      }> {
+        const protocolDefinition: ProtocolDefinition = {
+          protocol,
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['create'] }],
+            },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, author, protocolDefinition);
+        return {
+          protocolDefinition,
+          encryptedDefinition,
+          roleRuleSet: encryptedDefinition.structure.member as ProtocolRuleSet,
+        };
+      }
+
+      async function createAudienceControlWriteWithFreshKey(input: {
+        author: Persona;
+        dateCreated?: string;
+        delegatedGrant?: DataEncodedRecordsWriteMessage;
+        protocol: string;
+        roleRuleSet: ProtocolRuleSet;
+        signer?: Persona;
+      }): Promise<AudienceControlWrite> {
+        const audienceKeyPersona = await TestDataGenerator.generateDidKeyPersona();
+        const publicKeyJwk = audienceKeyPersona.encryptionKeyPair.publicJwk;
+        const keyId = await Encryption.getKeyId(publicKeyJwk);
+
+        return createAudienceControlWrite({
+          author           : input.author,
+          dateCreated      : input.dateCreated,
+          delegatedGrant   : input.delegatedGrant,
+          payloadOverrides : { keyId, publicKeyJwk },
+          protocol         : input.protocol,
+          rolePath         : 'member',
+          roleRuleSet      : input.roleRuleSet,
+          signer           : input.signer,
+          tags             : { keyId },
+        });
+      }
+
+      async function queryAudienceRecordIds(input: {
+        tenant: string;
+        requester: Persona;
+        protocol: string;
+        keyId?: string;
+      }): Promise<string[]> {
+        const tags: Record<string, string> = {
+          protocol  : input.protocol,
+          rolePath  : 'member',
+          contextId : '',
+        };
+        if (input.keyId !== undefined) {
+          tags.keyId = input.keyId;
+        }
+
+        const query = await RecordsQuery.create({
+          filter: {
+            protocol     : input.protocol,
+            protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+            tags,
+          },
+          signer: Jws.createSigner(input.requester),
+        });
+        const reply = await dwn.processMessage(input.tenant, query.message);
+        expect(reply.status.code).toBe(200);
+        return reply.entries?.map(entry => entry.recordId) ?? [];
+      }
 
       it('should reject when published is set to false with a dateSort set to sorting by `PublishedAscending` or `PublishedDescending`', async () => {
         const alice = await TestDataGenerator.generatePersona();
@@ -309,6 +394,269 @@ export function testRecordsQueryHandler(): void {
         const reply = await dwn.processMessage(alice.did, query.message);
         expect(reply.status.code).toBe(200);
         expect(reply.entries?.map(entry => entry.recordId)).not.toContain(audience.recordsWrite.message.recordId);
+      });
+
+      it('should project current audience records deterministically across ingestion order', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+        const { protocolDefinition, roleRuleSet } = await installAudienceProjectionProtocol(
+          alice,
+          'http://encryption-control-query-current-deterministic.xyz',
+        );
+        const dateCreated = Time.createOffsetTimestamp({ seconds: 1 });
+        const firstAudience = await createAudienceControlWriteWithFreshKey({
+          author   : bob,
+          dateCreated,
+          protocol : protocolDefinition.protocol,
+          roleRuleSet,
+        });
+        const secondAudience = await createAudienceControlWriteWithFreshKey({
+          author   : carol,
+          dateCreated,
+          protocol : protocolDefinition.protocol,
+          roleRuleSet,
+        });
+        const expectedRecordId = [firstAudience.recordsWrite.message.recordId, secondAudience.recordsWrite.message.recordId].sort()[0];
+
+        await processControlWrite(dwn, alice.did, firstAudience);
+        await processControlWrite(dwn, alice.did, secondAudience);
+        const firstOrderRecordIds = await queryAudienceRecordIds({
+          tenant    : alice.did,
+          requester : alice,
+          protocol  : protocolDefinition.protocol,
+        });
+
+        await messageStore.clear();
+        await dataStore.clear();
+        await resumableTaskStore.clear();
+        await installEncryptedProtocol(dwn, alice, {
+          ...protocolDefinition,
+          structure: {
+            member: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['create'] }],
+            },
+          },
+        });
+        await processControlWrite(dwn, alice.did, secondAudience);
+        await processControlWrite(dwn, alice.did, firstAudience);
+
+        const secondOrderRecordIds = await queryAudienceRecordIds({
+          tenant    : alice.did,
+          requester : alice,
+          protocol  : protocolDefinition.protocol,
+        });
+        expect(firstOrderRecordIds).toEqual([expectedRecordId]);
+        expect(secondOrderRecordIds).toEqual([expectedRecordId]);
+      });
+
+      it('should prefer tenant-signed audience records and treat author-delegated mints as non-tenant', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+        const { protocolDefinition, roleRuleSet } = await installAudienceProjectionProtocol(
+          alice,
+          'http://encryption-control-query-current-tenant-precedence.xyz',
+        );
+
+        const nonTenantAudience = await createAudienceControlWriteWithFreshKey({
+          author      : bob,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 1 }),
+          protocol    : protocolDefinition.protocol,
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, nonTenantAudience);
+
+        const grant = await TestDataGenerator.generateGrantCreate({
+          author    : alice,
+          grantedTo : carol,
+          delegated : true,
+          scope     : {
+            interface    : DwnInterfaceName.Records,
+            method       : DwnMethodName.Write,
+            protocol     : protocolDefinition.protocol,
+            protocolPath : 'member',
+          },
+        });
+        expect((await dwn.processMessage(alice.did, grant.message, { dataStream: grant.dataStream })).status.code).toBe(202);
+
+        const delegatedAudience = await createAudienceControlWriteWithFreshKey({
+          author         : alice,
+          dateCreated    : Time.createOffsetTimestamp({ seconds: 2 }),
+          delegatedGrant : grant.dataEncodedMessage,
+          protocol       : protocolDefinition.protocol,
+          roleRuleSet,
+          signer         : carol,
+        });
+        await processControlWrite(dwn, alice.did, delegatedAudience);
+
+        expect(await queryAudienceRecordIds({
+          tenant    : alice.did,
+          requester : alice,
+          protocol  : protocolDefinition.protocol,
+        })).toEqual([nonTenantAudience.recordsWrite.message.recordId]);
+
+        const tenantAudience = await createAudienceControlWriteWithFreshKey({
+          author      : alice,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 3 }),
+          protocol    : protocolDefinition.protocol,
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, tenantAudience);
+
+        expect(await queryAudienceRecordIds({
+          tenant    : alice.did,
+          requester : alice,
+          protocol  : protocolDefinition.protocol,
+        })).toEqual([tenantAudience.recordsWrite.message.recordId]);
+
+        const pagedQuery = await RecordsQuery.create({
+          filter: {
+            protocol     : protocolDefinition.protocol,
+            protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+            tags         : {
+              protocol  : protocolDefinition.protocol,
+              rolePath  : 'member',
+              contextId : '',
+            },
+          },
+          pagination : { limit: 1 },
+          signer     : Jws.createSigner(alice),
+        });
+        const pagedReply = await dwn.processMessage(alice.did, pagedQuery.message);
+        expect(pagedReply.status.code).toBe(200);
+        expect(pagedReply.entries?.map(entry => entry.recordId)).toEqual([tenantAudience.recordsWrite.message.recordId]);
+      });
+
+      it('should use oldest dateCreated for non-tenant audience projection and make later floods inert', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const { protocolDefinition, roleRuleSet } = await installAudienceProjectionProtocol(
+          alice,
+          'http://encryption-control-query-current-date-order.xyz',
+        );
+        const oldestAuthor = await TestDataGenerator.generateDidKeyPersona();
+        const oldestAudience = await createAudienceControlWriteWithFreshKey({
+          author      : oldestAuthor,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 1 }),
+          protocol    : protocolDefinition.protocol,
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, oldestAudience);
+
+        for (let i = 0; i < 8; i++) {
+          const floodAuthor = await TestDataGenerator.generateDidKeyPersona();
+          const floodAudience = await createAudienceControlWriteWithFreshKey({
+            author      : floodAuthor,
+            dateCreated : Time.createOffsetTimestamp({ seconds: i + 2 }),
+            protocol    : protocolDefinition.protocol,
+            roleRuleSet,
+          });
+          await processControlWrite(dwn, alice.did, floodAudience);
+        }
+
+        expect(await queryAudienceRecordIds({
+          tenant    : alice.did,
+          requester : alice,
+          protocol  : protocolDefinition.protocol,
+        })).toEqual([oldestAudience.recordsWrite.message.recordId]);
+      });
+
+      it('should bypass current-key projection for exact keyId queries and RecordsRead by recordId', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const { protocolDefinition, roleRuleSet } = await installAudienceProjectionProtocol(
+          alice,
+          'http://encryption-control-query-current-exact-bypass.xyz',
+        );
+        const loserAudience = await createAudienceControlWriteWithFreshKey({
+          author      : bob,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 1 }),
+          protocol    : protocolDefinition.protocol,
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, loserAudience);
+
+        const tenantAudience = await createAudienceControlWriteWithFreshKey({
+          author      : alice,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 2 }),
+          protocol    : protocolDefinition.protocol,
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, tenantAudience);
+
+        expect(await queryAudienceRecordIds({
+          tenant    : alice.did,
+          requester : alice,
+          protocol  : protocolDefinition.protocol,
+          keyId     : loserAudience.keyId,
+        })).toEqual([loserAudience.recordsWrite.message.recordId]);
+
+        const recordsRead = await RecordsRead.create({
+          filter : { recordId: loserAudience.recordsWrite.message.recordId },
+          signer : Jws.createSigner(alice),
+        });
+        const readReply = await dwn.processMessage(alice.did, recordsRead.message);
+        expect(readReply.status.code).toBe(200);
+        expect(readReply.entry?.recordsWrite?.recordId).toBe(loserAudience.recordsWrite.message.recordId);
+      });
+
+      it('should not inject a current audience record that does not match an enumeration filter', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const { protocolDefinition, roleRuleSet } = await installAudienceProjectionProtocol(
+          alice,
+          'http://encryption-control-query-current-range-filter.xyz',
+        );
+        const currentDateCreated = Time.createOffsetTimestamp({ seconds: 1 });
+        const loserDateCreated = Time.createOffsetTimestamp({ seconds: 2 });
+        const currentAudience = await createAudienceControlWriteWithFreshKey({
+          author      : alice,
+          dateCreated : currentDateCreated,
+          protocol    : protocolDefinition.protocol,
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, currentAudience);
+
+        const loserAudience = await createAudienceControlWriteWithFreshKey({
+          author      : bob,
+          dateCreated : loserDateCreated,
+          protocol    : protocolDefinition.protocol,
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, loserAudience);
+
+        const rangeFilter = {
+          protocol     : protocolDefinition.protocol,
+          protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+          dateCreated  : { from: loserDateCreated },
+          tags         : {
+            protocol  : protocolDefinition.protocol,
+            rolePath  : 'member',
+            contextId : '',
+          },
+        };
+        const rangeQuery = await RecordsQuery.create({
+          filter : rangeFilter,
+          signer : Jws.createSigner(alice),
+        });
+        const rangeReply = await dwn.processMessage(alice.did, rangeQuery.message);
+        expect(rangeReply.status.code).toBe(200);
+        expect(rangeReply.entries?.map(entry => entry.recordId)).toEqual([]);
+
+        const exactLoserQuery = await RecordsQuery.create({
+          filter: {
+            ...rangeFilter,
+            tags: {
+              ...rangeFilter.tags,
+              keyId: loserAudience.keyId,
+            },
+          },
+          signer: Jws.createSigner(alice),
+        });
+        const exactLoserReply = await dwn.processMessage(alice.did, exactLoserQuery.message);
+        expect(exactLoserReply.status.code).toBe(200);
+        expect(exactLoserReply.entries?.map(entry => entry.recordId)).toEqual([loserAudience.recordsWrite.message.recordId]);
       });
 
       it('should return delivery control records only to the recipient', async () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
@@ -263,9 +263,10 @@ export function testRecordsSubscribeHandler(): void {
         });
       });
 
-      it('should authorize exact-tuple audience control subscriptions for snapshots and live events', async () => {
+      it('should project exact-tuple audience control subscription snapshots and live events to the current key', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
         const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
 
         const protocolDefinition: ProtocolDefinition = {
           protocol  : 'http://encryption-control-subscribe-audience.xyz',
@@ -274,15 +275,19 @@ export function testRecordsSubscribeHandler(): void {
             member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
           },
           structure: {
-            member: { $role: true },
+            member: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['create'] }],
+            },
           },
         };
         const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
         const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
         const initialAudience = await createAudienceControlWrite({
-          author   : alice,
-          protocol : protocolDefinition.protocol,
-          rolePath : 'member',
+          author      : bob,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 1 }),
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
           roleRuleSet,
         });
         await processControlWrite(dwn, alice.did, initialAudience);
@@ -309,16 +314,97 @@ export function testRecordsSubscribeHandler(): void {
         expect(subReply.status.code).toBe(200);
         expect(subReply.entries?.map(entry => entry.recordId)).toEqual([initialAudience.recordsWrite.message.recordId]);
 
-        const liveAudience = await createAudienceControlWrite({
-          author   : alice,
-          protocol : protocolDefinition.protocol,
-          rolePath : 'member',
+        const nonCurrentLiveAudience = await createAudienceControlWrite({
+          author      : carol,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 2 }),
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
           roleRuleSet,
         });
-        await processControlWrite(dwn, alice.did, liveAudience);
+        await processControlWrite(dwn, alice.did, nonCurrentLiveAudience);
+
+        const currentLiveAudience = await createAudienceControlWrite({
+          author      : alice,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 3 }),
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, currentLiveAudience);
 
         await Poller.pollUntilSuccessOrTimeout(async () => {
-          expect(receivedEvents.map(event => (event.message as RecordsWriteMessage).recordId)).toContain(liveAudience.recordsWrite.message.recordId);
+          const liveRecordIds = receivedEvents.map(event => (event.message as RecordsWriteMessage).recordId);
+          expect(liveRecordIds).toContain(currentLiveAudience.recordsWrite.message.recordId);
+          expect(liveRecordIds).not.toContain(nonCurrentLiveAudience.recordsWrite.message.recordId);
+        });
+      });
+
+      it('should deliver live exact-keyId audience events even when the key is not current', async () => {
+        const alice = await TestDataGenerator.generateDidKeyPersona();
+        const bob = await TestDataGenerator.generateDidKeyPersona();
+        const carol = await TestDataGenerator.generateDidKeyPersona();
+
+        const protocolDefinition: ProtocolDefinition = {
+          protocol  : 'http://encryption-control-subscribe-exact-audience.xyz',
+          published : false,
+          types     : {
+            member: { schema: 'http://member-schema', dataFormats: ['application/json'] },
+          },
+          structure: {
+            member: {
+              $role    : true,
+              $actions : [{ who: 'anyone', can: ['create'] }],
+            },
+          },
+        };
+        const encryptedDefinition = await installEncryptedProtocol(dwn, alice, protocolDefinition);
+        const roleRuleSet = encryptedDefinition.structure.member as ProtocolRuleSet;
+        const currentAudience = await createAudienceControlWrite({
+          author      : alice,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 1 }),
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet,
+        });
+        await processControlWrite(dwn, alice.did, currentAudience);
+
+        const nonCurrentLiveAudience = await createAudienceControlWrite({
+          author      : carol,
+          dateCreated : Time.createOffsetTimestamp({ seconds: 2 }),
+          protocol    : protocolDefinition.protocol,
+          rolePath    : 'member',
+          roleRuleSet,
+        });
+
+        const receivedEvents: RecordEvent[] = [];
+        const subscriptionHandler: SubscriptionListener = (msg): void => {
+          if (msg.type === 'event') {
+            receivedEvents.push(msg.event as RecordEvent);
+          }
+        };
+        const recordsSubscribe = await RecordsSubscribe.create({
+          filter: {
+            protocol     : protocolDefinition.protocol,
+            protocolPath : ENCRYPTION_CONTROL_AUDIENCE_PATH,
+            tags         : {
+              protocol  : protocolDefinition.protocol,
+              rolePath  : 'member',
+              contextId : '',
+              keyId     : nonCurrentLiveAudience.keyId,
+            },
+          },
+          signer: Jws.createSigner(bob),
+        });
+        const subReply = await dwn.processMessage(alice.did, recordsSubscribe.message, { subscriptionHandler });
+        expect(subReply.status.code).toBe(200);
+        expect(subReply.entries?.map(entry => entry.recordId)).toEqual([]);
+
+        await processControlWrite(dwn, alice.did, nonCurrentLiveAudience);
+
+        await Poller.pollUntilSuccessOrTimeout(async () => {
+          expect(receivedEvents.map(event => (event.message as RecordsWriteMessage).recordId)).toEqual([
+            nonCurrentLiveAudience.recordsWrite.message.recordId,
+          ]);
         });
       });
 

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -1,10 +1,10 @@
 import type { DidResolver } from '@enbox/dids';
 import type { EncryptionInput } from '../../src/interfaces/records-write.js';
 import type { EventLog } from '../../src/types/subscriptions.js';
-import type { GenerateFromRecordsWriteOut } from '../utils/test-data-generator.js';
 import type { Persona } from '../utils/test-data-generator.js';
 import type { DataEncodedRecordsWriteMessage, RecordsQueryReplyEntry } from '../../src/types/records-types.js';
 import type { DataStore, MessageStore, ResumableTaskStore } from '../../src/index.js';
+import type { GenerateFromRecordsWriteOut, GenerateRecordsWriteOutput } from '../utils/test-data-generator.js';
 import type { ProtocolDefinition, ProtocolRuleSet } from '../../src/types/protocols-types.js';
 
 import anyoneCollaborateProtocolDefinition from '../vectors/protocol-definitions/anyone-collaborate.json' with { type: 'json' };
@@ -118,6 +118,7 @@ export function testRecordsWriteHandler(): void {
       async function createAudienceControlWrite(input: {
         author: Persona;
         contextId?: string;
+        dateCreated?: string;
         delegatedGrant?: DataEncodedRecordsWriteMessage;
         payloadOverrides?: Record<string, unknown>;
         permissionGrantId?: string;
@@ -152,6 +153,8 @@ export function testRecordsWriteHandler(): void {
         const recordsWrite = await RecordsWrite.create({
           data              : dataBytes,
           dataFormat        : 'application/json',
+          dateCreated       : input.dateCreated,
+          messageTimestamp  : input.dateCreated,
           delegatedGrant    : input.delegatedGrant,
           permissionGrantId : input.permissionGrantId,
           protocol          : input.protocol,
@@ -4303,6 +4306,132 @@ export function testRecordsWriteHandler(): void {
 
           const writeReply = await dwn.processMessage(alice.did, recordsWrite.message, { dataStream: recordsWrite.dataStream });
           expect(writeReply.status.code).toBe(202);
+        });
+
+        it('should admit role-audience records and deliveries that reference a stored non-current audience key', async () => {
+          const alice = await TestDataGenerator.generateDidKeyPersona();
+          const bob = await TestDataGenerator.generateDidKeyPersona();
+
+          const protocolDefinition: ProtocolDefinition = {
+            protocol  : 'http://role-audience-loser-key-admission.xyz',
+            published : false,
+            types     : {
+              member  : { schema: 'http://member-schema', dataFormats: ['application/json'] },
+              message : { schema: 'http://message-schema', dataFormats: ['text/plain'], encryptionRequired: true },
+            },
+            structure: {
+              member: {
+                $role    : true,
+                $actions : [{ who: 'anyone', can: ['create'] }],
+              },
+              message: {
+                $actions: [
+                  { role: 'member', can: ['read'] },
+                ],
+              },
+            },
+          };
+
+          const encryptedProtocolDefinition = await installEncryptedProtocol(alice, protocolDefinition);
+          const memberRuleSet = encryptedProtocolDefinition.structure.member as ProtocolRuleSet;
+          const messageRuleSet = encryptedProtocolDefinition.structure.message as ProtocolRuleSet;
+          const rolePath = 'member';
+
+          const loserAudience = await createAudienceControlWrite({
+            author      : bob,
+            dateCreated : '2025-01-01T00:00:00.000000Z',
+            protocol    : protocolDefinition.protocol,
+            rolePath,
+            roleRuleSet : memberRuleSet,
+          });
+          expect((await dwn.processMessage(
+            alice.did,
+            loserAudience.recordsWrite.message,
+            { dataStream: DataStream.fromBytes(loserAudience.dataBytes) }
+          )).status.code).toBe(202);
+
+          const currentAudience = await createAudienceControlWrite({
+            author      : alice,
+            dateCreated : '2025-01-02T00:00:00.000000Z',
+            protocol    : protocolDefinition.protocol,
+            rolePath,
+            roleRuleSet : memberRuleSet,
+          });
+          expect((await dwn.processMessage(
+            alice.did,
+            currentAudience.recordsWrite.message,
+            { dataStream: DataStream.fromBytes(currentAudience.dataBytes) }
+          )).status.code).toBe(202);
+
+          const buildEncryptedMessage = async (plaintext: string): Promise<GenerateRecordsWriteOutput> => {
+            const dataEncryptionKey = TestDataGenerator.randomBytes(32);
+            const dataEncryptionInitializationVector = TestDataGenerator.randomBytes(16);
+            const encryptedData = await Encryption.encrypt(
+              ContentEncryptionAlgorithm.A256CTR,
+              dataEncryptionKey,
+              dataEncryptionInitializationVector,
+              Encoder.stringToBytes(plaintext),
+            );
+            const protocolPathPublicKey = messageRuleSet.$keyAgreement!.publicKeyJwk;
+            const encryptionInput: EncryptionInput = {
+              initializationVector : dataEncryptionInitializationVector,
+              key                  : dataEncryptionKey,
+              keyEncryptionInputs  : [
+                {
+                  algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                  keyId            : await Encryption.getKeyId(protocolPathPublicKey),
+                  publicKey        : protocolPathPublicKey,
+                  derivationScheme : KeyDerivationScheme.ProtocolPath,
+                },
+                {
+                  algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+                  keyId            : loserAudience.keyId,
+                  publicKey        : bob.encryptionKeyPair.publicJwk,
+                  derivationScheme : ROLE_AUDIENCE_DERIVATION_SCHEME,
+                  protocol         : protocolDefinition.protocol,
+                  rolePath,
+                },
+              ],
+            };
+
+            return TestDataGenerator.generateRecordsWrite({
+              author       : alice,
+              protocol     : protocolDefinition.protocol,
+              protocolPath : 'message',
+              schema       : 'http://message-schema',
+              dataFormat   : 'text/plain',
+              data         : encryptedData,
+              encryptionInput,
+            });
+          };
+
+          const directWrite = await buildEncryptedMessage('direct write to loser key');
+          const directReply = await dwn.processMessage(alice.did, directWrite.message, { dataStream: directWrite.dataStream });
+          expect(directReply.status.code).toBe(202);
+
+          const replicatedWrite = await buildEncryptedMessage('replicated write to loser key');
+          const replicatedResult = await dwn.applyReplicatedMessage(
+            alice.did,
+            replicatedWrite.message,
+            { dataStream: replicatedWrite.dataStream },
+          );
+          expect(replicatedResult).toEqual(expect.objectContaining({ kind: 'Applied' }));
+
+          const delivery = await createDeliveryControlWrite({
+            author             : alice,
+            keyId              : loserAudience.keyId,
+            protocol           : protocolDefinition.protocol,
+            recipient          : bob.did,
+            recipientAuthority : EncryptionControlDeliveryRecipientAuthority.RoleCreatorAnyone,
+            rolePath,
+            roleRuleSet        : memberRuleSet,
+          });
+          const deliveryReply = await dwn.processMessage(
+            alice.did,
+            delivery.recordsWrite.message,
+            { dataStream: DataStream.fromBytes(delivery.dataBytes) },
+          );
+          expect(deliveryReply.status.code).toBe(202);
         });
 
         it('should reject an encrypted role-readable RecordsWrite when the roleAudience keyId does not match the audience record', async () => {

--- a/packages/dwn-sdk-js/tests/utils/encryption-control-test-utils.ts
+++ b/packages/dwn-sdk-js/tests/utils/encryption-control-test-utils.ts
@@ -39,12 +39,15 @@ export async function installEncryptedProtocol(
 export async function createAudienceControlWrite(input: {
   author: Persona;
   contextId?: string;
+  dateCreated?: string;
   delegatedGrant?: DataEncodedRecordsWriteMessage;
+  messageTimestamp?: string;
   payloadOverrides?: Record<string, unknown>;
   permissionGrantId?: string;
   protocol: string;
   protocolRole?: string;
   published?: boolean;
+  recordId?: string;
   rolePath: string;
   roleRuleSet: ProtocolRuleSet;
   sealKeyId?: string;
@@ -69,30 +72,34 @@ export async function createAudienceControlWrite(input: {
     },
     ...input.payloadOverrides,
   };
+  const payloadKeyId = typeof payload.keyId === 'string' ? payload.keyId : audienceKeyId;
   const dataBytes = Encoder.objectToBytes(payload);
   const recordsWrite = await RecordsWrite.create({
     data              : dataBytes,
     dataFormat        : 'application/json',
+    dateCreated       : input.dateCreated,
     delegatedGrant    : input.delegatedGrant,
+    messageTimestamp  : input.messageTimestamp ?? input.dateCreated,
     permissionGrantId : input.permissionGrantId,
     protocol          : input.protocol,
     protocolPath      : ENCRYPTION_CONTROL_AUDIENCE_PATH,
     protocolRole      : input.protocolRole,
     published         : input.published,
+    recordId          : input.recordId,
     schema            : 'https://identity.foundation/dwn/json-schemas/encryption/audience.json',
     signer            : Jws.createSigner(input.signer ?? input.author),
     tags              : {
       protocol  : input.protocol,
       rolePath  : input.rolePath,
       contextId : input.contextId ?? '',
-      keyId     : audienceKeyId,
+      keyId     : payloadKeyId,
       ...input.tags,
     },
   });
 
   return {
     dataBytes,
-    keyId: audienceKeyId,
+    keyId: payloadKeyId,
     payload,
     recordsWrite,
   };

--- a/packages/dwn-server/tests/scenarios/registration.test.ts
+++ b/packages/dwn-server/tests/scenarios/registration.test.ts
@@ -614,7 +614,7 @@ async function installDefaultTestProtocolViaHttp(endpoint: string, persona: Pers
   });
   const responseBody = await response.json() as JsonRpcResponse;
   const { code, detail } = responseBody.result.reply.status;
-  if (code !== 202) {
+  if (code !== 202 && code !== 409) {
     throw new Error(`Failed to install default test protocol via HTTP: ${code} ${detail}`);
   }
 }


### PR DESCRIPTION
## Summary
- add deterministic current-key projection for source-protocol audience control records, grouped by protocol/rolePath/contextId
- apply the projection to Records query/count/subscribe enumeration while preserving stored-record exact lookup and admission semantics
- keep enumeration filter semantics strict: projection does not inject a current key that does not match the caller's filter; exact keyId and recordId fetches still return stored records
- memoize current-key resolution within Records query/subscribe snapshot requests and export the resolver for the agent wrap-target work

## Test plan
- [x] bun run lint
- [x] bun run --filter @enbox/dwn-sdk-js build
- [x] bun run --filter @enbox/agent build
- [x] packages/dwn-sdk-js: GREP="does not match an enumeration filter|broad protocol counts|exact-keyId audience" bun run test:node-grep
- [x] packages/dwn-sdk-js: GREP="reuse current audience resolution|does not match an enumeration filter" bun run test:node-grep
- [x] packages/dwn-sdk-js: bun run test:node
- [x] packages/agent: attempted full `bun run test:node` with DID-DHT env after `bun run dev:ensure`; local DWN server process exited during the run, leaving the remote-sync group unable to connect to http://localhost:3000
