### PR TITLE
fix(agent): honor requested connect session ttl

### DIFF
--- a/.changeset/connect-requested-session-ttl.md
+++ b/.changeset/connect-requested-session-ttl.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+fix: honor requested connect session TTLs when stamping wallet grants

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -882,12 +882,14 @@ function resolveRequestedSessionTtlSeconds(requestedSessionTtlSeconds: number | 
     return CONNECT_SESSION_DEFAULT_TTL_SECONDS;
   }
 
-  if (!Number.isFinite(requestedSessionTtlSeconds) || requestedSessionTtlSeconds <= 0) {
-    throw new Error('Connect requestedSessionTtlSeconds must be a positive finite number.');
+  const requestedWholeSeconds = Math.floor(requestedSessionTtlSeconds);
+
+  if (!Number.isFinite(requestedSessionTtlSeconds) || requestedWholeSeconds <= 0) {
+    throw new Error('Connect requestedSessionTtlSeconds must resolve to at least one whole second.');
   }
 
   return Math.min(
-    Math.floor(requestedSessionTtlSeconds),
+    requestedWholeSeconds,
     CONNECT_SESSION_MAX_TTL_SECONDS,
   );
 }

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -131,6 +131,9 @@ const CONNECT_PERF_LOG_PREFIX = '[connect.perf]';
  */
 export const CONNECT_SESSION_DEFAULT_TTL_SECONDS = 24 * 60 * 60;
 
+/** Maximum lifetime a wallet will stamp onto relay connect session grants. */
+export const CONNECT_SESSION_MAX_TTL_SECONDS = 90 * 24 * 60 * 60;
+
 const CONNECT_SESSION_METADATA_LIMITS = {
   id        : 128,
   appName   : 128,
@@ -874,6 +877,21 @@ function createConnectSessionMetadata(
   };
 }
 
