### PR TITLE
chore(migrations): document stable numeric naming

### DIFF
--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -95,12 +95,13 @@ export const allServerMigrations: ReadonlyArray<readonly [name: string, factory:
 
 ## Migration conventions
 
-1. **Naming**: `NNN-kebab-case-description.ts` (e.g., `003-add-squash-column.ts`). Zero-padded 3-digit prefix for sort order.
-2. **Forward-only**: Migrations have `up()` only — no `down()`. Rollback is done by deploying a new forward migration.
-3. **Idempotent DDL**: Use `ifNotExists()` for `createTable` and `createIndex`. Wrap `alterTable` in try/catch when the column might already exist.
-4. **No data migrations**: Migration files are for DDL only. Data migrations belong in application code.
-5. **No inline DDL in stores**: Store `open()` / `initialize()` methods must NOT create or alter tables. They perform a `SELECT 1 FROM <table> LIMIT 0` health check and throw if the table is missing.
-6. **Run before stores**: Migrations must run before any store `open()` call. In `dwn-server`, `runServerMigrationsIfNeeded()` is called first in `DwnServer.#setupServer()`, before `RegistrationManager.create()` or any admin store creation.
+1. **Naming**: migration modules use `NNN-kebab-case-description.ts` (e.g., `003-add-squash-column.ts`). This convention is scoped to migration files only; do not use numbered prefixes for ordinary source files.
+2. **Stable names**: the filename stem is also the Kysely migration key stored in the migration tracking table. Never rename, renumber, reorder, or remove a released migration. Add the next sequential migration instead.
+3. **Forward-only**: Migrations have `up()` only — no `down()`. Rollback is done by deploying a new forward migration.
+4. **Idempotent DDL**: Use `ifNotExists()` for `createTable` and `createIndex`. Wrap `alterTable` in try/catch when the column might already exist.
+5. **No data migrations**: Migration files are for DDL only. Data migrations belong in application code.
+6. **No inline DDL in stores**: Store `open()` / `initialize()` methods must NOT create or alter tables. They perform a `SELECT 1 FROM <table> LIMIT 0` health check and throw if the table is missing.
+7. **Run before stores**: Migrations must run before any store `open()` call. In `dwn-server`, `runServerMigrationsIfNeeded()` is called first in `DwnServer.#setupServer()`, before `RegistrationManager.create()` or any admin store creation.
 
 ## Startup order (`DwnServer`)
 

--- a/packages/dwn-server/src/migrations/001-initial-server-schema.ts
+++ b/packages/dwn-server/src/migrations/001-initial-server-schema.ts
@@ -23,7 +23,7 @@ export const migration001InitialServerSchema: ServerMigrationFactory = (dialect)
 
   async up(db: Kysely<any>): Promise<void> {
 
-    // ─── registeredTenants ────────────────────────────────────────────
+    // registeredTenants
     await db.schema
       .createTable('registeredTenants')
       .ifNotExists()
@@ -36,7 +36,7 @@ export const migration001InitialServerSchema: ServerMigrationFactory = (dialect)
       .addColumn('metadata', 'text')
       .execute();
 
-    // ─── tenantQuotas ─────────────────────────────────────────────────
+    // tenantQuotas
     await db.schema
       .createTable('tenantQuotas')
       .ifNotExists()
@@ -45,7 +45,7 @@ export const migration001InitialServerSchema: ServerMigrationFactory = (dialect)
       .addColumn('maxStorageBytes', 'bigint', (col) => col.defaultTo(0))
       .execute();
 
-    // ─── adminAuditLog ────────────────────────────────────────────────
+    // adminAuditLog
     let auditTable = db.schema
       .createTable('adminAuditLog')
       .ifNotExists()
@@ -73,7 +73,7 @@ export const migration001InitialServerSchema: ServerMigrationFactory = (dialect)
         .ifNotExists().on('adminAuditLog').column('action').execute();
     } catch { /* index already exists */ }
 
-    // ─── adminWebhooks ────────────────────────────────────────────────
+    // adminWebhooks
     await db.schema
       .createTable('adminWebhooks')
       .ifNotExists()
@@ -84,7 +84,7 @@ export const migration001InitialServerSchema: ServerMigrationFactory = (dialect)
       .addColumn('createdAt', 'text', (col) => col.notNull())
       .execute();
 
-    // ─── adminPasskeys ────────────────────────────────────────────────
+    // adminPasskeys
     await db.schema
       .createTable('adminPasskeys')
       .ifNotExists()
@@ -97,7 +97,7 @@ export const migration001InitialServerSchema: ServerMigrationFactory = (dialect)
       .addColumn('lastUsedAt', 'text')
       .execute();
 
-    // ─── cacheEntries (TTL cache) ─────────────────────────────────────
+    // cacheEntries (TTL cache)
     await db.schema
       .createTable('cacheEntries')
       .ifNotExists()

--- a/packages/dwn-server/tests/migrations-index.test.ts
+++ b/packages/dwn-server/tests/migrations-index.test.ts
@@ -1,0 +1,40 @@
+import { join } from 'node:path';
+import { readdir } from 'node:fs/promises';
+
+import { describe, expect, it } from 'bun:test';
+
+import { allServerMigrations } from '../src/migrations/index.js';
+
+const migrationNamePattern = /^\d{3}-[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+async function getMigrationFilenames(migrationsPath: string): Promise<string[]> {
+  const entries = await readdir(migrationsPath);
+  return entries
+    .filter((entry): boolean => entry.endsWith('.ts') && entry !== 'index.ts')
+    .sort();
+}
+
+function getServerMigrationNames(): string[] {
+  return allServerMigrations.map(([name]): string => name);
+}
+
+describe('allServerMigrations', (): void => {
+  it('should use unique ordered migration names with numeric prefixes', (): void => {
+    const names = getServerMigrationNames();
+
+    expect(names).toEqual([...names].sort());
+    expect(new Set(names).size).toBe(names.length);
+
+    for (const name of names) {
+      expect(name).toMatch(migrationNamePattern);
+    }
+  });
+
+  it('should keep migration filenames aligned with persisted migration names', async (): Promise<void> => {
+    const migrationsPath = join(import.meta.dir, '..', 'src', 'migrations');
+    const filenames = await getMigrationFilenames(migrationsPath);
+    const expectedFilenames = getServerMigrationNames().map((name): string => `${name}.ts`);
+
+    expect(filenames).toEqual(expectedFilenames);
+  });
+});

--- a/packages/dwn-sql-store/src/migrations/001-initial-schema.ts
+++ b/packages/dwn-sql-store/src/migrations/001-initial-schema.ts
@@ -15,7 +15,7 @@ export const migration001InitialSchema: DwnMigrationFactory = (dialect: Dialect)
 
   async up(db: Kysely<any>): Promise<void> {
 
-    // ─── messageStoreMessages ───────────────────────────────────────────
+    // messageStoreMessages
     if (!(await dialect.hasTable(db, 'messageStoreMessages'))) {
       let table = db.schema
         .createTable('messageStoreMessages')
@@ -80,7 +80,7 @@ export const migration001InitialSchema: DwnMigrationFactory = (dialect: Dialect)
       }
     }
 
-    // ─── messageStoreRecordsTags ─────────────────────────────────────────
+    // messageStoreRecordsTags
     if (!(await dialect.hasTable(db, 'messageStoreRecordsTags'))) {
       let table = db.schema
         .createTable('messageStoreRecordsTags')
@@ -107,7 +107,7 @@ export const migration001InitialSchema: DwnMigrationFactory = (dialect: Dialect)
       }
     }
 
-    // ─── dataStore ──────────────────────────────────────────────────────
+    // dataStore
     if (!(await dialect.hasTable(db, 'dataStore'))) {
       let table = db.schema
         .createTable('dataStore')
@@ -124,7 +124,7 @@ export const migration001InitialSchema: DwnMigrationFactory = (dialect: Dialect)
         .on('dataStore').columns(['tenant', 'recordId', 'dataCid']).unique().execute();
     }
 
-    // ─── resumableTasks ─────────────────────────────────────────────────
+    // resumableTasks
     if (!(await dialect.hasTable(db, 'resumableTasks'))) {
       await db.schema
         .createTable('resumableTasks')

--- a/packages/dwn-sql-store/src/migrations/002-content-addressed-datastore.ts
+++ b/packages/dwn-sql-store/src/migrations/002-content-addressed-datastore.ts
@@ -33,7 +33,7 @@ export const migration002ContentAddressedDatastore: DwnMigrationFactory = (diale
 
   async up(db: Kysely<any>): Promise<void> {
 
-    // ─── Create dataRefs table ──────────────────────────────────────────
+    // Create dataRefs table.
     if (!(await dialect.hasTable(db, 'dataRefs'))) {
       await db.schema
         .createTable('dataRefs')
@@ -57,7 +57,7 @@ export const migration002ContentAddressedDatastore: DwnMigrationFactory = (diale
         .on('dataRefs').column('tenant').execute();
     }
 
-    // ─── Create dataBlocks table ────────────────────────────────────────
+    // Create dataBlocks table.
     if (!(await dialect.hasTable(db, 'dataBlocks'))) {
       let table = db.schema
         .createTable('dataBlocks')
@@ -73,7 +73,7 @@ export const migration002ContentAddressedDatastore: DwnMigrationFactory = (diale
         .on('dataBlocks').columns(['rootDataCid', 'blockCid']).unique().execute();
     }
 
-    // ─── Migrate data from old dataStore table ──────────────────────────
+    // Migrate data from old dataStore table.
     const oldTableExists = await dialect.hasTable(db, 'dataStore');
     if (oldTableExists) {
       // Check if old table has any data to migrate

--- a/packages/dwn-sql-store/tests/migrations-index.spec.ts
+++ b/packages/dwn-sql-store/tests/migrations-index.spec.ts
@@ -1,0 +1,40 @@
+import { join } from 'node:path';
+import { readdir } from 'node:fs/promises';
+
+import { describe, expect, it } from 'bun:test';
+
+import { allDwnMigrations } from '../src/migrations/index.js';
+
+const migrationNamePattern = /^\d{3}-[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+async function getMigrationFilenames(migrationsPath: string): Promise<string[]> {
+  const entries = await readdir(migrationsPath);
+  return entries
+    .filter((entry): boolean => entry.endsWith('.ts') && entry !== 'index.ts')
+    .sort();
+}
+
+function getDwnMigrationNames(): string[] {
+  return allDwnMigrations.map(([name]): string => name);
+}
+
+describe('allDwnMigrations', (): void => {
+  it('should use unique ordered migration names with numeric prefixes', (): void => {
+    const names = getDwnMigrationNames();
+
+    expect(names).toEqual([...names].sort());
+    expect(new Set(names).size).toBe(names.length);
+
+    for (const name of names) {
+      expect(name).toMatch(migrationNamePattern);
+    }
+  });
+
+  it('should keep migration filenames aligned with persisted migration names', async (): Promise<void> => {
+    const migrationsPath = join(import.meta.dir, '..', 'src', 'migrations');
+    const filenames = await getMigrationFilenames(migrationsPath);
+    const expectedFilenames = getDwnMigrationNames().map((name): string => `${name}.ts`);
+
+    expect(filenames).toEqual(expectedFilenames);
+  });
+});


### PR DESCRIPTION
Summary
- Clarify that numeric prefixes are a migration-only convention and that released Kysely migration names are stable persisted keys.
- Add migration-index tests for DWN store and server migrations so filenames stay aligned with registered migration names.
- Replace decorative Unicode section comments in existing migration modules with plain comments.

Test plan
- [x] bun test tests/migrations-index.spec.ts (packages/dwn-sql-store)
- [x] bun test tests/migrations-index.test.ts (packages/dwn-server)
- [x] bun run lint
- [x] bun run build
- [x] bun run --filter @enbox/agent build
- [x] bun run dev:ensure
- [x] bun run test:node (packages/agent; first run hit one local rate-limit failure, targeted rerun passed, full rerun passed)
- [x] bun run test (packages/dwn-sql-store)
- [x] bun run test:node (packages/dwn-server)