### PR TITLE
feat(cli): add relay connect handler

### DIFF
--- a/.changeset/cli-connect-relay.md
+++ b/.changeset/cli-connect-relay.md
@@ -1,0 +1,7 @@
+---
+"@enbox/agent": patch
+"@enbox/auth": patch
+"@enbox/cli": minor
+---
+
+feat: add a CLI relay connect handler package

--- a/.changeset/cli-connect-relay.md
+++ b/.changeset/cli-connect-relay.md
@@ -1,7 +1,7 @@
 ---
 "@enbox/agent": patch
 "@enbox/auth": patch
-"@enbox/cli": minor
+"@enbox/cli": patch
 ---
 
 feat: add a CLI relay connect handler package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Enbox is a **Bun** monorepo for **Decentralized Web Nodes (DWN)**, **DIDs** (`di
 
 - A spec-aligned **DWN engine** (`@enbox/dwn-sdk-js`) and **SQL-backed stores** (`@enbox/dwn-sql-store`).
 - A production-style **DWN server** (`@enbox/dwn-server`) with HTTP/WebSocket APIs, registration, and admin features.
-- **Client libraries**: low-level DWN clients (`@enbox/dwn-clients`), an **agent** with encrypted vault and DWN-backed stores (`@enbox/agent`), **headless auth** (`@enbox/auth`), a **high-level SDK** (`@enbox/api`), and **browser helpers** (`@enbox/browser`).
+- **Client libraries**: low-level DWN clients (`@enbox/dwn-clients`), an **agent** with encrypted vault and DWN-backed stores (`@enbox/agent`), **headless auth** (`@enbox/auth`), a **high-level SDK** (`@enbox/api`), **browser helpers** (`@enbox/browser`), and **CLI helpers** (`@enbox/cli`).
 - **Shared protocol definitions** (`@enbox/protocols`) and optional **codegen** (`@enbox/protocol-codegen`).
 - **`apps/docs`**: the public documentation site (Fumadocs + Next.js); it uses its own linter (Biome), not the ESLint graph used by packages.
 
@@ -128,6 +128,7 @@ Published / primary packages live under `packages/`. Root `package.json` lists a
 | `@enbox/auth` | `AuthManager`, sessions, password/connect flows, storage adapters |
 | `@enbox/api` | App-facing SDK; composes agent + auth |
 | `@enbox/browser` | Browser connect handlers and DWeb wiring (builds on agent, api, auth) |
+| `@enbox/cli` | Terminal connect handlers and CLI entrypoint helpers (builds on agent, api, auth) |
 | `@enbox/protocols` | Reusable protocol definitions for the ecosystem |
 | `@enbox/protocol-codegen` | CLI to generate TS from schemas / protocols |
 | `@enbox/dwn-server-admin-ui` | Bundled Preact admin UI assets for the server |
@@ -150,6 +151,7 @@ Core stack (simplified — follow `workspace:*` in each `package.json` for exact
               @enbox/api (high-level app SDK — uses agent + auth + dwn-clients)
                 @enbox/protocols (published protocol definitions — uses api + dwn-sdk-js)
                 @enbox/browser (BrowserConnectHandler, DWeb connect UI helpers — uses agent + api + auth + dids)
+                @enbox/cli (CliConnectHandler, terminal helpers — uses agent + api + auth)
 ```
 
 Notes on the graph:
@@ -157,6 +159,7 @@ Notes on the graph:
 - `@enbox/agent` does **not** depend on `@enbox/dwn-sql-store`; only `@enbox/dwn-server` does. The agent talks to a DWN over `@enbox/dwn-clients`.
 - `@enbox/auth` depends directly on `@enbox/agent`, `@enbox/dwn-sdk-js`, and `@enbox/dwn-clients` (plus `common`/`crypto`/`dids`).
 - `@enbox/browser` composes `agent` + `api` + `auth` + `dids`; it does not pull in `dwn-server` or `dwn-sql-store`.
+- `@enbox/cli` composes `agent` + `api` + `auth` with Node/Bun-only terminal dependencies; it does not expose a browser bundle.
 
 Build from the bottom up. If you change `dwn-sdk-js`, rebuild it before building `agent`:
 
@@ -170,7 +173,7 @@ Most packages expose a `build:browser` script, but it means different things:
 - **`@enbox/agent`**, **`@enbox/api`**, **`@enbox/auth`**, and **`@enbox/browser`** emit bundled `dist/browser.mjs` artifacts via `build/browser-bundle.js` (esbuild). `agent`, `api`, and `browser` expose those artifacts from their browser-conditioned root exports; `auth` exposes its browser-safe surface from `@enbox/auth/browser` and from the root browser condition.
 - **`@enbox/common`**, **`@enbox/crypto`**, and **`@enbox/dids`** expose `build:browser` for their browser bundle artifacts.
 - **`@enbox/dwn-sdk-js`** emits `dist/browser.mjs` via its `bundle` script, not a `build:browser` script.
-- **`@enbox/dwn-clients`**, **`@enbox/dwn-server`**, **`@enbox/dwn-sql-store`**, **`@enbox/protocols`**, and **`@enbox/protocol-codegen`** do not define `build:browser`.
+- **`@enbox/cli`**, **`@enbox/dwn-clients`**, **`@enbox/dwn-server`**, **`@enbox/dwn-sql-store`**, **`@enbox/protocols`**, and **`@enbox/protocol-codegen`** do not define `build:browser`.
 
 Browser storage rule: do not replace the browser Level stack with SQLite or in-memory stores. In browsers, `level` resolves to `browser-level` over IndexedDB, which is required for concurrent writes from tabs, workers, and service workers on the same origin.
 
@@ -190,6 +193,7 @@ Browser storage rule: do not replace the browser Level stack with SQLite or in-m
 | `packages/dwn-sdk-js/json-schemas/` | JSON Schema definitions for DWN messages |
 | `packages/dwn-clients/src/` | DWN client transport / JSON-RPC |
 | `packages/auth/src/` | `AuthManager`, storage adapters, connect and discovery helpers |
+| `packages/cli/src/` | CLI connect handler and terminal wallet approval helpers |
 | `packages/protocols/src/` | Shared protocol definitions consumed by apps |
 | `packages/protocol-codegen/src/` | Codegen CLI implementation |
 | `packages/dwn-server-admin-ui/` | Admin UI bundle source and build scripts |
@@ -222,6 +226,7 @@ When changing public APIs, assume **multiple external apps** pin different semve
 | Agent vault, DWN-backed stores, sync | `packages/agent/src/` |
 | Login/session/connect, `AuthManager` | `packages/auth/src/` |
 | High-level APIs for apps | `packages/api/src/` |
+| CLI wallet connect, terminal QR/link flows | `packages/cli/src/` |
 | `dwn://` discovery, browser connect | `packages/browser/src/`, `packages/auth/src/discovery.ts` |
 | Shared protocol definitions | `packages/protocols/` |
 | Docs site content | `apps/docs/content/docs/` |
@@ -272,6 +277,7 @@ After `bun run dev:ensure`, just run the suite — the `export DID_DHT_*` lines 
 | `@enbox/crypto` | `bun test` | `bun run test:node` |
 | `@enbox/dids` | `bun test` | `bun run test:node` |
 | `@enbox/auth` | `bun test` | `bun run test:node` |
+| `@enbox/cli` | `bun test` | `bun run test:node` |
 | `@enbox/dwn-clients` | `bun test` | `bun run test:node` |
 | `@enbox/protocols` | `bun test` | `bun run test:node` |
 | `@enbox/protocol-codegen` | `bun test` | `bun run test:node` |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Enbox is a Bun/TypeScript monorepo for building apps on
 - A headless auth layer for local vaults, wallet connect, session restore, and sync startup.
 - An agent runtime with encrypted identity/key stores and live/durable DWN sync.
 - A self-hostable DWN server with HTTP/WebSocket APIs and SQL-backed persistence.
-- Shared DID, crypto, protocol, browser, and codegen packages.
+- Shared DID, crypto, protocol, browser, CLI, and codegen packages.
 
 The model is protocol-first: apps define portable record schemas and access
 rules, users control their DIDs and DWN endpoints, and encrypted data can move
@@ -97,6 +97,8 @@ console.log(session.did, record.id, records.length);
 
 For browser apps, `@enbox/browser` re-exports the main app APIs and adds
 browser-specific connect helpers and DRL polyfills.
+For terminal tools, `@enbox/cli` provides the same app APIs with a relay/PIN
+connect handler that prints a QR code or opens the wallet approval link.
 
 See [packages/api/README.md](./packages/api/README.md) and the
 [public docs site](https://enbox-docs.pages.dev) for more examples.
@@ -145,6 +147,7 @@ configuration, storage backends, and registration options.
 | [`@enbox/api`](./packages/api) | High-level SDK: `Enbox.connect()`, typed protocols, records, subscriptions |
 | [`@enbox/auth`](./packages/auth) | Headless auth, local vault connect, wallet connect, session restore |
 | [`@enbox/browser`](./packages/browser) | Browser helpers and polyfills |
+| [`@enbox/cli`](./packages/cli) | CLI helpers and relay/PIN wallet connect handler |
 | [`@enbox/protocols`](./packages/protocols) | Shared protocol definitions and JSON Schemas |
 | [`@enbox/protocol-codegen`](./packages/protocol-codegen) | TypeScript generation from protocol definitions and schemas |
 | [`@enbox/agent`](./packages/agent) | Identity vault, key management, local DWN, sync engine |

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -112,6 +112,7 @@ liveQuery.on('delete', (record) => {
 |---|---|
 | [`@enbox/api`](/docs/packages/api) | High-level SDK — `Enbox.connect()`, typed protocols, records CRUD |
 | [`@enbox/browser`](/docs/packages/browser) | Browser entrypoint — app APIs, auth helpers, wallet connect, DWeb utilities |
+| [`@enbox/cli`](/docs/packages/cli) | CLI entrypoint — app APIs, auth helpers, relay/PIN wallet connect |
 | [`@enbox/auth`](/docs/guides/auth) | Authentication — connect, lock, disconnect, multi-identity |
 | [`@enbox/dwn-server`](/docs/packages/dwn-server) | Self-hostable DWN server with PostgreSQL, MySQL, SQLite |
 | [`@enbox/agent`](/docs/packages/agent) | Low-level agent runtime for DID and DWN operations |

--- a/apps/docs/content/docs/packages/cli.mdx
+++ b/apps/docs/content/docs/packages/cli.mdx
@@ -1,0 +1,44 @@
+---
+title: "@enbox/cli"
+description: CLI-first Enbox entrypoint for app APIs, auth, and relay/PIN wallet connect.
+---
+
+`@enbox/cli` is the terminal-focused package for Enbox apps. It re-exports the
+main app API from `@enbox/api`, auth/session helpers from `@enbox/auth`, and a
+Node/Bun-only connect handler for wallet approvals.
+
+## Installation
+
+```bash
+bun add @enbox/cli
+```
+
+## Usage
+
+```ts
+import { CliConnectHandler, Enbox, defineProtocol } from '@enbox/cli';
+
+const { enbox, session } = await Enbox.connect({
+  connectHandler: CliConnectHandler({
+    appName          : 'Notes CLI',
+    connectServerUrl : 'https://your-dwn.example/connect',
+  }),
+  protocols: [NotesProtocol],
+});
+```
+
+The handler uses the encrypted relay flow. It prints a terminal QR code and
+wallet link by default, prompts for the wallet-displayed PIN, then returns the
+delegated session through the normal `Enbox.connect()` lifecycle.
+
+Set `openBrowser: true` for same-machine flows that should open the wallet
+approval link in the local default browser instead of printing a QR code.
+
+## Key exports
+
+| Export | Description |
+|---|---|
+| `Enbox` | High-level app API from `@enbox/api` |
+| `defineProtocol()` | Type-safe protocol definition helper |
+| `AuthManager` | Auth/session lifecycle from `@enbox/auth` |
+| `CliConnectHandler` | Terminal relay/PIN wallet connect handler |

--- a/apps/docs/content/docs/packages/cli.mdx
+++ b/apps/docs/content/docs/packages/cli.mdx
@@ -18,12 +18,30 @@ bun add @enbox/cli
 ```ts
 import { CliConnectHandler, Enbox, defineProtocol } from '@enbox/cli';
 
+const NotesProtocol = defineProtocol({
+  protocol  : 'https://example.com/protocols/notes',
+  published : true,
+  types     : {
+    note: {
+      schema      : 'https://example.com/schemas/note',
+      dataFormats : ['application/json'],
+    },
+  },
+  structure: {
+    note: {},
+  },
+});
+
 const { enbox, session } = await Enbox.connect({
   connectHandler: CliConnectHandler({
     appName          : 'Notes CLI',
     connectServerUrl : 'https://your-dwn.example/connect',
   }),
-  protocols: [NotesProtocol],
+  protocols: [{ definition: NotesProtocol.definition, permissions: ['write'] }],
+});
+
+await enbox.using(NotesProtocol).records.create('note', {
+  data: { body: `Connected as ${session.did}` },
 });
 ```
 

--- a/apps/docs/content/docs/packages/meta.json
+++ b/apps/docs/content/docs/packages/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "api",
     "browser",
+    "cli",
     "dwn-server",
     "replication-sync",
     "agent",

--- a/bun.lock
+++ b/bun.lock
@@ -145,6 +145,27 @@
         "vitest": "4.0.18",
       },
     },
+    "packages/cli": {
+      "name": "@enbox/cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "@enbox/agent": "workspace:*",
+        "@enbox/api": "workspace:*",
+        "@enbox/auth": "workspace:*",
+        "qrcode": "1.5.4",
+      },
+      "devDependencies": {
+        "@enbox/common": "workspace:*",
+        "@enbox/dwn-sdk-js": "workspace:*",
+        "@types/node": "22.19.15",
+        "@types/qrcode": "1.5.6",
+        "@types/sinon": "22.0.0",
+        "bun-types": "1.3.14",
+        "eslint": "9.7.0",
+        "sinon": "18.0.0",
+        "typescript": "5.9.3",
+      },
+    },
     "packages/common": {
       "name": "@enbox/common",
       "version": "0.1.2",
@@ -657,6 +678,8 @@
     "@enbox/auth": ["@enbox/auth@workspace:packages/auth"],
 
     "@enbox/browser": ["@enbox/browser@workspace:packages/browser"],
+
+    "@enbox/cli": ["@enbox/cli@workspace:packages/cli"],
 
     "@enbox/common": ["@enbox/common@workspace:packages/common"],
 
@@ -1264,6 +1287,8 @@
 
     "@types/pg-cursor": ["@types/pg-cursor@2.7.0", "", { "dependencies": { "@types/node": "*", "@types/pg": "*" } }, "sha512-4Milg/OUqTO2VuPvvRwPxaQTaiVb+bXvSK+ZCwiHjwinbD4/lPqV9AREg8sJAT0cy5ruY38aaajBc2FbdPaKcA=="],
 
+    "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -1456,6 +1481,8 @@
 
     "clipboardy": ["clipboardy@3.0.0", "", { "dependencies": { "arch": "^2.2.0", "execa": "^5.1.1", "is-wsl": "^2.2.0" } }, "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg=="],
 
+    "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
@@ -1496,6 +1523,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
@@ -1522,6 +1551,8 @@
 
     "diff": ["diff@5.2.2", "", {}, "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A=="],
 
+    "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
+
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
     "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
@@ -1532,7 +1563,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 
-    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.17.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA=="],
 
@@ -1673,6 +1704,8 @@
     "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
@@ -2242,7 +2275,7 @@
 
     "png-to-ico": ["png-to-ico@2.1.8", "", { "dependencies": { "@types/node": "^17.0.36", "minimist": "^1.2.6", "pngjs": "^6.0.0" }, "bin": { "png-to-ico": "bin/cli.js" } }, "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w=="],
 
-    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+    "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
@@ -2283,6 +2316,8 @@
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
     "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
+    "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
@@ -2360,7 +2395,11 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -2395,6 +2434,8 @@
     "serve": ["serve@14.2.6", "", { "dependencies": { "@zeit/schemas": "2.36.0", "ajv": "8.18.0", "arg": "5.0.2", "boxen": "7.0.0", "chalk": "5.0.1", "chalk-template": "0.4.0", "clipboardy": "3.0.0", "compression": "1.8.1", "is-port-reachable": "4.0.0", "serve-handler": "6.1.7", "update-check": "1.5.4" }, "bin": { "serve": "build/main.js" } }, "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q=="],
 
     "serve-handler": ["serve-handler@6.1.7", "", { "dependencies": { "bytes": "3.0.0", "content-disposition": "0.5.2", "mime-types": "2.1.18", "minimatch": "3.1.5", "path-is-inside": "1.0.2", "path-to-regexp": "3.3.0", "range-parser": "1.2.0" } }, "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg=="],
+
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -2442,7 +2483,7 @@
 
     "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
 
-    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2622,6 +2663,8 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "widest-line": ["widest-line@4.0.1", "", { "dependencies": { "string-width": "^5.0.1" } }, "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig=="],
@@ -2636,7 +2679,13 @@
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
+    "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
+    "yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -2664,6 +2713,8 @@
 
     "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
+    "@enbox/cli/@types/sinon": ["@types/sinon@22.0.0", "", { "dependencies": { "@types/sinonjs__fake-timers": "*" } }, "sha512-TDbVpbccc2HfiqHR09Argj3mHV1KMW7sCCKj52fsl8lbRLkEn7fB1966EWhOKWUBcqfBueZuPoA7/OK1CKiy3g=="],
+
     "@enbox/docs/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -2677,6 +2728,8 @@
     "@ipld/dag-cbor/cborg": ["cborg@5.1.6", "", { "bin": { "cborg": "lib/bin.js" } }, "sha512-apu/mOSODJ98JXBz3cbiv/gAFX4oaCZQQ53+8b4IPjc1wylYxd8eJis87QP7ic4AOE4O02j02jjfUgVZUJIIvA=="],
 
     "@ipld/dag-json/cborg": ["cborg@5.1.6", "", { "bin": { "cborg": "lib/bin.js" } }, "sha512-apu/mOSODJ98JXBz3cbiv/gAFX4oaCZQQ53+8b4IPjc1wylYxd8eJis87QP7ic4AOE4O02j02jjfUgVZUJIIvA=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -2724,6 +2777,8 @@
 
     "@types/pg-cursor/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
+    "@types/qrcode/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
     "@types/ws/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/utils": ["@typescript-eslint/utils@8.32.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.32.1", "@typescript-eslint/types": "8.32.1", "@typescript-eslint/typescript-estree": "8.32.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA=="],
@@ -2742,19 +2797,23 @@
 
     "@vaadin/router/path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
+    "@vitest/browser/pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
     "@vitest/browser/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "acorn-loose/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-walk/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
-    "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "boxen/chalk": ["chalk@5.0.1", "", {}, "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="],
+
+    "boxen/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "boxen/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
     "bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -2826,6 +2885,8 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
+    "pixelmatch/pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
     "png-to-ico/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 
     "png-to-ico/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
@@ -2844,10 +2905,6 @@
 
     "serve-handler/path-to-regexp": ["path-to-regexp@3.3.0", "", {}, "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="],
 
-    "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "tsconfig-paths-webpack-plugin/enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
@@ -2860,11 +2917,17 @@
 
     "weald/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
+    "widest-line/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -2875,6 +2938,8 @@
     "@enbox/docs/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -2892,6 +2957,8 @@
 
     "@types/pg/pg-types/postgres-interval": ["postgres-interval@3.0.0", "", {}, "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw=="],
 
+    "@types/qrcode/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
     "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -2902,7 +2969,9 @@
 
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
-    "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "boxen/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "boxen/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -2966,8 +3035,6 @@
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
     "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
@@ -3016,9 +3083,15 @@
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "widest-line/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "widest-line/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
@@ -3034,7 +3107,13 @@
 
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
+    "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "electrobun/@types/bun/bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -156,6 +156,7 @@
       },
       "devDependencies": {
         "@enbox/common": "workspace:*",
+        "@enbox/dids": "workspace:*",
         "@enbox/dwn-sdk-js": "workspace:*",
         "@types/node": "22.19.15",
         "@types/qrcode": "1.5.6",

--- a/examples/cli-demo/README.md
+++ b/examples/cli-demo/README.md
@@ -1,0 +1,27 @@
+# Enbox CLI Demo
+
+This example exercises the CLI wallet-connect lifecycle:
+
+1. Connect with `CliConnectHandler` through the relay QR/link flow.
+2. Write one protocol record as the delegated session.
+3. Shut down the auth manager to simulate a process restart.
+4. Restore the persisted session and write another record.
+5. Disconnect, requesting self-revocation for the session grants.
+
+Run it from the repository root after `bun install`:
+
+```bash
+ENBOX_CONNECT_SERVER_URL=https://your-dwn.example/connect \
+  bun examples/cli-demo/src/connect.ts
+```
+
+Use `--open` to open the wallet approval URL in the local browser instead of
+printing only a terminal QR code:
+
+```bash
+ENBOX_CONNECT_SERVER_URL=https://your-dwn.example/connect \
+  bun examples/cli-demo/src/connect.ts --open
+```
+
+The demo imports the local `packages/cli/src` entrypoint so it runs before
+`@enbox/cli` is published. Downstream apps should import from `@enbox/cli`.

--- a/examples/cli-demo/package.json
+++ b/examples/cli-demo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@enbox/example-cli-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "connect": "bun src/connect.ts"
+  },
+  "dependencies": {
+    "@enbox/cli": "workspace:*"
+  }
+}

--- a/examples/cli-demo/package.json
+++ b/examples/cli-demo/package.json
@@ -4,8 +4,5 @@
   "type": "module",
   "scripts": {
     "connect": "bun src/connect.ts"
-  },
-  "dependencies": {
-    "@enbox/cli": "workspace:*"
   }
 }

