### PR TITLE
fix(local-node): persist pairing sessions

### DIFF
--- a/.changeset/local-node-core.md
+++ b/.changeset/local-node-core.md
@@ -1,5 +1,5 @@
 ---
-"@enbox/local-node": minor
+"@enbox/local-node": patch
 "@enbox/agent": patch
 ---
 

--- a/.changeset/local-node-pairing-persistence.md
+++ b/.changeset/local-node-pairing-persistence.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-server": patch
+"@enbox/local-node": patch
+---
+
+fix: persist local-node browser pairing sessions across restarts

--- a/packages/dwn-server/src/index.ts
+++ b/packages/dwn-server/src/index.ts
@@ -20,6 +20,7 @@ export type {
   LocalNodePairingManagerOptions,
   LocalNodePairingPollResult,
   LocalNodePairingRequestView,
+  LocalNodePairingSessionRecord,
 } from './local-node-pairing.js';
 export type { MessageProcessedContext, MessageProcessedHook } from './message-processed-hook.js';
 export { OpenAuthHandler } from './registration/open-auth-handler.js';

--- a/packages/dwn-server/src/local-node-pairing.ts
+++ b/packages/dwn-server/src/local-node-pairing.ts
@@ -20,6 +20,12 @@ export type LocalNodePairingRequestView = {
   expiresAt : number;
 };
 
+export type LocalNodePairingSessionRecord = {
+  createdAt : number;
+  origin? : string;
+  token : string;
+};
+
 export type LocalNodePairingManagerOptions = {
   now? : () => number;
   pairingRequestTtlMs? : number;
@@ -228,6 +234,34 @@ export class LocalNodePairingManager {
     });
 
     return token;
+  }
+
+  public exportSessions(): LocalNodePairingSessionRecord[] {
+    return Array.from(this.#sessionsByToken.values())
+      .map((session: LocalNodeSession): LocalNodePairingSessionRecord => {
+        const record: LocalNodePairingSessionRecord = {
+          createdAt : session.createdAt,
+          token     : session.token,
+        };
+
+        if (session.origin !== undefined) {
+          record.origin = session.origin;
+        }
+
+        return record;
+      });
+  }
+
+  public importSessions(sessions: LocalNodePairingSessionRecord[]): void {
+    this.#sessionsByToken.clear();
+
+    for (const session of sessions) {
+      this.#sessionsByToken.set(session.token, {
+        createdAt : session.createdAt,
+        origin    : session.origin,
+        token     : session.token,
+      });
+    }
   }
 
   public validateSession(origin: string | undefined, token: string | undefined): boolean {

--- a/packages/dwn-server/tests/local-node-pairing.test.ts
+++ b/packages/dwn-server/tests/local-node-pairing.test.ts
@@ -95,4 +95,18 @@ describe('LocalNodePairingManager', () => {
     expect(manager.validateSession(undefined, token)).toBe(true);
     expect(manager.validateSession('https://app.example', token)).toBe(false);
   });
+
+  it('should export, import, and revoke sessions', () => {
+    const manager = new LocalNodePairingManager({ now: (): number => 1234 });
+    const browserToken = manager.createSession('https://app.example');
+    const localToken = manager.createSession(undefined);
+
+    const restoredManager = new LocalNodePairingManager();
+    restoredManager.importSessions(manager.exportSessions());
+
+    expect(restoredManager.validateSession('https://app.example', browserToken)).toBe(true);
+    expect(restoredManager.validateSession(undefined, localToken)).toBe(true);
+    expect(restoredManager.revokeToken(browserToken)).toBe(true);
+    expect(restoredManager.validateSession('https://app.example', browserToken)).toBe(false);
+  });
 });

--- a/packages/local-node/src/index.ts
+++ b/packages/local-node/src/index.ts
@@ -1,3 +1,4 @@
 export * from './local-node.js';
 export * from './local-node-config.js';
+export * from './pairing-session-store.js';
 export * from './pairing-broker.js';

