### PR TITLE
fix(examples): let cli-demo discover the relay via well-known

### DIFF
--- a/examples/cli-demo/README.md
+++ b/examples/cli-demo/README.md
@@ -8,7 +8,17 @@ This example exercises the CLI wallet-connect lifecycle:
 4. Restore the persisted session and write another record.
 5. Disconnect, requesting self-revocation for the session grants.
 
-Run it from the repository root after `bun install`:
+Run it from the repository root after `bun install` — no configuration
+needed; the connect relay is discovered from the wallet origin's
+`/.well-known/enbox-connect` document (you are prompted for the wallet URL,
+with the default wallet suggested):
+
+```bash
+bun examples/cli-demo/src/connect.ts
+```
+
+To pin a specific relay instead of discovering it, set
+`ENBOX_CONNECT_SERVER_URL`:
 
 ```bash
 ENBOX_CONNECT_SERVER_URL=https://your-dwn.example/connect \

--- a/examples/cli-demo/src/connect.ts
+++ b/examples/cli-demo/src/connect.ts
@@ -16,10 +16,10 @@ const DemoProtocol = defineProtocol({
   },
 });
 
-const connectServerUrl = process.env.ENBOX_CONNECT_SERVER_URL;
-if (connectServerUrl === undefined || connectServerUrl.trim() === '') {
-  throw new Error('Set ENBOX_CONNECT_SERVER_URL to your DWN server connect relay URL, for example https://example.com/connect.');
-}
+// Optional override. When unset, the handler resolves the relay from the
+// wallet origin's /.well-known/enbox-connect document, and prompts only if
+// the wallet does not advertise one.
+const connectServerUrl = process.env.ENBOX_CONNECT_SERVER_URL?.trim() || undefined;
 
 const dataPath = process.env.ENBOX_DATA_PATH ?? '.enbox-cli-demo';
 const password = process.env.ENBOX_PASSWORD ?? 'enbox-cli-demo-password';


### PR DESCRIPTION
## Summary
Makes `ENBOX_CONNECT_SERVER_URL` an optional override in `examples/cli-demo`. The demo previously threw without it and always passed the relay explicitly — and an explicit option wins over discovery by design — so the zero-config path (wallet prompt → `/.well-known/enbox-connect` → relay) could never be demonstrated. Now `bun examples/cli-demo/src/connect.ts` with no environment exercises the canonical onboarding flow end to end; the env var remains available to pin a relay.

Example-only change (examples are not workspace packages): no changeset.

## Test plan
- [x] `bun build` parse check on the modified script
- [ ] Zero-env run against the deployed wallet resolves the relay from the well-known document (prints "Using connect relay from wallet: https://enbox-dwn.fly.dev/connect")