### PR TITLE
test(browser): cover remaining sonar zero-coverage files

### DIFF
--- a/packages/browser/src/ui/wallet-selector.ts
+++ b/packages/browser/src/ui/wallet-selector.ts
@@ -21,7 +21,13 @@ export function showWalletSelector(wallets: WalletOption[]): Promise<string> {
     host.id = 'enbox-wallet-selector';
     const shadow = host.attachShadow({ mode: 'open' });
 
+    let onKeydown: ((e: KeyboardEvent) => void) | undefined;
     const cleanup = (): void => {
+      if (onKeydown !== undefined) {
+        document.removeEventListener('keydown', onKeydown);
+        onKeydown = undefined;
+      }
+
       try { document.body.removeChild(host); } catch { /* best effort */ }
     };
 
@@ -169,9 +175,8 @@ export function showWalletSelector(wallets: WalletOption[]): Promise<string> {
     });
 
     // Close on Escape.
-    const onKeydown = (e: KeyboardEvent): void => {
+    onKeydown = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') {
-        document.removeEventListener('keydown', onKeydown);
         cleanup();
         reject(new Error('[@enbox/browser] Wallet selection cancelled.'));
       }

--- a/packages/browser/tests/wallet-selector.spec.ts
+++ b/packages/browser/tests/wallet-selector.spec.ts
@@ -1,0 +1,162 @@
+import type { WalletOption } from '../src/browser-connect-handler.js';
+
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { showWalletSelector } from '../src/ui/wallet-selector.js';
+
+const WALLETS: WalletOption[] = [
+  {
+    name        : 'Enbox Wallet',
+    url         : 'https://wallet.example.com',
+    icon        : 'https://wallet.example.com/icon.png',
+    description : 'Primary test wallet',
+  },
+  {
+    name        : 'Fallback Wallet',
+    url         : 'https://fallback.example.com/connect',
+    description : 'Wallet without a custom icon',
+  },
+];
+
+function getHost(): HTMLDivElement {
+  const host = document.querySelector<HTMLDivElement>('#enbox-wallet-selector');
+  if (host === null) {
+    throw new Error('expected wallet selector host to exist');
+  }
+
+  return host;
+}
+
+function getShadowRoot(): ShadowRoot {
+  const shadow = getHost().shadowRoot;
+  if (shadow === null) {
+    throw new Error('expected wallet selector shadow root to exist');
+  }
+
+  return shadow;
+}
+
+function queryRequired<T extends Element>(selector: string): T {
+  const element = getShadowRoot().querySelector<T>(selector);
+  if (element === null) {
+    throw new Error(`expected selector '${selector}' to match`);
+  }
+
+  return element;
+}
+
+function inputWalletUrl(value: string): void {
+  const input = queryRequired<HTMLInputElement>('.url-input');
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('showWalletSelector', () => {
+  afterEach(() => {
+    document.querySelector('#enbox-wallet-selector')?.remove();
+  });
+
+  it('should render wallet choices, resolve selected wallet URL, and clean up the modal', async () => {
+    const promise = showWalletSelector(WALLETS);
+    const walletItems = Array.from(getShadowRoot().querySelectorAll<HTMLButtonElement>('.wallet-item'));
+
+    expect(walletItems).toHaveLength(2);
+    expect(walletItems[0].querySelector('.wallet-name')?.textContent).toBe('Enbox Wallet');
+    expect(walletItems[0].querySelector('.wallet-description')?.textContent).toBe('Primary test wallet');
+    expect(walletItems[0].querySelector<HTMLImageElement>('img')?.src).toBe(WALLETS[0].icon);
+
+    const fallbackIcon = walletItems[1].querySelector<HTMLImageElement>('img');
+    expect(fallbackIcon?.src).toContain('https://t3.gstatic.com/faviconV2');
+    expect(fallbackIcon?.src).toContain(`url=${WALLETS[1].url}`);
+
+    fallbackIcon?.onerror?.(new Event('error'));
+    expect(fallbackIcon?.style.display).toBe('none');
+
+    walletItems[1].click();
+
+    await expect(promise).resolves.toBe(WALLETS[1].url);
+    expect(document.querySelector('#enbox-wallet-selector')).toBeNull();
+  });
+
+  it('should enable custom URL submission only for valid URLs and normalize to the origin', async () => {
+    const promise = showWalletSelector(WALLETS);
+    const goButton = queryRequired<HTMLButtonElement>('.go-btn');
+
+    expect(goButton.disabled).toBe(true);
+
+    inputWalletUrl('ftp://wallet.example.com');
+    expect(goButton.disabled).toBe(true);
+
+    inputWalletUrl('wallet.example.com/path?ignored=true');
+    expect(goButton.disabled).toBe(false);
+
+    goButton.click();
+
+    await expect(promise).resolves.toBe('https://wallet.example.com');
+    expect(document.querySelector('#enbox-wallet-selector')).toBeNull();
+  });
+
+  it('should submit a valid custom URL when Enter is pressed', async () => {
+    const promise = showWalletSelector(WALLETS);
+
+    inputWalletUrl('http://localhost:3000/wallet');
+    queryRequired<HTMLInputElement>('.url-input').dispatchEvent(new KeyboardEvent('keydown', {
+      bubbles : true,
+      key     : 'Enter',
+    }));
+
+    await expect(promise).resolves.toBe('http://localhost:3000');
+  });
+
+  it('should reject and clean up when the close button is clicked', async () => {
+    const promise = showWalletSelector(WALLETS);
+
+    queryRequired<HTMLButtonElement>('.close-btn').click();
+
+    await expect(promise).rejects.toThrow('Wallet selection cancelled');
+    expect(document.querySelector('#enbox-wallet-selector')).toBeNull();
+  });
+
+  it('should reject and clean up when the overlay is clicked', async () => {
+    const promise = showWalletSelector(WALLETS);
+
+    queryRequired<HTMLDivElement>('.overlay').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    await expect(promise).rejects.toThrow('Wallet selection cancelled');
+    expect(document.querySelector('#enbox-wallet-selector')).toBeNull();
+  });
+
+  it('should reject and clean up when Escape is pressed', async () => {
+    const promise = showWalletSelector(WALLETS);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      bubbles : true,
+      key     : 'Escape',
+    }));
+
+    await expect(promise).rejects.toThrow('Wallet selection cancelled');
+    expect(document.querySelector('#enbox-wallet-selector')).toBeNull();
+  });
+
+  it('should use dark mode styles when the browser prefers a dark color scheme', () => {
+    const matchMediaSpy = spyOn(window, 'matchMedia').mockReturnValue({
+      addEventListener    : () => undefined,
+      addListener         : () => undefined,
+      dispatchEvent       : () => false,
+      matches             : true,
+      media               : '(prefers-color-scheme: dark)',
+      onchange            : null,
+      removeEventListener : () => undefined,
+      removeListener      : () => undefined,
+    });
+
+    const promise = showWalletSelector(WALLETS);
+    const styles = queryRequired<HTMLStyleElement>('style').textContent;
+    queryRequired<HTMLButtonElement>('.close-btn').click();
+
+    matchMediaSpy.mockRestore();
+
+    expect(styles).toContain('background: #1a1a2e');
+    return expect(promise).rejects.toThrow('Wallet selection cancelled');
+  });
+});

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,8 @@ sonar.pullrequest.github.repository=enboxorg/enbox
 
 sonar.exclusions=**/node_modules/**,**/dist/**,**/out/**,**/.next/**,**/.turbo/**,**/coverage/**,**/coverage-browser/**,**/coverage-browser-*/**,**/generated/**,apps/docs/content/**
 # Admin UI and docs app source stay in Sonar analysis, but they do not currently emit LCOV.
-sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx,**/*.config.ts,**/*.config.js,**/*.config.cjs,**/*.config.mjs,**/*.d.ts,**/dist/**,**/out/**,packages/dwn-server-admin-ui/src/**,apps/docs/src/**
+# `dwn-server/src/main.ts` is a non-terminating CLI entrypoint; the agent browser FS file is a bundle alias shim tested in discovery specs.
+sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx,**/*.config.ts,**/*.config.js,**/*.config.cjs,**/*.config.mjs,**/*.d.ts,**/dist/**,**/out/**,packages/agent/src/dwn-discovery-file-fs.browser.ts,packages/dwn-server/src/main.ts,packages/dwn-server-admin-ui/src/**,apps/docs/src/**
 sonar.cpd.exclusions=packages/**/tests/**
 
 # ─── Rule-specific issue ignores ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Follow-up to #1204 after it merged; keeps the remaining coverage cleanup in one small PR.
- Add wallet selector browser coverage for wallet selection, custom URL normalization, cancellation/escape cleanup, fallback icons, and dark-mode styling.
- Fix `showWalletSelector` to remove the Escape key listener on every cleanup path.
- Exclude the remaining non-LCOV/non-testable listed files: the agent browser FS alias shim and the non-terminating dwn-server CLI entrypoint.

## Test plan
- [x] bun install
- [x] bun run build
- [x] bun run --filter @enbox/browser lint
- [x] BROWSER=chromium CI=true bun run --filter @enbox/browser test:browser:coverage -- --browser.connectTimeout=120000
- [x] bun run lint
- [x] bun run --filter @enbox/agent build
- [x] bun run dev:ensure
- [x] bun run test:node (from packages/agent, with foreground DWN server on :3000 after the watched dev server dropped)
- [x] git diff --check