### PR TITLE
fix(dwn-server): include workspace manifests in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY packages/agent/package.json             packages/agent/
 COPY packages/api/package.json               packages/api/
 COPY packages/auth/package.json              packages/auth/
 COPY packages/browser/package.json           packages/browser/
+COPY packages/cli/package.json               packages/cli/
 COPY packages/electrobun-dwn/package.json    packages/electrobun-dwn/
 COPY packages/protocols/package.json         packages/protocols/
 COPY packages/protocol-codegen/package.json  packages/protocol-codegen/
@@ -82,9 +83,11 @@ COPY packages/agent/package.json             packages/agent/
 COPY packages/api/package.json               packages/api/
 COPY packages/auth/package.json              packages/auth/
 COPY packages/browser/package.json           packages/browser/
+COPY packages/cli/package.json               packages/cli/
 COPY packages/electrobun-dwn/package.json    packages/electrobun-dwn/
 COPY packages/protocols/package.json         packages/protocols/
 COPY packages/protocol-codegen/package.json  packages/protocol-codegen/
+COPY apps/docs/package.json                  apps/docs/
 
 # Build packages in dependency order.
 # common -> crypto -> dids -> dwn-sdk-js -> dwn-sql-store, dwn-clients, admin-ui -> dwn-server


### PR DESCRIPTION
Summary
- add the missing packages/cli workspace manifest to the Dockerfile deps and build stages
- include apps/docs/package.json in the build stage so every root workspace has a manifest during Bun workspace resolution

Test plan
- [x] flyctl deploy --remote-only --config /home/liran/src/enboxorg/enbox-internal-dev-deploy/fly.toml
- [x] docker build -t 387235730938.dkr.ecr.us-east-1.amazonaws.com/dwn-server:sha-ec96762 -t 387235730938.dkr.ecr.us-east-1.amazonaws.com/dwn-server:latest .

Rollout notes
- This fixes the deploy-time error: Workspace not found "packages/cli".