### PR TITLE
test(browser): cover dweb wallet support probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
               - 'tsconfig.json'
               - 'turbo.json'
               - 'eslint.config.cjs'
+              - 'sonar-project.properties'
               - '.github/workflows/ci.yml'
               - 'scripts/**'
               - 'build/**'

--- a/packages/browser/tests/dweb-connect-client.spec.ts
+++ b/packages/browser/tests/dweb-connect-client.spec.ts
@@ -333,3 +333,75 @@ describe('DWebConnect.initClient', () => {
     });
   });
 });
+
+describe('DWebConnect.probeWalletSupport', () => {
+  const probeWalletUrl = `${globalThis.location.origin}/wallet-support`;
+  const probeWalletOrigin = globalThis.location.origin;
+
+  afterEach(() => {
+    document.querySelectorAll('iframe').forEach((iframe) => iframe.remove());
+  });
+
+  it('should post a support request to the wallet iframe and resolve true when supported', async () => {
+    const promise = DWebConnect.probeWalletSupport(probeWalletUrl, TEST_DID, 1000);
+    const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+
+    expect(iframe).toBeDefined();
+    expect(iframe.style.display).toBe('none');
+    expect(iframe.src).toBe(probeWalletUrl);
+
+    const postMessageSpy = spyOn(iframe.contentWindow!, 'postMessage');
+    iframe.dispatchEvent(new Event('load'));
+
+    expect(postMessageSpy).toHaveBeenCalledWith({
+      type : 'dweb-connect-support-request',
+      did  : TEST_DID,
+    }, probeWalletOrigin);
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data   : { type: 'dweb-connect-support-response', supported: true },
+      origin : probeWalletOrigin,
+    }));
+
+    await expect(promise).resolves.toBe(true);
+    expect(document.querySelector('iframe')).toBeNull();
+
+    postMessageSpy.mockRestore();
+  });
+
+  it('should resolve false when the wallet reports unsupported DID', async () => {
+    const promise = DWebConnect.probeWalletSupport(probeWalletUrl, TEST_DID, 1000);
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data   : { type: 'dweb-connect-support-response', supported: false },
+      origin : probeWalletOrigin,
+    }));
+
+    await expect(promise).resolves.toBe(false);
+    expect(document.querySelector('iframe')).toBeNull();
+  });
+
+  it('should ignore support responses from other origins', async () => {
+    const promise = DWebConnect.probeWalletSupport(probeWalletUrl, TEST_DID, 1000);
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data   : { type: 'dweb-connect-support-response', supported: true },
+      origin : 'https://evil.example.com',
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(document.querySelector('iframe')).not.toBeNull();
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data   : { type: 'dweb-connect-support-response', supported: true },
+      origin : probeWalletOrigin,
+    }));
+
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it('should resolve false and remove the iframe when probing times out', async () => {
+    await expect(DWebConnect.probeWalletSupport(probeWalletUrl, TEST_DID, 10)).resolves.toBe(false);
+    expect(document.querySelector('iframe')).toBeNull();
+  });
+});

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,8 @@ sonar.javascript.lcov.reportPaths=./coverage/merged/lcov.info
 sonar.pullrequest.github.repository=enboxorg/enbox
 
 sonar.exclusions=**/node_modules/**,**/dist/**,**/out/**,**/.next/**,**/.turbo/**,**/coverage/**,**/coverage-browser/**,**/coverage-browser-*/**,**/generated/**,apps/docs/content/**
-sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx,**/*.config.ts,**/*.config.js,**/*.config.cjs,**/*.config.mjs,**/*.d.ts,**/dist/**,**/out/**
+# Admin UI and docs app source stay in Sonar analysis, but they do not currently emit LCOV.
+sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx,**/*.config.ts,**/*.config.js,**/*.config.cjs,**/*.config.mjs,**/*.d.ts,**/dist/**,**/out/**,packages/dwn-server-admin-ui/src/**,apps/docs/src/**
 sonar.cpd.exclusions=packages/**/tests/**
 
 # ─── Rule-specific issue ignores ──────────────────────────────────────────


### PR DESCRIPTION
Summary
- Add browser coverage for DWebConnect.probeWalletSupport iframe request, supported/unsupported responses, origin filtering, and timeout cleanup.
- Exclude admin UI and docs app source from Sonar coverage metrics while keeping them in Sonar analysis, because they do not currently emit LCOV.
- Treat sonar-project.properties changes as workspace-level CI changes so Sonar config PRs produce the full coverage artifact set.

Test plan
- [x] bun run --filter @enbox/browser lint
- [x] BROWSER=chromium CI=true bun run --filter @enbox/browser test:browser:coverage -- --browser.connectTimeout=120000
- [x] bun run lint
- [x] bun run --filter @enbox/agent build
- [x] bun run dev:ensure
- [x] bun run test:node (from packages/agent, with foreground DWN server on :3000)
- [x] bun run coverage:merge:reports
- [x] git diff --check