--- a/packages/local-node/src/local-node.ts
+++ b/packages/local-node/src/local-node.ts
@@ -1,3 +1,4 @@
+import type { LocalNodePairingSessionStore } from './pairing-session-store.js';
 import type { LocalNodeServerConfigOptions } from './local-node-config.js';
 import type { PairingBroker } from './pairing-broker.js';
 import type { DwnDiscoveryFile, DwnDiscoveryRecord } from '@enbox/agent';
@@ -15,6 +16,7 @@ import {
 import { LocalNodePairingManager as DefaultLocalNodePairingManager, DwnServer } from '@enbox/dwn-server';
 
 import { createLocalNodeDwnServerConfig } from './local-node-config.js';
+import { LocalNodePairingSessionFile } from './pairing-session-store.js';
 
 export type LocalNodeState = 'stopped' | 'running';
 
@@ -61,6 +63,7 @@ export type LocalNodeOptions = Omit<LocalNodeServerConfigOptions, 'port'> & {
   pairingBroker? : PairingBroker;
   pairingPollIntervalMs? : number;
   pairingManager? : LocalNodePairingManager;
+  pairingSessionStore? : LocalNodePairingSessionStore;
   pid? : number;
   portCandidates? : readonly number[];
 };
@@ -86,6 +89,7 @@ export class LocalNode {
   readonly #pairingBroker: PairingBroker | undefined;
   readonly #pairingManager: LocalNodePairingManager;
   readonly #pairingPollIntervalMs: number;
+  readonly #pairingSessionStore: LocalNodePairingSessionStore;
   readonly #pid: number;
   readonly #portCandidates: readonly number[];
   readonly #inFlightPairingRequestIds: Set<string> = new Set();
@@ -124,6 +128,7 @@ export class LocalNode {
     this.#pairingBroker = options.pairingBroker;
     this.#pairingManager = options.pairingManager ?? new DefaultLocalNodePairingManager();
     this.#pairingPollIntervalMs = options.pairingPollIntervalMs ?? 500;
+    this.#pairingSessionStore = options.pairingSessionStore ?? new LocalNodePairingSessionFile();
     this.#pid = options.pid ?? process.pid;
     this.#portCandidates = options.portCandidates ?? localDwnPortCandidates;
   }
@@ -153,6 +158,8 @@ export class LocalNode {
     if (existingNode !== undefined) {
       throw new LocalNodeAlreadyRunningError(existingNode);
     }
+
+    await this.#loadPairingSessions();
 
     const startResult = await this.#startFirstAvailableServer();
     this.#server = startResult.server;
@@ -221,6 +228,16 @@ export class LocalNode {
       state                  : this.#state,
       webSocketSupport       : this.#configOptions.webSocketSupport ?? true,
     };
+  }
+
+  public async revokePairingToken(token: string): Promise<boolean> {
+    const revoked = this.#pairingManager.revokeToken(token);
+    if (!revoked) {
+      return false;
+    }
+
+    await this.#savePairingSessions();
+    return true;
   }
 
   public async processPendingPairingRequests(): Promise<void> {
@@ -313,7 +330,10 @@ export class LocalNode {
     try {
       const decision = await this.#pairingBroker!.decidePairingRequest(request);
       if (decision === 'approve') {
-        this.#pairingManager.approveRequest(request.id);
+        const approved = this.#pairingManager.approveRequest(request.id);
+        if (approved) {
+          await this.#savePairingSessions();
+        }
       } else {
         this.#pairingManager.denyRequest(request.id);
       }
@@ -335,6 +355,18 @@ export class LocalNode {
     } catch {
       return false;
     }
+  }
+
+  async #loadPairingSessions(): Promise<void> {
+    const sessions = await this.#pairingSessionStore.read();
+    this.#pairingManager.importSessions(sessions);
+  }
+
+  async #savePairingSessions(): Promise<void> {
+    const browserSessions = this.#pairingManager.exportSessions()
+      .filter((session): boolean => session.origin !== undefined);
+
+    await this.#pairingSessionStore.write(browserSessions);
   }
 
   #getStartResult(): LocalNodeStartResult {

--- a/packages/local-node/src/pairing-session-store.ts
+++ b/packages/local-node/src/pairing-session-store.ts
@@ -1,0 +1,132 @@
+import type { LocalNodePairingSessionRecord } from '@enbox/dwn-server';
+
+import { homedir } from 'node:os';
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+export const LOCAL_NODE_PAIRING_SESSIONS_FILENAME = 'local-node-sessions.json';
+
+const localNodePairingSessionsVersion = 1;
+
+export interface LocalNodePairingSessionStore {
+  readonly path: string;
+  read(): Promise<LocalNodePairingSessionRecord[]>;
+  remove(): Promise<void>;
+  write(sessions: LocalNodePairingSessionRecord[]): Promise<void>;
+}
+
+export class LocalNodePairingSessionFile implements LocalNodePairingSessionStore {
+  readonly #filePath: string;
+
+  public constructor(filePath?: string) {
+    this.#filePath = filePath ?? join(homedir(), '.enbox', LOCAL_NODE_PAIRING_SESSIONS_FILENAME);
+  }
+
+  public get path(): string {
+    return this.#filePath;
+  }
+
+  public async read(): Promise<LocalNodePairingSessionRecord[]> {
+    let raw: string;
+    try {
+      raw = await readFile(this.#filePath, 'utf-8');
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        return [];
+      }
+      throw error;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      await this.remove();
+      return [];
+    }
+
+    if (!isValidPairingSessionsFile(parsed)) {
+      await this.remove();
+      return [];
+    }
+
+    return parsed.sessions.map((session: SerializedPairingSession): LocalNodePairingSessionRecord => ({
+      createdAt : session.createdAt,
+      origin    : session.origin,
+      token     : session.token,
+    }));
+  }
+
+  public async write(sessions: LocalNodePairingSessionRecord[]): Promise<void> {
+    const browserSessions = sessions.filter((session): session is SerializedPairingSession => session.origin !== undefined);
+    const serialized = {
+      sessions : browserSessions,
+      version  : localNodePairingSessionsVersion,
+    };
+    const json = JSON.stringify(serialized, null, 2);
+    const tempPath = `${this.#filePath}.${process.pid}.tmp`;
+
+    await mkdir(dirname(this.#filePath), { recursive: true });
+    await writeFile(tempPath, json, { encoding: 'utf-8', mode: 0o600 });
+    await rename(tempPath, this.#filePath);
+    await chmod(this.#filePath, 0o600);
+  }
+
+  public async remove(): Promise<void> {
+    await rm(this.#filePath, { force: true });
+  }
+}
+
+type SerializedPairingSession = {
+  createdAt : number;
+  origin : string;
+  token : string;
+};
+
+type SerializedPairingSessionsFile = {
+  sessions : SerializedPairingSession[];
+  version : typeof localNodePairingSessionsVersion;
+};
+
+function isMissingFileError(error: unknown): boolean {
+  return Boolean(error)
+    && typeof error === 'object'
+    && (error as { code?: unknown }).code === 'ENOENT';
+}
+
+function isValidPairingSessionsFile(value: unknown): value is SerializedPairingSessionsFile {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const file = value as Record<string, unknown>;
+  return file.version === localNodePairingSessionsVersion
+    && Array.isArray(file.sessions)
+    && file.sessions.every(isValidPairingSession);
+}
+
+function isValidPairingSession(value: unknown): value is SerializedPairingSession {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const session = value as Record<string, unknown>;
+  const createdAt = session.createdAt;
+  return typeof createdAt === 'number'
+    && Number.isInteger(createdAt)
+    && createdAt > 0
+    && typeof session.token === 'string'
+    && session.token.length > 0
+    && typeof session.origin === 'string'
+    && isValidHttpOrigin(session.origin);
+}
+
+function isValidHttpOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return (url.protocol === 'http:' || url.protocol === 'https:')
+      && url.origin === origin;
+  } catch {
+    return false;
+  }
+}

--- a/packages/local-node/tests/local-node.spec.ts
+++ b/packages/local-node/tests/local-node.spec.ts
@@ -1,6 +1,11 @@
 import type { LocalNodeDwnServer } from '../src/local-node.js';
+import type { LocalNodePairingSessionStore } from '../src/pairing-session-store.js';
 import type { DwnDiscoveryFile, DwnDiscoveryRecord } from '@enbox/agent';
-import type { DwnServerConfig, LocalNodePairingManager as LocalNodePairingManagerType } from '@enbox/dwn-server';
+import type {
+  DwnServerConfig,
+  LocalNodePairingManager as LocalNodePairingManagerType,
+  LocalNodePairingSessionRecord,
+} from '@enbox/dwn-server';
 import type { PairingBroker, PairingDecision } from '../src/pairing-broker.js';
 
 import { describe, expect, it } from 'bun:test';
@@ -39,6 +44,29 @@ class FailingWriteDiscoveryFile extends MemoryDiscoveryFile {
   public async write(_record: DwnDiscoveryRecord): Promise<void> {
     this.writeCount += 1;
     throw new Error('write failed');
+  }
+}
+
+class MemoryPairingSessionStore implements LocalNodePairingSessionStore {
+  public readonly path = '/tmp/enbox-local-node/local-node-sessions.json';
+  public sessions: LocalNodePairingSessionRecord[];
+  public writeCount = 0;
+
+  public constructor(sessions: LocalNodePairingSessionRecord[] = []) {
+    this.sessions = sessions;
+  }
+
+  public async read(): Promise<LocalNodePairingSessionRecord[]> {
+    return this.sessions.map(clonePairingSession);
+  }
+
+  public async write(sessions: LocalNodePairingSessionRecord[]): Promise<void> {
+    this.sessions = sessions.map(clonePairingSession);
+    this.writeCount += 1;
+  }
+
+  public async remove(): Promise<void> {
+    this.sessions = [];
   }
 }
 
@@ -93,6 +121,14 @@ function createDiscoveryFile(record?: DwnDiscoveryRecord): MemoryDiscoveryFile &
   return new MemoryDiscoveryFile(record) as MemoryDiscoveryFile & DwnDiscoveryFile;
 }
 
+function createPairingSessionStore(sessions: LocalNodePairingSessionRecord[] = []): MemoryPairingSessionStore {
+  return new MemoryPairingSessionStore(sessions);
+}
+
+function clonePairingSession(session: LocalNodePairingSessionRecord): LocalNodePairingSessionRecord {
+  return { ...session };
+}
+
 describe('LocalNode', () => {
   it('should select the first available port and write a discovery record with a no-Origin token', async () => {
     const discoveryFile = createDiscoveryFile();
@@ -102,8 +138,9 @@ describe('LocalNode', () => {
       createServer,
       discoveryFile,
       pairingManager,
-      pid            : 1234,
-      portCandidates : [55500, 55501],
+      pairingSessionStore : createPairingSessionStore(),
+      pid                 : 1234,
+      portCandidates      : [55500, 55501],
     });
 
     const result = await node.start();
@@ -141,8 +178,9 @@ describe('LocalNode', () => {
     const node = new LocalNode({
       createServer,
       discoveryFile,
-      fetch          : fetchOk,
-      portCandidates : [55500],
+      fetch               : fetchOk,
+      pairingSessionStore : createPairingSessionStore(),
+      portCandidates      : [55500],
     });
 
     await expect(node.start()).rejects.toThrow(LocalNodeAlreadyRunningError);
@@ -162,8 +200,9 @@ describe('LocalNode', () => {
     const node = new LocalNode({
       createServer,
       discoveryFile,
-      fetch          : fetchWrongServer,
-      portCandidates : [55500],
+      fetch               : fetchWrongServer,
+      pairingSessionStore : createPairingSessionStore(),
+      portCandidates      : [55500],
     });
 
     await node.start();
@@ -180,7 +219,8 @@ describe('LocalNode', () => {
     const node = new LocalNode({
       createServer,
       discoveryFile,
-      portCandidates: [55500],
+      pairingSessionStore : createPairingSessionStore(),
+      portCandidates      : [55500],
     });
 
     await expect(node.start()).rejects.toThrow('write failed');
@@ -205,6 +245,7 @@ describe('LocalNode', () => {
       pairingBroker         : broker,
       pairingManager,
       pairingPollIntervalMs : 60_000,
+      pairingSessionStore   : createPairingSessionStore(),
       portCandidates        : [55500],
     });
 
@@ -239,6 +280,7 @@ describe('LocalNode', () => {
       pairingBroker         : broker,
       pairingManager,
       pairingPollIntervalMs : 60_000,
+      pairingSessionStore   : createPairingSessionStore(),
       portCandidates        : [55500],
     });
 
@@ -254,6 +296,96 @@ describe('LocalNode', () => {
       origin : 'https://app.example',
       status : 'denied',
     });
+
+    await node.stop();
+  });
+
+  it('should persist approved browser pairings and reload them on restart', async () => {
+    const sessionStore = createPairingSessionStore([{
+      createdAt : 1000,
+      origin    : 'https://existing.example',
+      token     : 'existing-token',
+    }]);
+    const broker: PairingBroker = {
+      async decidePairingRequest(): Promise<PairingDecision> {
+        return 'approve';
+      },
+    };
+    const firstDiscoveryFile = createDiscoveryFile();
+    const firstPairingManager = new LocalNodePairingManager();
+    const firstServerFactory = createFakeServerFactory();
+    const firstNode = new LocalNode({
+      createServer          : firstServerFactory.createServer,
+      discoveryFile         : firstDiscoveryFile,
+      pairingBroker         : broker,
+      pairingManager        : firstPairingManager,
+      pairingPollIntervalMs : 60_000,
+      pairingSessionStore   : sessionStore,
+      portCandidates        : [55500],
+    });
+
+    await firstNode.start();
+    expect(firstPairingManager.validateSession('https://existing.example', 'existing-token')).toBe(true);
+
+    const createResult = firstPairingManager.createRequest('https://app.example');
+    if (createResult.status !== 'created') {
+      throw new Error(`expected created request, got ${createResult.status}`);
+    }
+
+    await firstNode.processPendingPairingRequests();
+    const pollResult = firstPairingManager.pollRequest(createResult.requestId);
+    if (pollResult?.status !== 'approved' || pollResult.token === undefined) {
+      throw new Error('expected approved pairing token');
+    }
+
+    expect(sessionStore.sessions.map((session) => session.origin)).toEqual([
+      'https://existing.example',
+      'https://app.example',
+    ]);
+    expect(sessionStore.sessions.some((session) => session.origin === undefined)).toBe(false);
+
+    await firstNode.stop();
+
+    const secondPairingManager = new LocalNodePairingManager();
+    const secondServerFactory = createFakeServerFactory();
+    const secondNode = new LocalNode({
+      createServer        : secondServerFactory.createServer,
+      discoveryFile       : createDiscoveryFile(),
+      pairingManager      : secondPairingManager,
+      pairingSessionStore : sessionStore,
+      portCandidates      : [55500],
+    });
+
+    await secondNode.start();
+
+    expect(secondPairingManager.validateSession('https://app.example', pollResult.token)).toBe(true);
+    expect(secondPairingManager.validateSession('https://existing.example', 'existing-token')).toBe(true);
+
+    await secondNode.stop();
+  });
+
+  it('should persist pairing revocation', async () => {
+    const sessionStore = createPairingSessionStore([{
+      createdAt : 1000,
+      origin    : 'https://app.example',
+      token     : 'paired-token',
+    }]);
+    const pairingManager = new LocalNodePairingManager();
+    const { createServer } = createFakeServerFactory();
+    const node = new LocalNode({
+      createServer,
+      discoveryFile       : createDiscoveryFile(),
+      pairingManager,
+      pairingSessionStore : sessionStore,
+      portCandidates      : [55500],
+    });
+
+    await node.start();
+
+    expect(pairingManager.validateSession('https://app.example', 'paired-token')).toBe(true);
+    expect(await node.revokePairingToken('paired-token')).toBe(true);
+    expect(pairingManager.validateSession('https://app.example', 'paired-token')).toBe(false);
+    expect(sessionStore.sessions).toEqual([]);
 
     await node.stop();
   });

--- a/packages/local-node/tests/pairing-session-store.spec.ts
+++ b/packages/local-node/tests/pairing-session-store.spec.ts
@@ -1,0 +1,75 @@
+import { join } from 'node:path';
+import { LocalNodePairingSessionFile } from '../src/pairing-session-store.js';
+import { tmpdir } from 'node:os';
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+
+describe('LocalNodePairingSessionFile', () => {
+  let tempDirs: string[] = [];
+
+  async function createTempFilePath(): Promise<string> {
+    const tempDir = await mkdtemp(join(tmpdir(), 'enbox-local-node-sessions-'));
+    tempDirs.push(tempDir);
+    return join(tempDir, 'sessions.json');
+  }
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map(async (tempDir): Promise<void> => {
+      await rm(tempDir, { force: true, recursive: true });
+    }));
+    tempDirs = [];
+  });
+
+  it('should return an empty session list when the file is missing', async () => {
+    const file = new LocalNodePairingSessionFile(await createTempFilePath());
+
+    expect(await file.read()).toEqual([]);
+  });
+
+  it('should write and read origin-bound pairing sessions', async () => {
+    const filePath = await createTempFilePath();
+    const file = new LocalNodePairingSessionFile(filePath);
+    const expectedSessions = [{
+      createdAt : 1234,
+      origin    : 'https://app.example',
+      token     : 'token-1',
+    }];
+    const sessions = [{
+      createdAt : 1234,
+      origin    : 'https://app.example',
+      token     : 'token-1',
+    }, {
+      createdAt : 5678,
+      token     : 'local-discovery-token',
+    }];
+
+    await file.write(sessions);
+
+    expect(await file.read()).toEqual(expectedSessions);
+    expect(JSON.parse(await readFile(filePath, 'utf-8'))).toEqual({
+      sessions : expectedSessions,
+      version  : 1,
+    });
+    expect((await stat(filePath)).mode & 0o777).toBe(0o600);
+  });
+
+  it('should remove corrupt or malformed session files', async () => {
+    const corruptPath = await createTempFilePath();
+    const corruptFile = new LocalNodePairingSessionFile(corruptPath);
+    await writeFile(corruptPath, '{');
+
+    expect(await corruptFile.read()).toEqual([]);
+    await expect(readFile(corruptPath, 'utf-8')).rejects.toThrow();
+
+    const malformedPath = await createTempFilePath();
+    const malformedFile = new LocalNodePairingSessionFile(malformedPath);
+    await writeFile(malformedPath, JSON.stringify({
+      sessions : [{ createdAt: 1234, token: 'missing-origin' }],
+      version  : 1,
+    }));
+
+    expect(await malformedFile.read()).toEqual([]);
+    await expect(readFile(malformedPath, 'utf-8')).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Persist origin-bound local-node pairing sessions in a private `~/.enbox/local-node-sessions.json` file and reload them on startup.
- Add pairing-manager session import/export plus local-node revocation persistence.
- Keep pending local-node changesets patch-only.

## Test plan
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run --filter @enbox/local-node test:node`
- [x] `bun run --filter @enbox/dwn-server test:node`
- [x] `bunx changeset status`
- [x] `git diff --check`

Refs #1162