### PR TITLE
fix(auth): validate connect grants in the shared path for every transport

### DIFF
--- a/.changeset/shared-connect-grant-validation.md
+++ b/.changeset/shared-connect-grant-validation.md
@@ -1,0 +1,8 @@
+---
+"@enbox/auth": patch
+"@enbox/cli": patch
+---
+
+fix: validate connect grants (grantee, scope subset) in the shared connect path for every transport
+
+The grantee-matches-delegate and granted-scopes-subset checks lived in the CLI handler only, so browser popup and direct relay connects imported whatever a wallet returned. The validation now runs in AuthManager's handler flow and in walletConnect, and @enbox/cli drops its private copy.

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -53,6 +53,7 @@ import { importFromPortable } from './connect/import.js';
 import { normalizeProtocolRequests } from './permissions.js';
 import { restoreSession } from './connect/restore.js';
 import { STORAGE_KEYS } from './types.js';
+import { validateConnectResultGrants } from './connect/validate-grants.js';
 import { vaultConnect } from './connect/vault.js';
 import { walletConnect } from './connect/wallet.js';
 import { deriveActiveSyncScope, ensureVaultReady, finalizeDelegateSession, importDelegateAndSetupSync, resolveIdentityDids, resolvePassword, startSyncIfEnabled, toSyncIdentityProtocols } from './connect/lifecycle.js';
@@ -1052,7 +1053,12 @@ export class AuthManager {
       throw new Error('[@enbox/auth] Connect was denied or cancelled by the user.');
     }
 
-    // 5. Import delegate DID, process grants, set up sync.
+    // 5. Validate the returned grants against the request before importing
+    //    anything — grantee must be the delegate DID and every scope must
+    //    have been requested.
+    validateConnectResultGrants(result, permissionRequests);
+
+    // 6. Import delegate DID, process grants, set up sync.
     const {
       delegatePortableDid, connectedDid, delegateGrants, sessionRevocations,
     } = result;
@@ -1061,7 +1067,7 @@ export class AuthManager {
       flowName: 'Connect',
     });
 
-    // 6. Finalize session. Pass the transient delegate state explicitly
+    // 7. Finalize session. Pass the transient delegate state explicitly
     // so `persistOrClearDelegateSecrets` doesn't need to read it back
     // off the identity (which was the old `(identity as any)._foo`
     // smuggling pattern).

