### PR TITLE
feat(local-node): add runtime core

### DIFF
--- a/.changeset/local-node-core.md
+++ b/.changeset/local-node-core.md
@@ -1,0 +1,6 @@
+---
+"@enbox/local-node": minor
+"@enbox/agent": patch
+---
+
+feat: add local-node runtime core and discovery-file token metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       needs_dwn_sql_store: ${{ steps.propagate.outputs.needs_dwn_sql_store }}
       needs_dwn_server: ${{ steps.propagate.outputs.needs_dwn_server }}
       needs_agent: ${{ steps.propagate.outputs.needs_agent }}
+      needs_local_node: ${{ steps.propagate.outputs.needs_local_node }}
       needs_auth: ${{ steps.propagate.outputs.needs_auth }}
       needs_api: ${{ steps.propagate.outputs.needs_api }}
       needs_agent_api_group: ${{ steps.propagate.outputs.needs_agent_api_group }}
@@ -128,6 +129,12 @@ jobs:
               - 'packages/dwn-server/tsconfig.json'
               - 'packages/dwn-server/vitest*.config.*'
 
+            local-node:
+              - 'packages/local-node/src/**'
+              - 'packages/local-node/tests/**'
+              - 'packages/local-node/package.json'
+              - 'packages/local-node/tsconfig.json'
+
             agent:
               - 'packages/agent/src/**'
               - 'packages/agent/tests/**'
@@ -185,6 +192,7 @@ jobs:
           dwn_clients="${{ steps.filter.outputs.dwn-clients }}"
           dwn_sql_store="${{ steps.filter.outputs.dwn-sql-store }}"
           dwn_server="${{ steps.filter.outputs.dwn-server }}"
+          local_node="${{ steps.filter.outputs.local-node }}"
           agent="${{ steps.filter.outputs.agent }}"
           auth="${{ steps.filter.outputs.auth }}"
           api="${{ steps.filter.outputs.api }}"
@@ -201,10 +209,11 @@ jobs:
           needs_dwn_sql_store=$( [ "$needs_dwn_sdk" = "true" ] || [ "$dwn_sql_store" = "true" ] && echo true || echo false )
           needs_dwn_server=$( [ "$needs_dwn_sdk" = "true" ] || [ "$needs_dwn_clients" = "true" ] || [ "$needs_dwn_sql_store" = "true" ] || [ "$dwn_server" = "true" ] && echo true || echo false )
           needs_agent=$( [ "$needs_dids" = "true" ] || [ "$needs_dwn_sdk" = "true" ] || [ "$needs_dwn_clients" = "true" ] || [ "$agent" = "true" ] && echo true || echo false )
