### PR TITLE
fix(dwn-server): honor local-node allowed origins

### DIFF
--- a/.changeset/local-node-allowed-origin-http.md
+++ b/.changeset/local-node-allowed-origin-http.md
@@ -1,0 +1,5 @@
+---
+"@enbox/dwn-server": patch
+---
+
+fix: auto-approve configured local-node pairing origins over HTTP

--- a/packages/dwn-server/src/http-api.ts
+++ b/packages/dwn-server/src/http-api.ts
@@ -721,7 +721,8 @@ export class HttpApi {
   }
 
   #handleLocalNodePairRequest(req: Request): Response {
-    const result = this.#localNodePairingManager.createRequest(req.headers.get('origin'));
+    const origin = req.headers.get('origin');
+    const result = this.#localNodePairingManager.createRequest(origin);
 
     if (result.status === 'invalid-origin') {
       return Response.json({ error: result.message }, { status: 400 });
@@ -735,6 +736,10 @@ export class HttpApi {
           status  : 429,
         },
       );
+    }
+
+    if (origin !== null && this.#config.localNodeAllowedOrigins.includes(origin)) {
+      this.#localNodePairingManager.approveRequest(result.requestId);
     }
 
     return Response.json({

--- a/packages/dwn-server/tests/http-api.test.ts
+++ b/packages/dwn-server/tests/http-api.test.ts
@@ -1383,6 +1383,67 @@ describe('http api', function () {
       }
     });
 
+    it('should auto-approve pairing requests from configured local-node allowed origins', async () => {
+      const localNodePairingManager = new LocalNodePairingManager();
+      const { api, url } = await createStartedHttpApiWithConfig({
+        hostname                : '127.0.0.1',
+        localNodeAllowedOrigins : ['https://app.example'],
+        localNodeProfileEnabled : true,
+      }, { localNodePairingManager });
+
+      try {
+        const pairResponse = await fetch(`${url}/local/pair`, {
+          headers : { origin: 'https://app.example' },
+          method  : 'POST',
+        });
+        expect(pairResponse.status).toBe(200);
+        expect(pairResponse.headers.get('access-control-allow-origin')).toBe('https://app.example');
+
+        const pairBody = await pairResponse.json() as { requestId: string; status: string };
+        expect(typeof pairBody.requestId).toBe('string');
+        expect(pairBody.status).toBe('pending');
+        expect(localNodePairingManager.listPendingRequests()).toEqual([]);
+
+        const approvedResponse = await fetch(`${url}/local/pair/${pairBody.requestId}`, {
+          headers: { origin: 'https://app.example' },
+        });
+        expect(approvedResponse.headers.get('access-control-allow-origin')).toBe('https://app.example');
+
+        const approvedBody = await approvedResponse.json() as { origin: string; status: string; token?: string };
+        expect(approvedBody.origin).toBe('https://app.example');
+        expect(approvedBody.status).toBe('approved');
+        expect(typeof approvedBody.token).toBe('string');
+        expect(localNodePairingManager.validateSession('https://app.example', approvedBody.token)).toBe(true);
+
+        const authenticatedResponse = await fetch(`${url}/health`, {
+          headers: {
+            authorization : `Bearer ${approvedBody.token}`,
+            origin        : 'https://app.example',
+          },
+        });
+        expect(authenticatedResponse.status).toBe(200);
+
+        const unlistedPairResponse = await fetch(`${url}/local/pair`, {
+          headers : { origin: 'https://unlisted.example' },
+          method  : 'POST',
+        });
+        const unlistedPairBody = await unlistedPairResponse.json() as { requestId: string; status: string };
+        expect(unlistedPairResponse.status).toBe(200);
+        expect(unlistedPairBody.status).toBe('pending');
+        expect(localNodePairingManager.listPendingRequests().map((request): string => request.origin)).toEqual(['https://unlisted.example']);
+
+        const unlistedPollResponse = await fetch(`${url}/local/pair/${unlistedPairBody.requestId}`, {
+          headers: { origin: 'https://unlisted.example' },
+        });
+        expect(await unlistedPollResponse.json()).toEqual({
+          origin : 'https://unlisted.example',
+          status : 'pending',
+        });
+      } finally {
+        await api.close();
+      }
+    });
+
     it('should rate-limit completed pairing requests per origin over HTTP', async () => {
       const localNodePairingManager = new LocalNodePairingManager({
         now                        : (): number => 1_000,


### PR DESCRIPTION
## Summary

- Honor `localNodeAllowedOrigins` in the dwn-server HTTP pairing route by auto-approving validated exact-Origin pairing requests.
- Preserve the existing browser client contract: `POST /local/pair` still returns `status: pending`, and the token is returned by polling.
- Add HTTP regression coverage for allowlisted auto-approval and unlisted origins remaining pending.
- Add a patch changeset for `@enbox/dwn-server`.

## Test plan

- [x] `bun run --filter @enbox/dwn-server lint`
- [x] `bunx turbo run build --filter=@enbox/dwn-server... --filter='!@enbox/docs' --filter='!@enbox/electrobun-dwn'`
- [x] `bun test tests/http-api.test.ts` from `packages/dwn-server`
- [x] `bun run --filter @enbox/dwn-server test:node`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run --filter @enbox/local-node test:node`
- [x] `bunx changeset status`

No shared local dev server was started.
