### PR TITLE
fix(dwn-server): forward record data with delivery-service messages

### DIFF
--- a/.changeset/delivery-service-data-payload.md
+++ b/.changeset/delivery-service-data-payload.md
@@ -1,0 +1,7 @@
+---
+"@enbox/dwn-server": patch
+---
+
+fix: forward record data with DeliveryService messages
+
+Endpoint forwarding and `$delivery: 'direct'` participant delivery previously POSTed data-bearing `RecordsWrite` messages with an empty body, so receiving DWNs only ever got metadata. `DeliveryService` now reads the record data back from the source tenant's stores (`encodedData` for small records, the data store for large ones) and sends it as the `application/octet-stream` request body.

--- a/packages/dwn-server/src/delivery-service.ts
+++ b/packages/dwn-server/src/delivery-service.ts
@@ -1,4 +1,5 @@
 import type { DwnServerConfig } from './config.js';
+import type { JsonRpcRequest } from '@enbox/dwn-clients';
 import type { DidDocument, DidResolver } from '@enbox/dids';
 import type { Dwn, GenericMessage, ProtocolDefinition, ProtocolRuleSet, RecordsQueryReplyEntry, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 import type { MessageProcessedContext, MessageProcessedHook } from './message-processed-hook.js';
@@ -53,8 +54,6 @@ type DeliveryTarget = {
 type SendMessageAttemptResult = 'retry' | 'sent' | 'skipped';
 
 type RequestInitWithDuplex = RequestInit & { duplex?: 'half' };
-
-type DwnProcessMessageRpcRequest = ReturnType<typeof createJsonRpcRequest>;
 
 // ---------------------------------------------------------------------------
 // DeliveryService
@@ -779,6 +778,10 @@ export class DeliveryService implements MessageProcessedHook {
     return fetchOptions;
   }
 
+  /**
+   * Creates the request body for one send attempt; record data streams are one-shot,
+   * so retries must re-read them from local storage instead of replaying a prior body.
+   */
   async #createRequestBody(
     sourceTenant: string,
     endpointUrl: string,
@@ -802,7 +805,7 @@ export class DeliveryService implements MessageProcessedHook {
   }
 
   static #createHeaders(
-    rpcRequest: DwnProcessMessageRpcRequest,
+    rpcRequest: JsonRpcRequest,
     dataBearingWrite: RecordsWriteMessage | undefined,
   ): Record<string, string> {
     return {

--- a/packages/dwn-server/src/delivery-service.ts
+++ b/packages/dwn-server/src/delivery-service.ts
@@ -50,6 +50,12 @@ type DeliveryTarget = {
   endpoints: DwnEndpoint[];
 };
 
+type SendMessageAttemptResult = 'retry' | 'sent' | 'skipped';
+
+type RequestInitWithDuplex = RequestInit & { duplex?: 'half' };
+
+type DwnProcessMessageRpcRequest = ReturnType<typeof createJsonRpcRequest>;
+
 // ---------------------------------------------------------------------------
 // DeliveryService
 // ---------------------------------------------------------------------------
@@ -696,60 +702,135 @@ export class DeliveryService implements MessageProcessedHook {
       { target, message },
     );
 
-    const dataBearingWrite = Records.isRecordsWrite(message) && message.descriptor.dataSize > 0 ? message : undefined;
-
-    const headers: Record<string, string> = {
-      'content-type' : dataBearingWrite !== undefined ? 'application/octet-stream' : 'application/json',
-      'dwn-request'  : JSON.stringify(rpcRequest),
-    };
+    const dataBearingWrite = DeliveryService.#getDataBearingWrite(message);
+    const headers = DeliveryService.#createHeaders(rpcRequest, dataBearingWrite);
 
     for (let attempt = 0; attempt <= DeliveryService.#maxRetries; attempt++) {
-      try {
-        // Data streams are one-shot, so the body is re-read from local
-        // storage on every attempt rather than replayed.
-        let body: BodyInit = new Uint8Array(0);
-        if (dataBearingWrite !== undefined) {
-          const data = await this.#getRecordsWriteData(sourceTenant, dataBearingWrite);
-          if (data === undefined) {
-            log.warn(`DeliveryService: data for ${dataBearingWrite.recordId} is no longer available locally; skipping send to ${endpointUrl}`);
-            return;
-          }
-          body = data;
-        }
-
-        const fetchOptions: RequestInit & { duplex?: 'half' } = {
-          method: 'POST', headers, body, signal: AbortSignal.timeout(DeliveryService.#requestTimeoutMs),
-        };
-        if (body instanceof ReadableStream) {
-          // Required by the Fetch standard for streaming request bodies.
-          fetchOptions.duplex = 'half';
-        }
-
-        const response = await fetch(endpointUrl, fetchOptions);
-
-        if (response.ok) {
-          log.debug(`DeliveryService: sent to ${endpointUrl} for ${target} (${response.status})`);
-          return;
-        }
-
-        // 409 means duplicate — the remote already has this message. That's success.
-        if (response.status === 409) {
-          log.debug(`DeliveryService: ${endpointUrl} already has message for ${target} (409)`);
-          return;
-        }
-
-        log.warn(`DeliveryService: ${endpointUrl} returned ${response.status} (attempt ${attempt + 1})`);
-      } catch (err) {
-        log.warn(`DeliveryService: fetch error to ${endpointUrl} (attempt ${attempt + 1}):`, err);
+      const result = await this.#sendMessageAttempt({
+        attempt,
+        dataBearingWrite,
+        endpointUrl,
+        headers,
+        sourceTenant,
+        target,
+      });
+      if (result !== 'retry') {
+        return;
       }
 
-      // Wait before retry (skip wait on last attempt).
-      if (attempt < DeliveryService.#maxRetries) {
-        await sleep(DeliveryService.#retryDelaysMs[attempt]);
-      }
+      await DeliveryService.#sleepBeforeRetry(attempt);
     }
 
     log.error(`DeliveryService: delivery to ${endpointUrl} failed after ${DeliveryService.#maxRetries + 1} attempts`);
+  }
+
+  async #sendMessageAttempt({
+    attempt,
+    dataBearingWrite,
+    endpointUrl,
+    headers,
+    sourceTenant,
+    target,
+  }: {
+    attempt: number;
+    dataBearingWrite: RecordsWriteMessage | undefined;
+    endpointUrl: string;
+    headers: Record<string, string>;
+    sourceTenant: string;
+    target: string;
+  }): Promise<SendMessageAttemptResult> {
+    try {
+      const fetchOptions = await this.#createFetchOptions(sourceTenant, endpointUrl, headers, dataBearingWrite);
+      if (fetchOptions === undefined) {
+        return 'skipped';
+      }
+
+      const response = await fetch(endpointUrl, fetchOptions);
+      return DeliveryService.#handleSendResponse(endpointUrl, target, response, attempt);
+    } catch (err) {
+      log.warn(`DeliveryService: fetch error to ${endpointUrl} (attempt ${attempt + 1}):`, err);
+      return 'retry';
+    }
+  }
+
+  async #createFetchOptions(
+    sourceTenant: string,
+    endpointUrl: string,
+    headers: Record<string, string>,
+    dataBearingWrite: RecordsWriteMessage | undefined,
+  ): Promise<RequestInitWithDuplex | undefined> {
+    const body = await this.#createRequestBody(sourceTenant, endpointUrl, dataBearingWrite);
+    if (body === undefined) {
+      return undefined;
+    }
+
+    const fetchOptions: RequestInitWithDuplex = {
+      body,
+      headers,
+      method : 'POST',
+      signal : AbortSignal.timeout(DeliveryService.#requestTimeoutMs),
+    };
+
+    if (body instanceof ReadableStream) {
+      // Required by the Fetch standard for streaming request bodies.
+      fetchOptions.duplex = 'half';
+    }
+
+    return fetchOptions;
+  }
+
+  async #createRequestBody(
+    sourceTenant: string,
+    endpointUrl: string,
+    dataBearingWrite: RecordsWriteMessage | undefined,
+  ): Promise<BodyInit | undefined> {
+    if (dataBearingWrite === undefined) {
+      return new Uint8Array(0);
+    }
+
+    const data = await this.#getRecordsWriteData(sourceTenant, dataBearingWrite);
+    if (data === undefined) {
+      log.warn(`DeliveryService: data for ${dataBearingWrite.recordId} is no longer available locally; skipping send to ${endpointUrl}`);
+      return undefined;
+    }
+
+    return data;
+  }
+
+  static #getDataBearingWrite(message: GenericMessage): RecordsWriteMessage | undefined {
+    return Records.isRecordsWrite(message) && message.descriptor.dataSize > 0 ? message : undefined;
+  }
+
+  static #createHeaders(
+    rpcRequest: DwnProcessMessageRpcRequest,
+    dataBearingWrite: RecordsWriteMessage | undefined,
+  ): Record<string, string> {
+    return {
+      'content-type' : dataBearingWrite !== undefined ? 'application/octet-stream' : 'application/json',
+      'dwn-request'  : JSON.stringify(rpcRequest),
+    };
+  }
+
+  static #handleSendResponse(endpointUrl: string, target: string, response: Response, attempt: number): SendMessageAttemptResult {
+    if (response.ok) {
+      log.debug(`DeliveryService: sent to ${endpointUrl} for ${target} (${response.status})`);
+      return 'sent';
+    }
+
+    // 409 means duplicate — the remote already has this message. That's success.
+    if (response.status === 409) {
+      log.debug(`DeliveryService: ${endpointUrl} already has message for ${target} (409)`);
+      return 'sent';
+    }
+
+    log.warn(`DeliveryService: ${endpointUrl} returned ${response.status} (attempt ${attempt + 1})`);
+    return 'retry';
+  }
+
+  static async #sleepBeforeRetry(attempt: number): Promise<void> {
+    if (attempt < DeliveryService.#maxRetries) {
+      await sleep(DeliveryService.#retryDelaysMs[attempt]);
+    }
   }
 
   /**

--- a/packages/dwn-server/src/delivery-service.ts
+++ b/packages/dwn-server/src/delivery-service.ts
@@ -1,13 +1,13 @@
 import type { DwnServerConfig } from './config.js';
 import type { DidDocument, DidResolver } from '@enbox/dids';
-import type { Dwn, GenericMessage, ProtocolDefinition, ProtocolRuleSet } from '@enbox/dwn-sdk-js';
+import type { Dwn, GenericMessage, ProtocolDefinition, ProtocolRuleSet, RecordsQueryReplyEntry, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
 import type { MessageProcessedContext, MessageProcessedHook } from './message-processed-hook.js';
 
 import log from 'loglevel';
 
 import { createJsonRpcRequest } from '@enbox/dwn-clients';
 import { sleep } from '@enbox/common';
-import { DwnInterfaceName, DwnMethodName, getRuleSetAtPath, Message } from '@enbox/dwn-sdk-js';
+import { DataStream, DwnConstant, DwnInterfaceName, DwnMethodName, Encoder, getRuleSetAtPath, Message, Records } from '@enbox/dwn-sdk-js';
 
 /** Strips trailing `/` characters without regex (avoids ReDoS scanners). */
 function stripTrailingSlashes(value: string): string {
@@ -16,6 +16,15 @@ function stripTrailingSlashes(value: string): string {
     end--;
   }
   return end === value.length ? value : value.slice(0, end);
+}
+
+/**
+ * Type guard for `RecordsWrite` messages as read back from the message store,
+ * which optionally carry the record data inline as `encodedData`
+ * (`RecordsQueryReplyEntry`).
+ */
+function isStoredRecordsWrite(message: GenericMessage): message is RecordsQueryReplyEntry {
+  return Records.isRecordsWrite(message);
 }
 
 // ---------------------------------------------------------------------------
