### PR TITLE
feat(connect): carry wallet connect params in the URI fragment

### DIFF
--- a/.changeset/wallet-connect-uri-fragment.md
+++ b/.changeset/wallet-connect-uri-fragment.md
@@ -1,0 +1,8 @@
+---
+"@enbox/agent": minor
+"@enbox/auth": patch
+---
+
+feat: carry the wallet connect request pointer and encryption key in the URI fragment
+
+`EnboxConnectProtocol` now exposes `buildWalletConnectUri` and `parseWalletConnectUri`, which place the relay `request_uri` and the single-use `encryption_key` in the URI **fragment** rather than the query string. The fragment never leaves the local channel (it is not sent to the wallet's web server on the deep-link path), so the single-use symmetric key protecting the pushed request cannot surface in server or CDN logs. `WalletConnect.initClient` builds the wallet URI through the new helper; consumers that read connect parameters from a wallet URI should parse them with `parseWalletConnectUri`.

--- a/.changeset/wallet-connect-uri-fragment.md
+++ b/.changeset/wallet-connect-uri-fragment.md
@@ -1,5 +1,5 @@
 ---
-"@enbox/agent": minor
+"@enbox/agent": patch
 "@enbox/auth": patch
 ---
 

--- a/packages/agent/src/enbox-connect-protocol.ts
+++ b/packages/agent/src/enbox-connect-protocol.ts
@@ -317,6 +317,65 @@ function buildConnectUrl({
   }
 }
 
+/**
+ * Builds the wallet URI handed to the user (QR code or deep link) for a
+ * pushed connect request.
+ *
+ * The request pointer and the single-use symmetric encryption key travel in
+ * the URI **fragment**, never in the query string: the fragment stays on the
+ * local channel (terminal → camera, or entirely within the opening browser)
+ * and is never sent to the wallet's web server, so the key cannot surface in
+ * server or CDN logs on the deep-link path.
+ *
+ * @param options.walletUri - The wallet app URI (typically ending in the
+ *   connect route, e.g. `https://wallet.example/connect/app`).
+ * @param options.requestUri - The relay `request_uri` returned by the pushed
+ *   authorization request.
+ * @param options.encryptionKey - The single-use symmetric key protecting the
+ *   pushed request.
+ */
+function buildWalletConnectUri({
+  walletUri,
+  requestUri,
+  encryptionKey,
+}: {
+  walletUri: string;
+  requestUri: string;
+  encryptionKey: Uint8Array;
+}): string {
+  const uri = new URL(walletUri);
+  const fragmentParams = new URLSearchParams();
+  fragmentParams.set('request_uri', requestUri);
+  fragmentParams.set('encryption_key', Convert.uint8Array(encryptionKey).toBase64Url());
+  uri.hash = fragmentParams.toString();
+  return uri.toString();
+}
+
+/**
+ * Parses a wallet connect URI produced by {@link buildWalletConnectUri},
+ * returning the relay request pointer and the request encryption key, or
+ * `undefined` when the URI does not carry connect parameters.
+ */
+function parseWalletConnectUri(uri: string): {
+  requestUri: string;
+  encryptionKeyBase64Url: string;
+} | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return undefined;
+  }
+  const fragment = parsed.hash.startsWith('#') ? parsed.hash.slice(1) : parsed.hash;
+  const params = new URLSearchParams(fragment);
+  const requestUri = params.get('request_uri');
+  const encryptionKeyBase64Url = params.get('encryption_key');
+  if (!requestUri || !encryptionKeyBase64Url) {
+    return undefined;
+  }
+  return { requestUri, encryptionKeyBase64Url };
+}
+
 // ---------------------------------------------------------------------------
 // JWT signing and verification
 // ---------------------------------------------------------------------------