--- a/examples/cli-demo/src/connect.ts
+++ b/examples/cli-demo/src/connect.ts
@@ -1,4 +1,6 @@
-import { CliConnectHandler, Enbox, defineProtocol } from '@enbox/cli';
+import type { EnboxConnectResult } from '../../../packages/cli/src/index.js';
+
+import { AuthManager, CliConnectHandler, Enbox, defineProtocol } from '../../../packages/cli/src/index.js';
 
 const DemoProtocol = defineProtocol({
   protocol  : 'https://example.com/enbox/cli-demo',
@@ -19,8 +21,13 @@ if (connectServerUrl === undefined || connectServerUrl.trim() === '') {
   throw new Error('Set ENBOX_CONNECT_SERVER_URL to your DWN server connect relay URL, for example https://example.com/connect.');
 }
 
+const dataPath = process.env.ENBOX_DATA_PATH ?? '.enbox-cli-demo';
+const password = process.env.ENBOX_PASSWORD ?? 'enbox-cli-demo-password';
 const openBrowser = process.argv.includes('--open');
-const { enbox, session } = await Enbox.connect({
+
+const connected = await Enbox.connect({
+  dataPath,
+  password,
   connectHandler: CliConnectHandler({
     appName: 'Enbox CLI Demo',
     connectServerUrl,
@@ -29,13 +36,39 @@ const { enbox, session } = await Enbox.connect({
   protocols: [DemoProtocol],
 });
 
-await enbox.records.write({
-  protocol : DemoProtocol.protocol,
-  schema   : 'https://example.com/enbox/cli-demo/note',
-  data     : {
-    body      : `CLI demo write at ${new Date().toISOString()}`,
-    connected : session.connectedDid,
-  },
-});
+try {
+  await writeDemoNote(connected, 'initial connect');
+  console.log(`Connected as ${connected.session.did}. Wrote one demo note.`);
+} finally {
+  await connected.auth.shutdown();
+}
 
-console.log(`Connected as ${session.connectedDid}. Wrote one demo note.`);
+const restoredAuth = await AuthManager.create({ dataPath, password });
+try {
+  const restoredSession = await restoredAuth.restoreSession();
+  if (restoredSession === undefined) {
+    throw new Error('Unable to restore the CLI demo session after restart.');
+  }
+
+  const restoredEnbox = Enbox.fromSession(restoredSession);
+  await writeDemoNote({ enbox: restoredEnbox, session: restoredSession }, 'restored session');
+  console.log(`Restored ${restoredSession.did}. Wrote one more demo note.`);
+
+  await restoredAuth.disconnect();
+  console.log('Disconnected and requested session revocation.');
+} finally {
+  await restoredAuth.shutdown();
+}
+
+type ActiveSession = Pick<EnboxConnectResult, 'enbox' | 'session'>;
+
+async function writeDemoNote(active: ActiveSession, phase: string): Promise<void> {
+  await active.enbox.records.write({
+    protocol : DemoProtocol.protocol,
+    schema   : 'https://example.com/enbox/cli-demo/note',
+    data     : {
+      body      : `CLI demo ${phase} write at ${new Date().toISOString()}`,
+      connected : active.session.did,
+    },
+  });
+}

--- a/examples/cli-demo/src/connect.ts
+++ b/examples/cli-demo/src/connect.ts
@@ -1,0 +1,41 @@
+import { CliConnectHandler, Enbox, defineProtocol } from '@enbox/cli';
+
+const DemoProtocol = defineProtocol({
+  protocol  : 'https://example.com/enbox/cli-demo',
+  published : true,
+  types     : {
+    note: {
+      schema      : 'https://example.com/enbox/cli-demo/note',
+      dataFormats : ['application/json'],
+    },
+  },
+  structure: {
+    note: {},
+  },
+});
+
+const connectServerUrl = process.env.ENBOX_CONNECT_SERVER_URL;
+if (connectServerUrl === undefined || connectServerUrl.trim() === '') {
+  throw new Error('Set ENBOX_CONNECT_SERVER_URL to your DWN server connect relay URL, for example https://example.com/connect.');
+}
+
+const openBrowser = process.argv.includes('--open');
+const { enbox, session } = await Enbox.connect({
+  connectHandler: CliConnectHandler({
+    appName: 'Enbox CLI Demo',
+    connectServerUrl,
+    openBrowser,
+  }),
+  protocols: [DemoProtocol],
+});
+
+await enbox.records.write({
+  protocol : DemoProtocol.protocol,
+  schema   : 'https://example.com/enbox/cli-demo/note',
+  data     : {
+    body      : `CLI demo write at ${new Date().toISOString()}`,
+    connected : session.connectedDid,
+  },
+});
+
+console.log(`Connected as ${session.connectedDid}. Wrote one demo note.`);

--- a/examples/cli-demo/src/connect.ts
+++ b/examples/cli-demo/src/connect.ts
@@ -33,7 +33,7 @@ const connected = await Enbox.connect({
     connectServerUrl,
     openBrowser,
   }),
-  protocols: [DemoProtocol],
+  protocols: [{ definition: DemoProtocol.definition, permissions: ['write'] }],
 });
 
 try {
@@ -63,10 +63,8 @@ try {
 type ActiveSession = Pick<EnboxConnectResult, 'enbox' | 'session'>;
 
 async function writeDemoNote(active: ActiveSession, phase: string): Promise<void> {
-  await active.enbox.records.write({
-    protocol : DemoProtocol.protocol,
-    schema   : 'https://example.com/enbox/cli-demo/note',
-    data     : {
+  await active.enbox.using(DemoProtocol).records.create('note', {
+    data: {
       body      : `CLI demo ${phase} write at ${new Date().toISOString()}`,
       connected : active.session.did,
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "packages/auth",
     "packages/protocols",
     "packages/browser",
+    "packages/cli",
     "packages/protocol-codegen",
     "packages/dwn-sdk-js",
     "packages/dwn-sql-store",

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -190,6 +190,9 @@ export type EnboxConnectRequest = {
   /** Optional client/environment metadata for wallet session display. */
   clientMetadata?: ConnectClientMetadata;
 
+  /** Preferred session TTL in seconds. Wallets may clamp this to their policy maximum. */
+  requestedSessionTtlSeconds?: number;
+
   /** DWN protocols and permission scopes being requested. */
   permissionRequests: ConnectPermissionRequest[];
 
@@ -419,6 +422,12 @@ function requireNumber(payload: Record<string, unknown>, field: string, context:
   if (typeof payload[field] !== 'number') { fail(context, field, 'must be a number'); }
 }
 
+function requireOptionalNumber(payload: Record<string, unknown>, field: string, context: string): void {
+  if (payload[field] !== undefined && typeof payload[field] !== 'number') {
+    fail(context, field, 'must be a number when present');
+  }
+}
+
 function requireArray(payload: Record<string, unknown>, field: string, context: string): void {
   if (!Array.isArray(payload[field])) { fail(context, field, 'must be an array'); }
 }
@@ -482,6 +491,7 @@ function assertConnectRequest(payload: Record<string, unknown>): asserts payload
   requireString(payload, 'appName', ctx);
   requireOptionalString(payload, 'appIcon', ctx);
   requireOptionalObject(payload, 'clientMetadata', ctx);
+  requireOptionalNumber(payload, 'requestedSessionTtlSeconds', ctx);
   requireArray(payload, 'permissionRequests', ctx);
   requireString(payload, 'nonce', ctx);
   requireString(payload, 'state', ctx);

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -230,10 +230,11 @@ describe('enbox connect', () => {
       });
 
       const options = {
-        appName            : 'Sample App',
-        clientDid          : clientEphemeralPortableDid.uri,
-        permissionRequests : [{ protocolDefinition, permissionScopes }],
-        callbackUrl        : callbackUrl,
+        appName                    : 'Sample App',
+        clientDid                  : clientEphemeralPortableDid.uri,
+        permissionRequests         : [{ protocolDefinition, permissionScopes }],
+        callbackUrl                : callbackUrl,
+        requestedSessionTtlSeconds : 2_592_000,
       };
       connectRequest = await EnboxConnectProtocol.createConnectRequest(options);
       expect(connectRequest).toEqual(expect.objectContaining(options));

--- a/packages/auth/src/connect/wallet.ts
+++ b/packages/auth/src/connect/wallet.ts
@@ -40,14 +40,17 @@ export async function walletConnect(
 
   // Run the Enbox Connect relay flow.
   const result = await WalletConnect.initClient({
-    displayName        : options.displayName,
-    appIcon            : options.appIcon,
-    clientMetadata     : options.clientMetadata,
-    connectServerUrl   : options.connectServerUrl,
-    walletUri          : options.walletUri ?? 'enbox://connect',
-    permissionRequests : options.permissionRequests,
-    onWalletUriReady   : options.onWalletUriReady,
-    validatePin        : options.validatePin,
+    displayName                : options.displayName,
+    appIcon                    : options.appIcon,
+    clientMetadata             : options.clientMetadata,
+    requestedSessionTtlSeconds : options.requestedSessionTtlSeconds,
+    connectServerUrl           : options.connectServerUrl,
+    walletUri                  : options.walletUri ?? 'enbox://connect',
+    permissionRequests         : options.permissionRequests,
+    onWalletUriReady           : options.onWalletUriReady,
+    validatePin                : options.validatePin,
+    timeoutMs                  : options.timeoutMs,
+    pollIntervalMs             : options.pollIntervalMs,
   });
 
   if (!result) {

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -543,6 +543,9 @@ export interface WalletConnectOptions {
   /** Optional client/environment metadata for wallet session display. */
   clientMetadata?: ConnectClientMetadata;
 
+  /** Preferred session TTL in seconds. Wallets may clamp this to their policy maximum. */
+  requestedSessionTtlSeconds?: number;
+
   /** URL of the connect relay server. */
   connectServerUrl: string;
 
@@ -560,10 +563,22 @@ export interface WalletConnectOptions {
   permissionRequests: ConnectPermissionRequest[];
 
   /** Called when the wallet URI is ready (render as QR code). */
-  onWalletUriReady: (uri: string) => void;
+  onWalletUriReady: (uri: string) => Promise<void> | void;
 
   /** Called to collect the PIN from the user. */
   validatePin: () => Promise<string>;
+
+  /**
+   * Milliseconds to wait for wallet approval.
+   * Defaults to the relay client's 300 second poll TTL.
+   */
+  timeoutMs?: number;
+
+  /**
+   * Milliseconds between relay polling attempts.
+   * Defaults to 3000.
+   */
+  pollIntervalMs?: number;
 
   /** Override manager default sync interval. */
   sync?: SyncOption;

--- a/packages/auth/src/wallet-connect-client.ts
+++ b/packages/auth/src/wallet-connect-client.ts
@@ -38,6 +38,9 @@ export type WalletConnectClientOptions = {
   /** Optional client/environment metadata for wallet session display. */
   clientMetadata?: ConnectClientMetadata;
 
+  /** Preferred session TTL in seconds. Wallets may clamp this to their policy maximum. */
+  requestedSessionTtlSeconds?: number;
+
   /** The URL of the connect server which relays messages between the app and wallet. */
   connectServerUrl: string;
 
@@ -61,7 +64,7 @@ export type WalletConnectClientOptions = {
    *
    * @param uri - The wallet URI with connect payload.
    */
-  onWalletUriReady: (uri: string) => void;
+  onWalletUriReady: (uri: string) => Promise<void> | void;
 
   /**
    * Called to collect the PIN from the user. The PIN is used as AAD
@@ -70,6 +73,18 @@ export type WalletConnectClientOptions = {
    * @returns A promise that resolves to the PIN as a string.
    */
   validatePin: () => Promise<string>;
+
+  /**
+   * Milliseconds to poll the relay for a wallet response.
+   * @default 300_000
+   */
+  timeoutMs?: number;
+
+  /**
+   * Milliseconds between relay polling attempts.
+   * @default 3000
+   */
+  pollIntervalMs?: number;
 };
 
 import type { Permission } from './types.js';
@@ -93,11 +108,14 @@ async function initClient({
   displayName,
   appIcon,
   clientMetadata,
+  requestedSessionTtlSeconds,
   connectServerUrl,
   walletUri,
   permissionRequests,
   onWalletUriReady,
   validatePin,
+  timeoutMs = 300_000,
+  pollIntervalMs = 3000,
 }: WalletConnectClientOptions): Promise<{
   delegateGrants: EnboxConnectResponse['delegateGrants'];
   delegatePortableDid: EnboxConnectResponse['delegatePortableDid'];
@@ -128,6 +146,7 @@ async function initClient({
     appName            : displayName,
     appIcon,
     clientMetadata,
+    requestedSessionTtlSeconds,
   });
 
   // Sign the request as a JWT.
@@ -176,7 +195,7 @@ async function initClient({
   );
 
   // call user's callback so they can send the URI to the wallet as they see fit
-  onWalletUriReady(generatedWalletUri.toString());
+  await onWalletUriReady(generatedWalletUri.toString());
 
   const tokenUrl = EnboxConnectProtocol.buildConnectUrl({
     baseURL    : connectServerUrl,
@@ -184,8 +203,12 @@ async function initClient({
     tokenParam : request.state,
   });
 
-  // subscribe to receiving a response from the wallet with default TTL. receive ciphertext of {@link EnboxConnectResponse}
-  const authResponse = await pollWithTtl(() => fetch(tokenUrl, { signal: AbortSignal.timeout(30_000) }));
+  // subscribe to receiving a response from the wallet. receive ciphertext of {@link EnboxConnectResponse}
+  const authResponse = await pollWithTtl(
+    () => fetch(tokenUrl, { signal: AbortSignal.timeout(30_000) }),
+    pollIntervalMs,
+    timeoutMs,
+  );
 
   if (authResponse) {
     const jwe = await authResponse?.text();

--- a/packages/auth/tests/wallet-connect-client.spec.ts
+++ b/packages/auth/tests/wallet-connect-client.spec.ts
@@ -59,16 +59,17 @@ describe('WalletConnect', () => {
   describe('initClient — happy path', () => {
     it('should complete the full relay flow and return delegate info', async () => {
       // Stub EnboxConnectProtocol methods used by initClient.
-      sinon.stub(EnboxConnectProtocol, 'createConnectRequest').resolves({
-        clientDid           : 'did:jwk:test',
-        callbackUrl         : 'http://localhost:3000/connect/callback',
-        permissionRequests  : [],
-        appName             : 'Sample App',
-        nonce               : 'test-nonce',
-        responseMode        : 'direct_post',
-        state               : 'test-state',
-        supportedDidMethods : ['did:dht', 'did:jwk'],
-      } as any);
+      sinon.stub(EnboxConnectProtocol, 'createConnectRequest').callsFake(async (options: any): Promise<any> => ({
+        clientDid                  : 'did:jwk:test',
+        callbackUrl                : 'http://localhost:3000/connect/callback',
+        permissionRequests         : [],
+        appName                    : 'Sample App',
+        requestedSessionTtlSeconds : options.requestedSessionTtlSeconds,
+        nonce                      : 'test-nonce',
+        responseMode               : 'direct_post',
+        state                      : 'test-state',
+        supportedDidMethods        : ['did:dht', 'did:jwk'],
+      }));
       sinon.stub(EnboxConnectProtocol, 'signJwt').resolves('signed.jwt.value');
       sinon.stub(EnboxConnectProtocol, 'encryptRequest').resolves('encrypted-jwe');
       sinon.stub(EnboxConnectProtocol, 'decryptResponse').resolves('decrypted.jwt.value');
@@ -100,12 +101,13 @@ describe('WalletConnect', () => {
       const walletUris: string[] = [];
 
       const result = await WalletConnect.initClient({
-        displayName        : 'Sample App',
-        walletUri          : 'http://localhost:3000/',
-        connectServerUrl   : 'http://localhost:3000/connect',
-        permissionRequests : [{ protocolDefinition: {} as any, permissionScopes: [] as any }],
-        onWalletUriReady   : (uri: string): void => { walletUris.push(uri); },
-        validatePin        : async (): Promise<string> => '1234',
+        displayName                : 'Sample App',
+        walletUri                  : 'http://localhost:3000/',
+        connectServerUrl           : 'http://localhost:3000/connect',
+        permissionRequests         : [{ protocolDefinition: {} as any, permissionScopes: [] as any }],
+        onWalletUriReady           : (uri: string): void => { walletUris.push(uri); },
+        validatePin                : async (): Promise<string> => '1234',
+        requestedSessionTtlSeconds : 2_592_000,
       });
 
       // Verify result shape.
@@ -113,6 +115,7 @@ describe('WalletConnect', () => {
       expect(result!.connectedDid).toBe('did:dht:provider789');
       expect(result!.delegatePortableDid.uri).toBe('did:dht:delegate123');
       expect(result!.delegateGrants).toHaveLength(1);
+      expect((EnboxConnectProtocol.createConnectRequest as sinon.SinonStub).firstCall.args[0].requestedSessionTtlSeconds).toBe(2_592_000);
 
       // Verify onWalletUriReady was called with the correct URI.
       expect(walletUris).toHaveLength(1);
@@ -161,6 +164,86 @@ describe('WalletConnect', () => {
 
       expect(result).toBeUndefined();
       expect(decryptResponse.called).toBe(false);
+    });
+
+    it('should await wallet URI handling before polling for the response', async () => {
+      sinon.stub(EnboxConnectProtocol, 'createConnectRequest').resolves({
+        clientDid           : 'did:jwk:test',
+        callbackUrl         : 'http://localhost:3000/connect/callback',
+        permissionRequests  : [],
+        appName             : 'Sample App',
+        nonce               : 'test-nonce',
+        responseMode        : 'direct_post',
+        state               : 'test-state',
+        supportedDidMethods : ['did:dht', 'did:jwk'],
+      } as any);
+      sinon.stub(EnboxConnectProtocol, 'signJwt').resolves('signed.jwt.value');
+      sinon.stub(EnboxConnectProtocol, 'encryptRequest').resolves('encrypted-jwe');
+
+      let callbackComplete = false;
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+      fetchStub.onFirstCall().resolves(
+        new Response(JSON.stringify({ request_uri: 'http://localhost:3000/connect/authorize/req.jwt' }), {
+          status  : 200,
+          headers : { 'Content-Type': 'application/json' },
+        })
+      );
+      fetchStub.onSecondCall().callsFake(async (): Promise<Response> => {
+        expect(callbackComplete).toBe(true);
+        return new Response('DENIED', { status: 200 });
+      });
+
+      const result = await WalletConnect.initClient({
+        displayName        : 'Sample App',
+        walletUri          : 'http://localhost:3000/',
+        connectServerUrl   : 'http://localhost:3000/connect',
+        permissionRequests : [{ protocolDefinition: {} as any, permissionScopes: [] as any }],
+        onWalletUriReady   : async (): Promise<void> => {
+          await new Promise((resolve): void => { setTimeout(resolve, 0); });
+          callbackComplete = true;
+        },
+        validatePin: async (): Promise<string> => '1234',
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should stop polling after a custom timeout', async () => {
+      sinon.stub(EnboxConnectProtocol, 'createConnectRequest').resolves({
+        clientDid           : 'did:jwk:test',
+        callbackUrl         : 'http://localhost:3000/connect/callback',
+        permissionRequests  : [],
+        appName             : 'Sample App',
+        nonce               : 'test-nonce',
+        responseMode        : 'direct_post',
+        state               : 'test-state',
+        supportedDidMethods : ['did:dht', 'did:jwk'],
+      } as any);
+      sinon.stub(EnboxConnectProtocol, 'signJwt').resolves('signed.jwt.value');
+      sinon.stub(EnboxConnectProtocol, 'encryptRequest').resolves('encrypted-jwe');
+
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+      fetchStub.onFirstCall().resolves(
+        new Response(JSON.stringify({ request_uri: 'http://localhost:3000/connect/authorize/req.jwt' }), {
+          status  : 200,
+          headers : { 'Content-Type': 'application/json' },
+        })
+      );
+      fetchStub.callsFake(async (): Promise<Response> => new Response('Not Found', { status: 404 }));
+
+      const result = await WalletConnect.initClient({
+        displayName        : 'Sample App',
+        walletUri          : 'http://localhost:3000/',
+        connectServerUrl   : 'http://localhost:3000/connect',
+        permissionRequests : [{ protocolDefinition: {} as any, permissionScopes: [] as any }],
+        onWalletUriReady   : (): void => {},
+        validatePin        : async (): Promise<string> => '1234',
+        timeoutMs          : 5,
+        pollIntervalMs     : 1,
+      });
+
+      expect(result).toBeUndefined();
+      expect(fetchStub.callCount).toBeGreaterThan(1);
     });
 
   });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,36 @@
+# Enbox CLI
+
+> **Research Preview** — Enbox is under active development. APIs may change without notice.
+
+`@enbox/cli` provides Node/Bun-specific helpers for terminal applications that
+need Enbox sessions.
+
+## Install
+
+```bash
+bun add @enbox/cli
+```
+
+## Usage
+
+```ts
+import { CliConnectHandler, Enbox } from '@enbox/cli';
+
+const { enbox, session } = await Enbox.connect({
+  connectHandler: CliConnectHandler({
+    appName          : 'Notes CLI',
+    connectServerUrl : 'https://your-dwn.example/connect',
+  }),
+  protocols: [NotesProtocol],
+});
+```
+
+The handler uses the existing encrypted relay flow:
+
+1. The CLI pushes an encrypted request to the connect relay.
+2. The CLI prints a QR code and link for the wallet approval page.
+3. The user approves in the wallet and enters the wallet-displayed PIN in the terminal.
+4. The handler returns the delegated DID and grants to `Enbox.connect()`.
+
+Set `openBrowser: true` to open the generated wallet URL on the same machine
+instead of printing a QR code.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@enbox/cli",
+  "version": "0.1.0",
+  "description": "CLI helpers and connect handlers for Enbox",
+  "type": "module",
+  "main": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
+  "types": "./dist/types/index.d.ts",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "build": "bun run clean && bun run build:esm",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "test:node": "bun test --timeout 10000 .spec.ts",
+    "test:node:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage .spec.ts"
+  },
+  "homepage": "https://github.com/enboxorg/enbox/tree/main/packages/cli#readme",
+  "bugs": "https://github.com/enboxorg/enbox/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enboxorg/enbox.git",
+    "directory": "packages/cli"
+  },
+  "license": "Apache-2.0",
+  "contributors": [
+    {
+      "name": "Liran Cohen",
+      "url": "https://github.com/LiranCohen"
+    }
+  ],
+  "files": [
+    "dist",
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "keywords": [
+    "cli",
+    "decentralized",
+    "decentralized-applications",
+    "decentralized-identity",
+    "DID",
+    "enbox",
+    "wallet-connect"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "bun": ">=1.0.0"
+  },
+  "dependencies": {
+    "@enbox/agent": "workspace:*",
+    "@enbox/api": "workspace:*",
+    "@enbox/auth": "workspace:*",
+    "qrcode": "1.5.4"
+  },
+  "devDependencies": {
+    "@enbox/common": "workspace:*",
+    "@enbox/dwn-sdk-js": "workspace:*",
+    "@types/node": "22.19.15",
+    "@types/qrcode": "1.5.6",
+    "@types/sinon": "22.0.0",
+    "bun-types": "1.3.14",
+    "eslint": "9.7.0",
+    "sinon": "18.0.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@enbox/common": "workspace:*",
+    "@enbox/dids": "workspace:*",
     "@enbox/dwn-sdk-js": "workspace:*",
     "@types/node": "22.19.15",
     "@types/qrcode": "1.5.6",

--- a/packages/cli/src/cli-connect-handler.ts
+++ b/packages/cli/src/cli-connect-handler.ts
@@ -126,7 +126,7 @@ export function CliConnectHandler(options: CliConnectHandlerOptions = {}): Conne
 
 async function resolveWalletUrl(options: CliConnectHandlerOptions, state: WalletUrlState): Promise<string> {
   if (options.walletUrl !== undefined && options.walletUrl.trim() !== '') {
-    const normalized = normalizeWalletUrl(options.walletUrl);
+    const normalized = normalizeUrl(options.walletUrl);
     if (normalized !== undefined) {
       return normalized;
     }
@@ -139,7 +139,7 @@ async function resolveWalletUrl(options: CliConnectHandlerOptions, state: Wallet
     const defaultWalletUrl = state.lastPromptedWalletUrl ?? DEFAULT_CLI_WALLET_URL;
     const answer = (await prompt(`Wallet [${defaultWalletUrl}]: `)).trim();
     const walletUrl = answer === '' ? defaultWalletUrl : answer;
-    const normalized = normalizeWalletUrl(walletUrl);
+    const normalized = normalizeUrl(walletUrl);
 
     if (normalized !== undefined) {
       state.lastPromptedWalletUrl = normalized;
@@ -152,20 +152,38 @@ async function resolveWalletUrl(options: CliConnectHandlerOptions, state: Wallet
 
 async function resolveConnectServerUrl(options: CliConnectHandlerOptions): Promise<string> {
   if (options.connectServerUrl !== undefined && options.connectServerUrl.trim() !== '') {
-    return options.connectServerUrl.trim();
+    const normalized = normalizeUrl(options.connectServerUrl);
+    if (normalized !== undefined) {
+      return normalized;
+    }
+
+    throw new Error(`@enbox/cli: invalid connect relay URL '${options.connectServerUrl}'. Enter a URL such as https://dwn.example/connect.`);
   }
 
   const providedUrl = await options.connectServerUrlProvider?.();
   if (providedUrl !== undefined && providedUrl.trim() !== '') {
-    return providedUrl.trim();
+    const normalized = normalizeUrl(providedUrl);
+    if (normalized !== undefined) {
+      return normalized;
+    }
+
+    throw new Error(`@enbox/cli: invalid connect relay URL '${providedUrl}'. Enter a URL such as https://dwn.example/connect.`);
   }
 
   const prompt = options.connectServerUrlPrompt ?? defaultPrompt(options);
-  const answer = (await prompt('Connect relay URL: ')).trim();
-  if (answer === '') {
-    throw new Error('@enbox/cli: connect relay URL is required.');
+  while (true) {
+    const answer = (await prompt('Connect relay URL: ')).trim();
+    if (answer === '') {
+      throw new Error('@enbox/cli: connect relay URL is required.');
+    }
+
+    const normalized = normalizeUrl(answer);
+    if (normalized !== undefined) {
+      return normalized;
+    }
+
+    writeLine(options, '@enbox/cli: invalid connect relay URL. Enter a URL such as https://dwn.example/connect.');
   }
-  return answer;
 }
 
 function defaultPrompt(options: CliConnectHandlerOptions): PromptFunction {
@@ -184,15 +202,15 @@ function buildWalletUri(walletUrl: string): string {
   return url.toString();
 }
 
-function normalizeWalletUrl(walletUrl: string): string | undefined {
-  const trimmedWalletUrl = walletUrl.trim();
-  if (trimmedWalletUrl === '') {
+function normalizeUrl(url: string): string | undefined {
+  const trimmedUrl = url.trim();
+  if (trimmedUrl === '') {
     return undefined;
   }
 
-  const candidate = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmedWalletUrl)
-    ? trimmedWalletUrl
-    : `https://${trimmedWalletUrl}`;
+  const candidate = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmedUrl)
+    ? trimmedUrl
+    : `https://${trimmedUrl}`;
 
   try {
     return new URL(candidate).toString();

--- a/packages/cli/src/cli-connect-handler.ts
+++ b/packages/cli/src/cli-connect-handler.ts
@@ -8,14 +8,15 @@ import { DwnPermissionGrant, DwnPermissionsProtocol } from '@enbox/agent';
 import { openBrowser as defaultOpenBrowser, promptLine, renderTerminalQr } from './terminal.js';
 
 export const DEFAULT_CLI_WALLET_URL = 'https://enbox-wallet.pages.dev';
-const DEFAULT_CONNECT_TIMEOUT_MS = 300_000;
 const DEFAULT_WALLET_CONNECT_PATH = '/connect/app';
-
-let lastPromptedWalletUrl: string | undefined;
 
 export type PromptFunction = (question: string) => Promise<string>;
 export type QrRenderer = (uri: string) => Promise<string> | string;
 export type BrowserOpenFunction = (uri: string) => Promise<void> | void;
+
+type WalletUrlState = {
+  lastPromptedWalletUrl?: string;
+};
 
 export interface CliConnectHandlerOptions {
   /** Wallet app URL. A bare origin is normalized to `/connect/app`. */
@@ -88,11 +89,13 @@ export interface CliConnectHandlerOptions {
  * returns the same delegated session shape as the browser connect handler.
  */
 export function CliConnectHandler(options: CliConnectHandlerOptions = {}): ConnectHandler {
+  const walletUrlState: WalletUrlState = {};
+
   return {
     async requestAccess(params: {
       permissionRequests: ConnectPermissionRequest[];
     }): Promise<ConnectResult | undefined> {
-      const walletUrl = await resolveWalletUrl(options);
+      const walletUrl = await resolveWalletUrl(options, walletUrlState);
       const connectServerUrl = await resolveConnectServerUrl(options);
       const walletUri = buildWalletUri(walletUrl);
       const result = await WalletConnect.initClient({
@@ -107,7 +110,7 @@ export function CliConnectHandler(options: CliConnectHandlerOptions = {}): Conne
           await handleAuthUrl(uri, options);
         },
         validatePin    : async (): Promise<string> => resolvePin(options),
-        timeoutMs      : options.timeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
+        timeoutMs      : options.timeoutMs,
         pollIntervalMs : options.pollIntervalMs,
       } satisfies WalletConnectClientOptions);
 
@@ -121,17 +124,30 @@ export function CliConnectHandler(options: CliConnectHandlerOptions = {}): Conne
   };
 }
 
-async function resolveWalletUrl(options: CliConnectHandlerOptions): Promise<string> {
+async function resolveWalletUrl(options: CliConnectHandlerOptions, state: WalletUrlState): Promise<string> {
   if (options.walletUrl !== undefined && options.walletUrl.trim() !== '') {
-    return options.walletUrl.trim();
+    const normalized = normalizeWalletUrl(options.walletUrl);
+    if (normalized !== undefined) {
+      return normalized;
+    }
+
+    throw new Error(`@enbox/cli: invalid wallet URL '${options.walletUrl}'. Enter a URL such as https://wallet.example.`);
   }
 
   const prompt = options.walletPrompt ?? defaultPrompt(options);
-  const defaultWalletUrl = lastPromptedWalletUrl ?? DEFAULT_CLI_WALLET_URL;
-  const answer = (await prompt(`Wallet [${defaultWalletUrl}]: `)).trim();
-  const walletUrl = answer === '' ? defaultWalletUrl : answer;
-  lastPromptedWalletUrl = walletUrl;
-  return walletUrl;
+  while (true) {
+    const defaultWalletUrl = state.lastPromptedWalletUrl ?? DEFAULT_CLI_WALLET_URL;
+    const answer = (await prompt(`Wallet [${defaultWalletUrl}]: `)).trim();
+    const walletUrl = answer === '' ? defaultWalletUrl : answer;
+    const normalized = normalizeWalletUrl(walletUrl);
+
+    if (normalized !== undefined) {
+      state.lastPromptedWalletUrl = normalized;
+      return normalized;
+    }
+
+    writeLine(options, '@enbox/cli: invalid wallet URL. Enter a URL such as https://wallet.example.');
+  }
 }
 
 async function resolveConnectServerUrl(options: CliConnectHandlerOptions): Promise<string> {
@@ -166,6 +182,23 @@ function buildWalletUri(walletUrl: string): string {
     url.pathname = DEFAULT_WALLET_CONNECT_PATH;
   }
   return url.toString();
+}
+
+function normalizeWalletUrl(walletUrl: string): string | undefined {
+  const trimmedWalletUrl = walletUrl.trim();
+  if (trimmedWalletUrl === '') {
+    return undefined;
+  }
+
+  const candidate = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmedWalletUrl)
+    ? trimmedWalletUrl
+    : `https://${trimmedWalletUrl}`;
+
+  try {
+    return new URL(candidate).toString();
+  } catch {
+    return undefined;
+  }
 }
 
 async function resolvePin(options: CliConnectHandlerOptions): Promise<string> {

--- a/packages/cli/src/cli-connect-handler.ts
+++ b/packages/cli/src/cli-connect-handler.ts
@@ -1,0 +1,282 @@
+import type { ConnectClientMetadata, ConnectPermissionRequest, DwnPermissionScope } from '@enbox/agent';
+import type { ConnectHandler, ConnectResult, WalletConnectClientOptions } from '@enbox/auth';
+import type { Readable, Writable } from 'node:stream';
+
+import { WalletConnect } from '@enbox/auth';
+import { DwnPermissionGrant, DwnPermissionsProtocol } from '@enbox/agent';
+
+import { openBrowser as defaultOpenBrowser, promptLine, renderTerminalQr } from './terminal.js';
+
+export const DEFAULT_CLI_WALLET_URL = 'https://enbox-wallet.pages.dev';
+const DEFAULT_CONNECT_TIMEOUT_MS = 300_000;
+const DEFAULT_WALLET_CONNECT_PATH = '/connect/app';
+
+let lastPromptedWalletUrl: string | undefined;
+
+export type PromptFunction = (question: string) => Promise<string>;
+export type QrRenderer = (uri: string) => Promise<string> | string;
+export type BrowserOpenFunction = (uri: string) => Promise<void> | void;
+
+export interface CliConnectHandlerOptions {
+  /** Wallet app URL. A bare origin is normalized to `/connect/app`. */
+  walletUrl?: string;
+
+  /**
+   * Connect relay URL. Usually the dwn-server URL already configured by the
+   * hosting tool, with `/connect` available on that server.
+   */
+  connectServerUrl?: string;
+
+  /**
+   * Optional late-bound relay URL provider for tool config stores.
+   * `connectServerUrl` takes precedence when both are provided.
+   */
+  connectServerUrlProvider?: () => Promise<string | undefined> | string | undefined;
+
+  /** Display name shown in the wallet approval screen. */
+  appName?: string;
+
+  /** Optional icon URL shown in the wallet approval screen. */
+  appIcon?: string;
+
+  /** Optional client/environment metadata for wallet session display. */
+  clientMetadata?: ConnectClientMetadata;
+
+  /**
+   * Preferred session TTL in seconds. Wallets may clamp this to their policy maximum.
+   */
+  requestedSessionTtlSeconds?: number;
+
+  /** Open the generated wallet URL in the local default browser instead of printing a QR code. */
+  openBrowser?: boolean;
+
+  /** Called with the wallet authorization URL for embedding hosts. */
+  onAuthUrl?: (uri: string) => Promise<void> | void;
+
+  /** Prompt for the PIN shown by the wallet. */
+  pinPrompt?: PromptFunction;
+
+  /** Prompt for a wallet URL when `walletUrl` is omitted. */
+  walletPrompt?: PromptFunction;
+
+  /** Prompt for a connect relay URL when no option/provider value is available. */
+  connectServerUrlPrompt?: PromptFunction;
+
+  /** Milliseconds to wait for wallet approval. Defaults to 300 seconds. */
+  timeoutMs?: number;
+
+  /** Milliseconds between relay polling attempts. Defaults to 3000. */
+  pollIntervalMs?: number;
+
+  /** Terminal input stream used by default prompts. */
+  input?: Readable;
+
+  /** Terminal output stream used by default prompts and QR/link rendering. */
+  output?: Writable;
+
+  /** Custom QR renderer, primarily for host integration and tests. */
+  qrRenderer?: QrRenderer;
+
+  /** Custom browser opener, primarily for host integration and tests. */
+  browserOpener?: BrowserOpenFunction;
+}
+
+/**
+ * Create a CLI connect handler backed by the encrypted relay/PIN flow.
+ *
+ * The handler plugs into `Enbox.connect({ connectHandler, protocols })` and
+ * returns the same delegated session shape as the browser connect handler.
+ */
+export function CliConnectHandler(options: CliConnectHandlerOptions = {}): ConnectHandler {
+  return {
+    async requestAccess(params: {
+      permissionRequests: ConnectPermissionRequest[];
+    }): Promise<ConnectResult | undefined> {
+      const walletUrl = await resolveWalletUrl(options);
+      const connectServerUrl = await resolveConnectServerUrl(options);
+      const walletUri = buildWalletUri(walletUrl);
+      const result = await WalletConnect.initClient({
+        displayName                : options.appName ?? 'Enbox CLI',
+        appIcon                    : options.appIcon,
+        clientMetadata             : options.clientMetadata,
+        requestedSessionTtlSeconds : options.requestedSessionTtlSeconds,
+        connectServerUrl,
+        walletUri,
+        permissionRequests         : params.permissionRequests,
+        onWalletUriReady           : async (uri: string): Promise<void> => {
+          await handleAuthUrl(uri, options);
+        },
+        validatePin    : async (): Promise<string> => resolvePin(options),
+        timeoutMs      : options.timeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
+        pollIntervalMs : options.pollIntervalMs,
+      } satisfies WalletConnectClientOptions);
+
+      if (result === undefined) {
+        return undefined;
+      }
+
+      validateConnectResult(result, params.permissionRequests);
+      return result;
+    },
+  };
+}
+
+async function resolveWalletUrl(options: CliConnectHandlerOptions): Promise<string> {
+  if (options.walletUrl !== undefined && options.walletUrl.trim() !== '') {
+    return options.walletUrl.trim();
+  }
+
+  const prompt = options.walletPrompt ?? defaultPrompt(options);
+  const defaultWalletUrl = lastPromptedWalletUrl ?? DEFAULT_CLI_WALLET_URL;
+  const answer = (await prompt(`Wallet [${defaultWalletUrl}]: `)).trim();
+  const walletUrl = answer === '' ? defaultWalletUrl : answer;
+  lastPromptedWalletUrl = walletUrl;
+  return walletUrl;
+}
+
+async function resolveConnectServerUrl(options: CliConnectHandlerOptions): Promise<string> {
+  if (options.connectServerUrl !== undefined && options.connectServerUrl.trim() !== '') {
+    return options.connectServerUrl.trim();
+  }
+
+  const providedUrl = await options.connectServerUrlProvider?.();
+  if (providedUrl !== undefined && providedUrl.trim() !== '') {
+    return providedUrl.trim();
+  }
+
+  const prompt = options.connectServerUrlPrompt ?? defaultPrompt(options);
+  const answer = (await prompt('Connect relay URL: ')).trim();
+  if (answer === '') {
+    throw new Error('@enbox/cli: connect relay URL is required.');
+  }
+  return answer;
+}
+
+function defaultPrompt(options: CliConnectHandlerOptions): PromptFunction {
+  return (question: string): Promise<string> => promptLine({
+    input  : options.input,
+    output : options.output,
+    question,
+  });
+}
+
+function buildWalletUri(walletUrl: string): string {
+  const url = new URL(walletUrl);
+  if (url.pathname === '' || url.pathname === '/') {
+    url.pathname = DEFAULT_WALLET_CONNECT_PATH;
+  }
+  return url.toString();
+}
+
+async function resolvePin(options: CliConnectHandlerOptions): Promise<string> {
+  const prompt = options.pinPrompt ?? defaultPrompt(options);
+  const pin = (await prompt('Enter the PIN shown in your wallet: ')).trim();
+  if (pin === '') {
+    throw new Error('@enbox/cli: wallet PIN is required.');
+  }
+  return pin;
+}
+
+async function handleAuthUrl(uri: string, options: CliConnectHandlerOptions): Promise<void> {
+  await options.onAuthUrl?.(uri);
+
+  if (options.openBrowser === true) {
+    await (options.browserOpener ?? defaultOpenBrowser)(uri);
+    writeLine(options, 'Opening wallet for approval...');
+    writeLine(options, 'Waiting for approval...');
+    return;
+  }
+
+  writeLine(options, 'Scan with your wallet, or open the link in a browser:');
+  writeLine(options, '');
+  const qr = await (options.qrRenderer ?? renderTerminalQr)(uri);
+  writeLine(options, qr);
+  writeLine(options, '');
+  writeLine(options, uri);
+  writeLine(options, '');
+  writeLine(options, 'Waiting for approval...');
+}
+
+function writeLine(options: CliConnectHandlerOptions, line: string): void {
+  const output = options.output ?? process.stdout;
+  output.write(`${line}\n`);
+}
+
+function validateConnectResult(result: ConnectResult, permissionRequests: ConnectPermissionRequest[]): void {
+  const delegateDid = result.delegatePortableDid.uri;
+  const revocationGrantIds = new Map<string, string>();
+
+  for (const revocation of result.sessionRevocations ?? []) {
+    revocationGrantIds.set(revocation.revocationGrantId, revocation.grantId);
+  }
+
+  for (const grantMessage of result.delegateGrants) {
+    const grant = DwnPermissionGrant.parse(grantMessage);
+
+    if (grant.grantee !== delegateDid) {
+      throw new Error(
+        `@enbox/cli: wallet returned a grant for '${grant.grantee}', but the delegate DID is '${delegateDid}'. ` +
+        'Revoke the approved session in your wallet.'
+      );
+    }
+
+    if (isSessionRevocationGrant(grant, revocationGrantIds)) {
+      continue;
+    }
+
+    if (!isRequestedScope(grant.scope, permissionRequests)) {
+      throw new Error('@enbox/cli: wallet returned a grant outside the requested permission scope. Revoke the approved session in your wallet.');
+    }
+  }
+}
+
+function isSessionRevocationGrant(
+  grant: ReturnType<typeof DwnPermissionGrant.parse>,
+  revocationGrantIds: Map<string, string>,
+): boolean {
+  const revokedGrantId = revocationGrantIds.get(grant.id);
+  if (revokedGrantId === undefined) {
+    return false;
+  }
+
+  return grant.scope.interface === 'Records' &&
+    grant.scope.method === 'Write' &&
+    'protocol' in grant.scope &&
+    grant.scope.protocol === DwnPermissionsProtocol.uri &&
+    'contextId' in grant.scope &&
+    grant.scope.contextId === revokedGrantId;
+}
+
+function isRequestedScope(grantScope: DwnPermissionScope, permissionRequests: ConnectPermissionRequest[]): boolean {
+  return permissionRequests.some((permissionRequest) =>
+    permissionRequest.permissionScopes.some((requestedScope) => isScopeSubset(grantScope, requestedScope))
+  );
+}
+
+function isScopeSubset(grantScope: DwnPermissionScope, requestedScope: DwnPermissionScope): boolean {
+  if (grantScope.interface !== requestedScope.interface || grantScope.method !== requestedScope.method) {
+    return false;
+  }
+
+  const requested = requestedScope as Record<string, unknown>;
+  const granted = grantScope as Record<string, unknown>;
+  for (const [key, requestedValue] of Object.entries(requested)) {
+    if (!isEqualScopeValue(granted[key], requestedValue)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isEqualScopeValue(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+
+  return JSON.stringify(left) === JSON.stringify(right);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * @enbox/cli — CLI helpers for Enbox apps.
+ *
+ * Provides Node/Bun-specific connect handlers while re-exporting the high-level
+ * Enbox API and auth session primitives for terminal applications.
+ *
+ * @packageDocumentation
+ */
+
+export {
+  Enbox,
+  defineProtocol,
+  repository,
+} from '@enbox/api';
+
+export type {
+  EnboxAnonymousOptions,
+  EnboxConnectOptions,
+  EnboxConnectResult,
+  EnboxParams,
+  EnboxSessionParams,
+} from '@enbox/api';
+
+export {
+  AuthManager,
+  AuthSession,
+  normalizeProtocolRequests,
+  WalletConnect,
+} from '@enbox/auth';
+
+export type {
+  AuthEvent,
+  AuthEventHandler,
+  AuthManagerOptions,
+  AuthState,
+  ConnectHandler,
+  ConnectOptions,
+  ConnectResult,
+  DisconnectOptions,
+  HandlerConnectOptions,
+  ImportFromPortableOptions,
+  Permission,
+  PortableIdentity,
+  ProtocolRequest,
+  RegistrationOptions,
+  StorageAdapter,
+  SyncOption,
+  VaultConnectOptions,
+  WalletConnectOptions,
+} from '@enbox/auth';
+
+export { CliConnectHandler, DEFAULT_CLI_WALLET_URL } from './cli-connect-handler.js';
+export type { BrowserOpenFunction, CliConnectHandlerOptions, PromptFunction, QrRenderer } from './cli-connect-handler.js';

--- a/packages/cli/src/terminal.ts
+++ b/packages/cli/src/terminal.ts
@@ -1,0 +1,73 @@
+import type { Readable, Writable } from 'node:stream';
+
+import { createInterface } from 'node:readline/promises';
+import { spawn } from 'node:child_process';
+
+import QRCode from 'qrcode';
+
+/**
+ * Prompt for one line of terminal input.
+ */
+export async function promptLine({
+  input = process.stdin,
+  output = process.stdout,
+  question,
+}: {
+  input?: Readable;
+  output?: Writable;
+  question: string;
+}): Promise<string> {
+  const readline = createInterface({ input, output });
+  try {
+    return await readline.question(question);
+  } finally {
+    readline.close();
+  }
+}
+
+/**
+ * Render a URL as a terminal QR code.
+ */
+export async function renderTerminalQr(uri: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    QRCode.toString(uri, { small: true, type: 'terminal' }, (error, qr) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(qr);
+    });
+  });
+}
+
+/**
+ * Open a URL with the host platform's default browser.
+ */
+export async function openBrowser(uri: string): Promise<void> {
+  const platform = process.platform;
+  let command: string;
+  let args: string[];
+
+  if (platform === 'darwin') {
+    command = 'open';
+    args = [uri];
+  } else if (platform === 'win32') {
+    command = 'cmd';
+    args = ['/c', 'start', '', uri];
+  } else {
+    command = 'xdg-open';
+    args = [uri];
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      detached : true,
+      stdio    : 'ignore',
+    });
+    child.once('error', reject);
+    child.once('spawn', () => {
+      child.unref();
+      resolve();
+    });
+  });
+}

--- a/packages/cli/src/terminal.ts
+++ b/packages/cli/src/terminal.ts
@@ -5,6 +5,11 @@ import { spawn } from 'node:child_process';
 
 import QRCode from 'qrcode';
 
+export type BrowserOpenCommand = {
+  args: string[];
+  command: string;
+};
+
 /**
  * Prompt for one line of terminal input.
  */
@@ -44,20 +49,7 @@ export async function renderTerminalQr(uri: string): Promise<string> {
  * Open a URL with the host platform's default browser.
  */
 export async function openBrowser(uri: string): Promise<void> {
-  const platform = process.platform;
-  let command: string;
-  let args: string[];
-
-  if (platform === 'darwin') {
-    command = 'open';
-    args = [uri];
-  } else if (platform === 'win32') {
-    command = 'cmd';
-    args = ['/c', 'start', '', uri];
-  } else {
-    command = 'xdg-open';
-    args = [uri];
-  }
+  const { args, command } = getBrowserOpenCommand(uri);
 
   await new Promise<void>((resolve, reject) => {
     const child = spawn(command, args, {
@@ -70,4 +62,28 @@ export async function openBrowser(uri: string): Promise<void> {
       resolve();
     });
   });
+}
+
+/**
+ * Returns the platform command used to open URLs in the default browser.
+ */
+export function getBrowserOpenCommand(uri: string, platform: NodeJS.Platform = process.platform): BrowserOpenCommand {
+  if (platform === 'darwin') {
+    return {
+      args    : [uri],
+      command : 'open',
+    };
+  }
+
+  if (platform === 'win32') {
+    return {
+      args    : ['url.dll,FileProtocolHandler', uri],
+      command : 'rundll32',
+    };
+  }
+
+  return {
+    args    : [uri],
+    command : 'xdg-open',
+  };
 }

--- a/packages/cli/tests/cli-connect-handler.spec.ts
+++ b/packages/cli/tests/cli-connect-handler.spec.ts
@@ -1,9 +1,14 @@
+import type { AddressInfo } from 'node:net';
 import type { ConnectPermissionRequest, DwnPermissionScope } from '@enbox/agent';
 import type { ConnectResult, WalletConnectClientOptions } from '@enbox/auth';
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 
 import sinon from 'sinon';
 
 import { Convert } from '@enbox/common';
+import { createServer } from 'node:http';
+import { DidJwk } from '@enbox/dids';
+import { EnboxConnectProtocol } from '@enbox/agent';
 import { WalletConnect } from '@enbox/auth';
 import { afterEach, describe, expect, it } from 'bun:test';
 import { DwnInterfaceName, DwnMethodName } from '@enbox/dwn-sdk-js';
@@ -67,6 +72,93 @@ describe('CliConnectHandler', () => {
     expect(authUrls).toEqual(['https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test']);
     expect(output.text()).toContain('[qr]');
     expect(output.text()).toContain('Waiting for approval...');
+  });
+
+  it('should complete through an encrypted relay stub and consume relay artifacts once', async () => {
+    const relay = await createTestRelay();
+    let requestUri = '';
+    let tokenUrl = '';
+
+    try {
+      const output = createWritableBuffer();
+      const handler = CliConnectHandler({
+        appName                    : 'Relay CLI',
+        walletUrl                  : 'https://wallet.example/connect/app',
+        connectServerUrl           : `${relay.url}/connect`,
+        output,
+        pinPrompt                  : async (): Promise<string> => '428113',
+        qrRenderer                 : async (): Promise<string> => '[qr]',
+        timeoutMs                  : 1000,
+        pollIntervalMs             : 1,
+        requestedSessionTtlSeconds : 2_592_000,
+        onAuthUrl                  : async (uri: string): Promise<void> => {
+          const walletUrl = new URL(uri);
+          requestUri = getRequiredSearchParam(walletUrl, 'request_uri');
+          const encryptionKey = getRequiredSearchParam(walletUrl, 'encryption_key');
+          const connectRequest = await EnboxConnectProtocol.getConnectRequest(requestUri, encryptionKey);
+
+          expect(connectRequest.appName).toBe('Relay CLI');
+          expect(connectRequest.requestedSessionTtlSeconds).toBe(2_592_000);
+
+          const delegateBearerDid = await DidJwk.create();
+          const delegatePortableDid = await delegateBearerDid.export();
+          const clientDidResolution = await DidJwk.resolve(connectRequest.clientDid);
+          if (clientDidResolution?.didDocument === undefined) {
+            throw new Error('test setup failed to resolve client DID');
+          }
+
+          const delegatePublicKeyJwk = delegateBearerDid.document.verificationMethod?.[0].publicKeyJwk;
+          if (delegatePublicKeyJwk === undefined) {
+            throw new Error('test setup failed to read delegate public key');
+          }
+
+          const sharedKey = await EnboxConnectProtocol.deriveSharedKey(delegateBearerDid, clientDidResolution.didDocument);
+          const responseObject = await EnboxConnectProtocol.createConnectResponse({
+            providerDid    : connectedDid,
+            delegateDid    : delegateBearerDid.uri,
+            aud            : connectRequest.clientDid,
+            nonce          : connectRequest.nonce,
+            delegateGrants : [createGrant({ grantee: delegateBearerDid.uri, scope: requestedScope })],
+            delegatePortableDid,
+          });
+          const responseJwt = await EnboxConnectProtocol.signJwt({
+            did  : delegateBearerDid,
+            data : responseObject,
+          });
+          if (responseJwt === undefined) {
+            throw new Error('test setup failed to sign connect response');
+          }
+
+          const encryptedResponse = await EnboxConnectProtocol.encryptResponse({
+            jwt           : responseJwt,
+            encryptionKey : sharedKey,
+            delegatePublicKeyJwk,
+            pin           : '428113',
+          });
+
+          const callbackResponse = await fetch(connectRequest.callbackUrl, {
+            body    : new URLSearchParams({ id_token: encryptedResponse, state: connectRequest.state }).toString(),
+            method  : 'POST',
+            headers : { 'Content-Type': 'application/x-www-form-urlencoded' },
+          });
+          expect(callbackResponse.status).toBe(200);
+          tokenUrl = `${relay.url}/connect/token/${connectRequest.state}.jwt`;
+        },
+      });
+
+      const result = await handler.requestAccess({ permissionRequests });
+
+      expect(result?.connectedDid).toBe(connectedDid);
+      expect(result?.delegatePortableDid.uri.startsWith('did:jwk:')).toBe(true);
+      expect(result?.delegateGrants).toHaveLength(1);
+      expect(output.text()).toContain('[qr]');
+      expect(relay.requestReads()).toBe(1);
+      expect(relay.tokenReads()).toBe(1);
+      expect((await fetch(requestUri)).status).toBe(404);
+      expect((await fetch(tokenUrl)).status).toBe(404);
+    } finally {
+      await relay.close();
+    }
   });
 
   it('should open the browser instead of printing a QR code when requested', async () => {
@@ -256,6 +348,186 @@ describe('CliConnectHandler', () => {
     expect(capturedOptions?.connectServerUrl).toBe('https://relay.example/connect');
   });
 });
+
+type TestRelay = {
+  close: () => Promise<void>;
+  requestReads: () => number;
+  tokenReads: () => number;
+  url: string;
+};
+
+type StoredRelayEntry = {
+  consumed: boolean;
+  value: string;
+};
+
+async function createTestRelay(): Promise<TestRelay> {
+  const requests = new Map<string, StoredRelayEntry>();
+  const tokens = new Map<string, StoredRelayEntry>();
+  let requestReadCount = 0;
+  let tokenReadCount = 0;
+  let nextRequestId = 0;
+  let baseUrl = '';
+
+  const server = createServer((request: IncomingMessage, response: ServerResponse): void => {
+    void handleRelayRequest({
+      baseUrl,
+      request,
+      requests,
+      response,
+      tokens,
+      nextRequestId: (): string => {
+        nextRequestId += 1;
+        return `request-${nextRequestId}`;
+      },
+      incrementRequestReads : (): void => { requestReadCount += 1; },
+      incrementTokenReads   : (): void => { tokenReadCount += 1; },
+    }).catch((error: unknown): void => {
+      writeResponse(response, 500, error instanceof Error ? error.message : String(error));
+    });
+  });
+
+  await listen(server);
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+
+  return {
+    url          : baseUrl,
+    requestReads : (): number => requestReadCount,
+    tokenReads   : (): number => tokenReadCount,
+    close        : (): Promise<void> => close(server),
+  };
+}
+
+async function handleRelayRequest({
+  baseUrl,
+  request,
+  requests,
+  response,
+  tokens,
+  nextRequestId,
+  incrementRequestReads,
+  incrementTokenReads,
+}: {
+  baseUrl: string;
+  request: IncomingMessage;
+  requests: Map<string, StoredRelayEntry>;
+  response: ServerResponse;
+  tokens: Map<string, StoredRelayEntry>;
+  nextRequestId: () => string;
+  incrementRequestReads: () => void;
+  incrementTokenReads: () => void;
+}): Promise<void> {
+  const url = new URL(request.url ?? '/', baseUrl);
+
+  if (request.method === 'POST' && url.pathname === '/connect/par') {
+    const body = JSON.parse(await readRequestBody(request)) as { request?: string };
+    if (body.request === undefined) {
+      writeResponse(response, 400, 'missing request');
+      return;
+    }
+
+    const requestId = nextRequestId();
+    requests.set(requestId, { consumed: false, value: body.request });
+    writeJson(response, {
+      request_uri: `${baseUrl}/connect/authorize/${requestId}.jwt`,
+    });
+    return;
+  }
+
+  const authorizeMatch = url.pathname.match(/^\/connect\/authorize\/([^/]+)\.jwt$/);
+  if (request.method === 'GET' && authorizeMatch !== null) {
+    const requestId = authorizeMatch[1];
+    const stored = requests.get(requestId);
+    if (stored === undefined || stored.consumed) {
+      writeResponse(response, 404, 'not found');
+      return;
+    }
+
+    stored.consumed = true;
+    incrementRequestReads();
+    writeResponse(response, 200, stored.value, 'application/jwt');
+    return;
+  }
+
+  if (request.method === 'POST' && url.pathname === '/connect/callback') {
+    const body = new URLSearchParams(await readRequestBody(request));
+    const state = body.get('state');
+    const idToken = body.get('id_token');
+    if (state === null || idToken === null) {
+      writeResponse(response, 400, 'missing response');
+      return;
+    }
+
+    tokens.set(state, { consumed: false, value: idToken });
+    writeResponse(response, 200, 'ok');
+    return;
+  }
+
+  const tokenMatch = url.pathname.match(/^\/connect\/token\/([^/]+)\.jwt$/);
+  if (request.method === 'GET' && tokenMatch !== null) {
+    const state = tokenMatch[1];
+    const stored = tokens.get(state);
+    if (stored === undefined || stored.consumed) {
+      writeResponse(response, 404, 'not found');
+      return;
+    }
+
+    stored.consumed = true;
+    incrementTokenReads();
+    writeResponse(response, 200, stored.value, 'application/jwt');
+    return;
+  }
+
+  writeResponse(response, 404, 'not found');
+}
+
+function getRequiredSearchParam(url: URL, name: string): string {
+  const value = url.searchParams.get(name);
+  if (value === null || value === '') {
+    throw new Error(`missing ${name} search parameter`);
+  }
+  return value;
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    request.on('data', (chunk: Buffer | string): void => {
+      body += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    });
+    request.on('end', (): void => { resolve(body); });
+    request.on('error', (error: Error): void => { reject(error); });
+  });
+}
+
+function writeJson(response: ServerResponse, body: unknown): void {
+  writeResponse(response, 200, JSON.stringify(body), 'application/json');
+}
+
+function writeResponse(response: ServerResponse, statusCode: number, body: string, contentType = 'text/plain'): void {
+  response.writeHead(statusCode, { 'Content-Type': contentType });
+  response.end(body);
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', (error: Error): void => { reject(error); });
+    server.listen(0, '127.0.0.1', (): void => { resolve(); });
+  });
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error?: Error): void => {
+      if (error !== undefined) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
 
 function createConnectResult(
   delegateGrants: ConnectResult['delegateGrants'],

--- a/packages/cli/tests/cli-connect-handler.spec.ts
+++ b/packages/cli/tests/cli-connect-handler.spec.ts
@@ -1,0 +1,321 @@
+import type { ConnectPermissionRequest, DwnPermissionScope } from '@enbox/agent';
+import type { ConnectResult, WalletConnectClientOptions } from '@enbox/auth';
+
+import sinon from 'sinon';
+
+import { Convert } from '@enbox/common';
+import { WalletConnect } from '@enbox/auth';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { DwnInterfaceName, DwnMethodName } from '@enbox/dwn-sdk-js';
+
+import { CliConnectHandler, DEFAULT_CLI_WALLET_URL } from '../src/cli-connect-handler.js';
+
+const delegateDid = 'did:jwk:delegate';
+const connectedDid = 'did:dht:owner';
+const requestedScope: DwnPermissionScope = {
+  interface : DwnInterfaceName.Records,
+  method    : DwnMethodName.Write,
+  protocol  : 'https://example.com/protocols/notes',
+};
+const permissionRequests: ConnectPermissionRequest[] = [{
+  protocolDefinition: {
+    published : true,
+    protocol  : 'https://example.com/protocols/notes',
+    types     : {},
+    structure : {},
+  },
+  permissionScopes: [requestedScope],
+}];
+
+describe('CliConnectHandler', () => {
+  afterEach((): void => {
+    sinon.restore();
+  });
+
+  it('should complete an approved relay flow and validate the returned grants', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    const result = createConnectResult([createGrant({ scope: requestedScope })]);
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      await options.onWalletUriReady('https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test');
+      expect(await options.validatePin()).toBe('428113');
+      return result;
+    });
+
+    const output = createWritableBuffer();
+    const authUrls: string[] = [];
+    const handler = CliConnectHandler({
+      appName                    : 'Test CLI',
+      walletUrl                  : 'https://wallet.example',
+      connectServerUrl           : 'https://relay.example/connect',
+      output,
+      onAuthUrl                  : (uri: string): void => { authUrls.push(uri); },
+      pinPrompt                  : async (): Promise<string> => '428113',
+      qrRenderer                 : async (): Promise<string> => '[qr]',
+      timeoutMs                  : 10_000,
+      requestedSessionTtlSeconds : 2_592_000,
+    });
+
+    const connectResult = await handler.requestAccess({ permissionRequests });
+
+    expect(connectResult).toBe(result);
+    expect(capturedOptions?.displayName).toBe('Test CLI');
+    expect(capturedOptions?.walletUri).toBe('https://wallet.example/connect/app');
+    expect(capturedOptions?.connectServerUrl).toBe('https://relay.example/connect');
+    expect(capturedOptions?.timeoutMs).toBe(10_000);
+    expect(capturedOptions?.requestedSessionTtlSeconds).toBe(2_592_000);
+    expect(authUrls).toEqual(['https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test']);
+    expect(output.text()).toContain('[qr]');
+    expect(output.text()).toContain('Waiting for approval...');
+  });
+
+  it('should open the browser instead of printing a QR code when requested', async () => {
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      await options.onWalletUriReady('https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test');
+      return createConnectResult([createGrant({ scope: requestedScope })]);
+    });
+
+    const openedUrls: string[] = [];
+    const output = createWritableBuffer();
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'https://relay.example/connect',
+      output,
+      openBrowser      : true,
+      browserOpener    : (uri: string): void => { openedUrls.push(uri); },
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(openedUrls).toEqual(['https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test']);
+    expect(output.text()).toContain('Opening wallet for approval...');
+    expect(output.text()).not.toContain('[qr]');
+  });
+
+  it('should return undefined when the wallet denies the request', async () => {
+    sinon.stub(WalletConnect, 'initClient').resolves(undefined);
+
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'https://relay.example/connect',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await expect(handler.requestAccess({ permissionRequests })).resolves.toBeUndefined();
+  });
+
+  it('should surface PIN mismatch failures from the relay client', async () => {
+    sinon.stub(WalletConnect, 'initClient').rejects(new Error('failed to decrypt response'));
+
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'https://relay.example/connect',
+      pinPrompt        : async (): Promise<string> => '000000',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await expect(handler.requestAccess({ permissionRequests })).rejects.toThrow('failed to decrypt response');
+  });
+
+  it('should pass polling controls to the relay client', async () => {
+    let timeoutMs: number | undefined;
+    let pollIntervalMs: number | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      timeoutMs = options.timeoutMs;
+      pollIntervalMs = options.pollIntervalMs;
+      return undefined;
+    });
+
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'https://relay.example/connect',
+      timeoutMs        : 1234,
+      pollIntervalMs   : 50,
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(timeoutMs).toBe(1234);
+    expect(pollIntervalMs).toBe(50);
+  });
+
+  it('should reject grants issued to a DID other than the returned delegate DID', async () => {
+    sinon.stub(WalletConnect, 'initClient').resolves(createConnectResult([
+      createGrant({ grantee: 'did:jwk:other', scope: requestedScope }),
+    ]));
+
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'https://relay.example/connect',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await expect(handler.requestAccess({ permissionRequests })).rejects.toThrow('Revoke the approved session in your wallet');
+  });
+
+  it('should reject grants broader than the requested scope', async () => {
+    const broaderScope: DwnPermissionScope = {
+      interface : DwnInterfaceName.Records,
+      method    : DwnMethodName.Write,
+    };
+    sinon.stub(WalletConnect, 'initClient').resolves(createConnectResult([
+      createGrant({ scope: broaderScope }),
+    ]));
+
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'https://relay.example/connect',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await expect(handler.requestAccess({ permissionRequests })).rejects.toThrow('outside the requested permission scope');
+  });
+
+  it('should allow session revocation grants returned with sessionRevocations metadata', async () => {
+    const sessionGrant = createGrant({ grantId: 'grant-1', scope: requestedScope });
+    const revocationGrant = createGrant({
+      grantId : 'revocation-1',
+      scope   : {
+        interface : DwnInterfaceName.Records,
+        method    : DwnMethodName.Write,
+        protocol  : 'https://identity.foundation/dwn/permissions',
+        contextId : 'grant-1',
+      },
+    });
+    sinon.stub(WalletConnect, 'initClient').resolves(createConnectResult(
+      [sessionGrant, revocationGrant],
+      { sessionRevocations: [{ grantId: 'grant-1', revocationGrantId: 'revocation-1' }] },
+    ));
+
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'https://relay.example/connect',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    const result = await handler.requestAccess({ permissionRequests });
+
+    expect(result?.delegateGrants).toHaveLength(2);
+  });
+
+  it('should prompt for wallet and relay URLs when options are omitted', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+
+    const prompts: string[] = [];
+    const answers = ['', 'https://relay.example/connect'];
+    const handler = CliConnectHandler({
+      walletPrompt: async (question: string): Promise<string> => {
+        prompts.push(question);
+        return answers.shift() ?? '';
+      },
+      connectServerUrlPrompt: async (question: string): Promise<string> => {
+        prompts.push(question);
+        return answers.shift() ?? '';
+      },
+      pinPrompt  : async (): Promise<string> => '428113',
+      qrRenderer : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(prompts[0]).toBe(`Wallet [${DEFAULT_CLI_WALLET_URL}]: `);
+    expect(prompts[1]).toBe('Connect relay URL: ');
+    expect(capturedOptions?.walletUri).toBe(`${DEFAULT_CLI_WALLET_URL}/connect/app`);
+    expect(capturedOptions?.connectServerUrl).toBe('https://relay.example/connect');
+  });
+
+  it('should use a provider-supplied relay URL before prompting', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+
+    const handler = CliConnectHandler({
+      walletUrl                : 'https://wallet.example',
+      connectServerUrlProvider : async (): Promise<string> => 'https://relay.example/connect',
+      connectServerUrlPrompt   : async (): Promise<string> => { throw new Error('should not prompt'); },
+      pinPrompt                : async (): Promise<string> => '428113',
+      qrRenderer               : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(capturedOptions?.connectServerUrl).toBe('https://relay.example/connect');
+  });
+});
+
+function createConnectResult(
+  delegateGrants: ConnectResult['delegateGrants'],
+  overrides: Partial<ConnectResult> = {},
+): ConnectResult {
+  return {
+    delegatePortableDid: { uri: delegateDid, document: {}, metadata: {} },
+    connectedDid,
+    delegateGrants,
+    ...overrides,
+  };
+}
+
+function createGrant({
+  grantId = 'grant-1',
+  grantee = delegateDid,
+  scope,
+}: {
+  grantId?: string;
+  grantee?: string;
+  scope: DwnPermissionScope;
+}): ConnectResult['delegateGrants'][number] {
+  return {
+    recordId    : grantId,
+    contextId   : grantId,
+    encodedData : Convert.object({
+      dateExpires : '2040-01-01T00:00:00.000000Z',
+      delegated   : true,
+      scope,
+    }).toBase64Url(),
+    descriptor: {
+      interface    : DwnInterfaceName.Records,
+      method       : DwnMethodName.Write,
+      protocol     : 'https://identity.foundation/dwn/permissions',
+      protocolPath : 'grant',
+      recipient    : grantee,
+      dateCreated  : '2026-01-01T00:00:00.000000Z',
+      dataFormat   : 'application/json',
+      dataCid      : 'bafytest',
+      dataSize     : 100,
+    },
+    authorization: {
+      signature: {
+        signatures: [{
+          protected: Convert.object({ kid: `${connectedDid}#key-1` }).toBase64Url(),
+        }],
+      },
+    },
+  };
+}
+
+function createWritableBuffer(): Writable & { text(): string } {
+  let text = '';
+  return {
+    write(chunk: string | Uint8Array): boolean {
+      text += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+      return true;
+    },
+    text(): string {
+      return text;
+    },
+  } as Writable & { text(): string };
+}

--- a/packages/cli/tests/cli-connect-handler.spec.ts
+++ b/packages/cli/tests/cli-connect-handler.spec.ts
@@ -425,6 +425,67 @@ describe('CliConnectHandler', () => {
     await expect(handler.requestAccess({ permissionRequests })).rejects.toThrow('@enbox/cli: invalid wallet URL');
   });
 
+  it('should normalize configured bare relay URLs', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'my-dwn.example/connect',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(capturedOptions?.connectServerUrl).toBe('https://my-dwn.example/connect');
+  });
+
+  it('should reject configured invalid relay URLs with a friendly error', async () => {
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'http://',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await expect(handler.requestAccess({ permissionRequests })).rejects.toThrow('@enbox/cli: invalid connect relay URL');
+  });
+
+  it('should normalize bare prompted relay hosts and re-prompt invalid relay URLs', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+
+    const prompts: string[] = [];
+    const answers = ['http://', 'my-dwn.example/connect'];
+    const output = createWritableBuffer();
+    const handler = CliConnectHandler({
+      output,
+      walletUrl              : 'https://wallet.example',
+      connectServerUrlPrompt : async (question: string): Promise<string> => {
+        prompts.push(question);
+        return answers.shift() ?? '';
+      },
+      pinPrompt  : async (): Promise<string> => '428113',
+      qrRenderer : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(prompts).toEqual([
+      'Connect relay URL: ',
+      'Connect relay URL: ',
+    ]);
+    expect(capturedOptions?.connectServerUrl).toBe('https://my-dwn.example/connect');
+    expect(output.text()).toContain('invalid connect relay URL');
+  });
+
   it('should use a provider-supplied relay URL before prompting', async () => {
     let capturedOptions: WalletConnectClientOptions | undefined;
     sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
@@ -434,7 +495,7 @@ describe('CliConnectHandler', () => {
 
     const handler = CliConnectHandler({
       walletUrl                : 'https://wallet.example',
-      connectServerUrlProvider : async (): Promise<string> => 'https://relay.example/connect',
+      connectServerUrlProvider : async (): Promise<string> => 'provider-dwn.example/connect',
       connectServerUrlPrompt   : async (): Promise<string> => { throw new Error('should not prompt'); },
       pinPrompt                : async (): Promise<string> => '428113',
       qrRenderer               : async (): Promise<string> => '[qr]',
@@ -442,7 +503,7 @@ describe('CliConnectHandler', () => {
 
     await handler.requestAccess({ permissionRequests });
 
-    expect(capturedOptions?.connectServerUrl).toBe('https://relay.example/connect');
+    expect(capturedOptions?.connectServerUrl).toBe('https://provider-dwn.example/connect');
   });
 });
 

--- a/packages/cli/tests/cli-connect-handler.spec.ts
+++ b/packages/cli/tests/cli-connect-handler.spec.ts
@@ -236,6 +236,25 @@ describe('CliConnectHandler', () => {
     expect(pollIntervalMs).toBe(50);
   });
 
+  it('should let the relay client apply the default timeout', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'https://relay.example/connect',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(capturedOptions?.timeoutMs).toBeUndefined();
+  });
+
   it('should reject grants issued to a DID other than the returned delegate DID', async () => {
     sinon.stub(WalletConnect, 'initClient').resolves(createConnectResult([
       createGrant({ grantee: 'did:jwk:other', scope: requestedScope }),
@@ -326,6 +345,84 @@ describe('CliConnectHandler', () => {
     expect(prompts[1]).toBe('Connect relay URL: ');
     expect(capturedOptions?.walletUri).toBe(`${DEFAULT_CLI_WALLET_URL}/connect/app`);
     expect(capturedOptions?.connectServerUrl).toBe('https://relay.example/connect');
+  });
+
+  it('should normalize bare prompted wallet hosts and re-prompt invalid wallet URLs', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+
+    const prompts: string[] = [];
+    const answers = ['http://', 'localhost:5173', 'https://relay.example/connect'];
+    const output = createWritableBuffer();
+    const handler = CliConnectHandler({
+      output,
+      walletPrompt: async (question: string): Promise<string> => {
+        prompts.push(question);
+        return answers.shift() ?? '';
+      },
+      connectServerUrlPrompt: async (question: string): Promise<string> => {
+        prompts.push(question);
+        return answers.shift() ?? '';
+      },
+      pinPrompt  : async (): Promise<string> => '428113',
+      qrRenderer : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(prompts).toEqual([
+      `Wallet [${DEFAULT_CLI_WALLET_URL}]: `,
+      `Wallet [${DEFAULT_CLI_WALLET_URL}]: `,
+      'Connect relay URL: ',
+    ]);
+    expect(capturedOptions?.walletUri).toBe('https://localhost:5173/connect/app');
+    expect(output.text()).toContain('invalid wallet URL');
+  });
+
+  it('should remember prompted wallet URLs per handler instance', async () => {
+    const walletUris: string[] = [];
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      walletUris.push(options.walletUri);
+      return undefined;
+    });
+
+    const firstHandlerAnswers = ['https://wallet-one.example', ''];
+    const firstHandler = CliConnectHandler({
+      connectServerUrl : 'https://relay.example/connect',
+      walletPrompt     : async (): Promise<string> => firstHandlerAnswers.shift() ?? '',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+    const secondHandler = CliConnectHandler({
+      connectServerUrl : 'https://relay.example/connect',
+      walletPrompt     : async (): Promise<string> => '',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await firstHandler.requestAccess({ permissionRequests });
+    await firstHandler.requestAccess({ permissionRequests });
+    await secondHandler.requestAccess({ permissionRequests });
+
+    expect(walletUris).toEqual([
+      'https://wallet-one.example/connect/app',
+      'https://wallet-one.example/connect/app',
+      `${DEFAULT_CLI_WALLET_URL}/connect/app`,
+    ]);
+  });
+
+  it('should reject configured invalid wallet URLs with a friendly error', async () => {
+    const handler = CliConnectHandler({
+      walletUrl        : 'http://',
+      connectServerUrl : 'https://relay.example/connect',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await expect(handler.requestAccess({ permissionRequests })).rejects.toThrow('@enbox/cli: invalid wallet URL');
   });
 
   it('should use a provider-supplied relay URL before prompting', async () => {

--- a/packages/cli/tests/exports.spec.ts
+++ b/packages/cli/tests/exports.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+
+import cliPackageJson from '../package.json' with { type: 'json' };
+
+describe('@enbox/cli exports', () => {
+  async function getCliExports(): Promise<Record<string, unknown>> {
+    return import('../src/index.js') as unknown as Record<string, unknown>;
+  }
+
+  it('exports Enbox from @enbox/api', async () => {
+    const mod = await getCliExports();
+    expect(mod.Enbox).toBeDefined();
+    expect(typeof mod.Enbox).toBe('function');
+  });
+
+  it('exports AuthManager from @enbox/auth', async () => {
+    const mod = await getCliExports();
+    expect(mod.AuthManager).toBeDefined();
+    expect(typeof mod.AuthManager).toBe('function');
+  });
+
+  it('exports CliConnectHandler', async () => {
+    const mod = await getCliExports();
+    expect(mod.CliConnectHandler).toBeDefined();
+    expect(typeof mod.CliConnectHandler).toBe('function');
+  });
+
+  it('declares a node import root entrypoint', () => {
+    expect(cliPackageJson.exports['.'].import).toBe('./dist/esm/index.js');
+    expect(cliPackageJson.exports['.'].types).toBe('./dist/types/index.d.ts');
+  });
+});

--- a/packages/cli/tests/terminal.spec.ts
+++ b/packages/cli/tests/terminal.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test';
+
+import { getBrowserOpenCommand } from '../src/terminal.js';
+
+describe('terminal', () => {
+  describe('getBrowserOpenCommand()', () => {
+    it('should use a Windows browser opener that preserves wallet query strings', () => {
+      const uri = 'https://wallet.example/connect/app?request_uri=urn%3Atest&encryption_key=test';
+
+      const command = getBrowserOpenCommand(uri, 'win32');
+
+      expect(command).toEqual({
+        args    : ['url.dll,FileProtocolHandler', uri],
+        command : 'rundll32',
+      });
+    });
+  });
+});

--- a/packages/cli/tests/tsconfig.json
+++ b/packages/cli/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun-types", "node"]
+  },
+  "include": [
+    "../src",
+    "."
+  ]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": [
+      "DOM",
+      "ES2022"
+    ],
+    "types": [
+      "bun-types",
+      "node"
+    ],
+    "strict": true,
+    "declarationDir": "dist/types",
+    "outDir": "dist/esm"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the new `@enbox/cli` workspace package with a `CliConnectHandler` for relay/PIN wallet connect, terminal QR/link output, optional browser opening, prompt hooks, timeout controls, and returned-grant validation
- thread async wallet URI handling, polling controls, and requested session TTL hints through the auth wallet-connect client
- document the CLI package, add a CLI demo, and include a changeset

## Test plan
- [x] `bunx changeset status`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run --filter @enbox/cli test:node`
- [x] `bun test packages/auth/tests/wallet-connect-client.spec.ts`
- [x] `bun run dev:ensure` / persistent `bun run dev`, then `bun run test:node` from `packages/agent` (1262 pass, 4 skip)
- [x] `bun run --filter @enbox/docs types:check`

## Notes
- `bun run --filter @enbox/docs lint` currently exits before checking files because `apps/docs/biome.json` requires a local ignore file that is not present; I validated the touched docs with `bunx biome check --vcs-use-ignore-file=false content/docs/index.mdx content/docs/packages/meta.json content/docs/packages/cli.mdx` and `types:check`.
