### PR TITLE
Type $actions as a non-empty tuple in ProtocolRuleSet

### DIFF
--- a/packages/dwn-sdk-js/src/types/protocols-types.ts
+++ b/packages/dwn-sdk-js/src/types/protocols-types.ts
@@ -247,7 +247,16 @@ export type ProtocolRuleSet = {
    * Key agreement setting for records at this protocol path.
    */
   $keyAgreement?: ProtocolKeyAgreement;
-  $actions?: ProtocolActionRule[];
+
+  /**
+   * Action rules governing which actors may access records at this protocol path.
+   *
+   * Typed as a non-empty tuple: when present, `$actions` must contain at least one
+   * rule. The DWN schema validation rejects an empty array at runtime
+   * ("must NOT have fewer than 1 items"), so `$actions: []` is a compile-time error.
+   * To express "no rules", omit `$actions` entirely.
+   */
+  $actions?: [ProtocolActionRule, ...ProtocolActionRule[]];
 
   /**
    * If true, this marks a record as a `role` that may used within a context.

--- a/packages/dwn-sdk-js/tests/core/process-message-parity.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/process-message-parity.spec.ts
@@ -4,7 +4,7 @@ import type { GenericMessageReply } from '../../src/types/message-types.js';
 import type { DataStore, MessageStore, ResumableTaskStore } from '../../src/index.js';
 import type { RecordsQueryReply, RecordsReadReply } from '../../src/types/records-types.js';
 
-import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
+import friendRoleProtocolDefinitionJson from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
 import nestedProtocolDefinition from '../vectors/protocol-definitions/nested.json' with { type: 'json' };
 
 import { DataStream } from '../../src/utils/data-stream.js';
@@ -18,6 +18,9 @@ import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { DidKey, UniversalResolver } from '@enbox/dids';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const friendRoleProtocolDefinition = asProtocolDefinition(friendRoleProtocolDefinitionJson);
 
 function expectReplyWithPosition(reply: GenericMessageReply, status: GenericMessageReply['status']): void {
   expect(reply).toEqual({

--- a/packages/dwn-sdk-js/tests/core/validation-read-closure.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/validation-read-closure.spec.ts
@@ -5,8 +5,8 @@ import type { RecordingValidationStateReader } from '../../src/core/recording-va
 import type { DataStore, MessageStore, ResumableTaskStore } from '../../src/index.js';
 import type { ProtocolDefinition, ProtocolRuleSet } from '../../src/types/protocols-types.js';
 
-import freeForAllProtocolDefinition from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
-import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
+import freeForAllProtocolDefinitionJson from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
+import friendRoleProtocolDefinitionJson from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
 import nestedProtocolDefinition from '../vectors/protocol-definitions/nested.json' with { type: 'json' };
 
 import { DataStream } from '../../src/utils/data-stream.js';
@@ -29,6 +29,10 @@ import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
 import { EncryptionProtocol, KeyDerivationScheme, Protocols } from '../../src/index.js';
 import { readFileSync, writeFileSync } from 'node:fs';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const freeForAllProtocolDefinition = asProtocolDefinition(freeForAllProtocolDefinitionJson);
+const friendRoleProtocolDefinition = asProtocolDefinition(friendRoleProtocolDefinitionJson);
 
 const VALIDATION_READER_METHODS = new Set<string>([
   'fetchInitialRecordsWrite',

--- a/packages/dwn-sdk-js/tests/core/validation-state-reader.spec.ts
+++ b/packages/dwn-sdk-js/tests/core/validation-state-reader.spec.ts
@@ -7,7 +7,7 @@ import type { RecordsWriteMessage } from '../../src/types/records-types.js';
 import type { ValidationStateReader } from '../../src/types/validation-state-reader.js';
 import type { DataStore, MessageStore, ResumableTaskStore } from '../../src/index.js';
 
-import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
+import friendRoleProtocolDefinitionJson from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
 import nestedProtocolDefinition from '../vectors/protocol-definitions/nested.json' with { type: 'json' };
 
 import { DataStream } from '../../src/utils/data-stream.js';
@@ -26,6 +26,9 @@ import { Time } from '../../src/utils/time.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-method.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const friendRoleProtocolDefinition = asProtocolDefinition(friendRoleProtocolDefinitionJson);
 
 /**
  * Validation-state reader parity: replicated apply returns structured repair outcomes, but it

--- a/packages/dwn-sdk-js/tests/features/author-delegated-grant.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/author-delegated-grant.spec.ts
@@ -3,10 +3,10 @@ import type { RecordsWriteMessage } from '../../src/types/records-types.js';
 import type { DataStore, MessageStore, PermissionScope, ResumableTaskStore } from '../../src/index.js';
 import type { EventLog, SubscriptionMessage } from '../../src/types/subscriptions.js';
 
-import emailProtocolDefinition from '../vectors/protocol-definitions/email.json' with { type: 'json' };
-import messageProtocolDefinition from '../vectors/protocol-definitions/message.json' with { type: 'json' };
+import emailProtocolDefinitionJson from '../vectors/protocol-definitions/email.json' with { type: 'json' };
+import messageProtocolDefinitionJson from '../vectors/protocol-definitions/message.json' with { type: 'json' };
 import sinon from 'sinon';
-import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import threadRoleProtocolDefinitionJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 
 import { base64url } from 'multiformats/bases/base64';
 import { DataStream } from '../../src/utils/data-stream.js';
@@ -23,6 +23,12 @@ import { Time } from '../../src/utils/time.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnInterfaceName, DwnMethodName, Encoder, Message, PermissionsProtocol, RecordsDelete, RecordsQuery, RecordsRead, RecordsSubscribe } from '../../src/index.js';
+import type { ProtocolDefinition } from '../../src/types/protocols-types.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const emailProtocolDefinition = asProtocolDefinition(emailProtocolDefinitionJson);
+const messageProtocolDefinition = asProtocolDefinition(messageProtocolDefinitionJson);
+const threadRoleProtocolDefinition = asProtocolDefinition(threadRoleProtocolDefinitionJson);
 
 
 export function testAuthorDelegatedGrant(): void {
@@ -165,7 +171,7 @@ export function testAuthorDelegatedGrant(): void {
         expect(signer).toBe(bob.did);
 
         // verify that bob cannot configure a different protocol
-        const otherProtocolDefinition = {
+        const otherProtocolDefinition: ProtocolDefinition = {
           ...emailProtocolDefinition,
           protocol: 'https://example.com/protocol/otherProtocol'
         };

--- a/packages/dwn-sdk-js/tests/features/records-prune.spec.ts
+++ b/packages/dwn-sdk-js/tests/features/records-prune.spec.ts
@@ -6,7 +6,7 @@ import type {
   ResumableTaskStore,
 } from '../../src/index.js';
 
-import messageProtocolDefinition from '../vectors/protocol-definitions/message.json' with { type: 'json' };
+import messageProtocolDefinitionJson from '../vectors/protocol-definitions/message.json' with { type: 'json' };
 import nestedProtocolDefinition from '../vectors/protocol-definitions/nested.json' with { type: 'json' };
 import sinon from 'sinon';
 
@@ -17,6 +17,10 @@ import { TestStores } from '../test-stores.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { DataStream, Dwn, DwnConstant, DwnErrorCode, Jws, ProtocolsConfigure, RecordsDelete, RecordsQuery, RecordsWrite, SortDirection, Time } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
+import type { ProtocolDefinition } from '../../src/types/protocols-types.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const messageProtocolDefinition = asProtocolDefinition(messageProtocolDefinitionJson);
 
 
 export function testRecordsPrune(): void {
@@ -434,7 +438,7 @@ export function testRecordsPrune(): void {
         const bob = await TestDataGenerator.generateDidKeyPersona();
 
         // 1. Alice installs a protocol allowing others to add and prune records.
-        const protocolDefinition = {
+        const protocolDefinition: ProtocolDefinition = {
           protocol  : 'http://post-protocol.xyz',
           published : true,
           types     : {
@@ -615,7 +619,7 @@ export function testRecordsPrune(): void {
         const carol = await TestDataGenerator.generateDidKeyPersona();
 
         // 1. Alice installs a protocol allowing others to add and prune records.
-        const protocolDefinition = {
+        const protocolDefinition: ProtocolDefinition = {
           protocol  : 'http://post-protocol.xyz',
           published : true,
           types     : {
@@ -725,7 +729,7 @@ export function testRecordsPrune(): void {
         const carol = await TestDataGenerator.generateDidKeyPersona();
 
         // 1. Alice installs a protocol allowing others to add records AND only author to prune.
-        const protocolDefinition = {
+        const protocolDefinition: ProtocolDefinition = {
           protocol  : 'http://post-protocol.xyz',
           published : true,
           types     : {
@@ -826,7 +830,7 @@ export function testRecordsPrune(): void {
         const bob = await TestDataGenerator.generateDidKeyPersona();
 
         // 1. Alice installs a protocol allowing others to add and delete (not prune) records.
-        const protocolDefinition = {
+        const protocolDefinition: ProtocolDefinition = {
           protocol  : 'http://post-protocol.xyz',
           published : true,
           types     : {
@@ -909,7 +913,7 @@ export function testRecordsPrune(): void {
       it('should not allow creation of a protocol definition with action rule containing `prune` without `create`', async () => {
         const alice = await TestDataGenerator.generateDidKeyPersona();
 
-        const protocolDefinition = {
+        const protocolDefinition: ProtocolDefinition = {
           protocol  : 'http://prune-without-create.xyz',
           published : true,
           types     : {

--- a/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-query.spec.ts
@@ -1,7 +1,7 @@
 import type { DidResolver } from '@enbox/dids';
 import type { DataStore, MessageStore, ProtocolDefinition, ProtocolRuleSet, ReplicationFeedReader, ResumableTaskStore } from '../../src/index.js';
 
-import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
+import freeForAllJson from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { DidKey, UniversalResolver } from '@enbox/dids';
@@ -12,6 +12,9 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestStores } from '../test-stores.js';
 import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, EncryptionProtocol, PermissionsProtocol, Replication } from '../../src/index.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const freeForAll = asProtocolDefinition(freeForAllJson);
 
 function getFeedReader(messageStore: MessageStore): ReplicationFeedReader | undefined {
   const candidate = messageStore as Partial<ReplicationFeedReader>;

--- a/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-read.spec.ts
@@ -11,7 +11,7 @@ import type {
 
 import { Encoder } from '../../src/utils/encoder.js';
 import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
-import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
+import freeForAllJson from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
 import { GeneralJwsVerifier } from '../../src/jose/jws/general/verifier.js';
 import { Message } from '../../src/core/message.js';
 import minimalProtocolDefinition from '../vectors/protocol-definitions/minimal.json' with { type: 'json' };
@@ -23,6 +23,9 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { DataStream, Dwn, DwnConstant, DwnErrorCode, DwnInterfaceName, DwnMethodName, Jws, PermissionGrant, PermissionsProtocol, Time } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const freeForAll = asProtocolDefinition(freeForAllJson);
 
 export function testMessagesReadHandler(): void {
   describe('MessagesReadHandler.handle()', () => {

--- a/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/messages-subscribe.spec.ts
@@ -5,7 +5,7 @@ import type { GenerateGrantCreateOutput, GenerateRecordsWriteOutput, Persona } f
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
-import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
+import freeForAllJson from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
 import sinon from 'sinon';
 
 import { Dwn } from '../../src/dwn.js';
@@ -26,6 +26,9 @@ import { DataStream, DwnInterfaceName, DwnMethodName, PermissionGrant, Permissio
 import { DidKey, UniversalResolver } from '@enbox/dids';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const freeForAll = asProtocolDefinition(freeForAllJson);
 
 export function testMessagesSubscribeHandler(): void {
   describe('MessagesSubscribe.handle()', () => {

--- a/packages/dwn-sdk-js/tests/handlers/protocols-configure.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/protocols-configure.spec.ts
@@ -9,7 +9,7 @@ import type {
   ResumableTaskStore,
 } from '../../src/index.js';
 
-import dexProtocolDefinition from '../vectors/protocol-definitions/dex.json' with { type: 'json' };
+import dexProtocolDefinitionJson from '../vectors/protocol-definitions/dex.json' with { type: 'json' };
 import minimalProtocolDefinition from '../vectors/protocol-definitions/minimal.json' with { type: 'json' };
 import sinon from 'sinon';
 
@@ -26,6 +26,9 @@ import { Time } from '../../src/utils/time.js';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { DataStream, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, Jws, PermissionGrant, PermissionsProtocol, RecordsDelete, RecordsRead, RecordsWrite } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const dexProtocolDefinition = asProtocolDefinition(dexProtocolDefinitionJson);
 
 export function testProtocolsConfigureHandler(): void {
   describe('ProtocolsConfigureHandler.handle()', () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-count.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-count.spec.ts
@@ -9,7 +9,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { DataStream } from '../../src/utils/data-stream.js';
 import { Encoder } from '../../src/utils/encoder.js';
 import { EncryptionControlDeliveryRecipientAuthority } from '../../src/types/encryption-types.js';
-import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
+import freeForAllJson from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
 import { Jws } from '../../src/utils/jws.js';
 import { PermissionsProtocol } from '../../src/protocols/permissions.js';
 import { RecordsCount } from '../../src/interfaces/records-count.js';
@@ -17,11 +17,15 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
-import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import threadRoleProtocolDefinitionJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 import { createAudienceControlWrite, createDeliveryControlWrite, installEncryptedProtocol, processControlWrite } from '../utils/encryption-control-test-utils.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Time } from '../../src/index.js';
 import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const freeForAll = asProtocolDefinition(freeForAllJson);
+const threadRoleProtocolDefinition = asProtocolDefinition(threadRoleProtocolDefinitionJson);
 
 export function testRecordsCountHandler(): void {
   describe('RecordsCountHandler.handle()', () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-delete.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-delete.spec.ts
@@ -16,11 +16,11 @@ import sinon from 'sinon';
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
-import anyoneCollaborateProtocolDefinition from '../vectors/protocol-definitions/anyone-collaborate.json' with { type: 'json' };
-import authorCanProtocolDefinition from '../vectors/protocol-definitions/author-can.json' with { type: 'json' };
-import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
-import recipientCanProtocolDefinition from '../vectors/protocol-definitions/recipient-can.json' with { type: 'json' };
-import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import anyoneCollaborateProtocolDefinitionJson from '../vectors/protocol-definitions/anyone-collaborate.json' with { type: 'json' };
+import authorCanProtocolDefinitionJson from '../vectors/protocol-definitions/author-can.json' with { type: 'json' };
+import friendRoleProtocolDefinitionJson from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
+import recipientCanProtocolDefinitionJson from '../vectors/protocol-definitions/recipient-can.json' with { type: 'json' };
+import threadRoleProtocolDefinitionJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 
 import { ArrayUtility } from '../../src/utils/array.js';
 import { DwnErrorCode } from '../../src/core/dwn-error.js';
@@ -41,6 +41,13 @@ import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-m
 import { Encryption, KeyAgreementAlgorithm } from '../../src/utils/encryption.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const anyoneCollaborateProtocolDefinition = asProtocolDefinition(anyoneCollaborateProtocolDefinitionJson);
+const authorCanProtocolDefinition = asProtocolDefinition(authorCanProtocolDefinitionJson);
+const friendRoleProtocolDefinition = asProtocolDefinition(friendRoleProtocolDefinitionJson);
+const recipientCanProtocolDefinition = asProtocolDefinition(recipientCanProtocolDefinitionJson);
+const threadRoleProtocolDefinition = asProtocolDefinition(threadRoleProtocolDefinitionJson);
 
 export function testRecordsDeleteHandler(): void {
   describe('RecordsDeleteHandler.handle()', () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-query.spec.ts
@@ -7,10 +7,10 @@ import sinon from 'sinon';
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
-import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
-import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
+import freeForAllJson from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
+import friendRoleProtocolDefinitionJson from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
 import nestedProtocol from '../vectors/protocol-definitions/nested.json' with { type: 'json' };
-import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import threadRoleProtocolDefinitionJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 
 import { ArrayUtility } from '../../src/utils/array.js';
 import { DataStream } from '../../src/utils/data-stream.js';
@@ -39,6 +39,11 @@ import { DwnInterfaceName, DwnMethodName } from '../../src/enums/dwn-interface-m
 import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const freeForAll = asProtocolDefinition(freeForAllJson);
+const friendRoleProtocolDefinition = asProtocolDefinition(friendRoleProtocolDefinitionJson);
+const threadRoleProtocolDefinition = asProtocolDefinition(threadRoleProtocolDefinitionJson);
 
 export function testRecordsQueryHandler(): void {
   describe('RecordsQueryHandler.handle()', () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-read.spec.ts
@@ -4,13 +4,13 @@ import type { EncryptionInput } from '../../src/interfaces/records-write.js';
 import type { EventLog } from '../../src/types/subscriptions.js';
 import type { DataStore, MessageStore, ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureMessage, ResumableTaskStore } from '../../src/index.js';
 
-import emailProtocolDefinition from '../vectors/protocol-definitions/email.json' with { type: 'json' };
-import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
+import emailProtocolDefinitionJson from '../vectors/protocol-definitions/email.json' with { type: 'json' };
+import friendRoleProtocolDefinitionJson from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
 import minimalProtocolDefinition from '../vectors/protocol-definitions/minimal.json' with { type: 'json' };
 import nestedProtocol from '../vectors/protocol-definitions/nested.json' with { type: 'json' };
 import sinon from 'sinon';
-import socialMediaProtocolDefinition from '../vectors/protocol-definitions/social-media.json' with { type: 'json' };
-import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import socialMediaProtocolDefinitionJson from '../vectors/protocol-definitions/social-media.json' with { type: 'json' };
+import threadRoleProtocolDefinitionJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 
 import { ArrayUtility } from '../../src/utils/array.js';
 import { authenticate } from '../../src/core/auth.js';
@@ -34,6 +34,12 @@ import { DwnConstant, PermissionsProtocol, Time } from '../../src/index.js';
 import { DwnInterfaceName, DwnMethodName } from '../../src/index.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const emailProtocolDefinition = asProtocolDefinition(emailProtocolDefinitionJson);
+const friendRoleProtocolDefinition = asProtocolDefinition(friendRoleProtocolDefinitionJson);
+const socialMediaProtocolDefinition = asProtocolDefinition(socialMediaProtocolDefinitionJson);
+const threadRoleProtocolDefinition = asProtocolDefinition(threadRoleProtocolDefinitionJson);
 
 export function testRecordsReadHandler(): void {
   describe('RecordsReadHandler.handle()', () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-subscribe.spec.ts
@@ -8,8 +8,8 @@ import sinon from 'sinon';
 import { sleep } from '@enbox/common';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
-import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
-import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import friendRoleProtocolDefinitionJson from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
+import threadRoleProtocolDefinitionJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 
 import { DataStream } from '../../src/utils/data-stream.js';
 import { Encoder } from '../../src/utils/encoder.js';
@@ -31,6 +31,10 @@ import { DurableEventLog, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Ti
 import { ENCRYPTION_CONTROL_AUDIENCE_PATH, ENCRYPTION_CONTROL_DELIVERY_PATH } from '../../src/core/constants.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const friendRoleProtocolDefinition = asProtocolDefinition(friendRoleProtocolDefinitionJson);
+const threadRoleProtocolDefinition = asProtocolDefinition(threadRoleProtocolDefinitionJson);
 
 export function testRecordsSubscribeHandler(): void {
   describe('RecordsSubscribeHandler.handle()', () => {

--- a/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/handlers/records-write.spec.ts
@@ -7,20 +7,20 @@ import type { DataStore, MessageStore, ResumableTaskStore } from '../../src/inde
 import type { GenerateFromRecordsWriteOut, GenerateRecordsWriteOutput } from '../utils/test-data-generator.js';
 import type { ProtocolDefinition, ProtocolRuleSet } from '../../src/types/protocols-types.js';
 
-import anyoneCollaborateProtocolDefinition from '../vectors/protocol-definitions/anyone-collaborate.json' with { type: 'json' };
-import authorCanProtocolDefinition from '../vectors/protocol-definitions/author-can.json' with { type: 'json' };
-import credentialIssuanceProtocolDefinition from '../vectors/protocol-definitions/credential-issuance.json' with { type: 'json' };
-import dexProtocolDefinition from '../vectors/protocol-definitions/dex.json' with { type: 'json' };
-import emailProtocolDefinition from '../vectors/protocol-definitions/email.json' with { type: 'json' };
-import friendRoleProtocolDefinition from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
-import messageProtocolDefinition from '../vectors/protocol-definitions/message.json' with { type: 'json' };
+import anyoneCollaborateProtocolDefinitionJson from '../vectors/protocol-definitions/anyone-collaborate.json' with { type: 'json' };
+import authorCanProtocolDefinitionJson from '../vectors/protocol-definitions/author-can.json' with { type: 'json' };
+import credentialIssuanceProtocolDefinitionJson from '../vectors/protocol-definitions/credential-issuance.json' with { type: 'json' };
+import dexProtocolDefinitionJson from '../vectors/protocol-definitions/dex.json' with { type: 'json' };
+import emailProtocolDefinitionJson from '../vectors/protocol-definitions/email.json' with { type: 'json' };
+import friendRoleProtocolDefinitionJson from '../vectors/protocol-definitions/friend-role.json' with { type: 'json' };
+import messageProtocolDefinitionJson from '../vectors/protocol-definitions/message.json' with { type: 'json' };
 import minimalProtocolDefinition from '../vectors/protocol-definitions/minimal.json' with { type: 'json' };
 import nestedProtocol from '../vectors/protocol-definitions/nested.json' with { type: 'json' };
 import privateProtocol from '../vectors/protocol-definitions/private-protocol.json' with { type: 'json' };
-import recipientCanProtocol from '../vectors/protocol-definitions/recipient-can.json' with { type: 'json' };
+import recipientCanProtocolJson from '../vectors/protocol-definitions/recipient-can.json' with { type: 'json' };
 import sinon from 'sinon';
-import socialMediaProtocolDefinition from '../vectors/protocol-definitions/social-media.json' with { type: 'json' };
-import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import socialMediaProtocolDefinitionJson from '../vectors/protocol-definitions/social-media.json' with { type: 'json' };
+import threadRoleProtocolDefinitionJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
@@ -53,6 +53,18 @@ import { DidKey, UniversalResolver } from '@enbox/dids';
 import { DwnError, DwnErrorCode } from '../../src/core/dwn-error.js';
 
 import { createTestValidationStateReader } from '../utils/test-validation-state-reader.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const anyoneCollaborateProtocolDefinition = asProtocolDefinition(anyoneCollaborateProtocolDefinitionJson);
+const authorCanProtocolDefinition = asProtocolDefinition(authorCanProtocolDefinitionJson);
+const credentialIssuanceProtocolDefinition = asProtocolDefinition(credentialIssuanceProtocolDefinitionJson);
+const dexProtocolDefinition = asProtocolDefinition(dexProtocolDefinitionJson);
+const emailProtocolDefinition = asProtocolDefinition(emailProtocolDefinitionJson);
+const friendRoleProtocolDefinition = asProtocolDefinition(friendRoleProtocolDefinitionJson);
+const messageProtocolDefinition = asProtocolDefinition(messageProtocolDefinitionJson);
+const recipientCanProtocol = asProtocolDefinition(recipientCanProtocolJson);
+const socialMediaProtocolDefinition = asProtocolDefinition(socialMediaProtocolDefinitionJson);
+const threadRoleProtocolDefinition = asProtocolDefinition(threadRoleProtocolDefinitionJson);
 
 type AudienceControlWrite = {
   dataBytes: Uint8Array;

--- a/packages/dwn-sdk-js/tests/interfaces/protocols-configure.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/protocols-configure.spec.ts
@@ -1,6 +1,6 @@
 import type { ProtocolDefinition, ProtocolRuleSet, ProtocolsConfigureDescriptor, ProtocolsConfigureMessage } from '../../src/index.js';
 
-import dexProtocolDefinition from '../vectors/protocol-definitions/dex.json' with { type: 'json' };
+import dexProtocolDefinitionJson from '../vectors/protocol-definitions/dex.json' with { type: 'json' };
 import { Jws } from '../../src/utils/jws.js';
 import { ProtocolAction } from '../../src/types/protocols-types.js';
 import { ProtocolsConfigure } from '../../src/interfaces/protocols-configure.js';
@@ -9,6 +9,9 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { Time } from '../../src/utils/time.js';
 import { afterEach, describe, expect, it } from 'bun:test';
 import { DwnErrorCode, DwnInterfaceName, DwnMethodName, Message, Protocols } from '../../src/index.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const dexProtocolDefinition = asProtocolDefinition(dexProtocolDefinitionJson);
 
 describe('ProtocolsConfigure', () => {
   describe('parse()', () => {
@@ -368,7 +371,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('should allow `role` property in an `action` to have protocol path to a role record.', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -406,7 +409,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('should allow `role` property in an `action` that have protocol path to a role record.', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -440,7 +443,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('should allow role rules whose role parent depth matches the rule path context depth', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -474,7 +477,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('rejects protocol definitions with `role` actions that contain invalid roles', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -506,7 +509,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('should reject role rules whose role parent is deeper than the rule path context', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -541,7 +544,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('should reject cross-protocol role rules whose role parent is deeper than the rule path context', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           uses      : {
@@ -572,7 +575,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('rejects protocol definitions with actions that contain `of` and  `who` is `anyone`', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -601,7 +604,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('rejects protocol definitions with actions that have direct-recipient-can rules with actions other than delete or update', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -629,7 +632,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('rejects protocol definitions with actions that don\'t contain `of` and  `who` is `author`', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -658,7 +661,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('allows `who`-based rules with `of` that have read action', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -686,7 +689,7 @@ describe('ProtocolsConfigure', () => {
       });
 
       it('allows `who`-based rules with `of` that have read action alongside other actions', async () => {
-        const definition = {
+        const definition: ProtocolDefinition = {
           published : true,
           protocol  : 'http://example.com',
           types     : {
@@ -806,7 +809,7 @@ describe('ProtocolsConfigure', () => {
           originalWarn = console.warn;
           console.warn = (...args: unknown[]): void => { capturedWarnings.push(String(args[0])); };
 
-          const definition = {
+          const definition: ProtocolDefinition = {
             published : true,
             protocol  : 'http://example.com/encryption-warning',
             types     : {
@@ -840,7 +843,7 @@ describe('ProtocolsConfigure', () => {
           originalWarn = console.warn;
           console.warn = (...args: unknown[]): void => { capturedWarnings.push(String(args[0])); };
 
-          const definition = {
+          const definition: ProtocolDefinition = {
             published : true,
             protocol  : 'http://example.com/nested-warning',
             types     : {
@@ -876,7 +879,7 @@ describe('ProtocolsConfigure', () => {
           originalWarn = console.warn;
           console.warn = (...args: unknown[]): void => { capturedWarnings.push(String(args[0])); };
 
-          const definition = {
+          const definition: ProtocolDefinition = {
             published : true,
             protocol  : 'http://example.com/no-encryption',
             types     : {
@@ -906,7 +909,7 @@ describe('ProtocolsConfigure', () => {
           originalWarn = console.warn;
           console.warn = (...args: unknown[]): void => { capturedWarnings.push(String(args[0])); };
 
-          const definition = {
+          const definition: ProtocolDefinition = {
             published : true,
             protocol  : 'http://example.com/encryption-no-anyone',
             types     : {

--- a/packages/dwn-sdk-js/tests/scenarios/deleted-record.spec.ts
+++ b/packages/dwn-sdk-js/tests/scenarios/deleted-record.spec.ts
@@ -2,9 +2,9 @@ import type { DidResolver } from '@enbox/dids';
 import type { EventLog } from '../../src/types/subscriptions.js';
 import type { DataStore, MessageStore, RecordsReadReply, ResumableTaskStore } from '../../src/index.js';
 
-import freeForAllProtocolDefinition from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
+import freeForAllProtocolDefinitionJson from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
 import sinon from 'sinon';
-import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import threadRoleProtocolDefinitionJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { TestDataGenerator } from '../utils/test-data-generator.js';
@@ -15,6 +15,11 @@ import { TestStubGenerator } from '../utils/test-stub-generator.js';
 import { DataStream, Dwn, DwnErrorCode, DwnInterfaceName, DwnMethodName, Jws, PermissionsProtocol, ProtocolsConfigure, RecordsRead, Time } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { Encoder, RecordsDelete, RecordsWrite } from '../../src/index.js';
+import type { ProtocolDefinition } from '../../src/types/protocols-types.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const freeForAllProtocolDefinition = asProtocolDefinition(freeForAllProtocolDefinitionJson);
+const threadRoleProtocolDefinition = asProtocolDefinition(threadRoleProtocolDefinitionJson);
 
 export function testDeletedRecordScenarios(): void {
   describe('End-to-end Scenarios Spanning Features', () => {
@@ -164,7 +169,7 @@ export function testDeletedRecordScenarios(): void {
         TestStubGenerator.stubDidResolver(didResolver, [alice, bob]);
 
         // Install a protocol where recipient can read (requires `of` property)
-        const protocolDefinition = {
+        const protocolDefinition: ProtocolDefinition = {
           protocol  : 'http://recipient-read.xyz',
           published : true,
           types     : {
@@ -387,7 +392,7 @@ export function testDeletedRecordScenarios(): void {
         TestStubGenerator.stubDidResolver(didResolver, [alice, bob, carol]);
 
         // Install a protocol where only author and recipient can read (no 'anyone' can 'read')
-        const protocolDefinition = {
+        const protocolDefinition: ProtocolDefinition = {
           protocol  : 'http://restricted-read.xyz',
           published : true,
           types     : {

--- a/packages/dwn-sdk-js/tests/scenarios/end-to-end-tests.spec.ts
+++ b/packages/dwn-sdk-js/tests/scenarios/end-to-end-tests.spec.ts
@@ -10,7 +10,7 @@ import { TestDataGenerator } from '../utils/test-data-generator.js';
 import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { TestStubGenerator } from '../utils/test-stub-generator.js';
-import threadRoleProtocolDefinition from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import threadRoleProtocolDefinitionJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import {
@@ -28,6 +28,9 @@ import {
   ROLE_AUDIENCE_DERIVATION_SCHEME
 } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const threadRoleProtocolDefinition = asProtocolDefinition(threadRoleProtocolDefinitionJson);
 
 export function testEndToEndScenarios(): void {
   describe('End-to-end Scenarios Spanning Features', () => {

--- a/packages/dwn-sdk-js/tests/scenarios/nested-roles.spec.ts
+++ b/packages/dwn-sdk-js/tests/scenarios/nested-roles.spec.ts
@@ -3,7 +3,7 @@ import type { EventLog } from '../../src/types/subscriptions.js';
 import type { DataStore, MessageStore, ResumableTaskStore } from '../../src/index.js';
 
 import sinon from 'sinon';
-import slackProtocolDefinition from '../vectors/protocol-definitions/slack.json' with { type: 'json' };
+import slackProtocolDefinitionJson from '../vectors/protocol-definitions/slack.json' with { type: 'json' };
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
 import { Dwn } from '../../src/dwn.js';
@@ -14,6 +14,9 @@ import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
 import { RecordsQuery, RecordsRead } from '../../src/index.js';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const slackProtocolDefinition = asProtocolDefinition(slackProtocolDefinitionJson);
 
 export function testNestedRoleScenarios(): void {
   describe('Nested role scenarios', () => {

--- a/packages/dwn-sdk-js/tests/scenarios/subscriptions.spec.ts
+++ b/packages/dwn-sdk-js/tests/scenarios/subscriptions.spec.ts
@@ -7,8 +7,8 @@ import type {
   ResumableTaskStore,
 } from '../../src/index.js';
 
-import freeForAll from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
-import threadProtocol from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
+import freeForAllJson from '../vectors/protocol-definitions/free-for-all.json' with { type: 'json' };
+import threadProtocolJson from '../vectors/protocol-definitions/thread-role.json' with { type: 'json' };
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 
@@ -18,6 +18,10 @@ import { TestEventLog } from '../test-event-stream.js';
 import { TestStores } from '../test-stores.js';
 import { DataStream, Dwn, DwnInterfaceName, DwnMethodName, Jws, Message, PermissionGrant, PermissionsProtocol, Time } from '../../src/index.js';
 import { DidKey, UniversalResolver } from '@enbox/dids';
+import { asProtocolDefinition } from '../utils/protocol-definition.js';
+
+const freeForAll = asProtocolDefinition(freeForAllJson);
+const threadProtocol = asProtocolDefinition(threadProtocolJson);
 
 // NOTE: We use `Poller.pollUntilSuccessOrTimeout` to poll for the expected results.
 // In some cases, the EventLog is a coordinated pub/sub system and the message events are emitted over the network

--- a/packages/dwn-sdk-js/tests/utils/protocol-definition.ts
+++ b/packages/dwn-sdk-js/tests/utils/protocol-definition.ts
@@ -1,0 +1,11 @@
+import type { ProtocolDefinition } from '../../src/index.js';
+
+/**
+ * Cast a JSON-imported protocol-definition vector to `ProtocolDefinition` while keeping its
+ * concrete literal shape. The double-cast is required because `resolveJsonModule` infers arrays
+ * (not the non-empty `$actions` tuple), so `satisfies` cannot express it; centralized here so the
+ * single unsound cast lives in one reviewable place.
+ */
+export function asProtocolDefinition<T>(json: T): ProtocolDefinition & T {
+  return json as unknown as ProtocolDefinition & T;
+}


### PR DESCRIPTION
Fixes #557

## Summary

`ProtocolRuleSet.$actions` (used throughout `ProtocolDefinition.structure`) is
currently typed as `ProtocolActionRule[]`, which accepts `$actions: []` at
compile time. The DWN schema validation, however, rejects an empty actions
array at runtime with `must NOT have fewer than 1 items`. TypeScript therefore
gives no feedback — the error only surfaces at runtime when calling
`protocols.configure()`.

This applies the issue's preferred **Option A**: type `$actions` as a
non-empty tuple so an empty array becomes a compile-time error.

## Change

`packages/dwn-sdk-js/src/types/protocols-types.ts` — one field on
`ProtocolRuleSet`:

```ts
// before
$actions?: ProtocolActionRule[];

// after
$actions?: [ProtocolActionRule, ...ProtocolActionRule[]];
```

(plus a doc comment explaining the intent). The element type is
`ProtocolActionRule`, the existing per-rule type in this package. A non-empty
tuple is still assignable to the `ProtocolRuleSetValue` index-signature union,
so the surrounding type is unchanged. The change is **type-level only** — no
runtime behavior changes.

## Validation

- **Gap reproduced.** A standalone throwaway that imports the real
  `ProtocolRuleSet` and assigns `{ $actions: [] }` compiles cleanly against the
  pre-change type (`tsc` exit 0).
- **Fix confirmed.** After the change, the same assignment is a compile error:

  ```
  error TS2322: Type '[]' is not assignable to type
  '[ProtocolActionRule, ...ProtocolActionRule[]]'.
    Source has 0 element(s) but target requires 1.
  ```

  A valid non-empty definition (`$actions: [{ who: 'anyone', can: ['create'] }]`)
  and omitting `$actions` both still compile.
- **Full build type-checks green.** `bun run build` in `packages/dwn-sdk-js`
  (whose `tsconfig` `include`s `tests/`) completes with zero `tsc` errors.
- **Runtime suite unaffected.** The full store-dependent suite passes
  (`bun test tests/store-dependent-tests.spec.ts` — 784/784), including all the
  handler/feature/scenario specs whose fixtures were touched. The fuzz suite's
  intentional `$actions: []` runtime-rejection case
  (`tests/fuzz/protocol-definition.fuzz.spec.ts`) and
  `tests/interfaces/protocols-configure.spec.ts` both still pass.

## Test suite

Note: this is a type-level breaking change — consumer code that assigns a
general array (a variable, a JSON import, or a `.map()` result, rather than a
fresh inline literal) to `$actions` will need the same cast/annotation the test
fixtures below received.

Tightening `$actions` to a non-empty tuple makes the full `tsc` build (which
`include`s `tests/`) flag test fixtures that produce `$actions` as a plain
array. Those fixtures were updated so `bun run build` passes, without weakening
the tuple guard and with no `src/` changes:

- **JSON protocol-definition vectors** imported with `with { type: 'json' }`:
  `resolveJsonModule` always infers arrays, never tuples. Each imported vector
  is passed through a single shared `asProtocolDefinition` helper (in
  `tests/utils/protocol-definition.ts`) that returns `ProtocolDefinition &
  typeof <vector>Json`, so it is assignable to the tuple while keeping the
  vector's concrete literal shape (required fields such as `types.*.dataFormats`
  that some tests read directly). Centralizing the cast keeps the single
  unsound `as unknown as` in one reviewable place instead of copy-pasted across
  fixtures.
- **Inline definition literals** are given contextual typing via a
  `: ProtocolDefinition` annotation. A valid non-empty `$actions: [ … ]` then
  type-checks and an empty `$actions: []` remains a compile error, so the guard
  still holds at every fixture site.

Intentionally-invalid inputs are left reaching the runtime unchanged — most
notably the fuzz spec's untyped `{ $actions: [] }` case, which still asserts the
DWN runtime rejects it. The changes are type-level only; runtime values and
behavior are unchanged.
