### PR TITLE
feat(cli): well-known relay discovery and 30-day session default

### DIFF
--- a/.changeset/cli-wellknown-relay-ttl-default.md
+++ b/.changeset/cli-wellknown-relay-ttl-default.md
@@ -1,0 +1,5 @@
+---
+"@enbox/cli": patch
+---
+
+feat: resolve the connect relay from the wallet's well-known document and default CLI sessions to a 30-day requested TTL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,12 @@ jobs:
               - 'packages/browser/tsconfig.json'
               - 'packages/browser/vitest*.config.*'
 
+            cli:
+              - 'packages/cli/src/**'
+              - 'packages/cli/tests/**'
+              - 'packages/cli/package.json'
+              - 'packages/cli/tsconfig.json'
+
       - name: Propagate changes through dependency graph
         id: propagate
         run: |
@@ -184,6 +190,7 @@ jobs:
           protocols="${{ steps.filter.outputs.protocols }}"
           protocol_codegen="${{ steps.filter.outputs.protocol-codegen }}"
           browser_pkg="${{ steps.filter.outputs.browser-pkg }}"
+          cli="${{ steps.filter.outputs.cli }}"
 
           # Propagate down the dependency graph
           needs_common_crypto=$( [ "$workspace" = "true" ] || [ "$common_crypto" = "true" ] && echo true || echo false )