+          needs_local_node=$( [ "$needs_agent" = "true" ] || [ "$needs_dwn_server" = "true" ] || [ "$local_node" = "true" ] && echo true || echo false )
           needs_auth=$( [ "$needs_agent" = "true" ] || [ "$auth" = "true" ] && echo true || echo false )
           needs_api=$( [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$api" = "true" ] && echo true || echo false )
           needs_cli=$( [ "$needs_api" = "true" ] || [ "$cli" = "true" ] && echo true || echo false )
-          needs_lightweight=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_auth" = "true" ] || [ "$protocol_codegen" = "true" ] || [ "$needs_cli" = "true" ] && echo true || echo false )
+          needs_lightweight=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_auth" = "true" ] || [ "$protocol_codegen" = "true" ] || [ "$needs_cli" = "true" ] || [ "$needs_local_node" = "true" ] && echo true || echo false )
           needs_agent_api_group=$( [ "$needs_dids" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_auth" = "true" ] || [ "$needs_api" = "true" ] || [ "$dwn_clients" = "true" ] || [ "$protocols" = "true" ] && echo true || echo false )
           needs_browser_tests=$( [ "$needs_common_crypto" = "true" ] || [ "$needs_dids" = "true" ] || [ "$needs_dwn_sdk" = "true" ] || [ "$needs_agent" = "true" ] || [ "$needs_api" = "true" ] || [ "$browser_pkg" = "true" ] && echo true || echo false )
           needs_e2e=$( [ "$needs_agent" = "true" ] && echo true || echo false )
@@ -219,6 +228,7 @@ jobs:
             echo "needs_dwn_sql_store=$needs_dwn_sql_store"
             echo "needs_dwn_server=$needs_dwn_server"
             echo "needs_agent=$needs_agent"
+            echo "needs_local_node=$needs_local_node"
             echo "needs_auth=$needs_auth"
             echo "needs_api=$needs_api"
             echo "needs_agent_api_group=$needs_agent_api_group"
@@ -229,7 +239,7 @@ jobs:
           echo "Change detection results:"
           echo "  common_crypto=$needs_common_crypto dids=$needs_dids dwn_sdk=$needs_dwn_sdk"
           echo "  dwn_clients=$needs_dwn_clients dwn_sql_store=$needs_dwn_sql_store dwn_server=$needs_dwn_server"
-          echo "  agent=$needs_agent auth=$needs_auth api=$needs_api protocol_codegen=$protocol_codegen cli=$needs_cli"
+          echo "  agent=$needs_agent local_node=$needs_local_node auth=$needs_auth api=$needs_api protocol_codegen=$protocol_codegen cli=$needs_cli"
           echo "  agent_api_group=$needs_agent_api_group browser=$needs_browser_tests e2e=$needs_e2e"
 
   # ---------------------------------------------------------------------------
@@ -308,7 +318,7 @@ jobs:
           retention-days: 1
 
   # ---------------------------------------------------------------------------
-  # Lightweight packages: common, crypto, auth, protocol-codegen, cli
+  # Lightweight packages: common, crypto, auth, protocol-codegen, cli, local-node
   # (no external services needed)
   # ---------------------------------------------------------------------------
   test-lightweight:
@@ -351,16 +361,18 @@ jobs:
           bun run --filter @enbox/auth    test:node:coverage
           bun run --filter @enbox/protocol-codegen test:node:coverage
           bun run --filter @enbox/cli     test:node:coverage
+          bun run --filter @enbox/local-node test:node:coverage
 
       - name: Stage coverage
         if: always()
         run: |
-          mkdir -p coverage-staging/packages/common/coverage coverage-staging/packages/crypto/coverage coverage-staging/packages/auth/coverage coverage-staging/packages/protocol-codegen/coverage coverage-staging/packages/cli/coverage
+          mkdir -p coverage-staging/packages/common/coverage coverage-staging/packages/crypto/coverage coverage-staging/packages/auth/coverage coverage-staging/packages/protocol-codegen/coverage coverage-staging/packages/cli/coverage coverage-staging/packages/local-node/coverage
           cp packages/common/coverage/lcov.info coverage-staging/packages/common/coverage/lcov.info 2>/dev/null || true
           cp packages/crypto/coverage/lcov.info coverage-staging/packages/crypto/coverage/lcov.info 2>/dev/null || true
           cp packages/auth/coverage/lcov.info coverage-staging/packages/auth/coverage/lcov.info 2>/dev/null || true
           cp packages/protocol-codegen/coverage/lcov.info coverage-staging/packages/protocol-codegen/coverage/lcov.info 2>/dev/null || true
           cp packages/cli/coverage/lcov.info coverage-staging/packages/cli/coverage/lcov.info 2>/dev/null || true
+          cp packages/local-node/coverage/lcov.info coverage-staging/packages/local-node/coverage/lcov.info 2>/dev/null || true
 
       - name: Upload coverage
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ Published / primary packages live under `packages/`. Root `package.json` lists a
 | `@enbox/protocols` | Reusable protocol definitions for the ecosystem |
 | `@enbox/protocol-codegen` | CLI to generate TS from schemas / protocols |
 | `@enbox/dwn-server-admin-ui` | Bundled Preact admin UI assets for the server |
+| `@enbox/local-node` | Shell-agnostic local DWN node runtime and headless CLI |
 | `@enbox/electrobun-dwn` | **Private** desktop wrapper embedding the server |
 
 ### Package dependency graph (build order)
@@ -147,6 +148,7 @@ Core stack (simplified — follow `workspace:*` in each `package.json` for exact
         @enbox/dwn-clients (DWN JSON-RPC / transport clients)
           @enbox/dwn-server (HTTP/WebSocket DWN server, registration, admin API — uses dwn-sdk-js + dwn-sql-store + dwn-clients)
           @enbox/agent (identity vault, DWN-backed stores, sync — uses dwn-sdk-js + dwn-clients)
+            @enbox/local-node (local-profile server runtime — uses agent discovery helpers + dwn-server)
             @enbox/auth (AuthManager, sessions, connect flows — uses agent + dwn-sdk-js + dwn-clients)
               @enbox/api (high-level app SDK — uses agent + auth + dwn-clients)
                 @enbox/protocols (published protocol definitions — uses api + dwn-sdk-js)
@@ -160,6 +162,7 @@ Notes on the graph:
 - `@enbox/auth` depends directly on `@enbox/agent`, `@enbox/dwn-sdk-js`, and `@enbox/dwn-clients` (plus `common`/`crypto`/`dids`).
 - `@enbox/browser` composes `agent` + `api` + `auth` + `dids`; it does not pull in `dwn-server` or `dwn-sql-store`.
 - `@enbox/cli` composes `agent` + `api` + `auth` with Node/Bun-only terminal dependencies; it does not expose a browser bundle.
+- `@enbox/local-node` composes `agent` discovery helpers with `dwn-server`; it is shell-agnostic local-node runtime code, not browser code.
 
 Build from the bottom up. If you change `dwn-sdk-js`, rebuild it before building `agent`:
 
@@ -173,7 +176,7 @@ Most packages expose a `build:browser` script, but it means different things:
 - **`@enbox/agent`**, **`@enbox/api`**, **`@enbox/auth`**, and **`@enbox/browser`** emit bundled `dist/browser.mjs` artifacts via `build/browser-bundle.js` (esbuild). `agent`, `api`, and `browser` expose those artifacts from their browser-conditioned root exports; `auth` exposes its browser-safe surface from `@enbox/auth/browser` and from the root browser condition.
 - **`@enbox/common`**, **`@enbox/crypto`**, and **`@enbox/dids`** expose `build:browser` for their browser bundle artifacts.
 - **`@enbox/dwn-sdk-js`** emits `dist/browser.mjs` via its `bundle` script, not a `build:browser` script.
-- **`@enbox/cli`**, **`@enbox/dwn-clients`**, **`@enbox/dwn-server`**, **`@enbox/dwn-sql-store`**, **`@enbox/protocols`**, and **`@enbox/protocol-codegen`** do not define `build:browser`.
+- **`@enbox/cli`**, **`@enbox/dwn-clients`**, **`@enbox/dwn-server`**, **`@enbox/dwn-sql-store`**, **`@enbox/local-node`**, **`@enbox/protocols`**, and **`@enbox/protocol-codegen`** do not define `build:browser`.
 
 Browser storage rule: do not replace the browser Level stack with SQLite or in-memory stores. In browsers, `level` resolves to `browser-level` over IndexedDB, which is required for concurrent writes from tabs, workers, and service workers on the same origin.
 
@@ -194,6 +197,7 @@ Browser storage rule: do not replace the browser Level stack with SQLite or in-m
 | `packages/dwn-clients/src/` | DWN client transport / JSON-RPC |
 | `packages/auth/src/` | `AuthManager`, storage adapters, connect and discovery helpers |
 | `packages/cli/src/` | CLI connect handler and terminal wallet approval helpers |
+| `packages/local-node/src/` | Shell-agnostic local DWN node runtime and headless CLI |
 | `packages/protocols/src/` | Shared protocol definitions consumed by apps |
 | `packages/protocol-codegen/src/` | Codegen CLI implementation |
 | `packages/dwn-server-admin-ui/` | Admin UI bundle source and build scripts |
@@ -227,6 +231,7 @@ When changing public APIs, assume **multiple external apps** pin different semve
 | Login/session/connect, `AuthManager` | `packages/auth/src/` |
 | High-level APIs for apps | `packages/api/src/` |
 | CLI wallet connect, terminal QR/link flows | `packages/cli/src/` |
+| Local DWN node runtime, pairing broker, discovery file writer | `packages/local-node/` |
 | `dwn://` discovery, browser connect | `packages/browser/src/`, `packages/auth/src/discovery.ts` |
 | Shared protocol definitions | `packages/protocols/` |
 | Docs site content | `apps/docs/content/docs/` |
@@ -278,6 +283,7 @@ After `bun run dev:ensure`, just run the suite — the `export DID_DHT_*` lines 
 | `@enbox/dids` | `bun test` | `bun run test:node` |
 | `@enbox/auth` | `bun test` | `bun run test:node` |
 | `@enbox/cli` | `bun test` | `bun run test:node` |
+| `@enbox/local-node` | `bun test` | `bun run test:node` |
 | `@enbox/dwn-clients` | `bun test` | `bun run test:node` |
 | `@enbox/protocols` | `bun test` | `bun run test:node` |
 | `@enbox/protocol-codegen` | `bun test` | `bun run test:node` |

--- a/bun.lock
+++ b/bun.lock
@@ -453,6 +453,25 @@
         "@types/bun": "1.3.14",
       },
     },
+    "packages/local-node": {
+      "name": "@enbox/local-node",
+      "version": "0.0.0",
+      "bin": {
+        "enbox-local-node": "./dist/esm/src/cli.js",
+      },
+      "dependencies": {
+        "@enbox/agent": "workspace:*",
+        "@enbox/dwn-server": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "22.19.15",
+        "@typescript-eslint/eslint-plugin": "8.32.1",
+        "@typescript-eslint/parser": "8.32.1",
+        "bun-types": "1.3.14",
+        "eslint": "9.7.0",
+        "typescript": "5.9.3",
+      },
+    },
     "packages/protocol-codegen": {
       "name": "@enbox/protocol-codegen",
       "version": "0.1.1",
@@ -701,6 +720,8 @@
     "@enbox/dwn-sql-store": ["@enbox/dwn-sql-store@workspace:packages/dwn-sql-store"],
 
     "@enbox/electrobun-dwn": ["@enbox/electrobun-dwn@workspace:packages/electrobun-dwn"],
+
+    "@enbox/local-node": ["@enbox/local-node@workspace:packages/local-node"],
 
     "@enbox/protocol-codegen": ["@enbox/protocol-codegen@workspace:packages/protocol-codegen"],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "packages/dwn-sql-store",
     "packages/dwn-server",
     "packages/dwn-server-admin-ui",
+    "packages/local-node",
     "packages/electrobun-dwn",
     "apps/docs"
   ],

--- a/packages/agent/src/dwn-discovery-file.ts
+++ b/packages/agent/src/dwn-discovery-file.ts
@@ -36,6 +36,11 @@ export interface DwnDiscoveryRecord {
    * Optional per the DWN Transport Spec.
    */
   capabilities?: string[];
+  /**
+   * Bearer token for local non-browser clients that do not send an Origin header.
+   * Browser origins receive their own tokens through the pairing flow.
+   */
+  localNodeToken?: string;
 }
 
 /**
@@ -172,6 +177,10 @@ export class DwnDiscoveryFile {
       result.capabilities = parsed.capabilities;
     }
 
+    if (parsed.localNodeToken !== undefined) {
+      result.localNodeToken = parsed.localNodeToken;
+    }
+
     return result;
   }
 
@@ -188,6 +197,10 @@ export class DwnDiscoveryFile {
 
     if (record.capabilities !== undefined && record.capabilities.length > 0) {
       serialized.capabilities = record.capabilities;
+    }
+
+    if (record.localNodeToken !== undefined) {
+      serialized.localNodeToken = record.localNodeToken;
     }
 
     const json = JSON.stringify(serialized, null, 2);
@@ -231,6 +244,9 @@ function isValidRecord(value: unknown): value is DwnDiscoveryRecord {
     }
   }
 
+  if (record.localNodeToken !== undefined && (typeof record.localNodeToken !== 'string' || record.localNodeToken.length === 0)) {
+    return false;
+  }
+
   return true;
 }
-

--- a/packages/agent/tests/dwn-discovery-file.spec.ts
+++ b/packages/agent/tests/dwn-discovery-file.spec.ts
@@ -397,6 +397,38 @@ describe('DwnDiscoveryFile', () => {
     });
   });
 
+  describe('localNodeToken', () => {
+    it('should round-trip a record with a local node token', async () => {
+      const fs = createMemoryFs({ isProcessAlive: () => true });
+      const file = new DwnDiscoveryFile(fs, testFilePath);
+
+      const record: DwnDiscoveryRecord = {
+        endpoint       : 'http://127.0.0.1:55500',
+        localNodeToken : 'local-node-token',
+        pid            : 42,
+      };
+      await file.write(record);
+      const result = await file.read();
+
+      expect(result).toEqual(record);
+    });
+
+    it('should reject an empty local node token', async () => {
+      const fs = createMemoryFs({ isProcessAlive: () => true });
+      fs.files.set(testFilePath, JSON.stringify({
+        endpoint       : 'http://127.0.0.1:55500',
+        localNodeToken : '',
+        pid            : 42,
+      }));
+
+      const file = new DwnDiscoveryFile(fs, testFilePath);
+      const result = await file.read();
+
+      expect(result).toBeUndefined();
+      expect(fs.files.has(testFilePath)).toBe(false);
+    });
+  });
+
   describe('round-trip', () => {
     it('should write and then read the same record', async () => {
       const fs = createMemoryFs({ isProcessAlive: () => true });

--- a/packages/local-node/package.json
+++ b/packages/local-node/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@enbox/local-node",
+  "version": "0.0.0",
+  "description": "Shell-agnostic local DWN node runtime for Enbox",
+  "type": "module",
+  "main": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
+  "types": "./dist/types/index.d.ts",
+  "bin": {
+    "enbox-local-node": "./dist/esm/cli.js"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
+    "build": "bun run clean && bun run build:esm",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "test:node": "bun test --timeout 10000 .spec.ts",
+    "test:node:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage .spec.ts"
+  },
+  "homepage": "https://github.com/enboxorg/enbox/tree/main/packages/local-node#readme",
+  "bugs": "https://github.com/enboxorg/enbox/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enboxorg/enbox.git",
+    "directory": "packages/local-node"
+  },
+  "license": "Apache-2.0",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "bun": ">=1.3.14"
+  },
+  "dependencies": {
+    "@enbox/agent": "workspace:*",
+    "@enbox/dwn-server": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.15",
+    "@typescript-eslint/eslint-plugin": "8.32.1",
+    "@typescript-eslint/parser": "8.32.1",
+    "bun-types": "1.3.14",
+    "eslint": "9.7.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/local-node/src/cli.ts
+++ b/packages/local-node/src/cli.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env bun
+
+import { AllowOriginPairingBroker, LocalNode, TtyPairingBroker } from './index.js';
+
+type CliOptions = {
+  allowedOrigins : string[];
+  help : boolean;
+  hostname? : string;
+  port? : number;
+  storageUrl? : string;
+  webSocketSupport : boolean;
+};
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    allowedOrigins   : [],
+    help             : false,
+    webSocketSupport : true,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--allow-origin') {
+      options.allowedOrigins.push(readValue(args, i, arg));
+      i += 1;
+    } else if (arg === '--host') {
+      options.hostname = readValue(args, i, arg);
+      i += 1;
+    } else if (arg === '--no-ws') {
+      options.webSocketSupport = false;
+    } else if (arg === '--port') {
+      options.port = parsePort(readValue(args, i, arg));
+      i += 1;
+    } else if (arg === '--storage-url') {
+      options.storageUrl = readValue(args, i, arg);
+      i += 1;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function readValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith('-')) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+function parsePort(value: string): number {
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error(`Invalid port: ${value}`);
+  }
+  return port;
+}
+
+function printHelp(): void {
+  console.log(`Usage: enbox-local-node [options]
+
+Options:
+  --allow-origin <origin>  Auto-approve a browser origin for dev/CI. Repeatable.
+  --host <hostname>        Loopback bind hostname. Defaults to 127.0.0.1.
+  --port <port>            Bind a single port instead of the shared candidate list.
+  --storage-url <url>      DWN Level/SQL storage URL. Defaults to dwn-server config.
+  --no-ws                  Disable WebSocket support.
+  -h, --help               Show this help text.
+`);
+}
+
+async function run(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const node = new LocalNode({
+    allowedOrigins   : options.allowedOrigins,
+    hostname         : options.hostname,
+    pairingBroker    : new AllowOriginPairingBroker(options.allowedOrigins, new TtyPairingBroker()),
+    portCandidates   : options.port === undefined ? undefined : [options.port],
+    storageUrl       : options.storageUrl,
+    webSocketSupport : options.webSocketSupport,
+  });
+
+  const result = await node.start();
+  console.log(`Enbox local node listening on ${result.endpoint}`);
+  console.log(`Discovery file: ${result.discoveryFilePath}`);
+
+  const shutdown = async (): Promise<void> => {
+    await node.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => {
+    void shutdown();
+  });
+  process.on('SIGTERM', () => {
+    void shutdown();
+  });
+
+  await new Promise((): void => {});
+}
+
+run().catch((error: unknown): void => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/local-node/src/cli.ts
+++ b/packages/local-node/src/cli.ts
@@ -108,7 +108,9 @@ async function run(): Promise<void> {
   await new Promise((): void => {});
 }
 
-run().catch((error: unknown): void => {
+try {
+  await run();
+} catch (error: unknown) {
   console.error(error);
   process.exit(1);
-});
+}

--- a/packages/local-node/src/index.ts
+++ b/packages/local-node/src/index.ts
@@ -1,0 +1,3 @@
+export * from './local-node.js';
+export * from './local-node-config.js';
+export * from './pairing-broker.js';

--- a/packages/local-node/src/local-node-config.ts
+++ b/packages/local-node/src/local-node-config.ts
@@ -1,0 +1,55 @@
+import type { DwnServerConfig } from '@enbox/dwn-server';
+
+import { defaultDwnServerConfig } from '@enbox/dwn-server';
+
+export type LocalNodeServerConfigOptions = {
+  allowedOrigins? : string[];
+  baseUrl? : string;
+  dataStore? : string;
+  deliveryEnabled? : boolean;
+  eventBusPluginPath? : string;
+  forwardingEnabled? : boolean;
+  hostname? : string;
+  logLevel? : string;
+  maxRecordDataSize? : number;
+  messageStore? : string;
+  packageJsonPath? : string;
+  port : number;
+  registrationStoreUrl? : string;
+  resumableTaskStore? : string;
+  serverName? : string;
+  storageUrl? : string;
+  termsOfServiceFilePath? : string;
+  ttlCacheUrl? : string;
+  webSocketSupport? : boolean;
+};
+
+export const defaultLocalNodeHostname = '127.0.0.1';
+
+export function createLocalNodeDwnServerConfig(options: LocalNodeServerConfigOptions): DwnServerConfig {
+  const hostname = options.hostname ?? defaultLocalNodeHostname;
+  const storageUrl = options.storageUrl ?? defaultDwnServerConfig.messageStore;
+
+  return {
+    ...defaultDwnServerConfig,
+    baseUrl                 : options.baseUrl ?? `http://${hostname}:${options.port}`,
+    dataStore               : options.dataStore ?? storageUrl,
+    deliveryEnabled         : options.deliveryEnabled ?? true,
+    eventBusPluginPath      : options.eventBusPluginPath ?? defaultDwnServerConfig.eventBusPluginPath,
+    forwardingEnabled       : options.forwardingEnabled ?? true,
+    hostname,
+    localNodeAllowedOrigins : options.allowedOrigins ?? [],
+    localNodeProfileEnabled : true,
+    logLevel                : options.logLevel ?? defaultDwnServerConfig.logLevel,
+    maxRecordDataSize       : options.maxRecordDataSize ?? 1_073_741_824,
+    messageStore            : options.messageStore ?? storageUrl,
+    packageJsonPath         : options.packageJsonPath ?? defaultDwnServerConfig.packageJsonPath,
+    port                    : options.port,
+    registrationStoreUrl    : options.registrationStoreUrl ?? defaultDwnServerConfig.registrationStoreUrl,
+    resumableTaskStore      : options.resumableTaskStore ?? storageUrl,
+    serverName              : options.serverName ?? defaultDwnServerConfig.serverName,
+    termsOfServiceFilePath  : options.termsOfServiceFilePath ?? defaultDwnServerConfig.termsOfServiceFilePath,
+    ttlCacheUrl             : options.ttlCacheUrl ?? defaultDwnServerConfig.ttlCacheUrl,
+    webSocketSupport        : options.webSocketSupport ?? defaultDwnServerConfig.webSocketSupport,
+  };
+}

--- a/packages/local-node/src/local-node.ts
+++ b/packages/local-node/src/local-node.ts
@@ -324,7 +324,8 @@ export class LocalNode {
 
   async #isLiveLocalNode(endpoint: string): Promise<boolean> {
     try {
-      const response = await this.#fetch(`${endpoint.replace(/\/+$/, '')}/info`);
+      const endpointWithTrailingSlash = endpoint.endsWith('/') ? endpoint : `${endpoint}/`;
+      const response = await this.#fetch(new URL('info', endpointWithTrailingSlash).toString());
       if (!response.ok) {
         return false;
       }

--- a/packages/local-node/src/local-node.ts
+++ b/packages/local-node/src/local-node.ts
@@ -1,0 +1,400 @@
+import type { LocalNodeServerConfigOptions } from './local-node-config.js';
+import type { PairingBroker } from './pairing-broker.js';
+import type { DwnDiscoveryFile, DwnDiscoveryRecord } from '@enbox/agent';
+import type {
+  DwnServerConfig,
+  LocalNodePairingManager,
+  LocalNodePairingRequestView,
+} from '@enbox/dwn-server';
+
+import {
+  DwnDiscoveryFile as DefaultDwnDiscoveryFile,
+  localDwnPortCandidates,
+  localDwnServerName,
+} from '@enbox/agent';
+import { LocalNodePairingManager as DefaultLocalNodePairingManager, DwnServer } from '@enbox/dwn-server';
+
+import { createLocalNodeDwnServerConfig } from './local-node-config.js';
+
+export type LocalNodeState = 'stopped' | 'running';
+
+export type LocalNodeDwnServer = {
+  dwn?: { close(): Promise<void> };
+  localNodePairingManager: LocalNodePairingManager;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+};
+
+export type LocalNodeStartResult = {
+  discoveryFilePath : string;
+  endpoint : string;
+  localNodeToken : string;
+  pid : number;
+  port : number;
+};
+
+export type LocalNodeStatus = {
+  discoveryFilePath : string;
+  endpoint? : string;
+  localNodeToken? : string;
+  pendingPairingRequests : LocalNodePairingRequestView[];
+  pid : number;
+  port? : number;
+  state : LocalNodeState;
+  webSocketSupport : boolean;
+};
+
+export type ExistingLocalNode = {
+  endpoint : string;
+  pid : number;
+};
+
+type LocalNodeInfoResponse = {
+  localNode?: boolean;
+  server?: string;
+};
+
+export type LocalNodeOptions = Omit<LocalNodeServerConfigOptions, 'port'> & {
+  createServer? : (config: DwnServerConfig, pairingManager: LocalNodePairingManager) => LocalNodeDwnServer;
+  discoveryFile? : DwnDiscoveryFile;
+  fetch? : typeof fetch;
+  pairingBroker? : PairingBroker;
+  pairingPollIntervalMs? : number;
+  pairingManager? : LocalNodePairingManager;
+  pid? : number;
+  portCandidates? : readonly number[];
+};
+
+export class LocalNodeAlreadyRunningError extends Error {
+  public readonly endpoint: string;
+  public readonly pid: number;
+
+  public constructor(existingNode: ExistingLocalNode) {
+    super(`LocalNode: local node is already running at ${existingNode.endpoint}.`);
+    this.name = 'LocalNodeAlreadyRunningError';
+    this.endpoint = existingNode.endpoint;
+    this.pid = existingNode.pid;
+  }
+}
+
+export class LocalNode {
+  readonly #allowedOrigins: string[];
+  readonly #configOptions: Omit<LocalNodeServerConfigOptions, 'allowedOrigins' | 'port'>;
+  readonly #createServer: (config: DwnServerConfig, pairingManager: LocalNodePairingManager) => LocalNodeDwnServer;
+  readonly #discoveryFile: DwnDiscoveryFile;
+  readonly #fetch: typeof fetch;
+  readonly #pairingBroker: PairingBroker | undefined;
+  readonly #pairingManager: LocalNodePairingManager;
+  readonly #pairingPollIntervalMs: number;
+  readonly #pid: number;
+  readonly #portCandidates: readonly number[];
+  readonly #inFlightPairingRequestIds: Set<string> = new Set();
+
+  #endpoint: string | undefined;
+  #localNodeToken: string | undefined;
+  #pairingBrokerTimer: ReturnType<typeof setInterval> | undefined;
+  #port: number | undefined;
+  #server: LocalNodeDwnServer | undefined;
+  #state: LocalNodeState = 'stopped';
+
+  public constructor(options: LocalNodeOptions = {}) {
+    this.#allowedOrigins = options.allowedOrigins ?? [];
+    this.#configOptions = {
+      baseUrl                : options.baseUrl,
+      dataStore              : options.dataStore,
+      deliveryEnabled        : options.deliveryEnabled,
+      eventBusPluginPath     : options.eventBusPluginPath,
+      forwardingEnabled      : options.forwardingEnabled,
+      hostname               : options.hostname,
+      logLevel               : options.logLevel,
+      maxRecordDataSize      : options.maxRecordDataSize,
+      messageStore           : options.messageStore,
+      packageJsonPath        : options.packageJsonPath,
+      registrationStoreUrl   : options.registrationStoreUrl,
+      resumableTaskStore     : options.resumableTaskStore,
+      serverName             : options.serverName,
+      storageUrl             : options.storageUrl,
+      termsOfServiceFilePath : options.termsOfServiceFilePath,
+      ttlCacheUrl            : options.ttlCacheUrl,
+      webSocketSupport       : options.webSocketSupport,
+    };
+    this.#createServer = options.createServer ?? LocalNode.#createDwnServer;
+    this.#discoveryFile = options.discoveryFile ?? new DefaultDwnDiscoveryFile();
+    this.#fetch = options.fetch ?? fetch;
+    this.#pairingBroker = options.pairingBroker;
+    this.#pairingManager = options.pairingManager ?? new DefaultLocalNodePairingManager();
+    this.#pairingPollIntervalMs = options.pairingPollIntervalMs ?? 500;
+    this.#pid = options.pid ?? process.pid;
+    this.#portCandidates = options.portCandidates ?? localDwnPortCandidates;
+  }
+
+  public get discoveryFilePath(): string {
+    return this.#discoveryFile.path;
+  }
+
+  public get endpoint(): string | undefined {
+    return this.#endpoint;
+  }
+
+  public get pairingManager(): LocalNodePairingManager {
+    return this.#pairingManager;
+  }
+
+  public get state(): LocalNodeState {
+    return this.#state;
+  }
+
+  public async start(): Promise<LocalNodeStartResult> {
+    if (this.#state === 'running') {
+      return this.#getStartResult();
+    }
+
+    const existingNode = await this.findExistingNode();
+    if (existingNode !== undefined) {
+      throw new LocalNodeAlreadyRunningError(existingNode);
+    }
+
+    const startResult = await this.#startFirstAvailableServer();
+    this.#server = startResult.server;
+    this.#port = startResult.port;
+    this.#endpoint = startResult.endpoint;
+    this.#localNodeToken = this.#pairingManager.createSession(undefined);
+    this.#state = 'running';
+
+    try {
+      await this.#writeDiscoveryFile();
+      this.#startPairingBrokerLoop();
+    } catch (error) {
+      await this.#cleanupStartedServer();
+      throw error;
+    }
+
+    return this.#getStartResult();
+  }
+
+  public async stop(): Promise<void> {
+    if (this.#state === 'stopped') {
+      return;
+    }
+
+    this.#stopPairingBrokerLoop();
+
+    try {
+      await this.#discoveryFile.remove();
+    } finally {
+      await this.#server?.stop();
+      this.#endpoint = undefined;
+      this.#localNodeToken = undefined;
+      this.#port = undefined;
+      this.#server = undefined;
+      this.#state = 'stopped';
+      this.#inFlightPairingRequestIds.clear();
+    }
+  }
+
+  public async findExistingNode(): Promise<ExistingLocalNode | undefined> {
+    const record = await this.#discoveryFile.read();
+    if (record === undefined) {
+      return undefined;
+    }
+
+    const isLive = await this.#isLiveLocalNode(record.endpoint);
+    if (!isLive) {
+      await this.#discoveryFile.remove();
+      return undefined;
+    }
+
+    return {
+      endpoint : record.endpoint,
+      pid      : record.pid,
+    };
+  }
+
+  public getStatus(): LocalNodeStatus {
+    return {
+      discoveryFilePath      : this.#discoveryFile.path,
+      endpoint               : this.#endpoint,
+      localNodeToken         : this.#localNodeToken,
+      pendingPairingRequests : this.#pairingManager.listPendingRequests(),
+      pid                    : this.#pid,
+      port                   : this.#port,
+      state                  : this.#state,
+      webSocketSupport       : this.#configOptions.webSocketSupport ?? true,
+    };
+  }
+
+  public async processPendingPairingRequests(): Promise<void> {
+    if (this.#pairingBroker === undefined) {
+      return;
+    }
+
+    const pendingRequests = this.#pairingManager.listPendingRequests();
+    for (const request of pendingRequests) {
+      if (this.#inFlightPairingRequestIds.has(request.id)) {
+        continue;
+      }
+
+      this.#inFlightPairingRequestIds.add(request.id);
+      await this.#processPairingRequest(request);
+    }
+  }
+
+  static #createDwnServer(config: DwnServerConfig, pairingManager: LocalNodePairingManager): LocalNodeDwnServer {
+    return new DwnServer({
+      config,
+      localNodePairingManager: pairingManager,
+    });
+  }
+
+  async #startFirstAvailableServer(): Promise<{ endpoint: string; port: number; server: LocalNodeDwnServer }> {
+    for (const port of this.#portCandidates) {
+      const config = createLocalNodeDwnServerConfig({
+        ...this.#configOptions,
+        allowedOrigins: this.#allowedOrigins,
+        port,
+      });
+      const server = this.#createServer(config, this.#pairingManager);
+
+      try {
+        await server.start();
+        return {
+          endpoint: config.baseUrl,
+          port,
+          server,
+        };
+      } catch (error) {
+        await LocalNode.#closeFailedServer(server);
+        if (!isAddressInUseError(error) || this.#portCandidates.length === 1) {
+          throw error;
+        }
+      }
+    }
+
+    throw new Error(`LocalNode: no available port found in ${Array.from(this.#portCandidates).join(', ')}.`);
+  }
+
+  async #writeDiscoveryFile(): Promise<void> {
+    if (this.#endpoint === undefined || this.#localNodeToken === undefined) {
+      throw new Error('LocalNode: cannot write discovery file before the node has started.');
+    }
+
+    const capabilities = this.#configOptions.webSocketSupport === false ? ['http'] : ['http', 'ws'];
+    const record: DwnDiscoveryRecord = {
+      capabilities,
+      endpoint       : this.#endpoint,
+      localNodeToken : this.#localNodeToken,
+      pid            : this.#pid,
+    };
+
+    await this.#discoveryFile.write(record);
+  }
+
+  #startPairingBrokerLoop(): void {
+    if (this.#pairingBroker === undefined || this.#pairingBrokerTimer !== undefined) {
+      return;
+    }
+
+    void this.processPendingPairingRequests();
+    this.#pairingBrokerTimer = setInterval((): void => {
+      void this.processPendingPairingRequests();
+    }, this.#pairingPollIntervalMs);
+  }
+
+  #stopPairingBrokerLoop(): void {
+    if (this.#pairingBrokerTimer === undefined) {
+      return;
+    }
+
+    clearInterval(this.#pairingBrokerTimer);
+    this.#pairingBrokerTimer = undefined;
+  }
+
+  async #processPairingRequest(request: LocalNodePairingRequestView): Promise<void> {
+    try {
+      const decision = await this.#pairingBroker!.decidePairingRequest(request);
+      if (decision === 'approve') {
+        this.#pairingManager.approveRequest(request.id);
+      } else {
+        this.#pairingManager.denyRequest(request.id);
+      }
+    } finally {
+      this.#inFlightPairingRequestIds.delete(request.id);
+    }
+  }
+
+  async #isLiveLocalNode(endpoint: string): Promise<boolean> {
+    try {
+      const response = await this.#fetch(`${endpoint.replace(/\/+$/, '')}/info`);
+      if (!response.ok) {
+        return false;
+      }
+
+      const serverInfo = await response.json() as LocalNodeInfoResponse;
+      return serverInfo.server === localDwnServerName && serverInfo.localNode === true;
+    } catch {
+      return false;
+    }
+  }
+
+  #getStartResult(): LocalNodeStartResult {
+    if (this.#endpoint === undefined || this.#localNodeToken === undefined || this.#port === undefined) {
+      throw new Error('LocalNode: node is not running.');
+    }
+
+    return {
+      discoveryFilePath : this.#discoveryFile.path,
+      endpoint          : this.#endpoint,
+      localNodeToken    : this.#localNodeToken,
+      pid               : this.#pid,
+      port              : this.#port,
+    };
+  }
+
+  static async #closeFailedServer(server: LocalNodeDwnServer): Promise<void> {
+    try {
+      await server.stop();
+    } catch {
+      // Best-effort cleanup for partially-started servers.
+    }
+
+    try {
+      await server.dwn?.close();
+    } catch {
+      // Best-effort cleanup for partially-created DWN instances.
+    }
+  }
+
+  async #cleanupStartedServer(): Promise<void> {
+    this.#stopPairingBrokerLoop();
+
+    try {
+      await this.#server?.stop();
+    } finally {
+      this.#endpoint = undefined;
+      this.#localNodeToken = undefined;
+      this.#port = undefined;
+      this.#server = undefined;
+      this.#state = 'stopped';
+      this.#inFlightPairingRequestIds.clear();
+    }
+  }
+}
+
+function isAddressInUseError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const maybeCode = (error as { code?: unknown }).code;
+  if (maybeCode === 'EADDRINUSE') {
+    return true;
+  }
+
+  const maybeMessage = (error as { message?: unknown }).message;
+  if (typeof maybeMessage === 'string' && maybeMessage.toLowerCase().includes('address already in use')) {
+    return true;
+  }
+
+  const maybeCause = (error as { cause?: unknown }).cause;
+  return isAddressInUseError(maybeCause);
+}

--- a/packages/local-node/src/pairing-broker.ts
+++ b/packages/local-node/src/pairing-broker.ts
@@ -1,0 +1,64 @@
+import type { LocalNodePairingRequestView } from '@enbox/dwn-server';
+import type { Readable, Writable } from 'node:stream';
+
+import { createInterface } from 'node:readline/promises';
+import { stdin as defaultInput, stdout as defaultOutput } from 'node:process';
+
+type TtyReadable = Readable & { isTTY?: boolean };
+type TtyWritable = Writable & { isTTY?: boolean };
+
+export type PairingDecision = 'approve' | 'deny';
+
+export interface PairingBroker {
+  decidePairingRequest(request: LocalNodePairingRequestView): Promise<PairingDecision>;
+}
+
+export class AllowOriginPairingBroker implements PairingBroker {
+  readonly #allowedOrigins: Set<string>;
+  readonly #fallback: PairingBroker | undefined;
+
+  public constructor(allowedOrigins: string[] = [], fallback?: PairingBroker) {
+    this.#allowedOrigins = new Set(allowedOrigins);
+    this.#fallback = fallback;
+  }
+
+  public async decidePairingRequest(request: LocalNodePairingRequestView): Promise<PairingDecision> {
+    if (this.#allowedOrigins.has(request.origin)) {
+      return 'approve';
+    }
+
+    if (this.#fallback !== undefined) {
+      return this.#fallback.decidePairingRequest(request);
+    }
+
+    return 'deny';
+  }
+}
+
+export class TtyPairingBroker implements PairingBroker {
+  readonly #input: TtyReadable;
+  readonly #output: TtyWritable;
+
+  public constructor(options: { input?: TtyReadable; output?: TtyWritable } = {}) {
+    this.#input = options.input ?? defaultInput;
+    this.#output = options.output ?? defaultOutput;
+  }
+
+  public async decidePairingRequest(request: LocalNodePairingRequestView): Promise<PairingDecision> {
+    if (this.#input.isTTY !== true || this.#output.isTTY !== true) {
+      return 'deny';
+    }
+
+    const readline = createInterface({
+      input  : this.#input,
+      output : this.#output,
+    });
+
+    try {
+      const answer = await readline.question(`Approve local DWN pairing for ${request.origin}? [y/N] `);
+      return /^(?:y|yes)$/i.test(answer.trim()) ? 'approve' : 'deny';
+    } finally {
+      readline.close();
+    }
+  }
+}

--- a/packages/local-node/tests/local-node-config.spec.ts
+++ b/packages/local-node/tests/local-node-config.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createLocalNodeDwnServerConfig, defaultLocalNodeHostname } from '../src/local-node-config.js';
+
+describe('createLocalNodeDwnServerConfig', () => {
+  it('should enable the local-node profile with loopback defaults', () => {
+    const config = createLocalNodeDwnServerConfig({ port: 55500 });
+
+    expect(config.baseUrl).toBe('http://127.0.0.1:55500');
+    expect(config.hostname).toBe(defaultLocalNodeHostname);
+    expect(config.localNodeProfileEnabled).toBe(true);
+    expect(config.localNodeAllowedOrigins).toEqual([]);
+    expect(config.forwardingEnabled).toBe(true);
+    expect(config.deliveryEnabled).toBe(true);
+  });
+
+  it('should apply caller-provided local-node server options', () => {
+    const config = createLocalNodeDwnServerConfig({
+      allowedOrigins   : ['https://app.example'],
+      baseUrl          : 'http://localhost:55501',
+      hostname         : 'localhost',
+      port             : 55501,
+      storageUrl       : 'level://custom-data',
+      webSocketSupport : false,
+    });
+
+    expect(config.baseUrl).toBe('http://localhost:55501');
+    expect(config.dataStore).toBe('level://custom-data');
+    expect(config.hostname).toBe('localhost');
+    expect(config.localNodeAllowedOrigins).toEqual(['https://app.example']);
+    expect(config.messageStore).toBe('level://custom-data');
+    expect(config.resumableTaskStore).toBe('level://custom-data');
+    expect(config.webSocketSupport).toBe(false);
+  });
+});

--- a/packages/local-node/tests/local-node.spec.ts
+++ b/packages/local-node/tests/local-node.spec.ts
@@ -146,7 +146,7 @@ describe('LocalNode', () => {
     });
 
     await expect(node.start()).rejects.toThrow(LocalNodeAlreadyRunningError);
-    expect(servers.length).toBe(0);
+    expect(servers).toHaveLength(0);
   });
 
   it('should remove a stale discovery file when liveness validation fails', async () => {

--- a/packages/local-node/tests/local-node.spec.ts
+++ b/packages/local-node/tests/local-node.spec.ts
@@ -1,0 +1,260 @@
+import type { LocalNodeDwnServer } from '../src/local-node.js';
+import type { DwnDiscoveryFile, DwnDiscoveryRecord } from '@enbox/agent';
+import type { DwnServerConfig, LocalNodePairingManager as LocalNodePairingManagerType } from '@enbox/dwn-server';
+import type { PairingBroker, PairingDecision } from '../src/pairing-broker.js';
+
+import { describe, expect, it } from 'bun:test';
+
+import { localDwnServerName } from '@enbox/agent';
+import { LocalNodePairingManager } from '@enbox/dwn-server';
+
+import { LocalNode, LocalNodeAlreadyRunningError } from '../src/local-node.js';
+
+class MemoryDiscoveryFile {
+  public path = '/tmp/enbox-local-node/dwn.json';
+  public record: DwnDiscoveryRecord | undefined;
+  public removeCount = 0;
+  public writeCount = 0;
+
+  public constructor(record?: DwnDiscoveryRecord) {
+    this.record = record;
+  }
+
+  public async read(): Promise<DwnDiscoveryRecord | undefined> {
+    return this.record;
+  }
+
+  public async write(record: DwnDiscoveryRecord): Promise<void> {
+    this.record = record;
+    this.writeCount += 1;
+  }
+
+  public async remove(): Promise<void> {
+    this.record = undefined;
+    this.removeCount += 1;
+  }
+}
+
+class FailingWriteDiscoveryFile extends MemoryDiscoveryFile {
+  public async write(_record: DwnDiscoveryRecord): Promise<void> {
+    this.writeCount += 1;
+    throw new Error('write failed');
+  }
+}
+
+type FakeServer = LocalNodeDwnServer & {
+  closedDwn : boolean;
+  config : DwnServerConfig;
+  started : boolean;
+  stopped : boolean;
+};
+
+function createFakeServerFactory(options: { busyPorts?: number[] } = {}): {
+  createServer: (config: DwnServerConfig, pairingManager: LocalNodePairingManagerType) => FakeServer;
+  servers: FakeServer[];
+} {
+  const busyPorts = new Set(options.busyPorts ?? []);
+  const servers: FakeServer[] = [];
+
+  return {
+    createServer(config: DwnServerConfig, pairingManager: LocalNodePairingManagerType): FakeServer {
+      const server: FakeServer = {
+        closedDwn : false,
+        config,
+        dwn       : {
+          async close(): Promise<void> {
+            server.closedDwn = true;
+          },
+        },
+        localNodePairingManager : pairingManager,
+        started                 : false,
+        stopped                 : false,
+        async start(): Promise<void> {
+          if (busyPorts.has(config.port)) {
+            const error = new Error('address already in use') as Error & { code: string };
+            error.code = 'EADDRINUSE';
+            throw error;
+          }
+          this.started = true;
+        },
+        async stop(): Promise<void> {
+          this.stopped = true;
+        },
+      };
+
+      servers.push(server);
+      return server;
+    },
+    servers,
+  };
+}
+
+function createDiscoveryFile(record?: DwnDiscoveryRecord): MemoryDiscoveryFile & DwnDiscoveryFile {
+  return new MemoryDiscoveryFile(record) as MemoryDiscoveryFile & DwnDiscoveryFile;
+}
+
+describe('LocalNode', () => {
+  it('should select the first available port and write a discovery record with a no-Origin token', async () => {
+    const discoveryFile = createDiscoveryFile();
+    const { createServer, servers } = createFakeServerFactory({ busyPorts: [55500] });
+    const pairingManager = new LocalNodePairingManager();
+    const node = new LocalNode({
+      createServer,
+      discoveryFile,
+      pairingManager,
+      pid            : 1234,
+      portCandidates : [55500, 55501],
+    });
+
+    const result = await node.start();
+
+    expect(result.endpoint).toBe('http://127.0.0.1:55501');
+    expect(result.port).toBe(55501);
+    expect(result.localNodeToken.length).toBeGreaterThan(0);
+    expect(discoveryFile.record).toEqual({
+      capabilities   : ['http', 'ws'],
+      endpoint       : 'http://127.0.0.1:55501',
+      localNodeToken : result.localNodeToken,
+      pid            : 1234,
+    });
+    expect(pairingManager.validateSession(undefined, result.localNodeToken)).toBe(true);
+    expect(servers[0].closedDwn).toBe(true);
+    expect(servers[1].started).toBe(true);
+
+    await node.stop();
+
+    expect(discoveryFile.record).toBeUndefined();
+    expect(servers[1].stopped).toBe(true);
+    expect(node.state).toBe('stopped');
+  });
+
+  it('should refuse to start when the discovery file points to a live local node', async () => {
+    const discoveryFile = createDiscoveryFile({
+      endpoint : 'http://127.0.0.1:55500',
+      pid      : 2222,
+    });
+    const { createServer, servers } = createFakeServerFactory();
+    const fetchOk: typeof fetch = async (): Promise<Response> => Response.json({
+      localNode : true,
+      server    : localDwnServerName,
+    });
+    const node = new LocalNode({
+      createServer,
+      discoveryFile,
+      fetch          : fetchOk,
+      portCandidates : [55500],
+    });
+
+    await expect(node.start()).rejects.toThrow(LocalNodeAlreadyRunningError);
+    expect(servers.length).toBe(0);
+  });
+
+  it('should remove a stale discovery file when liveness validation fails', async () => {
+    const discoveryFile = createDiscoveryFile({
+      endpoint : 'http://127.0.0.1:55500',
+      pid      : 2222,
+    });
+    const { createServer } = createFakeServerFactory();
+    const fetchWrongServer: typeof fetch = async (): Promise<Response> => Response.json({
+      localNode : false,
+      server    : 'other-server',
+    });
+    const node = new LocalNode({
+      createServer,
+      discoveryFile,
+      fetch          : fetchWrongServer,
+      portCandidates : [55500],
+    });
+
+    await node.start();
+
+    expect(discoveryFile.removeCount).toBe(1);
+    expect(discoveryFile.writeCount).toBe(1);
+
+    await node.stop();
+  });
+
+  it('should stop the server if writing the discovery file fails', async () => {
+    const discoveryFile = new FailingWriteDiscoveryFile() as FailingWriteDiscoveryFile & DwnDiscoveryFile;
+    const { createServer, servers } = createFakeServerFactory();
+    const node = new LocalNode({
+      createServer,
+      discoveryFile,
+      portCandidates: [55500],
+    });
+
+    await expect(node.start()).rejects.toThrow('write failed');
+
+    expect(discoveryFile.writeCount).toBe(1);
+    expect(servers[0].stopped).toBe(true);
+    expect(node.state).toBe('stopped');
+  });
+
+  it('should approve pending pairing requests through the broker', async () => {
+    const discoveryFile = createDiscoveryFile();
+    const { createServer } = createFakeServerFactory();
+    const broker: PairingBroker = {
+      async decidePairingRequest(): Promise<PairingDecision> {
+        return 'approve';
+      },
+    };
+    const pairingManager = new LocalNodePairingManager();
+    const node = new LocalNode({
+      createServer,
+      discoveryFile,
+      pairingBroker         : broker,
+      pairingManager,
+      pairingPollIntervalMs : 60_000,
+      portCandidates        : [55500],
+    });
+
+    await node.start();
+    const createResult = pairingManager.createRequest('https://app.example');
+    if (createResult.status !== 'created') {
+      throw new Error(`expected created request, got ${createResult.status}`);
+    }
+
+    await node.processPendingPairingRequests();
+    const pollResult = pairingManager.pollRequest(createResult.requestId);
+
+    expect(pollResult?.status).toBe('approved');
+    expect(pollResult?.origin).toBe('https://app.example');
+    expect(pollResult?.status === 'approved' && pollResult.token !== undefined).toBe(true);
+
+    await node.stop();
+  });
+
+  it('should deny pending pairing requests through the broker', async () => {
+    const discoveryFile = createDiscoveryFile();
+    const { createServer } = createFakeServerFactory();
+    const broker: PairingBroker = {
+      async decidePairingRequest(): Promise<PairingDecision> {
+        return 'deny';
+      },
+    };
+    const pairingManager = new LocalNodePairingManager();
+    const node = new LocalNode({
+      createServer,
+      discoveryFile,
+      pairingBroker         : broker,
+      pairingManager,
+      pairingPollIntervalMs : 60_000,
+      portCandidates        : [55500],
+    });
+
+    await node.start();
+    const createResult = pairingManager.createRequest('https://app.example');
+    if (createResult.status !== 'created') {
+      throw new Error(`expected created request, got ${createResult.status}`);
+    }
+
+    await node.processPendingPairingRequests();
+
+    expect(pairingManager.pollRequest(createResult.requestId)).toEqual({
+      origin : 'https://app.example',
+      status : 'denied',
+    });
+
+    await node.stop();
+  });
+});

--- a/packages/local-node/tests/pairing-broker.spec.ts
+++ b/packages/local-node/tests/pairing-broker.spec.ts
@@ -1,0 +1,55 @@
+import type { LocalNodePairingRequestView } from '@enbox/dwn-server';
+import type { PairingBroker, PairingDecision } from '../src/pairing-broker.js';
+
+import { PassThrough } from 'node:stream';
+import { describe, expect, it } from 'bun:test';
+
+import { AllowOriginPairingBroker, TtyPairingBroker } from '../src/pairing-broker.js';
+
+function createRequest(origin: string): LocalNodePairingRequestView {
+  return {
+    createdAt : 1,
+    expiresAt : 2,
+    id        : 'request-id',
+    origin,
+    status    : 'pending',
+  };
+}
+
+describe('AllowOriginPairingBroker', () => {
+  it('should approve allowed origins', async () => {
+    const broker = new AllowOriginPairingBroker(['https://app.example']);
+
+    await expect(broker.decidePairingRequest(createRequest('https://app.example'))).resolves.toBe('approve');
+  });
+
+  it('should deny unlisted origins without a fallback broker', async () => {
+    const broker = new AllowOriginPairingBroker(['https://app.example']);
+
+    await expect(broker.decidePairingRequest(createRequest('https://other.example'))).resolves.toBe('deny');
+  });
+
+  it('should delegate unlisted origins to the fallback broker', async () => {
+    const fallback: PairingBroker = {
+      async decidePairingRequest(request: LocalNodePairingRequestView): Promise<PairingDecision> {
+        return request.origin === 'https://other.example' ? 'approve' : 'deny';
+      },
+    };
+    const broker = new AllowOriginPairingBroker(['https://app.example'], fallback);
+
+    await expect(broker.decidePairingRequest(createRequest('https://other.example'))).resolves.toBe('approve');
+  });
+});
+
+describe('TtyPairingBroker', () => {
+  it('should deny requests when no interactive TTY is available', async () => {
+    const input = new PassThrough() as PassThrough & { isTTY?: boolean };
+    const output = new PassThrough() as PassThrough & { isTTY?: boolean };
+    input.isTTY = false;
+    output.isTTY = false;
+
+    const broker = new TtyPairingBroker({ input, output });
+
+    await expect(broker.decidePairingRequest(createRequest('https://app.example'))).resolves.toBe('deny');
+  });
+});

--- a/packages/local-node/tests/tsconfig.json
+++ b/packages/local-node/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun-types", "node"]
+  },
+  "include": [
+    "../src",
+    "."
+  ]
+}

--- a/packages/local-node/tsconfig.json
+++ b/packages/local-node/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declarationDir": "dist/types",
+    "outDir": "dist/esm"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/local-node/tsconfig.json
+++ b/packages/local-node/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declarationDir": "dist/types",
-    "outDir": "dist/esm"
+    "outDir": "dist/esm",
+    "target": "ES2022"
   },
   "include": [
     "src"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ set -e
 #   L3: browser, dwn-sdk-js                             (dids | crypto, dids)
 #   L4: dwn-sql-store, dwn-clients                      (dwn-sdk-js | common, crypto, dwn-sdk-js)
 #   L5: agent, dwn-server                               (common, crypto, dids, dwn-clients, dwn-sdk-js | + dwn-sql-store, dwn-server-admin-ui)
-#   L6: auth                                            (agent, common, dids, dwn-clients)
+#   L6: auth, local-node                                (agent, common, dids, dwn-clients | agent, dwn-server)
 #   L7: api                                             (agent, auth, common, dwn-clients)
 #   L8: protocols, electrobun-dwn                       (api, dwn-sdk-js | agent, dwn-server)
 
@@ -38,8 +38,8 @@ bun run --filter '@enbox/dwn-sql-store' --filter '@enbox/dwn-clients' build
 echo "[L5] agent, dwn-server"
 bun run --filter '@enbox/agent' --filter '@enbox/dwn-server' build
 
-echo "[L6] auth"
-bun run --filter '@enbox/auth' build
+echo "[L6] auth, local-node"
+bun run --filter '@enbox/auth' --filter '@enbox/local-node' build
 
 echo "[L7] api"
 bun run --filter '@enbox/api' build

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -36,6 +36,7 @@ PACKAGES=(
   "packages/dwn-sql-store"
   "packages/dwn-server-admin-ui"
   "packages/dwn-server"
+  "packages/local-node"
 )
 
 # resolve_workspace_deps <package.json path>

--- a/scripts/run-node-coverage.sh
+++ b/scripts/run-node-coverage.sh
@@ -70,6 +70,7 @@ node_packages=(
   "@enbox/crypto"
   "@enbox/auth"
   "@enbox/cli"
+  "@enbox/local-node"
   "@enbox/protocols"
   "@enbox/protocol-codegen"
   "@enbox/dwn-sdk-js"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,8 +4,8 @@ sonar.organization=SONAR_ORG
 sonar.projectName=enbox
 sonar.sourceEncoding=UTF-8
 
-sonar.sources=packages/agent/src,packages/api/src,packages/auth/src,packages/browser/src,packages/cli/src,packages/common/src,packages/crypto/src,packages/dids/src,packages/dwn-clients/src,packages/dwn-sdk-js/src,packages/dwn-server/src,packages/dwn-server-admin-ui/src,packages/dwn-sql-store/src,packages/protocol-codegen/src,packages/protocols/src,apps/docs/src
-sonar.tests=packages/agent/tests,packages/api/tests,packages/auth/tests,packages/browser/tests,packages/cli/tests,packages/common/tests,packages/crypto/tests,packages/dids/tests,packages/dwn-clients/tests,packages/dwn-sdk-js/tests,packages/dwn-server/tests,packages/dwn-sql-store/tests,packages/protocol-codegen/tests,packages/protocols/tests
+sonar.sources=packages/agent/src,packages/api/src,packages/auth/src,packages/browser/src,packages/cli/src,packages/common/src,packages/crypto/src,packages/dids/src,packages/dwn-clients/src,packages/dwn-sdk-js/src,packages/dwn-server/src,packages/dwn-server-admin-ui/src,packages/dwn-sql-store/src,packages/local-node/src,packages/protocol-codegen/src,packages/protocols/src,apps/docs/src
+sonar.tests=packages/agent/tests,packages/api/tests,packages/auth/tests,packages/browser/tests,packages/cli/tests,packages/common/tests,packages/crypto/tests,packages/dids/tests,packages/dwn-clients/tests,packages/dwn-sdk-js/tests,packages/dwn-server/tests,packages/dwn-sql-store/tests,packages/local-node/tests,packages/protocol-codegen/tests,packages/protocols/tests
 sonar.test.inclusions=packages/*/tests/**/*.ts,packages/*/tests/**/*.tsx
 
 sonar.typescript.tsconfigPath=tsconfig.json
@@ -14,8 +14,8 @@ sonar.pullrequest.github.repository=enboxorg/enbox
 
 sonar.exclusions=**/node_modules/**,**/dist/**,**/out/**,**/.next/**,**/.turbo/**,**/coverage/**,**/coverage-browser/**,**/coverage-browser-*/**,**/generated/**,apps/docs/content/**
 # Admin UI and docs app source stay in Sonar analysis, but they do not currently emit LCOV.
-# `dwn-server/src/main.ts` is a non-terminating CLI entrypoint; the agent browser FS file is a bundle alias shim tested in discovery specs.
-sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx,**/*.config.ts,**/*.config.js,**/*.config.cjs,**/*.config.mjs,**/*.d.ts,**/dist/**,**/out/**,packages/agent/src/dwn-discovery-file-fs.browser.ts,packages/dwn-server/src/main.ts,packages/dwn-server-admin-ui/src/**,apps/docs/src/**
+# `dwn-server/src/main.ts` and `local-node/src/cli.ts` are non-terminating CLI entrypoints; the agent browser FS file is a bundle alias shim tested in discovery specs.
+sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/*.spec.tsx,**/*.test.ts,**/*.test.tsx,**/*.config.ts,**/*.config.js,**/*.config.cjs,**/*.config.mjs,**/*.d.ts,**/dist/**,**/out/**,packages/agent/src/dwn-discovery-file-fs.browser.ts,packages/dwn-server/src/main.ts,packages/local-node/src/cli.ts,packages/dwn-server-admin-ui/src/**,apps/docs/src/**
 sonar.cpd.exclusions=packages/**/tests/**
 
 # ─── Rule-specific issue ignores ──────────────────────────────────────────


### PR DESCRIPTION
Summary:
- Add `@enbox/local-node` with shell-agnostic `LocalNode` lifecycle, loopback local-profile DWN server config, discovery-file write/remove, single-instance liveness checks, no-Origin local token support, pending pairing broker loop, and a headless CLI.
- Extend `DwnDiscoveryFile` with optional `localNodeToken` metadata for non-browser local clients.
- Wire the new package into workspaces, CI coverage, Sonar, build/publish helpers, AGENTS metadata, and changesets.

Scope note:
- This is the local-node core/headless slice for #1164. Durable persisted pairing records, native tray embedding, immediate live WebSocket shutdown on revocation, and SDK detection/pairing remain follow-up slices.

Test plan:
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run --filter @enbox/local-node test:node`
- [x] `bun test tests/dwn-discovery-file.spec.ts` from `packages/agent`
- [x] `bunx changeset status`
- [x] `git diff --check`
- [x] `git diff --cached --check`