@@ -282,7 +291,7 @@ export class DeliveryService implements MessageProcessedHook {
 
       // For delivery, the target is the participant DID (not the tenant).
       // We need to send to each participant's DWN with the *participant* as the target.
-      await this.#sendToEndpointsGrouped(uniqueEndpoints, endpointTargetMap, message, concurrency);
+      await this.#sendToEndpointsGrouped(uniqueEndpoints, endpointTargetMap, tenant, message, concurrency);
     }
 
     // 'subscribe' strategy: no outbound push needed from the origin.
@@ -641,7 +650,7 @@ export class DeliveryService implements MessageProcessedHook {
     for (let i = 0; i < endpoints.length; i += concurrency) {
       const batch = endpoints.slice(i, i + concurrency);
       await Promise.allSettled(
-        batch.map((ep: DwnEndpoint): Promise<void> => this.#sendMessage(ep.url, tenant, message)),
+        batch.map((ep: DwnEndpoint): Promise<void> => this.#sendMessage(ep.url, tenant, message, tenant)),
       );
     }
   }
@@ -649,10 +658,13 @@ export class DeliveryService implements MessageProcessedHook {
   /**
    * Sends a DWN message to endpoints grouped by target DID.
    * Used for delivery where each endpoint maps to a specific participant DID.
+   * The record data still lives in the *origin* tenant's stores, so `tenant`
+   * is threaded through separately from the per-endpoint target DID.
    */
   async #sendToEndpointsGrouped(
     endpoints: DwnEndpoint[],
     endpointTargetMap: Map<string, string>,
+    tenant: string,
     message: GenericMessage,
     concurrency: number,
   ): Promise<void> {
@@ -661,7 +673,7 @@ export class DeliveryService implements MessageProcessedHook {
       await Promise.allSettled(
         batch.map((ep: DwnEndpoint): Promise<void> => {
           const targetDid = endpointTargetMap.get(ep.url)!;
-          return this.#sendMessage(ep.url, targetDid, message);
+          return this.#sendMessage(ep.url, targetDid, message, tenant);
         }),
       );
     }
@@ -669,26 +681,51 @@ export class DeliveryService implements MessageProcessedHook {
 
   /**
    * Sends a single DWN message to a remote endpoint via JSON-RPC over HTTP.
+   * The JSON-RPC envelope rides the `dwn-request` header; for data-bearing
+   * `RecordsWrite` messages the record data is sent as an
+   * `application/octet-stream` request body (the same wire shape
+   * `HttpDwnRpcClient.sendDwnRequest` produces), read back from the source
+   * tenant's local stores since the original request stream was consumed
+   * when the message was processed.
    * Follows the same retry pattern as WebhookManager.
    */
-  async #sendMessage(endpointUrl: string, target: string, message: GenericMessage): Promise<void> {
+  async #sendMessage(endpointUrl: string, target: string, message: GenericMessage, sourceTenant: string): Promise<void> {
     const rpcRequest = createJsonRpcRequest(
       crypto.randomUUID(),
       'dwn.processMessage',
       { target, message },
     );
 
-    const body = JSON.stringify(rpcRequest);
+    const dataBearingWrite = Records.isRecordsWrite(message) && message.descriptor.dataSize > 0 ? message : undefined;
+
     const headers: Record<string, string> = {
-      'content-type' : 'application/json',
-      'dwn-request'  : body,
+      'content-type' : dataBearingWrite !== undefined ? 'application/octet-stream' : 'application/json',
+      'dwn-request'  : JSON.stringify(rpcRequest),
     };
 
     for (let attempt = 0; attempt <= DeliveryService.#maxRetries; attempt++) {
       try {
-        const response = await fetch(endpointUrl, {
-          method: 'POST', headers, body: new Uint8Array(0), signal: AbortSignal.timeout(DeliveryService.#requestTimeoutMs),
-        });
+        // Data streams are one-shot, so the body is re-read from local
+        // storage on every attempt rather than replayed.
+        let body: BodyInit = new Uint8Array(0);
+        if (dataBearingWrite !== undefined) {
+          const data = await this.#getRecordsWriteData(sourceTenant, dataBearingWrite);
+          if (data === undefined) {
+            log.warn(`DeliveryService: data for ${dataBearingWrite.recordId} is no longer available locally; skipping send to ${endpointUrl}`);
+            return;
+          }
+          body = data;
+        }
+
+        const fetchOptions: RequestInit & { duplex?: 'half' } = {
+          method: 'POST', headers, body, signal: AbortSignal.timeout(DeliveryService.#requestTimeoutMs),
+        };
+        if (body instanceof ReadableStream) {
+          // Required by the Fetch standard for streaming request bodies.
+          fetchOptions.duplex = 'half';
+        }
+
+        const response = await fetch(endpointUrl, fetchOptions);
 
         if (response.ok) {
           log.debug(`DeliveryService: sent to ${endpointUrl} for ${target} (${response.status})`);
@@ -713,6 +750,33 @@ export class DeliveryService implements MessageProcessedHook {
     }
 
     log.error(`DeliveryService: delivery to ${endpointUrl} failed after ${DeliveryService.#maxRetries + 1} attempts`);
+  }
+
+  /**
+   * Reads the stored record data of a data-bearing `RecordsWrite` as a stream
+   * for use as the outbound request body. Data at or below
+   * `DwnConstant.maxDataSizeAllowedToBeEncoded` lives as `encodedData` on the
+   * stored message; larger data lives in the data store.
+   *
+   * Returns `undefined` when the data is no longer available locally — e.g.
+   * the message was displaced by a newer write between processing and this
+   * fire-and-forget send. The displacing write triggers its own dispatch, so
+   * the stale send is skipped rather than retried.
+   */
+  async #getRecordsWriteData(tenant: string, message: RecordsWriteMessage): Promise<ReadableStream<Uint8Array> | undefined> {
+    const { dataCid, dataSize } = message.descriptor;
+
+    if (dataSize <= DwnConstant.maxDataSizeAllowedToBeEncoded) {
+      const messageCid = await Message.getCid(message);
+      const storedMessage = await this.#dwn.storage.messageStore.get(tenant, messageCid);
+      if (storedMessage === undefined || !isStoredRecordsWrite(storedMessage) || storedMessage.encodedData === undefined) {
+        return undefined;
+      }
+      return DataStream.fromBytes(Encoder.base64UrlToBytes(storedMessage.encodedData));
+    }
+
+    const result = await this.#dwn.storage.dataStore.get(tenant, message.recordId, dataCid);
+    return result?.dataStream;
   }
 
   // -------------------------------------------------------------------------

--- a/packages/dwn-server/tests/delivery-service-coverage.test.ts
+++ b/packages/dwn-server/tests/delivery-service-coverage.test.ts
@@ -4,7 +4,7 @@ import type { Dwn, GenericMessage, ProtocolDefinition } from '@enbox/dwn-sdk-js'
 
 import sinon from 'sinon';
 import { afterEach, describe, expect, it } from 'bun:test';
-import { DwnInterfaceName, DwnMethodName } from '@enbox/dwn-sdk-js';
+import { DataStream, DwnConstant, DwnInterfaceName, DwnMethodName, Encoder, Message } from '@enbox/dwn-sdk-js';
 
 import { config } from '../src/config.js';
 import { DeliveryService } from '../src/delivery-service.js';
@@ -54,13 +54,24 @@ function throwingResolver(): DidResolver {
   } as unknown as DidResolver;
 }
 
+/** Optional storage stubs for `mockDwn` — used by the record-data forwarding tests. */
+type MockDwnStorage = {
+  messageStoreGet?: sinon.SinonStub;
+  dataStoreGet?: sinon.SinonStub;
+};
+
 /** Creates a mock DWN with a configurable processMessage stub. */
-function mockDwn(processMessageFn?: sinon.SinonStub): Dwn {
+function mockDwn(processMessageFn?: sinon.SinonStub, storage: MockDwnStorage = {}): Dwn {
   return {
     processMessage: processMessageFn ?? sinon.stub().resolves({
       status  : { code: 200 },
       entries : [],
     }),
+    storage: {
+      messageStore : { get: storage.messageStoreGet ?? sinon.stub().resolves(undefined) },
+      dataStore    : { get: storage.dataStoreGet ?? sinon.stub().resolves(undefined) },
+      eventLog     : undefined,
+    },
     close: sinon.stub(),
   } as unknown as Dwn;
 }
@@ -132,6 +143,23 @@ function recordsWriteMessage(recordId = 'test-record'): GenericMessage {
       messageTimestamp : new Date().toISOString(),
     },
     recordId,
+  } as unknown as GenericMessage;
+}
+
+/**
+ * A RecordsWrite message referencing record data, for payload-forwarding tests.
+ * Every descriptor key is defined so the message can be CID-computed.
+ */
+function dataBearingWriteMessage(opts: { recordId?: string; dataCid?: string; dataSize: number }): GenericMessage {
+  return {
+    descriptor: {
+      interface        : DwnInterfaceName.Records,
+      method           : DwnMethodName.Write,
+      messageTimestamp : new Date().toISOString(),
+      dataCid          : opts.dataCid ?? 'bafy-test-data-cid',
+      dataSize         : opts.dataSize,
+    },
+    recordId: opts.recordId ?? 'data-record-1',
   } as unknown as GenericMessage;
 }
 
@@ -536,6 +564,229 @@ describe('DeliveryService — coverage', () => {
       await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 100));
 
       expect(fetchStub.callCount).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Record data payloads (#getRecordsWriteData)
+  // -----------------------------------------------------------------------
+
+  describe('forwarding record data', () => {
+    it('should attach small record data from the message store as the request body', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+        new Response(null, { status: 200 }),
+      );
+
+      const dataBytes = new TextEncoder().encode('{"hello":"world"}');
+      const message = dataBearingWriteMessage({ dataSize: dataBytes.length });
+      const messageStoreGet = sinon.stub().resolves({ ...message, encodedData: Encoder.bytesToBase64Url(dataBytes) });
+
+      const tenant = 'did:test:alice';
+      const resolver = fakeResolver({
+        [tenant]: didDocWithDwnService(tenant, ['http://self.example.com', 'http://peer.example.com']),
+      });
+
+      const dwn = mockDwn(undefined, { messageStoreGet });
+      const svc = DeliveryService.create(dwn, resolver, testConfig());
+
+      svc.dispatchIfNeeded(tenant, message, 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      expect(fetchStub.callCount).toBe(1);
+      expect(messageStoreGet.callCount).toBe(1);
+      expect(messageStoreGet.firstCall.args[0]).toBe(tenant);
+      expect(messageStoreGet.firstCall.args[1]).toBe(await Message.getCid(message));
+
+      const [, fetchOptions] = fetchStub.firstCall.args;
+      const headers = new Headers(fetchOptions?.headers);
+      expect(headers.get('content-type')).toBe('application/octet-stream');
+      expect(fetchOptions?.body).toBeInstanceOf(ReadableStream);
+
+      const sentBytes = new Uint8Array(await new Response(fetchOptions?.body).arrayBuffer());
+      expect(sentBytes).toEqual(dataBytes);
+    });
+
+    it('should stream large record data from the data store with a one-shot body', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+        new Response(null, { status: 200 }),
+      );
+
+      const dataSize = DwnConstant.maxDataSizeAllowedToBeEncoded + 1;
+      const dataBytes = new TextEncoder().encode('large-record-data');
+      const dataStoreGet = sinon.stub().callsFake(
+        async (): Promise<{ dataSize: number; dataStream: ReadableStream<Uint8Array> }> => ({
+          dataSize,
+          dataStream: DataStream.fromBytes(dataBytes),
+        }),
+      );
+      const message = dataBearingWriteMessage({ recordId: 'large-record-1', dataSize });
+
+      const tenant = 'did:test:alice';
+      const resolver = fakeResolver({
+        [tenant]: didDocWithDwnService(tenant, ['http://self.example.com', 'http://peer.example.com']),
+      });
+
+      const dwn = mockDwn(undefined, { dataStoreGet });
+      const svc = DeliveryService.create(dwn, resolver, testConfig());
+
+      svc.dispatchIfNeeded(tenant, message, 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      expect(fetchStub.callCount).toBe(1);
+      expect(dataStoreGet.callCount).toBe(1);
+      expect(dataStoreGet.firstCall.args).toEqual([tenant, 'large-record-1', 'bafy-test-data-cid']);
+
+      const [, fetchOptions] = fetchStub.firstCall.args;
+      const headers = new Headers(fetchOptions?.headers);
+      expect(headers.get('content-type')).toBe('application/octet-stream');
+      expect(fetchOptions).toMatchObject({ duplex: 'half' });
+      expect(fetchOptions?.body).toBeInstanceOf(ReadableStream);
+
+      const sentBytes = new Uint8Array(await new Response(fetchOptions?.body).arrayBuffer());
+      expect(sentBytes).toEqual(dataBytes);
+    });
+
+    it('should skip the send without retrying when record data is no longer available locally', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
+      const message = dataBearingWriteMessage({ recordId: 'displaced-record-1', dataSize: 32 });
+      const messageStoreGet = sinon.stub().resolves(undefined);
+
+      const tenant = 'did:test:alice';
+      const resolver = fakeResolver({
+        [tenant]: didDocWithDwnService(tenant, ['http://self.example.com', 'http://peer.example.com']),
+      });
+
+      const dwn = mockDwn(undefined, { messageStoreGet });
+      const svc = DeliveryService.create(dwn, resolver, testConfig());
+
+      svc.dispatchIfNeeded(tenant, message, 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      expect(fetchStub.callCount).toBe(0);
+      expect(messageStoreGet.callCount).toBe(1);
+    });
+
+    it('should re-read the data for each retry attempt', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+      fetchStub.onFirstCall().resolves(new Response(null, { status: 500 }));
+      fetchStub.onSecondCall().resolves(new Response(null, { status: 200 }));
+
+      const dataSize = DwnConstant.maxDataSizeAllowedToBeEncoded + 1;
+      const dataBytes = new TextEncoder().encode('retry-payload');
+      const dataStoreGet = sinon.stub().callsFake(
+        async (): Promise<{ dataSize: number; dataStream: ReadableStream<Uint8Array> }> => ({
+          dataSize,
+          dataStream: DataStream.fromBytes(dataBytes),
+        }),
+      );
+      const message = dataBearingWriteMessage({ recordId: 'retry-record-1', dataSize });
+
+      const tenant = 'did:test:alice';
+      const resolver = fakeResolver({
+        [tenant]: didDocWithDwnService(tenant, ['http://self.example.com', 'http://peer.example.com']),
+      });
+
+      const dwn = mockDwn(undefined, { dataStoreGet });
+      const svc = DeliveryService.create(dwn, resolver, testConfig());
+
+      svc.dispatchIfNeeded(tenant, message, 202);
+
+      // Wait for the first attempt plus the 1s retry delay.
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 2_500));
+
+      // Each attempt gets a freshly-read body — a stream cannot be replayed.
+      expect(fetchStub.callCount).toBe(2);
+      expect(dataStoreGet.callCount).toBe(2);
+    }, 10_000);
+
+    it('should read delivery payload data from the origin tenant while targeting the participant', async () => {
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+        new Response(null, { status: 200 }),
+      );
+
+      const tenant = 'did:test:alice';
+      const participant = 'did:test:bob';
+
+      const protocolDef: ProtocolDefinition = {
+        protocol  : 'http://example.com/chat',
+        published : true,
+        types     : {
+          thread      : {},
+          participant : {},
+          message     : {},
+        },
+        structure: {
+          thread: {
+            participant : { $actions: [{ role: 'thread/participant', can: ['read'] }] },
+            message     : {
+              $delivery : 'direct',
+              $actions  : [{ role: 'thread/participant', can: ['create', 'read'] }],
+            },
+          },
+        },
+      };
+
+      const processStub = sinon.stub();
+      processStub.onFirstCall().resolves({
+        status  : { code: 200 },
+        entries : [{ descriptor: { definition: protocolDef } }],
+      });
+      processStub.onSecondCall().resolves({
+        status  : { code: 200 },
+        entries : [
+          { descriptor: { recipient: participant } },
+        ],
+      });
+
+      const dataSize = DwnConstant.maxDataSizeAllowedToBeEncoded + 1;
+      const dataBytes = new TextEncoder().encode('delivered-data');
+      const dataStoreGet = sinon.stub().callsFake(
+        async (): Promise<{ dataSize: number; dataStream: ReadableStream<Uint8Array> }> => ({
+          dataSize,
+          dataStream: DataStream.fromBytes(dataBytes),
+        }),
+      );
+
+      const dwn = mockDwn(processStub, { dataStoreGet });
+      const resolver = fakeResolver({
+        [participant]: didDocWithDwnService(participant, ['http://bob-dwn.example.com']),
+      });
+
+      const svc = DeliveryService.create(dwn, resolver, testConfig({
+        forwardingEnabled : false,
+        deliveryEnabled   : true,
+      }));
+
+      const message = {
+        descriptor: {
+          interface        : DwnInterfaceName.Records,
+          method           : DwnMethodName.Write,
+          messageTimestamp : new Date().toISOString(),
+          protocol         : 'http://example.com/chat',
+          protocolPath     : 'thread/message',
+          contextId        : 'ctx-data-1',
+          dataCid          : 'bafy-delivered-data',
+          dataSize,
+        },
+        recordId: 'deliver-data-1',
+      } as unknown as GenericMessage;
+
+      svc.dispatchIfNeeded(tenant, message, 202);
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+
+      expect(fetchStub.callCount).toBe(1);
+      expect(fetchStub.firstCall.args[0]).toBe('http://bob-dwn.example.com');
+
+      // The data is read from the origin tenant's store...
+      expect(dataStoreGet.callCount).toBe(1);
+      expect(dataStoreGet.firstCall.args[0]).toBe(tenant);
+
+      // ...while the JSON-RPC envelope targets the participant.
+      const [, fetchOptions] = fetchStub.firstCall.args;
+      const headers = new Headers(fetchOptions?.headers);
+      const rpcRequest = JSON.parse(headers.get('dwn-request') ?? '');
+      expect(rpcRequest.params.target).toBe(participant);
     });
   });
 

