### PR TITLE
feat(agent): add local node drain sync API

### DIFF
--- a/.changeset/local-node-drain-api.md
+++ b/.changeset/local-node-drain-api.md
@@ -1,0 +1,5 @@
+---
+"@enbox/agent": patch
+---
+
+Add a sync drain API that reconciles registered identities to an explicit DWN endpoint and reports convergence progress.

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -10,7 +10,29 @@ import { parseDurationInMilliseconds, sleep } from '@enbox/common';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { PermissionsApi } from './types/permissions.js';
 import type { SyncMessageEntry } from './sync-messages.js';
-import type { DeadLetterCategory, DeadLetterEntry, DirectionCheckpoint, NonEmptyStringArray, PushFailure, PushResult, ReplicationLinkState, StartSyncParams, SyncAuthorization, SyncConnectivityState, SyncEngine, SyncEvent, SyncEventListener, SyncEventScope, SyncHealthSummary, SyncIdentityOptions, SyncMode, SyncScope } from './types/sync.js';
+import type {
+  DeadLetterCategory,
+  DeadLetterEntry,
+  DirectionCheckpoint,
+  NonEmptyStringArray,
+  PushFailure,
+  PushResult,
+  ReplicationLinkState,
+  StartSyncParams,
+  SyncAuthorization,
+  SyncConnectivityState,
+  SyncDrainOptions,
+  SyncDrainResult,
+  SyncDrainTargetResult,
+  SyncEngine,
+  SyncEvent,
+  SyncEventListener,
+  SyncEventScope,
+  SyncHealthSummary,
+  SyncIdentityOptions,
+  SyncMode,
+  SyncScope,
+} from './types/sync.js';
 
 import { AgentPermissionsApi } from './permissions-api.js';
 
