### PR TITLE
fix(agent): stop sync before revocation and park links on revoked authorization

### DIFF
--- a/.changeset/disconnect-sync-ordering.md
+++ b/.changeset/disconnect-sync-ordering.md
@@ -1,0 +1,8 @@
+---
+"@enbox/agent": patch
+"@enbox/auth": patch
+---
+
+fix: stop sync before revoking session grants and park links on revoked/expired authorization
+
+Disconnect revoked delegated grants while live sync still ran under them, so the engine treated the self-inflicted 401s as repairable failures — error stacks and pointless retries on every successful delegate disconnect. AuthManager.disconnect() now stops sync first (revocation delivery is direct RPC and unaffected), and SyncEngineLevel classifies GrantAuthorizationGrantRevoked/GrantAuthorizationGrantExpired/MessagesSubscribeDeliveryAuthorizationFailed as terminal: the link parks (paused) with one concise log line instead of repair-retrying, which also quiets wallet-initiated revocation while a tool is running.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -4,7 +4,7 @@ import type { DwnSubscriptionHandler, ResubscribeFactory } from '@enbox/dwn-clie
 import type { GenericMessage, MessageEvent, MessagesFilter, MessagesQueryReply, MessagesQueryReplyEntry, MessagesSubscribeReply, ProgressToken, ProtocolDefinition, RecordsQueryReply, SubscriptionMessage } from '@enbox/dwn-sdk-js';
 
 import { Level } from 'level';
-import { DwnInterfaceName, DwnMethodName, Encoder, Message } from '@enbox/dwn-sdk-js';
+import { DwnErrorCode, DwnInterfaceName, DwnMethodName, Encoder, Message } from '@enbox/dwn-sdk-js';
 import { parseDurationInMilliseconds, sleep } from '@enbox/common';
 
 import type { EnboxPlatformAgent } from './types/agent.js';
