### PR TITLE
fix(agent): harden local node phase 0

### DIFF
--- a/.changeset/local-node-phase0.md
+++ b/.changeset/local-node-phase0.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+fix: harden local DWN remote-mode foundations

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -65,7 +65,7 @@ import type {
 
 import { AgentPermissionsApi } from './permissions-api.js';
 import { DwnDiscoveryFile } from './dwn-discovery-file.js';
-import { LocalDwnDiscovery } from './local-dwn.js';
+import { DEFAULT_LOCAL_DWN_STRATEGY, LocalDwnDiscovery } from './local-dwn.js';
 import { DwnInterface, dwnMessageConstructors } from './types/dwn.js';
 import { getDwnServiceEndpointUrls, isRecordsWrite } from './utils.js';
 
@@ -209,7 +209,7 @@ export class AgentDwnApi {
   private _localDwnDiscovery?: LocalDwnDiscovery;
 
   constructor(params: DwnApiParams) {
-    const { agent, localDwnStrategy = 'prefer' } = params;
+    const { agent, localDwnStrategy = DEFAULT_LOCAL_DWN_STRATEGY } = params;
 
     // If an agent is provided, set it as the execution context for this API.
     this._agent = agent;

--- a/packages/agent/src/enbox-user-agent.ts
+++ b/packages/agent/src/enbox-user-agent.ts
@@ -14,6 +14,7 @@ import { AgentDidApi } from './did-api.js';
 import { AgentDwnApi } from './dwn-api.js';
 import { AgentIdentityApi } from './identity-api.js';
 import { AgentPermissionsApi } from './permissions-api.js';
+import { DEFAULT_LOCAL_DWN_STRATEGY } from './local-dwn.js';
 import { DwnDidStore } from './store-did.js';
 import { DwnIdentityStore } from './store-identity.js';
 import { DwnKeyStore } from './store-key.js';
@@ -196,13 +197,13 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
         // RPC to the local DWN server.
         dwnApi = new AgentDwnApi({
           localDwnEndpoint,
-          localDwnStrategy: localDwnStrategy ?? 'prefer',
+          localDwnStrategy: localDwnStrategy ?? DEFAULT_LOCAL_DWN_STRATEGY,
         });
       } else {
         // Local mode: create an in-process DWN with LevelDB stores.
         dwnApi = new AgentDwnApi({
           dwn              : await AgentDwnApi.createDwn({ dataPath, didResolver: didApi }),
-          localDwnStrategy : localDwnStrategy ?? 'prefer',
+          localDwnStrategy : localDwnStrategy ?? DEFAULT_LOCAL_DWN_STRATEGY,
         });
       }
     }

--- a/packages/agent/src/local-dwn.ts
+++ b/packages/agent/src/local-dwn.ts
@@ -22,14 +22,39 @@ import type { DwnDiscoveryFile } from './dwn-discovery-file.js';
 /**
  * Controls how the agent discovers and routes to a local DWN server.
  *
- * - `'off'`    — (default) skip local discovery entirely.
- * - `'prefer'` — try local DWN first; fall back to DID-document endpoints.
+ * - `'prefer'` — (default) use a paired local DWN first; fall back to DID-document endpoints.
  * - `'only'`   — require a local server; throw if none is found.
+ * - `'off'`    — skip local discovery entirely.
  */
 export type LocalDwnStrategy = 'prefer' | 'only' | 'off';
 
+/** Default local DWN strategy. Discovery is passive: no localhost port sweep is performed. */
+export const DEFAULT_LOCAL_DWN_STRATEGY: LocalDwnStrategy = 'prefer';
+
 /** The `server` field returned by `GET /info` on `@enbox/dwn-server`. */
 export const localDwnServerName = '@enbox/dwn-server';
+
+/**
+ * Well-known ports the packaged local DWN server may bind to.
+ *
+ * This list is used by the server/runtime surfaces for port selection and
+ * status display. Client discovery must use an explicit pairing channel
+ * (discovery file, persisted endpoint, or `dwn://connect`) rather than sweeping
+ * this list.
+ */
+export const localDwnPortCandidates = [
+  55500,
+  55501,
+  55502,
+  55503,
+  55504,
+  55505,
+  55506,
+  55507,
+  55508,
+  55509,
+  3000,
+] as const;
 
 /** Strips a trailing slash from a URL so endpoint comparisons are consistent. */
 export function normalizeBaseUrl(url: string): string {

--- a/packages/agent/src/sync-admit-closure.ts
+++ b/packages/agent/src/sync-admit-closure.ts
@@ -66,6 +66,8 @@ type AdmissionEntryResult =
   | { kind: 'retry'; entries: SyncMessageEntry[] }
   | { kind: 'done'; outcome: AdmitOutcome };
 
+type ScopeCheckResult = 'in-scope' | 'out-of-scope' | 'unknown';
+
 // applyReplicatedMessage reports the full set of missing ancestors in a single
 // Incomplete, so a well-formed closure converges in a handful of passes. Keep a
 // high cap anyway as a safety bound against malformed or adversarial remotes (and
@@ -141,10 +143,18 @@ class AdmitClosureContext {
 
   private async admitEntry(rootCid: string, entry: SyncMessageEntry): Promise<AdmissionEntryResult> {
     const cid = await this.rememberEntry(entry);
-    if (cid === rootCid && !await this.rootIsInScope(entry)) {
+    const rootScope = cid === rootCid ? await this.checkRootScope(entry) : 'in-scope';
+    if (rootScope !== 'in-scope') {
       return {
         kind    : 'done',
-        outcome : { kind: 'failed', rootCid, reason: 'terminal', detail: 'root message is outside the sync scope' },
+        outcome : {
+          kind   : 'failed',
+          rootCid,
+          reason : 'terminal',
+          detail : rootScope === 'unknown'
+            ? 'root message scope is unknown'
+            : 'root message is outside the sync scope',
+        },
       };
     }
 
@@ -227,18 +237,17 @@ class AdmitClosureContext {
     return fetched;
   }
 
-  private async rootIsInScope(entry: SyncMessageEntry): Promise<boolean> {
+  private async checkRootScope(entry: SyncMessageEntry): Promise<ScopeCheckResult> {
     const { scope } = this.deps;
     if (scope === undefined || scope.kind === 'full') {
-      return true;
+      return 'in-scope';
     }
 
-    const classification = classifySyncMessageScope({
+    return classifySyncMessageScope({
       message      : entry.message,
       initialWrite : await this.getInitialWriteForDelete(entry.message),
       scope,
     });
-    return classification === 'in-scope';
   }
 
   private async getInitialWriteForDelete(message: GenericMessage): Promise<RecordsWriteMessage | undefined> {

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -25,6 +25,7 @@ import type { PortableIdentity } from '../src/types/identity.js';
 import type { BearerIdentity } from '../src/bearer-identity.js';
 import type { DwnPermissionScope } from '../src/types/dwn.js';
 
+import { DEFAULT_LOCAL_DWN_STRATEGY } from '../src/local-dwn.js';
 import { DwnInterface } from '../src/types/dwn.js';
 import emailProtocolDefinition from './fixtures/protocol-definitions/email.json' with { type: 'json' };
 import freeForAllProtocolDefinition from './fixtures/protocol-definitions/free-for-all.json' with { type: 'json' };
@@ -87,6 +88,14 @@ describe('AgentDwnApi', () => {
       expect(dwnApi).toBeDefined();
       expect(dwnApi.node).toBeDefined();
       expect(dwnApi.node).toHaveProperty('test', 'value');
+    });
+
+    it('defaults to passive local DWN preference', () => {
+      const mockDwn = ({} as unknown) as Dwn;
+      const dwnApi = new AgentDwnApi({ dwn: mockDwn });
+
+      expect(dwnApi.localDwnStrategy).toBe(DEFAULT_LOCAL_DWN_STRATEGY);
+      expect(dwnApi.localDwnStrategy).toBe('prefer');
     });
   });
 

--- a/packages/agent/tests/local-dwn.spec.ts
+++ b/packages/agent/tests/local-dwn.spec.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'bun:test';
 import type { DwnDiscoveryFile, DwnDiscoveryRecord } from '../src/dwn-discovery-file.js';
 import {
   LocalDwnDiscovery,
+  localDwnPortCandidates,
   localDwnServerName,
 } from '../src/local-dwn.js';
 
@@ -39,6 +40,22 @@ function createDiscoveryFileStub(record?: DwnDiscoveryRecord | null): DwnDiscove
 describe('LocalDwnDiscovery', () => {
   afterEach(() => {
     sinon.restore();
+  });
+
+  it('exports the authoritative local DWN server port candidates', () => {
+    expect([...localDwnPortCandidates]).toEqual([
+      55500,
+      55501,
+      55502,
+      55503,
+      55504,
+      55505,
+      55506,
+      55507,
+      55508,
+      55509,
+      3000,
+    ]);
   });
 
   // ─── No discovery file (browser-like) ─────────────────────────

--- a/packages/agent/tests/remote-mode-integration.spec.ts
+++ b/packages/agent/tests/remote-mode-integration.spec.ts
@@ -1,0 +1,413 @@
+import type { BearerDid } from '@enbox/dids';
+import type { BearerIdentity } from '../src/bearer-identity.js';
+import type { DwnServerConfig } from '../../dwn-server/src/config.js';
+import type { EnboxPlatformAgent } from '../src/types/agent.js';
+import type { Dwn, MessageSigner, ProtocolDefinition, RecordsWriteMessage } from '@enbox/dwn-sdk-js';
+
+import sinon from 'sinon';
+
+import { DidJwk } from '@enbox/dids';
+
+import { config as defaultDwnServerConfig } from '../../dwn-server/src/config.js';
+import { HttpApi } from '../../dwn-server/src/http-api.js';
+import { runServerMigrationsIfNeeded } from '../../dwn-server/src/storage.js';
+import { WsApi } from '../../dwn-server/src/ws-api.js';
+
+import { AgentDwnApi } from '../src/dwn-api.js';
+import { DwnInterface } from '../src/types/dwn.js';
+import { PlatformAgentTestHarness } from '../src/test-harness.js';
+import { TestAgent } from './utils/test-agent.js';
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { DataStream, DwnInterfaceName, DwnMethodName, Message, MessagesQuery, ProtocolsConfigure, RecordsRead, RecordsWrite, Time } from '@enbox/dwn-sdk-js';
+
+type TestDwnRpcServer = {
+  dwn: Dwn;
+  httpApi: HttpApi;
+  httpUrl: string;
+  wsApi: WsApi;
+};
+
+type RemoteModeContext = {
+  alice: BearerIdentity;
+  bob: BearerIdentity;
+  localServer: TestDwnRpcServer;
+  remoteServer: TestDwnRpcServer;
+  testHarness: PlatformAgentTestHarness;
+};
+
+type NoteRecordWriteParams = {
+  dataFormat: string;
+  protocol: string;
+  protocolPath: string;
+  schema: string;
+};
+
+type MessageCidEntry = {
+  messageCid: string;
+};
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const notesProtocol: ProtocolDefinition = {
+  published : true,
+  protocol  : 'https://remote-mode.integration.example/notes',
+  types     : {
+    note: {
+      schema      : 'https://remote-mode.integration.example/schemas/note',
+      dataFormats : ['text/plain'],
+    },
+  },
+  structure: {
+    note: {},
+  },
+};
+
+describe('Agent remote mode integration', () => {
+  let context: RemoteModeContext | undefined;
+
+  afterEach(async () => {
+    sinon.restore();
+    await context?.testHarness.agent.sync.stopSync();
+    await closeTestServer(context?.localServer);
+    await closeTestServer(context?.remoteServer);
+    await context?.testHarness.clearStorage();
+    await context?.testHarness.closeStorage();
+    context = undefined;
+  });
+
+  it('syncs push and pull through a real local DWN server and persists checkpoints', async () => {
+    context = await setupRemoteModeContext('durable');
+    const { alice, bob, localServer, remoteServer, testHarness } = context;
+    const syncEngine = testHarness.agent.sync as any;
+
+    await configureLocalProtocol(testHarness.agent, alice.did.uri, notesProtocol);
+    const localWrite = await writeLocalRecord(testHarness.agent, alice.did.uri, 'local push body');
+    const tenantWideMessagesGrant = await testHarness.agent.permissions.createGrant({
+      author      : alice.did.uri,
+      dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+      grantedTo   : bob.did.uri,
+      scope       : { interface: DwnInterfaceName.Messages, method: DwnMethodName.Read },
+      store       : true,
+    });
+    const grantedFeedCids = await queryMessageCidsWithGrant({
+      agent             : testHarness.agent,
+      dwnUrl            : localServer.httpUrl,
+      granteeDid        : bob.did,
+      permissionGrantId : tenantWideMessagesGrant.message.recordId,
+      tenantDid         : alice.did.uri,
+    });
+
+    expect(grantedFeedCids).toContain(await Message.getCid(localWrite));
+
+    await testHarness.agent.sync.registerIdentity({
+      did     : alice.did.uri,
+      options : { protocols: [notesProtocol.protocol] },
+    });
+    await testHarness.agent.sync.sync('push');
+
+    expect(await readRecordTextFromServer(testHarness.agent, remoteServer.httpUrl, alice.did, localWrite.recordId)).toBe('local push body');
+
+    const remoteWrite = await writeRecordToServer(testHarness.agent, remoteServer.httpUrl, alice.did, 'remote pull body');
+    await configureProtocolOnServer(testHarness.agent, remoteServer.httpUrl, bob.did, notesProtocol);
+    const bobRemoteWrite = await writeRecordToServer(testHarness.agent, remoteServer.httpUrl, bob.did, 'bob must not pull');
+
+    await testHarness.agent.sync.sync('pull');
+
+    expect(await readLocalRecordText(testHarness.agent, alice.did.uri, remoteWrite.recordId)).toBe('remote pull body');
+    expect(await readLocalRecordText(testHarness.agent, bob.did.uri, bobRemoteWrite.recordId)).toBeUndefined();
+
+    const links = await syncEngine.ledger.getLinksForTenant(alice.did.uri);
+    const link = links.find((candidate: any): boolean => candidate.remoteEndpoint === remoteServer.httpUrl);
+
+    expect(link).toBeDefined();
+    expect(link.push.contiguousAppliedToken).toBeDefined();
+    expect(link.pull.contiguousAppliedToken).toBeDefined();
+    expect(localServer.httpUrl).not.toBe(remoteServer.httpUrl);
+  });
+
+  it('receives live WebSocket pull events through a real remote-mode local node', async () => {
+    context = await setupRemoteModeContext('live');
+    const { alice, remoteServer, testHarness } = context;
+    const syncEngine = testHarness.agent.sync as any;
+
+    await testHarness.agent.sync.registerIdentity({
+      did     : alice.did.uri,
+      options : { protocols: [notesProtocol.protocol] },
+    });
+    await testHarness.agent.sync.startSync({ mode: 'live', interval: '30s' });
+
+    expect(testHarness.agent.sync.hasActiveSubscriptions).toBe(true);
+
+    await configureProtocolOnServer(testHarness.agent, remoteServer.httpUrl, alice.did, notesProtocol);
+    const remoteWrite = await writeRecordToServer(testHarness.agent, remoteServer.httpUrl, alice.did, 'live pull body');
+
+    await waitFor(async () =>
+      await readLocalRecordText(testHarness.agent, alice.did.uri, remoteWrite.recordId) === 'live pull body'
+    );
+
+    const activeLinks = [...syncEngine._activeLinks.values()];
+    const link = activeLinks.find((candidate: any): boolean =>
+      candidate.tenantDid === alice.did.uri &&
+      candidate.remoteEndpoint === remoteServer.httpUrl
+    );
+
+    expect(link).toBeDefined();
+    expect(link.status).toBe('live');
+    expect(link.pull.contiguousAppliedToken).toBeDefined();
+    expect(link.pull.contiguousAppliedToken.messageCid).toBeDefined();
+  });
+});
+
+async function setupRemoteModeContext(name: string): Promise<RemoteModeContext> {
+  const testHarness = await PlatformAgentTestHarness.setup({
+    agentClass       : TestAgent,
+    agentStores      : 'memory',
+    testDataLocation : `__TESTDATA__/remote-mode-integration/${name}-${crypto.randomUUID()}`,
+  });
+
+  testHarness.agent.agentDid = await DidJwk.create();
+  const alice = await testHarness.agent.identity.create({
+    didMethod : 'jwk',
+    metadata  : { name: `${name} Alice` },
+  });
+  const bob = await testHarness.agent.identity.create({
+    didMethod : 'jwk',
+    metadata  : { name: `${name} Bob` },
+  });
+
+  const localServer = await startTestServer(`${name}-local`);
+  const remoteServer = await startTestServer(`${name}-remote`);
+  testHarness.agent.dwn = new AgentDwnApi({
+    agent            : testHarness.agent,
+    localDwnEndpoint : localServer.httpUrl,
+  });
+  sinon.stub(testHarness.agent.dwn, 'getRemoteDwnEndpointUrls').callsFake(async (did: string): Promise<string[]> => {
+    return did === alice.did.uri || did === bob.did.uri ? [remoteServer.httpUrl] : [];
+  });
+
+  return { alice, bob, localServer, remoteServer, testHarness };
+}
+
+async function startTestServer(name: string): Promise<TestDwnRpcServer> {
+  const config = createTestServerConfig();
+  const ttlCacheDialect = await runServerMigrationsIfNeeded(config);
+  const dwn = await AgentDwnApi.createDwn({
+    dataPath: `__TESTDATA__/remote-mode-integration/server-${name}-${crypto.randomUUID()}`,
+  });
+  const httpApi = await HttpApi.create(config, dwn, undefined, undefined, undefined, { ttlCacheDialect });
+
+  await httpApi.start(0);
+  const wsApi = new WsApi(httpApi, dwn, { config });
+  wsApi.start();
+
+  return {
+    dwn,
+    httpApi,
+    httpUrl: `http://127.0.0.1:${httpApi.server.port}`,
+    wsApi,
+  };
+}
+
+function createTestServerConfig(): DwnServerConfig {
+  return {
+    ...defaultDwnServerConfig,
+    adminToken                       : undefined,
+    baseUrl                          : 'http://127.0.0.1',
+    logLevel                         : 'ERROR',
+    port                             : 0,
+    rateLimitRequestsPerSecond       : 0,
+    rateLimitTenantRequestsPerSecond : 0,
+    registrationStoreUrl             : undefined,
+    ttlCacheUrl                      : 'sqlite://',
+    webSocketSupport                 : true,
+  };
+}
+
+async function closeTestServer(server: TestDwnRpcServer | undefined): Promise<void> {
+  if (server === undefined) {
+    return;
+  }
+
+  await server.wsApi.close();
+  await server.httpApi.close();
+  await server.dwn.close();
+}
+
+async function configureLocalProtocol(
+  agent: EnboxPlatformAgent,
+  did: string,
+  definition: ProtocolDefinition,
+): Promise<void> {
+  const { reply } = await agent.dwn.processRequest({
+    author        : did,
+    target        : did,
+    messageType   : DwnInterface.ProtocolsConfigure,
+    messageParams : { definition },
+  });
+
+  expect(reply.status.code).toBe(202);
+}
+
+async function configureProtocolOnServer(
+  agent: EnboxPlatformAgent,
+  dwnUrl: string,
+  did: BearerDid,
+  definition: ProtocolDefinition,
+): Promise<void> {
+  const protocolsConfigure = await ProtocolsConfigure.create({
+    definition,
+    signer: await signerForDid(did),
+  });
+
+  const reply = await agent.rpc.sendDwnRequest({
+    dwnUrl,
+    targetDid : did.uri,
+    message   : protocolsConfigure.message,
+  });
+
+  expect(reply.status.code).toBe(202);
+}
+
+async function writeLocalRecord(
+  agent: EnboxPlatformAgent,
+  did: string,
+  text: string,
+): Promise<RecordsWriteMessage> {
+  const { reply, message } = await agent.dwn.processRequest({
+    author        : did,
+    target        : did,
+    messageType   : DwnInterface.RecordsWrite,
+    messageParams : recordWriteParams(),
+    dataStream    : new Blob([textEncoder.encode(text)]),
+  });
+
+  expect(reply.status.code).toBe(202);
+  return message as RecordsWriteMessage;
+}
+
+async function writeRecordToServer(
+  agent: EnboxPlatformAgent,
+  dwnUrl: string,
+  did: BearerDid,
+  text: string,
+): Promise<RecordsWriteMessage> {
+  const data = textEncoder.encode(text);
+  const recordsWrite = await RecordsWrite.create({
+    ...recordWriteParams(),
+    data,
+    signer: await signerForDid(did),
+  });
+  const reply = await agent.rpc.sendDwnRequest({
+    dwnUrl,
+    targetDid : did.uri,
+    message   : recordsWrite.message,
+    data      : DataStream.fromBytes(data),
+  });
+
+  expect(reply.status.code).toBe(202);
+  return recordsWrite.message;
+}
+
+function recordWriteParams(): NoteRecordWriteParams {
+  return {
+    dataFormat   : 'text/plain',
+    protocol     : notesProtocol.protocol,
+    protocolPath : 'note',
+    schema       : notesProtocol.types.note.schema!,
+  };
+}
+
+async function readLocalRecordText(
+  agent: EnboxPlatformAgent,
+  did: string,
+  recordId: string,
+): Promise<string | undefined> {
+  const { reply } = await agent.dwn.processRequest({
+    author        : did,
+    target        : did,
+    messageType   : DwnInterface.RecordsRead,
+    messageParams : { filter: { recordId } },
+  });
+
+  if (reply.status.code !== 200 || reply.entry?.data === undefined) {
+    return undefined;
+  }
+
+  return textDecoder.decode(await DataStream.toBytes(reply.entry.data));
+}
+
+async function readRecordTextFromServer(
+  agent: EnboxPlatformAgent,
+  dwnUrl: string,
+  did: BearerDid,
+  recordId: string,
+): Promise<string | undefined> {
+  const recordsRead = await RecordsRead.create({
+    filter : { recordId },
+    signer : await signerForDid(did),
+  });
+  const reply = await agent.rpc.sendDwnRequest({
+    dwnUrl,
+    targetDid : did.uri,
+    message   : recordsRead.message,
+  });
+
+  if (reply.status.code !== 200 || reply.entry?.data === undefined) {
+    return undefined;
+  }
+
+  return textDecoder.decode(await DataStream.toBytes(reply.entry.data));
+}
+
+async function queryMessageCidsWithGrant({
+  agent,
+  dwnUrl,
+  granteeDid,
+  permissionGrantId,
+  tenantDid,
+}: {
+  agent: EnboxPlatformAgent;
+  dwnUrl: string;
+  granteeDid: BearerDid;
+  permissionGrantId: string;
+  tenantDid: string;
+}): Promise<string[]> {
+  const messagesQuery = await MessagesQuery.create({
+    cidsOnly           : true,
+    permissionGrantIds : [permissionGrantId],
+    signer             : await signerForDid(granteeDid),
+  });
+  const reply = await agent.rpc.sendDwnRequest({
+    dwnUrl,
+    targetDid : tenantDid,
+    message   : messagesQuery.message,
+  }) as { entries?: MessageCidEntry[]; status: { code: number; }; };
+
+  expect(reply.status.code).toBe(200);
+  return (reply.entries ?? []).map((entry: MessageCidEntry): string => entry.messageCid);
+}
+
+async function signerForDid(did: BearerDid): Promise<MessageSigner> {
+  const signer = await did.getSigner();
+
+  return {
+    algorithm : signer.algorithm,
+    keyId     : signer.keyId,
+    sign      : async (content: Uint8Array): Promise<Uint8Array> => signer.sign({ data: content }),
+  };
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 5000): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (await predicate()) {
+      return;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+
+  throw new Error('timed out waiting for condition');
+}

--- a/packages/agent/tests/sync-admit-closure.spec.ts
+++ b/packages/agent/tests/sync-admit-closure.spec.ts
@@ -210,6 +210,33 @@ describe('admitClosure', () => {
     expect(agent.rpc.sendDwnRequest.called).toBe(false);
   });
 
+  it('fails scoped RecordsDelete admission as unknown when the initial write is unavailable in remote mode', async () => {
+    const protocol = 'https://example.com/protocol';
+    const initial = await TestDataGenerator.generateRecordsWrite({ protocol });
+    const recordsDelete = await TestDataGenerator.generateRecordsDelete({
+      author   : initial.author,
+      recordId : initial.message.recordId,
+    });
+    const rootCid = await Message.getCid(recordsDelete.message);
+    const agent = createMockAgent();
+
+    const outcome = await admitClosure(rootCid, {
+      did        : 'did:example:alice',
+      dwnUrl     : 'https://dwn.example.com',
+      scope      : { kind: 'protocolSet', protocols: [protocol] },
+      agent,
+      prefetched : [{ message: recordsDelete.message }],
+    });
+
+    expect(outcome).toEqual({
+      kind   : 'failed',
+      rootCid,
+      reason : 'terminal',
+      detail : 'root message scope is unknown',
+    });
+    expect(agent.dwn.applyReplicatedMessage.called).toBe(false);
+  });
+
   it('fetches dependencies by message CID', async () => {
     const root = await TestDataGenerator.generateRecordsWrite();
     const dependency = await TestDataGenerator.generateRecordsWrite({ data: new Uint8Array([1, 2, 3]) });

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -302,8 +302,14 @@ export interface AuthManagerOptions {
 
   /**
    * Controls local DWN discovery behavior for remote-target DWN sends/sync.
-   * `'off'` (default) disables local probing, `'prefer'` tries local first
-   * then falls back to DID-document endpoints, `'only'` requires a local server.
+   * `'prefer'` (default) uses a paired local DWN first, then falls back to
+   * DID-document endpoints. `'only'` requires a local server. `'off'` disables
+   * local DWN discovery entirely.
+   *
+   * Discovery is passive by default: the SDK validates only an explicit
+   * `dwn://connect` result, a persisted endpoint, or the native discovery file.
+   * It does not sweep localhost ports.
+   *
    * Ignored when `agent` is provided.
    */
   localDwnStrategy?: LocalDwnStrategy;

--- a/packages/electrobun-dwn/src/bun/index.ts
+++ b/packages/electrobun-dwn/src/bun/index.ts
@@ -6,18 +6,9 @@ import { existsSync, rmSync } from 'node:fs';
 import {
   buildDwnDiscoveryRedirectUrl,
   DwnDiscoveryFile,
+  localDwnPortCandidates,
   parseDwnConnectUrl,
 } from '@enbox/agent';
-
-/**
- * Well-known port candidates for the local DWN server.
- *
- * Previously imported as `localDwnPortCandidates` from `@enbox/agent`, but
- * that export was removed as part of the port-probing removal refactor
- * (see https://github.com/enboxorg/enbox/issues/711). The server-side port
- * selection list is maintained here as a local constant.
- */
-const localDwnPortCandidates = [3000, 55500, 55501, 55502, 55503, 55504, 55505, 55506, 55507, 55508, 55509] as const;
 import Electrobun, { ApplicationMenu, BrowserWindow, Tray, Utils } from 'electrobun/bun';
 
 function selectPortCandidates(): number[] {

--- a/packages/electrobun-dwn/src/mainview/pages/home/index.js
+++ b/packages/electrobun-dwn/src/mainview/pages/home/index.js
@@ -124,7 +124,7 @@ class HomePage extends SignalWatcher(LitElement) {
                     : html`<span class="server-url">--</span>`}
                 </div>
                 <div class="metric-note">
-                  Close this window to stop the server. The DWN uses ports 3000, then 55500-55509.
+                  Close this window to stop the server. The DWN uses ports 55500-55509, then 3000.
                 </div>
               </wa-card>
             </div>

--- a/packages/electrobun-dwn/src/mainview/services/server-status.ts
+++ b/packages/electrobun-dwn/src/mainview/services/server-status.ts
@@ -3,9 +3,11 @@ import type {
   ConnectionSnapshot,
 } from '../state/app-store.js';
 
+import { localDwnPortCandidates } from '@enbox/agent';
 import { sleep } from '@enbox/common';
 
-const candidatePorts = [3000, 55500, 55501, 55502, 55503, 55504, 55505, 55506, 55507, 55508, 55509];
+const defaultCandidatePort = localDwnPortCandidates[0];
+const candidatePorts = [...localDwnPortCandidates];
 const candidateHosts = ['127.0.0.1'];
 const maxRetries = 5;
 const retryDelayMs = 800;
@@ -109,7 +111,7 @@ async function detectLocalDwnBaseUrl(): Promise<string> {
     }
   }
 
-  return 'http://127.0.0.1:3000';
+  return `http://127.0.0.1:${defaultCandidatePort}`;
 }
 
 async function resolveServerEndpoint(): Promise<string> {
@@ -133,4 +135,3 @@ async function fetchServerInfo(baseUrl: string): Promise<ServerInfo | null> {
     return null;
   }
 }
-


### PR DESCRIPTION
Summary
- Add live remote-mode local-node integration coverage for push/pull checkpoints, WS subscriptions, multi-tenant isolation, replicated apply, and tenant-wide Messages.Read grants.
- Centralize local DWN port candidates in @enbox/agent and reuse them from Electrobun runtime/status UI.
- Align passive local DWN strategy defaults and bound unknown scoped remote admission.

Test plan
- [x] bun run lint
- [x] bun run --filter @enbox/agent lint
- [x] bun run build
- [x] bun run --filter @enbox/electrobun-dwn build
- [x] bun test --timeout 30000 packages/agent/tests/local-dwn.spec.ts
- [x] bun test --timeout 30000 packages/agent/tests/sync-admit-closure.spec.ts
- [x] bun test --timeout 60000 packages/agent/tests/remote-mode-integration.spec.ts
- [x] cd packages/agent && bun run test:node (passed against a foreground DWN server before the final tenant-wide grant assertion; final rerun was stopped to avoid contending for shared :3000, and the focused remote-mode spec was rerun after that edit)
- [x] bunx changeset status

Closes #1163
Refs #1162