--- a/packages/dwn-server/tests/delivery-service.test.ts
+++ b/packages/dwn-server/tests/delivery-service.test.ts
@@ -6,7 +6,7 @@ import type { Dwn, GenericMessage } from '@enbox/dwn-sdk-js';
 import sinon from 'sinon';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { DidKey, UniversalResolver } from '@enbox/dids';
-import { DwnConstant, DwnInterfaceName, DwnMethodName, TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { DwnConstant, DwnInterfaceName, DwnMethodName, RecordsRead, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
 import { config } from '../src/config.js';
 import { createJsonRpcRequest } from '@enbox/dwn-clients';
@@ -406,6 +406,90 @@ describe('DeliveryService', () => {
 
       await testDwn.close();
     });
+  });
+
+  describe('forwarding to a live dwn-server', () => {
+    /**
+     * Reproduces the #1169 scenario end-to-end with a real HTTP hop: a write
+     * processed on the sender is forwarded (real fetch, no stubs) to a running
+     * receiver `DwnServer`, then read back from the receiver with the data.
+     */
+    async function forwardAndReadBack(data: Uint8Array): Promise<void> {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const { recordsWrite, dataStream } = await createRecordsWriteMessage(alice, { data });
+
+      // Receiver: a live DwnServer on an ephemeral port.
+      const receiverConfig: DwnServerConfig = {
+        ...config,
+        port               : 0,
+        forwardingEnabled  : false,
+        deliveryEnabled    : false,
+        messageStore       : 'sqlite://',
+        dataStore          : 'sqlite://',
+        resumableTaskStore : 'sqlite://',
+        packageJsonPath    : './package.json',
+      };
+      const { dwn: receiverDwn } = await getTestDwn();
+      await TestDataGenerator.installDefaultTestProtocol(receiverDwn, alice);
+      const receiverServer = new DwnServer({ config: receiverConfig, dwn: receiverDwn });
+      await receiverServer.start();
+      const receiverUrl = `http://127.0.0.1:${receiverServer.httpServer.port}`;
+
+      // Sender: a DWN whose DeliveryService resolves alice's endpoints to the receiver.
+      const { dwn: senderDwn } = await getTestDwn();
+      await TestDataGenerator.installDefaultTestProtocol(senderDwn, alice);
+
+      const senderConfig: DwnServerConfig = {
+        ...config,
+        baseUrl           : 'http://localhost:9999',
+        forwardingEnabled : true,
+        deliveryEnabled   : false,
+      };
+      const deliveryService = DeliveryService.create(senderDwn, endpointResolver(alice.did, [receiverUrl]), senderConfig);
+
+      const dwnRequest = createJsonRpcRequest(crypto.randomUUID(), 'dwn.processMessage', {
+        message : recordsWrite.toJSON(),
+        target  : alice.did,
+      });
+      const context: RequestContext = {
+        dwn                   : senderDwn,
+        transport             : 'http',
+        dataStream,
+        messageProcessedHooks : [deliveryService],
+      };
+
+      const { jsonRpcResponse } = await handleDwnProcessMessage(dwnRequest, context);
+      expect(jsonRpcResponse.error).toBeUndefined();
+      expect(jsonRpcResponse.result.reply.status.code).toBe(202);
+
+      // The forward is fire-and-forget — poll the receiver until the record lands.
+      const recordsRead = await RecordsRead.create({
+        filter : { recordId: recordsWrite.message.recordId },
+        signer : alice.signer,
+      });
+      let readReply = await receiverDwn.processMessage(alice.did, recordsRead.message);
+      for (let i = 0; i < 40 && readReply.status.code !== 200; i++) {
+        await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 200));
+        readReply = await receiverDwn.processMessage(alice.did, recordsRead.message);
+      }
+
+      expect(readReply.status.code).toBe(200);
+      expect(readReply.entry?.data).toBeDefined();
+      const receivedBytes = new Uint8Array(await new Response(readReply.entry?.data).arrayBuffer());
+      expect(receivedBytes).toEqual(data);
+
+      await receiverServer.stop();
+      await receiverDwn.close();
+      await senderDwn.close();
+    }
+
+    it('should replicate a small record with its data to the receiving server', async () => {
+      await forwardAndReadBack(randomBytes(256));
+    }, 15_000);
+
+    it('should replicate a large record with its data to the receiving server', async () => {
+      await forwardAndReadBack(randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1_000));
+    }, 15_000);
   });
 
   describe('endpoint resolution', () => {

--- a/packages/dwn-server/tests/delivery-service.test.ts
+++ b/packages/dwn-server/tests/delivery-service.test.ts
@@ -1,20 +1,39 @@
 import type { DwnServerConfig } from '../src/config.js';
 import type { RequestContext } from '../src/lib/json-rpc-router.js';
+import type { DidResolutionResult, DidResolver } from '@enbox/dids';
 import type { Dwn, GenericMessage } from '@enbox/dwn-sdk-js';
 
 import sinon from 'sinon';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { DidKey, UniversalResolver } from '@enbox/dids';
-import { DwnInterfaceName, DwnMethodName, TestDataGenerator } from '@enbox/dwn-sdk-js';
+import { DwnConstant, DwnInterfaceName, DwnMethodName, TestDataGenerator } from '@enbox/dwn-sdk-js';
 
 import { config } from '../src/config.js';
 import { createJsonRpcRequest } from '@enbox/dwn-clients';
-import { createRecordsWriteMessage } from './utils.js';
 import { DeliveryService } from '../src/delivery-service.js';
 import { DwnServer } from '../src/dwn-server.js';
 import { getTestDwn } from './test-dwn.js';
 import { handleDwnApplyReplicatedMessage } from '../src/json-rpc-handlers/dwn/apply-replicated-message.js';
 import { handleDwnProcessMessage } from '../src/json-rpc-handlers/dwn/process-message.js';
+import { createRecordsWriteMessage, randomBytes } from './utils.js';
+
+/** Creates a fake DidResolver that resolves any DID to the given DWN endpoints. */
+function endpointResolver(did: string, endpoints: string[]): DidResolver {
+  return {
+    resolve: async (): Promise<DidResolutionResult> => ({
+      didResolutionMetadata : {},
+      didDocument           : {
+        id      : did,
+        service : [{
+          id              : `${did}#dwn`,
+          type            : 'DecentralizedWebNode',
+          serviceEndpoint : endpoints,
+        }],
+      },
+      didDocumentMetadata: {},
+    } as DidResolutionResult),
+  } as unknown as DidResolver;
+}
 
 describe('DeliveryService', () => {
   let dwn: Dwn;
@@ -275,6 +294,115 @@ describe('DeliveryService', () => {
       expect(hookSpy.calledOnce).toBe(true);
       expect(hookSpy.firstCall.args[0].tenant).toBe(alice.did);
       expect(hookSpy.firstCall.args[0].status.code).toBe(202);
+
+      await testDwn.close();
+    });
+  });
+
+  describe('forwarded record data', () => {
+    it('should forward small record data read back from the message store', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const data = randomBytes(256);
+      const { recordsWrite, dataStream } = await createRecordsWriteMessage(alice, { data });
+
+      const { dwn: testDwn } = await getTestDwn();
+      await TestDataGenerator.installDefaultTestProtocol(testDwn, alice);
+
+      const testConfig: DwnServerConfig = {
+        ...config,
+        baseUrl           : 'http://localhost:9999',
+        forwardingEnabled : true,
+        deliveryEnabled   : false,
+      };
+
+      const resolver = endpointResolver(alice.did, ['http://peer.example.com']);
+      const deliveryService = DeliveryService.create(testDwn, resolver, testConfig);
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(new Response(null, { status: 200 }));
+
+      const requestId = crypto.randomUUID();
+      const dwnRequest = createJsonRpcRequest(requestId, 'dwn.processMessage', {
+        message : recordsWrite.toJSON(),
+        target  : alice.did,
+      });
+
+      const context: RequestContext = {
+        dwn                   : testDwn,
+        transport             : 'http',
+        dataStream,
+        messageProcessedHooks : [deliveryService],
+      };
+
+      const { jsonRpcResponse } = await handleDwnProcessMessage(dwnRequest, context);
+      expect(jsonRpcResponse.error).toBeUndefined();
+      expect(jsonRpcResponse.result.reply.status.code).toBe(202);
+
+      // Forwarding is fire-and-forget; give the async dispatch time to run.
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 300));
+
+      expect(fetchStub.callCount).toBe(1);
+      expect(fetchStub.firstCall.args[0]).toBe('http://peer.example.com');
+
+      const [, fetchOptions] = fetchStub.firstCall.args;
+      const headers = new Headers(fetchOptions?.headers);
+      expect(headers.get('content-type')).toBe('application/octet-stream');
+
+      const rpcRequest = JSON.parse(headers.get('dwn-request') ?? '');
+      expect(rpcRequest.params.target).toBe(alice.did);
+
+      const sentBytes = new Uint8Array(await new Response(fetchOptions?.body).arrayBuffer());
+      expect(sentBytes).toEqual(data);
+
+      await testDwn.close();
+    });
+
+    it('should forward large record data streamed from the data store', async () => {
+      const alice = await TestDataGenerator.generateDidKeyPersona();
+      const data = randomBytes(DwnConstant.maxDataSizeAllowedToBeEncoded + 1_000);
+      const { recordsWrite, dataStream } = await createRecordsWriteMessage(alice, { data });
+
+      const { dwn: testDwn } = await getTestDwn();
+      await TestDataGenerator.installDefaultTestProtocol(testDwn, alice);
+
+      const testConfig: DwnServerConfig = {
+        ...config,
+        baseUrl           : 'http://localhost:9999',
+        forwardingEnabled : true,
+        deliveryEnabled   : false,
+      };
+
+      const resolver = endpointResolver(alice.did, ['http://peer.example.com']);
+      const deliveryService = DeliveryService.create(testDwn, resolver, testConfig);
+      const fetchStub = sinon.stub(globalThis, 'fetch').resolves(new Response(null, { status: 200 }));
+
+      const requestId = crypto.randomUUID();
+      const dwnRequest = createJsonRpcRequest(requestId, 'dwn.processMessage', {
+        message : recordsWrite.toJSON(),
+        target  : alice.did,
+      });
+
+      const context: RequestContext = {
+        dwn                   : testDwn,
+        transport             : 'http',
+        dataStream,
+        messageProcessedHooks : [deliveryService],
+      };
+
+      const { jsonRpcResponse } = await handleDwnProcessMessage(dwnRequest, context);
+      expect(jsonRpcResponse.error).toBeUndefined();
+      expect(jsonRpcResponse.result.reply.status.code).toBe(202);
+
+      await new Promise((resolve): ReturnType<typeof setTimeout> => setTimeout(resolve, 300));
+
+      expect(fetchStub.callCount).toBe(1);
+
+      const [, fetchOptions] = fetchStub.firstCall.args;
+      const headers = new Headers(fetchOptions?.headers);
+      expect(headers.get('content-type')).toBe('application/octet-stream');
+      expect(fetchOptions).toMatchObject({ duplex: 'half' });
+      expect(fetchOptions?.body).toBeInstanceOf(ReadableStream);
+
+      const sentBytes = new Uint8Array(await new Response(fetchOptions?.body).arrayBuffer());
+      expect(sentBytes).toEqual(data);
 
       await testDwn.close();
     });


### PR DESCRIPTION
## Summary

Fixes #1169 — `DeliveryService.#sendMessage` POSTed forwarded messages with an empty body, so endpoint forwarding and `$delivery: 'direct'` participant delivery of data-bearing `RecordsWrite` messages replicated metadata only: the receiving DWN rejected the write (`RecordsWriteMissingDataInPrevious` / `RecordsWriteMissingEncodedDataInPrevious` for non-initial writes) and the record data never arrived.

- Data-bearing `RecordsWrite` messages now send the record data as an `application/octet-stream` request body — the same wire shape `HttpDwnRpcClient.sendDwnRequest` produces — with the JSON-RPC envelope staying in the `dwn-request` header.
- The data is read back from the source tenant's local stores via the `Dwn.storage` seam, since the original request stream was consumed when the message was processed: `encodedData` on the stored message for records at or below `DwnConstant.maxDataSizeAllowedToBeEncoded`, the data store for larger ones — mirroring how `records-read` serves data.
- Streams are one-shot, so every retry attempt re-reads the data instead of replaying the body.
- If the data is no longer available locally (e.g. the write was displaced by a newer write before the fire-and-forget send ran), the send is skipped with a warning — the displacing write triggers its own dispatch with its own data.
- `$delivery` sends thread the origin tenant separately from the per-endpoint target DID: the data lives in the origin tenant's stores while the envelope targets the participant.
- Message narrowing uses the `Records.isRecordsWrite` type guard (plus a local guard to `RecordsQueryReplyEntry` for message-store reads) and `duplex` is a declared optional property of the fetch options type — no type assertions.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run --filter @enbox/dwn-server build` — clean
- [x] Full `@enbox/dwn-server` suite green (607 tests)
- [x] New unit tests (`delivery-service-coverage.test.ts`): small-data body read from `encodedData`; large-data body streamed from the data store with `duplex: 'half'`; skip-without-retry when the data is gone locally; per-attempt re-read on retry; `$delivery` reads data under the origin tenant while the JSON-RPC envelope targets the participant
- [x] New integration tests (`delivery-service.test.ts`): real DWN + SQL stores — a processed `RecordsWrite` forwards with a byte-identical payload for both small (`encodedData`) and large (data store) records
- [x] New end-to-end tests (`delivery-service.test.ts`): the #1169 repro scenario with a real HTTP hop and no stubs — sender DWN forwards to a live receiver `DwnServer`; a signed `RecordsRead` on the receiver returns the record with byte-identical data for both small and large payloads
