### PR TITLE
fix(auth): restore the session's delegate, clean up revoked delegates, surface auth failures

### DIFF
--- a/.changeset/stale-delegate-restore.md
+++ b/.changeset/stale-delegate-restore.md
@@ -1,0 +1,8 @@
+---
+"@enbox/auth": patch
+"@enbox/api": patch
+---
+
+fix: restore the active identity (not a stale delegate), remove revoked delegates on disconnect, and surface authorization failures in delegate protocol ensure
+
+restoreSession preferred any connected identity over the persisted active marker, so a leftover delegate from a disconnected session (grants revoked) shadowed the current one and every call failed with 401. Disconnect now also removes the dead delegate identity locally after clean revocation (kept while revocations are queued for retry), and TypedEnbox reports the query status when the wallet's protocol definition cannot be fetched instead of misreporting a revoked grant as a missing protocol.

--- a/packages/api/src/typed-enbox.ts
+++ b/packages/api/src/typed-enbox.ts
@@ -839,10 +839,19 @@ export class TypedEnbox<
    * Returns the local import response when the remote configuration was found.
    */
   private async _autoConfigureDelegateProtocol(): Promise<ProtocolsConfigureResponse | undefined> {
-    const { protocols: remoteProtocols } = await this._dwn.protocols.query({
+    const { protocols: remoteProtocols, status: queryStatus } = await this._dwn.protocols.query({
       from   : this._dwn.connectedDid,
       filter : { protocol: this._definition.protocol },
     });
+
+    if (queryStatus !== undefined && queryStatus.code >= 300) {
+      throw new Error(
+        `TypedEnbox: delegate could not fetch the wallet's protocol definition for ` +
+        `'${this._definition.protocol}' from the owner's DWN: ${queryStatus.code} ` +
+        `${queryStatus.detail}. A revoked or expired session grant fails with 401 — ` +
+        `reconnect to obtain fresh grants.`,
+      );
+    }
 
     if (remoteProtocols.length === 0) {
       return undefined;

--- a/packages/api/tests/typed-enbox-delegate-protocol.spec.ts
+++ b/packages/api/tests/typed-enbox-delegate-protocol.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test';
+
+import { TypedEnbox } from '../src/typed-enbox.js';
+
+/**
+ * Builds a TypedEnbox instance over a stubbed DwnApi so the private
+ * delegate-protocol ensure path can be exercised without an agent.
+ */
+function createDelegateTypedEnbox(queryResult: unknown): any {
+  const typed: any = Object.create((TypedEnbox as any).prototype);
+  typed._definition = { protocol: 'https://example.com/protocols/demo', types: {}, structure: {} };
+  typed._dwn = {
+    connectedDid : 'did:dht:owner',
+    isDelegate   : true,
+    protocols    : {
+      query: async (): Promise<unknown> => queryResult,
+    },
+  };
+  return typed;
+}
+
+describe('TypedEnbox delegate protocol ensure', () => {
+  it('should surface authorization failures instead of reporting a missing protocol', async () => {
+    const typed = createDelegateTypedEnbox({
+      status    : { code: 401, detail: 'GrantAuthorizationGrantRevoked: grant has been revoked' },
+      protocols : [],
+    });
+
+    await expect(typed._autoConfigureDelegateProtocol()).rejects.toThrow(
+      '401 GrantAuthorizationGrantRevoked'
+    );
+  });
+
+  it('should return undefined when the wallet has genuinely not installed the protocol', async () => {
+    const typed = createDelegateTypedEnbox({
+      status    : { code: 200, detail: 'OK' },
+      protocols : [],
+    });
+
+    await expect(typed._autoConfigureDelegateProtocol()).resolves.toBeUndefined();
+  });
+});

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -732,6 +732,29 @@ export class AuthManager {
       } catch { /* best effort */ }
     }
 
+    // A cleanly revoked delegate is dead — connect sessions have no renewal
+    // path and its grants are revoked — so remove the identity locally.
+    // Otherwise a later restore can select the stale delegate and every
+    // call under its revoked grants fails with 401. Keep the identity while
+    // revocations are queued for retry: the retry path signs as the delegate.
+    if (delegateDid && failedRevocations.length === 0) {
+      try {
+        const delegateIdentity = await this._userAgent.identity.get({ didUri: delegateDid });
+        if (delegateIdentity) {
+          try {
+            await this._userAgent.did.delete({
+              didUri    : delegateIdentity.did.uri,
+              tenant    : delegateIdentity.metadata.tenant,
+              deleteKey : true,
+            });
+          } catch { /* best effort */ }
+          await this._userAgent.identity.delete({ didUri: delegateIdentity.did.uri });
+        }
+      } catch {
+        // Best-effort — a leftover identity is recoverable by reconnecting.
+      }
+    }
+
     this._setState('unlocked');
 
     if (did) {

--- a/packages/auth/src/connect/restore.ts
+++ b/packages/auth/src/connect/restore.ts
@@ -107,19 +107,27 @@ export async function restoreSession(
   const storedDelegateDid = await storage.get(STORAGE_KEYS.DELEGATE_DID);
 
   // First try the connected identity (wallet-connected sessions).
-  let identity = await userAgent.identity.connectedIdentity();
+  // Prefer the session's persisted delegate identity: a stale delegate from
+  // an earlier session (its grants revoked on disconnect) must not shadow
+  // the one the most recent session finalized. DELEGATE_DID stores that
+  // identity's own DID; ACTIVE_IDENTITY stores the connected (owner) DID,
+  // which only resolves an identity for local (non-delegate) sessions.
+  let identity = storedDelegateDid
+    ? await userAgent.identity.get({ didUri: storedDelegateDid })
+    : undefined;
+
+  if (!identity && activeIdentityDid) {
+    identity = await userAgent.identity.get({ didUri: activeIdentityDid });
+  }
 
   if (!identity) {
-    // Try to find the specific active identity.
-    if (activeIdentityDid) {
-      identity = await userAgent.identity.get({ didUri: activeIdentityDid });
-    }
+    identity = await userAgent.identity.connectedIdentity();
+  }
 
-    // Fall back to the first available identity.
-    if (!identity) {
-      const identities = await userAgent.identity.list();
-      identity = identities[0];
-    }
+  // Fall back to the first available identity.
+  if (!identity) {
+    const identities = await userAgent.identity.list();
+    identity = identities[0];
   }
 
   if (!identity) {

--- a/packages/auth/tests/auth-manager.spec.ts
+++ b/packages/auth/tests/auth-manager.spec.ts
@@ -573,22 +573,31 @@ describe('AuthManager', () => {
   describe('in-memory cache cleanup on reconnect', () => {
     test('clears previous delegate keys on successful reconnect', async () => {
       const clearCalls: (string | undefined)[] = [];
-      const identity = createMockIdentity({
+      const oldIdentity = createMockIdentity({
         did      : { uri: 'did:delegate:old' },
         metadata : { name: 'Old', tenant: 'did:dht:testagent', connectedDid: 'did:dht:connected' },
       });
+      const newIdentity = createMockIdentity({
+        did      : { uri: 'did:delegate:new' },
+        metadata : { name: 'New', tenant: 'did:dht:testagent', connectedDid: 'did:dht:connected' },
+      });
+      let identities = [oldIdentity];
+      const storage = new MemoryStorage();
       const agent = createMockAgent({
         firstLaunch                    : async () => false,
-        identityList                   : async () => [identity],
+        identityList                   : async () => identities,
         dwnClearDelegateDecryptionKeys : (did?: string) => { clearCalls.push(did); },
       });
-      const manager = createTestManager(agent);
+      const manager = createTestManager(agent, { storage });
 
       // First connect — no previous session, so no clear.
       await manager.connect({ password: 'test' });
       expect(clearCalls).toHaveLength(0);
 
-      // Reconnect — should clear the previous delegate's keys.
+      // Simulate a fresh wallet connect having replaced the delegate, then
+      // reconnect — the previous delegate's in-memory keys must be cleared.
+      identities = [oldIdentity, newIdentity];
+      await storage.set(STORAGE_KEYS.DELEGATE_DID, 'did:delegate:new');
       await manager.connect({ password: 'test' });
       expect(clearCalls).toHaveLength(1);
       expect(clearCalls[0]).toBe('did:delegate:old');
@@ -691,6 +700,37 @@ describe('AuthManager', () => {
 
   });
 
+  describe('restoreSession() identity selection', () => {
+    test('prefers the persisted active identity over other connected identities', async () => {
+      const staleIdentity = createMockIdentity({
+        did      : { uri: 'did:jwk:stale-delegate' },
+        metadata : { name: 'Stale', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner456' },
+      });
+      const activeIdentity = createMockIdentity({
+        did      : { uri: 'did:jwk:fresh-delegate' },
+        metadata : { name: 'Fresh', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner456' },
+      });
+      const storage = new MemoryStorage();
+      await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
+      // Production persists the owner DID in ACTIVE_IDENTITY and the
+      // delegate's own DID in DELEGATE_DID.
+      await storage.set(STORAGE_KEYS.ACTIVE_IDENTITY, 'did:dht:owner456');
+      await storage.set(STORAGE_KEYS.DELEGATE_DID, 'did:jwk:fresh-delegate');
+
+      const agent = createMockAgent({
+        firstLaunch               : async () => false,
+        identityGet               : async (params: any) => (params?.didUri === 'did:jwk:fresh-delegate' ? activeIdentity : undefined),
+        identityConnectedIdentity : async () => staleIdentity,
+        identityList              : async () => [staleIdentity, activeIdentity],
+      });
+
+      const manager = createTestManager(agent, { storage });
+      const session = await manager.restoreSession();
+
+      expect(session?.delegateDid).toBe('did:jwk:fresh-delegate');
+    });
+  });
+
   describe('disconnect()', () => {
     test('stops sync before sending session revocations', async () => {
       const order: string[] = [];
@@ -723,6 +763,59 @@ describe('AuthManager', () => {
       const firstReadIndex = order.indexOf('dwn:RecordsRead');
       expect(stopIndex).toBeGreaterThanOrEqual(0);
       expect(firstReadIndex).toBeGreaterThan(stopIndex);
+    });
+
+    test('clean disconnect removes the delegate identity locally', async () => {
+      const storage = new MemoryStorage();
+      await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
+      const delegateIdentity = createMockIdentity({
+        did      : { uri: 'did:jwk:delegate123' },
+        metadata : { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner456' },
+      });
+      const deletedDids: string[] = [];
+      const deletedIdentities: string[] = [];
+      const agent = createMockAgent({
+        firstLaunch    : async () => false,
+        identityList   : async () => [delegateIdentity],
+        identityGet    : async () => delegateIdentity,
+        didDelete      : async (params: any) => { deletedDids.push(params.didUri); },
+        identityDelete : async (params: any) => { deletedIdentities.push(params.didUri); },
+      });
+      const manager = createTestManager(agent, { storage });
+      await manager.connect({ password: 'test' });
+
+      await manager.disconnect();
+
+      expect(deletedDids).toContain('did:jwk:delegate123');
+      expect(deletedIdentities).toContain('did:jwk:delegate123');
+    });
+
+    test('disconnect keeps the delegate identity while revocations are queued for retry', async () => {
+      const storage = new MemoryStorage();
+      await storage.set(STORAGE_KEYS.PREVIOUSLY_CONNECTED, 'true');
+      await storage.set(STORAGE_KEYS.SESSION_REVOCATIONS, JSON.stringify([{ grantId: 'g1', revocationGrantId: 'r1' }]));
+      const delegateIdentity = createMockIdentity({
+        did      : { uri: 'did:jwk:delegate123' },
+        metadata : { name: 'Delegate', tenant: 'did:dht:testagent', connectedDid: 'did:dht:owner456' },
+      });
+      const deletedIdentities: string[] = [];
+      const agent = createMockAgent({
+        firstLaunch    : async () => false,
+        identityList   : async () => [delegateIdentity],
+        identityGet    : async () => delegateIdentity,
+        identityDelete : async (params: any) => { deletedIdentities.push(params.didUri); },
+      });
+      // The revocation read returns 202, so every revocation fails and
+      // lands in the retry queue — the delegate must remain usable.
+      (agent as any).dwn.processRequest = async (): Promise<any> => ({ reply: { status: { code: 202, detail: 'Accepted' } } });
+
+      const manager = createTestManager(agent, { storage });
+      await manager.connect({ password: 'test' });
+
+      await manager.disconnect();
+
+      expect(deletedIdentities).toHaveLength(0);
+      expect(await storage.get(STORAGE_KEYS.REVOCATION_RETRY_CONTEXT)).not.toBeNull();
     });
 
     test('clean disconnect removes session markers', async () => {

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -156,9 +156,14 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
     }),
 
     identity: {
-      list              : overrides.identityList ?? (async (): Promise<MockIdentity[]> => [defaultIdentity]),
-      create            : overrides.identityCreate ?? (async (): Promise<MockIdentity> => defaultIdentity),
-      get               : overrides.identityGet ?? (async (): Promise<MockIdentity | undefined> => defaultIdentity),
+      list   : overrides.identityList ?? (async (): Promise<MockIdentity[]> => [defaultIdentity]),
+      create : overrides.identityCreate ?? (async (): Promise<MockIdentity> => defaultIdentity),
+      // Mirrors the real store: resolves only the identity whose own DID
+      // matches `didUri` (from the same list the mock exposes).
+      get    : overrides.identityGet ?? (async (params: any): Promise<MockIdentity | undefined> => {
+        const identities = await (overrides.identityList ?? (async (): Promise<MockIdentity[]> => [defaultIdentity]))();
+        return identities.find((identity) => identity.did.uri === params?.didUri);
+      }),
       import            : overrides.identityImport ?? (async (): Promise<MockIdentity> => defaultIdentity),
       delete            : overrides.identityDelete ?? (async (): Promise<void> => {}),
       export            : overrides.identityExport ?? (async (): Promise<any> => ({})),


### PR DESCRIPTION
Fixes #1186 — the "delegate cannot install protocol" crash and stale-active wallet session from the second CLI e2e attempt.

## Root cause (field-diagnosed against the live session)

The restored session was **the previous day's delegate**, whose grants that session's disconnect had correctly revoked. `restoreSession` selection order was `connectedIdentity() → ACTIVE_IDENTITY → first`, and the stale delegate — never removed on disconnect — was the first connected identity. Every call under it returned `401 GrantAuthorizationGrantRevoked`, which `TypedEnbox._autoConfigureDelegateProtocol` swallowed (it only checked `protocols.length`) and misreported as "the wallet's remote protocol definition could not be found". The definition was present on both remotes the whole time.

## Fix

- **`@enbox/auth` (restore)**: select by the persisted `DELEGATE_DID` marker first — it stores the session identity's own DID. `ACTIVE_IDENTITY` (owner DID; resolves only local identities) and `connectedIdentity()` remain as fallbacks.
- **`@enbox/auth` (disconnect)**: after clean revocation, delete the dead delegate identity + DID locally — a disconnected session has no renewal path, and the leftover identity is what future restores mis-selected. Kept when revocations are queued for retry (the retry signs as the delegate).
- **`@enbox/api`**: `_autoConfigureDelegateProtocol` propagates a non-2xx query status into the error ("…401 GrantAuthorizationGrantRevoked… reconnect to obtain fresh grants") instead of the misleading missing-protocol message.
- **Test realism**: the auth mock's `identity.get` now honors `didUri` like the real store; one reconnect test that passed only via the blind mock (its "reconnect" accidentally restored a different identity) now simulates an actual delegate change.

## Field proof

Reproduction against the real crashed session, before → after:

```
restored delegate: did:jwk:…hrPEC… (yesterday's, revoked)   →  did:jwk:…HVOAN… (current)
LOCAL/REMOTE protocols.query: 401 GrantRevoked, count=0 ×6  →  200 OK, count=1 ×6
```

Wallet-side companion (session list shows revoked sessions as active — expiry-only check): enboxorg/web-wallet#155.

## Test plan
- [x] New: restore prefers `DELEGATE_DID` over other connected identities; clean disconnect deletes the delegate identity; retry-pending disconnect keeps it; delegate ensure surfaces 401 vs. genuine not-found (2 api tests)
- [x] `@enbox/auth`: 505 pass; `@enbox/api` new spec: 2 pass
- [x] `bun run build`, `bun run lint`
- [ ] Post-release: back-to-back cli-demo runs (connect → disconnect → connect → restart → write) pass without clearing local state
