### PR TITLE
feat(dwn-server): add local node pairing auth

### DIFF
--- a/.changeset/local-node-pairing.md
+++ b/.changeset/local-node-pairing.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-server": patch
+---
+
+feat: add local-node pairing endpoints and bearer-token enforcement

--- a/packages/dwn-server/src/config.ts
+++ b/packages/dwn-server/src/config.ts
@@ -71,9 +71,8 @@ export const config = {
   localNodeProfileEnabled: process.env.DWN_LOCAL_NODE_PROFILE === 'true',
 
   /**
-   * Origins allowed to use local-node protected routes before the dynamic
-   * pairing store is wired in. Public local-node routes such as `/info` still
-   * reflect the caller origin because they are used to initiate pairing.
+   * Origins supplied by local-node wrappers for development/CI policy.
+   * Protected local-node routes are authorized by per-origin pairing tokens.
    */
   localNodeAllowedOrigins: parseCommaSeparatedList(process.env.DWN_LOCAL_NODE_ALLOWED_ORIGINS),
 

--- a/packages/dwn-server/src/dwn-server.ts
+++ b/packages/dwn-server/src/dwn-server.ts
@@ -1,6 +1,7 @@
 import type { DidResolver } from '@enbox/dids';
 import type { DwnServerConfig } from './config.js';
 import type { EventBus } from './event-bus.js';
+import type { LocalNodePairingManager } from './local-node-pairing.js';
 import type { MessageProcessedHook } from './message-processed-hook.js';
 import type { ProcessHandlers } from './process-handlers.js';
 import type { ProviderAuthPlugin } from './registration/provider-auth-plugin.js';
@@ -19,6 +20,7 @@ import { DeliveryService } from './delivery-service.js';
 import { Dwn } from '@enbox/dwn-sdk-js';
 import { HttpApi } from './http-api.js';
 import { InMemoryEventBus } from './event-bus.js';
+import { LocalNodePairingManager as InMemoryLocalNodePairingManager } from './local-node-pairing.js';
 import { JwtProviderAuthPlugin } from './registration/jwt-provider-auth-plugin.js';
 import { loadProviderAuthPlugin } from './registration/provider-auth-plugin.js';
 import log from 'loglevel';
@@ -70,6 +72,12 @@ export type DwnServerOptions = {
    * open-auth flow with a pre-built DWN.
    */
   openAuthHandler?: OpenAuthHandler;
+
+  /**
+   * Pairing/session manager used by the local-node profile.
+   * Shell-specific wrappers use this to approve or deny pairing requests.
+   */
+  localNodePairingManager?: LocalNodePairingManager;
 };
 
 /**
@@ -103,6 +111,7 @@ export class DwnServer {
   readonly #externalHooks: MessageProcessedHook[];
   readonly #externalRegistrationManager: RegistrationManager | undefined;
   readonly #externalOpenAuthHandler: OpenAuthHandler | undefined;
+  readonly #localNodePairingManager: LocalNodePairingManager;
 
   /**
    * @param options.dwn - Dwn instance to use as an override.
@@ -117,6 +126,7 @@ export class DwnServer {
     this.#externalHooks = options.messageProcessedHooks ?? [];
     this.#externalRegistrationManager = options.registrationManager;
     this.#externalOpenAuthHandler = options.openAuthHandler;
+    this.#localNodePairingManager = options.localNodePairingManager ?? new InMemoryLocalNodePairingManager();
 
     log.setLevel(this.config.logLevel as log.LogLevelDesc);
   }
@@ -334,7 +344,8 @@ export class DwnServer {
       {
         adminStore, registrationStore, ipRateLimiter, tenantRateLimiter,
         messageProcessedHooks, openAuthHandler, sessionManager,
-        ttlCacheDialect: serverDialect,
+        localNodePairingManager : this.#localNodePairingManager,
+        ttlCacheDialect         : serverDialect,
       },
     );
 
@@ -471,6 +482,10 @@ export class DwnServer {
 
   get httpServer(): Server<WsData> {
     return this.#httpApi.server;
+  }
+
+  get localNodePairingManager(): LocalNodePairingManager {
+    return this.#localNodePairingManager;
   }
 
   /**

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -11,6 +11,7 @@ import type { AdminSessionManager } from './admin/admin-session.js';
 import type { AdminStore } from './admin/admin-store.js';
 import type { DwnServerConfig } from './config.js';
 import type { DwnServerError } from './dwn-error.js';
+import type { LocalNodePairingManager } from './local-node-pairing.js';
 import type { MessageProcessedHook } from './message-processed-hook.js';
 import type { OpenAuthHandler } from './registration/open-auth-handler.js';
 import type { RateLimiter } from './rate-limiter.js';
@@ -35,6 +36,7 @@ import { join, resolve } from 'path';
 
 import { ConnectServer } from './connect/connect-server.js';
 import { getDialectFromUrl } from './storage.js';
+import { LocalNodePairingManager as InMemoryLocalNodePairingManager } from './local-node-pairing.js';
 import { jsonRpcRouter } from './json-rpc-api.js';
 import { validateAdminAuth } from './admin/admin-auth.js';
 import { assertLocalNodeBindHostname, isLocalNodeHostHeaderAllowed } from './local-node-profile.js';
@@ -72,6 +74,7 @@ export class HttpApi {
   #openAuthHandler: OpenAuthHandler | undefined;
   #sessionManager: AdminSessionManager | undefined;
   #adminUiPath: string | undefined;
+  #localNodePairingManager: LocalNodePairingManager;
   connectServer: ConnectServer;
   registrationManager: RegistrationManager;
   dwn: Dwn;
@@ -93,6 +96,7 @@ export class HttpApi {
       openAuthHandler? : OpenAuthHandler;
       sessionManager? : AdminSessionManager;
       ttlCacheDialect? : Dialect;
+      localNodePairingManager?: LocalNodePairingManager;
     },
   ): Promise<HttpApi> {
     const httpApi = new HttpApi();
@@ -132,6 +136,7 @@ export class HttpApi {
     httpApi.#openAuthHandler = options?.openAuthHandler;
     httpApi.#sessionManager = options?.sessionManager;
     httpApi.#adminUiPath = resolvedAdminUiPath;
+    httpApi.#localNodePairingManager = options?.localNodePairingManager ?? new InMemoryLocalNodePairingManager();
 
     if (registrationManager !== undefined) {
       httpApi.registrationManager = registrationManager;
@@ -177,6 +182,10 @@ export class HttpApi {
     return this.#registrationStore;
   }
 
+  get localNodePairingManager(): LocalNodePairingManager {
+    return this.#localNodePairingManager;
+  }
+
   // ---------------------------------------------------------------------------
   // HTTP request handler
   // ---------------------------------------------------------------------------
@@ -200,6 +209,14 @@ export class HttpApi {
 
         if (self.#config.localNodeProfileEnabled && !isLocalNodeHostHeaderAllowed(req.headers.get('host'))) {
           return new Response('Forbidden', { status: 403 });
+        }
+
+        if (self.#config.localNodeProfileEnabled) {
+          const authorizationResponse = self.#authorizeLocalNodeRequest(req, url, path, method);
+          if (authorizationResponse !== undefined) {
+            self.#applyCorsHeaders(req, authorizationResponse, path);
+            return authorizationResponse;
+          }
         }
 
         // --- WebSocket upgrade ---
@@ -381,6 +398,14 @@ export class HttpApi {
 
     if (method === 'GET' && path === '/info') {
       return this.#handleInfo();
+    }
+
+    if (this.#config.localNodeProfileEnabled && path === '/local/pair' && method === 'POST') {
+      return this.#handleLocalNodePairRequest(req);
+    }
+
+    if (this.#config.localNodeProfileEnabled && path.startsWith('/local/pair/') && method === 'GET') {
+      return this.#handleLocalNodePairPoll(path);
     }
 
     // --- JSON-RPC POST ---
@@ -605,13 +630,97 @@ export class HttpApi {
       return origin;
     }
 
-    return this.#config.localNodeAllowedOrigins.includes(origin) ? origin : undefined;
+    return this.#localNodePairingManager.isOriginPaired(origin) ? origin : undefined;
   }
 
   static #isLocalNodePublicCorsRoute(path: string): boolean {
     return path === '/info'
       || path === '/local/pair'
       || path.startsWith('/local/pair/');
+  }
+
+  static #isLocalNodePublicRoute(path: string, method: string): boolean {
+    return method === 'OPTIONS'
+      || (method === 'GET' && path === '/info')
+      || (method === 'POST' && path === '/local/pair')
+      || (method === 'GET' && path.startsWith('/local/pair/'));
+  }
+
+  #authorizeLocalNodeRequest(req: Request, url: URL, path: string, method: string): Response | undefined {
+    if (HttpApi.#isLocalNodePublicRoute(path, method)) {
+      return undefined;
+    }
+
+    const origin = req.headers.get('origin') ?? undefined;
+    const token = HttpApi.#getLocalNodeAuthToken(req, url);
+    if (this.#localNodePairingManager.validateSession(origin, token)) {
+      return undefined;
+    }
+
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  static #getLocalNodeAuthToken(req: Request, url: URL): string | undefined {
+    const bearerToken = HttpApi.#getBearerToken(req.headers.get('authorization'));
+    if (bearerToken !== undefined) {
+      return bearerToken;
+    }
+
+    if (req.headers.get('upgrade') === 'websocket') {
+      return url.searchParams.get('localNodeToken') ?? undefined;
+    }
+
+    return undefined;
+  }
+
+  static #getBearerToken(authorizationHeader: string | null): string | undefined {
+    if (authorizationHeader === null) {
+      return undefined;
+    }
+
+    const parts = authorizationHeader.trim().split(/\s+/);
+    if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') {
+      return undefined;
+    }
+
+    return parts[1];
+  }
+
+  #handleLocalNodePairRequest(req: Request): Response {
+    const result = this.#localNodePairingManager.createRequest(req.headers.get('origin'));
+
+    if (result.status === 'invalid-origin') {
+      return Response.json({ error: result.message }, { status: 400 });
+    }
+
+    if (result.status === 'rate-limited') {
+      return Response.json(
+        { error: 'Pairing rate limit exceeded.' },
+        {
+          headers : { 'retry-after': String(Math.ceil(result.retryAfterMs / 1000)) },
+          status  : 429,
+        },
+      );
+    }
+
+    return Response.json({
+      requestId : result.requestId,
+      status    : 'pending',
+    });
+  }
+
+  #handleLocalNodePairPoll(path: string): Response {
+    const requestId = path.slice('/local/pair/'.length);
+    if (requestId.length === 0) {
+      return Response.json({ error: 'Pairing request ID is required.' }, { status: 400 });
+    }
+
+    const result = this.#localNodePairingManager.pollRequest(requestId);
+    if (result === undefined) {
+      return Response.json({ error: 'Pairing request not found.' }, { status: 404 });
+    }
+
+    return Response.json(result);
   }
 
   async #handleJsonRpcPost(req: Request): Promise<Response> {

--- a/packages/dwn-server/src/index.ts
+++ b/packages/dwn-server/src/index.ts
@@ -14,6 +14,13 @@ export { InMemoryEventBus } from './event-bus.js';
 export type { EventBus } from './event-bus.js';
 export { HttpApi } from './http-api.js';
 export { jsonRpcRouter } from './json-rpc-api.js';
+export { LocalNodePairingManager } from './local-node-pairing.js';
+export type {
+  LocalNodePairingCreateResult,
+  LocalNodePairingManagerOptions,
+  LocalNodePairingPollResult,
+  LocalNodePairingRequestView,
+} from './local-node-pairing.js';
 export type { MessageProcessedContext, MessageProcessedHook } from './message-processed-hook.js';
 export { OpenAuthHandler } from './registration/open-auth-handler.js';
 export { RegistrationManager } from './registration/registration-manager.js';

--- a/packages/dwn-server/src/local-node-pairing.ts
+++ b/packages/dwn-server/src/local-node-pairing.ts
@@ -1,0 +1,324 @@
+import { randomBytes, randomUUID, timingSafeEqual } from 'crypto';
+
+export type LocalNodePairingCreateResult =
+  | { status: 'created'; requestId: string }
+  | { status: 'coalesced'; requestId: string }
+  | { status: 'invalid-origin'; message: string }
+  | { status: 'rate-limited'; retryAfterMs: number };
+
+export type LocalNodePairingPollResult =
+  | { status: 'pending'; origin: string }
+  | { status: 'approved'; origin: string; token?: string }
+  | { status: 'denied'; origin: string }
+  | { status: 'expired'; origin: string };
+
+export type LocalNodePairingRequestView = {
+  id : string;
+  origin : string;
+  status : LocalNodePairingPollResult['status'];
+  createdAt : number;
+  expiresAt : number;
+};
+
+export type LocalNodePairingManagerOptions = {
+  now? : () => number;
+  pairingRequestTtlMs? : number;
+  pairingRateLimitMax? : number;
+  pairingRateLimitWindowMs? : number;
+  terminalRequestRetentionMs?: number;
+};
+
+type LocalNodePairingRequest = {
+  id : string;
+  origin : string;
+  status : LocalNodePairingPollResult['status'];
+  createdAt : number;
+  expiresAt : number;
+  completedAt? : number;
+  token? : string;
+  tokenReturned : boolean;
+};
+
+type LocalNodeSession = {
+  origin : string | undefined;
+  token : string;
+  createdAt : number;
+};
+
+const defaultPairingRequestTtlMs = 5 * 60 * 1000;
+const defaultPairingRateLimitMax = 5;
+const defaultPairingRateLimitWindowMs = 60 * 1000;
+const defaultTerminalRequestRetentionMs = 5 * 60 * 1000;
+
+function normalizeOrigin(origin: string): string | undefined {
+  try {
+    const url = new URL(origin);
+    if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.origin !== origin) {
+      return undefined;
+    }
+    return origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export class LocalNodePairingManager {
+  readonly #now: () => number;
+  readonly #pairingRequestTtlMs: number;
+  readonly #pairingRateLimitMax: number;
+  readonly #pairingRateLimitWindowMs: number;
+  readonly #terminalRequestRetentionMs: number;
+  readonly #requests: Map<string, LocalNodePairingRequest> = new Map();
+  readonly #pendingRequestIdsByOrigin: Map<string, string> = new Map();
+  readonly #pairingAttemptsByOrigin: Map<string, number[]> = new Map();
+  readonly #sessionsByToken: Map<string, LocalNodeSession> = new Map();
+
+  public constructor(options: LocalNodePairingManagerOptions = {}) {
+    this.#now = options.now ?? ((): number => Date.now());
+    this.#pairingRequestTtlMs = options.pairingRequestTtlMs ?? defaultPairingRequestTtlMs;
+    this.#pairingRateLimitMax = options.pairingRateLimitMax ?? defaultPairingRateLimitMax;
+    this.#pairingRateLimitWindowMs = options.pairingRateLimitWindowMs ?? defaultPairingRateLimitWindowMs;
+    this.#terminalRequestRetentionMs = options.terminalRequestRetentionMs ?? defaultTerminalRequestRetentionMs;
+  }
+
+  public createRequest(originHeader: string | null): LocalNodePairingCreateResult {
+    if (originHeader === null) {
+      return { status: 'invalid-origin', message: 'Origin header is required.' };
+    }
+
+    const origin = normalizeOrigin(originHeader);
+    if (origin === undefined) {
+      return { status: 'invalid-origin', message: 'Origin header must be an http(s) origin.' };
+    }
+
+    const now = this.#now();
+    this.#prune(now);
+
+    const pendingRequestId = this.#pendingRequestIdsByOrigin.get(origin);
+    if (pendingRequestId !== undefined) {
+      const pendingRequest = this.#requests.get(pendingRequestId);
+      if (pendingRequest !== undefined && pendingRequest.status === 'pending' && pendingRequest.expiresAt > now) {
+        return { status: 'coalesced', requestId: pendingRequest.id };
+      }
+    }
+
+    const retryAfterMs = this.#consumePairingAttempt(origin, now);
+    if (retryAfterMs !== undefined) {
+      return { status: 'rate-limited', retryAfterMs };
+    }
+
+    const request: LocalNodePairingRequest = {
+      createdAt     : now,
+      expiresAt     : now + this.#pairingRequestTtlMs,
+      id            : randomUUID(),
+      origin,
+      status        : 'pending',
+      tokenReturned : false,
+    };
+
+    this.#requests.set(request.id, request);
+    this.#pendingRequestIdsByOrigin.set(origin, request.id);
+
+    return { status: 'created', requestId: request.id };
+  }
+
+  public approveRequest(requestId: string): boolean {
+    const request = this.#getActivePendingRequest(requestId);
+    if (request === undefined) {
+      return false;
+    }
+
+    const now = this.#now();
+    const token = randomBytes(32).toString('base64url');
+    request.status = 'approved';
+    request.completedAt = now;
+    request.token = token;
+    this.#pendingRequestIdsByOrigin.delete(request.origin);
+    this.#sessionsByToken.set(token, { createdAt: now, origin: request.origin, token });
+
+    return true;
+  }
+
+  public denyRequest(requestId: string): boolean {
+    const request = this.#getActivePendingRequest(requestId);
+    if (request === undefined) {
+      return false;
+    }
+
+    request.status = 'denied';
+    request.completedAt = this.#now();
+    this.#pendingRequestIdsByOrigin.delete(request.origin);
+
+    return true;
+  }
+
+  public pollRequest(requestId: string): LocalNodePairingPollResult | undefined {
+    const request = this.#requests.get(requestId);
+    if (request === undefined) {
+      return undefined;
+    }
+
+    const now = this.#now();
+    if (request.status === 'pending' && request.expiresAt <= now) {
+      request.status = 'expired';
+      request.completedAt = now;
+      this.#pendingRequestIdsByOrigin.delete(request.origin);
+    }
+
+    if (request.status === 'approved') {
+      if (request.tokenReturned || request.token === undefined) {
+        return { origin: request.origin, status: 'approved' };
+      }
+
+      request.tokenReturned = true;
+      return { origin: request.origin, status: 'approved', token: request.token };
+    }
+
+    return { origin: request.origin, status: request.status };
+  }
+
+  public getRequest(requestId: string): LocalNodePairingRequestView | undefined {
+    const request = this.#requests.get(requestId);
+    if (request === undefined) {
+      return undefined;
+    }
+
+    return {
+      createdAt : request.createdAt,
+      expiresAt : request.expiresAt,
+      id        : request.id,
+      origin    : request.origin,
+      status    : request.status,
+    };
+  }
+
+  public listPendingRequests(): LocalNodePairingRequestView[] {
+    const now = this.#now();
+    this.#prune(now);
+
+    return Array.from(this.#requests.values())
+      .filter((request: LocalNodePairingRequest): boolean => request.status === 'pending')
+      .map((request: LocalNodePairingRequest): LocalNodePairingRequestView => ({
+        createdAt : request.createdAt,
+        expiresAt : request.expiresAt,
+        id        : request.id,
+        origin    : request.origin,
+        status    : request.status,
+      }));
+  }
+
+  public createSession(origin: string | undefined): string {
+    const normalizedOrigin = origin === undefined ? undefined : normalizeOrigin(origin);
+    if (origin !== undefined && normalizedOrigin === undefined) {
+      throw new Error('LocalNodePairingManager: origin must be an http(s) origin.');
+    }
+
+    const token = randomBytes(32).toString('base64url');
+    this.#sessionsByToken.set(token, {
+      createdAt : this.#now(),
+      origin    : normalizedOrigin,
+      token,
+    });
+
+    return token;
+  }
+
+  public validateSession(origin: string | undefined, token: string | undefined): boolean {
+    if (token === undefined) {
+      return false;
+    }
+
+    const session = this.#sessionsByToken.get(token);
+    if (session === undefined || !constantTimeEqual(session.token, token)) {
+      return false;
+    }
+
+    if (session.origin === undefined) {
+      return origin === undefined;
+    }
+
+    return origin === session.origin;
+  }
+
+  public isOriginPaired(originHeader: string | null): boolean {
+    if (originHeader === null || normalizeOrigin(originHeader) === undefined) {
+      return false;
+    }
+
+    for (const session of this.#sessionsByToken.values()) {
+      if (session.origin === originHeader) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  public revokeToken(token: string): boolean {
+    return this.#sessionsByToken.delete(token);
+  }
+
+  #getActivePendingRequest(requestId: string): LocalNodePairingRequest | undefined {
+    const request = this.#requests.get(requestId);
+    const now = this.#now();
+    if (request === undefined || request.status !== 'pending') {
+      return undefined;
+    }
+
+    if (request.expiresAt <= now) {
+      request.status = 'expired';
+      request.completedAt = now;
+      this.#pendingRequestIdsByOrigin.delete(request.origin);
+      return undefined;
+    }
+
+    return request;
+  }
+
+  #consumePairingAttempt(origin: string, now: number): number | undefined {
+    const attemptWindowStart = now - this.#pairingRateLimitWindowMs;
+    const recentAttempts = (this.#pairingAttemptsByOrigin.get(origin) ?? [])
+      .filter((attemptedAt: number): boolean => attemptedAt > attemptWindowStart);
+
+    if (recentAttempts.length >= this.#pairingRateLimitMax) {
+      return this.#pairingRateLimitWindowMs - (now - recentAttempts[0]);
+    }
+
+    recentAttempts.push(now);
+    this.#pairingAttemptsByOrigin.set(origin, recentAttempts);
+
+    return undefined;
+  }
+
+  #prune(now: number): void {
+    const terminalRequestCutoff = now - this.#terminalRequestRetentionMs;
+    for (const [requestId, request] of this.#requests) {
+      if (request.status === 'pending' && request.expiresAt <= now) {
+        request.status = 'expired';
+        request.completedAt = now;
+        this.#pendingRequestIdsByOrigin.delete(request.origin);
+      }
+
+      if (request.status !== 'pending' && request.completedAt !== undefined && request.completedAt <= terminalRequestCutoff) {
+        this.#requests.delete(requestId);
+      }
+    }
+
+    const attemptWindowStart = now - this.#pairingRateLimitWindowMs;
+    for (const [origin, attempts] of this.#pairingAttemptsByOrigin) {
+      const recentAttempts = attempts.filter((attemptedAt: number): boolean => attemptedAt > attemptWindowStart);
+      if (recentAttempts.length === 0) {
+        this.#pairingAttemptsByOrigin.delete(origin);
+      } else {
+        this.#pairingAttemptsByOrigin.set(origin, recentAttempts);
+      }
+    }
+  }
+}

--- a/packages/dwn-server/tests/dwn-server.test.ts
+++ b/packages/dwn-server/tests/dwn-server.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'bun:test';
 import { config } from '../src/config.js';
 import { DwnServer } from '../src/dwn-server.js';
 import { getTestDwn } from './test-dwn.js';
+import { LocalNodePairingManager } from '../src/local-node-pairing.js';
 
 describe('DwnServer', () => {
   const dwnServerConfig = { ...config, port: 0 };
@@ -60,6 +61,27 @@ describe('DwnServer', () => {
   });
 
   describe('local node profile', () => {
+    it('should expose the injected local node pairing manager', async () => {
+      ({ dwn } = await getTestDwn());
+      const localNodePairingManager = new LocalNodePairingManager();
+      const server = new DwnServer({
+        dwn,
+        localNodePairingManager,
+        config: {
+          ...dwnServerConfig,
+          hostname                : '127.0.0.1',
+          localNodeProfileEnabled : true,
+        }
+      });
+
+      try {
+        await server.start();
+        expect(server.localNodePairingManager).toBe(localNodePairingManager);
+      } finally {
+        await server.stop();
+      }
+    });
+
     it('should reject non-loopback bind hostnames', async () => {
       ({ dwn } = await getTestDwn());
       const server = new DwnServer({

--- a/packages/dwn-server/tests/http-api.test.ts
+++ b/packages/dwn-server/tests/http-api.test.ts
@@ -3,6 +3,7 @@ import type { DwnServerConfig } from '../src/config.js';
 import type { Dwn, Persona, ProtocolsConfigureMessage, RecordsQueryReply } from '@enbox/dwn-sdk-js';
 import type { JsonRpcErrorResponse, JsonRpcResponse, ServerInfo } from '@enbox/dwn-clients';
 
+import { connect } from 'net';
 import { Convert } from '@enbox/common';
 import log from 'loglevel';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
@@ -20,6 +21,7 @@ import CommonScenarioValidator from './common-scenario-validator.js';
 import { config } from '../src/config.js';
 import { getTestDwn } from './test-dwn.js';
 import { HttpApi } from '../src/http-api.js';
+import { LocalNodePairingManager } from '../src/local-node-pairing.js';
 import { RegistrationManager } from '../src/registration/registration-manager.js';
 import { runServerMigrationsIfNeeded } from '../src/storage.js';
 import { createJsonRpcRequest, JsonRpcErrorCodes } from '@enbox/dwn-clients';
@@ -38,12 +40,18 @@ describe('http api', function () {
   let clock;
   let baseUrl: string;
 
-  async function createStartedHttpApiWithConfig(overrides: Partial<DwnServerConfig>): Promise<{ api: HttpApi; url: string; }> {
+  async function createStartedHttpApiWithConfig(
+    overrides: Partial<DwnServerConfig>,
+    options: { localNodePairingManager?: LocalNodePairingManager } = {},
+  ): Promise<{ api: HttpApi; url: string; }> {
     const testConfig: DwnServerConfig = {
       ...config,
       ...overrides,
     };
-    const api = await HttpApi.create(testConfig, dwn, registrationManager, undefined, undefined, { ttlCacheDialect: dialect });
+    const api = await HttpApi.create(testConfig, dwn, registrationManager, undefined, undefined, {
+      localNodePairingManager : options.localNodePairingManager,
+      ttlCacheDialect         : dialect,
+    });
     await api.start(0);
 
     const hostname = testConfig.hostname ?? 'localhost';
@@ -1206,24 +1214,31 @@ describe('http api', function () {
       }
     });
 
-    it('should only reflect configured origins on local-node protected routes', async () => {
+    it('should only reflect paired origins on local-node protected routes', async () => {
+      const localNodePairingManager = new LocalNodePairingManager();
+      const token = localNodePairingManager.createSession('https://paired.example');
       const { api, url } = await createStartedHttpApiWithConfig({
         hostname                : '127.0.0.1',
-        localNodeAllowedOrigins : ['https://paired.example'],
         localNodeProfileEnabled : true,
-      });
+      }, { localNodePairingManager });
 
       try {
         const pairedResponse = await fetch(`${url}/health`, {
-          headers: { origin: 'https://paired.example' },
+          headers: {
+            authorization : `Bearer ${token}`,
+            origin        : 'https://paired.example',
+          },
         });
         expect(pairedResponse.status).toBe(200);
         expect(pairedResponse.headers.get('access-control-allow-origin')).toBe('https://paired.example');
 
         const unpairedResponse = await fetch(`${url}/health`, {
-          headers: { origin: 'https://unpaired.example' },
+          headers: {
+            authorization : `Bearer ${token}`,
+            origin        : 'https://unpaired.example',
+          },
         });
-        expect(unpairedResponse.status).toBe(200);
+        expect(unpairedResponse.status).toBe(401);
         expect(unpairedResponse.headers.get('access-control-allow-origin')).toBeNull();
       } finally {
         await api.close();
@@ -1232,6 +1247,178 @@ describe('http api', function () {
   });
 
   describe('local node profile', () => {
+    async function requestWebSocketUpgradeStatus(wsUrl: string, origin: string): Promise<number> {
+      const url = new URL(wsUrl);
+      const requestPath = `${url.pathname}${url.search}`;
+
+      return new Promise<number>((resolve, reject) => {
+        const socket = connect({
+          host : url.hostname,
+          port : Number.parseInt(url.port, 10),
+        });
+        let response = '';
+        const timeout = setTimeout((): void => {
+          socket.destroy();
+          reject(new Error('WebSocket upgrade response timeout'));
+        }, 3000);
+
+        socket.setEncoding('utf8');
+        socket.once('connect', (): void => {
+          socket.write([
+            `GET ${requestPath} HTTP/1.1`,
+            `Host: ${url.host}`,
+            'Upgrade: websocket',
+            'Connection: Upgrade',
+            'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+            'Sec-WebSocket-Version: 13',
+            `Origin: ${origin}`,
+            '',
+            '',
+          ].join('\r\n'));
+        });
+        socket.on('data', (chunk: string): void => {
+          response += chunk;
+          const statusLineEnd = response.indexOf('\r\n');
+          if (statusLineEnd === -1) {
+            return;
+          }
+
+          clearTimeout(timeout);
+          socket.destroy();
+
+          const statusLine = response.slice(0, statusLineEnd);
+          const statusMatch = /^HTTP\/1\.1 (\d{3})/.exec(statusLine);
+          if (statusMatch === null) {
+            reject(new Error(`unexpected WebSocket upgrade response: ${statusLine}`));
+            return;
+          }
+
+          resolve(Number.parseInt(statusMatch[1], 10));
+        });
+        socket.once('error', (error: Error): void => {
+          clearTimeout(timeout);
+          reject(error);
+        });
+      });
+    }
+
+    it('should create and poll pairing requests and return approved tokens once', async () => {
+      const localNodePairingManager = new LocalNodePairingManager();
+      const { api, url } = await createStartedHttpApiWithConfig({
+        hostname                : '127.0.0.1',
+        localNodeProfileEnabled : true,
+      }, { localNodePairingManager });
+
+      try {
+        const pairResponse = await fetch(`${url}/local/pair`, {
+          headers : { origin: 'https://app.example' },
+          method  : 'POST',
+        });
+        expect(pairResponse.status).toBe(200);
+        expect(pairResponse.headers.get('access-control-allow-origin')).toBe('https://app.example');
+
+        const pairBody = await pairResponse.json() as { requestId: string; status: string };
+        expect(typeof pairBody.requestId).toBe('string');
+        expect(pairBody.status).toBe('pending');
+        expect(localNodePairingManager.listPendingRequests()[0].origin).toBe('https://app.example');
+
+        const pendingResponse = await fetch(`${url}/local/pair/${pairBody.requestId}`, {
+          headers: { origin: 'https://app.example' },
+        });
+        expect(await pendingResponse.json()).toEqual({
+          origin : 'https://app.example',
+          status : 'pending',
+        });
+
+        expect(localNodePairingManager.approveRequest(pairBody.requestId)).toBe(true);
+
+        const approvedResponse = await fetch(`${url}/local/pair/${pairBody.requestId}`, {
+          headers: { origin: 'https://app.example' },
+        });
+        const approvedBody = await approvedResponse.json() as { origin: string; status: string; token?: string };
+        expect(approvedBody.origin).toBe('https://app.example');
+        expect(approvedBody.status).toBe('approved');
+        expect(typeof approvedBody.token).toBe('string');
+
+        const secondApprovedResponse = await fetch(`${url}/local/pair/${pairBody.requestId}`, {
+          headers: { origin: 'https://app.example' },
+        });
+        expect(await secondApprovedResponse.json()).toEqual({
+          origin : 'https://app.example',
+          status : 'approved',
+        });
+
+        const authenticatedResponse = await fetch(`${url}/health`, {
+          headers: {
+            authorization : `Bearer ${approvedBody.token}`,
+            origin        : 'https://app.example',
+          },
+        });
+        expect(authenticatedResponse.status).toBe(200);
+        expect(authenticatedResponse.headers.get('access-control-allow-origin')).toBe('https://app.example');
+
+        const missingTokenResponse = await fetch(`${url}/health`, {
+          headers: { origin: 'https://app.example' },
+        });
+        expect(missingTokenResponse.status).toBe(401);
+        expect(missingTokenResponse.headers.get('access-control-allow-origin')).toBe('https://app.example');
+      } finally {
+        await api.close();
+      }
+    });
+
+    it('should reject pairing requests without an Origin header', async () => {
+      const { api, url } = await createStartedHttpApiWithConfig({
+        hostname                : '127.0.0.1',
+        localNodeProfileEnabled : true,
+      });
+
+      try {
+        const response = await fetch(`${url}/local/pair`, { method: 'POST' });
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Origin header is required.' });
+      } finally {
+        await api.close();
+      }
+    });
+
+    it('should accept no-Origin requests with a no-Origin local session token', async () => {
+      const localNodePairingManager = new LocalNodePairingManager();
+      const token = localNodePairingManager.createSession(undefined);
+      const { api, url } = await createStartedHttpApiWithConfig({
+        hostname                : '127.0.0.1',
+        localNodeProfileEnabled : true,
+      }, { localNodePairingManager });
+
+      try {
+        const response = await fetch(`${url}/health`, {
+          headers: { authorization: `Bearer ${token}` },
+        });
+        expect(response.status).toBe(200);
+        expect(response.headers.get('access-control-allow-origin')).toBeNull();
+      } finally {
+        await api.close();
+      }
+    });
+
+    it('should enforce local-node tokens before WebSocket upgrade', async () => {
+      const localNodePairingManager = new LocalNodePairingManager();
+      const token = localNodePairingManager.createSession('https://paired.example');
+      const { api, url } = await createStartedHttpApiWithConfig({
+        hostname                : '127.0.0.1',
+        localNodeProfileEnabled : true,
+      }, { localNodePairingManager });
+      const wsUrl = url.replace(/^http:/, 'ws:');
+
+      try {
+        await expect(requestWebSocketUpgradeStatus(`${wsUrl}?localNodeToken=wrong`, 'https://paired.example')).resolves.toBe(401);
+        await expect(requestWebSocketUpgradeStatus(`${wsUrl}?localNodeToken=${token}`, 'https://unpaired.example')).resolves.toBe(401);
+        await expect(requestWebSocketUpgradeStatus(`${wsUrl}?localNodeToken=${token}`, 'https://paired.example')).resolves.toBe(101);
+      } finally {
+        await api.close();
+      }
+    });
+
     it('should reject requests with non-loopback Host headers', async () => {
       const { api, url } = await createStartedHttpApiWithConfig({
         hostname                : '127.0.0.1',

--- a/packages/dwn-server/tests/local-node-pairing.test.ts
+++ b/packages/dwn-server/tests/local-node-pairing.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test';
+
+import { LocalNodePairingManager } from '../src/local-node-pairing.js';
+
+describe('LocalNodePairingManager', () => {
+  it('should coalesce pending requests and return an approved token once', () => {
+    const manager = new LocalNodePairingManager();
+
+    const firstCreate = manager.createRequest('https://app.example');
+    expect(firstCreate.status).toBe('created');
+    if (firstCreate.status !== 'created') {
+      throw new Error('expected created pairing request');
+    }
+
+    const secondCreate = manager.createRequest('https://app.example');
+    expect(secondCreate.status).toBe('coalesced');
+    expect(secondCreate.requestId).toBe(firstCreate.requestId);
+
+    expect(manager.approveRequest(firstCreate.requestId)).toBe(true);
+
+    const firstPoll = manager.pollRequest(firstCreate.requestId);
+    expect(firstPoll?.status).toBe('approved');
+    if (firstPoll?.status !== 'approved') {
+      throw new Error('expected approved pairing request');
+    }
+
+    expect(typeof firstPoll.token).toBe('string');
+    expect(manager.validateSession('https://app.example', firstPoll.token)).toBe(true);
+    expect(manager.validateSession('https://other.example', firstPoll.token)).toBe(false);
+
+    const secondPoll = manager.pollRequest(firstCreate.requestId);
+    expect(secondPoll).toEqual({ origin: 'https://app.example', status: 'approved' });
+  });
+
+  it('should reject missing and non-http origins', () => {
+    const manager = new LocalNodePairingManager();
+
+    expect(manager.createRequest(null)).toEqual({
+      message : 'Origin header is required.',
+      status  : 'invalid-origin',
+    });
+    expect(manager.createRequest('chrome-extension://abc')).toEqual({
+      message : 'Origin header must be an http(s) origin.',
+      status  : 'invalid-origin',
+    });
+    expect(manager.createRequest('https://app.example/path')).toEqual({
+      message : 'Origin header must be an http(s) origin.',
+      status  : 'invalid-origin',
+    });
+  });
+
+  it('should expire pending requests', () => {
+    let now = 1_000;
+    const manager = new LocalNodePairingManager({
+      now                 : (): number => now,
+      pairingRequestTtlMs : 100,
+    });
+
+    const created = manager.createRequest('https://app.example');
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') {
+      throw new Error('expected created pairing request');
+    }
+
+    now += 101;
+    expect(manager.approveRequest(created.requestId)).toBe(false);
+    expect(manager.pollRequest(created.requestId)).toEqual({
+      origin : 'https://app.example',
+      status : 'expired',
+    });
+  });
+
+  it('should rate limit new pairing requests per origin', () => {
+    const manager = new LocalNodePairingManager({
+      pairingRateLimitMax      : 1,
+      pairingRateLimitWindowMs : 60_000,
+    });
+
+    const created = manager.createRequest('https://app.example');
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') {
+      throw new Error('expected created pairing request');
+    }
+
+    expect(manager.denyRequest(created.requestId)).toBe(true);
+
+    const rateLimited = manager.createRequest('https://app.example');
+    expect(rateLimited.status).toBe('rate-limited');
+  });
+
+  it('should validate no-Origin sessions only for no-Origin requests', () => {
+    const manager = new LocalNodePairingManager();
+    const token = manager.createSession(undefined);
+
+    expect(manager.validateSession(undefined, token)).toBe(true);
+    expect(manager.validateSession('https://app.example', token)).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary
- Add an in-memory LocalNodePairingManager with coalesced per-origin pairing requests, request expiry, rate limiting, approve/deny controls, token-return-once polling, no-Origin sessions, and token revocation.
- Add local-profile /local/pair endpoints and enforce local-node auth before HTTP routing and before WebSocket upgrade.
- Switch protected local-profile CORS reflection to paired origins and expose the pairing manager through DwnServer for the upcoming @enbox/local-node wrapper.

Scope note
- This is the server pairing/auth slice for #1164. Durable pairing storage, shell-specific approval prompts, discovery-file token distribution, immediate live WebSocket close on revocation, and the @enbox/local-node package remain for the next Phase 1 slices.

Test plan
- [x] bun run lint
- [x] bun run build
- [x] bun run --filter @enbox/dwn-server lint
- [x] bun test --timeout 30000 tests/local-node-pairing.test.ts tests/local-node-profile.test.ts tests/http-api.test.ts tests/dwn-server.test.ts (from packages/dwn-server after build)
- [x] bun run --filter @enbox/dwn-server test:node
- [x] bunx changeset status
- [x] git diff --check HEAD

Refs #1164