@@ -1649,6 +1649,13 @@ export class SyncEngineLevel implements SyncEngine {
       // hot-remove + re-add, don't retry or terminalize the replacement link.
       if (this._engineGeneration !== generation || isStaleLink()) { return; }
 
+      if (SyncEngineLevel.isTerminalAuthorizationFailure(String(error?.message ?? error))) {
+        console.warn(`SyncEngineLevel: sync authorization for ${did} -> ${dwnUrl} was revoked or expired — pausing link (reconnect to resume).`);
+        this.emitEvent({ type: 'repair:failed', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, attempt: attempts, error: String(error.message ?? error) });
+        await this.transitionToPaused(linkKey, link);
+        return;
+      }
+
       console.error(`SyncEngineLevel: Repair failed for ${did} -> ${dwnUrl} (attempt ${attempts})`, error);
       this.emitEvent({ type: 'repair:failed', tenantDid: did, remoteEndpoint: dwnUrl, ...eventScope, attempt: attempts, error: String(error.message ?? error) });
 
@@ -2359,10 +2366,33 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
+  /**
+   * Authorization failures that cannot heal by retrying — the link's grant
+   * was revoked or expired, so every repair attempt would fail identically.
+   * Such links park (`paused`) until a reconnect installs fresh grants.
+   */
+  private static isTerminalAuthorizationFailure(detail: string | undefined): boolean {
+    if (!detail) {
+      return false;
+    }
+
+    return detail.includes(DwnErrorCode.GrantAuthorizationGrantRevoked) ||
+      detail.includes(DwnErrorCode.GrantAuthorizationGrantExpired) ||
+      detail.includes(DwnErrorCode.MessagesSubscribeDeliveryAuthorizationFailed);
+  }
+
   private async handleLivePullSubscriptionError(
     { did, dwnUrl, linkKey, link, isStale }: LivePullContext,
     subMessage: Extract<SubscriptionMessage, { type: 'error' }>,
   ): Promise<void> {
+    if (SyncEngineLevel.isTerminalAuthorizationFailure(String(subMessage.error.code ?? ''))) {
+      console.warn(`SyncEngineLevel: sync authorization for ${did} -> ${dwnUrl} was revoked or expired — pausing link (reconnect to resume).`);
+      if (link && !isStale()) {
+        await this.transitionToPaused(linkKey, link);
+      }
+      return;
+    }
+
     console.warn(`SyncEngineLevel: subscription error for ${did} -> ${dwnUrl}: ${subMessage.error.code}`);
 
     if (link && !isStale()) {

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -55,6 +55,41 @@ describe('SyncEngineLevel', () => {
     });
   });
 
+  describe('terminal authorization failures', () => {
+    const isTerminal = (detail: string | undefined): boolean =>
+      (SyncEngineLevel as any).isTerminalAuthorizationFailure(detail);
+
+    it('should classify revoked, expired, and subscribe-delivery authorization failures as terminal', () => {
+      expect(isTerminal('401 GrantAuthorizationGrantRevoked: Permission grant with CID bafy… has been revoked')).toBe(true);
+      expect(isTerminal('GrantAuthorizationGrantExpired: grant expired')).toBe(true);
+      expect(isTerminal('MessagesSubscribeDeliveryAuthorizationFailed')).toBe(true);
+      expect(isTerminal('503 something transient')).toBe(false);
+      expect(isTerminal(undefined)).toBe(false);
+      expect(isTerminal('')).toBe(false);
+    });
+
+    it('should pause instead of repairing when a live pull subscription reports a terminal authorization error', async () => {
+      const syncEngine = new SyncEngineLevel({ agent: { agentDid: 'did:method:abc123' } as any, db: {} as any });
+      const transitions: string[] = [];
+      (syncEngine as any).transitionToPaused = async (): Promise<void> => { transitions.push('paused'); };
+      (syncEngine as any).transitionToRepairing = async (): Promise<void> => { transitions.push('repairing'); };
+
+      const context = { did: 'did:dht:tenant', dwnUrl: 'https://dwn.example', linkKey: 'k', link: {} as any, isStale: (): boolean => false };
+
+      await (syncEngine as any).handleLivePullSubscriptionError(context, {
+        type  : 'error',
+        error : { code: 'MessagesSubscribeDeliveryAuthorizationFailed', message: 'delivery authorization failed' },
+      });
+      expect(transitions).toEqual(['paused']);
+
+      await (syncEngine as any).handleLivePullSubscriptionError(context, {
+        type  : 'error',
+        error : { code: 'SomeTransientCode', message: 'flaky network' },
+      });
+      expect(transitions).toEqual(['paused', 'repairing']);
+    });
+  });
+
   describe('delegated permission grant bootstrap', () => {
     it('uses delegate-local grant entries without probing the owner signer', async () => {
       const ownerDid = 'did:example:owner';

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -486,10 +486,18 @@ export class AuthManager {
     const { clearStorage = false, timeout = 2000 } = options;
     const did = this._session?.did;
 
-    // Revoke delegated session grants BEFORE stopping sync so the
-    // revocations can be sent to the owner's remote DWN endpoints.
-    // Each revocation grant is contextId-scoped to the specific
-    // session grant it can revoke.
+    // Stop live sync BEFORE revoking. Revocation delivery uses direct RPC
+    // (not the sync engine), and revoking while subscriptions and the
+    // repair loop still run under the session's grants makes them fail
+    // against the delegate's own revocation.
+    try {
+      await this._userAgent.sync.stopSync(timeout);
+    } catch {
+      // Best-effort — sync may never have been started.
+    }
+
+    // Revoke delegated session grants. Each revocation grant is
+    // contextId-scoped to the specific session grant it can revoke.
     const delegateDid = this._session?.delegateDid;
     const connectedDid = this._session?.did;
     let failedRevocations: { grantId: string; revocationGrantId: string }[] = [];
@@ -625,11 +633,6 @@ export class AuthManager {
       } catch (error: any) {
         console.warn(`AuthManager: Grant revocation on disconnect failed: ${error.message}`);
       }
-    }
-
-    // Stop sync AFTER revocations are sent to remote endpoints.
-    if (this._session) {
-      await this._userAgent.sync.stopSync(timeout);
     }
 
     this._session = undefined;

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -575,6 +575,39 @@ describe('AuthManager', () => {
   });
 
   describe('disconnect()', () => {
+    test('stops sync before sending session revocations', async () => {
+      const order: string[] = [];
+      const storage = new MemoryStorage();
+      await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
+      await storage.set(STORAGE_KEYS.SESSION_REVOCATIONS, JSON.stringify([{ grantId: 'g1', revocationGrantId: 'r1' }]));
+
+      const delegateIdentity = createMockIdentity({
+        did      : { uri: 'did:jwk:delegate123' },
+        metadata : { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner456' },
+      });
+      const agent = createMockAgent({
+        firstLaunch  : async () => false,
+        identityList : async () => [delegateIdentity],
+        syncStopSync : async () => { order.push('stopSync'); },
+      });
+      // Disconnect reads revocation grants through the agent's DWN API.
+      (agent as any).dwn.processRequest = async (params: any): Promise<any> => {
+        order.push(`dwn:${params.messageType}`);
+        return { reply: { status: { code: 202, detail: 'Accepted' } } };
+      };
+
+      const manager = createTestManager(agent, { storage });
+      await manager.connect({ password: 'test' });
+      order.length = 0; // observe only the disconnect sequence
+
+      await manager.disconnect();
+
+      const stopIndex = order.indexOf('stopSync');
+      const firstReadIndex = order.indexOf('dwn:RecordsRead');
+      expect(stopIndex).toBeGreaterThanOrEqual(0);
+      expect(firstReadIndex).toBeGreaterThan(stopIndex);
+    });
+
     test('clean disconnect removes session markers', async () => {
       const storage = new MemoryStorage();
       await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');


### PR DESCRIPTION
Fixes #1182 — the error storm observed in the CLI e2e acceptance run's disconnect leg.

## Summary
- **Ordering** (`@enbox/auth`): `disconnect()` stops live sync *before* writing revocations. The old comment claimed revocations had to go first "so they can be sent to remote endpoints", but delivery uses direct RPC (`rpc.sendDwnRequest`), not the sync engine — nothing is lost, and the engine no longer races its own revocation. The redundant post-revocation `stopSync` is removed.
- **Classification** (`@enbox/agent`): `SyncEngineLevel` treats `GrantAuthorizationGrantRevoked`, `GrantAuthorizationGrantExpired`, and `MessagesSubscribeDeliveryAuthorizationFailed` as terminal for a link — both in the live-pull subscription error handler and in the repair path. The link transitions to the existing `paused` state with one concise `console.warn` ("authorization revoked or expired — pausing link (reconnect to resume)") instead of repair-retrying with error stacks. This also quiets the case where the *wallet* revokes a session while a CLI is still running.

## Test plan
- [x] New: terminal-classification truth table + subscription-error routing (terminal → paused, transient → repairing)
- [x] New: disconnect ordering — `stopSync` observed before the first revocation `RecordsRead`
- [x] `@enbox/auth` suite: 499 pass; `sync-engine-level` + `sync-live-handler-path`: 69 pass (with dev gateway)
- [x] `bun run build`, `bun run lint`
- [ ] Post-merge: cli-demo disconnect leg prints no error output (needs the manual run)
