### PR TITLE
feat(auth): add local node eject flip

### DIFF
--- a/.changeset/local-node-eject-flip.md
+++ b/.changeset/local-node-eject-flip.md
@@ -1,5 +1,9 @@
 ---
+"@enbox/agent": patch
 "@enbox/auth": patch
+"@enbox/dwn-clients": patch
+"@enbox/dwn-server": patch
+"@enbox/local-node": patch
 ---
 
-feat: add local-node eject marker and next-session remote-mode boot
+Harden local-node ejection with authenticated stable drains, safe outage fallback, persisted consent, native token discovery, and durable local storage.

--- a/.changeset/local-node-eject-flip.md
+++ b/.changeset/local-node-eject-flip.md
@@ -1,0 +1,5 @@
+---
+"@enbox/auth": patch
+---
+
+feat: add local-node eject marker and next-session remote-mode boot

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -241,6 +241,11 @@ export class AgentDwnApi {
     return this._dwn === undefined;
   }
 
+  /** The fixed local-side DWN endpoint used when this API operates in remote mode. */
+  get localDwnEndpoint(): string | undefined {
+    return this._localDwnEndpoint;
+  }
+
   /**
    * Retrieves the `EnboxPlatformAgent` execution context.
    *

--- a/packages/agent/src/dwn-discovery-file-fs.ts
+++ b/packages/agent/src/dwn-discovery-file-fs.ts
@@ -8,6 +8,7 @@ export function createNodeDiscoveryFileFs(): DiscoveryFileFs | undefined {
   try {
     const nodeRequire = require;
     const fs = nodeRequire('node:fs/promises') as {
+      chmod(path: string, mode: number): Promise<void>;
       readFile(path: string, encoding: string): Promise<string>;
       writeFile(path: string, data: string, options: { encoding: string; mode?: number }): Promise<void>;
       mkdir(path: string, options: { recursive: boolean }): Promise<string | undefined>;
@@ -31,8 +32,24 @@ export function createNodeDiscoveryFileFs(): DiscoveryFileFs | undefined {
 
       async writeFile(filePath: string, contents: string): Promise<void> {
         await fs.mkdir(path.dirname(filePath), { recursive: true });
-        // mode 0o600: owner read/write only; this file contains the endpoint and PID of a local DWN server.
+        try {
+          // Restrict a legacy file before replacing its contents so a newly
+          // written bearer token is never briefly exposed under the old mode.
+          await fs.chmod(filePath, 0o600);
+        } catch (error: unknown) {
+          const errorCode = typeof error === 'object' && error !== null && 'code' in error
+            ? error.code
+            : undefined;
+          if (errorCode !== 'ENOENT') {
+            throw error;
+          }
+        }
+
+        // mode 0o600: owner read/write only; this file may contain a bearer token.
         await fs.writeFile(filePath, contents, { encoding: 'utf-8', mode: 0o600 });
+        // `mode` only applies when creating a file, so explicitly repair the
+        // permissions when replacing a legacy discovery file as well.
+        await fs.chmod(filePath, 0o600);
       },
 
       async removeFile(filePath: string): Promise<void> {

--- a/packages/agent/src/local-dwn.ts
+++ b/packages/agent/src/local-dwn.ts
@@ -84,6 +84,7 @@ export function normalizeBaseUrl(url: string): string {
 export class LocalDwnDiscovery {
   private _cachedEndpoint?: string;
   private _cacheExpiry = 0;
+  private _fileAuthenticatedEndpoint?: string;
 
   constructor(
     private readonly _rpcClient: EnboxRpc,
@@ -150,6 +151,7 @@ export class LocalDwnDiscovery {
   public clearCache(): void {
     this._cachedEndpoint = undefined;
     this._cacheExpiry = 0;
+    this._clearFileAuthentication();
   }
 
   // ─── Private ──────────────────────────────────────────────────
@@ -167,15 +169,46 @@ export class LocalDwnDiscovery {
     try {
       const record = await this._discoveryFile.read();
       if (!record) {
+        this._clearFileAuthentication();
         return undefined;
+      }
+
+      const hasAuthenticationForEndpoint = record.endpoint === this._fileAuthenticatedEndpoint
+        && record.localNodeToken !== undefined;
+      if (!hasAuthenticationForEndpoint) {
+        this._clearFileAuthentication();
       }
 
       // Validate that the server is actually alive and is ours.
       const valid = await this._validateEndpoint(record.endpoint);
-      return valid ? record.endpoint : undefined;
+      if (!valid) {
+        this._clearFileAuthentication();
+        return undefined;
+      }
+
+      if (
+        record.localNodeToken !== undefined
+        && this._rpcClient.clearDwnEndpointBearerToken !== undefined
+        && this._rpcClient.setDwnEndpointBearerToken !== undefined
+      ) {
+        this._rpcClient.setDwnEndpointBearerToken?.(record.endpoint, record.localNodeToken);
+        this._fileAuthenticatedEndpoint = record.endpoint;
+      }
+
+      return record.endpoint;
     } catch {
+      this._clearFileAuthentication();
       return undefined;
     }
+  }
+
+  /** Removes credentials installed from a previous discovery-file record. */
+  private _clearFileAuthentication(): void {
+    if (this._fileAuthenticatedEndpoint !== undefined) {
+      this._rpcClient.clearDwnEndpointBearerToken?.(this._fileAuthenticatedEndpoint);
+    }
+
+    this._fileAuthenticatedEndpoint = undefined;
   }
 
   /**

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1168,7 +1168,7 @@ export class SyncEngineLevel implements SyncEngine {
         scope             : target.scope,
         completed         : error === undefined,
         cancelled         : stopReason === 'cancelled',
-        converged         : result.converged === true && link.status !== 'paused' && !feedHeadChanged && stopReason === undefined,
+        converged         : SyncEngineLevel.drainConverged(result, link.status === 'paused', feedHeadChanged, stopReason),
         pushCheckpoint    : link.push.contiguousAppliedToken,
         localFingerprint  : result.localFingerprint,
         remoteFingerprint : result.remoteFingerprint,
@@ -1233,6 +1233,15 @@ export class SyncEngineLevel implements SyncEngine {
     if (result.converged !== true) {
       return 'feed fingerprints did not converge';
     }
+  }
+
+  private static drainConverged(
+    result: SyncReconcileResult,
+    paused: boolean,
+    feedHeadChanged: boolean,
+    stopReason: SyncDrainStopReason | undefined,
+  ): boolean {
+    return result.converged === true && !paused && !feedHeadChanged && stopReason === undefined;
   }
 
   private static stoppedDrainTarget(target: SyncTarget, stopReason: SyncDrainStopReason): SyncDrainTargetResult {

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -141,6 +141,8 @@ type SyncDrainPlan = {
   failures: SyncDrainTargetResult[];
 };
 
+type SyncDrainStopReason = 'cancelled' | 'topology-changed';
+
 type SyncScopeClosureValidationState = {
   requestedProtocols: Set<string>;
   protocolsToScan: string[];
@@ -776,6 +778,7 @@ export class SyncEngineLevel implements SyncEngine {
       'deferredPulls',
       'registeredIdentities',
       'replicationLinks',
+      'syncMetadata',
     ];
 
     for (const sublevelName of sublevelNames) {
@@ -991,23 +994,52 @@ export class SyncEngineLevel implements SyncEngine {
     }
 
     const normalizedEndpoint = SyncEngineLevel.normalizeDwnEndpoint(endpoint);
+    if (options.signal?.aborted === true) {
+      return {
+        endpoint        : normalizedEndpoint,
+        completed       : false,
+        cancelled       : true,
+        topologyChanged : false,
+        targets         : [],
+        error           : 'drain aborted',
+      };
+    }
+
     this._syncLock = true;
     try {
+      await this.registerSupplementalDwnEndpoint(normalizedEndpoint);
+      const topologyGeneration = this._syncTargetsCacheGeneration;
+      const getStopReason = (): SyncDrainStopReason | undefined => {
+        if (options.signal?.aborted === true) {
+          return 'cancelled';
+        }
+        if (this._syncTargetsCacheGeneration !== topologyGeneration) {
+          return 'topology-changed';
+        }
+      };
+
       const plan = await this.buildSyncDrainPlan(normalizedEndpoint);
-      const shouldContinue = (): boolean => options.signal?.aborted !== true;
+      await this.initializeDrainTargetsForLiveSync(plan.targets, getStopReason);
       const targets = [...plan.failures];
 
       for (const target of plan.targets) {
-        targets.push(await this.drainSyncTarget(target, shouldContinue));
+        targets.push(await this.drainSyncTarget(target, getStopReason));
       }
 
-      const completed = targets.every((target): boolean => target.completed);
+      const stopReason = getStopReason();
+      const cancelled = stopReason === 'cancelled' || targets.some((target): boolean => target.cancelled);
+      const topologyChanged = stopReason === 'topology-changed';
+      const completed = targets.length > 0 && !cancelled && !topologyChanged && targets.every((target): boolean => target.completed);
+      const error = SyncEngineLevel.drainResultError(targets, stopReason);
       this.updateConnectivityAfterDrain(targets);
 
       return {
-        completed,
         endpoint: normalizedEndpoint,
+        completed,
+        cancelled,
+        topologyChanged,
         targets,
+        ...(error !== undefined ? { error } : {}),
       };
     } finally {
       this._syncLock = false;
@@ -1029,6 +1061,7 @@ export class SyncEngineLevel implements SyncEngine {
           tenantDid : did,
           remoteEndpoint,
           completed : false,
+          cancelled : false,
           converged : false,
           error     : `corrupt sync options: ${SyncEngineLevel.errorMessage(error)}`,
         });
@@ -1043,6 +1076,7 @@ export class SyncEngineLevel implements SyncEngine {
           remoteEndpoint,
           scope     : SyncEngineLevel.syncScopeForDrainFailure(parsed),
           completed : false,
+          cancelled : false,
           converged : false,
           error     : SyncEngineLevel.errorMessage(error),
         });
@@ -1052,8 +1086,43 @@ export class SyncEngineLevel implements SyncEngine {
     return plan;
   }
 
-  private async drainSyncTarget(target: SyncTarget, shouldContinue: () => boolean): Promise<SyncDrainTargetResult> {
+  /**
+   * A drain endpoint is a durable handoff target, not only a one-shot URL.
+   * When live sync is already running, open the new links before reconciling
+   * so writes that race the drain continue to be delivered after parity.
+   */
+  private async initializeDrainTargetsForLiveSync(
+    targets: SyncTarget[],
+    getStopReason: () => SyncDrainStopReason | undefined,
+  ): Promise<void> {
+    if (this._syncMode !== 'live') {
+      return;
+    }
+
+    for (const target of targets) {
+      if (getStopReason() !== undefined) {
+        return;
+      }
+
+      const link = await this.getOrCreateReplicationLink(target);
+      const linkKey = this.getReplicationLinkKey(target, link);
+      if (!this._activeLinks.has(linkKey)) {
+        await this.initializeLinkTargetWithRetry(target);
+      }
+    }
+  }
+
+  private async drainSyncTarget(
+    target: SyncTarget,
+    getStopReason: () => SyncDrainStopReason | undefined,
+  ): Promise<SyncDrainTargetResult> {
+    const stopReasonAtStart = getStopReason();
+    if (stopReasonAtStart !== undefined) {
+      return SyncEngineLevel.stoppedDrainTarget(target, stopReasonAtStart);
+    }
+
     try {
+      const shouldContinue = (): boolean => getStopReason() === undefined;
       const result = await this.syncTargetWithDurableFeeds(target, { verifyConvergence: true }, shouldContinue);
       if (result.admittedCids !== undefined && result.admittedCids.length > 0) {
         this.emitReconcileApplied(target, result.admittedCids);
@@ -1064,32 +1133,59 @@ export class SyncEngineLevel implements SyncEngine {
         await this.recordTerminalSyncPushFailures(target, pushFailures);
       }
 
-      if (result.converged === false) {
-        await this.handleVerifiedFeedDivergence(target, result);
-      } else if (result.converged === true) {
-        await this.clearFeedConvergenceFailure(target);
+      const link = await this.getOrCreateReplicationLink(target);
+      let feedHeadChanged = false;
+      if (
+        link.status !== 'paused' &&
+        result.converged === true &&
+        pushFailures.length === 0 &&
+        getStopReason() === undefined
+      ) {
+        const stability = await this.verifyFeedConvergence(target, (): boolean => getStopReason() === undefined);
+        feedHeadChanged = stability.converged !== true ||
+          stability.localFingerprint !== result.localFingerprint ||
+          stability.remoteFingerprint !== result.remoteFingerprint;
+        result.aborted ||= stability.aborted;
+        result.converged = !feedHeadChanged;
+        result.localFingerprint = stability.localFingerprint ?? result.localFingerprint;
+        result.remoteFingerprint = stability.remoteFingerprint ?? result.remoteFingerprint;
       }
 
-      const link = await this.getOrCreateReplicationLink(target);
-      const error = SyncEngineLevel.drainError(result, pushFailures);
+      if (getStopReason() === undefined) {
+        if (result.converged === false && !feedHeadChanged) {
+          await this.handleVerifiedFeedDivergence(target, result);
+        } else if (result.converged === true) {
+          await this.clearFeedConvergenceFailure(target);
+        }
+      }
+
+      const stopReason = getStopReason();
+      const error = SyncEngineLevel.drainError(result, pushFailures, link.status === 'paused', feedHeadChanged, stopReason);
 
       return {
         tenantDid         : target.did,
         remoteEndpoint    : target.dwnUrl,
         scope             : target.scope,
         completed         : error === undefined,
-        converged         : result.converged === true,
+        cancelled         : stopReason === 'cancelled',
+        converged         : result.converged === true && link.status !== 'paused' && !feedHeadChanged && stopReason === undefined,
         pushCheckpoint    : link.push.contiguousAppliedToken,
         localFingerprint  : result.localFingerprint,
         remoteFingerprint : result.remoteFingerprint,
         ...(error !== undefined ? { error } : {}),
       };
     } catch (error: unknown) {
+      const stopReason = getStopReason();
+      if (stopReason !== undefined) {
+        return SyncEngineLevel.stoppedDrainTarget(target, stopReason);
+      }
+
       return {
         tenantDid      : target.did,
         remoteEndpoint : target.dwnUrl,
         scope          : target.scope,
         completed      : false,
+        cancelled      : getStopReason() === 'cancelled',
         converged      : false,
         error          : SyncEngineLevel.errorMessage(error),
       };
@@ -1109,7 +1205,25 @@ export class SyncEngineLevel implements SyncEngine {
     this.recordSyncFailure();
   }
 
-  private static drainError(result: SyncReconcileResult, pushFailures: PushFailure[]): string | undefined {
+  private static drainError(
+    result: SyncReconcileResult,
+    pushFailures: PushFailure[],
+    paused: boolean,
+    feedHeadChanged: boolean,
+    stopReason: SyncDrainStopReason | undefined,
+  ): string | undefined {
+    if (stopReason === 'cancelled') {
+      return 'drain aborted';
+    }
+    if (stopReason === 'topology-changed') {
+      return 'sync registrations changed during drain; retry required';
+    }
+    if (paused) {
+      return 'replication link is paused';
+    }
+    if (feedHeadChanged) {
+      return 'feed head changed during drain; retry required';
+    }
     if (result.aborted === true) {
       return 'drain aborted';
     }
@@ -1118,6 +1232,35 @@ export class SyncEngineLevel implements SyncEngine {
     }
     if (result.converged !== true) {
       return 'feed fingerprints did not converge';
+    }
+  }
+
+  private static stoppedDrainTarget(target: SyncTarget, stopReason: SyncDrainStopReason): SyncDrainTargetResult {
+    return {
+      tenantDid      : target.did,
+      remoteEndpoint : target.dwnUrl,
+      scope          : target.scope,
+      completed      : false,
+      cancelled      : stopReason === 'cancelled',
+      converged      : false,
+      error          : stopReason === 'cancelled'
+        ? 'drain aborted'
+        : 'sync registrations changed during drain; retry required',
+    };
+  }
+
+  private static drainResultError(
+    targets: SyncDrainTargetResult[],
+    stopReason: SyncDrainStopReason | undefined,
+  ): string | undefined {
+    if (stopReason === 'cancelled') {
+      return 'drain aborted';
+    }
+    if (stopReason === 'topology-changed') {
+      return 'sync registrations changed during drain; retry required';
+    }
+    if (targets.length === 0) {
+      return 'drain plan contained no registered sync targets';
     }
   }
 
@@ -1145,6 +1288,74 @@ export class SyncEngineLevel implements SyncEngine {
     url.search = '';
     const normalized = url.toString();
     return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
+  }
+
+  private async registerSupplementalDwnEndpoint(endpoint: string): Promise<void> {
+    const metadata = this._db.sublevel('syncMetadata');
+    const existing = await this.getSupplementalDwnEndpoint();
+    if (existing === endpoint) {
+      return;
+    }
+
+    await metadata.put('supplementalDwnEndpoint', endpoint);
+    this._syncTargetsCache = undefined;
+    this._syncTargetsCacheGeneration++;
+  }
+
+  private async getSupplementalDwnEndpoint(): Promise<string | undefined> {
+    try {
+      return await this._db.sublevel('syncMetadata').get('supplementalDwnEndpoint') as string;
+    } catch (error: unknown) {
+      if ((error as { code?: string }).code === 'LEVEL_NOT_FOUND') {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private async getSyncEndpointUrls(did: string): Promise<string[]> {
+    let supplementalEndpoint = await this.getSupplementalDwnEndpoint();
+    const activeLocalEndpoint = this.agent.dwn.localDwnEndpoint;
+    if (
+      supplementalEndpoint !== undefined
+      && this.agent.dwn.isRemoteMode
+      && (activeLocalEndpoint === undefined ||
+        SyncEngineLevel.normalizeDwnEndpoint(activeLocalEndpoint) === SyncEngineLevel.normalizeDwnEndpoint(supplementalEndpoint))
+    ) {
+      // After the session-boundary flip, the persisted handoff endpoint is
+      // the agent's local side. It must never also be scheduled as a remote
+      // replication target, regardless of the configured discovery strategy.
+      supplementalEndpoint = undefined;
+    }
+    let resolvedEndpoints: string[];
+    try {
+      resolvedEndpoints = await this.agent.dwn.getRemoteDwnEndpointUrls(did);
+    } catch (error: unknown) {
+      if (supplementalEndpoint === undefined) {
+        throw error;
+      }
+      resolvedEndpoints = [];
+    }
+
+    const endpointsByKey = new Map<string, string>();
+    for (const endpoint of [supplementalEndpoint, ...resolvedEndpoints]) {
+      if (endpoint === undefined) {
+        continue;
+      }
+
+      let key = endpoint;
+      try {
+        key = SyncEngineLevel.normalizeDwnEndpoint(endpoint);
+      } catch {
+        // Endpoint validation still occurs at the transport boundary. This key
+        // is only used to avoid duplicating an equivalent supplemental URL.
+      }
+      if (!endpointsByKey.has(key)) {
+        endpointsByKey.set(key, endpoint);
+      }
+    }
+
+    return [...endpointsByKey.values()];
   }
 
   private static errorMessage(error: unknown): string {
@@ -2238,7 +2449,7 @@ export class SyncEngineLevel implements SyncEngine {
 
   /** Hot-add a single identity to the active live sync session. */
   private async addIdentityToLiveSync(did: string, options: SyncIdentityOptions): Promise<Set<string>> {
-    const dwnEndpointUrls = await this.agent.dwn.getRemoteDwnEndpointUrls(did);
+    const dwnEndpointUrls = await this.getSyncEndpointUrls(did);
     if (dwnEndpointUrls.length === 0) { return new Set(); }
 
     const targets: SyncTarget[] = [];
@@ -4947,7 +5158,7 @@ export class SyncEngineLevel implements SyncEngine {
         continue;
       }
 
-      const dwnEndpointUrls = await this.agent.dwn.getRemoteDwnEndpointUrls(did);
+      const dwnEndpointUrls = await this.getSyncEndpointUrls(did);
       if (dwnEndpointUrls.length === 0) {
         anyTargetUnavailable = true;
         continue;

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -381,6 +381,8 @@ export type SyncDrainTargetResult = {
   remoteEndpoint: string;
   scope?: SyncScope;
   completed: boolean;
+  /** True only when this target stopped because the caller's abort signal fired. */
+  cancelled: boolean;
   converged: boolean;
   pushCheckpoint?: ProgressToken;
   localFingerprint?: string;
@@ -394,7 +396,12 @@ export type SyncDrainTargetResult = {
 export type SyncDrainResult = {
   endpoint: string;
   completed: boolean;
+  /** True only when the caller's abort signal was observed before completion. */
+  cancelled: boolean;
+  /** True when identity registration or agent topology changed while the drain was running. */
+  topologyChanged: boolean;
   targets: SyncDrainTargetResult[];
+  error?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -552,8 +559,11 @@ export interface SyncEngine {
    * Drains every registered sync identity to the given DWN endpoint.
    *
    * This is a one-shot eject primitive: it creates or resumes durable
-   * replication links for `endpoint`, replays local and remote feeds, and
-   * verifies cids-only feed convergence before marking a target complete.
+   * replication links for `endpoint`, persists it as a supplemental target
+   * for later poll/live sync, replays local and remote feeds, and requires two
+   * stable cids-only convergence snapshots before marking a target complete.
+   * Empty plans, paused links, cancellation, or registration changes produce
+   * an incomplete result that callers may safely retry.
    *
    * @throws {Error} if another one-shot sync or drain is already in progress.
    */

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -141,11 +141,13 @@ describe('AgentDwnApi', () => {
       const mockDwn = ({} as unknown) as Dwn;
       const dwnApi = new AgentDwnApi({ dwn: mockDwn });
       expect(dwnApi.isRemoteMode).toBe(false);
+      expect(dwnApi.localDwnEndpoint).toBeUndefined();
     });
 
     it('returns true when a localDwnEndpoint is provided instead of a DWN', () => {
       const dwnApi = new AgentDwnApi({ localDwnEndpoint: 'http://127.0.0.1:55557' });
       expect(dwnApi.isRemoteMode).toBe(true);
+      expect(dwnApi.localDwnEndpoint).toBe('http://127.0.0.1:55557');
     });
   });
 

--- a/packages/agent/tests/dwn-discovery-file.spec.ts
+++ b/packages/agent/tests/dwn-discovery-file.spec.ts
@@ -2,7 +2,7 @@ import * as BrowserDiscoveryFileFs from '../src/dwn-discovery-file-fs.browser.js
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { chmod, mkdtemp, rm, stat } from 'node:fs/promises';
 
 import {
   createNodeDiscoveryFileFs,
@@ -97,6 +97,10 @@ describe('DwnDiscoveryFile', () => {
       try {
         await fs.writeFile(filePath, 'hello');
         expect(await fs.readFile(filePath)).toBe('hello');
+
+        await chmod(filePath, 0o644);
+        await fs.writeFile(filePath, 'updated');
+        expect((await stat(filePath)).mode & 0o777).toBe(0o600);
 
         await fs.removeFile(filePath);
         expect(await fs.readFile(filePath)).toBeNull();

--- a/packages/agent/tests/local-dwn.spec.ts
+++ b/packages/agent/tests/local-dwn.spec.ts
@@ -137,6 +137,93 @@ describe('LocalDwnDiscovery', () => {
       expect((rpcClient.getServerInfo as sinon.SinonStub).firstCall.args[0]).toBe('http://127.0.0.1:55557');
     });
 
+    it('should register a discovery-file token for the validated endpoint', async () => {
+      const clearDwnEndpointBearerToken = sinon.stub();
+      const setDwnEndpointBearerToken = sinon.stub();
+      const rpcClient = {
+        clearDwnEndpointBearerToken,
+        getServerInfo: sinon.stub().resolves({ server: localDwnServerName }),
+        setDwnEndpointBearerToken,
+      } as unknown as EnboxRpc;
+      const discoveryFile = createDiscoveryFileStub({
+        endpoint       : 'http://127.0.0.1:55557',
+        localNodeToken : 'native-local-node-token',
+        pid            : 12345,
+      });
+
+      const discovery = new LocalDwnDiscovery(rpcClient, 10_000, discoveryFile);
+
+      expect(await discovery.getEndpoint()).toBe('http://127.0.0.1:55557');
+      expect(setDwnEndpointBearerToken.calledOnceWithExactly(
+        'http://127.0.0.1:55557',
+        'native-local-node-token',
+      )).toBe(true);
+    });
+
+    it('should clear a registered token when the discovery file later disappears', async () => {
+      const clearDwnEndpointBearerToken = sinon.stub();
+      const discoveryFile = createDiscoveryFileStub();
+      const record = {
+        endpoint       : 'http://127.0.0.1:55557',
+        localNodeToken : 'native-local-node-token',
+        pid            : 12345,
+      };
+      (discoveryFile.read as sinon.SinonStub)
+        .onFirstCall().resolves(record)
+        .onSecondCall().resolves(undefined);
+      const rpcClient = {
+        clearDwnEndpointBearerToken,
+        getServerInfo             : sinon.stub().resolves({ server: localDwnServerName }),
+        setDwnEndpointBearerToken : sinon.stub(),
+      } as unknown as EnboxRpc;
+      const discovery = new LocalDwnDiscovery(rpcClient, 0, discoveryFile);
+
+      expect(await discovery.getEndpoint()).toBe(record.endpoint);
+      expect(await discovery.getEndpoint()).toBeUndefined();
+      expect(clearDwnEndpointBearerToken.calledOnceWithExactly(record.endpoint)).toBe(true);
+    });
+
+    it('should clear a registered token when the endpoint later fails validation', async () => {
+      const clearDwnEndpointBearerToken = sinon.stub();
+      const discoveryFile = createDiscoveryFileStub({
+        endpoint       : 'http://127.0.0.1:55557',
+        localNodeToken : 'native-local-node-token',
+        pid            : 12345,
+      });
+      const getServerInfo = sinon.stub();
+      getServerInfo.onFirstCall().resolves({ server: localDwnServerName });
+      getServerInfo.onSecondCall().resolves({ server: 'some-other-server' });
+      const rpcClient = {
+        clearDwnEndpointBearerToken,
+        getServerInfo,
+        setDwnEndpointBearerToken: sinon.stub(),
+      } as unknown as EnboxRpc;
+      const discovery = new LocalDwnDiscovery(rpcClient, 0, discoveryFile);
+
+      expect(await discovery.getEndpoint()).toBe('http://127.0.0.1:55557');
+      expect(await discovery.getEndpoint()).toBeUndefined();
+      expect(clearDwnEndpointBearerToken.calledOnceWithExactly('http://127.0.0.1:55557')).toBe(true);
+    });
+
+    it('should not register a discovery-file token for an invalid endpoint', async () => {
+      const setDwnEndpointBearerToken = sinon.stub();
+      const rpcClient = {
+        clearDwnEndpointBearerToken : sinon.stub(),
+        getServerInfo               : sinon.stub().resolves({ server: 'some-other-server' }),
+        setDwnEndpointBearerToken,
+      } as unknown as EnboxRpc;
+      const discoveryFile = createDiscoveryFileStub({
+        endpoint       : 'http://127.0.0.1:55557',
+        localNodeToken : 'native-local-node-token',
+        pid            : 12345,
+      });
+
+      const discovery = new LocalDwnDiscovery(rpcClient, 10_000, discoveryFile);
+
+      expect(await discovery.getEndpoint()).toBeUndefined();
+      expect(setDwnEndpointBearerToken.called).toBe(false);
+    });
+
     it('should return undefined when the discovery file is empty', async () => {
       const rpcClient = createRpcStub('valid');
       const discoveryFile = createDiscoveryFileStub(null);
@@ -246,10 +333,17 @@ describe('LocalDwnDiscovery', () => {
 
   describe('clearCache', () => {
     it('should force fresh discovery on the next getEndpoint call', async () => {
-      const rpcClient = createRpcStub('valid');
+      const clearDwnEndpointBearerToken = sinon.stub();
+      const setDwnEndpointBearerToken = sinon.stub();
+      const rpcClient = {
+        clearDwnEndpointBearerToken,
+        getServerInfo: sinon.stub().resolves({ server: localDwnServerName }),
+        setDwnEndpointBearerToken,
+      } as unknown as EnboxRpc;
       const discoveryFile = createDiscoveryFileStub({
-        endpoint : 'http://127.0.0.1:55557',
-        pid      : 12345,
+        endpoint       : 'http://127.0.0.1:55557',
+        localNodeToken : 'native-local-node-token',
+        pid            : 12345,
       });
       const discovery = new LocalDwnDiscovery(rpcClient, 10_000, discoveryFile);
 
@@ -259,6 +353,8 @@ describe('LocalDwnDiscovery', () => {
 
       // Two validation calls: one before and one after cache clear.
       expect((rpcClient.getServerInfo as sinon.SinonStub).callCount).toBe(2);
+      expect(clearDwnEndpointBearerToken.calledOnceWithExactly('http://127.0.0.1:55557')).toBe(true);
+      expect(setDwnEndpointBearerToken.callCount).toBe(2);
     });
 
     it('should clear a previously cached positive result', async () => {

--- a/packages/agent/tests/remote-mode-integration.spec.ts
+++ b/packages/agent/tests/remote-mode-integration.spec.ts
@@ -169,6 +169,30 @@ describe('Agent remote mode integration', () => {
     expect(link).toBeDefined();
     expect(link.push.contiguousAppliedToken).toEqual(target.pushCheckpoint);
     expect(link.pull.contiguousAppliedToken).toBeDefined();
+
+    // The explicit handoff endpoint remains a durable supplemental target.
+    // This late write must still reach it even though DID endpoint resolution
+    // is unavailable after the one-shot parity check.
+    const lateWrite = await writeLocalRecord(testHarness.agent, alice.did.uri, 'late handoff body');
+    await testHarness.agent.sync.sync('push');
+    expect(await readRecordTextFromServer(testHarness.agent, remoteServer.httpUrl, alice.did, lateWrite.recordId)).toBe('late handoff body');
+  });
+
+  it('excludes the active local DWN endpoint from supplemental targets after remote-mode boot', async () => {
+    context = await setupRemoteModeContext('self-sync-exclusion');
+    const { alice, localServer, remoteServer, testHarness } = context;
+    const syncEngine = testHarness.agent.sync as any;
+
+    await testHarness.agent.sync.registerIdentity({
+      did     : alice.did.uri,
+      options : { protocols: [notesProtocol.protocol] },
+    });
+    await syncEngine.registerSupplementalDwnEndpoint(localServer.httpUrl);
+
+    const targets = await syncEngine.getSyncTargets();
+
+    expect(targets.some((target: any): boolean => target.dwnUrl === localServer.httpUrl)).toBe(false);
+    expect(targets.some((target: any): boolean => target.dwnUrl === remoteServer.httpUrl)).toBe(true);
   });
 
   it('receives live WebSocket pull events through a real remote-mode local node', async () => {

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -551,6 +551,20 @@ describe('SyncEngineLevel', () => {
         await expect(syncEngine.drainTo('ftp://dwn.example')).rejects.toThrow('SyncEngineLevel: drain endpoint must use http or https.');
       });
 
+      it('does not complete an empty drain plan', async () => {
+        sinon.stub(syncEngine as any, 'buildSyncDrainPlan').resolves({ failures: [], targets: [] });
+
+        const result = await syncEngine.drainTo('https://dwn.example');
+
+        expect(result).toMatchObject({
+          completed       : false,
+          cancelled       : false,
+          topologyChanged : false,
+          targets         : [],
+          error           : 'drain plan contained no registered sync targets',
+        });
+      });
+
       it('reports target failures without throwing', async () => {
         const target = {
           authorization      : { kind: 'owner' },
@@ -596,6 +610,7 @@ describe('SyncEngineLevel', () => {
       });
 
       it('reports aborted drains without throwing', async () => {
+        const controller = new AbortController();
         const target = {
           authorization      : { kind: 'owner' },
           authorizationEpoch : 'owner-epoch',
@@ -607,18 +622,124 @@ describe('SyncEngineLevel', () => {
           failures : [],
           targets  : [target],
         });
-        sinon.stub(syncEngine as any, 'syncTargetWithDurableFeeds').resolves({ aborted: true, pushFailures: [] });
+        sinon.stub(syncEngine as any, 'syncTargetWithDurableFeeds').callsFake(async (): Promise<any> => {
+          controller.abort();
+          return { aborted: true, pushFailures: [] };
+        });
 
-        const result = await syncEngine.drainTo('https://dwn.example');
+        const result = await syncEngine.drainTo('https://dwn.example', { signal: controller.signal });
 
         expect(result.completed).toBe(false);
+        expect(result.cancelled).toBe(true);
+        expect(result.topologyChanged).toBe(false);
+        expect(result.error).toBe('drain aborted');
         expect(result.targets).toHaveLength(1);
         expect(result.targets[0]).toMatchObject({
           completed      : false,
+          cancelled      : true,
           converged      : false,
           error          : 'drain aborted',
           remoteEndpoint : 'https://dwn.example',
           tenantDid      : alice.did.uri,
+        });
+      });
+
+      it('does not report a paused replication link as completed or converged', async () => {
+        const target = {
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+          did                : alice.did.uri,
+          dwnUrl             : 'https://dwn.example',
+          scope              : { kind: 'full' },
+        };
+        sinon.stub(syncEngine as any, 'buildSyncDrainPlan').resolves({ failures: [], targets: [target] });
+        sinon.stub(syncEngine as any, 'syncTargetWithDurableFeeds').resolves({
+          converged         : true,
+          localFingerprint  : 'fingerprint',
+          pushFailures      : [],
+          remoteFingerprint : 'fingerprint',
+        });
+        sinon.stub(syncEngine as any, 'getOrCreateReplicationLink').resolves({
+          status : 'paused',
+          push   : {},
+        });
+
+        const result = await syncEngine.drainTo('https://dwn.example');
+
+        expect(result.completed).toBe(false);
+        expect(result.targets[0]).toMatchObject({
+          completed : false,
+          cancelled : false,
+          converged : false,
+          error     : 'replication link is paused',
+        });
+      });
+
+      it('invalidates completion when sync registrations change during the drain', async () => {
+        const target = {
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+          did                : alice.did.uri,
+          dwnUrl             : 'https://dwn.example',
+          scope              : { kind: 'full' },
+        };
+        sinon.stub(syncEngine as any, 'buildSyncDrainPlan').resolves({ failures: [], targets: [target] });
+        sinon.stub(syncEngine as any, 'syncTargetWithDurableFeeds').callsFake(async (): Promise<any> => {
+          syncEngine['_syncTargetsCacheGeneration']++;
+          return {
+            converged         : true,
+            localFingerprint  : 'fingerprint',
+            pushFailures      : [],
+            remoteFingerprint : 'fingerprint',
+          };
+        });
+
+        const result = await syncEngine.drainTo('https://dwn.example');
+
+        expect(result).toMatchObject({
+          completed       : false,
+          cancelled       : false,
+          topologyChanged : true,
+          error           : 'sync registrations changed during drain; retry required',
+        });
+        expect(result.targets[0]).toMatchObject({
+          completed : false,
+          cancelled : false,
+          converged : false,
+          error     : 'sync registrations changed during drain; retry required',
+        });
+      });
+
+      it('requires a stable feed head before reporting completion', async () => {
+        const target = {
+          authorization      : { kind: 'owner' },
+          authorizationEpoch : 'owner-epoch',
+          did                : alice.did.uri,
+          dwnUrl             : 'https://dwn.example',
+          scope              : { kind: 'full' },
+        };
+        sinon.stub(syncEngine as any, 'buildSyncDrainPlan').resolves({ failures: [], targets: [target] });
+        sinon.stub(syncEngine as any, 'syncTargetWithDurableFeeds').resolves({
+          converged         : true,
+          localFingerprint  : 'first-fingerprint',
+          pushFailures      : [],
+          remoteFingerprint : 'first-fingerprint',
+        });
+        sinon.stub(syncEngine as any, 'verifyFeedConvergence').resolves({
+          converged         : true,
+          localFingerprint  : 'second-fingerprint',
+          pushFailures      : [],
+          remoteFingerprint : 'second-fingerprint',
+        });
+        const result = await syncEngine.drainTo('https://dwn.example');
+
+        expect(result.completed).toBe(false);
+        expect(result.targets[0]).toMatchObject({
+          completed         : false,
+          converged         : false,
+          error             : 'feed head changed during drain; retry required',
+          localFingerprint  : 'second-fingerprint',
+          remoteFingerprint : 'second-fingerprint',
         });
       });
 

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -1087,10 +1087,10 @@ export class AuthManager {
     }
 
     this._localDwnPairing = result.pairing;
+    this._userAgent.rpc = createLocalDwnRpcClient(result.pairing, this._userAgent.rpc);
 
     if (this._userAgent.dwn.isRemoteMode) {
       this._localDwnEndpoint = result.endpoint;
-      this._userAgent.rpc = createLocalDwnRpcClient(result.pairing);
       await this._userAgent.dwn.setCachedLocalDwnEndpoint(result.endpoint);
     } else {
       this._localDwnEndpoint = undefined;
@@ -1130,6 +1130,7 @@ export class AuthManager {
       throw new Error('[@enbox/auth] Local node eject requires an in-process DWN. The current agent is already in remote mode.');
     }
 
+    this._userAgent.rpc = createLocalDwnRpcClient(pairing, this._userAgent.rpc);
     const drain = await this._userAgent.sync.drainTo(pairing.endpoint, options);
     if (!drain.completed) {
       await clearLocalDwnEjection(this._storage);

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -31,6 +31,8 @@ import type {
   HeadlessConnectOptions,
   IdentitySyncProtocols,
   ImportFromPortableOptions,
+  LocalNodeEjectOptions,
+  LocalNodeEjectResult,
   RegistrationOptions,
   RestoreFromPhraseOptions,
   RestoreSessionOptions,
@@ -60,7 +62,15 @@ import { STORAGE_KEYS } from './types.js';
 import { validateConnectResultGrants } from './connect/validate-grants.js';
 import { vaultConnect } from './connect/vault.js';
 import { walletConnect } from './connect/wallet.js';
-import { createLocalDwnRpcClient, discoverLocalDwnPairing, probeLocalDwn, requestLocalDwnPairing } from './discovery.js';
+import {
+  clearLocalDwnEjection,
+  createLocalDwnRpcClient,
+  discoverLocalDwnPairing,
+  persistLocalDwnEjectionRecord,
+  probeLocalDwn,
+  readLocalDwnEjectionRecordForPairing,
+  requestLocalDwnPairing,
+} from './discovery.js';
 import { deriveActiveSyncScope, ensureVaultReady, finalizeDelegateSession, importDelegateAndSetupSync, resolveIdentityDids, resolvePassword, startSyncIfEnabled, toSyncIdentityProtocols } from './connect/lifecycle.js';
 
 /**
@@ -169,14 +179,18 @@ export class AuthManager {
     // zero vault/DWN dependencies — it reads the persisted pairing record
     // and validates it via GET /info plus authenticated /local/status.
     //
-    // When a local DWN server is available, the agent is created in
-    // "remote mode": it skips creating an in-process DWN and routes all
-    // DWN operations through RPC to the local server.
+    // A stored pairing alone is not enough to change the agent's storage mode:
+    // pairing establishes trust, while the ejection marker proves the local
+    // in-process DWN has drained to the paired node. Only then does the next
+    // session boot in remote mode.
     let localDwnEndpoint: string | undefined;
     let localDwnPairing: LocalDwnPairingRecord | undefined;
     if (!options.agent && options.localDwnStrategy !== 'off') {
       localDwnPairing = await discoverLocalDwnPairing(storage);
-      localDwnEndpoint = localDwnPairing?.endpoint;
+      if (localDwnPairing !== undefined) {
+        const ejection = await readLocalDwnEjectionRecordForPairing(storage, localDwnPairing);
+        localDwnEndpoint = ejection === undefined ? undefined : localDwnPairing.endpoint;
+      }
       // NOTE: We intentionally do NOT emit 'local-dwn-available' here
       // because event listeners aren't attached yet. Consumers should
       // check `authManager.localDwnEndpoint` after create() returns.
@@ -188,7 +202,9 @@ export class AuthManager {
       agentVault       : options.agentVault,
       localDwnStrategy : options.localDwnStrategy,
       localDwnEndpoint,
-      rpcClient        : localDwnPairing === undefined ? undefined : createLocalDwnRpcClient(localDwnPairing),
+      rpcClient        : localDwnEndpoint === undefined || localDwnPairing === undefined
+        ? undefined
+        : createLocalDwnRpcClient(localDwnPairing),
     });
 
     const manager = new AuthManager({
@@ -1041,9 +1057,11 @@ export class AuthManager {
   /**
    * Pair this origin with a local node and persist the resulting token.
    *
-   * When pairing succeeds, future `AuthManager.create()` calls boot in
-   * authenticated remote mode. If this manager was already created in remote
-   * mode, its RPC client is updated immediately.
+   * Pairing only establishes trust with the local node. Future
+   * `AuthManager.create()` calls boot in authenticated remote mode only after
+   * {@link ejectToLocalNode} drains the current in-process DWN and persists the
+   * ejection marker. If this manager was already created in remote mode, its
+   * RPC client is updated immediately.
    */
   async enableLocalNode(options: {
     endpoint?: string;
@@ -1068,17 +1086,73 @@ export class AuthManager {
       return result;
     }
 
-    this._localDwnEndpoint = result.endpoint;
     this._localDwnPairing = result.pairing;
 
     if (this._userAgent.dwn.isRemoteMode) {
+      this._localDwnEndpoint = result.endpoint;
       this._userAgent.rpc = createLocalDwnRpcClient(result.pairing);
       await this._userAgent.dwn.setCachedLocalDwnEndpoint(result.endpoint);
+    } else {
+      this._localDwnEndpoint = undefined;
+      await clearLocalDwnEjection(this._storage);
     }
 
     this._emitter.emit('local-dwn-available', { endpoint: result.endpoint, paired: true });
 
     return result;
+  }
+
+  /**
+   * Drain the current in-process DWN to the paired local node and mark the
+   * next session for remote-mode boot.
+   *
+   * This method deliberately does not mutate the active agent into remote mode.
+   * The local/remote switch happens only at the next `AuthManager.create()`
+   * boundary, which keeps the running agent's DWN handles and sync state stable.
+   */
+  async ejectToLocalNode(options: LocalNodeEjectOptions = {}): Promise<LocalNodeEjectResult> {
+    this._guardShutdown();
+
+    const pairing = this._localDwnPairing ?? await discoverLocalDwnPairing(this._storage);
+    if (pairing === undefined) {
+      await clearLocalDwnEjection(this._storage);
+      this._emitter.emit('local-dwn-unavailable', {});
+      return {
+        nextSessionRemoteMode : false,
+        reason                : 'not-paired',
+        status                : 'unavailable',
+      };
+    }
+
+    this._localDwnPairing = pairing;
+
+    if (this._userAgent.dwn.isRemoteMode) {
+      throw new Error('[@enbox/auth] Local node eject requires an in-process DWN. The current agent is already in remote mode.');
+    }
+
+    const drain = await this._userAgent.sync.drainTo(pairing.endpoint, options);
+    if (!drain.completed) {
+      await clearLocalDwnEjection(this._storage);
+      return {
+        drain,
+        endpoint              : drain.endpoint,
+        nextSessionRemoteMode : false,
+        status                : 'incomplete',
+      };
+    }
+
+    await persistLocalDwnEjectionRecord(this._storage, {
+      completedAt : Date.now(),
+      endpoint    : drain.endpoint,
+      version     : 1,
+    });
+
+    return {
+      drain,
+      endpoint              : drain.endpoint,
+      nextSessionRemoteMode : true,
+      status                : 'completed',
+    };
   }
 
   // ─── Private helpers ───────────────────────────────────────────

--- a/packages/auth/src/discovery.ts
+++ b/packages/auth/src/discovery.ts
@@ -31,6 +31,12 @@ export type LocalDwnPairingRecord = {
   createdAt: number;
 };
 
+export type LocalDwnEjectionRecord = {
+  version: 1;
+  endpoint: string;
+  completedAt: number;
+};
+
 export type LocalDwnUnsupportedReason = 'no-fetch' | 'insecure-context' | 'safari';
 
 export type LocalDwnProbeResult =
@@ -94,6 +100,7 @@ export type LocalDwnPairingRequestResult =
   | { status: 'timeout'; endpoint: string; requestId: string; pollUrl: string };
 
 const localDwnPairingRecordVersion = 1;
+const localDwnEjectionRecordVersion = 1;
 const defaultPairingTimeoutMs = 5 * 60 * 1000;
 const defaultPairingPollIntervalMs = 1500;
 
@@ -140,6 +147,42 @@ export async function persistLocalDwnPairingRecord(
   }));
 }
 
+/** Reads and validates the persisted local-node ejection marker. */
+export async function readLocalDwnEjectionRecord(
+  storage: StorageAdapter,
+): Promise<LocalDwnEjectionRecord | undefined> {
+  const raw = await storage.get(STORAGE_KEYS.LOCAL_DWN_EJECTION);
+  if (raw === null) {
+    return undefined;
+  }
+
+  const record = parseLocalDwnEjectionRecord(raw);
+  if (record === undefined) {
+    await clearLocalDwnEjection(storage);
+  }
+
+  return record;
+}
+
+/** Persists the marker that allows the next session to boot against the local node. */
+export async function persistLocalDwnEjectionRecord(
+  storage: StorageAdapter,
+  record: LocalDwnEjectionRecord,
+): Promise<void> {
+  await storage.set(STORAGE_KEYS.LOCAL_DWN_EJECTION, JSON.stringify({
+    ...record,
+    endpoint : normalizeBaseUrl(record.endpoint),
+    version  : localDwnEjectionRecordVersion,
+  }));
+}
+
+/** Clears the local-node ejection marker while leaving the pairing intact. */
+export async function clearLocalDwnEjection(
+  storage: StorageAdapter,
+): Promise<void> {
+  await storage.remove(STORAGE_KEYS.LOCAL_DWN_EJECTION);
+}
+
 /**
  * Clear the persisted local DWN pairing from auth storage.
  *
@@ -149,7 +192,53 @@ export async function persistLocalDwnPairingRecord(
 export async function clearLocalDwnEndpoint(
   storage: StorageAdapter,
 ): Promise<void> {
-  await storage.remove(STORAGE_KEYS.LOCAL_DWN_ENDPOINT);
+  await Promise.all([
+    storage.remove(STORAGE_KEYS.LOCAL_DWN_ENDPOINT),
+    clearLocalDwnEjection(storage),
+  ]);
+}
+
+/**
+ * Returns the persisted ejection marker only when it belongs to the validated
+ * pairing endpoint. Mismatched markers are stale and are cleared.
+ */
+export async function readLocalDwnEjectionRecordForPairing(
+  storage: StorageAdapter,
+  pairing: LocalDwnPairingRecord,
+): Promise<LocalDwnEjectionRecord | undefined> {
+  const ejection = await readLocalDwnEjectionRecord(storage);
+  if (ejection === undefined) {
+    return undefined;
+  }
+
+  if (!isSameEndpoint(ejection.endpoint, pairing.endpoint)) {
+    await clearLocalDwnEjection(storage);
+    return undefined;
+  }
+
+  return ejection;
+}
+
+/**
+ * Returns the validated pairing only when a successful drain/ejection marker
+ * exists for the same endpoint.
+ */
+export async function discoverEjectedLocalDwnPairing(
+  storage: StorageAdapter,
+  fetchOption?: FetchLike,
+): Promise<LocalDwnPairingRecord | undefined> {
+  const pairing = await discoverLocalDwnPairing(storage, fetchOption);
+  if (pairing === undefined) {
+    await clearLocalDwnEjection(storage);
+    return undefined;
+  }
+
+  const ejection = await readLocalDwnEjectionRecordForPairing(storage, pairing);
+  if (ejection === undefined) {
+    return undefined;
+  }
+
+  return pairing;
 }
 
 /**
@@ -468,6 +557,28 @@ function parseLocalDwnPairingRecord(raw: string): LocalDwnPairingRecord | undefi
       token        : value.token,
       version      : localDwnPairingRecordVersion,
       ...(value.localNodeId === undefined ? {} : { localNodeId: value.localNodeId }),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function parseLocalDwnEjectionRecord(raw: string): LocalDwnEjectionRecord | undefined {
+  try {
+    const value = JSON.parse(raw) as Partial<LocalDwnEjectionRecord>;
+    if (
+      value.version !== localDwnEjectionRecordVersion
+      || typeof value.endpoint !== 'string'
+      || typeof value.completedAt !== 'number'
+      || !Number.isFinite(value.completedAt)
+    ) {
+      return undefined;
+    }
+
+    return {
+      completedAt : value.completedAt,
+      endpoint    : normalizeBaseUrl(value.endpoint),
+      version     : localDwnEjectionRecordVersion,
     };
   } catch {
     return undefined;

--- a/packages/auth/src/discovery.ts
+++ b/packages/auth/src/discovery.ts
@@ -10,7 +10,17 @@
  */
 
 import type { EnboxUserAgent } from '@enbox/agent';
-import type { DwnRpcAuthOptions, ServerInfo } from '@enbox/dwn-clients';
+import type { ReplicationApplyResult } from '@enbox/dwn-sdk-js';
+import type {
+  DidRpcRequest,
+  DidRpcResponse,
+  DwnReplicationApplyRequest,
+  DwnRpcAuthOptions,
+  DwnRpcRequest,
+  DwnRpcResponse,
+  EnboxRpc,
+  ServerInfo,
+} from '@enbox/dwn-clients';
 
 import type { AuthEventEmitter } from './events.js';
 import type { StorageAdapter } from './types.js';
@@ -104,18 +114,103 @@ const localDwnEjectionRecordVersion = 1;
 const defaultPairingTimeoutMs = 5 * 60 * 1000;
 const defaultPairingPollIntervalMs = 1500;
 
+type LocalDwnPairingValidation =
+  | { status: 'paired'; serverInfo: ServerInfo }
+  | { status: 'revoked' }
+  | { status: 'unavailable' };
+
+type LocalDwnServerInfoResult =
+  | { status: 'found'; serverInfo: ServerInfo }
+  | { status: 'invalid' }
+  | { status: 'unavailable' };
+
+/**
+ * Routes paired-endpoint traffic through an authenticated client while
+ * preserving the caller's existing transports for every other endpoint.
+ */
+class LocalDwnAuthenticatedRpcClient implements EnboxRpc {
+  private readonly _authenticatedClient: EnboxRpc;
+  private readonly _fallbackClient: EnboxRpc;
+  private readonly _pairing: LocalDwnPairingRecord;
+
+  public constructor(pairing: LocalDwnPairingRecord, fallbackClient: EnboxRpc) {
+    const auth: DwnRpcAuthOptions = {
+      getBearerToken: (dwnUrl: string): string | undefined => {
+        return isSameEndpoint(dwnUrl, pairing.endpoint) ? pairing.token : undefined;
+      },
+    };
+
+    this._authenticatedClient = new EnboxRpcClient([], { auth });
+    this._fallbackClient = fallbackClient instanceof LocalDwnAuthenticatedRpcClient
+      ? fallbackClient._fallbackClient
+      : fallbackClient;
+    this._pairing = pairing;
+  }
+
+  public get transportProtocols(): string[] {
+    return [...new Set([
+      ...this._authenticatedClient.transportProtocols,
+      ...this._fallbackClient.transportProtocols,
+    ])];
+  }
+
+  public matchesPairing(pairing: LocalDwnPairingRecord): boolean {
+    return pairing.token === this._pairing.token
+      && isSameEndpoint(pairing.endpoint, this._pairing.endpoint);
+  }
+
+  public async close(): Promise<void> {
+    await Promise.all([
+      this._authenticatedClient.close(),
+      this._fallbackClient.close(),
+    ]);
+  }
+
+  public sendDidRequest(request: DidRpcRequest): Promise<DidRpcResponse> {
+    return this._fallbackClient.sendDidRequest(request);
+  }
+
+  public sendDwnRequest(request: DwnRpcRequest): Promise<DwnRpcResponse> {
+    return this.clientFor(request.dwnUrl).sendDwnRequest(request);
+  }
+
+  public applyReplicatedMessage(request: DwnReplicationApplyRequest): Promise<ReplicationApplyResult> {
+    return this.clientFor(request.dwnUrl).applyReplicatedMessage(request);
+  }
+
+  public getServerInfo(dwnUrl: string): Promise<ServerInfo> {
+    return this.clientFor(dwnUrl).getServerInfo(dwnUrl);
+  }
+
+  private clientFor(dwnUrl: string): EnboxRpc {
+    return isSameEndpoint(dwnUrl, this._pairing.endpoint)
+      ? this._authenticatedClient
+      : this._fallbackClient;
+  }
+}
+
 /**
  * Creates a DWN RPC client that attaches the pairing token only when requests
- * target the paired local-node endpoint.
+ * target the paired local-node endpoint. When a fallback client is supplied,
+ * its custom transports and non-local endpoint behavior are preserved.
  */
-export function createLocalDwnRpcClient(pairing: LocalDwnPairingRecord): EnboxRpcClient {
+export function createLocalDwnRpcClient(pairing: LocalDwnPairingRecord, fallbackClient?: EnboxRpc): EnboxRpc {
+  if (
+    fallbackClient instanceof LocalDwnAuthenticatedRpcClient
+    && fallbackClient.matchesPairing(pairing)
+  ) {
+    return fallbackClient;
+  }
+
   const auth: DwnRpcAuthOptions = {
     getBearerToken: (dwnUrl: string): string | undefined => {
       return isSameEndpoint(dwnUrl, pairing.endpoint) ? pairing.token : undefined;
     },
   };
 
-  return new EnboxRpcClient([], { auth });
+  return fallbackClient === undefined
+    ? new EnboxRpcClient([], { auth })
+    : new LocalDwnAuthenticatedRpcClient(pairing, fallbackClient);
 }
 
 /** Reads and validates the persisted local-node pairing record. */
@@ -258,16 +353,18 @@ export async function discoverLocalDwnPairing(
 
   const fetchFn = getFetch(fetchOption);
   if (fetchFn === undefined) {
+    await clearLocalDwnEjection(storage);
     return undefined;
   }
 
-  const serverInfo = await fetchLocalDwnServerInfo(pairing.endpoint, fetchFn);
-  const isPaired = serverInfo !== undefined
-    && serverInfo.localNode === true
-    && await fetchLocalDwnStatus(pairing, fetchFn);
-
-  if (!isPaired) {
+  const validation = await validateLocalDwnPairing(pairing, fetchFn);
+  if (validation.status === 'revoked') {
     await clearLocalDwnEndpoint(storage);
+    return undefined;
+  }
+
+  if (validation.status === 'unavailable') {
+    await clearLocalDwnEjection(storage);
     return undefined;
   }
 
@@ -337,25 +434,35 @@ export async function applyLocalDwnDiscovery(
  * only from a user gesture unless a stored pairing exists.
  */
 export async function probeLocalDwn(options: ProbeLocalDwnOptions = {}): Promise<LocalDwnProbeResult> {
+  const storage = options.storage;
   const fetchFn = getFetch(options.fetch);
   if (fetchFn === undefined) {
+    if (storage !== undefined) {
+      await clearLocalDwnEjection(storage);
+    }
     return { reason: 'no-fetch', status: 'unsupported' };
   }
 
-  const storedPairing = options.storage === undefined
+  const storedPairing = storage === undefined
     ? undefined
-    : await readLocalDwnPairingRecord(options.storage);
-  if (storedPairing !== undefined) {
-    const serverInfo = await fetchLocalDwnServerInfo(storedPairing.endpoint, fetchFn);
-    if (serverInfo !== undefined && await fetchLocalDwnStatus(storedPairing, fetchFn, options.origin)) {
+    : await readLocalDwnPairingRecord(storage);
+  if (storedPairing !== undefined && storage !== undefined) {
+    const validation = await validateLocalDwnPairing(storedPairing, fetchFn, options.origin);
+    if (validation.status === 'paired') {
       return {
-        endpoint : storedPairing.endpoint,
-        pairing  : storedPairing,
-        serverInfo,
-        status   : 'paired',
+        endpoint   : storedPairing.endpoint,
+        pairing    : storedPairing,
+        serverInfo : validation.serverInfo,
+        status     : 'paired',
       };
     }
-    await options.storage?.remove(STORAGE_KEYS.LOCAL_DWN_ENDPOINT);
+
+    if (validation.status === 'unavailable') {
+      await clearLocalDwnEjection(storage);
+      return { status: 'not-found' };
+    }
+
+    await clearLocalDwnEndpoint(storage);
   }
 
   const unsupportedReason = getUnsupportedReason();
@@ -585,18 +692,58 @@ function parseLocalDwnEjectionRecord(raw: string): LocalDwnEjectionRecord | unde
   }
 }
 
-async function fetchLocalDwnServerInfo(endpoint: string, fetchFn: FetchLike): Promise<ServerInfo | undefined> {
-  try {
-    const response = await fetchFn(endpointUrl(endpoint, '/info'), { method: 'GET' });
-    if (!response.ok) {
-      return undefined;
-    }
-
-    const serverInfo = await response.json() as ServerInfo;
-    return serverInfo.server === localDwnServerName ? serverInfo : undefined;
-  } catch {
-    return undefined;
+async function validateLocalDwnPairing(
+  pairing: LocalDwnPairingRecord,
+  fetchFn: FetchLike,
+  origin?: string,
+): Promise<LocalDwnPairingValidation> {
+  const infoResult = await fetchLocalDwnServerInfoResult(pairing.endpoint, fetchFn);
+  if (infoResult.status === 'unavailable') {
+    return infoResult;
   }
+
+  if (infoResult.status === 'invalid' || infoResult.serverInfo.localNode !== true) {
+    return { status: 'revoked' };
+  }
+
+  const status = await fetchLocalDwnStatus(pairing, fetchFn, origin);
+  return status === 'paired'
+    ? { serverInfo: infoResult.serverInfo, status }
+    : { status };
+}
+
+async function fetchLocalDwnServerInfo(endpoint: string, fetchFn: FetchLike): Promise<ServerInfo | undefined> {
+  const result = await fetchLocalDwnServerInfoResult(endpoint, fetchFn);
+  return result.status === 'found' ? result.serverInfo : undefined;
+}
+
+async function fetchLocalDwnServerInfoResult(endpoint: string, fetchFn: FetchLike): Promise<LocalDwnServerInfoResult> {
+  let response: Response;
+  try {
+    response = await fetchFn(endpointUrl(endpoint, '/info'), { method: 'GET' });
+  } catch {
+    return { status: 'unavailable' };
+  }
+
+  if (!response.ok) {
+    return { status: isTransientHttpStatus(response.status) ? 'unavailable' : 'invalid' };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return { status: 'invalid' };
+  }
+
+  if (body === null || typeof body !== 'object') {
+    return { status: 'invalid' };
+  }
+
+  const serverInfo = body as ServerInfo;
+  return serverInfo.server === localDwnServerName
+    ? { serverInfo, status: 'found' }
+    : { status: 'invalid' };
 }
 
 async function requireLocalDwnServerInfo(endpoint: string, fetchFn: FetchLike): Promise<ServerInfo> {
@@ -612,24 +759,32 @@ async function fetchLocalDwnStatus(
   pairing: LocalDwnPairingRecord,
   fetchFn: FetchLike,
   origin?: string,
-): Promise<boolean> {
+): Promise<'paired' | 'revoked' | 'unavailable'> {
+  let response: Response;
   try {
     const headers: Record<string, string> = { authorization: `Bearer ${pairing.token}` };
     attachOriginHeader(headers, origin);
 
-    const response = await fetchFn(endpointUrl(pairing.endpoint, '/local/status'), {
+    response = await fetchFn(endpointUrl(pairing.endpoint, '/local/status'), {
       headers,
       method: 'GET',
     });
-    if (!response.ok) {
-      return false;
-    }
-
-    const body = await response.json() as { localNode?: unknown; paired?: unknown };
-    return body.localNode === true && body.paired === true;
   } catch {
-    return false;
+    return 'unavailable';
   }
+
+  if (!response.ok) {
+    return isTransientHttpStatus(response.status) ? 'unavailable' : 'revoked';
+  }
+
+  let body: { localNode?: unknown; paired?: unknown };
+  try {
+    body = await response.json() as { localNode?: unknown; paired?: unknown };
+  } catch {
+    return 'revoked';
+  }
+
+  return body.localNode === true && body.paired === true ? 'paired' : 'revoked';
 }
 
 async function probeEndpointForPairing(endpoint: string, fetchFn: FetchLike): Promise<Extract<LocalDwnProbeResult, { status: 'found-unpaired' }> | { status: 'not-found' }> {
@@ -741,6 +896,10 @@ function normalizeComparableEndpoint(value: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function isTransientHttpStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
 }
 
 async function sleep(ms: number): Promise<void> {

--- a/packages/auth/src/shared.ts
+++ b/packages/auth/src/shared.ts
@@ -18,14 +18,18 @@ export { loadTokensFromStorage, saveTokensToStorage } from './registration.js';
 
 export {
   applyLocalDwnDiscovery,
+  clearLocalDwnEjection,
   clearLocalDwnEndpoint,
   createLocalDwnRpcClient,
+  discoverEjectedLocalDwnPairing,
   discoverLocalDwn,
   discoverLocalDwnPairing,
   initiateLocalDwnPairing,
+  persistLocalDwnEjectionRecord,
   persistLocalDwnPairingRecord,
   pollLocalDwnPairing,
   probeLocalDwn,
+  readLocalDwnEjectionRecord,
   readLocalDwnPairingRecord,
   requestLocalDwnPairing,
   restoreLocalDwnEndpoint,
@@ -33,6 +37,7 @@ export {
 
 export type {
   InitiateLocalDwnPairingOptions,
+  LocalDwnEjectionRecord,
   LocalDwnPairingInitiateResult,
   LocalDwnPairingPollResult,
   LocalDwnPairingRecord,
@@ -67,6 +72,8 @@ export type {
   IdentityInfo,
   IdentityVaultBackup,
   ImportFromPortableOptions,
+  LocalNodeEjectOptions,
+  LocalNodeEjectResult,
   LocalDwnStrategy,
   Permission,
   PortableIdentity,

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -4,7 +4,7 @@
  */
 
 import type { PortableDid } from '@enbox/dids';
-import type { AgentSessionIdentity, ConnectClientMetadata, ConnectPermissionRequest, DwnDataEncodedRecordsWriteMessage, DwnProtocolDefinition, EnboxUserAgent, HdIdentityVault, LocalDwnStrategy, PortableIdentity } from '@enbox/agent';
+import type { AgentSessionIdentity, ConnectClientMetadata, ConnectPermissionRequest, DwnDataEncodedRecordsWriteMessage, DwnProtocolDefinition, EnboxUserAgent, HdIdentityVault, LocalDwnStrategy, PortableIdentity, SyncDrainOptions, SyncDrainResult } from '@enbox/agent';
 
 import type { PasswordProvider } from './password-provider.js';
 
@@ -401,6 +401,27 @@ export interface AuthManagerOptions {
   connectHandler?: ConnectHandler;
 }
 
+export type LocalNodeEjectOptions = SyncDrainOptions;
+
+export type LocalNodeEjectResult =
+  | {
+    status: 'completed';
+    endpoint: string;
+    drain: SyncDrainResult;
+    nextSessionRemoteMode: true;
+  }
+  | {
+    status: 'incomplete';
+    endpoint: string;
+    drain: SyncDrainResult;
+    nextSessionRemoteMode: false;
+  }
+  | {
+    status: 'unavailable';
+    reason: 'not-paired';
+    nextSessionRemoteMode: false;
+  };
+
 /** Options for {@link AuthManager.connectVault}. */
 export interface VaultConnectOptions {
   /** Vault password (overrides manager default). */
@@ -736,6 +757,9 @@ export const STORAGE_KEYS = {
 
   /** Versioned local-node pairing record: endpoint, bearer token, origin, and metadata. */
   LOCAL_DWN_ENDPOINT: 'enbox:auth:localDwnEndpoint',
+
+  /** Versioned marker that allows a paired local node to become the next-session local DWN. */
+  LOCAL_DWN_EJECTION: 'enbox:auth:localDwnEjection',
 
   /**
    * JSON-serialised `Record<string, RegistrationTokenData>` for DWN endpoint

--- a/packages/auth/tests/auth-manager-create.spec.ts
+++ b/packages/auth/tests/auth-manager-create.spec.ts
@@ -9,9 +9,9 @@ import { EnboxUserAgent } from '@enbox/agent';
 
 import { AuthManager } from '../src/auth-manager.js';
 import { MemoryStorage } from '../src/storage/storage.js';
-import { persistLocalDwnPairingRecord } from '../src/discovery.js';
 import { WalletConnect } from '../src/wallet-connect-client.js';
 import { createMockAgent, createMockIdentity } from './helpers/mock-agent.js';
+import { persistLocalDwnEjectionRecord, persistLocalDwnPairingRecord, readLocalDwnEjectionRecord } from '../src/discovery.js';
 
 function createInitClientResult(): any {
   return {
@@ -205,7 +205,7 @@ describe('AuthManager.create()', () => {
     expect(capturedOptions.localDwnStrategy).toBe('only');
   });
 
-  test('creates remote-mode agent with a stored local-node pairing', async () => {
+  test('does not create remote-mode agent from a stored pairing before eject', async () => {
     const storage = new MemoryStorage();
     await persistLocalDwnPairingRecord(storage, {
       createdAt    : 123,
@@ -233,8 +233,52 @@ describe('AuthManager.create()', () => {
 
     const manager = await AuthManager.create({ storage });
 
+    expect(capturedOptions.localDwnEndpoint).toBeUndefined();
+    expect(capturedOptions.rpcClient).toBeUndefined();
+    expect(manager.localDwnEndpoint).toBeUndefined();
+    expect(manager.localDwnStatus).toEqual({
+      endpoint     : 'http://127.0.0.1:55500',
+      pairedOrigin : 'https://app.example',
+      status       : 'paired',
+    });
+  });
+
+  test('creates remote-mode agent with a stored local-node pairing after eject', async () => {
+    const storage = new MemoryStorage();
+    await persistLocalDwnPairingRecord(storage, {
+      createdAt    : 123,
+      endpoint     : 'http://127.0.0.1:55500',
+      pairedOrigin : 'https://app.example',
+      token        : 'paired-token',
+      version      : 1,
+    });
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : 'http://127.0.0.1:55500',
+      version     : 1,
+    });
+
+    sinon.stub(globalThis, 'fetch').callsFake(async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const href = url.toString();
+      if (href.endsWith('/info')) {
+        return jsonResponse(localNodeInfo());
+      }
+
+      expect((init?.headers as Record<string, string>).authorization).toBe('Bearer paired-token');
+      return jsonResponse({ localNode: true, paired: true });
+    });
+
+    let capturedOptions: any;
+    userAgentCreateStub.onFirstCall().callsFake((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    const manager = await AuthManager.create({ storage });
+
     expect(capturedOptions.localDwnEndpoint).toBe('http://127.0.0.1:55500');
     expect(capturedOptions.rpcClient).toBeDefined();
+    expect(manager.localDwnEndpoint).toBe('http://127.0.0.1:55500');
     expect(manager.localDwnStatus).toEqual({
       endpoint     : 'http://127.0.0.1:55500',
       pairedOrigin : 'https://app.example',
@@ -276,6 +320,7 @@ describe('AuthManager.create()', () => {
 
     expect(result.status).toBe('paired');
     expect(events).toEqual([{ endpoint: 'http://127.0.0.1:55500', paired: true }]);
+    expect(manager.localDwnEndpoint).toBeUndefined();
     expect(manager.localDwnStatus).toEqual({
       endpoint     : 'http://127.0.0.1:55500',
       pairedOrigin : 'https://app.example',
@@ -354,6 +399,189 @@ describe('AuthManager.create()', () => {
       pairedOrigin : 'https://app.example',
       status       : 'paired',
     });
+  });
+
+  test('ejectToLocalNode drains paired endpoint and marks the next session for remote mode', async () => {
+    const storage = new MemoryStorage();
+    await persistLocalDwnPairingRecord(storage, {
+      createdAt    : 123,
+      endpoint     : 'http://127.0.0.1:55500',
+      pairedOrigin : 'https://app.example',
+      token        : 'paired-token',
+      version      : 1,
+    });
+
+    sinon.stub(globalThis, 'fetch').callsFake(async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const href = url.toString();
+      if (href.endsWith('/info')) {
+        return jsonResponse(localNodeInfo());
+      }
+
+      expect((init?.headers as Record<string, string>).authorization).toBe('Bearer paired-token');
+      return jsonResponse({ localNode: true, paired: true });
+    });
+
+    const drainCalls: string[] = [];
+    const agent = createMockAgent({
+      syncDrainTo: async (endpoint): Promise<any> => {
+        drainCalls.push(endpoint);
+        return {
+          completed : true,
+          endpoint,
+          targets   : [{
+            completed      : true,
+            converged      : true,
+            remoteEndpoint : endpoint,
+            tenantDid      : 'did:dht:alice',
+          }],
+        };
+      },
+    });
+    userAgentCreateStub.onFirstCall().resolves(agent as any);
+
+    const manager = await AuthManager.create({ storage });
+    const result = await manager.ejectToLocalNode();
+
+    expect(result.status).toBe('completed');
+    expect(result.nextSessionRemoteMode).toBe(true);
+    expect(drainCalls).toEqual(['http://127.0.0.1:55500']);
+    expect(manager.localDwnEndpoint).toBeUndefined();
+    expect(await readLocalDwnEjectionRecord(storage)).toEqual({
+      completedAt : expect.any(Number),
+      endpoint    : 'http://127.0.0.1:55500',
+      version     : 1,
+    });
+
+    let capturedOptions: any;
+    userAgentCreateStub.onSecondCall().callsFake((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    const nextManager = await AuthManager.create({ storage });
+
+    expect(capturedOptions.localDwnEndpoint).toBe('http://127.0.0.1:55500');
+    expect(capturedOptions.rpcClient).toBeDefined();
+    expect(nextManager.localDwnEndpoint).toBe('http://127.0.0.1:55500');
+  });
+
+  test('ejectToLocalNode does not persist remote-mode marker when drain is incomplete', async () => {
+    const storage = new MemoryStorage();
+    await persistLocalDwnPairingRecord(storage, {
+      createdAt    : 123,
+      endpoint     : 'http://127.0.0.1:55500',
+      pairedOrigin : 'https://app.example',
+      token        : 'paired-token',
+      version      : 1,
+    });
+
+    sinon.stub(globalThis, 'fetch').callsFake(async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const href = url.toString();
+      if (href.endsWith('/info')) {
+        return jsonResponse(localNodeInfo());
+      }
+
+      expect((init?.headers as Record<string, string>).authorization).toBe('Bearer paired-token');
+      return jsonResponse({ localNode: true, paired: true });
+    });
+
+    const agent = createMockAgent({
+      syncDrainTo: async (endpoint): Promise<any> => ({
+        completed : false,
+        endpoint,
+        targets   : [{
+          completed      : false,
+          converged      : false,
+          error          : 'push failed',
+          remoteEndpoint : endpoint,
+          tenantDid      : 'did:dht:alice',
+        }],
+      }),
+    });
+    userAgentCreateStub.onFirstCall().resolves(agent as any);
+
+    const manager = await AuthManager.create({ storage });
+    const result = await manager.ejectToLocalNode();
+
+    expect(result.status).toBe('incomplete');
+    expect(result.nextSessionRemoteMode).toBe(false);
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
+
+    let capturedOptions: any;
+    userAgentCreateStub.onSecondCall().callsFake((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    const nextManager = await AuthManager.create({ storage });
+
+    expect(capturedOptions.localDwnEndpoint).toBeUndefined();
+    expect(capturedOptions.rpcClient).toBeUndefined();
+    expect(nextManager.localDwnEndpoint).toBeUndefined();
+  });
+
+  test('ejectToLocalNode returns unavailable and clears stale marker without a pairing', async () => {
+    const storage = new MemoryStorage();
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : 'http://127.0.0.1:55500',
+      version     : 1,
+    });
+
+    userAgentCreateStub.onFirstCall().resolves(createMockAgent() as any);
+
+    const manager = await AuthManager.create({ storage });
+    const events: any[] = [];
+    manager.on('local-dwn-unavailable', (event): void => {
+      events.push(event);
+    });
+
+    const result = await manager.ejectToLocalNode();
+
+    expect(result).toEqual({
+      nextSessionRemoteMode : false,
+      reason                : 'not-paired',
+      status                : 'unavailable',
+    });
+    expect(events).toEqual([{}]);
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
+  });
+
+  test('ejectToLocalNode rejects remote-mode agents before draining', async () => {
+    const storage = new MemoryStorage();
+    await persistLocalDwnPairingRecord(storage, {
+      createdAt    : 123,
+      endpoint     : 'http://127.0.0.1:55500',
+      pairedOrigin : 'https://app.example',
+      token        : 'paired-token',
+      version      : 1,
+    });
+
+    sinon.stub(globalThis, 'fetch').callsFake(async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const href = url.toString();
+      if (href.endsWith('/info')) {
+        return jsonResponse(localNodeInfo());
+      }
+
+      expect((init?.headers as Record<string, string>).authorization).toBe('Bearer paired-token');
+      return jsonResponse({ localNode: true, paired: true });
+    });
+
+    let drainCalls = 0;
+    userAgentCreateStub.onFirstCall().resolves(createMockAgent({
+      dwnIsRemoteMode : true,
+      syncDrainTo     : async (): Promise<any> => {
+        drainCalls += 1;
+        return { completed: true, endpoint: 'http://127.0.0.1:55500', targets: [] };
+      },
+    }) as any);
+
+    const manager = await AuthManager.create({ storage });
+
+    await expect(manager.ejectToLocalNode()).rejects.toThrow(
+      '[@enbox/auth] Local node eject requires an in-process DWN. The current agent is already in remote mode.'
+    );
+    expect(drainCalls).toBe(0);
   });
 });
 

--- a/packages/auth/tests/auth-manager-create.spec.ts
+++ b/packages/auth/tests/auth-manager-create.spec.ts
@@ -11,7 +11,12 @@ import { AuthManager } from '../src/auth-manager.js';
 import { MemoryStorage } from '../src/storage/storage.js';
 import { WalletConnect } from '../src/wallet-connect-client.js';
 import { createMockAgent, createMockIdentity } from './helpers/mock-agent.js';
-import { persistLocalDwnEjectionRecord, persistLocalDwnPairingRecord, readLocalDwnEjectionRecord } from '../src/discovery.js';
+import {
+  persistLocalDwnEjectionRecord,
+  persistLocalDwnPairingRecord,
+  readLocalDwnEjectionRecord,
+  readLocalDwnPairingRecord,
+} from '../src/discovery.js';
 
 function createInitClientResult(): any {
   return {
@@ -286,6 +291,53 @@ describe('AuthManager.create()', () => {
     });
   });
 
+  test('falls back to an in-process agent without discarding an unavailable pairing', async () => {
+    const storage = new MemoryStorage();
+    const pairing = {
+      createdAt    : 123,
+      endpoint     : 'http://127.0.0.1:55500',
+      pairedOrigin : 'https://app.example',
+      token        : 'paired-token',
+      version      : 1 as const,
+    };
+    await persistLocalDwnPairingRecord(storage, pairing);
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : pairing.endpoint,
+      version     : 1,
+    });
+
+    const fetchStub = sinon.stub(globalThis, 'fetch').rejects(new Error('connection refused'));
+    let capturedOptions: any;
+    userAgentCreateStub.onFirstCall().callsFake((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    const manager = await AuthManager.create({ storage });
+
+    expect(capturedOptions.localDwnEndpoint).toBeUndefined();
+    expect(capturedOptions.rpcClient).toBeUndefined();
+    expect(manager.localDwnStatus).toEqual({ status: 'unavailable' });
+    expect(await readLocalDwnPairingRecord(storage)).toEqual(pairing);
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
+
+    fetchStub.callsFake(async (url: string | URL | Request): Promise<Response> => {
+      return url.toString().endsWith('/info')
+        ? jsonResponse(localNodeInfo())
+        : jsonResponse({ localNode: true, paired: true });
+    });
+    userAgentCreateStub.onSecondCall().resolves(createMockAgent() as any);
+
+    const restoredManager = await AuthManager.create({ storage });
+    expect(restoredManager.localDwnStatus).toEqual({
+      endpoint     : pairing.endpoint,
+      pairedOrigin : pairing.pairedOrigin,
+      status       : 'paired',
+    });
+    expect(restoredManager.localDwnEndpoint).toBeUndefined();
+  });
+
   test('enableLocalNode pairs and emits local-dwn-available', async () => {
     const storage = new MemoryStorage();
     userAgentCreateStub.onFirstCall().resolves(createMockAgent() as any);
@@ -411,32 +463,59 @@ describe('AuthManager.create()', () => {
       version      : 1,
     });
 
+    const rpcAuthorizationHeaders: Array<string | undefined> = [];
     sinon.stub(globalThis, 'fetch').callsFake(async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
       const href = url.toString();
       if (href.endsWith('/info')) {
         return jsonResponse(localNodeInfo());
       }
 
-      expect((init?.headers as Record<string, string>).authorization).toBe('Bearer paired-token');
-      return jsonResponse({ localNode: true, paired: true });
+      const authorization = (init?.headers as Record<string, string>).authorization;
+      if (href.endsWith('/local/status')) {
+        expect(authorization).toBe('Bearer paired-token');
+        return jsonResponse({ localNode: true, paired: true });
+      }
+
+      rpcAuthorizationHeaders.push(authorization);
+      return jsonResponse({
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { result: { kind: 'Applied' } },
+      });
     });
 
     const drainCalls: string[] = [];
-    const agent = createMockAgent({
-      syncDrainTo: async (endpoint): Promise<any> => {
-        drainCalls.push(endpoint);
-        return {
-          completed : true,
-          endpoint,
-          targets   : [{
-            completed      : true,
-            converged      : true,
-            remoteEndpoint : endpoint,
-            tenantDid      : 'did:dht:alice',
-          }],
-        };
-      },
-    });
+    const fallbackCalls: string[] = [];
+    const agent = createMockAgent();
+    const originalRpc = agent.rpc;
+    originalRpc.sendDwnRequest = async (request): Promise<any> => {
+      fallbackCalls.push(request.dwnUrl);
+      return { status: { code: 200, detail: 'Custom transport' } };
+    };
+    agent.sync.drainTo = async (endpoint): Promise<any> => {
+      drainCalls.push(endpoint);
+      await agent.rpc.applyReplicatedMessage({
+        dwnUrl    : endpoint,
+        message   : { descriptor: {} } as any,
+        targetDid : 'did:dht:alice',
+      });
+      await agent.rpc.sendDwnRequest({
+        dwnUrl    : 'custom://remote.example',
+        message   : { descriptor: {} } as any,
+        targetDid : 'did:dht:alice',
+      });
+
+      return {
+        completed : true,
+        endpoint,
+        targets   : [{
+          completed      : true,
+          converged      : true,
+          remoteEndpoint : endpoint,
+          tenantDid      : 'did:dht:alice',
+        }],
+      };
+    };
     userAgentCreateStub.onFirstCall().resolves(agent as any);
 
     const manager = await AuthManager.create({ storage });
@@ -445,6 +524,9 @@ describe('AuthManager.create()', () => {
     expect(result.status).toBe('completed');
     expect(result.nextSessionRemoteMode).toBe(true);
     expect(drainCalls).toEqual(['http://127.0.0.1:55500']);
+    expect(rpcAuthorizationHeaders).toEqual(['Bearer paired-token']);
+    expect(fallbackCalls).toEqual(['custom://remote.example']);
+    expect(agent.rpc).not.toBe(originalRpc);
     expect(manager.localDwnEndpoint).toBeUndefined();
     expect(await readLocalDwnEjectionRecord(storage)).toEqual({
       completedAt : expect.any(Number),

--- a/packages/auth/tests/dwn-discovery.spec.ts
+++ b/packages/auth/tests/dwn-discovery.spec.ts
@@ -153,6 +153,11 @@ describe('local-node pairing storage', () => {
 
   test('clears malformed versioned pairing records', async () => {
     const storage = new MemoryStorage();
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : pairingRecord.endpoint,
+      version     : 1,
+    });
     await storage.set(STORAGE_KEYS.LOCAL_DWN_ENDPOINT, JSON.stringify({
       ...pairingRecord,
       localNodeId: 123,
@@ -160,11 +165,17 @@ describe('local-node pairing storage', () => {
 
     expect(await readLocalDwnPairingRecord(storage)).toBeUndefined();
     expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBeNull();
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_EJECTION)).toBeNull();
   });
 
   test('clears stale pairing records during passive discovery', async () => {
     const storage = new MemoryStorage();
     await persistLocalDwnPairingRecord(storage, pairingRecord);
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : pairingRecord.endpoint,
+      version     : 1,
+    });
 
     const result = await discoverLocalDwnPairing(storage, async (url, init): Promise<Response> => {
       if (url.toString().endsWith('/info')) {
@@ -177,6 +188,7 @@ describe('local-node pairing storage', () => {
 
     expect(result).toBeUndefined();
     expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBeNull();
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_EJECTION)).toBeNull();
   });
 
   test('returns valid stored pairing during passive discovery', async () => {
@@ -213,12 +225,18 @@ describe('local-node pairing storage', () => {
   test('returns undefined for stored pairing when fetch is unavailable', async () => {
     const storage = new MemoryStorage();
     await persistLocalDwnPairingRecord(storage, pairingRecord);
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : pairingRecord.endpoint,
+      version     : 1,
+    });
 
     await withoutGlobalFetch(async (): Promise<void> => {
       expect(await discoverLocalDwnPairing(storage)).toBeUndefined();
     });
 
     expect(await readLocalDwnPairingRecord(storage)).toEqual(pairingRecord);
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
   });
 
   test('restores stored pairing endpoint into an agent', async () => {
@@ -408,6 +426,11 @@ describe('probeLocalDwn', () => {
   test('clears stored pairing when probe revalidation fails', async () => {
     const storage = new MemoryStorage();
     await persistLocalDwnPairingRecord(storage, pairingRecord);
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : pairingRecord.endpoint,
+      version     : 1,
+    });
 
     const result = await probeLocalDwn({
       fetch: async (url): Promise<Response> => {
@@ -421,11 +444,17 @@ describe('probeLocalDwn', () => {
 
     expect(result).toEqual({ status: 'not-found' });
     expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBeNull();
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_EJECTION)).toBeNull();
   });
 
-  test('returns not-found when stored pairing status request throws', async () => {
+  test('retains stored pairing but clears ejection when status request is unavailable', async () => {
     const storage = new MemoryStorage();
     await persistLocalDwnPairingRecord(storage, pairingRecord);
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : pairingRecord.endpoint,
+      version     : 1,
+    });
 
     const result = await probeLocalDwn({
       fetch: async (url): Promise<Response> => {
@@ -440,7 +469,8 @@ describe('probeLocalDwn', () => {
     });
 
     expect(result).toEqual({ status: 'not-found' });
-    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBeNull();
+    expect(await readLocalDwnPairingRecord(storage)).toEqual(pairingRecord);
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
   });
 });
 
@@ -741,6 +771,52 @@ describe('createLocalDwnRpcClient', () => {
     });
 
     expect(authorizationHeaders).toEqual(['Bearer paired-token', undefined]);
+  });
+
+  test('authenticates the paired endpoint while preserving a fallback RPC client', async () => {
+    const fallbackRequests: string[] = [];
+    const fallback = {
+      applyReplicatedMessage : async (): Promise<any> => ({ status: { code: 202, detail: 'Applied' } }),
+      close                  : async (): Promise<void> => {},
+      getServerInfo          : async (): Promise<ServerInfo> => localNodeInfo,
+      sendDidRequest         : async (): Promise<any> => ({ ok: true, status: { code: 200, message: 'OK' } }),
+      sendDwnRequest         : async (request: any): Promise<any> => {
+        fallbackRequests.push(request.dwnUrl);
+        return { status: { code: 200, detail: 'Custom transport' } };
+      },
+      transportProtocols: ['custom:'],
+    };
+    const client = createLocalDwnRpcClient(pairingRecord, fallback as any);
+    const repeatedClient = createLocalDwnRpcClient(pairingRecord, client);
+    let authorization: string | undefined;
+
+    await withGlobalFetch(async (_url, init): Promise<Response> => {
+      authorization = (init?.headers as Record<string, string>).authorization;
+      return jsonResponse({
+        id      : 'test',
+        jsonrpc : '2.0',
+        result  : { reply: { status: { code: 202, detail: 'Accepted' } } },
+      });
+    }, async (): Promise<void> => {
+      const pairedReply = await client.sendDwnRequest({
+        dwnUrl    : pairingRecord.endpoint,
+        message   : { descriptor: {} } as any,
+        targetDid : 'did:dht:alice',
+      });
+      const customReply = await client.sendDwnRequest({
+        dwnUrl    : 'custom://remote.example',
+        message   : { descriptor: {} } as any,
+        targetDid : 'did:dht:alice',
+      });
+
+      expect(pairedReply.status.detail).toBe('Accepted');
+      expect(customReply.status.detail).toBe('Custom transport');
+    });
+
+    expect(authorization).toBe('Bearer paired-token');
+    expect(fallbackRequests).toEqual(['custom://remote.example']);
+    expect(client.transportProtocols).toContain('custom:');
+    expect(repeatedClient).toBe(client);
   });
 
   test('normalizes WebSocket URLs before attaching local-node token query params', async () => {

--- a/packages/auth/tests/dwn-discovery.spec.ts
+++ b/packages/auth/tests/dwn-discovery.spec.ts
@@ -8,14 +8,18 @@ import { MemoryStorage } from '../src/storage/storage.js';
 import { STORAGE_KEYS } from '../src/types.js';
 import {
   applyLocalDwnDiscovery,
+  clearLocalDwnEjection,
   clearLocalDwnEndpoint,
   createLocalDwnRpcClient,
+  discoverEjectedLocalDwnPairing,
   discoverLocalDwn,
   discoverLocalDwnPairing,
   initiateLocalDwnPairing,
+  persistLocalDwnEjectionRecord,
   persistLocalDwnPairingRecord,
   pollLocalDwnPairing,
   probeLocalDwn,
+  readLocalDwnEjectionRecord,
   readLocalDwnPairingRecord,
   requestLocalDwnPairing,
   restoreLocalDwnEndpoint,
@@ -61,6 +65,82 @@ describe('local-node pairing storage', () => {
     expect(raw).not.toBeNull();
     expect(JSON.parse(raw!)).toEqual(pairingRecord);
     expect(await readLocalDwnPairingRecord(storage)).toEqual(pairingRecord);
+  });
+
+  test('persists and reads a versioned ejection record', async () => {
+    const storage = new MemoryStorage();
+
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : `${pairingRecord.endpoint}/`,
+      version     : 1,
+    });
+
+    const expected = {
+      completedAt : 456,
+      endpoint    : pairingRecord.endpoint,
+      version     : 1,
+    };
+    const raw = await storage.get(STORAGE_KEYS.LOCAL_DWN_EJECTION);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toEqual(expected);
+    expect(await readLocalDwnEjectionRecord(storage)).toEqual(expected);
+  });
+
+  test('clears malformed ejection records', async () => {
+    const storage = new MemoryStorage();
+    await storage.set(STORAGE_KEYS.LOCAL_DWN_EJECTION, JSON.stringify({
+      completedAt : Number.NaN,
+      endpoint    : pairingRecord.endpoint,
+      version     : 1,
+    }));
+
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_EJECTION)).toBeNull();
+  });
+
+  test('clears ejection when clearing the pairing endpoint', async () => {
+    const storage = new MemoryStorage();
+    await persistLocalDwnPairingRecord(storage, pairingRecord);
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : pairingRecord.endpoint,
+      version     : 1,
+    });
+
+    await clearLocalDwnEndpoint(storage);
+
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_ENDPOINT)).toBeNull();
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_EJECTION)).toBeNull();
+  });
+
+  test('discovers an ejected pairing only when the marker matches the pairing endpoint', async () => {
+    const storage = new MemoryStorage();
+    await persistLocalDwnPairingRecord(storage, pairingRecord);
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      endpoint    : pairingRecord.endpoint,
+      version     : 1,
+    });
+
+    const fetchFn = async (url: string | URL | Request): Promise<Response> => {
+      return url.toString().endsWith('/info')
+        ? jsonResponse(localNodeInfo)
+        : jsonResponse({ localNode: true, paired: true });
+    };
+
+    expect(await discoverEjectedLocalDwnPairing(storage, fetchFn)).toEqual(pairingRecord);
+
+    await clearLocalDwnEjection(storage);
+    expect(await discoverEjectedLocalDwnPairing(storage, fetchFn)).toBeUndefined();
+
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 789,
+      endpoint    : 'http://127.0.0.1:55501',
+      version     : 1,
+    });
+    expect(await discoverEjectedLocalDwnPairing(storage, fetchFn)).toBeUndefined();
+    expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_EJECTION)).toBeNull();
   });
 
   test('clears legacy endpoint-only values', async () => {

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -204,7 +204,9 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
     },
 
     rpc: {
-      getServerInfo: overrides.rpcGetServerInfo ?? (async (): Promise<any> => ({
+      applyReplicatedMessage : async (): Promise<any> => ({ status: { code: 202, detail: 'Applied' } }),
+      close                  : async (): Promise<void> => {},
+      getServerInfo          : overrides.rpcGetServerInfo ?? (async (): Promise<any> => ({
         registrationRequirements : [],
         maxFileSize              : 10_000_000,
         server                   : '@enbox/dwn-server',
@@ -213,6 +215,9 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
         version                  : '0.0.1',
         webSocketSupport         : true,
       })),
+      sendDidRequest     : async (): Promise<any> => ({ ok: true, status: { code: 200, message: 'OK' } }),
+      sendDwnRequest     : async (): Promise<any> => ({ status: { code: 202, detail: 'Accepted' } }),
+      transportProtocols : ['http:', 'https:'],
     },
 
     vault: {

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -79,6 +79,7 @@ export interface MockAgentOverrides {
   syncStartSync?: (params: any) => Promise<void>;
   syncStopSync?: (timeout: number) => Promise<void>;
   syncSync?: (direction: string) => Promise<void>;
+  syncDrainTo?: (endpoint: string, options?: any) => Promise<any>;
   syncClose?: () => Promise<void>;
   syncHasActiveSubscriptions?: boolean;
   processDwnRequest?: (params: any) => Promise<any>;
@@ -181,6 +182,7 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
       startSync              : overrides.syncStartSync ?? (async (): Promise<void> => {}),
       stopSync               : overrides.syncStopSync ?? (async (): Promise<void> => {}),
       sync                   : overrides.syncSync ?? (async (): Promise<void> => {}),
+      drainTo                : overrides.syncDrainTo ?? (async (endpoint: string): Promise<any> => ({ completed: true, endpoint, targets: [] })),
       close                  : overrides.syncClose ?? (async (): Promise<void> => {}),
       hasActiveSubscriptions : overrides.syncHasActiveSubscriptions ?? false,
     },

--- a/packages/dwn-clients/src/rpc-auth.ts
+++ b/packages/dwn-clients/src/rpc-auth.ts
@@ -1,5 +1,26 @@
 import type { DwnRpcAuthOptions } from './dwn-rpc-types.js';
 
+/**
+ * Normalizes equivalent HTTP and WebSocket DWN endpoint URLs for
+ * endpoint-scoped transport authentication.
+ */
+export function normalizeDwnRpcAuthEndpoint(dwnUrl: string): string {
+  const url = new URL(dwnUrl);
+  if (url.protocol === 'ws:') {
+    url.protocol = 'http:';
+  } else if (url.protocol === 'wss:') {
+    url.protocol = 'https:';
+  }
+
+  url.password = '';
+  url.username = '';
+  url.hash = '';
+  url.search = '';
+
+  const normalized = url.toString();
+  return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
+}
+
 export function getBearerTokenForUrl(authOptions: DwnRpcAuthOptions | undefined, dwnUrl: string): string | undefined {
   return authOptions?.getBearerToken?.(dwnUrl);
 }

--- a/packages/dwn-clients/src/rpc-client.ts
+++ b/packages/dwn-clients/src/rpc-client.ts
@@ -6,6 +6,7 @@ import type { DwnServerInfoRpc, ServerInfo } from './server-info-types.js';
 import { createJsonRpcRequest } from './json-rpc.js';
 import { CryptoUtils } from '@enbox/crypto';
 import { HttpDwnRpcClient } from './http-dwn-rpc-client.js';
+import { normalizeDwnRpcAuthEndpoint } from './rpc-auth.js';
 import { WebSocketDwnRpcClient } from './web-socket-clients.js';
 
 /**
@@ -40,6 +41,15 @@ export type RpcStatus = {
 };
 
 export interface EnboxRpc extends DwnRpc, DidRpc, DwnServerInfoRpc {
+  /** Removes a previously registered endpoint bearer token. */
+  clearDwnEndpointBearerToken?(dwnUrl: string): void;
+
+  /**
+   * Registers a bearer token for one DWN endpoint. Implementations that do
+   * not support dynamic transport authentication may omit this method.
+   */
+  setDwnEndpointBearerToken?(dwnUrl: string, token: string): void;
+
   /**
    * Releases any persistent transport resources (e.g. pooled WebSocket
    * connections and their heartbeat timers). Called during application
@@ -56,17 +66,37 @@ export type EnboxRpcClientOptions = {
  * Client used to communicate with Dwn Servers
  */
 export class EnboxRpcClient implements EnboxRpc {
+  private readonly authenticatedTransportClients: Map<string, EnboxRpc>;
+  private readonly endpointBearerTokens = new Map<string, string>();
   private readonly transportClients: Map<string, EnboxRpc>;
 
   constructor(clients: EnboxRpc[] = [], options: EnboxRpcClientOptions = {}) {
+    this.authenticatedTransportClients = new Map();
     this.transportClients = new Map();
+
+    const auth: DwnRpcAuthOptions = {
+      getBearerToken: (dwnUrl: string): string | undefined => {
+        return this.endpointBearerTokens.get(normalizeDwnRpcAuthEndpoint(dwnUrl))
+          ?? options.auth?.getBearerToken?.(dwnUrl);
+      },
+    };
 
     // include http and socket clients as default.
     // can be overwritten for 'http:', 'https:', 'ws: or ':wss' if instantiated with other clients.
-    const httpClient = new HttpEnboxRpcClient(undefined, undefined, options.auth);
-    clients = [
+    const httpClient = new HttpEnboxRpcClient(undefined, undefined, auth);
+    const defaultClients: EnboxRpc[] = [
       httpClient,
-      new WebSocketEnboxRpcClient(httpClient, options.auth),
+      new WebSocketEnboxRpcClient(httpClient, auth),
+    ];
+
+    for (const client of defaultClients) {
+      for (const transportScheme of client.transportProtocols) {
+        this.authenticatedTransportClients.set(transportScheme, client);
+      }
+    }
+
+    clients = [
+      ...defaultClients,
       ...clients,
     ];
 
@@ -81,10 +111,28 @@ export class EnboxRpcClient implements EnboxRpc {
     return Array.from(this.transportClients.keys());
   }
 
+  /** Removes a dynamically registered bearer token from one normalized endpoint. */
+  public clearDwnEndpointBearerToken(dwnUrl: string): void {
+    this.endpointBearerTokens.delete(normalizeDwnRpcAuthEndpoint(dwnUrl));
+  }
+
+  /** Registers or rotates a bearer token for one normalized DWN endpoint. */
+  public setDwnEndpointBearerToken(dwnUrl: string, token: string): void {
+    if (token.length === 0) {
+      throw new Error('EnboxRpcClient: Endpoint bearer token must not be empty.');
+    }
+
+    this.endpointBearerTokens.set(normalizeDwnRpcAuthEndpoint(dwnUrl), token);
+  }
+
   /** Closes every distinct transport client (the same client may serve multiple schemes). */
   async close(): Promise<void> {
     const closed = new Set<EnboxRpc>();
-    for (const client of this.transportClients.values()) {
+    const clients = [
+      ...this.authenticatedTransportClients.values(),
+      ...this.transportClients.values(),
+    ];
+    for (const client of clients) {
       if (closed.has(client)) {
         continue;
       }
@@ -112,7 +160,7 @@ export class EnboxRpcClient implements EnboxRpc {
     // will throw if url is invalid
     const url = new URL(request.dwnUrl);
 
-    const transportClient = this.transportClients.get(url.protocol);
+    const transportClient = this.getTransportClient(url, request.dwnUrl);
     if (!transportClient) {
       const error = new Error(`no ${url.protocol} transport client available`);
       error.name = 'NO_TRANSPORT_CLIENT';
@@ -126,7 +174,7 @@ export class EnboxRpcClient implements EnboxRpc {
   applyReplicatedMessage(request: DwnReplicationApplyRequest): Promise<ReplicationApplyResult> {
     const url = new URL(request.dwnUrl);
 
-    const transportClient = this.transportClients.get(url.protocol);
+    const transportClient = this.getTransportClient(url, request.dwnUrl);
     if (!transportClient) {
       const error = new Error(`no ${url.protocol} transport client available`);
       error.name = 'NO_TRANSPORT_CLIENT';
@@ -150,6 +198,15 @@ export class EnboxRpcClient implements EnboxRpc {
     }
 
     return transportClient.getServerInfo(dwnUrl);
+  }
+
+  /** Selects the authenticated built-in transport only for registered endpoints. */
+  private getTransportClient(url: URL, dwnUrl: string): EnboxRpc | undefined {
+    if (this.endpointBearerTokens.has(normalizeDwnRpcAuthEndpoint(dwnUrl))) {
+      return this.authenticatedTransportClients.get(url.protocol);
+    }
+
+    return this.transportClients.get(url.protocol);
   }
 }
 

--- a/packages/dwn-clients/src/web-socket-clients.ts
+++ b/packages/dwn-clients/src/web-socket-clients.ts
@@ -71,6 +71,25 @@ function stripTrailingSlash(url: string): string {
   return url.endsWith('/') ? url.slice(0, -1) : url;
 }
 
+function redactConnectionError(error: unknown, url: URL, displayUrl: URL): string {
+  let detail = error instanceof Error ? error.message : String(error);
+  const unsafeUrls = new Set([url.toString(), stripTrailingSlash(url.toString())]);
+  for (const unsafeUrl of unsafeUrls) {
+    detail = detail.replaceAll(unsafeUrl, displayUrl.toString());
+  }
+
+  const sensitiveValues = [url.username, url.password, ...url.searchParams.values()];
+  for (const value of sensitiveValues) {
+    if (value.length === 0) {
+      continue;
+    }
+    detail = detail.replaceAll(value, '[REDACTED]');
+    detail = detail.replaceAll(encodeURIComponent(value), '[REDACTED]');
+  }
+
+  return detail;
+}
+
 function shouldReplaceLastCursor(current: ProgressToken | undefined, candidate: ProgressToken): boolean {
   if (current === undefined) {
     return true;
@@ -182,6 +201,11 @@ export class WebSocketDwnRpcClient implements DwnRpc {
     }
 
     const key = connectionCacheKey(url);
+    const displayUrl = new URL(url);
+    displayUrl.username = '';
+    displayUrl.password = '';
+    displayUrl.search = '';
+    displayUrl.hash = '';
     const existing = WebSocketDwnRpcClient.connections.get(key);
     if (existing !== undefined) {
       return existing;
@@ -195,7 +219,7 @@ export class WebSocketDwnRpcClient implements DwnRpc {
           return connection;
         })
         .catch((error: unknown) => {
-          throw new Error(`Error connecting to ${key}: ${(error as Error).message}`);
+          throw new Error(`Error connecting to ${displayUrl.toString()}: ${redactConnectionError(error, url, displayUrl)}`);
         })
         .finally(() => {
           WebSocketDwnRpcClient.pendingConnections.delete(key);

--- a/packages/dwn-clients/tests/rpc-client.spec.ts
+++ b/packages/dwn-clients/tests/rpc-client.spec.ts
@@ -8,7 +8,7 @@ import { TestDataGenerator } from '@enbox/dwn-sdk-js';
 import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
 import {
   createJsonRpcErrorResponse, createJsonRpcSuccessResponse,
-  DwnServerInfoCacheMemory, HttpDwnRpcClient, JsonRpcErrorCodes,
+  DwnServerInfoCacheMemory, HttpDwnRpcClient, JsonRpcErrorCodes, normalizeDwnRpcAuthEndpoint,
 } from '../src/index.js';
 import { DidRpcMethod, EnboxRpcClient, HttpEnboxRpcClient, WebSocketEnboxRpcClient } from '../src/rpc-client.js';
 
@@ -87,6 +87,62 @@ describe('RPC Clients', () => {
         'ws:',
         'wss:'
       ]));
+    });
+
+    describe('endpoint bearer tokens', () => {
+      it('should attach and clear a dynamically registered token only for the normalized endpoint', async () => {
+        const client = new EnboxRpcClient();
+        const localEndpoint = 'http://127.0.0.1:55500';
+        const authorizationHeaders: Array<string | null> = [];
+        client.setDwnEndpointBearerToken(`${localEndpoint}/`, 'native-local-node-token');
+
+        sinon.stub(globalThis, 'fetch').callsFake(async (_url, init): Promise<Response> => {
+          authorizationHeaders.push(new Headers(init?.headers).get('authorization'));
+          return new Response(JSON.stringify({
+            id      : 'test',
+            jsonrpc : '2.0',
+            result  : { reply: { status: { code: 202, detail: 'Accepted' } } },
+          }));
+        });
+
+        await client.sendDwnRequest({
+          dwnUrl    : `${localEndpoint}?transport=http`,
+          message   : { descriptor: {} } as any,
+          targetDid : 'did:dht:alice',
+        });
+        await client.sendDwnRequest({
+          dwnUrl    : 'http://127.0.0.1:55501',
+          message   : { descriptor: {} } as any,
+          targetDid : 'did:dht:alice',
+        });
+        client.clearDwnEndpointBearerToken(`ws://127.0.0.1:55500/?ignored=true`);
+        await client.sendDwnRequest({
+          dwnUrl    : localEndpoint,
+          message   : { descriptor: {} } as any,
+          targetDid : 'did:dht:alice',
+        });
+
+        expect(authorizationHeaders).toEqual(['Bearer native-local-node-token', null, null]);
+      });
+
+      it('should normalize WebSocket schemes without retaining credentials in the URL', () => {
+        const normalized = normalizeDwnRpcAuthEndpoint(
+          'ws://native-user:native-password@127.0.0.1:55500/?localNodeToken=must-not-leak#fragment',
+        );
+
+        expect(normalized).toBe('http://127.0.0.1:55500');
+        expect(normalized).not.toContain('native-user');
+        expect(normalized).not.toContain('native-password');
+        expect(normalized).not.toContain('must-not-leak');
+      });
+
+      it('should reject an empty endpoint bearer token', () => {
+        const client = new EnboxRpcClient();
+
+        expect(() => client.setDwnEndpointBearerToken('http://127.0.0.1:55500', '')).toThrow(
+          'EnboxRpcClient: Endpoint bearer token must not be empty.',
+        );
+      });
     });
 
     describe('sendDidRequest', () => {
@@ -276,6 +332,56 @@ describe('RPC Clients', () => {
 
         expect(response).toEqual(customResponse);
         expect((customClient.sendDwnRequest as sinon.SinonStub).callCount).toBe(1);
+      });
+
+      it('should preserve custom transports for endpoints without a registered token', async () => {
+        const localEndpoint = 'http://127.0.0.1:55500';
+        const fallbackRequests: string[] = [];
+        const customClient = {
+          get transportProtocols(): string[] { return ['http:', 'https:']; },
+          applyReplicatedMessage : sinon.stub().resolves({ kind: 'Applied' }),
+          close                  : sinon.stub().resolves(),
+          getServerInfo          : sinon.stub().resolves({ maxFileSize: 999 }),
+          sendDidRequest         : sinon.stub().resolves({ ok: true, status: { code: 200, message: 'OK' } }),
+          sendDwnRequest         : sinon.stub().callsFake(async (request): Promise<any> => {
+            fallbackRequests.push(request.dwnUrl);
+            return { status: { code: 200, detail: 'Custom transport' } };
+          }),
+        } as unknown as EnboxRpc;
+        const rpcClient = new EnboxRpcClient([customClient]);
+        let localAuthorization: string | null = null;
+        rpcClient.setDwnEndpointBearerToken(localEndpoint, 'native-local-node-token');
+
+        sinon.stub(globalThis, 'fetch').callsFake(async (_url, init): Promise<Response> => {
+          localAuthorization = new Headers(init?.headers).get('authorization');
+          return new Response(JSON.stringify({
+            id      : 'test',
+            jsonrpc : '2.0',
+            result  : { reply: { status: { code: 202, detail: 'Accepted' } } },
+          }));
+        });
+
+        await rpcClient.sendDwnRequest({
+          dwnUrl    : localEndpoint,
+          message   : { descriptor: {} } as any,
+          targetDid : 'did:dht:alice',
+        });
+        const customReply = await rpcClient.sendDwnRequest({
+          dwnUrl    : 'http://remote.example',
+          message   : { descriptor: {} } as any,
+          targetDid : 'did:dht:alice',
+        });
+        rpcClient.clearDwnEndpointBearerToken(localEndpoint);
+        const restoredCustomReply = await rpcClient.sendDwnRequest({
+          dwnUrl    : localEndpoint,
+          message   : { descriptor: {} } as any,
+          targetDid : 'did:dht:alice',
+        });
+
+        expect(localAuthorization).toBe('Bearer native-local-node-token');
+        expect(customReply.status.detail).toBe('Custom transport');
+        expect(restoredCustomReply.status.detail).toBe('Custom transport');
+        expect(fallbackRequests).toEqual(['http://remote.example', localEndpoint]);
       });
     });
 

--- a/packages/dwn-clients/tests/ws-dwn-rpc-client.spec.ts
+++ b/packages/dwn-clients/tests/ws-dwn-rpc-client.spec.ts
@@ -173,6 +173,39 @@ describe('WebSocketDwnRpcClient', () => {
       }
     });
 
+    it('redacts the local-node token from connection errors', async () => {
+      const localNodeToken = 'local-node-token-that-must-not-leak';
+      const authClient = new WebSocketDwnRpcClient(
+        { getServerInfo: async (): Promise<ServerInfo> => testServerInfo() },
+        { getBearerToken: (): string => localNodeToken },
+      );
+      const createConnectionStub = sinon.stub(WebSocketDwnRpcClient as any, 'createConnection').callsFake(async (url: URL): Promise<never> => {
+        throw new Error(`connection refused for ${url.toString()}`);
+      });
+      const { message } = await TestDataGenerator.generateRecordsQuery({
+        author : alice,
+        filter : { schema: 'foo/bar' },
+      });
+
+      let connectionError: Error | undefined;
+      try {
+        await authClient.sendDwnRequest({
+          dwnUrl    : 'ws://native-user:native-password@127.0.0.1:10',
+          targetDid : alice.did,
+          message,
+        });
+      } catch (error: unknown) {
+        connectionError = error as Error;
+      }
+
+      expect(createConnectionStub.calledOnce).toBe(true);
+      expect(connectionError?.message).toContain('Error connecting to ws://127.0.0.1:10/');
+      expect(connectionError?.message).not.toContain('localNodeToken');
+      expect(connectionError?.message).not.toContain(localNodeToken);
+      expect(connectionError?.message).not.toContain('native-user');
+      expect(connectionError?.message).not.toContain('native-password');
+    });
+
     it('responds to a RecordsRead message', async () => {
       // install the default test protocol so the DWN accepts the record
       await installDefaultTestProtocolViaHttp(httpClient, testDwnUrl, alice);

--- a/packages/dwn-server/src/index.ts
+++ b/packages/dwn-server/src/index.ts
@@ -21,6 +21,7 @@ export type {
   LocalNodePairingPollResult,
   LocalNodePairingRequestView,
   LocalNodePairingSessionRecord,
+  LocalNodePairingSessionsChangedListener,
 } from './local-node-pairing.js';
 export type { MessageProcessedContext, MessageProcessedHook } from './message-processed-hook.js';
 export { OpenAuthHandler } from './registration/open-auth-handler.js';

--- a/packages/dwn-server/src/local-node-pairing.ts
+++ b/packages/dwn-server/src/local-node-pairing.ts
@@ -26,6 +26,8 @@ export type LocalNodePairingSessionRecord = {
   token : string;
 };
 
+export type LocalNodePairingSessionsChangedListener = (sessions: LocalNodePairingSessionRecord[]) => void;
+
 export type LocalNodePairingManagerOptions = {
   now? : () => number;
   pairingRequestTtlMs? : number;
@@ -85,6 +87,7 @@ export class LocalNodePairingManager {
   readonly #pendingRequestIdsByOrigin: Map<string, string> = new Map();
   readonly #pairingAttemptsByOrigin: Map<string, number[]> = new Map();
   readonly #sessionsByToken: Map<string, LocalNodeSession> = new Map();
+  readonly #sessionsChangedListeners: Set<LocalNodePairingSessionsChangedListener> = new Set();
 
   public constructor(options: LocalNodePairingManagerOptions = {}) {
     this.#now = options.now ?? ((): number => Date.now());
@@ -148,6 +151,7 @@ export class LocalNodePairingManager {
     request.token = token;
     this.#pendingRequestIdsByOrigin.delete(request.origin);
     this.#sessionsByToken.set(token, { createdAt: now, origin: request.origin, token });
+    this.#notifySessionsChanged();
 
     return true;
   }
@@ -232,8 +236,20 @@ export class LocalNodePairingManager {
       origin    : normalizedOrigin,
       token,
     });
+    this.#notifySessionsChanged();
 
     return token;
+  }
+
+  /**
+   * Registers a listener that is called synchronously after the set of pairing sessions changes.
+   * The returned function removes the listener.
+   */
+  public onSessionsChanged(listener: LocalNodePairingSessionsChangedListener): () => void {
+    this.#sessionsChangedListeners.add(listener);
+    return (): void => {
+      this.#sessionsChangedListeners.delete(listener);
+    };
   }
 
   public exportSessions(): LocalNodePairingSessionRecord[] {
@@ -296,7 +312,19 @@ export class LocalNodePairingManager {
   }
 
   public revokeToken(token: string): boolean {
-    return this.#sessionsByToken.delete(token);
+    const revoked = this.#sessionsByToken.delete(token);
+    if (revoked) {
+      this.#notifySessionsChanged();
+    }
+
+    return revoked;
+  }
+
+  #notifySessionsChanged(): void {
+    const sessions = this.exportSessions();
+    for (const listener of this.#sessionsChangedListeners) {
+      listener(sessions.map((session: LocalNodePairingSessionRecord): LocalNodePairingSessionRecord => ({ ...session })));
+    }
   }
 
   #getActivePendingRequest(requestId: string): LocalNodePairingRequest | undefined {

--- a/packages/dwn-server/src/storage.ts
+++ b/packages/dwn-server/src/storage.ts
@@ -18,6 +18,7 @@ import type {
 
 import * as fs from 'fs';
 import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 
 import { Kysely } from 'kysely';
 
@@ -332,19 +333,23 @@ function getLevelStore(
   storeType: StoreType,
   wakePublisher?: WakePublisher,
 ): DwnStore {
+  const location = storeURI.host === ''
+    ? fileURLToPath(new URL(`file://${storeURI.pathname}`))
+    : storeURI.host + storeURI.pathname;
+
   switch (storeType) {
     case StoreType.DataStore:
       return new DataStoreLevel({
-        blockstoreLocation: storeURI.host + storeURI.pathname + '/DATASTORE',
+        blockstoreLocation: location + '/DATASTORE',
       });
     case StoreType.MessageStore:
       return new MessageStoreLevel({
-        location: storeURI.host + storeURI.pathname + '/MESSAGESTORE',
+        location: location + '/MESSAGESTORE',
         wakePublisher,
       });
     case StoreType.ResumableTaskStore:
       return new ResumableTaskStoreLevel({
-        location: storeURI.host + storeURI.pathname + '/RESUMABLE-TASK-STORE',
+        location: location + '/RESUMABLE-TASK-STORE',
       });
     default:
       throw new Error('Unexpected level store type');

--- a/packages/dwn-server/tests/local-node-pairing.test.ts
+++ b/packages/dwn-server/tests/local-node-pairing.test.ts
@@ -109,4 +109,30 @@ describe('LocalNodePairingManager', () => {
     expect(restoredManager.revokeToken(browserToken)).toBe(true);
     expect(restoredManager.validateSession('https://app.example', browserToken)).toBe(false);
   });
+
+  it('should notify session listeners after approvals and revocations', () => {
+    const manager = new LocalNodePairingManager({ now: (): number => 1234 });
+    const sessionSnapshots: string[][] = [];
+    const unsubscribe = manager.onSessionsChanged((sessions): void => {
+      sessionSnapshots.push(sessions.map((session): string => session.token));
+    });
+    const created = manager.createRequest('https://app.example');
+    if (created.status !== 'created') {
+      throw new Error('expected created pairing request');
+    }
+
+    expect(manager.approveRequest(created.requestId)).toBe(true);
+    const approved = manager.pollRequest(created.requestId);
+    if (approved?.status !== 'approved' || approved.token === undefined) {
+      throw new Error('expected approved pairing token');
+    }
+
+    expect(sessionSnapshots).toEqual([[approved.token]]);
+    expect(manager.revokeToken(approved.token)).toBe(true);
+    expect(sessionSnapshots).toEqual([[approved.token], []]);
+
+    unsubscribe();
+    manager.createSession('https://other.example');
+    expect(sessionSnapshots).toHaveLength(2);
+  });
 });

--- a/packages/dwn-server/tests/storage-coverage.test.ts
+++ b/packages/dwn-server/tests/storage-coverage.test.ts
@@ -2,6 +2,10 @@ import type { DwnServerConfig } from '../src/config.js';
 
 import sinon from 'sinon';
 
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { tmpdir } from 'node:os';
+
 import { config } from '../src/config.js';
 import { DurableEventLog } from '@enbox/dwn-sdk-js';
 import { InMemoryEventBus } from '../src/event-bus.js';
@@ -75,6 +79,21 @@ describe('storage — coverage', () => {
         dataStore          : 'level://test-data-store',
         messageStore       : 'level://test-message-store',
         resumableTaskStore : 'level://test-task-store',
+      });
+
+      const dwnConfig = await getDwnConfig(cfg, {});
+
+      expect(dwnConfig.dataStore).toBeDefined();
+      expect(dwnConfig.messageStore).toBeDefined();
+      expect(dwnConfig.resumableTaskStore).toBeDefined();
+    });
+
+    it('should create Level stores from an absolute file URL', async () => {
+      const storageUrl = pathToFileURL(join(tmpdir(), 'enbox absolute level store')).href.replace('file:', 'level:');
+      const cfg = testConfig({
+        dataStore          : storageUrl,
+        messageStore       : storageUrl,
+        resumableTaskStore : storageUrl,
       });
 
       const dwnConfig = await getDwnConfig(cfg, {});

--- a/packages/local-node/src/local-node-config.ts
+++ b/packages/local-node/src/local-node-config.ts
@@ -1,5 +1,9 @@
 import type { DwnServerConfig } from '@enbox/dwn-server';
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
 import { defaultDwnServerConfig } from '@enbox/dwn-server';
 
 export type LocalNodeServerConfigOptions = {
@@ -25,15 +29,16 @@ export type LocalNodeServerConfigOptions = {
 };
 
 export const defaultLocalNodeHostname = '127.0.0.1';
+export const defaultLocalNodeStorageUrl = pathToFileURL(join(homedir(), '.enbox', 'dwn')).href.replace('file:', 'level:');
 
 export function createLocalNodeDwnServerConfig(options: LocalNodeServerConfigOptions): DwnServerConfig {
   const hostname = options.hostname ?? defaultLocalNodeHostname;
-  const storageUrl = options.storageUrl ?? defaultDwnServerConfig.messageStore;
+  const storageUrl = options.storageUrl ?? process.env.DWN_STORAGE ?? defaultLocalNodeStorageUrl;
 
   return {
     ...defaultDwnServerConfig,
     baseUrl                 : options.baseUrl ?? `http://${hostname}:${options.port}`,
-    dataStore               : options.dataStore ?? storageUrl,
+    dataStore               : options.dataStore ?? process.env.DWN_STORAGE_DATA ?? storageUrl,
     deliveryEnabled         : options.deliveryEnabled ?? true,
     eventBusPluginPath      : options.eventBusPluginPath ?? defaultDwnServerConfig.eventBusPluginPath,
     forwardingEnabled       : options.forwardingEnabled ?? true,
@@ -42,11 +47,11 @@ export function createLocalNodeDwnServerConfig(options: LocalNodeServerConfigOpt
     localNodeProfileEnabled : true,
     logLevel                : options.logLevel ?? defaultDwnServerConfig.logLevel,
     maxRecordDataSize       : options.maxRecordDataSize ?? 1_073_741_824,
-    messageStore            : options.messageStore ?? storageUrl,
+    messageStore            : options.messageStore ?? process.env.DWN_STORAGE_MESSAGES ?? storageUrl,
     packageJsonPath         : options.packageJsonPath ?? defaultDwnServerConfig.packageJsonPath,
     port                    : options.port,
     registrationStoreUrl    : options.registrationStoreUrl ?? defaultDwnServerConfig.registrationStoreUrl,
-    resumableTaskStore      : options.resumableTaskStore ?? storageUrl,
+    resumableTaskStore      : options.resumableTaskStore ?? process.env.DWN_STORAGE_RESUMABLE_TASKS ?? storageUrl,
     serverName              : options.serverName ?? defaultDwnServerConfig.serverName,
     termsOfServiceFilePath  : options.termsOfServiceFilePath ?? defaultDwnServerConfig.termsOfServiceFilePath,
     ttlCacheUrl             : options.ttlCacheUrl ?? defaultDwnServerConfig.ttlCacheUrl,

--- a/packages/local-node/src/local-node.ts
+++ b/packages/local-node/src/local-node.ts
@@ -286,9 +286,7 @@ export class LocalNode {
     try {
       await processing;
     } finally {
-      if (this.#pairingBrokerProcessing === processing) {
-        this.#pairingBrokerProcessing = undefined;
-      }
+      this.#pairingBrokerProcessing = undefined;
     }
   }
 

--- a/packages/local-node/src/local-node.ts
+++ b/packages/local-node/src/local-node.ts
@@ -6,6 +6,7 @@ import type {
   DwnServerConfig,
   LocalNodePairingManager,
   LocalNodePairingRequestView,
+  LocalNodePairingSessionRecord,
 } from '@enbox/dwn-server';
 
 import {
@@ -93,11 +94,15 @@ export class LocalNode {
   readonly #pairingSessionStore: LocalNodePairingSessionStore;
   readonly #pid: number;
   readonly #portCandidates: readonly number[];
-  readonly #inFlightPairingRequestIds: Set<string> = new Set();
 
   #endpoint: string | undefined;
   #localNodeToken: string | undefined;
+  #pairingBrokerLoopFailure: { error: unknown } | undefined;
+  #pairingBrokerProcessing: Promise<void> | undefined;
   #pairingBrokerTimer: ReturnType<typeof setInterval> | undefined;
+  #pairingSessionChangeUnsubscribe: (() => void) | undefined;
+  #pairingSessionWriteFailure: { error: unknown } | undefined;
+  #pairingSessionWriteQueue: Promise<void> = Promise.resolve();
   #port: number | undefined;
   #server: LocalNodeDwnServer | undefined;
   #state: LocalNodeState = 'stopped';
@@ -161,15 +166,17 @@ export class LocalNode {
     }
 
     await this.#loadPairingSessions();
-
-    const startResult = await this.#startFirstAvailableServer();
-    this.#server = startResult.server;
-    this.#port = startResult.port;
-    this.#endpoint = startResult.endpoint;
-    this.#localNodeToken = this.#pairingManager.createSession(undefined);
-    this.#state = 'running';
+    const localNodeToken = this.#pairingManager.createSession(undefined);
+    this.#subscribeToPairingSessionChanges();
 
     try {
+      const startResult = await this.#startFirstAvailableServer();
+      this.#server = startResult.server;
+      this.#port = startResult.port;
+      this.#endpoint = startResult.endpoint;
+      this.#localNodeToken = localNodeToken;
+      this.#state = 'running';
+
       await this.#writeDiscoveryFile();
       this.#startPairingBrokerLoop();
     } catch (error) {
@@ -186,17 +193,37 @@ export class LocalNode {
     }
 
     this.#stopPairingBrokerLoop();
+    let stopFailure: { error: unknown } | undefined;
 
     try {
       await this.#discoveryFile.remove();
-    } finally {
+    } catch (error) {
+      stopFailure = { error };
+    }
+
+    try {
       await this.#server?.stop();
-      this.#endpoint = undefined;
-      this.#localNodeToken = undefined;
-      this.#port = undefined;
-      this.#server = undefined;
-      this.#state = 'stopped';
-      this.#inFlightPairingRequestIds.clear();
+    } catch (error) {
+      stopFailure ??= { error };
+    }
+
+    this.#unsubscribeFromPairingSessionChanges();
+    try {
+      await this.#flushPairingSessionWrites();
+    } catch (error) {
+      stopFailure ??= { error };
+    }
+
+    stopFailure ??= this.#pairingBrokerLoopFailure;
+    this.#endpoint = undefined;
+    this.#localNodeToken = undefined;
+    this.#pairingBrokerLoopFailure = undefined;
+    this.#port = undefined;
+    this.#server = undefined;
+    this.#state = 'stopped';
+
+    if (stopFailure !== undefined) {
+      throw stopFailure.error;
     }
   }
 
@@ -239,7 +266,7 @@ export class LocalNode {
       return false;
     }
 
-    await this.#savePairingSessions();
+    await this.#flushPairingSessionWrites();
     return true;
   }
 
@@ -248,13 +275,26 @@ export class LocalNode {
       return;
     }
 
+    if (this.#pairingBrokerProcessing !== undefined) {
+      await this.#pairingBrokerProcessing;
+      return;
+    }
+
+    const processing = this.#processPendingPairingRequests();
+    this.#pairingBrokerProcessing = processing;
+
+    try {
+      await processing;
+    } finally {
+      if (this.#pairingBrokerProcessing === processing) {
+        this.#pairingBrokerProcessing = undefined;
+      }
+    }
+  }
+
+  async #processPendingPairingRequests(): Promise<void> {
     const pendingRequests = this.#pairingManager.listPendingRequests();
     for (const request of pendingRequests) {
-      if (this.#inFlightPairingRequestIds.has(request.id)) {
-        continue;
-      }
-
-      this.#inFlightPairingRequestIds.add(request.id);
       await this.#processPairingRequest(request);
     }
   }
@@ -314,9 +354,13 @@ export class LocalNode {
       return;
     }
 
-    void this.processPendingPairingRequests();
+    void this.processPendingPairingRequests().catch((error: unknown): void => {
+      this.#pairingBrokerLoopFailure ??= { error };
+    });
     this.#pairingBrokerTimer = setInterval((): void => {
-      void this.processPendingPairingRequests();
+      void this.processPendingPairingRequests().catch((error: unknown): void => {
+        this.#pairingBrokerLoopFailure ??= { error };
+      });
     }, this.#pairingPollIntervalMs);
   }
 
@@ -330,18 +374,14 @@ export class LocalNode {
   }
 
   async #processPairingRequest(request: LocalNodePairingRequestView): Promise<void> {
-    try {
-      const decision = await this.#pairingBroker!.decidePairingRequest(request);
-      if (decision === 'approve') {
-        const approved = this.#pairingManager.approveRequest(request.id);
-        if (approved) {
-          await this.#savePairingSessions();
-        }
-      } else {
-        this.#pairingManager.denyRequest(request.id);
+    const decision = await this.#pairingBroker!.decidePairingRequest(request);
+    if (decision === 'approve') {
+      const approved = this.#pairingManager.approveRequest(request.id);
+      if (approved) {
+        await this.#flushPairingSessionWrites();
       }
-    } finally {
-      this.#inFlightPairingRequestIds.delete(request.id);
+    } else {
+      this.#pairingManager.denyRequest(request.id);
     }
   }
 
@@ -365,11 +405,48 @@ export class LocalNode {
     this.#pairingManager.importSessions(sessions);
   }
 
-  async #savePairingSessions(): Promise<void> {
-    const browserSessions = this.#pairingManager.exportSessions()
-      .filter((session): boolean => session.origin !== undefined);
+  #subscribeToPairingSessionChanges(): void {
+    this.#pairingSessionChangeUnsubscribe = this.#pairingManager.onSessionsChanged(
+      (sessions: LocalNodePairingSessionRecord[]): void => {
+        const browserSessions = sessions
+          .filter((session: LocalNodePairingSessionRecord): boolean => session.origin !== undefined);
 
-    await this.#pairingSessionStore.write(browserSessions);
+        this.#pairingSessionWriteQueue = this.#pairingSessionWriteQueue.then(async (): Promise<void> => {
+          try {
+            await this.#pairingSessionStore.write(browserSessions);
+          } catch (error) {
+            this.#pairingSessionWriteFailure ??= { error };
+          }
+        });
+      },
+    );
+  }
+
+  #unsubscribeFromPairingSessionChanges(): void {
+    this.#pairingSessionChangeUnsubscribe?.();
+    this.#pairingSessionChangeUnsubscribe = undefined;
+  }
+
+  async #flushPairingSessionWrites(): Promise<void> {
+    let pendingWrites: Promise<void>;
+    do {
+      pendingWrites = this.#pairingSessionWriteQueue;
+      await pendingWrites;
+    } while (pendingWrites !== this.#pairingSessionWriteQueue);
+
+    const failure = this.#pairingSessionWriteFailure;
+    this.#pairingSessionWriteFailure = undefined;
+    if (failure !== undefined) {
+      throw failure.error;
+    }
+  }
+
+  async #waitForPairingSessionWrites(): Promise<void> {
+    let pendingWrites: Promise<void>;
+    do {
+      pendingWrites = this.#pairingSessionWriteQueue;
+      await pendingWrites;
+    } while (pendingWrites !== this.#pairingSessionWriteQueue);
   }
 
   #getStartResult(): LocalNodeStartResult {
@@ -406,12 +483,14 @@ export class LocalNode {
     try {
       await this.#server?.stop();
     } finally {
+      this.#unsubscribeFromPairingSessionChanges();
+      await this.#waitForPairingSessionWrites();
       this.#endpoint = undefined;
       this.#localNodeToken = undefined;
+      this.#pairingBrokerLoopFailure = undefined;
       this.#port = undefined;
       this.#server = undefined;
       this.#state = 'stopped';
-      this.#inFlightPairingRequestIds.clear();
     }
   }
 }

--- a/packages/local-node/tests/local-node-config.spec.ts
+++ b/packages/local-node/tests/local-node-config.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { createLocalNodeDwnServerConfig, defaultLocalNodeHostname } from '../src/local-node-config.js';
+import { createLocalNodeDwnServerConfig, defaultLocalNodeHostname, defaultLocalNodeStorageUrl } from '../src/local-node-config.js';
 
 describe('createLocalNodeDwnServerConfig', () => {
   it('should enable the local-node profile with loopback defaults', () => {
@@ -12,6 +12,10 @@ describe('createLocalNodeDwnServerConfig', () => {
     expect(config.localNodeAllowedOrigins).toEqual([]);
     expect(config.forwardingEnabled).toBe(true);
     expect(config.deliveryEnabled).toBe(true);
+    expect(config.dataStore).toBe(process.env.DWN_STORAGE_DATA ?? process.env.DWN_STORAGE ?? defaultLocalNodeStorageUrl);
+    expect(config.messageStore).toBe(process.env.DWN_STORAGE_MESSAGES ?? process.env.DWN_STORAGE ?? defaultLocalNodeStorageUrl);
+    expect(config.resumableTaskStore).toBe(process.env.DWN_STORAGE_RESUMABLE_TASKS ?? process.env.DWN_STORAGE ?? defaultLocalNodeStorageUrl);
+    expect(defaultLocalNodeStorageUrl).toStartWith('level:///');
   });
 
   it('should apply caller-provided local-node server options', () => {

--- a/packages/local-node/tests/local-node.spec.ts
+++ b/packages/local-node/tests/local-node.spec.ts
@@ -70,6 +70,23 @@ class MemoryPairingSessionStore implements LocalNodePairingSessionStore {
   }
 }
 
+class ConcurrentTrackingPairingSessionStore extends MemoryPairingSessionStore {
+  public activeWrites = 0;
+  public maxActiveWrites = 0;
+
+  public async write(sessions: LocalNodePairingSessionRecord[]): Promise<void> {
+    this.activeWrites += 1;
+    this.maxActiveWrites = Math.max(this.maxActiveWrites, this.activeWrites);
+
+    try {
+      await Promise.resolve();
+      await super.write(sessions);
+    } finally {
+      this.activeWrites -= 1;
+    }
+  }
+}
+
 type FakeServer = LocalNodeDwnServer & {
   closedDwn : boolean;
   config : DwnServerConfig;
@@ -240,6 +257,27 @@ describe('LocalNode', () => {
     expect(node.state).toBe('stopped');
   });
 
+  it('should finish local cleanup when server shutdown fails', async () => {
+    const discoveryFile = createDiscoveryFile();
+    const { createServer, servers } = createFakeServerFactory();
+    const node = new LocalNode({
+      createServer,
+      discoveryFile,
+      pairingSessionStore : createPairingSessionStore(),
+      portCandidates      : [55500],
+    });
+
+    await node.start();
+    servers[0].stop = async (): Promise<void> => {
+      throw new Error('server stop failed');
+    };
+
+    await expect(node.stop()).rejects.toThrow('server stop failed');
+    expect(node.state).toBe('stopped');
+    expect(node.endpoint).toBeUndefined();
+    expect(discoveryFile.record).toBeUndefined();
+  });
+
   it('should approve pending pairing requests through the broker', async () => {
     const discoveryFile = createDiscoveryFile();
     const { createServer } = createFakeServerFactory();
@@ -271,6 +309,64 @@ describe('LocalNode', () => {
     expect(pollResult?.status).toBe('approved');
     expect(pollResult?.origin).toBe('https://app.example');
     expect(pollResult?.status === 'approved' && pollResult.token !== undefined).toBe(true);
+
+    await node.stop();
+  });
+
+  it('should serialize concurrent pairing broker passes', async () => {
+    let activeDecisions = 0;
+    let decisionCount = 0;
+    let maxActiveDecisions = 0;
+    let releaseFirstDecision: (() => void) | undefined;
+    const firstDecision = new Promise<void>((resolve): void => {
+      releaseFirstDecision = resolve;
+    });
+    const broker: PairingBroker = {
+      async decidePairingRequest(): Promise<PairingDecision> {
+        decisionCount += 1;
+        activeDecisions += 1;
+        maxActiveDecisions = Math.max(maxActiveDecisions, activeDecisions);
+
+        if (decisionCount === 1) {
+          await firstDecision;
+        }
+
+        activeDecisions -= 1;
+        return 'approve';
+      },
+    };
+    const pairingManager = new LocalNodePairingManager();
+    const { createServer } = createFakeServerFactory();
+    const node = new LocalNode({
+      createServer,
+      discoveryFile         : createDiscoveryFile(),
+      pairingBroker         : broker,
+      pairingManager,
+      pairingPollIntervalMs : 60_000,
+      pairingSessionStore   : createPairingSessionStore(),
+      portCandidates        : [55500],
+    });
+
+    await node.start();
+    await Promise.resolve();
+    const firstRequest = pairingManager.createRequest('https://first.example');
+    const secondRequest = pairingManager.createRequest('https://second.example');
+    if (firstRequest.status !== 'created' || secondRequest.status !== 'created') {
+      throw new Error('expected created pairing requests');
+    }
+
+    const firstPass = node.processPendingPairingRequests();
+    await Promise.resolve();
+    const overlappingPass = node.processPendingPairingRequests();
+
+    expect(decisionCount).toBe(1);
+    releaseFirstDecision?.();
+    await Promise.all([firstPass, overlappingPass]);
+
+    expect(decisionCount).toBe(2);
+    expect(maxActiveDecisions).toBe(1);
+    expect(pairingManager.pollRequest(firstRequest.requestId)?.status).toBe('approved');
+    expect(pairingManager.pollRequest(secondRequest.requestId)?.status).toBe('approved');
 
     await node.stop();
   });
@@ -372,6 +468,36 @@ describe('LocalNode', () => {
     expect(secondPairingManager.validateSession('https://existing.example', 'existing-token')).toBe(true);
 
     await secondNode.stop();
+  });
+
+  it('should persist and serialize session changes made by server-side auto approval', async () => {
+    const sessionStore = new ConcurrentTrackingPairingSessionStore();
+    const pairingManager = new LocalNodePairingManager();
+    const { createServer } = createFakeServerFactory();
+    const node = new LocalNode({
+      createServer,
+      discoveryFile       : createDiscoveryFile(),
+      pairingManager,
+      pairingSessionStore : sessionStore,
+      portCandidates      : [55500],
+    });
+
+    await node.start();
+    const firstRequest = pairingManager.createRequest('https://first.example');
+    const secondRequest = pairingManager.createRequest('https://second.example');
+    if (firstRequest.status !== 'created' || secondRequest.status !== 'created') {
+      throw new Error('expected created pairing requests');
+    }
+
+    expect(pairingManager.approveRequest(firstRequest.requestId)).toBe(true);
+    expect(pairingManager.approveRequest(secondRequest.requestId)).toBe(true);
+    await node.stop();
+
+    expect(sessionStore.sessions.map((session): string | undefined => session.origin)).toEqual([
+      'https://first.example',
+      'https://second.example',
+    ]);
+    expect(sessionStore.maxActiveWrites).toBe(1);
   });
 
   it('should persist pairing revocation', async () => {


### PR DESCRIPTION
## Summary

- Gate next-session remote-mode boot on a versioned eject marker written only after a verified drain.
- Persist the paired endpoint as a supplemental sync target and require a non-empty, stable two-snapshot convergence result; paused links, cancellation, feed movement, and topology changes remain incomplete.
- Authenticate the replication-apply path used during eject while preserving custom and non-local RPC transports. Temporary node outages now retain pairing consent, clear the eject marker, and fall back safely.
- Serialize pairing consent, persist server-side auto-approvals, consume and revoke native discovery-file tokens safely, redact credentials from WebSocket errors, and use stable per-user local-node storage.

## Test plan

- [x] `bun run lint`
- [x] `bun run build`
- [x] `@enbox/agent` full Node suite — 1,303 passed
- [x] `@enbox/dwn-server` full suite — 635 passed
- [x] `@enbox/auth` full Node suite — 526 passed
- [x] `@enbox/dwn-clients` full Node suite — 181 passed
- [x] `@enbox/local-node` full Node suite — 20 passed
- [x] `bunx changeset status`

## Rollout notes

- `SyncDrainResult` now reports explicit cancellation/topology state, including per-target cancellation.
- The unreleased local-node package defaults Level storage to `~/.enbox/dwn`; explicit CLI and `DWN_STORAGE*` overrides are preserved.
