### PR TITLE
fix(dwn-server): bind local pairing polls to origin

### DIFF
--- a/.changeset/local-node-pairing-origin.md
+++ b/.changeset/local-node-pairing-origin.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-server": patch
+---
+
+fix: require matching origins when polling local-node pairing requests

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -750,7 +750,7 @@ export class HttpApi {
     }
 
     const request = this.#localNodePairingManager.getRequest(requestId);
-    if (request === undefined || req.headers.get('origin') !== request.origin) {
+    if (req.headers.get('origin') !== request?.origin) {
       return Response.json({ error: 'Pairing request not found.' }, { status: 404 });
     }
 

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -418,7 +418,7 @@ export class HttpApi {
     }
 
     if (this.#config.localNodeProfileEnabled && path.startsWith('/local/pair/') && method === 'GET') {
-      return this.#handleLocalNodePairPoll(path);
+      return this.#handleLocalNodePairPoll(req, path);
     }
 
     // --- JSON-RPC POST ---
@@ -644,17 +644,17 @@ export class HttpApi {
       return undefined;
     }
 
-    if (HttpApi.#isLocalNodePublicCorsRoute(path)) {
+    if (path === '/info' || path === '/local/pair') {
       return origin;
     }
 
-    return this.#localNodePairingManager.isOriginPaired(origin) ? origin : undefined;
-  }
+    if (path.startsWith('/local/pair/')) {
+      const requestId = path.slice('/local/pair/'.length);
+      const request = this.#localNodePairingManager.getRequest(requestId);
+      return request?.origin === origin ? origin : undefined;
+    }
 
-  static #isLocalNodePublicCorsRoute(path: string): boolean {
-    return path === '/info'
-      || path === '/local/pair'
-      || path.startsWith('/local/pair/');
+    return this.#localNodePairingManager.isOriginPaired(origin) ? origin : undefined;
   }
 
   static #isLocalNodePublicRoute(path: string, method: string, isWebSocketUpgrade: boolean): boolean {
@@ -743,10 +743,15 @@ export class HttpApi {
     });
   }
 
-  #handleLocalNodePairPoll(path: string): Response {
+  #handleLocalNodePairPoll(req: Request, path: string): Response {
     const requestId = path.slice('/local/pair/'.length);
     if (requestId.length === 0) {
       return Response.json({ error: 'Pairing request ID is required.' }, { status: 400 });
+    }
+
+    const request = this.#localNodePairingManager.getRequest(requestId);
+    if (request === undefined || req.headers.get('origin') !== request.origin) {
+      return Response.json({ error: 'Pairing request not found.' }, { status: 404 });
     }
 
     const result = this.#localNodePairingManager.pollRequest(requestId);

--- a/packages/dwn-server/tests/http-api.test.ts
+++ b/packages/dwn-server/tests/http-api.test.ts
@@ -1322,6 +1322,16 @@ describe('http api', function () {
         expect(pairBody.status).toBe('pending');
         expect(localNodePairingManager.listPendingRequests()[0].origin).toBe('https://app.example');
 
+        const coalescedResponse = await fetch(`${url}/local/pair`, {
+          headers : { origin: 'https://app.example' },
+          method  : 'POST',
+        });
+        expect(coalescedResponse.status).toBe(200);
+        expect(await coalescedResponse.json()).toEqual({
+          requestId : pairBody.requestId,
+          status    : 'pending',
+        });
+
         const pendingResponse = await fetch(`${url}/local/pair/${pairBody.requestId}`, {
           headers: { origin: 'https://app.example' },
         });
@@ -1331,6 +1341,12 @@ describe('http api', function () {
         });
 
         expect(localNodePairingManager.approveRequest(pairBody.requestId)).toBe(true);
+
+        const wrongOriginResponse = await fetch(`${url}/local/pair/${pairBody.requestId}`, {
+          headers: { origin: 'https://evil.example' },
+        });
+        expect(wrongOriginResponse.status).toBe(404);
+        expect(wrongOriginResponse.headers.get('access-control-allow-origin')).toBeNull();
 
         const approvedResponse = await fetch(`${url}/local/pair/${pairBody.requestId}`, {
           headers: { origin: 'https://app.example' },
@@ -1362,6 +1378,41 @@ describe('http api', function () {
         });
         expect(missingTokenResponse.status).toBe(401);
         expect(missingTokenResponse.headers.get('access-control-allow-origin')).toBe('https://app.example');
+      } finally {
+        await api.close();
+      }
+    });
+
+    it('should rate-limit completed pairing requests per origin over HTTP', async () => {
+      const localNodePairingManager = new LocalNodePairingManager({
+        now                        : (): number => 1_000,
+        pairingRateLimitMax        : 1,
+        pairingRateLimitWindowMs   : 60_000,
+        terminalRequestRetentionMs : 60_000,
+      });
+      const { api, url } = await createStartedHttpApiWithConfig({
+        hostname                : '127.0.0.1',
+        localNodeProfileEnabled : true,
+      }, { localNodePairingManager });
+
+      try {
+        const pairResponse = await fetch(`${url}/local/pair`, {
+          headers : { origin: 'https://app.example' },
+          method  : 'POST',
+        });
+        const pairBody = await pairResponse.json() as { requestId: string };
+
+        expect(pairResponse.status).toBe(200);
+        expect(localNodePairingManager.denyRequest(pairBody.requestId)).toBe(true);
+
+        const rateLimitedResponse = await fetch(`${url}/local/pair`, {
+          headers : { origin: 'https://app.example' },
+          method  : 'POST',
+        });
+        expect(rateLimitedResponse.status).toBe(429);
+        expect(rateLimitedResponse.headers.get('retry-after')).toBe('60');
+        expect(rateLimitedResponse.headers.get('access-control-allow-origin')).toBe('https://app.example');
+        expect(await rateLimitedResponse.json()).toEqual({ error: 'Pairing rate limit exceeded.' });
       } finally {
         await api.close();
       }


### PR DESCRIPTION
## Summary
- Require `/local/pair/:requestId` polling to use the same Origin that created the pairing request.
- Avoid CORS reflection for wrong-origin pairing polls so approved tokens are not exposed or consumed cross-origin.
- Add HTTP-level coverage for pairing coalescing, wrong-origin polling, and pairing rate-limit responses.

## Test plan
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun test tests/http-api.test.ts tests/local-node-pairing.test.ts` from `packages/dwn-server`
- [x] `bun run --filter @enbox/dwn-server test:node`
- [x] `bunx changeset status`
- [x] `git diff --check`

Refs #1164