@@ -195,7 +202,8 @@ jobs:
           needs_agent=$( [ "$needs_dids" = "true" ] || [ "$needs_dwn_sdk" = "true" ] || [ "$needs_dwn_clients" = "true" ] || [ "$agent" = "true" ] && echo true || echo false )
           needs_auth=$( [ "$needs_agent" = "true" ] || [ "$auth" = "true" ] && echo true || echo false )
           needs_api=$( [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$api" = "true" ] && echo true || echo false )
-          needs_lightweight=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_auth" = "true" ] || [ "$protocol_codegen" = "true" ] && echo true || echo false )
+          needs_cli=$( [ "$needs_api" = "true" ] || [ "$cli" = "true" ] && echo true || echo false )
+          needs_lightweight=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_auth" = "true" ] || [ "$protocol_codegen" = "true" ] || [ "$needs_cli" = "true" ] && echo true || echo false )
           needs_agent_api_group=$( [ "$needs_dids" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$needs_api" = "true" ] || [ "$dwn_clients" = "true" ] || [ "$protocols" = "true" ] && echo true || echo false )
           needs_browser_tests=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_dids" = "true" ] || [ "$needs_dwn_sdk" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_api" = "true" ] || [ "$browser_pkg" = "true" ] && echo true || echo false )
           needs_e2e=$( [ "$needs_agent" = "true" ] && echo true || echo false )
@@ -220,7 +228,7 @@ jobs:
           echo "Change detection results:"
           echo "  common_crypto=$needs_common_crypto dids=$needs_dids dwn_sdk=$needs_dwn_sdk"
           echo "  dwn_clients=$needs_dwn_clients dwn_sql_store=$needs_dwn_sql_store dwn_server=$needs_dwn_server"
-          echo "  agent=$needs_agent auth=$needs_auth api=$needs_api protocol_codegen=$protocol_codegen"
+          echo "  agent=$needs_agent auth=$needs_auth api=$needs_api protocol_codegen=$protocol_codegen cli=$needs_cli"
           echo "  agent_api_group=$needs_agent_api_group browser=$needs_browser_tests e2e=$needs_e2e"
 
   # ---------------------------------------------------------------------------
@@ -299,10 +307,11 @@ jobs:
           retention-days: 1
 
   # ---------------------------------------------------------------------------
-  # Lightweight packages: common, crypto (no external services needed)
+  # Lightweight packages: common, crypto, auth, protocol-codegen, cli
+  # (no external services needed)
   # ---------------------------------------------------------------------------
   test-lightweight:
-    name: 'Test: common / crypto / auth'
+    name: 'Test: common / crypto / auth / cli'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     needs: [build, changes]
@@ -340,15 +349,17 @@ jobs:
           bun run --filter @enbox/crypto  test:node:coverage
           bun run --filter @enbox/auth    test:node:coverage
           bun run --filter @enbox/protocol-codegen test:node:coverage
+          bun run --filter @enbox/cli     test:node:coverage
 
       - name: Stage coverage
         if: always()
         run: |
-          mkdir -p coverage-staging/packages/common/coverage coverage-staging/packages/crypto/coverage coverage-staging/packages/auth/coverage coverage-staging/packages/protocol-codegen/coverage
+          mkdir -p coverage-staging/packages/common/coverage coverage-staging/packages/crypto/coverage coverage-staging/packages/auth/coverage coverage-staging/packages/protocol-codegen/coverage coverage-staging/packages/cli/coverage
           cp packages/common/coverage/lcov.info coverage-staging/packages/common/coverage/lcov.info 2>/dev/null || true
           cp packages/crypto/coverage/lcov.info coverage-staging/packages/crypto/coverage/lcov.info 2>/dev/null || true
           cp packages/auth/coverage/lcov.info coverage-staging/packages/auth/coverage/lcov.info 2>/dev/null || true
           cp packages/protocol-codegen/coverage/lcov.info coverage-staging/packages/protocol-codegen/coverage/lcov.info 2>/dev/null || true
+          cp packages/cli/coverage/lcov.info coverage-staging/packages/cli/coverage/lcov.info 2>/dev/null || true
 
       - name: Upload coverage
         if: always()

--- a/apps/docs/content/docs/packages/cli.mdx
+++ b/apps/docs/content/docs/packages/cli.mdx
@@ -49,6 +49,12 @@ The handler uses the encrypted relay flow. It prints a terminal QR code and
 wallet link by default, prompts for the wallet-displayed PIN, then returns the
 delegated session through the normal `Enbox.connect()` lifecycle.
 
+When `connectServerUrl` is omitted, the handler resolves the relay from
+`connectServerUrlProvider`, then from the wallet origin's
+`/.well-known/enbox-connect` document
+(`{ "connectServerUrl": "https://dwn.example/connect" }`), then prompts.
+Sessions request a 30-day TTL by default; wallets may clamp it.
+
 Set `openBrowser: true` for same-machine flows that should open the wallet
 approval link in the local default browser instead of printing a QR code.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -32,5 +32,10 @@ The handler uses the existing encrypted relay flow:
 3. The user approves in the wallet and enters the wallet-displayed PIN in the terminal.
 4. The handler returns the delegated DID and grants to `Enbox.connect()`.
 
+The relay URL resolves from `connectServerUrl`, then `connectServerUrlProvider`,
+then the wallet origin's `/.well-known/enbox-connect` document
+(`{ "connectServerUrl": "https://dwn.example/connect" }`), then an interactive
+prompt. Sessions request a 30-day TTL by default; wallets may clamp it.
+
 Set `openBrowser: true` to open the generated wallet URL on the same machine
 instead of printing a QR code.

--- a/packages/cli/src/cli-connect-handler.ts
+++ b/packages/cli/src/cli-connect-handler.ts
@@ -8,7 +8,15 @@ import { DwnPermissionGrant, DwnPermissionsProtocol } from '@enbox/agent';
 import { openBrowser as defaultOpenBrowser, promptLine, renderTerminalQr } from './terminal.js';
 
 export const DEFAULT_CLI_WALLET_URL = 'https://enbox-wallet.pages.dev';
+
+/** Default requested session TTL for CLI connects. Wallets may clamp it. */
+export const DEFAULT_CLI_SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/** Well-known path on the wallet origin naming its preferred connect relay. */
+export const WALLET_WELL_KNOWN_PATH = '/.well-known/enbox-connect';
+
 const DEFAULT_WALLET_CONNECT_PATH = '/connect/app';
+const WELL_KNOWN_FETCH_TIMEOUT_MS = 5_000;
 
 export type PromptFunction = (question: string) => Promise<string>;
 export type QrRenderer = (uri: string) => Promise<string> | string;
@@ -25,6 +33,9 @@ export interface CliConnectHandlerOptions {
   /**
    * Connect relay URL. Usually the dwn-server URL already configured by the
    * hosting tool, with `/connect` available on that server.
+   *
+   * When omitted, the handler tries `connectServerUrlProvider`, then the
+   * wallet origin's `/.well-known/enbox-connect` document, then prompts.
    */
   connectServerUrl?: string;
 
@@ -44,7 +55,9 @@ export interface CliConnectHandlerOptions {
   clientMetadata?: ConnectClientMetadata;
 
   /**
-   * Preferred session TTL in seconds. Wallets may clamp this to their policy maximum.
+   * Preferred session TTL in seconds. Defaults to 30 days
+   * ({@link DEFAULT_CLI_SESSION_TTL_SECONDS}). Wallets may clamp this to
+   * their policy maximum.
    */
   requestedSessionTtlSeconds?: number;
 
@@ -102,13 +115,13 @@ export function CliConnectHandler(options: CliConnectHandlerOptions = {}): Conne
       permissionRequests: ConnectPermissionRequest[];
     }): Promise<ConnectResult | undefined> {
       const walletUrl = await resolveWalletUrl(options, walletUrlState);
-      const connectServerUrl = await resolveConnectServerUrl(options);
+      const connectServerUrl = await resolveConnectServerUrl(options, walletUrl);
       const walletUri = buildWalletUri(walletUrl);
       const result = await WalletConnect.initClient({
         displayName                : options.appName ?? 'Enbox CLI',
         appIcon                    : options.appIcon,
         clientMetadata             : options.clientMetadata,
-        requestedSessionTtlSeconds : options.requestedSessionTtlSeconds,
+        requestedSessionTtlSeconds : options.requestedSessionTtlSeconds ?? DEFAULT_CLI_SESSION_TTL_SECONDS,
         preSupplyDelegateDid       : options.preSupplyDelegateDid ?? true,
         connectServerUrl,
         walletUri,
@@ -157,7 +170,7 @@ async function resolveWalletUrl(options: CliConnectHandlerOptions, state: Wallet
   }
 }
 
-async function resolveConnectServerUrl(options: CliConnectHandlerOptions): Promise<string> {
+async function resolveConnectServerUrl(options: CliConnectHandlerOptions, walletUrl: string): Promise<string> {
   if (options.connectServerUrl !== undefined && options.connectServerUrl.trim() !== '') {
     const normalized = normalizeUrl(options.connectServerUrl);
     if (normalized !== undefined) {
@@ -175,6 +188,11 @@ async function resolveConnectServerUrl(options: CliConnectHandlerOptions): Promi
     }
 
     throw new Error(`@enbox/cli: invalid connect relay URL '${providedUrl}'. Enter a URL such as https://dwn.example/connect.`);
+  }
+
+  const discoveredUrl = await discoverWellKnownConnectServerUrl(options, walletUrl);
+  if (discoveredUrl !== undefined) {
+    return discoveredUrl;
   }
 
   const prompt = options.connectServerUrlPrompt ?? defaultPrompt(options);
@@ -207,6 +225,46 @@ function buildWalletUri(walletUrl: string): string {
     url.pathname = DEFAULT_WALLET_CONNECT_PATH;
   }
   return url.toString();
+}
+
+/**
+ * Discover the wallet's preferred connect relay from its well-known document.
+ *
+ * Fetches `{walletOrigin}/.well-known/enbox-connect` and returns the
+ * `connectServerUrl` it names. Absent or unreachable documents resolve to
+ * `undefined` so resolution falls through to the prompt; a document naming an
+ * invalid URL is reported and ignored.
+ */
+async function discoverWellKnownConnectServerUrl(
+  options: CliConnectHandlerOptions,
+  walletUrl: string,
+): Promise<string | undefined> {
+  const wellKnownUrl = new URL(WALLET_WELL_KNOWN_PATH, new URL(walletUrl).origin).toString();
+
+  let payload: unknown;
+  try {
+    const response = await fetch(wellKnownUrl, { signal: AbortSignal.timeout(WELL_KNOWN_FETCH_TIMEOUT_MS) });
+    if (!response.ok) {
+      return undefined;
+    }
+    payload = await response.json();
+  } catch {
+    return undefined;
+  }
+
+  const connectServerUrl = (payload as { connectServerUrl?: unknown } | null)?.connectServerUrl;
+  if (typeof connectServerUrl !== 'string') {
+    return undefined;
+  }
+
+  const normalized = normalizeUrl(connectServerUrl);
+  if (normalized === undefined) {
+    writeLine(options, `@enbox/cli: ignoring invalid connect relay URL in ${wellKnownUrl}.`);
+    return undefined;
+  }
+
+  writeLine(options, `Using connect relay from wallet: ${normalized}`);
+  return normalized;
 }
 
 function normalizeUrl(url: string): string | undefined {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,5 +49,10 @@ export type {
   WalletConnectOptions,
 } from '@enbox/auth';
 
-export { CliConnectHandler, DEFAULT_CLI_WALLET_URL } from './cli-connect-handler.js';
+export {
+  CliConnectHandler,
+  DEFAULT_CLI_SESSION_TTL_SECONDS,
+  DEFAULT_CLI_WALLET_URL,
+  WALLET_WELL_KNOWN_PATH,
+} from './cli-connect-handler.js';
 export type { BrowserOpenFunction, CliConnectHandlerOptions, PromptFunction, QrRenderer } from './cli-connect-handler.js';

--- a/packages/cli/tests/cli-connect-handler.spec.ts
+++ b/packages/cli/tests/cli-connect-handler.spec.ts
@@ -13,7 +13,12 @@ import { WalletConnect } from '@enbox/auth';
 import { afterEach, describe, expect, it } from 'bun:test';
 import { DwnInterfaceName, DwnMethodName } from '@enbox/dwn-sdk-js';
 
-import { CliConnectHandler, DEFAULT_CLI_WALLET_URL } from '../src/cli-connect-handler.js';
+import {
+  CliConnectHandler,
+  DEFAULT_CLI_SESSION_TTL_SECONDS,
+  DEFAULT_CLI_WALLET_URL,
+  WALLET_WELL_KNOWN_PATH,
+} from '../src/cli-connect-handler.js';
 
 const delegateDid = 'did:jwk:delegate';
 const connectedDid = 'did:dht:owner';
@@ -58,7 +63,7 @@ describe('CliConnectHandler', () => {
       pinPrompt                  : async (): Promise<string> => '428113',
       qrRenderer                 : async (): Promise<string> => '[qr]',
       timeoutMs                  : 10_000,
-      requestedSessionTtlSeconds : 2_592_000,
+      requestedSessionTtlSeconds : 604_800,
     });
 
     const connectResult = await handler.requestAccess({ permissionRequests });
@@ -68,7 +73,7 @@ describe('CliConnectHandler', () => {
     expect(capturedOptions?.walletUri).toBe('https://wallet.example/connect/app');
     expect(capturedOptions?.connectServerUrl).toBe('https://relay.example/connect');
     expect(capturedOptions?.timeoutMs).toBe(10_000);
-    expect(capturedOptions?.requestedSessionTtlSeconds).toBe(2_592_000);
+    expect(capturedOptions?.requestedSessionTtlSeconds).toBe(604_800);
     expect(capturedOptions?.preSupplyDelegateDid).toBe(true);
     expect(authUrls).toEqual(['https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test']);
     expect(output.text()).toContain('[qr]');
@@ -325,6 +330,7 @@ describe('CliConnectHandler', () => {
       capturedOptions = options;
       return undefined;
     });
+    sinon.stub(globalThis, 'fetch').rejects(new Error('offline'));
 
     const prompts: string[] = [];
     const answers = ['', 'https://relay.example/connect'];
@@ -355,6 +361,7 @@ describe('CliConnectHandler', () => {
       capturedOptions = options;
       return undefined;
     });
+    sinon.stub(globalThis, 'fetch').rejects(new Error('offline'));
 
     const prompts: string[] = [];
     const answers = ['http://', 'localhost:5173', 'https://relay.example/connect'];
@@ -463,6 +470,7 @@ describe('CliConnectHandler', () => {
       capturedOptions = options;
       return undefined;
     });
+    sinon.stub(globalThis, 'fetch').rejects(new Error('offline'));
 
     const prompts: string[] = [];
     const answers = ['http://', 'my-dwn.example/connect'];
@@ -506,6 +514,103 @@ describe('CliConnectHandler', () => {
     await handler.requestAccess({ permissionRequests });
 
     expect(capturedOptions?.connectServerUrl).toBe('https://provider-dwn.example/connect');
+  });
+
+  it('should resolve the connect relay from the wallet well-known document', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+    const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+      new Response(JSON.stringify({ connectServerUrl: 'https://dwn.example/connect' }), {
+        status  : 200,
+        headers : { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const output = createWritableBuffer();
+    const handler = CliConnectHandler({
+      output,
+      walletUrl              : 'https://wallet.example/connect/app',
+      connectServerUrlPrompt : async (): Promise<string> => { throw new Error('should not prompt'); },
+      pinPrompt              : async (): Promise<string> => '428113',
+      qrRenderer             : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(fetchStub.firstCall.args[0]).toBe(`https://wallet.example${WALLET_WELL_KNOWN_PATH}`);
+    expect(capturedOptions?.connectServerUrl).toBe('https://dwn.example/connect');
+    expect(output.text()).toContain('Using connect relay from wallet: https://dwn.example/connect');
+  });
+
+  it('should fall back to prompting when the well-known document is missing', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+    sinon.stub(globalThis, 'fetch').resolves(new Response('not found', { status: 404 }));
+
+    const handler = CliConnectHandler({
+      walletUrl              : 'https://wallet.example',
+      connectServerUrlPrompt : async (): Promise<string> => 'https://relay.example/connect',
+      pinPrompt              : async (): Promise<string> => '428113',
+      qrRenderer             : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(capturedOptions?.connectServerUrl).toBe('https://relay.example/connect');
+  });
+
+  it('should ignore an invalid relay URL in the well-known document and prompt instead', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+    sinon.stub(globalThis, 'fetch').resolves(
+      new Response(JSON.stringify({ connectServerUrl: 'http://' }), {
+        status  : 200,
+        headers : { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const output = createWritableBuffer();
+    const handler = CliConnectHandler({
+      output,
+      walletUrl              : 'https://wallet.example',
+      connectServerUrlPrompt : async (): Promise<string> => 'https://relay.example/connect',
+      pinPrompt              : async (): Promise<string> => '428113',
+      qrRenderer             : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(capturedOptions?.connectServerUrl).toBe('https://relay.example/connect');
+    expect(output.text()).toContain('ignoring invalid connect relay URL');
+  });
+
+  it('should default the requested session TTL to 30 days', async () => {
+    let capturedOptions: WalletConnectClientOptions | undefined;
+    sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
+      capturedOptions = options;
+      return undefined;
+    });
+
+    const handler = CliConnectHandler({
+      walletUrl        : 'https://wallet.example',
+      connectServerUrl : 'https://relay.example/connect',
+      pinPrompt        : async (): Promise<string> => '428113',
+      qrRenderer       : async (): Promise<string> => '[qr]',
+    });
+
+    await handler.requestAccess({ permissionRequests });
+
+    expect(capturedOptions?.requestedSessionTtlSeconds).toBe(DEFAULT_CLI_SESSION_TTL_SECONDS);
+    expect(DEFAULT_CLI_SESSION_TTL_SECONDS).toBe(30 * 24 * 60 * 60);
   });
 });
 

--- a/scripts/run-node-coverage.sh
+++ b/scripts/run-node-coverage.sh
@@ -69,6 +69,7 @@ node_packages=(
   "@enbox/common"
   "@enbox/crypto"
   "@enbox/auth"
+  "@enbox/cli"
   "@enbox/protocols"
   "@enbox/protocol-codegen"
   "@enbox/dwn-sdk-js"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,8 +4,8 @@ sonar.organization=SONAR_ORG
 sonar.projectName=enbox
 sonar.sourceEncoding=UTF-8
 
-sonar.sources=packages/agent/src,packages/api/src,packages/auth/src,packages/browser/src,packages/common/src,packages/crypto/src,packages/dids/src,packages/dwn-clients/src,packages/dwn-sdk-js/src,packages/dwn-server/src,packages/dwn-server-admin-ui/src,packages/dwn-sql-store/src,packages/protocol-codegen/src,packages/protocols/src,apps/docs/src
-sonar.tests=packages/agent/tests,packages/api/tests,packages/auth/tests,packages/browser/tests,packages/common/tests,packages/crypto/tests,packages/dids/tests,packages/dwn-clients/tests,packages/dwn-sdk-js/tests,packages/dwn-server/tests,packages/dwn-sql-store/tests,packages/protocol-codegen/tests,packages/protocols/tests
+sonar.sources=packages/agent/src,packages/api/src,packages/auth/src,packages/browser/src,packages/cli/src,packages/common/src,packages/crypto/src,packages/dids/src,packages/dwn-clients/src,packages/dwn-sdk-js/src,packages/dwn-server/src,packages/dwn-server-admin-ui/src,packages/dwn-sql-store/src,packages/protocol-codegen/src,packages/protocols/src,apps/docs/src
+sonar.tests=packages/agent/tests,packages/api/tests,packages/auth/tests,packages/browser/tests,packages/cli/tests,packages/common/tests,packages/crypto/tests,packages/dids/tests,packages/dwn-clients/tests,packages/dwn-sdk-js/tests,packages/dwn-server/tests,packages/dwn-sql-store/tests,packages/protocol-codegen/tests,packages/protocols/tests
 sonar.test.inclusions=packages/*/tests/**/*.ts,packages/*/tests/**/*.tsx
 
 sonar.typescript.tsconfigPath=tsconfig.json


### PR DESCRIPTION
## Summary
- Resolve the connect relay from the wallet origin's `/.well-known/enbox-connect` document (`{ "connectServerUrl": "…" }`) when neither the `connectServerUrl` option nor `connectServerUrlProvider` supplies one — the wallet address stays the only input a user must know. Absent/unreachable/malformed documents fall through to the interactive prompt (malformed URLs are reported and ignored).
- Default `requestedSessionTtlSeconds` to 30 days (`DEFAULT_CLI_SESSION_TTL_SECONDS`) so unconfigured CLI tools get long-lived sessions instead of daily browser re-approvals; wallets clamp to their policy max (90 d) as before.
- Export `DEFAULT_CLI_SESSION_TTL_SECONDS` and `WALLET_WELL_KNOWN_PATH`; document the resolution order in the README and docs site.
- **Wire `@enbox/cli` into CI**: the package was linted and built but no job ran its tests, no change filter detected it, and Sonar didn't analyze it. Adds the `cli` path filter (propagated as a dependent of agent/auth/api), runs cli coverage in the lightweight test job (renamed `Test: common / crypto / auth / cli`), adds the package to `run-node-coverage.sh`, and registers `packages/cli/src`/`tests` with Sonar. This PR's own run is the first CI execution of the cli test suite.

These are the remaining small monorepo items from the CLI-connect plan (phase 2.5 client half and the TTL starting value) plus the CI gap found while auditing the test matrix. The fragment-links client change is intentionally not included — it must trail the wallet learning to read `location.hash`.

## Test plan
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run --filter @enbox/cli test:node` (27 pass: well-known discovery, 404 fallthrough, invalid-doc fallthrough + warning, origin-rooted fetch for pathed wallet URLs, 30-day default, explicit-TTL passthrough)
- [x] `bun run --filter @enbox/cli test:node:coverage` produces `packages/cli/coverage/lcov.info` (the exact command the lightweight job now runs)
- [x] `python3 -c "yaml.safe_load"` on ci.yml; `bash -n` on run-node-coverage.sh
- [x] `bunx changeset status`
- [x] CI on this PR shows `Test: common / crypto / auth / cli` running the 27 cli tests (passed, 31s)