@@ -1516,6 +1575,8 @@ async function submitConnectResponse(
 
 export const EnboxConnectProtocol = {
   buildConnectUrl,
+  buildWalletConnectUri,
+  parseWalletConnectUri,
   signJwt,
   verifyJwt,
   assertConnectRequest,

--- a/packages/agent/tests/enbox-connect-protocol-edge-cases.spec.ts
+++ b/packages/agent/tests/enbox-connect-protocol-edge-cases.spec.ts
@@ -66,8 +66,8 @@ describe('EnboxConnectProtocol — edge cases', () => {
 
     it('should carry the request pointer and key in the fragment, never the query', () => {
       const uri = EnboxConnectProtocol.buildWalletConnectUri({
-        walletUri     : 'https://wallet.example/connect/app',
-        requestUri    : 'https://relay.example/connect/authorize/req.jwt',
+        walletUri  : 'https://wallet.example/connect/app',
+        requestUri : 'https://relay.example/connect/authorize/req.jwt',
         encryptionKey,
       });
 
@@ -82,8 +82,8 @@ describe('EnboxConnectProtocol — edge cases', () => {
 
     it('should round-trip through parseWalletConnectUri', () => {
       const uri = EnboxConnectProtocol.buildWalletConnectUri({
-        walletUri     : 'https://wallet.example/connect/app',
-        requestUri    : 'urn:test:req',
+        walletUri  : 'https://wallet.example/connect/app',
+        requestUri : 'urn:test:req',
         encryptionKey,
       });
 
@@ -94,8 +94,8 @@ describe('EnboxConnectProtocol — edge cases', () => {
 
     it('should preserve an existing wallet path and origin', () => {
       const uri = EnboxConnectProtocol.buildWalletConnectUri({
-        walletUri     : 'https://wallet.example/connect/app',
-        requestUri    : 'urn:test:req',
+        walletUri  : 'https://wallet.example/connect/app',
+        requestUri : 'urn:test:req',
         encryptionKey,
       });
 

--- a/packages/agent/tests/enbox-connect-protocol-edge-cases.spec.ts
+++ b/packages/agent/tests/enbox-connect-protocol-edge-cases.spec.ts
@@ -61,6 +61,56 @@ describe('EnboxConnectProtocol — edge cases', () => {
     });
   });
 
+  describe('wallet connect URI (fragment)', () => {
+    const encryptionKey = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    it('should carry the request pointer and key in the fragment, never the query', () => {
+      const uri = EnboxConnectProtocol.buildWalletConnectUri({
+        walletUri     : 'https://wallet.example/connect/app',
+        requestUri    : 'https://relay.example/connect/authorize/req.jwt',
+        encryptionKey,
+      });
+
+      const parsed = new URL(uri);
+      expect(parsed.search).toBe('');
+      expect(parsed.hash.startsWith('#')).toBe(true);
+
+      const fragmentParams = new URLSearchParams(parsed.hash.slice(1));
+      expect(fragmentParams.get('request_uri')).toBe('https://relay.example/connect/authorize/req.jwt');
+      expect(fragmentParams.get('encryption_key')).toBe(Convert.uint8Array(encryptionKey).toBase64Url());
+    });
+
+    it('should round-trip through parseWalletConnectUri', () => {
+      const uri = EnboxConnectProtocol.buildWalletConnectUri({
+        walletUri     : 'https://wallet.example/connect/app',
+        requestUri    : 'urn:test:req',
+        encryptionKey,
+      });
+
+      const parsed = EnboxConnectProtocol.parseWalletConnectUri(uri);
+      expect(parsed?.requestUri).toBe('urn:test:req');
+      expect(parsed?.encryptionKeyBase64Url).toBe(Convert.uint8Array(encryptionKey).toBase64Url());
+    });
+
+    it('should preserve an existing wallet path and origin', () => {
+      const uri = EnboxConnectProtocol.buildWalletConnectUri({
+        walletUri     : 'https://wallet.example/connect/app',
+        requestUri    : 'urn:test:req',
+        encryptionKey,
+      });
+
+      const parsed = new URL(uri);
+      expect(parsed.origin).toBe('https://wallet.example');
+      expect(parsed.pathname).toBe('/connect/app');
+    });
+
+    it('should return undefined for a URI without connect fragment params', () => {
+      expect(EnboxConnectProtocol.parseWalletConnectUri('https://wallet.example/connect/app')).toBeUndefined();
+      expect(EnboxConnectProtocol.parseWalletConnectUri('https://wallet.example/connect/app#request_uri=urn:test')).toBeUndefined();
+      expect(EnboxConnectProtocol.parseWalletConnectUri('not a url')).toBeUndefined();
+    });
+  });
+
   // generateCodeChallenge tests removed — PKCE was never functional and has been stripped.
 
   describe('verifyJwt', () => {

--- a/packages/auth/src/wallet-connect-client.ts
+++ b/packages/auth/src/wallet-connect-client.ts
@@ -25,7 +25,7 @@ import type {
 } from '@enbox/agent';
 
 import { DidJwk } from '@enbox/dids';
-import { Convert, logger } from '@enbox/common';
+import { logger } from '@enbox/common';
 import { CryptoUtils, Ed25519 } from '@enbox/crypto';
 import { DwnInterfaceName, DwnMethodName } from '@enbox/dwn-sdk-js';
 import { EnboxConnectProtocol, pollWithTtl } from '@enbox/agent';
@@ -68,7 +68,7 @@ export type WalletConnectClientOptions = {
   connectServerUrl: string;
 
   /**
-   * The URI of the wallet app. Query params (`request_uri`, `encryption_key`)
+   * The URI of the wallet app. Fragment params (`request_uri`, `encryption_key`)
    * are appended and passed to `onWalletUriReady`.
    * @example `enbox://connect` or `http://localhost:3000/`
    */
@@ -82,7 +82,7 @@ export type WalletConnectClientOptions = {
   permissionRequests: ConnectPermissionRequest[];
 
   /**
-   * Called with the wallet URI including query params (`request_uri`, `encryption_key`).
+   * Called with the wallet URI carrying fragment params (`request_uri`, `encryption_key`).
    * The app should render this as a QR code or use it as a deep link.
    *
    * @param uri - The wallet URI with connect payload.
@@ -215,15 +215,14 @@ async function initClient({
   // a deeplink to a compatible wallet. if the wallet scans this link it should receive
   // a route to its Connect provider flow and the params of where to fetch the auth request.
   logger.log(`Wallet URI: ${walletUri}`);
-  const generatedWalletUri = new URL(walletUri);
-  generatedWalletUri.searchParams.set('request_uri', parData.request_uri);
-  generatedWalletUri.searchParams.set(
-    'encryption_key',
-    Convert.uint8Array(encryptionKey).toBase64Url()
-  );
+  const generatedWalletUri = EnboxConnectProtocol.buildWalletConnectUri({
+    walletUri,
+    requestUri: parData.request_uri,
+    encryptionKey,
+  });
 
   // call user's callback so they can send the URI to the wallet as they see fit
-  await onWalletUriReady(generatedWalletUri.toString());
+  await onWalletUriReady(generatedWalletUri);
 
   const tokenUrl = EnboxConnectProtocol.buildConnectUrl({
     baseURL    : connectServerUrl,

--- a/packages/auth/tests/wallet-connect-client.spec.ts
+++ b/packages/auth/tests/wallet-connect-client.spec.ts
@@ -118,11 +118,14 @@ describe('WalletConnect', () => {
       expect(result!.delegateGrants).toHaveLength(1);
       expect((EnboxConnectProtocol.createConnectRequest as sinon.SinonStub).firstCall.args[0].requestedSessionTtlSeconds).toBe(2_592_000);
 
-      // Verify onWalletUriReady was called with the correct URI.
+      // Verify onWalletUriReady was called with the correct URI. The relay
+      // pointer and encryption key ride in the fragment, never the query string.
       expect(walletUris).toHaveLength(1);
       const uri = new URL(walletUris[0]);
-      expect(uri.searchParams.get('request_uri')).toBe('http://localhost:3000/connect/authorize/req.jwt');
-      expect(uri.searchParams.get('encryption_key')).toBeDefined();
+      expect(uri.search).toBe('');
+      const parsed = EnboxConnectProtocol.parseWalletConnectUri(walletUris[0]);
+      expect(parsed?.requestUri).toBe('http://localhost:3000/connect/authorize/req.jwt');
+      expect(parsed?.encryptionKeyBase64Url).toBeDefined();
 
       // Verify fetch was called for PAR and poll.
       expect(fetchStub.callCount).toBeGreaterThanOrEqual(2);

--- a/packages/cli/tests/cli-connect-handler.spec.ts
+++ b/packages/cli/tests/cli-connect-handler.spec.ts
@@ -47,7 +47,7 @@ describe('CliConnectHandler', () => {
     const result = createConnectResult([createGrant({ scope: requestedScope })]);
     sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
       capturedOptions = options;
-      await options.onWalletUriReady('https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test');
+      await options.onWalletUriReady('https://wallet.example/connect/app#request_uri=urn:test&encryption_key=test');
       expect(await options.validatePin()).toBe('428113');
       return result;
     });
@@ -75,7 +75,7 @@ describe('CliConnectHandler', () => {
     expect(capturedOptions?.timeoutMs).toBe(10_000);
     expect(capturedOptions?.requestedSessionTtlSeconds).toBe(604_800);
     expect(capturedOptions?.preSupplyDelegateDid).toBe(true);
-    expect(authUrls).toEqual(['https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test']);
+    expect(authUrls).toEqual(['https://wallet.example/connect/app#request_uri=urn:test&encryption_key=test']);
     expect(output.text()).toContain('[qr]');
     expect(output.text()).toContain('Waiting for approval...');
   });
@@ -99,10 +99,12 @@ describe('CliConnectHandler', () => {
         pollIntervalMs             : 1,
         requestedSessionTtlSeconds : 2_592_000,
         onAuthUrl                  : async (uri: string): Promise<void> => {
-          const walletUrl = new URL(uri);
-          requestUri = getRequiredSearchParam(walletUrl, 'request_uri');
-          const encryptionKey = getRequiredSearchParam(walletUrl, 'encryption_key');
-          const connectRequest = await EnboxConnectProtocol.getConnectRequest(requestUri, encryptionKey);
+          const connectParams = EnboxConnectProtocol.parseWalletConnectUri(uri);
+          if (connectParams === undefined) {
+            throw new Error('wallet URI did not carry connect fragment params');
+          }
+          requestUri = connectParams.requestUri;
+          const connectRequest = await EnboxConnectProtocol.getConnectRequest(requestUri, connectParams.encryptionKeyBase64Url);
 
           expect(connectRequest.appName).toBe('Relay CLI');
           expect(connectRequest.requestedSessionTtlSeconds).toBe(2_592_000);
@@ -170,7 +172,7 @@ describe('CliConnectHandler', () => {
 
   it('should open the browser instead of printing a QR code when requested', async () => {
     sinon.stub(WalletConnect, 'initClient').callsFake(async (options: WalletConnectClientOptions): Promise<ConnectResult | undefined> => {
-      await options.onWalletUriReady('https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test');
+      await options.onWalletUriReady('https://wallet.example/connect/app#request_uri=urn:test&encryption_key=test');
       return createConnectResult([createGrant({ scope: requestedScope })]);
     });
 
@@ -188,7 +190,7 @@ describe('CliConnectHandler', () => {
 
     await handler.requestAccess({ permissionRequests });
 
-    expect(openedUrls).toEqual(['https://wallet.example/connect/app?request_uri=urn:test&encryption_key=test']);
+    expect(openedUrls).toEqual(['https://wallet.example/connect/app#request_uri=urn:test&encryption_key=test']);
     expect(output.text()).toContain('Opening wallet for approval...');
     expect(output.text()).not.toContain('[qr]');
   });
@@ -686,14 +688,6 @@ async function handleRelayRequest({
   }
 
   writeResponse(response, 404, 'not found');
-}
-
-function getRequiredSearchParam(url: URL, name: string): string {
-  const value = url.searchParams.get(name);
-  if (value === null || value === '') {
-    throw new Error(`missing ${name} search parameter`);
-  }
-  return value;
 }
 
 async function readRequestBody(request: IncomingMessage): Promise<string> {

--- a/packages/cli/tests/terminal.spec.ts
+++ b/packages/cli/tests/terminal.spec.ts
@@ -4,8 +4,8 @@ import { getBrowserOpenCommand } from '../src/terminal.js';
 
 describe('terminal', () => {
   describe('getBrowserOpenCommand()', () => {
-    it('should use a Windows browser opener that preserves wallet query strings', () => {
-      const uri = 'https://wallet.example/connect/app?request_uri=urn%3Atest&encryption_key=test';
+    it('should use a Windows browser opener that preserves the wallet URI fragment', () => {
+      const uri = 'https://wallet.example/connect/app#request_uri=urn%3Atest&encryption_key=test';
 
       const command = getBrowserOpenCommand(uri, 'win32');
 


### PR DESCRIPTION
## Summary

The wallet connect deep-link carried the relay request pointer (`request_uri`) and the **single-use symmetric `encryption_key`** that protects the pushed authorization request in the URI **query string**. On the deep-link path a query string is transmitted to the wallet's web server, so that key could surface in server and CDN access logs.

This moves both values into the URI **fragment**, which is never sent to the server — the key stays on the local channel (QR camera scan, or entirely within the opening browser).

### Changes

- **`@enbox/agent`** (minor): new `EnboxConnectProtocol.buildWalletConnectUri({ walletUri, requestUri, encryptionKey })` and `EnboxConnectProtocol.parseWalletConnectUri(uri)`. These are the single standard definition of the wallet-connect URI wire format; all consumers build/parse through them rather than hand-rolling query params.
- **`@enbox/auth`** (patch): `WalletConnect.initClient` builds the wallet URI via `buildWalletConnectUri`; doc comments updated from "query params" to "fragment params".

### Consumers

- In-repo: `@enbox/auth` (builder), the CLI connect handler + `examples/cli-demo` flow through the auth client transitively.
- Downstream: the web wallet's connect page and meshd's Go connect client conform to this format by parsing the fragment.

## Testing

- `bun test` — new round-trip + fragment-placement unit tests in `packages/agent/tests/enbox-connect-protocol-edge-cases.spec.ts` (15/15).
- `packages/auth/tests/wallet-connect-client.spec.ts` (15/15) — asserts params ride in the fragment, query string is empty.
- `packages/cli` full suite (24/24) — mock wallet parses via `parseWalletConnectUri`; hardcoded URIs updated to fragment form.
- `packages/agent/tests/connect.spec.ts` (57/57).
- `turbo run build` across agent/auth/cli and deps — clean (tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)