--- a/packages/auth/src/connect/validate-grants.ts
+++ b/packages/auth/src/connect/validate-grants.ts
@@ -1,0 +1,100 @@
+import type { ConnectResult } from '../types.js';
+import type { ConnectPermissionRequest, DwnPermissionScope } from '@enbox/agent';
+
+import { DwnPermissionGrant, DwnPermissionsProtocol } from '@enbox/agent';
+
+/**
+ * Validates that a wallet's connect result grants exactly what was requested.
+ *
+ * Every returned grant must target the delegate DID, and every grant scope —
+ * session-revocation grants excluded via the `sessionRevocations` mapping —
+ * must be a subset of a requested permission scope. A wallet that returns a
+ * grant for a different grantee or a broader scope than requested fails the
+ * connect, with an instruction to revoke the just-approved session (grants
+ * are written to the owner's DWN at approve time, before the client can
+ * check anything).
+ *
+ * Runs for every connect transport: the handler flow (browser popup, CLI
+ * relay) and the direct relay flow alike.
+ */
+export function validateConnectResultGrants(
+  result: ConnectResult,
+  permissionRequests: ConnectPermissionRequest[],
+): void {
+  const delegateDid = result.delegatePortableDid.uri;
+  const revocationGrantIds = new Map<string, string>();
+
+  for (const revocation of result.sessionRevocations ?? []) {
+    revocationGrantIds.set(revocation.revocationGrantId, revocation.grantId);
+  }
+
+  for (const grantMessage of result.delegateGrants) {
+    const grant = DwnPermissionGrant.parse(grantMessage);
+
+    if (grant.grantee !== delegateDid) {
+      throw new Error(
+        `[@enbox/auth] Wallet returned a grant for '${grant.grantee}', but the delegate DID is '${delegateDid}'. ` +
+        'Revoke the approved session in your wallet.'
+      );
+    }
+
+    if (isSessionRevocationGrant(grant, revocationGrantIds)) {
+      continue;
+    }
+
+    if (!isRequestedScope(grant.scope, permissionRequests)) {
+      throw new Error('[@enbox/auth] Wallet returned a grant outside the requested permission scope. Revoke the approved session in your wallet.');
+    }
+  }
+}
+
+function isSessionRevocationGrant(
+  grant: ReturnType<typeof DwnPermissionGrant.parse>,
+  revocationGrantIds: Map<string, string>,
+): boolean {
+  const revokedGrantId = revocationGrantIds.get(grant.id);
+  if (revokedGrantId === undefined) {
+    return false;
+  }
+
+  return grant.scope.interface === 'Records' &&
+    grant.scope.method === 'Write' &&
+    'protocol' in grant.scope &&
+    grant.scope.protocol === DwnPermissionsProtocol.uri &&
+    'contextId' in grant.scope &&
+    grant.scope.contextId === revokedGrantId;
+}
+
+function isRequestedScope(grantScope: DwnPermissionScope, permissionRequests: ConnectPermissionRequest[]): boolean {
+  return permissionRequests.some((permissionRequest) =>
+    permissionRequest.permissionScopes.some((requestedScope) => isScopeSubset(grantScope, requestedScope))
+  );
+}
+
+function isScopeSubset(grantScope: DwnPermissionScope, requestedScope: DwnPermissionScope): boolean {
+  if (grantScope.interface !== requestedScope.interface || grantScope.method !== requestedScope.method) {
+    return false;
+  }
+
+  const requested = requestedScope as Record<string, unknown>;
+  const granted = grantScope as Record<string, unknown>;
+  for (const [key, requestedValue] of Object.entries(requested)) {
+    if (!isEqualScopeValue(granted[key], requestedValue)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isEqualScopeValue(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+
+  return JSON.stringify(left) === JSON.stringify(right);
+}

--- a/packages/auth/src/connect/wallet.ts
+++ b/packages/auth/src/connect/wallet.ts
@@ -13,6 +13,7 @@ import type { WalletConnectOptions } from '../types.js';
 
 import { DEFAULT_DWN_ENDPOINTS } from '../types.js';
 import { registerWithDwnEndpoints } from '../registration.js';
+import { validateConnectResultGrants } from './validate-grants.js';
 import { WalletConnect } from '../wallet-connect-client.js';
 import { ensureVaultReady, finalizeDelegateSession, importDelegateAndSetupSync, resolvePassword } from './lifecycle.js';
 
@@ -58,6 +59,11 @@ export async function walletConnect(
   if (!result) {
     throw new Error('[@enbox/auth] Connection was denied by the wallet.');
   }
+
+  // Validate the returned grants against the request before importing
+  // anything — grantee must be the delegate DID and every scope must have
+  // been requested.
+  validateConnectResultGrants(result, options.permissionRequests);
 
   // Import delegate DID, process grants, and set up sync.
   const {

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -3,6 +3,7 @@ import type { DwnProtocolDefinition, EnboxUserAgent } from '@enbox/agent';
 import { describe, expect, test } from 'bun:test';
 
 import { AuthManager } from '../src/auth-manager.js';
+import { Convert } from '@enbox/common';
 import { MemoryStorage } from '../src/storage/storage.js';
 import { PasswordProvider } from '../src/password-provider.js';
 import { STORAGE_KEYS } from '../src/types.js';
@@ -21,6 +22,45 @@ const HANDLER_PROTOCOLS: DwnProtocolDefinition[] = [
     structure : {},
   },
 ];
+
+/** Builds a parseable delegated permission-grant message for validation tests. */
+function createGrantMessage({
+  grantId = 'grant-1',
+  grantee,
+  scope,
+}: {
+  grantId?: string;
+  grantee: string;
+  scope: Record<string, unknown>;
+}): any {
+  return {
+    recordId    : grantId,
+    contextId   : grantId,
+    encodedData : Convert.object({
+      dateExpires : '2040-01-01T00:00:00.000000Z',
+      delegated   : true,
+      scope,
+    }).toBase64Url(),
+    descriptor: {
+      interface    : 'Records',
+      method       : 'Write',
+      protocol     : 'https://identity.foundation/dwn/permissions',
+      protocolPath : 'grant',
+      recipient    : grantee,
+      dateCreated  : '2026-01-01T00:00:00.000000Z',
+      dataFormat   : 'application/json',
+      dataCid      : 'bafytest',
+      dataSize     : 100,
+    },
+    authorization: {
+      signature: {
+        signatures: [{
+          protected: Convert.object({ kid: 'did:dht:owner456#key-1' }).toBase64Url(),
+        }],
+      },
+    },
+  };
+}
 
 /**
  * Construct an AuthManager instance with a pre-built mock agent.
@@ -337,6 +377,83 @@ describe('AuthManager', () => {
 
       expect(session.did).toBe('did:dht:owner456');
       expect(manager.isConnected).toBe(true);
+    });
+
+    test('rejects grants issued to a DID other than the delegate DID', async () => {
+      const agent = createMockAgent({ firstLaunch: async () => false, identityList: async () => [] });
+      const handler = {
+        requestAccess: async (): Promise<any> => ({
+          delegatePortableDid : { uri: 'did:jwk:delegate123', document: {}, privateKeys: [] },
+          connectedDid        : 'did:dht:owner456',
+          delegateGrants      : [createGrantMessage({
+            grantee : 'did:jwk:someone-else',
+            scope   : { interface: 'Records', method: 'Write', protocol: 'https://example.com/handler-routing' },
+          })],
+        }),
+      };
+
+      const manager = createTestManager(agent);
+      await expect(manager.connect({ connectHandler: handler, protocols: HANDLER_PROTOCOLS }))
+        .rejects.toThrow('Revoke the approved session in your wallet');
+    });
+
+    test('rejects grants broader than the requested permission scopes', async () => {
+      const agent = createMockAgent({ firstLaunch: async () => false, identityList: async () => [] });
+      const handler = {
+        requestAccess: async (): Promise<any> => ({
+          delegatePortableDid : { uri: 'did:jwk:delegate123', document: {}, privateKeys: [] },
+          connectedDid        : 'did:dht:owner456',
+          delegateGrants      : [createGrantMessage({
+            grantee : 'did:jwk:delegate123',
+            scope   : { interface: 'Records', method: 'Write', protocol: 'https://example.com/other-protocol' },
+          })],
+        }),
+      };
+
+      const manager = createTestManager(agent);
+      await expect(manager.connect({ connectHandler: handler, protocols: HANDLER_PROTOCOLS }))
+        .rejects.toThrow('outside the requested permission scope');
+    });
+
+    test('accepts session revocation grants declared in sessionRevocations', async () => {
+      const delegateIdentity = createMockIdentity({
+        did      : { uri: 'did:jwk:delegate123' },
+        metadata : { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner456' },
+      });
+      const agent = createMockAgent({
+        firstLaunch    : async () => false,
+        identityList   : async () => [],
+        identityImport : async () => delegateIdentity,
+        syncSync       : async () => {},
+      });
+      const handler = {
+        requestAccess: async (): Promise<any> => ({
+          delegatePortableDid : { uri: 'did:jwk:delegate123', document: {}, privateKeys: [] },
+          connectedDid        : 'did:dht:owner456',
+          delegateGrants      : [
+            createGrantMessage({
+              grantId : 'session-grant',
+              grantee : 'did:jwk:delegate123',
+              scope   : { interface: 'Records', method: 'Write', protocol: 'https://example.com/handler-routing' },
+            }),
+            createGrantMessage({
+              grantId : 'revocation-grant',
+              grantee : 'did:jwk:delegate123',
+              scope   : {
+                interface : 'Records',
+                method    : 'Write',
+                protocol  : 'https://identity.foundation/dwn/permissions',
+                contextId : 'session-grant',
+              },
+            }),
+          ],
+          sessionRevocations: [{ grantId: 'session-grant', revocationGrantId: 'revocation-grant' }],
+        }),
+      };
+
+      const manager = createTestManager(agent);
+      const session = await manager.connect({ connectHandler: handler, protocols: HANDLER_PROTOCOLS });
+      expect(session.did).toBe('did:dht:owner456');
     });
 
     test('per-call connectHandler overrides default handler', async () => {

--- a/packages/auth/tests/wallet-connect.spec.ts
+++ b/packages/auth/tests/wallet-connect.spec.ts
@@ -29,7 +29,7 @@ function buildTestGrant(protocol: string, grantId: string): any {
       method       : 'Write',
       protocol     : 'https://identity.foundation/dwn/permissions',
       protocolPath : 'grant',
-      recipient    : 'did:jwk:delegate1',
+      recipient    : 'did:dht:delegate123',
       dateCreated  : '2025-01-01T00:00:00.000000Z',
       dataFormat   : 'application/json',
       dataCid      : 'bafytest',
@@ -58,7 +58,7 @@ function buildTestGrantNonMessages(grantId: string): any {
       method       : 'Write',
       protocol     : 'https://identity.foundation/dwn/permissions',
       protocolPath : 'grant',
-      recipient    : 'did:jwk:delegate1',
+      recipient    : 'did:dht:delegate123',
       dateCreated  : '2025-01-01T00:00:00.000000Z',
       dataFormat   : 'application/json',
       dataCid      : 'bafytest',
@@ -77,6 +77,18 @@ function createInitClientResult(delegateGrants: any[] = []): any {
     delegateGrants,
   };
 }
+
+const CHAT_PERMISSION_REQUESTS: any = [{
+  protocolDefinition: {
+    protocol  : 'https://proto.example/chat',
+    published : true,
+    types     : {},
+    structure : {},
+  },
+  permissionScopes: [
+    { interface: 'Messages', method: 'Read', protocol: 'https://proto.example/chat' },
+  ],
+}];
 
 let initClientStub: sinon.SinonStub;
 
@@ -559,7 +571,7 @@ describe('walletConnect', () => {
       {
         displayName        : 'Test App',
         connectServerUrl   : 'https://relay.example.com',
-        permissionRequests : [],
+        permissionRequests : CHAT_PERMISSION_REQUESTS,
         onWalletUriReady   : () => {},
         validatePin        : async () => '1234',
       },
@@ -624,7 +636,7 @@ describe('walletConnect', () => {
         {
           displayName        : 'Test App',
           connectServerUrl   : 'https://relay.example.com',
-          permissionRequests : [],
+          permissionRequests : CHAT_PERMISSION_REQUESTS,
           onWalletUriReady   : () => {},
           validatePin        : async () => '1234',
         },
@@ -662,7 +674,7 @@ describe('walletConnect', () => {
         {
           displayName        : 'Test App',
           connectServerUrl   : 'https://relay.example.com',
-          permissionRequests : [],
+          permissionRequests : CHAT_PERMISSION_REQUESTS,
           onWalletUriReady   : () => {},
           validatePin        : async () => '1234',
         },

--- a/packages/cli/src/cli-connect-handler.ts
+++ b/packages/cli/src/cli-connect-handler.ts
@@ -1,9 +1,8 @@
-import type { ConnectClientMetadata, ConnectPermissionRequest, DwnPermissionScope } from '@enbox/agent';
+import type { ConnectClientMetadata, ConnectPermissionRequest } from '@enbox/agent';
 import type { ConnectHandler, ConnectResult, WalletConnectClientOptions } from '@enbox/auth';
 import type { Readable, Writable } from 'node:stream';
 
 import { WalletConnect } from '@enbox/auth';
-import { DwnPermissionGrant, DwnPermissionsProtocol } from '@enbox/agent';
 
 import { openBrowser as defaultOpenBrowser, promptLine, renderTerminalQr } from './terminal.js';
 
@@ -134,11 +133,8 @@ export function CliConnectHandler(options: CliConnectHandlerOptions = {}): Conne
         pollIntervalMs : options.pollIntervalMs,
       } satisfies WalletConnectClientOptions);
 
-      if (result === undefined) {
-        return undefined;
-      }
-
-      validateConnectResult(result, params.permissionRequests);
+      // Grant validation (grantee + scope subset) runs in @enbox/auth's
+      // shared connect path for every handler.
       return result;
     },
   };
@@ -318,81 +314,3 @@ function writeLine(options: CliConnectHandlerOptions, line: string): void {
   output.write(`${line}\n`);
 }
 
-function validateConnectResult(result: ConnectResult, permissionRequests: ConnectPermissionRequest[]): void {
-  const delegateDid = result.delegatePortableDid.uri;
-  const revocationGrantIds = new Map<string, string>();
-
-  for (const revocation of result.sessionRevocations ?? []) {
-    revocationGrantIds.set(revocation.revocationGrantId, revocation.grantId);
-  }
-
-  for (const grantMessage of result.delegateGrants) {
-    const grant = DwnPermissionGrant.parse(grantMessage);
-
-    if (grant.grantee !== delegateDid) {
-      throw new Error(
-        `@enbox/cli: wallet returned a grant for '${grant.grantee}', but the delegate DID is '${delegateDid}'. ` +
-        'Revoke the approved session in your wallet.'
-      );
-    }
-
-    if (isSessionRevocationGrant(grant, revocationGrantIds)) {
-      continue;
-    }
-
-    if (!isRequestedScope(grant.scope, permissionRequests)) {
-      throw new Error('@enbox/cli: wallet returned a grant outside the requested permission scope. Revoke the approved session in your wallet.');
-    }
-  }
-}
-
-function isSessionRevocationGrant(
-  grant: ReturnType<typeof DwnPermissionGrant.parse>,
-  revocationGrantIds: Map<string, string>,
-): boolean {
-  const revokedGrantId = revocationGrantIds.get(grant.id);
-  if (revokedGrantId === undefined) {
-    return false;
-  }
-
-  return grant.scope.interface === 'Records' &&
-    grant.scope.method === 'Write' &&
-    'protocol' in grant.scope &&
-    grant.scope.protocol === DwnPermissionsProtocol.uri &&
-    'contextId' in grant.scope &&
-    grant.scope.contextId === revokedGrantId;
-}
-
-function isRequestedScope(grantScope: DwnPermissionScope, permissionRequests: ConnectPermissionRequest[]): boolean {
-  return permissionRequests.some((permissionRequest) =>
-    permissionRequest.permissionScopes.some((requestedScope) => isScopeSubset(grantScope, requestedScope))
-  );
-}
-
-function isScopeSubset(grantScope: DwnPermissionScope, requestedScope: DwnPermissionScope): boolean {
-  if (grantScope.interface !== requestedScope.interface || grantScope.method !== requestedScope.method) {
-    return false;
-  }
-
-  const requested = requestedScope as Record<string, unknown>;
-  const granted = grantScope as Record<string, unknown>;
-  for (const [key, requestedValue] of Object.entries(requested)) {
-    if (!isEqualScopeValue(granted[key], requestedValue)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function isEqualScopeValue(left: unknown, right: unknown): boolean {
-  if (left === right) {
-    return true;
-  }
-
-  if (left === undefined || right === undefined) {
-    return false;
-  }
-
-  return JSON.stringify(left) === JSON.stringify(right);
-}

--- a/packages/cli/tests/cli-connect-handler.spec.ts
+++ b/packages/cli/tests/cli-connect-handler.spec.ts
@@ -262,67 +262,8 @@ describe('CliConnectHandler', () => {
     expect(capturedOptions?.timeoutMs).toBeUndefined();
   });
 
-  it('should reject grants issued to a DID other than the returned delegate DID', async () => {
-    sinon.stub(WalletConnect, 'initClient').resolves(createConnectResult([
-      createGrant({ grantee: 'did:jwk:other', scope: requestedScope }),
-    ]));
 
-    const handler = CliConnectHandler({
-      walletUrl        : 'https://wallet.example',
-      connectServerUrl : 'https://relay.example/connect',
-      pinPrompt        : async (): Promise<string> => '428113',
-      qrRenderer       : async (): Promise<string> => '[qr]',
-    });
 
-    await expect(handler.requestAccess({ permissionRequests })).rejects.toThrow('Revoke the approved session in your wallet');
-  });
-
-  it('should reject grants broader than the requested scope', async () => {
-    const broaderScope: DwnPermissionScope = {
-      interface : DwnInterfaceName.Records,
-      method    : DwnMethodName.Write,
-    };
-    sinon.stub(WalletConnect, 'initClient').resolves(createConnectResult([
-      createGrant({ scope: broaderScope }),
-    ]));
-
-    const handler = CliConnectHandler({
-      walletUrl        : 'https://wallet.example',
-      connectServerUrl : 'https://relay.example/connect',
-      pinPrompt        : async (): Promise<string> => '428113',
-      qrRenderer       : async (): Promise<string> => '[qr]',
-    });
-
-    await expect(handler.requestAccess({ permissionRequests })).rejects.toThrow('outside the requested permission scope');
-  });
-
-  it('should allow session revocation grants returned with sessionRevocations metadata', async () => {
-    const sessionGrant = createGrant({ grantId: 'grant-1', scope: requestedScope });
-    const revocationGrant = createGrant({
-      grantId : 'revocation-1',
-      scope   : {
-        interface : DwnInterfaceName.Records,
-        method    : DwnMethodName.Write,
-        protocol  : 'https://identity.foundation/dwn/permissions',
-        contextId : 'grant-1',
-      },
-    });
-    sinon.stub(WalletConnect, 'initClient').resolves(createConnectResult(
-      [sessionGrant, revocationGrant],
-      { sessionRevocations: [{ grantId: 'grant-1', revocationGrantId: 'revocation-1' }] },
-    ));
-
-    const handler = CliConnectHandler({
-      walletUrl        : 'https://wallet.example',
-      connectServerUrl : 'https://relay.example/connect',
-      pinPrompt        : async (): Promise<string> => '428113',
-      qrRenderer       : async (): Promise<string> => '[qr]',
-    });
-
-    const result = await handler.requestAccess({ permissionRequests });
-
-    expect(result?.delegateGrants).toHaveLength(2);
-  });
 
   it('should prompt for wallet and relay URLs when options are omitted', async () => {
     let capturedOptions: WalletConnectClientOptions | undefined;


### PR DESCRIPTION
Fixes #1177 (follow-through from the abstractions review: the delegate-echo check moved to the shared client in #1173, but its two sibling checks stayed in the environment layer).

## Summary
- New `packages/auth/src/connect/validate-grants.ts`: every returned grant must target the delegate DID, and every scope (session-revocation grants excluded via `sessionRevocations`) must be a subset of a requested permission scope; failures throw with the revoke-the-session instruction, since grants exist on the owner's DWN by the time a client can check.
- Runs in **both** connect entry points: `AuthManager._handlerConnect` (covers `BrowserConnectHandler` and `CliConnectHandler`) after `requestAccess` and before any import, and `walletConnect` (direct relay path). The browser popup flow previously performed **neither check**.
- `@enbox/cli` drops its private copy — the handler keeps only environment concerns; its validation tests moved to auth (grantee mismatch, out-of-scope grant, revocation-grant exclusion) exercising the full `manager.connect()` path with parseable grant fixtures.
- `wallet-connect.spec` grant fixtures aligned with the new invariant (grantee = declared delegate; the grant-bearing tests request the scopes they grant — `permissionRequests: []` plus real grants is now correctly a rejection).

## Test plan
- [x] `bun run build`, `bun run lint`
- [x] `@enbox/auth`: 501 pass (3 new validation tests through `manager.connect()`)
- [x] `@enbox/cli`: 24 pass (moved tests removed; integration relay test unaffected)
