### PR TITLE
fix(dwn-server): close revoked local-node sockets

### DIFF
--- a/.changeset/local-node-ws-revocation.md
+++ b/.changeset/local-node-ws-revocation.md
@@ -1,0 +1,6 @@
+---
+"@enbox/dwn-server": patch
+"@enbox/local-node": patch
+---
+
+fix: close local-node WebSocket connections when pairing tokens are revoked

--- a/packages/dwn-server/src/connection/connection-manager.ts
+++ b/packages/dwn-server/src/connection/connection-manager.ts
@@ -20,6 +20,8 @@ export interface ConnectionManager {
   connect(socket: ServerWebSocket<WsData>): Promise<void>;
   /** closes all of the connections */
   closeAll(): Promise<void>;
+  /** Closes local-node connections authenticated with the given pairing token. */
+  closeLocalNodeConnectionsByToken(token: string): Promise<number>;
   /** Returns the number of active connections. */
   getConnectionCount(): number;
   /** Returns the total number of active subscriptions across all connections. */
@@ -65,6 +67,19 @@ export class InMemoryConnectionManager implements ConnectionManager {
     const closePromises: Promise<void>[] = [];
     this.connections.forEach((connection) => closePromises.push(connection.close()));
     await Promise.all(closePromises);
+  }
+
+  async closeLocalNodeConnectionsByToken(token: string): Promise<number> {
+    const closePromises: Promise<void>[] = [];
+
+    this.connections.forEach((connection, socket) => {
+      if (socket.data.localNodeSession?.token === token) {
+        closePromises.push(connection.close());
+      }
+    });
+
+    await Promise.all(closePromises);
+    return closePromises.length;
   }
 
   getConnectionCount(): number {

--- a/packages/dwn-server/src/dwn-server.ts
+++ b/packages/dwn-server/src/dwn-server.ts
@@ -489,6 +489,22 @@ export class DwnServer {
   }
 
   /**
+   * Revokes a local-node pairing token and immediately closes any live WebSocket connections authenticated by it.
+   */
+  public async revokeLocalNodePairingToken(token: string): Promise<boolean> {
+    const revoked = this.#localNodePairingManager.revokeToken(token);
+    if (!revoked) {
+      return false;
+    }
+
+    if (this.#wsApi !== undefined) {
+      await this.#wsApi.closeLocalNodeConnectionsByToken(token);
+    }
+
+    return true;
+  }
+
+  /**
    * Gets the RegistrationManager for testing purposes.
    */
   get registrationManager(): RegistrationManager {

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -54,8 +54,14 @@ try {
 }
 
 /** Data attached to each Bun WebSocket via `ws.data`. */
+export type LocalNodeWebSocketSession = {
+  origin : string | undefined;
+  token : string;
+};
+
 export interface WsData {
-  connection: SocketConnection;
+  connection: SocketConnection | null;
+  localNodeSession? : LocalNodeWebSocketSession;
 }
 
 export class HttpApi {
@@ -209,17 +215,22 @@ export class HttpApi {
           return new Response('Forbidden', { status: 403 });
         }
 
+        const isWebSocketUpgrade = method === 'GET' && req.headers.get('upgrade')?.toLowerCase() === 'websocket';
+        let localNodeSession: LocalNodeWebSocketSession | undefined;
+
         if (self.#config.localNodeProfileEnabled) {
-          const authorizationResponse = self.#authorizeLocalNodeRequest(req, url, path, method);
-          if (authorizationResponse !== undefined) {
-            self.#applyCorsHeaders(req, authorizationResponse, path);
-            return authorizationResponse;
+          const authorizationResult = self.#authorizeLocalNodeRequest(req, url, path, method, isWebSocketUpgrade);
+          if (authorizationResult.status === 'unauthorized') {
+            self.#applyCorsHeaders(req, authorizationResult.response, path);
+            return authorizationResult.response;
           }
+
+          localNodeSession = authorizationResult.session;
         }
 
         // --- WebSocket upgrade ---
-        if (method === 'GET' && req.headers.get('upgrade') === 'websocket') {
-          const upgraded = server.upgrade(req, { data: { connection: null } });
+        if (isWebSocketUpgrade) {
+          const upgraded = server.upgrade(req, { data: { connection: null, localNodeSession } });
           if (upgraded) {
             return undefined;
           }
@@ -646,25 +657,41 @@ export class HttpApi {
       || path.startsWith('/local/pair/');
   }
 
-  static #isLocalNodePublicRoute(path: string, method: string): boolean {
+  static #isLocalNodePublicRoute(path: string, method: string, isWebSocketUpgrade: boolean): boolean {
+    if (isWebSocketUpgrade) {
+      return false;
+    }
+
     return method === 'OPTIONS'
       || (method === 'GET' && path === '/info')
       || (method === 'POST' && path === '/local/pair')
       || (method === 'GET' && path.startsWith('/local/pair/'));
   }
 
-  #authorizeLocalNodeRequest(req: Request, url: URL, path: string, method: string): Response | undefined {
-    if (HttpApi.#isLocalNodePublicRoute(path, method)) {
-      return undefined;
+  #authorizeLocalNodeRequest(
+    req: Request,
+    url: URL,
+    path: string,
+    method: string,
+    isWebSocketUpgrade: boolean
+  ): { session?: LocalNodeWebSocketSession; status: 'authorized' } | { response: Response; status: 'unauthorized' } {
+    if (HttpApi.#isLocalNodePublicRoute(path, method, isWebSocketUpgrade)) {
+      return { status: 'authorized' };
     }
 
     const origin = req.headers.get('origin') ?? undefined;
     const token = HttpApi.#getLocalNodeAuthToken(req, url);
-    if (this.#localNodePairingManager.validateSession(origin, token)) {
-      return undefined;
+    if (token !== undefined && this.#localNodePairingManager.validateSession(origin, token)) {
+      return {
+        session : { origin, token },
+        status  : 'authorized',
+      };
     }
 
-    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    return {
+      response : Response.json({ error: 'Unauthorized' }, { status: 401 }),
+      status   : 'unauthorized',
+    };
   }
 
   static #getLocalNodeAuthToken(req: Request, url: URL): string | undefined {
@@ -673,7 +700,7 @@ export class HttpApi {
       return bearerToken;
     }
 
-    if (req.headers.get('upgrade') === 'websocket') {
+    if (req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
       return url.searchParams.get('localNodeToken') ?? undefined;
     }
 

--- a/packages/dwn-server/src/ws-api.ts
+++ b/packages/dwn-server/src/ws-api.ts
@@ -58,6 +58,13 @@ export class WsApi {
     return this.#connectionManager;
   }
 
+  /**
+   * Closes live local-node WebSocket connections authenticated by the given pairing token.
+   */
+  async closeLocalNodeConnectionsByToken(token: string): Promise<number> {
+    return this.#connectionManager.closeLocalNodeConnectionsByToken(token);
+  }
+
   async close(): Promise<void> {
     await this.#connectionManager.closeAll();
   }

--- a/packages/dwn-server/tests/admin/admin-api.test.ts
+++ b/packages/dwn-server/tests/admin/admin-api.test.ts
@@ -1063,11 +1063,12 @@ describe('AdminApi — metrics and connection manager lifecycle', () => {
 
     // setConnectionManager
     const mockConnectionManager = {
-      connect                : async (): Promise<void> => {},
-      closeAll               : async (): Promise<void> => {},
-      getConnectionCount     : (): number => 42,
-      getSubscriptionCount   : (): number => 7,
-      getConnectionSnapshots : (): any[] => [],
+      closeAll                         : async (): Promise<void> => {},
+      closeLocalNodeConnectionsByToken : async (): Promise<number> => 0,
+      connect                          : async (): Promise<void> => {},
+      getConnectionCount               : (): number => 42,
+      getConnectionSnapshots           : (): any[] => [],
+      getSubscriptionCount             : (): number => 7,
     };
     adminApi.setConnectionManager(mockConnectionManager);
 

--- a/packages/dwn-server/tests/dwn-server.test.ts
+++ b/packages/dwn-server/tests/dwn-server.test.ts
@@ -1,11 +1,48 @@
 import type { Dwn } from '@enbox/dwn-sdk-js';
 
+import { WebSocket } from 'ws';
 import { describe, expect, it } from 'bun:test';
 
 import { config } from '../src/config.js';
 import { DwnServer } from '../src/dwn-server.js';
 import { getTestDwn } from './test-dwn.js';
 import { LocalNodePairingManager } from '../src/local-node-pairing.js';
+
+async function waitForWebSocketOpen(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.OPEN) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout((): void => reject(new Error('WebSocket open timeout')), 3000);
+    socket.onopen = (): void => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    socket.onerror = (error): void => {
+      clearTimeout(timeout);
+      reject(error);
+    };
+  });
+}
+
+async function waitForWebSocketClose(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.CLOSED) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout((): void => reject(new Error('WebSocket close timeout')), 3000);
+    socket.onclose = (): void => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    socket.onerror = (error): void => {
+      clearTimeout(timeout);
+      reject(error);
+    };
+  });
+}
 
 describe('DwnServer', () => {
   const dwnServerConfig = { ...config, port: 0 };
@@ -97,6 +134,38 @@ describe('DwnServer', () => {
         await expect(server.start()).rejects.toThrow('DwnServer local node profile requires a loopback bind hostname.');
       } finally {
         await dwn.close();
+      }
+    });
+
+    it('should close live WebSocket connections when a local-node pairing token is revoked', async () => {
+      ({ dwn } = await getTestDwn({ withEvents: true }));
+      const localNodePairingManager = new LocalNodePairingManager();
+      const token = localNodePairingManager.createSession('https://paired.example');
+      const server = new DwnServer({
+        dwn,
+        localNodePairingManager,
+        config: {
+          ...dwnServerConfig,
+          hostname                : '127.0.0.1',
+          localNodeProfileEnabled : true,
+          webSocketSupport        : true,
+        }
+      });
+
+      try {
+        await server.start();
+        const socket = new WebSocket(`ws://127.0.0.1:${server.httpServer.port}?localNodeToken=${token}`, {
+          headers: { Origin: 'https://paired.example' },
+        });
+
+        await waitForWebSocketOpen(socket);
+        const closed = waitForWebSocketClose(socket);
+
+        expect(await server.revokeLocalNodePairingToken(token)).toBe(true);
+        await closed;
+        expect(localNodePairingManager.validateSession('https://paired.example', token)).toBe(false);
+      } finally {
+        await server.stop();
       }
     });
   });

--- a/packages/dwn-server/tests/http-api.test.ts
+++ b/packages/dwn-server/tests/http-api.test.ts
@@ -1443,6 +1443,7 @@ describe('http api', function () {
       const wsUrl = url.replace(/^http:/, 'ws:');
 
       try {
+        await expect(requestWebSocketUpgradeStatus(`${wsUrl}/info`, 'https://paired.example')).resolves.toBe(401);
         await expect(requestWebSocketUpgradeStatus(`${wsUrl}?localNodeToken=wrong`, 'https://paired.example')).resolves.toBe(401);
         await expect(requestWebSocketUpgradeStatus(`${wsUrl}?localNodeToken=${token}`, 'https://unpaired.example')).resolves.toBe(401);
         await expect(requestWebSocketUpgradeStatus(`${wsUrl}?localNodeToken=${token}`, 'https://paired.example')).resolves.toBe(101);

--- a/packages/local-node/src/local-node.ts
+++ b/packages/local-node/src/local-node.ts
@@ -23,6 +23,7 @@ export type LocalNodeState = 'stopped' | 'running';
 export type LocalNodeDwnServer = {
   dwn?: { close(): Promise<void> };
   localNodePairingManager: LocalNodePairingManager;
+  revokeLocalNodePairingToken?(token: string): Promise<boolean>;
   start(): Promise<void>;
   stop(): Promise<void>;
 };
@@ -231,7 +232,9 @@ export class LocalNode {
   }
 
   public async revokePairingToken(token: string): Promise<boolean> {
-    const revoked = this.#pairingManager.revokeToken(token);
+    const revoked = this.#server?.revokeLocalNodePairingToken !== undefined
+      ? await this.#server.revokeLocalNodePairingToken(token)
+      : this.#pairingManager.revokeToken(token);
     if (!revoked) {
       return false;
     }

--- a/packages/local-node/tests/local-node.spec.ts
+++ b/packages/local-node/tests/local-node.spec.ts
@@ -73,6 +73,7 @@ class MemoryPairingSessionStore implements LocalNodePairingSessionStore {
 type FakeServer = LocalNodeDwnServer & {
   closedDwn : boolean;
   config : DwnServerConfig;
+  revokedTokens : string[];
   started : boolean;
   stopped : boolean;
 };
@@ -95,8 +96,17 @@ function createFakeServerFactory(options: { busyPorts?: number[] } = {}): {
           },
         },
         localNodePairingManager : pairingManager,
+        revokedTokens           : [],
         started                 : false,
         stopped                 : false,
+        async revokeLocalNodePairingToken(token: string): Promise<boolean> {
+          const revoked = pairingManager.revokeToken(token);
+          if (revoked) {
+            this.revokedTokens.push(token);
+          }
+
+          return revoked;
+        },
         async start(): Promise<void> {
           if (busyPorts.has(config.port)) {
             const error = new Error('address already in use') as Error & { code: string };
@@ -371,7 +381,7 @@ describe('LocalNode', () => {
       token     : 'paired-token',
     }]);
     const pairingManager = new LocalNodePairingManager();
-    const { createServer } = createFakeServerFactory();
+    const { createServer, servers } = createFakeServerFactory();
     const node = new LocalNode({
       createServer,
       discoveryFile       : createDiscoveryFile(),
@@ -386,6 +396,7 @@ describe('LocalNode', () => {
     expect(await node.revokePairingToken('paired-token')).toBe(true);
     expect(pairingManager.validateSession('https://app.example', 'paired-token')).toBe(false);
     expect(sessionStore.sessions).toEqual([]);
+    expect(servers[0].revokedTokens).toEqual(['paired-token']);
 
     await node.stop();
   });


### PR DESCRIPTION
## Summary
- Attach local-node pairing token metadata to WebSocket connections during upgrade and require token auth for every local-node WS upgrade, including `/info`.
- Add a server/connection-manager revocation path that closes live WebSockets using a revoked pairing token.
- Route `LocalNode.revokePairingToken()` through the running server before persisting sessions.

## Test plan
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run --filter @enbox/local-node test:node`
- [x] `bun run --filter @enbox/dwn-server test:node`
- [x] `bunx changeset status`
- [x] `git diff --check`

Refs #1164