### PR TITLE
fix(dwn-server): add local node profile skeleton

### DIFF
--- a/.changeset/local-node-profile-skeleton.md
+++ b/.changeset/local-node-profile-skeleton.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-clients": patch
+"@enbox/dwn-server": patch
+---
+
+fix: add the local-node server profile skeleton

--- a/packages/dwn-clients/src/server-info-types.ts
+++ b/packages/dwn-clients/src/server-info-types.ts
@@ -16,7 +16,27 @@ export type ProviderAuthInfo = {
   managementUrl? : string;
 };
 
+/**
+ * Local-node pairing metadata exposed by `GET /info` when the server is running
+ * under the opt-in local-node profile.
+ */
+export type LocalNodePairingInfo = {
+  /** URL where browser clients initiate pairing. */
+  pairUrl : string;
+  /** URL template used to poll a pairing request, with `{requestId}` as placeholder. */
+  pollUrlTemplate : string;
+};
+
 export type ServerInfo = {
+  /**
+   * Indicates that this DWN is a localhost local-node profile, not a cloud DWN.
+   * Absent on ordinary DWN server deployments.
+   */
+  localNode?: boolean,
+  /**
+   * Pairing endpoints for browser clients. Present only when `localNode` is true.
+   */
+  localPairing?: LocalNodePairingInfo,
   /** the maximum file size the user can request to store */
   maxFileSize: number,
   /**

--- a/packages/dwn-server/src/config.ts
+++ b/packages/dwn-server/src/config.ts
@@ -9,6 +9,17 @@ const byteSizeUnits: Record<string, number> = {
   mb : 1024 ** 2,
 };
 
+function parseCommaSeparatedList(value: string | undefined): string[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((entry: string): string => entry.trim())
+    .filter((entry: string): boolean => entry.length > 0);
+}
+
 /**
  * Parses a byte-size string with optional b/kb/mb/gb suffix into bytes.
  */
@@ -46,6 +57,25 @@ export const config = {
    * Port that server listens on.
    */
   port: parseInt(process.env.DS_PORT || '3000'),
+
+  /**
+   * Hostname or interface that the HTTP server binds to. When the local-node
+   * profile is enabled, this defaults to loopback and non-loopback values are rejected.
+   */
+  hostname: process.env.DS_HOST || (process.env.DWN_LOCAL_NODE_PROFILE === 'true' ? '127.0.0.1' : undefined),
+
+  /**
+   * Enables the local DWN node trust profile. This profile is opt-in so cloud
+   * deployments keep their existing behavior unless explicitly configured.
+   */
+  localNodeProfileEnabled: process.env.DWN_LOCAL_NODE_PROFILE === 'true',
+
+  /**
+   * Origins allowed to use local-node protected routes before the dynamic
+   * pairing store is wired in. Public local-node routes such as `/info` still
+   * reflect the caller origin because they are used to initiate pairing.
+   */
+  localNodeAllowedOrigins: parseCommaSeparatedList(process.env.DWN_LOCAL_NODE_ALLOWED_ORIGINS),
 
   /**
    * The URL of the TTL cache used by the DWN.

--- a/packages/dwn-server/src/dwn-server.ts
+++ b/packages/dwn-server/src/dwn-server.ts
@@ -12,6 +12,7 @@ import { AdminApi } from './admin/admin-api.js';
 import { AdminPasskeyStore } from './admin/admin-passkey-store.js';
 import { AdminSessionManager } from './admin/admin-session.js';
 import { AdminStore } from './admin/admin-store.js';
+import { assertLocalNodeBindHostname } from './local-node-profile.js';
 import { AuditLog } from './admin/audit-log.js';
 import { config as defaultConfig } from './config.js';
 import { DeliveryService } from './delivery-service.js';
@@ -126,6 +127,10 @@ export class DwnServer {
   async start(): Promise<void> {
     if (this.serverState === DwnServerState.Started) {
       return;
+    }
+
+    if (this.config.localNodeProfileEnabled) {
+      assertLocalNodeBindHostname(this.config.hostname);
     }
 
     await this.#setupServer();

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -33,11 +33,11 @@ import { DateSort, type Dwn, ProtocolsQuery, RecordsQuery, RecordsRead } from '@
 import { existsSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
 
-import { config } from './config.js';
 import { ConnectServer } from './connect/connect-server.js';
 import { getDialectFromUrl } from './storage.js';
 import { jsonRpcRouter } from './json-rpc-api.js';
 import { validateAdminAuth } from './admin/admin-auth.js';
+import { assertLocalNodeBindHostname, isLocalNodeHostHeaderAllowed } from './local-node-profile.js';
 import { requestCounter, responseHistogram } from './metrics.js';
 
 /** Property names that must never be used as keys when building objects from user input. */
@@ -184,7 +184,12 @@ export class HttpApi {
   async start(port: number): Promise<void> {
     const self = this; // capture for closures
 
+    if (this.#config.localNodeProfileEnabled) {
+      assertLocalNodeBindHostname(this.#config.hostname);
+    }
+
     this.#server = Bun.serve<WsData>({
+      hostname: this.#config.hostname,
       port,
 
       async fetch(req: Request, server): Promise<Response | undefined> {
@@ -192,6 +197,10 @@ export class HttpApi {
         const url = new URL(req.url);
         const path = url.pathname;
         const method = req.method;
+
+        if (self.#config.localNodeProfileEnabled && !isLocalNodeHostHeaderAllowed(req.headers.get('host'))) {
+          return new Response('Forbidden', { status: 403 });
+        }
 
         // --- WebSocket upgrade ---
         if (method === 'GET' && req.headers.get('upgrade') === 'websocket') {
@@ -208,20 +217,18 @@ export class HttpApi {
           const result = self.#ipRateLimiter.consume(ip);
           if (result.allowed === false) {
             const retryAfterSec = Math.ceil(result.retryAfterMs / 1000);
-            return new Response(
+            const response = new Response(
               JSON.stringify({ error: 'Rate limit exceeded' }),
               {
                 status  : 429,
                 headers : {
-                  'content-type'                  : 'application/json',
-                  'retry-after'                   : String(retryAfterSec),
-                  'access-control-allow-origin'   : '*',
-                  'access-control-allow-methods'  : 'GET, POST, OPTIONS',
-                  'access-control-allow-headers'  : '*',
-                  'access-control-expose-headers' : 'dwn-response',
+                  'content-type' : 'application/json',
+                  'retry-after'  : String(retryAfterSec),
                 },
               },
             );
+            self.#applyCorsHeaders(req, response, path);
+            return response;
           }
         }
 
@@ -237,16 +244,7 @@ export class HttpApi {
         // --- CORS headers ---
         // Admin API and metrics endpoints do not receive wildcard CORS headers
         // to limit cross-origin access when the admin token is configured.
-        const isAdminRoute = path.startsWith('/admin') || path === '/metrics';
-        if (!isAdminRoute) {
-          response.headers.set('access-control-allow-origin', '*');
-          response.headers.set('access-control-allow-methods', 'GET, POST, OPTIONS');
-          response.headers.set('access-control-allow-headers', '*');
-          response.headers.set('access-control-expose-headers', 'dwn-response');
-          // Cache preflight responses for 24 hours to reduce OPTIONS round-trips
-          // for browser-based DWN clients communicating with a local server.
-          response.headers.set('access-control-max-age', '86400');
-        }
+        self.#applyCorsHeaders(req, response, path);
 
         // --- Response-time metrics ---
         const elapsed = performance.now() - startTime;
@@ -525,37 +523,95 @@ export class HttpApi {
 
   #handleInfo(): Response {
     const registrationRequirements: string[] = [];
-    if (config.registrationProofOfWorkEnabled) {
+    if (this.#config.registrationProofOfWorkEnabled) {
       registrationRequirements.push('proof-of-work-sha256-v0');
     }
-    if (config.termsOfServiceFilePath !== undefined) {
+    if (this.#config.termsOfServiceFilePath !== undefined) {
       registrationRequirements.push('terms-of-service');
     }
-    if (config.providerAuthEnabled && !registrationRequirements.includes('provider-auth-v0')) {
+    if (this.#config.providerAuthEnabled && !registrationRequirements.includes('provider-auth-v0')) {
       registrationRequirements.push('provider-auth-v0');
     }
 
     const serverInfo: ServerInfo = {
-      maxFileSize              : config.maxRecordDataSize,
-      maxInFlight              : config.maxInFlight,
+      maxFileSize              : this.#config.maxRecordDataSize,
+      maxInFlight              : this.#config.maxInFlight,
       registrationRequirements : registrationRequirements,
       server                   : this.#packageInfo.server,
       sdkVersion               : this.#packageInfo.sdkVersion,
-      url                      : config.baseUrl,
+      url                      : this.#config.baseUrl,
       version                  : this.#packageInfo.version,
-      webSocketSupport         : config.webSocketSupport,
+      webSocketSupport         : this.#config.webSocketSupport,
     };
 
-    if (config.providerAuthEnabled) {
+    if (this.#config.localNodeProfileEnabled) {
+      const baseUrl = this.#config.baseUrl.replace(/\/+$/, '');
+      serverInfo.localNode = true;
+      serverInfo.localPairing = {
+        pairUrl         : `${baseUrl}/local/pair`,
+        pollUrlTemplate : `${baseUrl}/local/pair/{requestId}`,
+      };
+    }
+
+    if (this.#config.providerAuthEnabled) {
       serverInfo.providerAuth = {
-        authorizeUrl  : config.providerAuthAuthorizeUrl,
-        tokenUrl      : config.providerAuthTokenUrl,
-        refreshUrl    : config.providerAuthRefreshUrl,
-        managementUrl : config.providerAuthManagementUrl,
+        authorizeUrl  : this.#config.providerAuthAuthorizeUrl,
+        tokenUrl      : this.#config.providerAuthTokenUrl,
+        refreshUrl    : this.#config.providerAuthRefreshUrl,
+        managementUrl : this.#config.providerAuthManagementUrl,
       };
     }
 
     return Response.json(serverInfo);
+  }
+
+  #applyCorsHeaders(req: Request, response: Response, path: string): void {
+    const isAdminRoute = path.startsWith('/admin') || path === '/metrics';
+    if (isAdminRoute) {
+      return;
+    }
+
+    const allowedOrigin = this.#getCorsAllowedOrigin(req, path);
+    if (allowedOrigin === undefined) {
+      return;
+    }
+
+    response.headers.set('access-control-allow-origin', allowedOrigin);
+    response.headers.set('access-control-allow-methods', 'GET, POST, OPTIONS');
+    response.headers.set('access-control-allow-headers', this.#config.localNodeProfileEnabled
+      ? 'authorization, content-type, dwn-request'
+      : '*');
+    response.headers.set('access-control-expose-headers', 'dwn-response');
+    // Cache preflight responses for 24 hours to reduce OPTIONS round-trips
+    // for browser-based DWN clients communicating with a local server.
+    response.headers.set('access-control-max-age', '86400');
+
+    if (allowedOrigin !== '*') {
+      response.headers.set('vary', 'Origin');
+    }
+  }
+
+  #getCorsAllowedOrigin(req: Request, path: string): string | undefined {
+    if (!this.#config.localNodeProfileEnabled) {
+      return '*';
+    }
+
+    const origin = req.headers.get('origin');
+    if (origin === null) {
+      return undefined;
+    }
+
+    if (HttpApi.#isLocalNodePublicCorsRoute(path)) {
+      return origin;
+    }
+
+    return this.#config.localNodeAllowedOrigins.includes(origin) ? origin : undefined;
+  }
+
+  static #isLocalNodePublicCorsRoute(path: string): boolean {
+    return path === '/info'
+      || path === '/local/pair'
+      || path.startsWith('/local/pair/');
   }
 
   async #handleJsonRpcPost(req: Request): Promise<Response> {

--- a/packages/dwn-server/src/local-node-profile.ts
+++ b/packages/dwn-server/src/local-node-profile.ts
@@ -1,0 +1,73 @@
+function normalizeHostname(hostname: string): string {
+  let normalized = hostname.trim().toLowerCase();
+
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    normalized = normalized.slice(1, -1);
+  }
+
+  if (normalized.endsWith('.')) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+}
+
+function isIpv4Loopback(hostname: string): boolean {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) {
+    return false;
+  }
+
+  if (parts.some((part: string): boolean => !/^\d+$/.test(part))) {
+    return false;
+  }
+
+  const octets = parts.map((part: string): number => Number.parseInt(part, 10));
+  if (octets.some((octet: number): boolean => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return false;
+  }
+
+  return octets[0] === 127;
+}
+
+export function isLoopbackHostname(hostname: string | undefined): boolean {
+  if (hostname === undefined) {
+    return false;
+  }
+
+  const normalized = normalizeHostname(hostname);
+  return normalized === 'localhost'
+    || normalized === '::1'
+    || isIpv4Loopback(normalized);
+}
+
+export function getHostnameFromHostHeader(hostHeader: string | null): string | undefined {
+  if (hostHeader === null) {
+    return undefined;
+  }
+
+  const trimmedHost = hostHeader.trim();
+  if (trimmedHost.length === 0) {
+    return undefined;
+  }
+
+  if (trimmedHost.startsWith('[')) {
+    const closingBracketIndex = trimmedHost.indexOf(']');
+    if (closingBracketIndex === -1) {
+      return undefined;
+    }
+    return trimmedHost.slice(1, closingBracketIndex);
+  }
+
+  return trimmedHost.split(':')[0];
+}
+
+export function isLocalNodeHostHeaderAllowed(hostHeader: string | null): boolean {
+  return isLoopbackHostname(getHostnameFromHostHeader(hostHeader));
+}
+
+export function assertLocalNodeBindHostname(hostname: string | undefined): void {
+  if (!isLoopbackHostname(hostname)) {
+    throw new Error('DwnServer local node profile requires a loopback bind hostname.');
+  }
+}

--- a/packages/dwn-server/tests/dwn-server.test.ts
+++ b/packages/dwn-server/tests/dwn-server.test.ts
@@ -58,4 +58,24 @@ describe('DwnServer', () => {
       console.log('server Stop');
     });
   });
+
+  describe('local node profile', () => {
+    it('should reject non-loopback bind hostnames', async () => {
+      ({ dwn } = await getTestDwn());
+      const server = new DwnServer({
+        dwn,
+        config: {
+          ...dwnServerConfig,
+          hostname                : '0.0.0.0',
+          localNodeProfileEnabled : true,
+        }
+      });
+
+      try {
+        await expect(server.start()).rejects.toThrow('DwnServer local node profile requires a loopback bind hostname.');
+      } finally {
+        await dwn.close();
+      }
+    });
+  });
 });

--- a/packages/dwn-server/tests/http-api.test.ts
+++ b/packages/dwn-server/tests/http-api.test.ts
@@ -1,6 +1,7 @@
 import type { Dialect } from '@enbox/dwn-sql-store';
+import type { DwnServerConfig } from '../src/config.js';
 import type { Dwn, Persona, ProtocolsConfigureMessage, RecordsQueryReply } from '@enbox/dwn-sdk-js';
-import type { JsonRpcErrorResponse, JsonRpcResponse } from '@enbox/dwn-clients';
+import type { JsonRpcErrorResponse, JsonRpcResponse, ServerInfo } from '@enbox/dwn-clients';
 
 import { Convert } from '@enbox/common';
 import log from 'loglevel';
@@ -36,6 +37,19 @@ describe('http api', function () {
   let dialect: Dialect;
   let clock;
   let baseUrl: string;
+
+  async function createStartedHttpApiWithConfig(overrides: Partial<DwnServerConfig>): Promise<{ api: HttpApi; url: string; }> {
+    const testConfig: DwnServerConfig = {
+      ...config,
+      ...overrides,
+    };
+    const api = await HttpApi.create(testConfig, dwn, registrationManager, undefined, undefined, { ttlCacheDialect: dialect });
+    await api.start(0);
+
+    const hostname = testConfig.hostname ?? 'localhost';
+    const urlHostname = hostname === '::1' ? '[::1]' : hostname;
+    return { api, url: `http://${urlHostname}:${api.server.port}` };
+  }
 
   beforeAll(async function () {
     clock = useFakeTimers({ shouldAdvanceTime: true });
@@ -979,6 +993,8 @@ describe('http api', function () {
       const info = await resp.json();
       expect(info['url']).toBe('http://localhost:3000');
       expect(info['server']).toBe('@enbox/dwn-server');
+      expect(info['localNode']).toBeUndefined();
+      expect(info['localPairing']).toBeUndefined();
       expect(info['registrationRequirements']).toContain('terms-of-service');
       expect(info['registrationRequirements']).toContain(
         'proof-of-work-sha256-v0',
@@ -1070,6 +1086,32 @@ describe('http api', function () {
       // restore server name config
       config.serverName = serverName;
     });
+
+    it('verify /info includes local-node metadata in local-node profile', async function () {
+      const { api, url } = await createStartedHttpApiWithConfig({
+        baseUrl                 : 'http://127.0.0.1:55500',
+        hostname                : '127.0.0.1',
+        localNodeProfileEnabled : true,
+      });
+
+      try {
+        const resp = await fetch(`${url}/info`, {
+          headers: { origin: 'https://app.example' },
+        });
+        const info = await resp.json() as ServerInfo;
+        expect(resp.status).toBe(200);
+
+        expect(info.localNode).toBe(true);
+        expect(info.localPairing).toEqual({
+          pairUrl         : 'http://127.0.0.1:55500/local/pair',
+          pollUrlTemplate : 'http://127.0.0.1:55500/local/pair/{requestId}',
+        });
+        expect(resp.headers.get('access-control-allow-origin')).toBe('https://app.example');
+        expect(resp.headers.get('vary')).toBe('Origin');
+      } finally {
+        await api.close();
+      }
+    });
   });
 
   describe('CORS headers', () => {
@@ -1142,6 +1184,72 @@ describe('http api', function () {
 
       expect(response.headers.get('access-control-allow-origin')).toBe('*');
       expect(response.headers.get('access-control-max-age')).toBe('86400');
+    });
+
+    it('should reflect public local-node route origins without wildcard CORS', async () => {
+      const { api, url } = await createStartedHttpApiWithConfig({
+        hostname                : '127.0.0.1',
+        localNodeProfileEnabled : true,
+      });
+
+      try {
+        const response = await fetch(`${url}/info`, {
+          headers: { origin: 'https://unpaired.example' },
+        });
+        expect(response.status).toBe(200);
+
+        expect(response.headers.get('access-control-allow-origin')).toBe('https://unpaired.example');
+        expect(response.headers.get('access-control-allow-headers')).toBe('authorization, content-type, dwn-request');
+        expect(response.headers.get('vary')).toBe('Origin');
+      } finally {
+        await api.close();
+      }
+    });
+
+    it('should only reflect configured origins on local-node protected routes', async () => {
+      const { api, url } = await createStartedHttpApiWithConfig({
+        hostname                : '127.0.0.1',
+        localNodeAllowedOrigins : ['https://paired.example'],
+        localNodeProfileEnabled : true,
+      });
+
+      try {
+        const pairedResponse = await fetch(`${url}/health`, {
+          headers: { origin: 'https://paired.example' },
+        });
+        expect(pairedResponse.status).toBe(200);
+        expect(pairedResponse.headers.get('access-control-allow-origin')).toBe('https://paired.example');
+
+        const unpairedResponse = await fetch(`${url}/health`, {
+          headers: { origin: 'https://unpaired.example' },
+        });
+        expect(unpairedResponse.status).toBe(200);
+        expect(unpairedResponse.headers.get('access-control-allow-origin')).toBeNull();
+      } finally {
+        await api.close();
+      }
+    });
+  });
+
+  describe('local node profile', () => {
+    it('should reject requests with non-loopback Host headers', async () => {
+      const { api, url } = await createStartedHttpApiWithConfig({
+        hostname                : '127.0.0.1',
+        localNodeProfileEnabled : true,
+      });
+
+      try {
+        const response = await fetch(`${url}/info`, {
+          headers: {
+            host   : 'evil.example',
+            origin : 'https://app.example',
+          },
+        });
+        expect(response.status).toBe(403);
+        expect(response.headers.get('access-control-allow-origin')).toBeNull();
+      } finally {
+        await api.close();
+      }
     });
   });
 

--- a/packages/dwn-server/tests/local-node-profile.test.ts
+++ b/packages/dwn-server/tests/local-node-profile.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+
+import { isLocalNodeHostHeaderAllowed } from '../src/local-node-profile.js';
+
+describe('local node profile', () => {
+  describe('isLocalNodeHostHeaderAllowed()', () => {
+    it('should accept loopback host headers', () => {
+      expect(isLocalNodeHostHeaderAllowed('localhost')).toBe(true);
+      expect(isLocalNodeHostHeaderAllowed('localhost:55500')).toBe(true);
+      expect(isLocalNodeHostHeaderAllowed('localhost.:55500')).toBe(true);
+      expect(isLocalNodeHostHeaderAllowed('127.0.0.1')).toBe(true);
+      expect(isLocalNodeHostHeaderAllowed('127.42.0.1:55500')).toBe(true);
+      expect(isLocalNodeHostHeaderAllowed('[::1]:55500')).toBe(true);
+    });
+
+    it('should reject malformed and non-loopback host headers', () => {
+      expect(isLocalNodeHostHeaderAllowed(null)).toBe(false);
+      expect(isLocalNodeHostHeaderAllowed('')).toBe(false);
+      expect(isLocalNodeHostHeaderAllowed('evil.example')).toBe(false);
+      expect(isLocalNodeHostHeaderAllowed('127.0.0.1evil')).toBe(false);
+      expect(isLocalNodeHostHeaderAllowed('127.0.0.999')).toBe(false);
+      expect(isLocalNodeHostHeaderAllowed('127.0.0.1.evil.example')).toBe(false);
+      expect(isLocalNodeHostHeaderAllowed('[::2]:55500')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Summary
- Add the opt-in dwn-server local-node profile foundation with loopback bind validation and Host header enforcement before HTTP routing/WS upgrade.
- Add local-node /info metadata and reflected CORS behavior for public local-node routes while preserving wildcard CORS for normal server deployments.
- Extend ServerInfo with local-node metadata and add coverage for malformed/non-loopback hosts, local-profile CORS, and bind refusal.

Scope note
- This establishes the Phase 1 server-profile skeleton and /info contract. Pairing endpoints, bearer-token enforcement, dynamic paired-origin storage, and @enbox/local-node remain the next Phase 1 slices.

Test plan
- [x] bun run lint
- [x] bun run build
- [x] cd packages/dwn-server && bun test --timeout 30000 tests/local-node-profile.test.ts tests/http-api.test.ts tests/dwn-server.test.ts
- [x] bun run --filter @enbox/dwn-server test:node
- [x] bun run --filter @enbox/dwn-clients lint
- [x] bun run --filter @enbox/dwn-clients build
- [x] bunx changeset status
- [x] git diff --check HEAD
- [ ] bun run --filter @enbox/dwn-clients test:node (fails locally because no DWN server is running on localhost:3000; not started to avoid shared-server contention)

Refs #1164