+function resolveRequestedSessionTtlSeconds(requestedSessionTtlSeconds: number | undefined): number {
+  if (requestedSessionTtlSeconds === undefined) {
+    return CONNECT_SESSION_DEFAULT_TTL_SECONDS;
+  }
+
+  if (!Number.isFinite(requestedSessionTtlSeconds) || requestedSessionTtlSeconds <= 0) {
+    throw new Error('Connect requestedSessionTtlSeconds must be a positive finite number.');
+  }
+
+  return Math.min(
+    Math.floor(requestedSessionTtlSeconds),
+    CONNECT_SESSION_MAX_TTL_SECONDS,
+  );
+}
+
 function resolveConnectPermissionGrantOptions(
   options?: ConnectPermissionGrantOptions,
 ): { dateExpires: string; connectSession: ConnectSessionMetadata } {
@@ -1180,11 +1198,13 @@ async function submitConnectResponse(
   );
 
   try {
+    const sessionTtlSeconds = resolveRequestedSessionTtlSeconds(connectRequest.requestedSessionTtlSeconds);
     const delegateBearerDid = await timed(`${CONNECT_PERF_LOG_PREFIX} delegateDid.create`, () => DidJwk.create());
     const delegatePortableDid = await delegateBearerDid.export();
     const connectSession = createConnectSessionMetadata({
       appName        : connectRequest.appName,
       appIcon        : connectRequest.appIcon,
+      ttlSeconds     : sessionTtlSeconds,
       clientMetadata : connectRequest.clientMetadata,
       transport      : 'relay',
     });

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -15,6 +15,7 @@ import { Convert, logger } from '@enbox/common';
 
 import { AgentPermissionsApi, DwnInterface, DwnPermissionGrant } from '../src/index.js';
 import {
+  CONNECT_SESSION_MAX_TTL_SECONDS,
   EnboxConnectProtocol,
   type EnboxConnectRequest,
   type EnboxConnectResponse,
@@ -783,6 +784,119 @@ describe('enbox connect', () => {
   });
 
   describe('submitConnectResponse', () => {
+    type SubmitConnectResponseStubs = {
+      capturedSessions: Array<{ createdAt: string; expiresAt: string }>;
+      revocationGrantStub: sinon.SinonStub;
+    };
+
+    function stubSubmitConnectResponseDependencies(): SubmitConnectResponseStubs {
+      const capturedSessions: Array<{ createdAt: string; expiresAt: string }> = [];
+      sinon.stub(EnboxConnectProtocol, 'createPermissionGrants').callsFake(async (
+        _selectedDid,
+        _delegateBearerDid,
+        _agent,
+        _scopes,
+        options,
+      ): Promise<any> => {
+        if (options?.connectSession !== undefined) {
+          capturedSessions.push(options.connectSession);
+        }
+        return permissionGrants as any;
+      });
+      const revocationGrantStub = sinon.stub(AgentPermissionsApi.prototype, 'createGrant').resolves({
+        grant   : {} as any,
+        message : { recordId: 'mock-revocation-grant-id', encodedData: btoa('{}') } as any,
+      });
+      sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+      sinon.stub(testHarness.agent, 'processDwnRequest').resolves({
+        messageCid : '',
+        reply      : { status: { code: 200, detail: 'OK' }, entries: [{ descriptor: { interface: 'Protocols', method: 'Configure' } }] },
+      } as any);
+      sinon.stub(testHarness.agent.dwn, 'getDwnEndpointUrlsForTarget').resolves([]);
+      sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+      return { capturedSessions, revocationGrantStub };
+    }
+
+    it('should stamp requested session TTL onto permission and revocation grants', async () => {
+      const requestedSessionTtlSeconds = 30 * 24 * 60 * 60;
+      const { capturedSessions, revocationGrantStub } = stubSubmitConnectResponseDependencies();
+      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+        baseURL  : 'http://localhost:3000',
+        endpoint : 'callback',
+      });
+      const request = await EnboxConnectProtocol.createConnectRequest({
+        appName            : 'Sample App',
+        clientDid          : clientEphemeralPortableDid.uri,
+        permissionRequests : [{ protocolDefinition, permissionScopes }],
+        callbackUrl,
+        requestedSessionTtlSeconds,
+      });
+
+      await EnboxConnectProtocol.submitConnectResponse(
+        providerIdentity.did.uri,
+        request,
+        randomPin,
+        testHarness.agent,
+      );
+
+      expect(capturedSessions).toHaveLength(1);
+      const session = capturedSessions[0];
+      expect(Date.parse(session.expiresAt) - Date.parse(session.createdAt)).toBe(requestedSessionTtlSeconds * 1000);
+      expect(revocationGrantStub.firstCall.args[0].dateExpires).toBe(session.expiresAt);
+    });
+
+    it('should clamp requested session TTL to the wallet maximum', async () => {
+      const { capturedSessions } = stubSubmitConnectResponseDependencies();
+      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+        baseURL  : 'http://localhost:3000',
+        endpoint : 'callback',
+      });
+      const request = await EnboxConnectProtocol.createConnectRequest({
+        appName                    : 'Sample App',
+        clientDid                  : clientEphemeralPortableDid.uri,
+        permissionRequests         : [{ protocolDefinition, permissionScopes }],
+        callbackUrl,
+        requestedSessionTtlSeconds : CONNECT_SESSION_MAX_TTL_SECONDS + 60,
+      });
+
+      await EnboxConnectProtocol.submitConnectResponse(
+        providerIdentity.did.uri,
+        request,
+        randomPin,
+        testHarness.agent,
+      );
+
+      expect(capturedSessions).toHaveLength(1);
+      const session = capturedSessions[0];
+      expect(Date.parse(session.expiresAt) - Date.parse(session.createdAt)).toBe(CONNECT_SESSION_MAX_TTL_SECONDS * 1000);
+    });
+
+    it('should reject invalid requested session TTL before creating a delegate DID', async () => {
+      const delegateCreateStub = sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+        baseURL  : 'http://localhost:3000',
+        endpoint : 'callback',
+      });
+      const request = await EnboxConnectProtocol.createConnectRequest({
+        appName                    : 'Sample App',
+        clientDid                  : clientEphemeralPortableDid.uri,
+        permissionRequests         : [{ protocolDefinition, permissionScopes }],
+        callbackUrl,
+        requestedSessionTtlSeconds : 0,
+      });
+
+      await expect(
+        EnboxConnectProtocol.submitConnectResponse(
+          providerIdentity.did.uri,
+          request,
+          randomPin,
+          testHarness.agent,
+        )
+      ).rejects.toThrow('Connect requestedSessionTtlSeconds must be a positive finite number.');
+      expect(delegateCreateStub.callCount).toBe(0);
+    });
+
     it('should emit a total perf log when submission fails', async () => {
       const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
         baseURL  : 'http://localhost:3000',

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -873,28 +873,31 @@ describe('enbox connect', () => {
     });
 
     it('should reject invalid requested session TTL before creating a delegate DID', async () => {
-      const delegateCreateStub = sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
-      const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
-        baseURL  : 'http://localhost:3000',
-        endpoint : 'callback',
-      });
-      const request = await EnboxConnectProtocol.createConnectRequest({
-        appName                    : 'Sample App',
-        clientDid                  : clientEphemeralPortableDid.uri,
-        permissionRequests         : [{ protocolDefinition, permissionScopes }],
-        callbackUrl,
-        requestedSessionTtlSeconds : 0,
-      });
+      for (const requestedSessionTtlSeconds of [0, 0.5]) {
+        const delegateCreateStub = sinon.stub(DidJwk, 'create').resolves(delegateBearerDid);
+        const callbackUrl = EnboxConnectProtocol.buildConnectUrl({
+          baseURL  : 'http://localhost:3000',
+          endpoint : 'callback',
+        });
+        const request = await EnboxConnectProtocol.createConnectRequest({
+          appName            : 'Sample App',
+          clientDid          : clientEphemeralPortableDid.uri,
+          permissionRequests : [{ protocolDefinition, permissionScopes }],
+          callbackUrl,
+          requestedSessionTtlSeconds,
+        });
 
-      await expect(
-        EnboxConnectProtocol.submitConnectResponse(
-          providerIdentity.did.uri,
-          request,
-          randomPin,
-          testHarness.agent,
-        )
-      ).rejects.toThrow('Connect requestedSessionTtlSeconds must be a positive finite number.');
-      expect(delegateCreateStub.callCount).toBe(0);
+        await expect(
+          EnboxConnectProtocol.submitConnectResponse(
+            providerIdentity.did.uri,
+            request,
+            randomPin,
+            testHarness.agent,
+          )
+        ).rejects.toThrow('Connect requestedSessionTtlSeconds must resolve to at least one whole second.');
+        expect(delegateCreateStub.callCount).toBe(0);
+        delegateCreateStub.restore();
+      }
     });
 
     it('should emit a total perf log when submission fails', async () => {


### PR DESCRIPTION
## Summary
- honor `requestedSessionTtlSeconds` when wallet-side connect response grants are stamped
- reject invalid requested TTLs before delegate DID creation and clamp oversized requests to the wallet maximum
- add focused submitConnectResponse coverage for requested, clamped, and invalid TTLs
- add a patch-only changeset for `@enbox/agent`

## Test plan
- [x] `bun run --filter @enbox/agent lint`
- [x] `bun run build`
- [x] `bun test tests/connect.spec.ts` from `packages/agent`
- [x] `bun run lint`
- [x] `bunx changeset status`
- [x] `git diff --check`
- [x] `bun run --filter @enbox/agent test:node`

## Notes
- Changeset status reports only patch bumps through internal dependency updates; no minor or major changesets.