### PR TITLE
refactor(encryption): share sealed audience helpers

### DIFF
--- a/.changeset/soft-seals-tap.md
+++ b/.changeset/soft-seals-tap.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-sdk-js": patch
+"@enbox/agent": patch
+---
+
+refactor: share sealed audience key wrapping and agent read-through helpers

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -11,6 +11,7 @@ import type {
   ProtocolActionRule,
   ProtocolDefinition,
   ProtocolRuleSet,
+  RecordsWriteDescriptor,
   RecordsWriteMessage,
   ReplicationApplyResult,
   RoleAudienceKeyEncryptionInput,
@@ -73,6 +74,7 @@ export { isDwnMessage, isDwnRequest, isMessagesPermissionScope, isRecordPermissi
 
 // Import type guards for internal use
 import { isDwnRequest } from './dwn-type-guards.js';
+import { processDwnRequestWithRemoteFallback as processDwnReadThrough } from './dwn-read-through.js';
 
 // Import extracted encryption functions
 import {
@@ -81,6 +83,7 @@ import {
   createAudienceRecord as createAudienceRecordFn,
   encryptAndComputeCid as encryptAndComputeCidFn,
   generateAudienceKey as generateAudienceKeyFn,
+  getAudienceDecryptionKeyCacheKey,
   getEncryptionKeyDeriver as getEncryptionKeyDeriverFn,
   getEncryptionKeyInfo as getEncryptionKeyInfoFn,
   getKeyDecrypter as getKeyDecrypterFn,
@@ -1037,7 +1040,7 @@ export class AgentDwnApi {
       sealingPublicKey,
       sourceDid         : params.sourceDid,
     });
-    this._audienceDecryptionKeyCache.set(this.getAudienceCacheKey({
+    this._audienceDecryptionKeyCache.set(getAudienceDecryptionKeyCacheKey({
       contextId    : params.contextId,
       keyId        : created.audienceKey.keyId,
       protocol     : params.protocol,
@@ -1122,7 +1125,7 @@ export class AgentDwnApi {
     }
 
     const records = reply.entries as RecordsWriteMessage[];
-    records.sort((left, right): number => this.compareAudienceRecords(params.sourceDid, left, right));
+    records.sort((left, right): number => EncryptionControl.compareAudienceProjectionCandidates(params.sourceDid, left, right));
     for (const record of records) {
       const payload = await this.readAudiencePayload(params.authorDid, params.sourceDid, record);
       if (payload !== undefined) {
@@ -1159,49 +1162,10 @@ export class AgentDwnApi {
     request: ProcessDwnRequest<T>,
     hasUsableReply: (reply: DwnMessageReply[T]) => boolean,
   ): Promise<DwnResponse<T>> {
-    const localResponse = await this.processRequest(request);
-    if (hasUsableReply(localResponse.reply)) {
-      return localResponse;
-    }
-
-    try {
-      return await this.sendRequest(request);
-    } catch (error) {
-      logger.log(
-        `AgentDwnApi: remote fallback for ${request.messageType} to '${request.target}' failed: ` +
-        `${error instanceof Error ? error.message : String(error)}`
-      );
-      return localResponse;
-    }
-  }
-
-  private compareAudienceRecords(tenant: string, left: RecordsWriteMessage, right: RecordsWriteMessage): number {
-    const leftTenantSigned = Message.getSigner(left) === tenant;
-    const rightTenantSigned = Message.getSigner(right) === tenant;
-    if (leftTenantSigned !== rightTenantSigned) {
-      return leftTenantSigned ? -1 : 1;
-    }
-
-    const dateCompare = left.descriptor.dateCreated.localeCompare(right.descriptor.dateCreated);
-    return dateCompare === 0 ? left.recordId.localeCompare(right.recordId) : dateCompare;
-  }
-
-  private getAudienceCacheKey(input: {
-    sourceDid: string;
-    recipientDid: string;
-    protocol: string;
-    contextId: string;
-    rolePath: string;
-    keyId: string;
-  }): string {
-    return `audience-key~${Encoder.stringToBase64Url(JSON.stringify([
-      input.sourceDid,
-      input.recipientDid,
-      input.protocol,
-      input.contextId,
-      input.rolePath,
-      input.keyId,
-    ]))}`;
+    return processDwnReadThrough({
+      process : this.processRequest.bind(this),
+      send    : this.sendRequest.bind(this),
+    }, request, hasUsableReply);
   }
 
   private async getRecipientRolePublicKey(params: {
@@ -1228,6 +1192,21 @@ export class AgentDwnApi {
     }
 
     return publicKeyJwk;
+  }
+
+  private async buildPendingAudienceRecordDescriptor(params: {
+    messageParams: DwnMessageParams[DwnInterface.RecordsWrite];
+    dataCid: string;
+    dataSize: number;
+  }): Promise<RecordsWriteDescriptor> {
+    const descriptorOptions = {
+      ...params.messageParams,
+      dataCid  : params.dataCid,
+      dataSize : params.dataSize,
+    };
+    delete descriptorOptions.data;
+
+    return RecordsWrite.createDescriptor(descriptorOptions);
   }
 
   private async constructDwnMessage<T extends DwnInterface>({ request }: {
@@ -1404,15 +1383,11 @@ export class AgentDwnApi {
           if (request.granteeDid && messageParams.permissionGrantId && !messageParams.delegatedGrant) {
             await this.populateDelegatedGrantForWrite(request.author, request.granteeDid, messageParams);
           }
-          const recordIdMessageParams = { ...messageParams };
-          delete recordIdMessageParams.dataCid;
-          delete recordIdMessageParams.dataSize;
-          messageParams.recordId ??= (await RecordsWrite.create({
-            ...recordIdMessageParams,
-            data   : encryptedBytes,
-            encryptionInput,
-            signer : request.granteeDid ? await this.getSigner(request.granteeDid) : await this.getSigner(request.author),
-          })).message.recordId;
+          messageParams.recordId ??= await RecordsWrite.getEntryId(request.author, await this.buildPendingAudienceRecordDescriptor({
+            dataCid,
+            dataSize,
+            messageParams,
+          }));
 
           for (const pending of roleAudienceInputs.pendingAudienceRecords) {
             const sourceContextId = messageParams.parentContextId === undefined
@@ -1449,7 +1424,7 @@ export class AgentDwnApi {
               sealingPublicKey  : pending.sealingPublicKey,
               sourceDid         : request.target,
             });
-            this._audienceDecryptionKeyCache.set(this.getAudienceCacheKey({
+            this._audienceDecryptionKeyCache.set(getAudienceDecryptionKeyCacheKey({
               contextId,
               keyId        : audienceKey.keyId,
               protocol     : audienceKey.protocol,

--- a/packages/agent/src/dwn-encryption.ts
+++ b/packages/agent/src/dwn-encryption.ts
@@ -17,7 +17,7 @@ import type {
   RecordsWriteMessage,
   RoleAudienceKeyMaterial,
 } from '@enbox/dwn-sdk-js';
-import type { Jwk, KeyIdentifier, PrivateKeyJwk, PublicKeyJwk } from '@enbox/crypto';
+import type { KeyIdentifier, PrivateKeyJwk, PublicKeyJwk } from '@enbox/crypto';
 
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type {
@@ -28,7 +28,6 @@ import type {
 } from './types/dwn.js';
 
 import { logger } from '@enbox/common';
-import { AesKw, Ed25519, Hkdf, X25519 } from '@enbox/crypto';
 import {
   Cid,
   ContentEncryptionAlgorithm,
@@ -38,7 +37,9 @@ import {
   Encoder,
   Encryption,
   ENCRYPTION_CONTROL_AUDIENCE_PATH,
+  ENCRYPTION_CONTROL_AUDIENCE_SCHEMA_URI,
   ENCRYPTION_CONTROL_DELIVERY_PATH,
+  ENCRYPTION_CONTROL_DELIVERY_SCHEMA_URI,
   EncryptionControlDeliveryRecipientAuthority,
   EncryptionProtocol,
   getGrantKeyDeliveryScopes,
@@ -53,21 +54,20 @@ import {
   Message,
   Records,
   ROLE_AUDIENCE_DERIVATION_SCHEME,
+  SEAL_DERIVATION_SCHEME,
   Time,
 } from '@enbox/dwn-sdk-js';
+import { Ed25519, X25519 } from '@enbox/crypto';
 
 import { DwnInterface } from './types/dwn.js';
 import { isDwnRequest } from './dwn-type-guards.js';
+import { processDwnRequestWithRemoteFallback as processDwnReadThrough } from './dwn-read-through.js';
 
 const GRANT_KEY_DERIVATION_PATH = [
   KeyDerivationScheme.ProtocolPath,
   EncryptionProtocol.uri,
   EncryptionProtocol.grantKeyPath,
 ];
-
-const AUDIENCE_SCHEMA_URI = 'https://identity.foundation/dwn/json-schemas/encryption/audience.json';
-const DELIVERY_SCHEMA_URI = 'https://identity.foundation/dwn/json-schemas/encryption/delivery.json';
-const SEAL_DERIVATION_SCHEME = 'seal';
 
 type DelegateDecryptionKeyCache = {
   get(key: string): DelegateDecryptionKeyEntry[] | undefined;
@@ -559,7 +559,7 @@ export async function createAudienceRecord(params: {
       protocol          : params.protocol,
       protocolPath      : ENCRYPTION_CONTROL_AUDIENCE_PATH,
       protocolRole      : params.protocolRole,
-      schema            : AUDIENCE_SCHEMA_URI,
+      schema            : ENCRYPTION_CONTROL_AUDIENCE_SCHEMA_URI,
       dataFormat        : 'application/json',
       dataSize          : payloadBytes.length,
       tags              : {
@@ -668,7 +668,7 @@ export async function createAudienceDeliveryRecord(params: {
       protocol          : params.audienceKey.protocol,
       protocolPath      : ENCRYPTION_CONTROL_DELIVERY_PATH,
       protocolRole      : params.protocolRole,
-      schema            : DELIVERY_SCHEMA_URI,
+      schema            : ENCRYPTION_CONTROL_DELIVERY_SCHEMA_URI,
       dataFormat        : 'application/json',
       dataCid,
       dataSize,
@@ -768,33 +768,19 @@ async function sealAudiencePrivateKey(params: {
   rolePath: string;
   sealingPublicKey: PublicKeyJwk;
 }): Promise<EncryptionControlSeal> {
-  const ephemeralPrivateKey = await X25519.generateKey() as PrivateKeyJwk;
-  const ephemeralPublicKey = await X25519.getPublicKey({ key: ephemeralPrivateKey }) as PublicKeyJwk;
-  const sharedSecret = await X25519.sharedSecret({
-    privateKeyA : ephemeralPrivateKey,
-    publicKeyB  : params.sealingPublicKey as Jwk,
+  return Encryption.wrapSeal({
+    privateKeyBytes : await X25519.privateKeyToBytes({ privateKey: params.privateKeyJwk }),
+    keyInput        : {
+      algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+      audienceKeyId    : params.audienceKeyId,
+      contextId        : params.contextId,
+      derivationScheme : SEAL_DERIVATION_SCHEME,
+      keyId            : await Encryption.getKeyId(params.sealingPublicKey),
+      protocol         : params.protocol,
+      publicKey        : params.sealingPublicKey,
+      rolePath         : params.rolePath,
+    },
   });
-  const kek = await deriveSealKek({
-    audienceKeyId : params.audienceKeyId,
-    contextId     : params.contextId,
-    protocol      : params.protocol,
-    rolePath      : params.rolePath,
-    sharedSecret,
-  });
-  const privateKeyBytes = await X25519.privateKeyToBytes({ privateKey: params.privateKeyJwk });
-  const unwrappedKey = await AesKw.bytesToPrivateKey({ privateKeyBytes });
-  const encryptedKey = await AesKw.wrapKey({
-    encryptionKey: { alg: 'A256KW', k: Encoder.bytesToBase64Url(kek), kty: 'oct' },
-    unwrappedKey,
-  });
-
-  return {
-    algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
-    derivationScheme : SEAL_DERIVATION_SCHEME,
-    encryptedKey     : Encoder.bytesToBase64Url(encryptedKey),
-    ephemeralPublicKey,
-    keyId            : await Encryption.getKeyId(params.sealingPublicKey),
-  };
 }
 
 async function unwrapAudienceSeal(params: {
@@ -805,50 +791,13 @@ async function unwrapAudienceSeal(params: {
   seal: EncryptionControlSeal;
   sealingPrivateKey: PrivateKeyJwk;
 }): Promise<Uint8Array> {
-  const sharedSecret = await X25519.sharedSecret({
-    privateKeyA : params.sealingPrivateKey,
-    publicKeyB  : params.seal.ephemeralPublicKey as Jwk,
-  });
-  const kek = await deriveSealKek({
-    audienceKeyId : params.audienceKeyId,
-    contextId     : params.contextId,
-    protocol      : params.protocol,
-    rolePath      : params.rolePath,
-    sharedSecret,
-  });
-  const unwrappedKey = await AesKw.unwrapKey({
-    decryptionKey       : { alg: 'A256KW', k: Encoder.bytesToBase64Url(kek), kty: 'oct' },
-    wrappedKeyAlgorithm : 'A256KW',
-    wrappedKeyBytes     : Encoder.base64UrlToBytes(params.seal.encryptedKey),
-  });
-
-  return AesKw.privateKeyToBytes({ privateKey: unwrappedKey });
-}
-
-async function deriveSealKek(params: {
-  audienceKeyId: string;
-  contextId: string;
-  protocol: string;
-  rolePath: string;
-  sharedSecret: Uint8Array;
-}): Promise<Uint8Array> {
-  if (params.sharedSecret.every((byte): boolean => byte === 0)) {
-    throw new Error('X25519 shared secret MUST NOT be all zeros.');
-  }
-
-  return Hkdf.deriveKeyBytes({
-    baseKeyBytes : params.sharedSecret,
-    hash         : 'SHA-256',
-    info         : JSON.stringify([
-      KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
-      SEAL_DERIVATION_SCHEME,
-      params.protocol,
-      params.rolePath,
-      params.contextId,
-      params.audienceKeyId,
-    ]),
-    length : 256,
-    salt   : new Uint8Array(),
+  return Encryption.unwrapSeal({
+    audienceKeyId       : params.audienceKeyId,
+    contextId           : params.contextId,
+    protocol            : params.protocol,
+    recipientPrivateKey : params.sealingPrivateKey,
+    rolePath            : params.rolePath,
+    seal                : params.seal,
   });
 }
 
@@ -1369,26 +1318,15 @@ async function getAudienceDeliveryEncryptedData(
   sourceDid: string,
   deliveryMessage: AudienceDeliveryMessage,
 ): Promise<Uint8Array | undefined> {
-  if (deliveryMessage.encodedData !== undefined) {
-    return Encoder.base64UrlToBytes(deliveryMessage.encodedData);
-  }
-
-  const { reply } = await processDwnRequestWithRemoteFallback(agent, {
-    author        : actor.authorDid,
-    granteeDid    : actor.granteeDid,
-    target        : sourceDid,
-    messageType   : DwnInterface.RecordsRead,
-    messageParams : {
-      delegatedGrant : actor.delegatedGrant,
-      filter         : { recordId: deliveryMessage.recordId },
-    },
-  }, hasRecordsReadData);
-
-  if (reply.status.code !== 200 || reply.entry?.data === undefined) {
-    return undefined;
-  }
-
-  return DataStream.toBytes(reply.entry.data);
+  return readRecordDataWithRemoteFallback({
+    agent,
+    authorDid      : actor.authorDid,
+    delegatedGrant : actor.delegatedGrant,
+    encodedData    : deliveryMessage.encodedData,
+    granteeDid     : actor.granteeDid,
+    recordId       : deliveryMessage.recordId,
+    targetDid      : sourceDid,
+  });
 }
 
 async function buildAudienceDeliveryDecrypters(params: {
@@ -1612,22 +1550,13 @@ async function getAudienceRecordData(
   sourceDid: string,
   audienceMessage: RecordsWriteMessage & { encodedData?: string },
 ): Promise<Uint8Array | undefined> {
-  if (audienceMessage.encodedData !== undefined) {
-    return Encoder.base64UrlToBytes(audienceMessage.encodedData);
-  }
-
-  const { reply } = await processDwnRequestWithRemoteFallback(agent, {
-    author        : authorDid,
-    target        : sourceDid,
-    messageType   : DwnInterface.RecordsRead,
-    messageParams : { filter: { recordId: audienceMessage.recordId } },
-  }, hasRecordsReadData);
-
-  if (reply.status.code !== 200 || reply.entry?.data === undefined) {
-    return undefined;
-  }
-
-  return DataStream.toBytes(reply.entry.data);
+  return readRecordDataWithRemoteFallback({
+    agent,
+    authorDid,
+    encodedData : audienceMessage.encodedData,
+    recordId    : audienceMessage.recordId,
+    targetDid   : sourceDid,
+  });
 }
 
 function audiencePayloadMatches(payload: EncryptionControlAudiencePayload, audienceMessage: RecordsWriteMessage, expected: {
@@ -1804,20 +1733,10 @@ async function processDwnRequestWithRemoteFallback<T extends DwnInterface>(
   request: ProcessDwnRequest<T>,
   hasUsableReply: (reply: DwnMessageReply[T]) => boolean,
 ): Promise<DwnResponse<T>> {
-  const localResponse = await agent.processDwnRequest(request);
-  if (hasUsableReply(localResponse.reply)) {
-    return localResponse;
-  }
-
-  try {
-    return await agent.sendDwnRequest(request as SendDwnRequest<T>);
-  } catch (error) {
-    logger.log(
-      `AgentDwnApi: remote fallback for ${request.messageType} to '${request.target}' failed: ` +
-      `${error instanceof Error ? error.message : String(error)}`
-    );
-    return localResponse;
-  }
+  return processDwnReadThrough({
+    process : agent.processDwnRequest.bind(agent),
+    send    : agent.sendDwnRequest.bind(agent),
+  }, request, hasUsableReply);
 }
 
 function hasRecordsQueryEntries(reply: DwnMessageReply[DwnInterface.RecordsQuery]): boolean {
@@ -1826,6 +1745,37 @@ function hasRecordsQueryEntries(reply: DwnMessageReply[DwnInterface.RecordsQuery
 
 function hasRecordsReadData(reply: DwnMessageReply[DwnInterface.RecordsRead]): boolean {
   return reply.status.code === 200 && reply.entry?.data !== undefined;
+}
+
+async function readRecordDataWithRemoteFallback(params: {
+  agent: EnboxPlatformAgent;
+  authorDid: string;
+  targetDid: string;
+  recordId: string;
+  encodedData?: string;
+  granteeDid?: string;
+  delegatedGrant?: DataEncodedRecordsWriteMessage;
+}): Promise<Uint8Array | undefined> {
+  if (params.encodedData !== undefined) {
+    return Encoder.base64UrlToBytes(params.encodedData);
+  }
+
+  const { reply } = await processDwnRequestWithRemoteFallback(params.agent, {
+    author        : params.authorDid,
+    granteeDid    : params.granteeDid,
+    target        : params.targetDid,
+    messageType   : DwnInterface.RecordsRead,
+    messageParams : {
+      delegatedGrant : params.delegatedGrant,
+      filter         : { recordId: params.recordId },
+    },
+  }, hasRecordsReadData);
+
+  if (reply.status.code !== 200 || reply.entry?.data === undefined) {
+    return undefined;
+  }
+
+  return DataStream.toBytes(reply.entry.data);
 }
 
 function hasProtocolsQueryDefinition(reply: DwnMessageReply[DwnInterface.ProtocolsQuery]): boolean {
@@ -1879,7 +1829,7 @@ function putAudienceKeyInMemoryCache(params: {
   params.audienceDecryptionKeyCache?.set?.(cacheKey, params.entry);
 }
 
-function getAudienceDecryptionKeyCacheKey(input: {
+export function getAudienceDecryptionKeyCacheKey(input: {
   sourceDid: string;
   recipientDid: string;
   protocol: string;
@@ -2162,22 +2112,13 @@ async function getGrantKeyEncryptedData(
   grantorDid: string,
   grantKeyMessage: RecordsWriteMessage & { encodedData?: string },
 ): Promise<Uint8Array | undefined> {
-  if (grantKeyMessage.encodedData !== undefined) {
-    return Encoder.base64UrlToBytes(grantKeyMessage.encodedData);
-  }
-
-  const { reply } = await processDwnRequestWithRemoteFallback(agent, {
-    author        : granteeDid,
-    target        : grantorDid,
-    messageType   : DwnInterface.RecordsRead,
-    messageParams : { filter: { recordId: grantKeyMessage.recordId } },
-  }, hasRecordsReadData);
-
-  if (reply.status.code !== 200 || reply.entry?.data === undefined) {
-    return undefined;
-  }
-
-  return DataStream.toBytes(reply.entry.data);
+  return readRecordDataWithRemoteFallback({
+    agent,
+    authorDid   : granteeDid,
+    encodedData : grantKeyMessage.encodedData,
+    recordId    : grantKeyMessage.recordId,
+    targetDid   : grantorDid,
+  });
 }
 
 async function readPermissionGrant(

--- a/packages/agent/src/dwn-read-through.ts
+++ b/packages/agent/src/dwn-read-through.ts
@@ -1,0 +1,39 @@
+import type {
+  DwnInterface,
+  DwnMessageReply,
+  DwnResponse,
+  ProcessDwnRequest,
+  SendDwnRequest,
+} from './types/dwn.js';
+
+import { logger } from '@enbox/common';
+
+export type DwnReadThroughExecutor = {
+  process<T extends DwnInterface>(request: ProcessDwnRequest<T>): Promise<DwnResponse<T>>;
+  send<T extends DwnInterface>(request: SendDwnRequest<T>): Promise<DwnResponse<T>>;
+};
+
+/**
+ * Reads from the local DWN first, then falls through to the remote DWN when the
+ * local reply is well-formed but missing the requested durable dependency.
+ */
+export async function processDwnRequestWithRemoteFallback<T extends DwnInterface>(
+  executor: DwnReadThroughExecutor,
+  request: ProcessDwnRequest<T>,
+  hasUsableReply: (reply: DwnMessageReply[T]) => boolean,
+): Promise<DwnResponse<T>> {
+  const localResponse = await executor.process(request);
+  if (hasUsableReply(localResponse.reply)) {
+    return localResponse;
+  }
+
+  try {
+    return await executor.send(request as SendDwnRequest<T>);
+  } catch (error) {
+    logger.log(
+      `AgentDwnApi: remote fallback for ${request.messageType} to '${request.target}' failed: ` +
+      `${error instanceof Error ? error.message : String(error)}`
+    );
+    return localResponse;
+  }
+}

--- a/packages/agent/tests/dwn-encryption.spec.ts
+++ b/packages/agent/tests/dwn-encryption.spec.ts
@@ -1363,6 +1363,12 @@ describe('dwn-encryption', () => {
             entries : [],
           },
         }),
+        sendDwnRequest: sinon.stub().resolves({
+          reply: {
+            status  : { code: 200, detail: 'OK' },
+            entries : [],
+          },
+        }),
       };
       const delegateCache = {
         get : sinon.stub().returns(undefined),
@@ -1391,6 +1397,7 @@ describe('dwn-encryption', () => {
         protocolPath : EncryptionProtocol.grantKeyPath,
         tags         : { protocol: 'https://proto.example.com' },
       });
+      expect(mockAgent.sendDwnRequest.calledOnce).toBe(true);
       expect(delegateCache.set.called).toBe(false);
       expect(mockAgent.keyManager.getKeyUri.called).toBe(false);
     });

--- a/packages/dwn-sdk-js/src/core/constants.ts
+++ b/packages/dwn-sdk-js/src/core/constants.ts
@@ -37,6 +37,16 @@ export const ENCRYPTION_CONTROL_AUDIENCE_PATH = `${ENCRYPTION_CONTROL_ROOT_PATH}
 export const ENCRYPTION_CONTROL_DELIVERY_PATH = `${ENCRYPTION_CONTROL_ROOT_PATH}/delivery`;
 
 /**
+ * Fixed JSON schema URI for source-protocol audience control records.
+ */
+export const ENCRYPTION_CONTROL_AUDIENCE_SCHEMA_URI = 'https://identity.foundation/dwn/json-schemas/encryption/audience.json';
+
+/**
+ * Fixed JSON schema URI for source-protocol delivery control records.
+ */
+export const ENCRYPTION_CONTROL_DELIVERY_SCHEMA_URI = 'https://identity.foundation/dwn/json-schemas/encryption/delivery.json';
+
+/**
  * Reserved encryption control protocol paths.
  */
 export const ENCRYPTION_CONTROL_PATHS = [

--- a/packages/dwn-sdk-js/src/core/encryption-control.ts
+++ b/packages/dwn-sdk-js/src/core/encryption-control.ts
@@ -1197,7 +1197,7 @@ export class EncryptionControl {
     return { protocol, rolePath, contextId };
   }
 
-  private static compareAudienceProjectionCandidates(
+  public static compareAudienceProjectionCandidates(
     tenant: string,
     left: RecordsWriteMessage,
     right: RecordsWriteMessage,

--- a/packages/dwn-sdk-js/src/index.ts
+++ b/packages/dwn-sdk-js/src/index.ts
@@ -19,7 +19,9 @@ export { CoreProtocolRegistry } from './core/core-protocol.js';
 export { EncryptionControl } from './core/encryption-control.js';
 export {
   ENCRYPTION_CONTROL_AUDIENCE_PATH,
+  ENCRYPTION_CONTROL_AUDIENCE_SCHEMA_URI,
   ENCRYPTION_CONTROL_DELIVERY_PATH,
+  ENCRYPTION_CONTROL_DELIVERY_SCHEMA_URI,
   ENCRYPTION_CONTROL_PATHS,
   ENCRYPTION_CONTROL_ROOT_PATH,
   ENCRYPTION_PROTOCOL_URI,
@@ -51,7 +53,7 @@ export { DwnInterfaceName, DwnMethodName } from './enums/dwn-interface-method.js
 export { Encoder } from './utils/encoder.js';
 export { MessagesSubscribe } from './interfaces/messages-subscribe.js';
 export type { MessagesSubscribeOptions } from './interfaces/messages-subscribe.js';
-export { Encryption, ContentEncryptionAlgorithm, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME } from './utils/encryption.js';
+export { Encryption, ContentEncryptionAlgorithm, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME, SEAL_DERIVATION_SCHEME } from './utils/encryption.js';
 export type {
   DwnEncryption,
   KeyUnwrapPayload,
@@ -59,6 +61,10 @@ export type {
   ProtocolPathKeyEncryptionInput,
   RoleAudienceKeyEncryption,
   RoleAudienceKeyEncryptionInput,
+  SealKeyWrap,
+  SealKeyWrapInput,
+  SealUnwrapInput,
+  SealWrapInput,
   X25519KeyEncryption,
   X25519KeyEncryptionInput,
   X25519KeyWrapInput,
@@ -122,7 +128,6 @@ export type {
   RoleAudienceKeyId,
   RoleAudienceKeyMaterial,
   RoleAudienceTuple,
-  X25519KeyWrap,
 } from './types/encryption-types.js';
 export { EncryptionControlDeliveryRecipientAuthority } from './types/encryption-types.js';
 export { Time } from './utils/time.js';

--- a/packages/dwn-sdk-js/src/interfaces/records-write.ts
+++ b/packages/dwn-sdk-js/src/interfaces/records-write.ts
@@ -301,45 +301,8 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
    *                                If not given, it means this write is for a root protocol record.
    */
   public static async create(options: RecordsWriteOptions): Promise<RecordsWrite> {
-    RecordsWrite.validateCreateOptions(options);
-
-    const dataCid = options.dataCid ?? await Cid.computeDagPbCidFromBytes(options.data!);
-    const dataSize = options.dataSize ?? options.data!.length;
-
-    const currentTime = Time.getCurrentTimestamp();
-    const permissionGrantInvocation = Message.normalizePermissionGrantInvocation({
-      permissionGrantId: options.permissionGrantId,
-    });
-
-    const descriptor: RecordsWriteDescriptor = {
-      interface        : DwnInterfaceName.Records,
-      method           : DwnMethodName.Write,
-      protocol         : normalizeProtocolUrl(options.protocol),
-      protocolPath     : options.protocolPath,
-      recipient        : options.recipient,
-      schema           : options.schema === undefined ? undefined : normalizeSchemaUrl(options.schema),
-      tags             : options.tags,
-      parentId         : RecordsWrite.getRecordIdFromContextId(options.parentContextId),
-      dataCid,
-      dataSize,
-      dateCreated      : options.dateCreated ?? currentTime,
-      messageTimestamp : options.messageTimestamp ?? currentTime,
-      published        : options.published,
-      datePublished    : options.datePublished,
-      dataFormat       : options.dataFormat,
-      squash           : options.squash,
-      ...permissionGrantInvocation,
-    };
-
-    // generate `datePublished` if the message is to be published but `datePublished` is not given
-    if (options.published === true &&
-      options.datePublished === undefined) {
-      descriptor.datePublished = currentTime;
-    }
-
-    // delete all descriptor properties that are `undefined` else the code will encounter the following IPLD issue when attempting to generate CID:
-    // Error: `undefined` is not supported by the IPLD Data Model and cannot be encoded
-    removeUndefinedProperties(descriptor);
+    RecordsWrite.validateCreateOptions(options, { requireSignerForDelegatedGrant: true });
+    const descriptor = await RecordsWrite.createDescriptor(options);
 
     // `recordId` computation
     const recordId = options.recordId;
@@ -350,6 +313,9 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
 
     // `encryption` generation
     const encryption = options.encryption ?? await createEncryptionProperty(options.encryptionInput);
+    const permissionGrantInvocation = Message.normalizePermissionGrantInvocation({
+      permissionGrantId: options.permissionGrantId,
+    });
 
     const message: InternalRecordsWriteMessage = {
       recordId,
@@ -374,7 +340,47 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
     return recordsWrite;
   }
 
-  private static validateCreateOptions(options: RecordsWriteOptions): void {
+  /**
+   * Creates the descriptor that determines a RecordsWrite entry id without signing the message.
+   */
+  public static async createDescriptor(options: RecordsWriteOptions): Promise<RecordsWriteDescriptor> {
+    RecordsWrite.validateCreateOptions(options, { requireSignerForDelegatedGrant: false });
+
+    const dataCid = options.dataCid ?? await Cid.computeDagPbCidFromBytes(options.data!);
+    const dataSize = options.dataSize ?? options.data!.length;
+    const currentTime = Time.getCurrentTimestamp();
+    const permissionGrantInvocation = Message.normalizePermissionGrantInvocation({
+      permissionGrantId: options.permissionGrantId,
+    });
+    const descriptor: RecordsWriteDescriptor = {
+      interface        : DwnInterfaceName.Records,
+      method           : DwnMethodName.Write,
+      protocol         : normalizeProtocolUrl(options.protocol),
+      protocolPath     : options.protocolPath,
+      recipient        : options.recipient,
+      schema           : options.schema === undefined ? undefined : normalizeSchemaUrl(options.schema),
+      tags             : options.tags,
+      parentId         : RecordsWrite.getRecordIdFromContextId(options.parentContextId),
+      dataCid,
+      dataSize,
+      dateCreated      : options.dateCreated ?? currentTime,
+      messageTimestamp : options.messageTimestamp ?? currentTime,
+      published        : options.published,
+      datePublished    : options.datePublished,
+      dataFormat       : options.dataFormat,
+      squash           : options.squash,
+      ...permissionGrantInvocation,
+    };
+
+    if (options.published === true && options.datePublished === undefined) {
+      descriptor.datePublished = currentTime;
+    }
+
+    removeUndefinedProperties(descriptor);
+    return descriptor;
+  }
+
+  private static validateCreateOptions(options: RecordsWriteOptions, optionsOverrides: { requireSignerForDelegatedGrant: boolean }): void {
     if (options.protocol === undefined || options.protocolPath === undefined) {
       throw new DwnError(DwnErrorCode.RecordsWriteCreateMissingProtocol, '`protocol` and `protocolPath` are required');
     }
@@ -389,7 +395,7 @@ export class RecordsWrite implements MessageInterface<RecordsWriteMessage> {
       throw new DwnError(DwnErrorCode.RecordsWriteCreateDataCidAndDataSizeMutuallyInclusive, '`dataCid` and `dataSize` must both be defined or undefined at the same time');
     }
 
-    if (options.signer === undefined && options.delegatedGrant !== undefined) {
+    if (optionsOverrides.requireSignerForDelegatedGrant && options.signer === undefined && options.delegatedGrant !== undefined) {
       throw new DwnError(DwnErrorCode.RecordsWriteCreateMissingSigner, '`signer` must be given when `delegatedGrant` is given');
     }
 

--- a/packages/dwn-sdk-js/src/types/encryption-types.ts
+++ b/packages/dwn-sdk-js/src/types/encryption-types.ts
@@ -1,5 +1,5 @@
 import type { KeyDerivationScheme } from '../utils/hd-key.js';
-import type { KeyUnwrapPayload } from '../utils/encryption.js';
+import type { KeyUnwrapPayload, SealKeyWrap } from '../utils/encryption.js';
 import type { PrivateKeyJwk, PublicKeyJwk } from './jose-types.js';
 
 export type RoleAudienceTuple = {
@@ -20,16 +20,7 @@ export type EncryptionControlDeliveryTags = RoleAudienceKeyId & {
   recipientAuthority: EncryptionControlDeliveryRecipientAuthority | `${EncryptionControlDeliveryRecipientAuthority}`;
 };
 
-export type X25519KeyWrap = {
-  algorithm: 'X25519-HKDF-SHA256+A256KW';
-  keyId: string;
-  ephemeralPublicKey: PublicKeyJwk;
-  encryptedKey: string;
-};
-
-export type EncryptionControlSeal = X25519KeyWrap & {
-  derivationScheme: 'seal';
-};
+export type EncryptionControlSeal = SealKeyWrap;
 
 export type EncryptionControlAudiencePayload = RoleAudienceKeyId & {
   publicKeyJwk: PublicKeyJwk;

--- a/packages/dwn-sdk-js/src/utils/encryption.ts
+++ b/packages/dwn-sdk-js/src/utils/encryption.ts
@@ -16,6 +16,7 @@ export enum KeyAgreementAlgorithm {
 }
 
 export const ROLE_AUDIENCE_DERIVATION_SCHEME = 'roleAudience';
+export const SEAL_DERIVATION_SCHEME = 'seal';
 
 const AES_256_KEY_LENGTH_BYTES = 32;
 const AES_CTR_COUNTER_LENGTH_BYTES = 16;
@@ -63,6 +64,10 @@ export type RoleAudienceKeyEncryption = SourceRoleAudienceKeyEncryption | Legacy
 
 export type X25519KeyEncryption = ProtocolPathKeyEncryption | RoleAudienceKeyEncryption;
 
+export type SealKeyWrap = X25519KeyEncryptionBase & {
+  derivationScheme: typeof SEAL_DERIVATION_SCHEME;
+};
+
 export type DwnEncryption = {
   algorithm: ContentEncryptionAlgorithm.A256CTR;
   initializationVector: string;
@@ -96,6 +101,14 @@ export type RoleAudienceKeyEncryptionInput = SourceRoleAudienceKeyEncryptionInpu
 
 export type X25519KeyEncryptionInput = ProtocolPathKeyEncryptionInput | RoleAudienceKeyEncryptionInput;
 
+export type SealKeyWrapInput = X25519KeyEncryptionInputBase & {
+  derivationScheme: typeof SEAL_DERIVATION_SCHEME;
+  protocol: string;
+  rolePath: string;
+  contextId: string;
+  audienceKeyId: string;
+};
+
 export type EncryptionInput = {
   algorithm?: ContentEncryptionAlgorithm;
   key: Uint8Array;
@@ -114,6 +127,34 @@ export type X25519KeyWrapInput = {
   keyInput: X25519KeyEncryptionInput;
   ephemeralPrivateKey?: Jwk;
 };
+
+export type SealWrapInput = {
+  privateKeyBytes: Uint8Array;
+  keyInput: SealKeyWrapInput;
+  ephemeralPrivateKey?: Jwk;
+};
+
+export type SealUnwrapInput = {
+  seal: SealKeyWrap;
+  recipientPrivateKey: Jwk;
+  protocol: string;
+  rolePath: string;
+  contextId: string;
+  audienceKeyId: string;
+};
+
+type SealKeyUnwrapInfo = SealKeyWrap & {
+  protocol: string;
+  rolePath: string;
+  contextId: string;
+  audienceKeyId: string;
+};
+
+type X25519KekDerivationInput =
+  | X25519KeyEncryptionInput
+  | X25519KeyEncryption
+  | SealKeyWrapInput
+  | SealKeyUnwrapInfo;
 
 export class Encryption {
   public static async encrypt(
@@ -176,6 +217,35 @@ export class Encryption {
     throw new Error(Encryption.unsupportedKeyAgreementAlgorithmMessage(input.keyInput.algorithm));
   }
 
+  public static async wrapSeal(input: SealWrapInput): Promise<SealKeyWrap> {
+    if (!Encryption.isX25519KeyAgreementAlgorithm(input.keyInput.algorithm)) {
+      throw new Error(Encryption.unsupportedKeyAgreementAlgorithmMessage(input.keyInput.algorithm));
+    }
+
+    Encryption.validateContentEncryptionKey(input.privateKeyBytes);
+
+    const privateKey = input.ephemeralPrivateKey ?? await X25519.generateKey();
+    const publicKey = await X25519.getPublicKey({ key: privateKey }) as PublicKeyJwk;
+    const sharedSecret = await X25519.sharedSecret({
+      privateKeyA : privateKey,
+      publicKeyB  : input.keyInput.publicKey as Jwk,
+    });
+    const kek = await Encryption.deriveKek(sharedSecret, input.keyInput);
+    const unwrappedKey = await AesKw.bytesToPrivateKey({ privateKeyBytes: input.privateKeyBytes });
+    const encryptedKey = await AesKw.wrapKey({
+      encryptionKey: Encryption.toA256KwJwk(kek),
+      unwrappedKey,
+    });
+
+    return {
+      algorithm          : input.keyInput.algorithm,
+      derivationScheme   : SEAL_DERIVATION_SCHEME,
+      encryptedKey       : Encoder.bytesToBase64Url(encryptedKey),
+      ephemeralPublicKey : publicKey,
+      keyId              : input.keyInput.keyId,
+    };
+  }
+
   private static async wrapX25519Key(input: X25519KeyWrapInput): Promise<{ encryptedKey: Uint8Array; ephemeralPublicKey: PublicKeyJwk }> {
     Encryption.validateContentEncryptionKey(input.cek);
 
@@ -202,6 +272,32 @@ export class Encryption {
     }
 
     throw new Error(Encryption.unsupportedKeyAgreementAlgorithmMessage(keyEncryption.algorithm));
+  }
+
+  public static async unwrapSeal(input: SealUnwrapInput): Promise<Uint8Array> {
+    if (!Encryption.isX25519KeyAgreementAlgorithm(input.seal.algorithm)) {
+      throw new Error(Encryption.unsupportedKeyAgreementAlgorithmMessage(input.seal.algorithm));
+    }
+
+    const keyEncryption: SealKeyUnwrapInfo = {
+      ...input.seal,
+      audienceKeyId : input.audienceKeyId,
+      contextId     : input.contextId,
+      protocol      : input.protocol,
+      rolePath      : input.rolePath,
+    };
+    const sharedSecret = await X25519.sharedSecret({
+      privateKeyA : input.recipientPrivateKey,
+      publicKeyB  : input.seal.ephemeralPublicKey as Jwk,
+    });
+    const kek = await Encryption.deriveKek(sharedSecret, keyEncryption);
+    const unwrappedKey = await AesKw.unwrapKey({
+      decryptionKey       : Encryption.toA256KwJwk(kek),
+      wrappedKeyAlgorithm : 'A256KW',
+      wrappedKeyBytes     : Encoder.base64UrlToBytes(input.seal.encryptedKey),
+    });
+
+    return AesKw.privateKeyToBytes({ privateKey: unwrappedKey });
   }
 
   private static async unwrapX25519Key(
@@ -320,7 +416,7 @@ export class Encryption {
 
   private static async deriveKek(
     sharedSecret: Uint8Array,
-    keyEncryption: X25519KeyEncryptionInput | X25519KeyEncryption,
+    keyEncryption: X25519KekDerivationInput,
   ): Promise<Uint8Array> {
     Encryption.validateSharedSecret(sharedSecret);
     const info = Encryption.getKekInfo(keyEncryption);
@@ -333,7 +429,18 @@ export class Encryption {
     });
   }
 
-  private static getKekInfo(keyEncryption: X25519KeyEncryptionInput | X25519KeyEncryption): string {
+  private static getKekInfo(keyEncryption: X25519KekDerivationInput): string {
+    if (keyEncryption.derivationScheme === SEAL_DERIVATION_SCHEME) {
+      return JSON.stringify([
+        KEK_INFO_PREFIX,
+        SEAL_DERIVATION_SCHEME,
+        keyEncryption.protocol,
+        keyEncryption.rolePath,
+        keyEncryption.contextId,
+        keyEncryption.audienceKeyId,
+      ]);
+    }
+
     if (keyEncryption.derivationScheme === ROLE_AUDIENCE_DERIVATION_SCHEME) {
       if ('rolePath' in keyEncryption) {
         return JSON.stringify([
@@ -396,6 +503,10 @@ export class Encryption {
 
   private static toA256CtrJwk(keyBytes: Uint8Array): Jwk {
     return { alg: ContentEncryptionAlgorithm.A256CTR, k: Encoder.bytesToBase64Url(keyBytes), kty: 'oct' };
+  }
+
+  private static toA256KwJwk(keyBytes: Uint8Array): Jwk {
+    return { alg: 'A256KW', k: Encoder.bytesToBase64Url(keyBytes), kty: 'oct' };
   }
 
   private static async readStream(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {

--- a/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
+++ b/packages/dwn-sdk-js/tests/interfaces/records-write.spec.ts
@@ -640,6 +640,43 @@ describe('RecordsWrite', () => {
       const author = undefined;
       await expect(RecordsWrite.getEntryId(author, message.descriptor)).rejects.toThrow(DwnErrorCode.RecordsWriteGetEntryIdUndefinedAuthor);
     });
+
+    it('should compute the signed record id from an unsigned descriptor', async () => {
+      const alice = await TestDataGenerator.generatePersona();
+      const bob = await TestDataGenerator.generatePersona();
+      const scope: PermissionScope = {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Write,
+        protocol  : 'chat'
+      };
+      const grantToBob = await PermissionsProtocol.createGrant({
+        signer      : Jws.createSigner(alice),
+        delegated   : true,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 100 }),
+        description : 'Allow Bob to write as me in chat protocol',
+        grantedTo   : bob.did,
+        scope
+      });
+      const options: RecordsWriteOptions = {
+        delegatedGrant   : grantToBob.dataEncodedMessage,
+        data             : TestDataGenerator.randomBytes(10),
+        dataFormat       : 'application/octet-stream',
+        dateCreated      : '2024-03-01T00:00:00.000000Z',
+        messageTimestamp : '2024-03-01T00:00:00.000000Z',
+        protocol         : 'http://test-protocol.xyz',
+        protocolPath     : 'testRecord',
+        signer           : Jws.createSigner(bob),
+      };
+
+      const descriptor = await RecordsWrite.createDescriptor({
+        ...options,
+        signer: undefined,
+      });
+      const signedWrite = await RecordsWrite.create(options);
+      const descriptorEntryId = await RecordsWrite.getEntryId(alice.did, descriptor);
+
+      expect(descriptorEntryId).toBe(signedWrite.message.recordId);
+    });
   });
 
   describe('signAsOwner()', () => {

--- a/packages/dwn-sdk-js/tests/utils/encryption.spec.ts
+++ b/packages/dwn-sdk-js/tests/utils/encryption.spec.ts
@@ -12,7 +12,7 @@ import { KeyDerivationScheme } from '../../src/utils/hd-key.js';
 import { Records } from '../../src/utils/records.js';
 import { TestDataGenerator } from './test-data-generator.js';
 import { X25519 } from '@enbox/crypto';
-import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME } from '../../src/utils/encryption.js';
+import { ContentEncryptionAlgorithm, Encryption, KeyAgreementAlgorithm, ROLE_AUDIENCE_DERIVATION_SCHEME, SEAL_DERIVATION_SCHEME } from '../../src/utils/encryption.js';
 import { describe, expect, it } from 'bun:test';
 
 const boundarySizes = [0, 1, 15, 16, 17, 32, 256];
@@ -230,6 +230,78 @@ describe('Encryption', () => {
       expect(ArrayUtility.byteArraysEqual(unwrapped2, cek)).toBe(true);
     });
 
+    it('should produce and open the sealed-audience-key fixture byte-for-byte', async () => {
+      const protocol = 'https://example.org/protocols/seal-fixture';
+      const rolePath = 'chat/member';
+      const contextId = 'root/thread';
+      const audienceKeyId = 'wGUj0R5Q0vED7B2EW4GFOCqJB1XXTPm6pIjixu2psL4';
+      const sealingKeyId = 'qKpn4plbkMfU3yWDjgvuQc0qGzvQJn031umInc0PnAE';
+      const sealingPrivateKey = {
+        crv : 'X25519',
+        d   : 'yFNS7zIsSPFOsaR5iTELRuAGRB7X0V_XaNE_XYU7yUY',
+        kty : 'OKP',
+        x   : '0Zf6pn0EvFNFTIoiZ8Krr36DkI3_dBrF5pBt2mC3CkM',
+      } as PrivateKeyJwk;
+      const sealingPublicKey = {
+        crv : 'X25519',
+        kty : 'OKP',
+        x   : '0Zf6pn0EvFNFTIoiZ8Krr36DkI3_dBrF5pBt2mC3CkM',
+      } as PublicKeyJwk;
+      const audiencePrivateKey = {
+        crv : 'X25519',
+        d   : '6MxyxL2s6wN4BygLw9kQqGV_nbzJnK8nPdkH2aOKiVw',
+        kty : 'OKP',
+        x   : '7OUu7CaMaUI0bEoF4m2yDnltlSF0FYbKNrY1odGnOHg',
+      } as PrivateKeyJwk;
+      const ephemeralPrivateKey = {
+        crv : 'X25519',
+        d   : 'cD9R8nGxWVe0P55JXcNm7skbIcsUztLsDcyxkMhyaF0',
+        kty : 'OKP',
+        x   : '-6WJjols0E4zpawS9S2povLwkpYNUcwGEXD2YSvD7Bc',
+      } as PrivateKeyJwk;
+      const ephemeralPublicKey = {
+        crv : 'X25519',
+        kid : '9tOb183nLY8lW1KtH-g7ou7lWYt6HC2yU5BnI8NRofs',
+        kty : 'OKP',
+        x   : '-6WJjols0E4zpawS9S2povLwkpYNUcwGEXD2YSvD7Bc',
+      } as PublicKeyJwk;
+      const audiencePrivateKeyBytes = await X25519.privateKeyToBytes({ privateKey: audiencePrivateKey });
+
+      const seal = await Encryption.wrapSeal({
+        ephemeralPrivateKey,
+        privateKeyBytes : audiencePrivateKeyBytes,
+        keyInput        : {
+          algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+          audienceKeyId,
+          contextId,
+          derivationScheme : SEAL_DERIVATION_SCHEME,
+          keyId            : sealingKeyId,
+          protocol,
+          publicKey        : sealingPublicKey,
+          rolePath,
+        },
+      });
+
+      expect(seal).toEqual({
+        algorithm        : KeyAgreementAlgorithm.X25519HkdfSha256A256Kw,
+        derivationScheme : SEAL_DERIVATION_SCHEME,
+        encryptedKey     : 'BNdM94UG2spUEF_dANHbBbfMHDqkq2-liqIion2nEGeKr87fQMnYLg',
+        ephemeralPublicKey,
+        keyId            : sealingKeyId,
+      });
+
+      const unwrappedPrivateKeyBytes = await Encryption.unwrapSeal({
+        audienceKeyId,
+        contextId,
+        protocol,
+        recipientPrivateKey: sealingPrivateKey,
+        rolePath,
+        seal,
+      });
+
+      expect(ArrayUtility.byteArraysEqual(unwrappedPrivateKeyBytes, audiencePrivateKeyBytes)).toBe(true);
+    });
+
     it('should reject unsupported key agreement algorithms', async () => {
       const recipientPrivateKey = await X25519.generateKey();
       const recipientPublicKey = await X25519.getPublicKey({ key: recipientPrivateKey }) as PublicKeyJwk;
@@ -264,6 +336,33 @@ describe('Encryption', () => {
       } as unknown as Parameters<typeof Encryption.unwrapKey>[1];
 
       await expect(Encryption.unwrapKey(recipientPrivateKey, unsupportedKeyEncryption)).rejects.toThrow(unsupportedMessage);
+      const unsupportedSealInput = {
+        algorithm        : unsupportedAlgorithm,
+        audienceKeyId    : keyId,
+        contextId        : 'context',
+        derivationScheme : SEAL_DERIVATION_SCHEME,
+        keyId,
+        protocol         : 'https://example.com/protocol',
+        publicKey        : recipientPublicKey,
+        rolePath         : 'member',
+      } as unknown as Parameters<typeof Encryption.wrapSeal>[0]['keyInput'];
+      await expect(Encryption.wrapSeal({ privateKeyBytes: cek, keyInput: unsupportedSealInput })).rejects.toThrow(unsupportedMessage);
+
+      const unsupportedSeal = {
+        algorithm          : unsupportedAlgorithm,
+        derivationScheme   : SEAL_DERIVATION_SCHEME,
+        encryptedKey       : Encoder.bytesToBase64Url(wrappedKey.encryptedKey),
+        ephemeralPublicKey : wrappedKey.ephemeralPublicKey,
+        keyId,
+      } as unknown as Parameters<typeof Encryption.unwrapSeal>[0]['seal'];
+      await expect(Encryption.unwrapSeal({
+        audienceKeyId       : keyId,
+        contextId           : 'context',
+        protocol            : 'https://example.com/protocol',
+        recipientPrivateKey : recipientPrivateKey,
+        rolePath            : 'member',
+        seal                : unsupportedSeal,
+      })).rejects.toThrow(unsupportedMessage);
       expect(() => Encryption.validateEncryptionProperty({
         algorithm            : ContentEncryptionAlgorithm.A256CTR,
         initializationVector : Encoder.bytesToBase64Url(TestDataGenerator.randomBytes(16)),


### PR DESCRIPTION
## Summary
- move sealed audience key wrap/unwrap into the dwn-sdk-js Encryption utilities with shared schema constants
- compute pending-audience RecordsWrite IDs from an unsigned descriptor instead of signing a throwaway write
- share agent DWN read-through, record-data fetch, audience-cache key, and projection comparator helpers

## Test plan
- [x] bun run lint
- [x] bun run --filter @enbox/dwn-sdk-js build && bun run --filter @enbox/agent build
- [x] cd packages/dwn-sdk-js && bun run test:node
- [x] cd packages/agent && DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node

Note: the clean full agent run used a local DWN server with request rate limits disabled to avoid local test-environment throttling.