### PR TITLE
fix(agent): release sockets and store handles on shutdown

### DIFF
--- a/.changeset/agent-shutdown-teardown.md
+++ b/.changeset/agent-shutdown-teardown.md
@@ -1,0 +1,9 @@
+---
+"@enbox/dwn-clients": patch
+"@enbox/agent": patch
+"@enbox/auth": patch
+---
+
+fix: release sockets and store handles on shutdown so CLI processes exit
+
+WebSocket RPC connections are pooled process-wide with heartbeat timers and were never closed, keeping the event loop alive after AuthManager.shutdown() resolved; the agent's DWN stores, DID resolver cache, and vault/secret stores also stayed open, wedging same-dataPath reopens and cross-process writes. Adds WebSocketDwnRpcClient.closeAllConnections() and a close() contract to EnboxRpc, a full EnboxUserAgent.shutdown() lifecycle, and delegates AuthManager.shutdown() to it.

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -432,6 +432,17 @@ export class AgentDwnApi {
    *   `EnboxPlatformAgent`. In other words, so that a developer can call `agent.dwn.node` to access
    *   the DWN instance and not `agent.dwn.dwn`.
    */
+  /**
+   * Closes the in-process DWN's stores (message store, data store, event log,
+   * resumable task store), releasing their LevelDB handles. No-op when the
+   * agent operates in remote mode (no in-process DWN).
+   */
+  public async close(): Promise<void> {
+    if (this._dwn !== undefined) {
+      await this._dwn.close();
+    }
+  }
+
   get node(): Dwn {
     if (!this._dwn) {
       throw new Error(

--- a/packages/agent/src/enbox-user-agent.ts
+++ b/packages/agent/src/enbox-user-agent.ts
@@ -303,4 +303,71 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
     // Set the Agent's DID.
     this.agentDid = await this.vault.getDid();
   }
+
+  /**
+   * Releases every resource the agent holds so the process can exit and the
+   * same data path can be reopened: stops sync (subscriptions and timers),
+   * closes the sync engine's store, drains the process-wide RPC socket pool
+   * (WebSocket heartbeats otherwise keep the event loop alive), locks the
+   * vault, and closes the in-process DWN's stores, the DID resolver cache,
+   * and the vault and secret stores.
+   *
+   * Each step is best-effort so a partially torn-down agent cannot block
+   * shutdown. The agent must not be used afterwards — create a new agent to
+   * reopen the same data path.
+   *
+   * @param options.syncStopTimeoutMs - How long to wait for in-flight sync
+   *   work to settle before force-stopping. Defaults to 2000.
+   */
+  public async shutdown(options: { syncStopTimeoutMs?: number } = {}): Promise<void> {
+    const { syncStopTimeoutMs = 2000 } = options;
+
+    try {
+      await this.sync.stopSync(syncStopTimeoutMs);
+    } catch {
+      // Best-effort — sync may never have been started.
+    }
+
+    try {
+      await this.sync.close();
+    } catch {
+      // Best-effort.
+    }
+
+    try {
+      await this.rpc.close();
+    } catch {
+      // Best-effort.
+    }
+
+    try {
+      await this.vault.lock();
+    } catch {
+      // Vault may already be locked or uninitialised — safe to ignore.
+    }
+
+    try {
+      await this.dwn.close();
+    } catch {
+      // Best-effort — remote-mode agents have no in-process DWN.
+    }
+
+    try {
+      await this.did.close();
+    } catch {
+      // Best-effort — the resolver cache may be in-memory.
+    }
+
+    try {
+      await this.vault.close();
+    } catch {
+      // Best-effort.
+    }
+
+    try {
+      await this.secrets.close();
+    } catch {
+      // Best-effort — the secret store may share the vault's store.
+    }
+  }
 }

--- a/packages/agent/src/hd-identity-vault.ts
+++ b/packages/agent/src/hd-identity-vault.ts
@@ -522,6 +522,15 @@ export class HdIdentityVault implements IdentityVault<{ InitializeResult: string
    * @throws An error if the identity vault has not been initialized.
    * @returns A promise that resolves when the vault is successfully locked.
    */
+  /**
+   * Closes the vault's backing store, releasing its resources (e.g. the
+   * LevelDB handle). Lock the vault first; after close the vault must not
+   * be used until a new instance is created over the same store location.
+   */
+  public async close(): Promise<void> {
+    await this._store.close();
+  }
+
   public async lock(): Promise<void> {
     // Verify the identity vault has already been initialized.
     if (await this.isInitialized() === false) {

--- a/packages/agent/src/secret-store.ts
+++ b/packages/agent/src/secret-store.ts
@@ -50,6 +50,12 @@ export interface SecretStore {
    * @returns `true` if the key existed and was removed, `false` otherwise.
    */
   delete(key: string): Promise<boolean>;
+
+  /**
+   * Releases the store's backing resources (e.g. a LevelDB handle).
+   * Called during application shutdown; the store must not be used after.
+   */
+  close(): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -88,6 +94,10 @@ export class VaultBackedSecretStore implements SecretStore {
   }) {
     this._vault = vault;
     this._store = store;
+  }
+
+  public async close(): Promise<void> {
+    await this._store.close();
   }
 
   public async put(
@@ -142,6 +152,10 @@ export class VaultBackedSecretStore implements SecretStore {
  */
 export class InMemorySecretStore implements SecretStore {
   private readonly _store = new Map<string, { value: Uint8Array; expiresAt?: string }>();
+
+  public async close(): Promise<void> {
+    this._store.clear();
+  }
 
   public async put(
     key: string,

--- a/packages/agent/tests/enbox-user-agent-shutdown.spec.ts
+++ b/packages/agent/tests/enbox-user-agent-shutdown.spec.ts
@@ -1,0 +1,80 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+
+import { rm } from 'node:fs/promises';
+
+import { EnboxUserAgent } from '../src/enbox-user-agent.js';
+
+describe('EnboxUserAgent.shutdown()', () => {
+  it('should tear down components in dependency order', async () => {
+    const calls: string[] = [];
+    const agent = await EnboxUserAgent.create({
+      agentVault: {
+        lock  : async (): Promise<void> => { calls.push('vault.lock'); },
+        close : async (): Promise<void> => { calls.push('vault.close'); },
+      } as any,
+      cryptoApi      : {} as any,
+      didApi         : { close: async (): Promise<void> => { calls.push('did.close'); } } as any,
+      dwnApi         : { close: async (): Promise<void> => { calls.push('dwn.close'); } } as any,
+      identityApi    : {} as any,
+      keyManager     : {} as any,
+      permissionsApi : {} as any,
+      rpcClient      : { close: async (): Promise<void> => { calls.push('rpc.close'); } } as any,
+      secretsApi     : { close: async (): Promise<void> => { calls.push('secrets.close'); } } as any,
+      syncApi        : {
+        stopSync : async (timeout: number): Promise<void> => { calls.push(`sync.stopSync:${timeout}`); },
+        close    : async (): Promise<void> => { calls.push('sync.close'); },
+      } as any,
+    });
+
+    await agent.shutdown({ syncStopTimeoutMs: 1234 });
+
+    expect(calls).toEqual([
+      'sync.stopSync:1234',
+      'sync.close',
+      'rpc.close',
+      'vault.lock',
+      'dwn.close',
+      'did.close',
+      'vault.close',
+      'secrets.close',
+    ]);
+  });
+
+  it('should complete when every component throws', async () => {
+    const failing = async (): Promise<never> => { throw new Error('teardown failure'); };
+    const agent = await EnboxUserAgent.create({
+      agentVault     : { lock: failing, close: failing } as any,
+      cryptoApi      : {} as any,
+      didApi         : { close: failing } as any,
+      dwnApi         : { close: failing } as any,
+      identityApi    : {} as any,
+      keyManager     : {} as any,
+      permissionsApi : {} as any,
+      rpcClient      : { close: failing } as any,
+      secretsApi     : { close: failing } as any,
+      syncApi        : { stopSync: failing, close: failing } as any,
+    });
+
+    await agent.shutdown();
+  });
+
+  describe('store lock release', () => {
+    const dataPath = '__TESTDATA__/enbox-user-agent-shutdown-reopen';
+
+    afterAll(async () => {
+      await rm(dataPath, { force: true, recursive: true });
+    });
+
+    it('should release store locks so the same dataPath reopens in-process', async () => {
+      const first = await EnboxUserAgent.create({ dataPath });
+      expect(await first.firstLaunch()).toBe(true);
+      await first.shutdown();
+
+      // Before shutdown released the vault, DWN store, and resolver cache
+      // LevelDB handles, this reopen wedged or failed with LEVEL_LOCKED.
+      const second = await EnboxUserAgent.create({ dataPath });
+      expect(await second.firstLaunch()).toBe(true);
+      await second.shutdown();
+    });
+  });
+});

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -766,32 +766,22 @@ export class AuthManager {
     const { timeout = 2000 } = options;
     const did = this._session?.did;
 
-    // 1. Stop sync.
+    // 1. Tear down the agent: stops sync, drains the RPC socket pool, locks
+    //    the vault, and closes the DWN stores, DID resolver cache, and vault
+    //    and secret stores. Without the full teardown the process cannot
+    //    exit (WebSocket heartbeats keep the event loop alive) and the same
+    //    dataPath cannot be reopened in-process.
     try {
-      await this._userAgent.sync.stopSync(timeout);
+      await this._userAgent.shutdown({ syncStopTimeoutMs: timeout });
+      this._emitter.emit('vault-locked', {});
     } catch {
-      // Best-effort — don't block shutdown on sync errors.
+      // Best-effort — don't block shutdown on teardown errors.
     }
 
     // 2. Clear the active session.
     this._session = undefined;
 
-    // 3. Lock the vault.
-    try {
-      await this._userAgent.vault.lock();
-      this._emitter.emit('vault-locked', {});
-    } catch {
-      // Vault may already be locked or uninitialised — safe to ignore.
-    }
-
-    // 4. Close the sync engine (releases LevelDB handles, timers).
-    try {
-      await this._userAgent.sync.close();
-    } catch {
-      // Best-effort.
-    }
-
-    // 5. Close the storage adapter (e.g. LevelDB session store).
+    // 3. Close the storage adapter (e.g. LevelDB session store).
     if (typeof this._storage.close === 'function') {
       try {
         await this._storage.close();
@@ -800,11 +790,11 @@ export class AuthManager {
       }
     }
 
-    // 6. Mark as shut down and transition state.
+    // 4. Mark as shut down and transition state.
     this._isShutDown = true;
     this._setState('locked');
 
-    // 7. Emit session-end if there was an active session.
+    // 5. Emit session-end if there was an active session.
     if (did) {
       this._emitter.emit('session-end', { did });
     }

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -88,6 +88,7 @@ export interface MockAgentOverrides {
   vaultIsLocked?: () => boolean;
   vaultUnlock?: (params: any) => Promise<void>;
   vaultLock?: () => Promise<void>;
+  shutdown?: (options?: { syncStopTimeoutMs?: number }) => Promise<void>;
   vaultChangePassword?: (params: any) => Promise<void>;
   vaultResetPasswordWithRecoveryPhrase?: (params: any) => Promise<void>;
   vaultBackup?: () => Promise<any>;
@@ -144,6 +145,15 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
     firstLaunch : overrides.firstLaunch ?? (async (): Promise<boolean> => false),
     initialize  : overrides.initialize ?? (async (): Promise<string> => 'word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12'),
     start       : overrides.start ?? (async (): Promise<void> => {}),
+
+    // Mirrors EnboxUserAgent.shutdown ordering (best-effort steps) so tests
+    // can observe component calls through the manager's delegated teardown.
+    shutdown: overrides.shutdown ?? (async function (this: any, options: { syncStopTimeoutMs?: number } = {}): Promise<void> {
+      const { syncStopTimeoutMs = 2000 } = options;
+      try { await this.sync.stopSync(syncStopTimeoutMs); } catch { /* best-effort */ }
+      try { await this.sync.close(); } catch { /* best-effort */ }
+      try { await this.vault.lock(); } catch { /* best-effort */ }
+    }),
 
     identity: {
       list              : overrides.identityList ?? (async (): Promise<MockIdentity[]> => [defaultIdentity]),

--- a/packages/dwn-clients/src/rpc-client.ts
+++ b/packages/dwn-clients/src/rpc-client.ts
@@ -39,7 +39,14 @@ export type RpcStatus = {
   message: string;
 };
 
-export interface EnboxRpc extends DwnRpc, DidRpc, DwnServerInfoRpc {}
+export interface EnboxRpc extends DwnRpc, DidRpc, DwnServerInfoRpc {
+  /**
+   * Releases any persistent transport resources (e.g. pooled WebSocket
+   * connections and their heartbeat timers). Called during application
+   * shutdown so the process's event loop can drain.
+   */
+  close(): Promise<void>;
+}
 
 /**
  * Client used to communicate with Dwn Servers
@@ -63,6 +70,18 @@ export class EnboxRpcClient implements EnboxRpc {
 
   get transportProtocols(): string[] {
     return Array.from(this.transportClients.keys());
+  }
+
+  /** Closes every distinct transport client (the same client may serve multiple schemes). */
+  async close(): Promise<void> {
+    const closed = new Set<EnboxRpc>();
+    for (const client of this.transportClients.values()) {
+      if (closed.has(client)) {
+        continue;
+      }
+      closed.add(client);
+      await client.close();
+    }
   }
 
   async sendDidRequest(request: DidRpcRequest): Promise<DidRpcResponse> {
@@ -126,6 +145,9 @@ export class EnboxRpcClient implements EnboxRpc {
 }
 
 export class HttpEnboxRpcClient extends HttpDwnRpcClient implements EnboxRpc {
+  /** HTTP transport holds no persistent connections — nothing to release. */
+  public async close(): Promise<void> {}
+
   async sendDidRequest(request: DidRpcRequest): Promise<DidRpcResponse> {
     const requestId = CryptoUtils.randomUuid();
     const jsonRpcRequest = createJsonRpcRequest(requestId, request.method, {
@@ -165,6 +187,11 @@ export class HttpEnboxRpcClient extends HttpDwnRpcClient implements EnboxRpc {
 }
 
 export class WebSocketEnboxRpcClient extends WebSocketDwnRpcClient implements EnboxRpc {
+  /** Closes the process-wide WebSocket connection pool. */
+  public async close(): Promise<void> {
+    await WebSocketDwnRpcClient.closeAllConnections();
+  }
+
   async sendDidRequest(_request: DidRpcRequest): Promise<DidRpcResponse> {
     throw new Error(`not implemented for transports [${this.transportProtocols.join(', ')}]`);
   }

--- a/packages/dwn-clients/src/web-socket-clients.ts
+++ b/packages/dwn-clients/src/web-socket-clients.ts
@@ -89,6 +89,44 @@ export class WebSocketDwnRpcClient implements DwnRpc {
 
   public constructor(private readonly serverInfoRpc: DwnServerInfoRpc = new HttpDwnRpcClient()) {}
 
+  /**
+   * Closes every pooled WebSocket connection and clears the pool.
+   *
+   * Each connection's tracked subscriptions are closed best-effort, then the
+   * underlying socket (and its heartbeat timer) is closed. Connections still
+   * being established are awaited so they cannot leak into a cleared pool.
+   * The pool is process-wide, so this is intended for application shutdown.
+   */
+  public static async closeAllConnections(): Promise<void> {
+    const pending = [...WebSocketDwnRpcClient.pendingConnections.values()];
+    WebSocketDwnRpcClient.pendingConnections.clear();
+    for (const pendingConnection of pending) {
+      try {
+        await pendingConnection;
+      } catch {
+        // The connection failed to establish — nothing to close.
+      }
+    }
+
+    const connections = [...WebSocketDwnRpcClient.connections.values()];
+    WebSocketDwnRpcClient.connections.clear();
+    for (const connection of connections) {
+      for (const tracked of connection.subscriptions.values()) {
+        try {
+          await tracked.subscription.close();
+        } catch {
+          // Best-effort — closing the socket below tears down the transport.
+        }
+      }
+      connection.subscriptions.clear();
+      try {
+        connection.socket.close();
+      } catch {
+        // Best-effort.
+      }
+    }
+  }
+
   async sendDwnRequest(request: DwnRpcRequest): Promise<DwnRpcResponse> {
 
     // validate that the dwn URL provided is a valid WebSocket URL

--- a/packages/dwn-clients/tests/web-socket-pool-close.spec.ts
+++ b/packages/dwn-clients/tests/web-socket-pool-close.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { WebSocketDwnRpcClient } from '../src/web-socket-clients.js';
+
+/**
+ * Seeds the client's process-wide connection pool with stub connections so
+ * `closeAllConnections()` can be verified without a live WebSocket server.
+ */
+function poolOf(client: typeof WebSocketDwnRpcClient): {
+  connections: Map<string, unknown>;
+  pendingConnections: Map<string, Promise<unknown>>;
+} {
+  return client as unknown as {
+    connections: Map<string, unknown>;
+    pendingConnections: Map<string, Promise<unknown>>;
+  };
+}
+
+describe('WebSocketDwnRpcClient.closeAllConnections()', () => {
+  afterEach(async () => {
+    await WebSocketDwnRpcClient.closeAllConnections();
+  });
+
+  it('should close pooled sockets and their subscriptions and clear the pool', async () => {
+    const socketCloses: string[] = [];
+    const subscriptionCloses: string[] = [];
+    const subscriptions = new Map([
+      ['sub-1', { subscription: { close: async (): Promise<void> => { subscriptionCloses.push('sub-1'); } } }],
+      ['sub-2', { subscription: { close: async (): Promise<void> => { subscriptionCloses.push('sub-2'); } } }],
+    ]);
+    poolOf(WebSocketDwnRpcClient).connections.set('wss://dwn.example/', {
+      socket: { close: (): void => { socketCloses.push('wss://dwn.example/'); } },
+      subscriptions,
+    });
+
+    await WebSocketDwnRpcClient.closeAllConnections();
+
+    expect(subscriptionCloses.sort()).toEqual(['sub-1', 'sub-2']);
+    expect(socketCloses).toEqual(['wss://dwn.example/']);
+    expect(poolOf(WebSocketDwnRpcClient).connections.size).toBe(0);
+    expect(subscriptions.size).toBe(0);
+  });
+
+  it('should await pending connections and close them once settled', async () => {
+    const socketCloses: string[] = [];
+    const connection = {
+      socket        : { close: (): void => { socketCloses.push('pending'); } },
+      subscriptions : new Map(),
+    };
+    const pool = poolOf(WebSocketDwnRpcClient);
+    pool.pendingConnections.set('wss://pending.example/', (async (): Promise<unknown> => {
+      pool.connections.set('wss://pending.example/', connection);
+      return connection;
+    })());
+
+    await WebSocketDwnRpcClient.closeAllConnections();
+
+    expect(socketCloses).toEqual(['pending']);
+    expect(pool.connections.size).toBe(0);
+    expect(pool.pendingConnections.size).toBe(0);
+  });
+
+  it('should tolerate failed pending connections and closing errors', async () => {
+    const pool = poolOf(WebSocketDwnRpcClient);
+    pool.pendingConnections.set('wss://broken.example/', Promise.reject(new Error('connect refused')));
+    pool.connections.set('wss://throws.example/', {
+      socket        : { close: (): void => { throw new Error('already closed'); } },
+      subscriptions : new Map([
+        ['sub', { subscription: { close: async (): Promise<void> => { throw new Error('gone'); } } }],
+      ]),
+    });
+
+    await WebSocketDwnRpcClient.closeAllConnections();
+
+    expect(pool.connections.size).toBe(0);
+    expect(pool.pendingConnections.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #1179 — found during the first end-to-end CLI connect acceptance run.

## Root cause

Three compounding gaps, one underlying defect: nothing owned full resource teardown.

1. `WebSocketDwnRpcClient` pools connections **process-wide** (`static connections` map), each wrapping a `JsonRpcSocket` with a heartbeat timer. The sync engine closes its *subscriptions*, but no API existed to close the pooled sockets — so after `AuthManager.shutdown()` resolved, four ESTABLISHED TLS connections (HTTP keep-alive + WebSocket per registered DWN endpoint) kept Bun's event loop alive and the process never exited.
2. `EnboxUserAgent` had **no teardown API at all** — the test harness enumerates eight store closes by hand because nothing else could.
3. `AuthManager.shutdown()` closed only what auth owns (sync engine, storage adapter), never the agent's DWN Level stores, DID resolver cache, or vault/secret stores.

Observed in the wild (cli-demo acceptance run): processes hang at exit; the demo's same-process restart wedges silently (stores still held); a zombie process holds the DWN store lock so the *next* process restores fine (vault accessible) and then hangs forever on its first write.

## Fix

- **`@enbox/dwn-clients`**: `WebSocketDwnRpcClient.closeAllConnections()` — awaits in-flight connection attempts so they cannot leak into a cleared pool, closes tracked subscriptions best-effort, closes each socket (stopping its heartbeat), clears the pool. `EnboxRpc` gains a `close()` contract: HTTP client no-op, WebSocket client drains the pool, composite client fans out over distinct transports.
- **`@enbox/agent`**: `EnboxUserAgent.shutdown({ syncStopTimeoutMs })` — stop sync → close sync store → drain RPC pool → lock vault → close DWN stores (no-op in remote mode) → close DID resolver cache → close vault store → close secret store; every step best-effort so a partially torn-down agent can't block shutdown. `AgentDwnApi.close()`, `HdIdentityVault.close()`, and `SecretStore.close()` (contract + both implementations) added.
- **`@enbox/auth`**: `AuthManager.shutdown()` delegates teardown to `agent.shutdown()`; keeps session clearing, `vault-locked`/`session-end` events, storage-adapter close, and state transitions.

## Evidence the fix works

The instrumented reproduction (restore production session → delegated write → shutdown) previously required SIGKILL after logging "shutdown complete". Against this branch it **exits 0 naturally in 4.8 s**:

```
[13:16:31.254Z] Enbox.connect (expect internal restore, no wallet round-trip)...
[13:16:34.942Z] connected: did:dht:hsmm…
[13:16:35.538Z] write complete
[13:16:35.908Z] shutdown complete — exiting cleanly   → exit 0, no kill
```

## Test plan
- [x] New: teardown ordering + all-components-throw tolerance (agent, stubbed via `create()` injection)
- [x] New: shutdown-then-reopen of the same `dataPath` in one process — fails with wedge/LEVEL_LOCKED before this fix (the cli-demo restart leg)
- [x] New: pool drain closes sockets/subscriptions, awaits pending connections, tolerates errors (dwn-clients)
- [x] `bun run build` (all 15), `bun run lint`
- [x] `@enbox/auth` suite: 498 pass (mock agent mirrors the real teardown ordering)
- [x] `@enbox/dwn-clients` suite: 172 pass
- [x] `@enbox/agent` full suite: 1276 pass on rerun (first run had 1 failure that did not reproduce — transient against the live dev gateway/server; CI is the arbiter)