@@ -112,6 +134,11 @@ type SyncReconcileOptions = {
 
 type SyncRunOptions = {
   verifyConvergence?: boolean;
+};
+
+type SyncDrainPlan = {
+  targets: SyncTarget[];
+  failures: SyncDrainTargetResult[];
 };
 
 type SyncScopeClosureValidationState = {
@@ -956,6 +983,172 @@ export class SyncEngineLevel implements SyncEngine {
     } finally {
       this._syncLock = false;
     }
+  }
+
+  public async drainTo(endpoint: string, options: SyncDrainOptions = {}): Promise<SyncDrainResult> {
+    if (this._syncLock) {
+      throw new Error('SyncEngineLevel: Sync operation is already in progress.');
+    }
+
+    const normalizedEndpoint = SyncEngineLevel.normalizeDwnEndpoint(endpoint);
+    this._syncLock = true;
+    try {
+      const plan = await this.buildSyncDrainPlan(normalizedEndpoint);
+      const shouldContinue = (): boolean => options.signal?.aborted !== true;
+      const targets = [...plan.failures];
+
+      for (const target of plan.targets) {
+        targets.push(await this.drainSyncTarget(target, shouldContinue));
+      }
+
+      const completed = targets.every((target): boolean => target.completed);
+      this.updateConnectivityAfterDrain(targets);
+
+      return {
+        completed,
+        endpoint: normalizedEndpoint,
+        targets,
+      };
+    } finally {
+      this._syncLock = false;
+    }
+  }
+
+  private async buildSyncDrainPlan(remoteEndpoint: string): Promise<SyncDrainPlan> {
+    const plan: SyncDrainPlan = {
+      failures : [],
+      targets  : [],
+    };
+
+    for await (const [did, options] of this._db.sublevel('registeredIdentities').iterator()) {
+      let parsed: SyncIdentityOptions;
+      try {
+        parsed = JSON.parse(options) as SyncIdentityOptions;
+      } catch (error: unknown) {
+        plan.failures.push({
+          tenantDid : did,
+          remoteEndpoint,
+          completed : false,
+          converged : false,
+          error     : `corrupt sync options: ${SyncEngineLevel.errorMessage(error)}`,
+        });
+        continue;
+      }
+
+      try {
+        plan.targets.push(...await this.buildSyncTargetsForEndpoint(did, remoteEndpoint, parsed));
+      } catch (error: unknown) {
+        plan.failures.push({
+          tenantDid : did,
+          remoteEndpoint,
+          scope     : SyncEngineLevel.syncScopeForDrainFailure(parsed),
+          completed : false,
+          converged : false,
+          error     : SyncEngineLevel.errorMessage(error),
+        });
+      }
+    }
+
+    return plan;
+  }
+
+  private async drainSyncTarget(target: SyncTarget, shouldContinue: () => boolean): Promise<SyncDrainTargetResult> {
+    try {
+      const result = await this.syncTargetWithDurableFeeds(target, { verifyConvergence: true }, shouldContinue);
+      if (result.admittedCids !== undefined && result.admittedCids.length > 0) {
+        this.emitReconcileApplied(target, result.admittedCids);
+      }
+
+      const pushFailures = result.pushFailures ?? [];
+      if (pushFailures.length > 0) {
+        await this.recordTerminalSyncPushFailures(target, pushFailures);
+      }
+
+      if (result.converged === false) {
+        await this.handleVerifiedFeedDivergence(target, result);
+      } else if (result.converged === true) {
+        await this.clearFeedConvergenceFailure(target);
+      }
+
+      const link = await this.getOrCreateReplicationLink(target);
+      const error = SyncEngineLevel.drainError(result, pushFailures);
+
+      return {
+        tenantDid         : target.did,
+        remoteEndpoint    : target.dwnUrl,
+        scope             : target.scope,
+        completed         : error === undefined,
+        converged         : result.converged === true,
+        pushCheckpoint    : link.push.contiguousAppliedToken,
+        localFingerprint  : result.localFingerprint,
+        remoteFingerprint : result.remoteFingerprint,
+        ...(error !== undefined ? { error } : {}),
+      };
+    } catch (error: unknown) {
+      return {
+        tenantDid      : target.did,
+        remoteEndpoint : target.dwnUrl,
+        scope          : target.scope,
+        completed      : false,
+        converged      : false,
+        error          : SyncEngineLevel.errorMessage(error),
+      };
+    }
+  }
+
+  private updateConnectivityAfterDrain(targets: SyncDrainTargetResult[]): void {
+    if (targets.length === 0) {
+      return;
+    }
+
+    if (targets.some((target): boolean => target.completed)) {
+      this.recordSyncSuccess();
+      return;
+    }
+
+    this.recordSyncFailure();
+  }
+
+  private static drainError(result: SyncReconcileResult, pushFailures: PushFailure[]): string | undefined {
+    if (result.aborted === true) {
+      return 'drain aborted';
+    }
+    if (pushFailures.length > 0) {
+      return `drain push failed for ${pushFailures.length} message(s)`;
+    }
+    if (result.converged !== true) {
+      return 'feed fingerprints did not converge';
+    }
+  }
+
+  private static syncScopeForDrainFailure(options: SyncIdentityOptions): SyncScope | undefined {
+    try {
+      return syncScopeFromProtocols(options.protocols);
+    } catch {
+      return;
+    }
+  }
+
+  private static normalizeDwnEndpoint(endpoint: string): string {
+    let url: URL;
+    try {
+      url = new URL(endpoint);
+    } catch {
+      throw new Error('SyncEngineLevel: drain endpoint must be a valid URL.');
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new Error('SyncEngineLevel: drain endpoint must use http or https.');
+    }
+
+    url.hash = '';
+    url.search = '';
+    const normalized = url.toString();
+    return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
+  }
+
+  private static errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 
   private async syncTargetGroups(

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -364,6 +364,39 @@ export type StartSyncParams = {
   interval?: string;
 };
 
+/**
+ * Options for a one-shot local-node drain. The abort signal is cooperative:
+ * in-flight DWN requests are allowed to settle, then remaining drain work stops.
+ */
+export type SyncDrainOptions = {
+  signal?: AbortSignal;
+};
+
+/**
+ * Per-link drain progress for a tenant and endpoint. A tenant can have more
+ * than one target when delegated grants split the requested sync scope.
+ */
+export type SyncDrainTargetResult = {
+  tenantDid: string;
+  remoteEndpoint: string;
+  scope?: SyncScope;
+  completed: boolean;
+  converged: boolean;
+  pushCheckpoint?: ProgressToken;
+  localFingerprint?: string;
+  remoteFingerprint?: string;
+  error?: string;
+};
+
+/**
+ * Result of draining all registered sync identities to a specific DWN endpoint.
+ */
+export type SyncDrainResult = {
+  endpoint: string;
+  completed: boolean;
+  targets: SyncDrainTargetResult[];
+};
+
 // ---------------------------------------------------------------------------
 // Sync observability events
 // ---------------------------------------------------------------------------
@@ -515,6 +548,16 @@ export interface SyncEngine {
    * @throws {Error} if a sync is already in progress or the sync operation fails.
    */
   sync(direction?: 'push' | 'pull'): Promise<void>;
+  /**
+   * Drains every registered sync identity to the given DWN endpoint.
+   *
+   * This is a one-shot eject primitive: it creates or resumes durable
+   * replication links for `endpoint`, replays local and remote feeds, and
+   * verifies cids-only feed convergence before marking a target complete.
+   *
+   * @throws {Error} if another one-shot sync or drain is already in progress.
+   */
+  drainTo(endpoint: string, options?: SyncDrainOptions): Promise<SyncDrainResult>;
   /**
    * Starts sync. In `'live'` mode opens real-time subscriptions with durable
    * feed repair; in `'poll'` mode uses periodic durable feed reconciliation.

--- a/packages/agent/tests/remote-mode-integration.spec.ts
+++ b/packages/agent/tests/remote-mode-integration.spec.ts
@@ -127,13 +127,15 @@ describe('Agent remote mode integration', () => {
     expect(localServer.httpUrl).not.toBe(remoteServer.httpUrl);
   });
 
-  it('drains local data to an explicit endpoint and reports convergence progress', async () => {
+  it('drains local and remote data to an explicit endpoint and reports convergence progress', async () => {
     context = await setupRemoteModeContext('drain');
     const { alice, remoteServer, testHarness } = context;
     const syncEngine = testHarness.agent.sync as any;
 
     await configureLocalProtocol(testHarness.agent, alice.did.uri, notesProtocol);
     const localWrite = await writeLocalRecord(testHarness.agent, alice.did.uri, 'drained local body');
+    await configureProtocolOnServer(testHarness.agent, remoteServer.httpUrl, alice.did, notesProtocol);
+    const remoteWrite = await writeRecordToServer(testHarness.agent, remoteServer.httpUrl, alice.did, 'drained remote body');
 
     await testHarness.agent.sync.registerIdentity({
       did     : alice.did.uri,
@@ -159,12 +161,14 @@ describe('Agent remote mode integration', () => {
     expect(target.localFingerprint).toBe(target.remoteFingerprint);
     expect(target.error).toBeUndefined();
     expect(await readRecordTextFromServer(testHarness.agent, remoteServer.httpUrl, alice.did, localWrite.recordId)).toBe('drained local body');
+    expect(await readLocalRecordText(testHarness.agent, alice.did.uri, remoteWrite.recordId)).toBe('drained remote body');
 
     const links = await syncEngine.ledger.getLinksForTenant(alice.did.uri);
     const link = links.find((candidate: any): boolean => candidate.remoteEndpoint === remoteServer.httpUrl);
 
     expect(link).toBeDefined();
     expect(link.push.contiguousAppliedToken).toEqual(target.pushCheckpoint);
+    expect(link.pull.contiguousAppliedToken).toBeDefined();
   });
 
   it('receives live WebSocket pull events through a real remote-mode local node', async () => {

--- a/packages/agent/tests/remote-mode-integration.spec.ts
+++ b/packages/agent/tests/remote-mode-integration.spec.ts
@@ -127,6 +127,46 @@ describe('Agent remote mode integration', () => {
     expect(localServer.httpUrl).not.toBe(remoteServer.httpUrl);
   });
 
+  it('drains local data to an explicit endpoint and reports convergence progress', async () => {
+    context = await setupRemoteModeContext('drain');
+    const { alice, remoteServer, testHarness } = context;
+    const syncEngine = testHarness.agent.sync as any;
+
+    await configureLocalProtocol(testHarness.agent, alice.did.uri, notesProtocol);
+    const localWrite = await writeLocalRecord(testHarness.agent, alice.did.uri, 'drained local body');
+
+    await testHarness.agent.sync.registerIdentity({
+      did     : alice.did.uri,
+      options : { protocols: [notesProtocol.protocol] },
+    });
+
+    const endpointResolutionStub = testHarness.agent.dwn.getRemoteDwnEndpointUrls as sinon.SinonStub;
+    endpointResolutionStub.rejects(new Error('drainTo must use the explicit endpoint'));
+
+    const result = await testHarness.agent.sync.drainTo(`${remoteServer.httpUrl}/`);
+
+    expect(result.endpoint).toBe(remoteServer.httpUrl);
+    expect(result.completed).toBe(true);
+    expect(result.targets).toHaveLength(1);
+
+    const target = result.targets[0]!;
+    expect(target.tenantDid).toBe(alice.did.uri);
+    expect(target.remoteEndpoint).toBe(remoteServer.httpUrl);
+    expect(target.completed).toBe(true);
+    expect(target.converged).toBe(true);
+    expect(target.pushCheckpoint).toBeDefined();
+    expect(target.localFingerprint).toBeDefined();
+    expect(target.localFingerprint).toBe(target.remoteFingerprint);
+    expect(target.error).toBeUndefined();
+    expect(await readRecordTextFromServer(testHarness.agent, remoteServer.httpUrl, alice.did, localWrite.recordId)).toBe('drained local body');
+
+    const links = await syncEngine.ledger.getLinksForTenant(alice.did.uri);
+    const link = links.find((candidate: any): boolean => candidate.remoteEndpoint === remoteServer.httpUrl);
+
+    expect(link).toBeDefined();
+    expect(link.push.contiguousAppliedToken).toEqual(target.pushCheckpoint);
+  });
+
   it('receives live WebSocket pull events through a real remote-mode local node', async () => {
     context = await setupRemoteModeContext('live');
     const { alice, remoteServer, testHarness } = context;

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -577,6 +577,84 @@ describe('SyncEngineLevel', () => {
           tenantDid      : alice.did.uri,
         });
       });
+
+      it('reports corrupt registered identities as drain failures', async () => {
+        await (syncEngine as any)._db.sublevel('registeredIdentities').put('did:example:corrupt', '{');
+
+        const result = await syncEngine.drainTo('https://dwn.example/path?token=secret#fragment');
+
+        expect(result.endpoint).toBe('https://dwn.example/path');
+        expect(result.completed).toBe(false);
+        expect(result.targets).toHaveLength(1);
+        expect(result.targets[0]).toMatchObject({
+          completed      : false,
+          converged      : false,
+          remoteEndpoint : 'https://dwn.example/path',
+          tenantDid      : 'did:example:corrupt',
+        });
+        expect(result.targets[0]!.error).toContain('corrupt sync options');
+      });
+
+      it('reports aborted drains without throwing', async () => {
+        const target = {
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+          did                : alice.did.uri,
+          dwnUrl             : 'https://dwn.example',
+          scope              : { kind: 'full' },
+        };
+        sinon.stub(syncEngine as any, 'buildSyncDrainPlan').resolves({
+          failures : [],
+          targets  : [target],
+        });
+        sinon.stub(syncEngine as any, 'syncTargetWithDurableFeeds').resolves({ aborted: true, pushFailures: [] });
+
+        const result = await syncEngine.drainTo('https://dwn.example');
+
+        expect(result.completed).toBe(false);
+        expect(result.targets).toHaveLength(1);
+        expect(result.targets[0]).toMatchObject({
+          completed      : false,
+          converged      : false,
+          error          : 'drain aborted',
+          remoteEndpoint : 'https://dwn.example',
+          tenantDid      : alice.did.uri,
+        });
+      });
+
+      it('reports push failures as incomplete drain progress', async () => {
+        const target = {
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+          did                : alice.did.uri,
+          dwnUrl             : 'https://dwn.example',
+          scope              : { kind: 'full' },
+        };
+        sinon.stub(syncEngine as any, 'buildSyncDrainPlan').resolves({
+          failures : [],
+          targets  : [target],
+        });
+        sinon.stub(syncEngine as any, 'syncTargetWithDurableFeeds').resolves({
+          converged         : true,
+          localFingerprint  : 'fingerprint',
+          pushFailures      : [{ cid: 'bafyreifailedcid' }],
+          remoteFingerprint : 'fingerprint',
+        });
+
+        const result = await syncEngine.drainTo('https://dwn.example');
+
+        expect(result.completed).toBe(false);
+        expect(result.targets).toHaveLength(1);
+        expect(result.targets[0]).toMatchObject({
+          completed         : false,
+          converged         : true,
+          error             : 'drain push failed for 1 message(s)',
+          localFingerprint  : 'fingerprint',
+          remoteEndpoint    : 'https://dwn.example',
+          remoteFingerprint : 'fingerprint',
+          tenantDid         : alice.did.uri,
+        });
+      });
     });
 
     describe('pull()', () => {

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -518,6 +518,67 @@ describe('SyncEngineLevel', () => {
       });
     });
 
+    describe('drainTo()', () => {
+      it('throws an error if a drain is currently already running', async () => {
+        const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+        const buildDrainPlanStub = sinon.stub(syncEngine as any, 'buildSyncDrainPlan');
+        buildDrainPlanStub.returns(new Promise<any>((resolve) => {
+          clock.setTimeout(() => {
+            resolve({ failures: [], targets: [] });
+          }, 90);
+        }));
+
+        const firstDrain = syncEngine.drainTo('https://dwn.example');
+
+        await clock.tickAsync(50);
+
+        try {
+          await syncEngine.drainTo('https://dwn.example');
+          throw new Error('Expected an error to be thrown');
+        } catch (error:any) {
+          expect(error.message).toBe('SyncEngineLevel: Sync operation is already in progress.');
+        }
+
+        await clock.tickAsync(50);
+        await firstDrain;
+
+        buildDrainPlanStub.restore();
+        clock.restore();
+      });
+
+      it('rejects invalid drain endpoints', async () => {
+        await expect(syncEngine.drainTo('not a url')).rejects.toThrow('SyncEngineLevel: drain endpoint must be a valid URL.');
+        await expect(syncEngine.drainTo('ftp://dwn.example')).rejects.toThrow('SyncEngineLevel: drain endpoint must use http or https.');
+      });
+
+      it('reports target failures without throwing', async () => {
+        const target = {
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+          did                : alice.did.uri,
+          dwnUrl             : 'https://dwn.example',
+          scope              : { kind: 'full' },
+        };
+        sinon.stub(syncEngine as any, 'buildSyncDrainPlan').resolves({
+          failures : [],
+          targets  : [target],
+        });
+        sinon.stub(syncEngine as any, 'syncTargetWithDurableFeeds').rejects(new Error('remote unavailable'));
+
+        const result = await syncEngine.drainTo('https://dwn.example');
+
+        expect(result.completed).toBe(false);
+        expect(result.targets).toHaveLength(1);
+        expect(result.targets[0]).toMatchObject({
+          completed      : false,
+          converged      : false,
+          error          : 'remote unavailable',
+          remoteEndpoint : 'https://dwn.example',
+          tenantDid      : alice.did.uri,
+        });
+      });
+    });
+
     describe('pull()', () => {
       it('synchronizes records that have been updated', async () => {
         // Write a test record to Alice's remote DWN.


### PR DESCRIPTION
Summary
- Add `SyncEngine.drainTo(endpoint)` to reconcile all registered identities against an explicit DWN endpoint.
- Return per-target drain progress with convergence state, push checkpoint, fingerprints, and failure details.
- Reuse durable feed reconciliation with cids-only convergence verification for the drain path.
- Add focused unit coverage for locking, endpoint validation, target exceptions, corrupt registered identities, aborts, and push failures.
- Expand the remote-mode integration test to verify bidirectional local/remote drain, explicit endpoint use, checkpoint updates, and matching convergence fingerprints.

Part of #1166.

Test plan
- [x] `bun run lint`
- [x] `bun run --filter @enbox/agent build`
- [x] `bun test --timeout 10000 tests/sync-engine-level.spec.ts -t drainTo`
- [x] `bun test tests/remote-mode-integration.spec.ts`
- [x] `bunx changeset status` (patch-only)
- [x] GitHub CI for PR #1225, including Node coverage and SonarCloud
- [ ] Local `bun run test:node` attempted after `bun run dev:ensure`; failed in pre-existing shared-server/did:dht sync/e2e cases with `GeneralJwsVerifierGetPublicKeyNotFound` / `Pkarr record not found` and cascading timeouts. The new drain tests passed in that run.