### PR TITLE
fix(changesets): keep pending bumps patch-only

### DIFF
--- a/.changeset/browser-entrypoints-no-shims.md
+++ b/.changeset/browser-entrypoints-no-shims.md
@@ -1,7 +1,7 @@
 ---
-"@enbox/agent": minor
+"@enbox/agent": patch
 "@enbox/api": patch
-"@enbox/auth": minor
+"@enbox/auth": patch
 "@enbox/browser": patch
 "@enbox/dids": patch
 ---


### PR DESCRIPTION
## Summary
- change the pending browser entrypoint changeset from minor to patch for `@enbox/agent` and `@enbox/auth`
- confirm Changesets now reports patch-only bumps

## Test plan
- [x] `bun run changeset status --since origin/main`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test tests/sync-engine-level.spec.ts -t 'synchronizes records for 1 identity from remote DWN to local DWN'`
- [x] `DID_DHT_GATEWAY_URI=http://localhost:7527 DID_DHT_ALLOW_PRIVATE_GATEWAY=1 bun run test:node` from `packages/agent` with local DWN server rate limits disabled
