### PR TITLE
fix(auth): bind local-node eject to replica proof

### DIFF
--- a/.changeset/local-node-eject-cleanup.md
+++ b/.changeset/local-node-eject-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@enbox/agent": minor
+"@enbox/auth": patch
+---
+
+fix: bind local-node ejection to the exact drained replica before remote-mode boot

--- a/.changeset/local-node-eject-cleanup.md
+++ b/.changeset/local-node-eject-cleanup.md
@@ -1,5 +1,5 @@
 ---
-"@enbox/agent": minor
+"@enbox/agent": patch
 "@enbox/auth": patch
 ---
 

--- a/packages/agent/src/enbox-user-agent.ts
+++ b/packages/agent/src/enbox-user-agent.ts
@@ -3,11 +3,12 @@ import type { BearerDid } from '@enbox/dids';
 import type { EnboxPlatformAgent } from './types/agent.js';
 import type { EnboxRpc } from '@enbox/dwn-clients';
 import type { LocalDwnStrategy } from './local-dwn.js';
+import type { ProgressToken } from '@enbox/dwn-sdk-js';
 import type { SecretStore } from './secret-store.js';
-import type { SyncEngine } from './types/sync.js';
 import type { DidInterface, DidRequest, DidResponse } from './did-api.js';
 import type { DwnInterface, DwnResponse, ProcessDwnRequest, SendDwnRequest } from './types/dwn.js';
 import type { ProcessVcRequest, SendVcRequest, VcResponse } from './types/vc.js';
+import type { SyncEjectionSnapshot, SyncEngine, SyncScope } from './types/sync.js';
 
 import { AgentCryptoApi } from './crypto-api.js';
 import { AgentDidApi } from './did-api.js';
@@ -21,6 +22,7 @@ import { DwnKeyStore } from './store-key.js';
 import { EnboxRpcClient } from '@enbox/dwn-clients';
 import { HdIdentityVault } from './hd-identity-vault.js';
 import { LocalKeyManager } from './local-key-manager.js';
+import { Replication } from '@enbox/dwn-sdk-js';
 import { DidDht, DidJwk } from '@enbox/dids';
 import { InMemorySecretStore, VaultBackedSecretStore } from './secret-store.js';
 
@@ -103,6 +105,33 @@ export type CreateUserAgentParams = Partial<AgentParams> & {
    */
   localDwnEndpoint?: string;
 };
+
+export type LocalReplicaDrainTargetProof = {
+  tenantDid: string;
+  scope: SyncScope;
+  pushCheckpoint?: ProgressToken;
+  localFingerprint: string;
+  remoteFingerprint: string;
+};
+
+export type LocalReplicaDrainProof = SyncEjectionSnapshot & {
+  targets: [LocalReplicaDrainTargetProof, ...LocalReplicaDrainTargetProof[]];
+};
+
+export type LocalReplicaDrainInspectionResult =
+  | { valid: true }
+  | { valid: false; reason: string };
+
+export type InspectLocalReplicaDrainProofOptions = {
+  dataPath?: string;
+  proof: LocalReplicaDrainProof;
+};
+
+type ClosableStore = {
+  close(): Promise<void>;
+};
+
+class LocalReplicaDrainProofMismatch extends Error { }
 
 export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManager> implements EnboxPlatformAgent<TKeyManager> {
   public crypto: AgentCryptoApi;
@@ -238,6 +267,255 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
       secretsApi,
       syncApi,
     });
+  }
+
+  /**
+   * Verifies that a retired in-process replica still matches the exact state
+   * proven by a completed local-node drain. This method never mutates or
+   * deletes replica data; any mismatch or inspection failure is reported as
+   * an invalid proof so callers can safely fall back to local mode.
+   */
+  public static async inspectLocalReplicaDrainProof({
+    dataPath = 'DATA/AGENT',
+    proof,
+  }: InspectLocalReplicaDrainProofOptions): Promise<LocalReplicaDrainInspectionResult> {
+    const invalidReason = EnboxUserAgent.invalidLocalReplicaDrainProofReason(proof);
+    if (invalidReason !== undefined) {
+      return { valid: false, reason: `malformed local replica drain proof: ${invalidReason}` };
+    }
+
+    const stores: ClosableStore[] = [];
+    let result: LocalReplicaDrainInspectionResult;
+
+    try {
+      const { SyncEngineLevel } = await import('./sync-engine-level.js');
+      const syncEngine = new SyncEngineLevel({ dataPath });
+      stores.push(syncEngine);
+
+      const snapshot = await syncEngine.getEjectionSnapshot();
+      EnboxUserAgent.assertLocalReplicaSyncSnapshot(proof, snapshot);
+
+      const { MessageStoreLevel, ResumableTaskStoreLevel } = await import('@enbox/dwn-sdk-js/stores/level');
+      const messageStore = new MessageStoreLevel({ location: `${dataPath}/DWN_MESSAGESTORE` });
+      const resumableTaskStore = new ResumableTaskStoreLevel({ location: `${dataPath}/DWN_RESUMABLETASKSTORE` });
+      stores.push(messageStore, resumableTaskStore);
+
+      await messageStore.open();
+      await resumableTaskStore.open();
+
+      for (const target of proof.targets) {
+        const fingerprintScopes = EnboxUserAgent.fingerprintScopesForSyncScope(target.scope);
+        const fingerprint = await messageStore.fingerprint(target.tenantDid, fingerprintScopes);
+        if (fingerprint !== target.localFingerprint) {
+          throw new LocalReplicaDrainProofMismatch(
+            `local replica fingerprint changed for tenant '${target.tenantDid}'`,
+          );
+        }
+
+        const bounds = await messageStore.logBounds(target.tenantDid);
+        EnboxUserAgent.assertLocalReplicaFeedHead(target, bounds?.latest);
+      }
+
+      for await (const _entry of resumableTaskStore.db.iterator()) {
+        throw new LocalReplicaDrainProofMismatch('local replica has a pending resumable task');
+      }
+
+      result = { valid: true };
+    } catch (error: unknown) {
+      const detail = error instanceof Error ? error.message : String(error);
+      result = {
+        valid  : false,
+        reason : error instanceof LocalReplicaDrainProofMismatch
+          ? detail
+          : `unable to inspect local replica drain proof: ${detail}`,
+      };
+    }
+
+    const closeResults = await Promise.allSettled(stores.reverse().map((store): Promise<void> => store.close()));
+    const closeFailure = closeResults.find((closeResult): closeResult is PromiseRejectedResult => closeResult.status === 'rejected');
+    if (closeFailure !== undefined) {
+      const detail = closeFailure.reason instanceof Error ? closeFailure.reason.message : String(closeFailure.reason);
+      return { valid: false, reason: `unable to close local replica proof stores: ${detail}` };
+    }
+
+    return result;
+  }
+
+  private static invalidLocalReplicaDrainProofReason(proof: LocalReplicaDrainProof): string | undefined {
+    if (typeof proof !== 'object' || proof === null) {
+      return 'proof must be an object';
+    }
+    if (typeof proof.replicaId !== 'string' || proof.replicaId.length === 0) {
+      return 'replicaId must be a non-empty string';
+    }
+    if (
+      typeof proof.registrationFingerprint !== 'string'
+      || !/^[A-Za-z0-9_-]{43}$/.test(proof.registrationFingerprint)
+    ) {
+      return 'registrationFingerprint must be a SHA-256 base64url value';
+    }
+    if (!Array.isArray(proof.targets) || proof.targets.length === 0) {
+      return 'targets must be a non-empty array';
+    }
+
+    const targetKeys = new Set<string>();
+    for (const target of proof.targets) {
+      const targetReason = EnboxUserAgent.invalidLocalReplicaDrainTargetProofReason(target);
+      if (targetReason !== undefined) {
+        return targetReason;
+      }
+
+      const targetKey = EnboxUserAgent.localReplicaDrainTargetKey(target);
+      if (targetKeys.has(targetKey)) {
+        return `duplicate target for tenant '${target.tenantDid}' and scope`;
+      }
+      targetKeys.add(targetKey);
+    }
+
+    return;
+  }
+
+  private static invalidLocalReplicaDrainTargetProofReason(
+    target: LocalReplicaDrainTargetProof,
+  ): string | undefined {
+    if (typeof target !== 'object' || target === null) {
+      return 'target must be an object';
+    }
+    if (typeof target.tenantDid !== 'string' || !/^did:[a-z0-9]+:[^\s]+$/.test(target.tenantDid)) {
+      return 'target tenantDid must be a DID URI';
+    }
+
+    const scopeReason = EnboxUserAgent.invalidLocalReplicaDrainScopeReason(target.scope);
+    if (scopeReason !== undefined) {
+      return `target for tenant '${target.tenantDid}' has invalid scope: ${scopeReason}`;
+    }
+
+    const fingerprintPattern = /^[0-9a-f]{64}$/;
+    if (typeof target.localFingerprint !== 'string' || !fingerprintPattern.test(target.localFingerprint)) {
+      return `target for tenant '${target.tenantDid}' has an invalid localFingerprint`;
+    }
+    if (typeof target.remoteFingerprint !== 'string' || !fingerprintPattern.test(target.remoteFingerprint)) {
+      return `target for tenant '${target.tenantDid}' has an invalid remoteFingerprint`;
+    }
+    if (target.localFingerprint !== target.remoteFingerprint) {
+      return `target for tenant '${target.tenantDid}' fingerprints do not prove parity`;
+    }
+
+    const checkpoint: unknown = target.pushCheckpoint;
+    if (checkpoint !== undefined) {
+      if (typeof checkpoint !== 'object' || checkpoint === null || Array.isArray(checkpoint)) {
+        return `target for tenant '${target.tenantDid}' has an invalid pushCheckpoint`;
+      }
+
+      const { streamId, epoch, position, messageCid } = checkpoint as Record<string, unknown>;
+      if (
+        typeof streamId !== 'string'
+        || streamId.length === 0
+        || typeof epoch !== 'string'
+        || epoch.length === 0
+        || typeof position !== 'string'
+        || !/^(0|[1-9][0-9]*)$/.test(position)
+        || (messageCid !== undefined && (typeof messageCid !== 'string' || messageCid.length === 0))
+      ) {
+        return `target for tenant '${target.tenantDid}' has an invalid pushCheckpoint`;
+      }
+    }
+
+    return;
+  }
+
+  private static localReplicaDrainTargetKey(target: LocalReplicaDrainTargetProof): string {
+    return JSON.stringify([
+      target.tenantDid,
+      target.scope.kind,
+      target.scope.kind === 'protocolSet' ? target.scope.protocols : [],
+    ]);
+  }
+
+  private static invalidLocalReplicaDrainScopeReason(scope: SyncScope): string | undefined {
+    if (typeof scope !== 'object' || scope === null) {
+      return 'scope must be an object';
+    }
+    if (scope.kind === 'full') {
+      return Object.keys(scope).length === 1 ? undefined : 'full scope must contain only kind';
+    }
+    if (scope.kind !== 'protocolSet' || !Array.isArray(scope.protocols) || scope.protocols.length === 0) {
+      return 'scope must be full or a non-empty protocol set';
+    }
+    const scopeKeys = Object.keys(scope);
+    if (scopeKeys.length !== 2 || scopeKeys.some((key: string): boolean => key !== 'kind' && key !== 'protocols')) {
+      return 'protocol-set scope must contain only kind and protocols';
+    }
+    if (scope.protocols.some((protocol: unknown): boolean => typeof protocol !== 'string' || protocol.length === 0)) {
+      return 'protocols must contain non-empty strings';
+    }
+
+    const canonicalProtocols = [...new Set(scope.protocols)].sort();
+    if (
+      canonicalProtocols.length !== scope.protocols.length
+      || canonicalProtocols.some((protocol: string, index: number): boolean => protocol !== scope.protocols[index])
+    ) {
+      return 'protocols must be sorted and duplicate-free';
+    }
+
+    return;
+  }
+
+  private static assertLocalReplicaSyncSnapshot(
+    proof: LocalReplicaDrainProof,
+    snapshot: SyncEjectionSnapshot,
+  ): void {
+    if (snapshot.replicaId !== proof.replicaId) {
+      throw new LocalReplicaDrainProofMismatch('local replica ID does not match the drain proof');
+    }
+    if (snapshot.registrationFingerprint !== proof.registrationFingerprint) {
+      throw new LocalReplicaDrainProofMismatch('local sync registrations changed after the drain');
+    }
+  }
+
+  private static assertLocalReplicaFeedHead(
+    target: LocalReplicaDrainTargetProof,
+    feedHead: ProgressToken | undefined,
+  ): void {
+    if (target.pushCheckpoint === undefined) {
+      if (feedHead !== undefined) {
+        throw new LocalReplicaDrainProofMismatch(
+          `local replica feed is no longer empty for tenant '${target.tenantDid}'`,
+        );
+      }
+      return;
+    }
+
+    if (feedHead === undefined) {
+      throw new LocalReplicaDrainProofMismatch(
+        `local replica feed is empty for checkpointed tenant '${target.tenantDid}'`,
+      );
+    }
+    if (
+      feedHead.streamId !== target.pushCheckpoint.streamId
+      || feedHead.epoch !== target.pushCheckpoint.epoch
+    ) {
+      throw new LocalReplicaDrainProofMismatch(
+        `local replica feed domain changed for tenant '${target.tenantDid}'`,
+      );
+    }
+    if (feedHead.position !== target.pushCheckpoint.position) {
+      throw new LocalReplicaDrainProofMismatch(
+        `local replica feed head changed for tenant '${target.tenantDid}'`,
+      );
+    }
+  }
+
+  private static fingerprintScopesForSyncScope(scope: SyncScope): string[] {
+    if (scope.kind === 'full') {
+      return [Replication.globalDomain];
+    }
+
+    const protocols = new Set(scope.protocols);
+    return [...protocols].flatMap((protocol: string): string[] => [
+      Replication.protocolDomain(protocol),
+      ...Replication.taggedCoreProtocolDomains(protocol, protocols),
+    ]);
   }
 
   public async firstLaunch(): Promise<boolean> {

--- a/packages/agent/src/enbox-user-agent.ts
+++ b/packages/agent/src/enbox-user-agent.ts
@@ -21,6 +21,7 @@ import { DwnIdentityStore } from './store-identity.js';
 import { DwnKeyStore } from './store-key.js';
 import { EnboxRpcClient } from '@enbox/dwn-clients';
 import { HdIdentityVault } from './hd-identity-vault.js';
+import { lexicographicalCompare } from './types/sync.js';
 import { LocalKeyManager } from './local-key-manager.js';
 import { Replication } from '@enbox/dwn-sdk-js';
 import { DidDht, DidJwk } from '@enbox/dids';
@@ -316,7 +317,8 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
         EnboxUserAgent.assertLocalReplicaFeedHead(target, bounds?.latest);
       }
 
-      for await (const _entry of resumableTaskStore.db.iterator()) {
+      const hasPendingTask = await EnboxUserAgent.hasIteratorEntry(resumableTaskStore.db.iterator({ limit: 1 }));
+      if (hasPendingTask) {
         throw new LocalReplicaDrainProofMismatch('local replica has a pending resumable task');
       }
 
@@ -331,7 +333,8 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
       };
     }
 
-    const closeResults = await Promise.allSettled(stores.reverse().map((store): Promise<void> => store.close()));
+    stores.reverse();
+    const closeResults = await Promise.allSettled(stores.map((store): Promise<void> => store.close()));
     const closeFailure = closeResults.find((closeResult): closeResult is PromiseRejectedResult => closeResult.status === 'rejected');
     if (closeFailure !== undefined) {
       const detail = closeFailure.reason instanceof Error ? closeFailure.reason.message : String(closeFailure.reason);
@@ -371,8 +374,6 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
       }
       targetKeys.add(targetKey);
     }
-
-    return;
   }
 
   private static invalidLocalReplicaDrainTargetProofReason(
@@ -414,14 +415,12 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
         || typeof epoch !== 'string'
         || epoch.length === 0
         || typeof position !== 'string'
-        || !/^(0|[1-9][0-9]*)$/.test(position)
+        || !/^(?:0|[1-9]\d*)$/.test(position)
         || (messageCid !== undefined && (typeof messageCid !== 'string' || messageCid.length === 0))
       ) {
         return `target for tenant '${target.tenantDid}' has an invalid pushCheckpoint`;
       }
     }
-
-    return;
   }
 
   private static localReplicaDrainTargetKey(target: LocalReplicaDrainTargetProof): string {
@@ -450,15 +449,21 @@ export class EnboxUserAgent<TKeyManager extends AgentKeyManager = LocalKeyManage
       return 'protocols must contain non-empty strings';
     }
 
-    const canonicalProtocols = [...new Set(scope.protocols)].sort();
+    const canonicalProtocols = [...new Set(scope.protocols)].sort(lexicographicalCompare);
     if (
       canonicalProtocols.length !== scope.protocols.length
       || canonicalProtocols.some((protocol: string, index: number): boolean => protocol !== scope.protocols[index])
     ) {
       return 'protocols must be sorted and duplicate-free';
     }
+  }
 
-    return;
+  private static async hasIteratorEntry<T>(iterator: AsyncGenerator<T>): Promise<boolean> {
+    try {
+      return !(await iterator.next()).done;
+    } finally {
+      await iterator.return(undefined);
+    }
   }
 
   private static assertLocalReplicaSyncSnapshot(

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -24,6 +24,7 @@ import type {
   SyncDrainOptions,
   SyncDrainResult,
   SyncDrainTargetResult,
+  SyncEjectionSnapshot,
   SyncEngine,
   SyncEvent,
   SyncEventListener,
@@ -43,7 +44,7 @@ import { DwnInterface } from './types/dwn.js';
 import { getProtocolClosureEdges } from './sync-scope-closure.js';
 import { isRecordsWrite } from './utils.js';
 import { ReplicationLedger } from './sync-replication-ledger.js';
-import { computeAuthorizationEpoch, computeProjectionId, isTenantInactivePushFailure, isTerminalPushFailure, lexicographicalCompare, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
+import { computeAuthorizationEpoch, computeProjectionId, isTenantInactivePushFailure, isTerminalPushFailure, lexicographicalCompare, normalizeSyncProtocols, protocolsForSyncScope, singleProtocolForSyncScope, syncScopeFromProtocols } from './types/sync.js';
 import { fetchRemoteMessages, pushMessageEntries, pushMessages, queryLocalMessageFeed, queryRemoteMessageFeed, SyncPullAbortedError } from './sync-messages.js';
 import { getMessagesPermissionGrantsForScope, permissionGrantIdsFromEntries, resolveMessagesScopes, SyncProtocolRootPermissionGrantMissingError, toMessagesPermissionGrantIds, toSyncAuthorizationGrants } from './sync-permission-grants.js';
 
@@ -69,6 +70,12 @@ const MAX_IN_FLIGHT_PULL_DELIVERIES = 100;
 
 /** Page size for local retained ProtocolsConfigure history scans. */
 const PROTOCOL_HISTORY_PAGE_LIMIT = 500;
+
+/** Version of the canonical registration topology included in eject snapshots. */
+const EJECTION_REGISTRATION_FINGERPRINT_VERSION = 1;
+
+/** Key containing the random replica identifier in the durable metadata sublevel. */
+const REPLICA_ID_KEY = 'replicaId';
 
 /** Tracks a live subscription to a remote DWN for one sync target. */
 type LiveSubscription = {
@@ -326,6 +333,7 @@ export class SyncEngineLevel implements SyncEngine {
   private _permissionsApi: PermissionsApi;
 
   private readonly _db: AbstractLevel<string | Buffer | Uint8Array>;
+  private _replicaIdPromise?: Promise<string>;
   private _syncIntervalId?: ReturnType<typeof setInterval>;
   private _syncLock = false;
 
@@ -772,6 +780,11 @@ export class SyncEngineLevel implements SyncEngine {
     return this._db.sublevel('deferredPulls') as unknown as AbstractLevel<string | Buffer | Uint8Array, string, string>;
   }
 
+  /** LevelDB sublevel for metadata that identifies the local replica itself. */
+  private get _replicaMetadata(): AbstractLevel<string | Buffer | Uint8Array, string, string> {
+    return this._db.sublevel('replicaMetadata') as unknown as AbstractLevel<string | Buffer | Uint8Array, string, string>;
+  }
+
   private async clearSyncDb(): Promise<void> {
     const sublevelNames = [
       'deadLetters',
@@ -869,6 +882,7 @@ export class SyncEngineLevel implements SyncEngine {
     this._syncMode = undefined;
     await this._permissionsApi.clear();
     await this.clearSyncDb();
+    this._replicaIdPromise = undefined;
   }
 
   public async close(): Promise<void> {
@@ -937,6 +951,79 @@ export class SyncEngineLevel implements SyncEngine {
       } else {
         throw new Error(`SyncEngineLevel: Error reading level: ${e.code}.`);
       }
+    }
+  }
+
+  public async getEjectionSnapshot(): Promise<SyncEjectionSnapshot> {
+    const generationAtStart = this._syncTargetsCacheGeneration;
+    const [replicaId, registrationFingerprint] = await Promise.all([
+      this.getReplicaId(),
+      this.computeRegistrationFingerprint(),
+    ]);
+
+    if (generationAtStart !== this._syncTargetsCacheGeneration) {
+      throw new Error('SyncEngineLevel: identity registrations changed while creating the ejection snapshot.');
+    }
+
+    return { replicaId, registrationFingerprint };
+  }
+
+  private getReplicaId(): Promise<string> {
+    this._replicaIdPromise ??= this.initializeReplicaId().catch((error: unknown) => {
+      this._replicaIdPromise = undefined;
+      throw error;
+    });
+    return this._replicaIdPromise;
+  }
+
+  private async initializeReplicaId(): Promise<string> {
+    try {
+      return await this._replicaMetadata.get(REPLICA_ID_KEY);
+    } catch (error: unknown) {
+      if ((error as { code?: string }).code !== 'LEVEL_NOT_FOUND') {
+        throw error;
+      }
+    }
+
+    const replicaId = crypto.randomUUID();
+    await this._replicaMetadata.put(REPLICA_ID_KEY, replicaId);
+    return replicaId;
+  }
+
+  private async computeRegistrationFingerprint(): Promise<string> {
+    const registrations: Array<{
+      did: string;
+      options: { delegateDid?: string; protocols: 'all' | NonEmptyStringArray };
+    }> = [];
+
+    for await (const [did, rawOptions] of this._db.sublevel('registeredIdentities').iterator()) {
+      const options = JSON.parse(rawOptions) as SyncIdentityOptions;
+      SyncEngineLevel.validateEjectionSnapshotOptions(did, options);
+      registrations.push({
+        did,
+        options: {
+          ...(options.delegateDid === undefined ? {} : { delegateDid: options.delegateDid }),
+          protocols: options.protocols === 'all' ? 'all' : normalizeSyncProtocols(options.protocols),
+        },
+      });
+    }
+
+    registrations.sort((a, b): number => lexicographicalCompare(a.did, b.did));
+    const canonical = JSON.stringify({
+      registrations,
+      version: EJECTION_REGISTRATION_FINGERPRINT_VERSION,
+    });
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(canonical));
+    return Encoder.bytesToBase64Url(new Uint8Array(digest));
+  }
+
+  private static validateEjectionSnapshotOptions(did: string, options: SyncIdentityOptions): void {
+    SyncEngineLevel.validateSyncIdentityOptions(options);
+    if (options.delegateDid !== undefined && typeof options.delegateDid !== 'string') {
+      throw new Error(`SyncEngineLevel: corrupt sync options for ${did}: delegateDid must be a string.`);
+    }
+    if (Array.isArray(options.protocols) && options.protocols.some((protocol): boolean => typeof protocol !== 'string')) {
+      throw new Error(`SyncEngineLevel: corrupt sync options for ${did}: protocols must contain only strings.`);
     }
   }
 
@@ -1069,7 +1156,20 @@ export class SyncEngineLevel implements SyncEngine {
       }
 
       try {
-        plan.targets.push(...await this.buildSyncTargetsForEndpoint(did, remoteEndpoint, parsed));
+        const targets = await this.buildSyncTargetsForEndpoint(did, remoteEndpoint, parsed);
+        if (targets.length === 0) {
+          plan.failures.push({
+            tenantDid : did,
+            remoteEndpoint,
+            scope     : SyncEngineLevel.syncScopeForDrainFailure(parsed),
+            completed : false,
+            cancelled : false,
+            converged : false,
+            error     : 'registered identity resolved no active sync projections',
+          });
+          continue;
+        }
+        plan.targets.push(...targets);
       } catch (error: unknown) {
         plan.failures.push({
           tenantDid : did,

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -30,6 +30,18 @@ export type SyncIdentityOptions = {
 };
 
 /**
+ * Durable identity of a local sync replica and the registrations it currently
+ * owns. Callers persist this snapshot with an eject marker so a later session
+ * can prove that it is retiring the same replica and registration topology.
+ */
+export type SyncEjectionSnapshot = {
+  /** Random identifier persisted for the lifetime of the sync-store replica. */
+  replicaId: string;
+  /** SHA-256 fingerprint of the canonical registered-identity configuration. */
+  registrationFingerprint: string;
+};
+
+/**
  * Connectivity state of the sync engine.
  */
 export type SyncConnectivityState = 'online' | 'offline' | 'unknown';
@@ -544,6 +556,11 @@ export interface SyncEngine {
    * Get the Sync Options for a specific identity.
    */
   getIdentityOptions(did: string): Promise<SyncIdentityOptions | undefined>;
+  /**
+   * Returns the durable replica identifier and a deterministic fingerprint of
+   * the current registered-identity topology.
+   */
+  getEjectionSnapshot(): Promise<SyncEjectionSnapshot>;
   /**
    * Update the Sync Options for a specific identity, replaces the existing options.
    */

--- a/packages/agent/tests/enbox-user-agent-drain-proof.spec.ts
+++ b/packages/agent/tests/enbox-user-agent-drain-proof.spec.ts
@@ -1,0 +1,321 @@
+import type { GenericMessage } from '@enbox/dwn-sdk-js';
+import type { LocalReplicaDrainProof } from '../src/enbox-user-agent.js';
+import type { SyncScope } from '../src/types/sync.js';
+
+import { join } from 'node:path';
+import sinon from 'sinon';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+
+import { Replication } from '@enbox/dwn-sdk-js';
+import { MessageStoreLevel, ResumableTaskStoreLevel } from '@enbox/dwn-sdk-js/stores/level';
+
+import { EnboxUserAgent } from '../src/enbox-user-agent.js';
+import { SyncEngineLevel } from '../src/sync-engine-level.js';
+
+const tenantDid = 'did:example:alice';
+const notesProtocol = 'https://example.com/protocols/notes';
+const photosProtocol = 'https://example.com/protocols/photos';
+
+describe('EnboxUserAgent.inspectLocalReplicaDrainProof()', () => {
+  const dataPaths: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(dataPaths.splice(0).map((dataPath) => rm(dataPath, { force: true, recursive: true })));
+  });
+
+  it('accepts an unchanged retired replica and closes every temporary store', async () => {
+    const dataPath = await createDataPath(dataPaths);
+    const proof = await createProof(dataPath, {
+      initialProtocols : [notesProtocol],
+      scope            : { kind: 'full' },
+    });
+
+    await expect(EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof })).resolves.toEqual({ valid: true });
+    await expect(EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof })).resolves.toEqual({ valid: true });
+  });
+
+  it('rejects an in-scope write committed after the drain snapshot', async () => {
+    const dataPath = await createDataPath(dataPaths);
+    const proof = await createProof(dataPath, {
+      initialProtocols : [notesProtocol],
+      scope            : { kind: 'protocolSet', protocols: [notesProtocol] },
+    });
+
+    await appendMessage(dataPath, notesProtocol, 'late-note');
+
+    const inspection = await EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof });
+    expect(inspection).toEqual({
+      valid  : false,
+      reason : `local replica fingerprint changed for tenant '${tenantDid}'`,
+    });
+  });
+
+  it('rejects an out-of-scope write by detecting the advanced feed head', async () => {
+    const dataPath = await createDataPath(dataPaths);
+    const proof = await createProof(dataPath, {
+      initialProtocols : [notesProtocol],
+      scope            : { kind: 'protocolSet', protocols: [notesProtocol] },
+    });
+
+    await appendMessage(dataPath, photosProtocol, 'late-photo');
+
+    const inspection = await EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof });
+    expect(inspection).toEqual({
+      valid  : false,
+      reason : `local replica feed head changed for tenant '${tenantDid}'`,
+    });
+  });
+
+  it('rejects the first out-of-scope write after an empty drain snapshot', async () => {
+    const dataPath = await createDataPath(dataPaths);
+    const proof = await createProof(dataPath, {
+      initialProtocols : [],
+      scope            : { kind: 'protocolSet', protocols: [notesProtocol] },
+    });
+
+    expect(proof.targets[0].pushCheckpoint).toBeUndefined();
+    await appendMessage(dataPath, photosProtocol, 'first-photo');
+
+    const inspection = await EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof });
+    expect(inspection).toEqual({
+      valid  : false,
+      reason : `local replica feed is no longer empty for tenant '${tenantDid}'`,
+    });
+  });
+
+  it('rejects the wrong replica path, replica ID, and registration snapshot', async () => {
+    const dataPath = await createDataPath(dataPaths);
+    const wrongDataPath = await createDataPath(dataPaths);
+    const proof = await createProof(dataPath, {
+      initialProtocols : [notesProtocol],
+      scope            : { kind: 'full' },
+    });
+
+    const wrongReplicaIdProof: LocalReplicaDrainProof = {
+      ...proof,
+      replicaId: 'wrong-replica-id',
+    };
+    await expect(EnboxUserAgent.inspectLocalReplicaDrainProof({
+      dataPath,
+      proof: wrongReplicaIdProof,
+    })).resolves.toEqual({
+      valid  : false,
+      reason : 'local replica ID does not match the drain proof',
+    });
+
+    await expect(EnboxUserAgent.inspectLocalReplicaDrainProof({
+      dataPath: wrongDataPath,
+      proof,
+    })).resolves.toEqual({
+      valid  : false,
+      reason : 'local replica ID does not match the drain proof',
+    });
+
+    const syncEngine = new SyncEngineLevel({ dataPath });
+    try {
+      await syncEngine.registerIdentity({
+        did     : 'did:example:bob',
+        options : { protocols: 'all' },
+      });
+    } finally {
+      await syncEngine.close();
+    }
+
+    await expect(EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof })).resolves.toEqual({
+      valid  : false,
+      reason : 'local sync registrations changed after the drain',
+    });
+  });
+
+  it('rejects a retired replica with a pending resumable task', async () => {
+    const dataPath = await createDataPath(dataPaths);
+    const proof = await createProof(dataPath, {
+      initialProtocols : [notesProtocol],
+      scope            : { kind: 'full' },
+    });
+    const taskStore = new ResumableTaskStoreLevel({ location: join(dataPath, 'DWN_RESUMABLETASKSTORE') });
+
+    try {
+      await taskStore.open();
+      await taskStore.register({ operation: 'records-write' }, 60);
+    } finally {
+      await taskStore.close();
+    }
+
+    await expect(EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof })).resolves.toEqual({
+      valid  : false,
+      reason : 'local replica has a pending resumable task',
+    });
+  });
+
+  it('closes stores opened before a later store-open failure', async () => {
+    const dataPath = await createDataPath(dataPaths);
+    const proof = await createProof(dataPath, {
+      initialProtocols : [notesProtocol],
+      scope            : { kind: 'full' },
+    });
+    const taskStoreOpenStub = sinon.stub(ResumableTaskStoreLevel.prototype, 'open').rejects(new Error('task store unavailable'));
+    try {
+      const inspection = await EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof });
+      expect(inspection.valid).toBe(false);
+    } finally {
+      taskStoreOpenStub.restore();
+    }
+
+    await expect(EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof })).resolves.toEqual({ valid: true });
+  });
+
+  it('rejects malformed, non-converged, and duplicate target proofs', async () => {
+    const dataPath = await createDataPath(dataPaths);
+    const proof = await createProof(dataPath, {
+      initialProtocols : [notesProtocol],
+      scope            : { kind: 'protocolSet', protocols: [notesProtocol] },
+    });
+    const target = proof.targets[0];
+    const malformedProofs: LocalReplicaDrainProof[] = [
+      {
+        ...proof,
+        targets: [{ ...target, remoteFingerprint: 'f'.repeat(64) }],
+      },
+      {
+        ...proof,
+        targets: [{ ...target, localFingerprint: 'NOT-A-FINGERPRINT' }],
+      },
+      {
+        ...proof,
+        targets: [{ ...target, tenantDid: 'not-a-did' }],
+      },
+      {
+        ...proof,
+        targets: [{
+          ...target,
+          scope: { kind: 'protocolSet', protocols: [] },
+        }],
+      },
+      {
+        ...proof,
+        targets: [{
+          ...target,
+          pushCheckpoint: { ...target.pushCheckpoint!, position: '-1' },
+        }],
+      },
+      {
+        ...proof,
+        targets: [{
+          ...target,
+          pushCheckpoint: null,
+        }],
+      },
+      {
+        ...proof,
+        targets: [target, target],
+      },
+      {
+        ...proof,
+        targets: [
+          target,
+          {
+            ...target,
+            scope: { protocols: [notesProtocol], kind: 'protocolSet' },
+          },
+        ],
+      },
+    ] as unknown as LocalReplicaDrainProof[];
+
+    for (const malformedProof of malformedProofs) {
+      const inspection = await EnboxUserAgent.inspectLocalReplicaDrainProof({
+        dataPath,
+        proof: malformedProof,
+      });
+      expect(inspection.valid).toBe(false);
+      if (!inspection.valid) {
+        expect(inspection.reason.startsWith('malformed local replica drain proof:')).toBe(true);
+      }
+    }
+  });
+});
+
+async function createDataPath(dataPaths: string[]): Promise<string> {
+  const dataPath = await mkdtemp(join(tmpdir(), 'enbox-local-replica-proof-'));
+  dataPaths.push(dataPath);
+  return dataPath;
+}
+
+async function createProof(dataPath: string, options: {
+  initialProtocols: string[];
+  scope: SyncScope;
+}): Promise<LocalReplicaDrainProof> {
+  const syncEngine = new SyncEngineLevel({ dataPath });
+  let snapshot;
+  try {
+    await syncEngine.registerIdentity({
+      did     : tenantDid,
+      options : { protocols: 'all' },
+    });
+    snapshot = await syncEngine.getEjectionSnapshot();
+  } finally {
+    await syncEngine.close();
+  }
+
+  const messageStore = new MessageStoreLevel({ location: join(dataPath, 'DWN_MESSAGESTORE') });
+  try {
+    await messageStore.open();
+    for (const [index, protocol] of options.initialProtocols.entries()) {
+      await putMessage(messageStore, protocol, `initial-${index}`);
+    }
+
+    const fingerprint = await messageStore.fingerprint(tenantDid, fingerprintScopes(options.scope));
+    const bounds = await messageStore.logBounds(tenantDid);
+    return {
+      ...snapshot,
+      targets: [{
+        tenantDid,
+        scope             : options.scope,
+        pushCheckpoint    : bounds?.latest,
+        localFingerprint  : fingerprint,
+        remoteFingerprint : fingerprint,
+      }],
+    };
+  } finally {
+    await messageStore.close();
+  }
+}
+
+async function appendMessage(dataPath: string, protocol: string, marker: string): Promise<void> {
+  const messageStore = new MessageStoreLevel({ location: join(dataPath, 'DWN_MESSAGESTORE') });
+  try {
+    await messageStore.open();
+    await putMessage(messageStore, protocol, marker);
+  } finally {
+    await messageStore.close();
+  }
+}
+
+async function putMessage(messageStore: MessageStoreLevel, protocol: string, marker: string): Promise<void> {
+  const messageTimestamp = `2026-07-09T00:00:00.${marker.length.toString().padStart(6, '0')}Z`;
+  const message = {
+    descriptor: {
+      interface : 'Records',
+      method    : 'Write',
+      messageTimestamp,
+      protocol,
+      marker,
+    },
+  } as GenericMessage;
+
+  await messageStore.put(tenantDid, message, { messageTimestamp, protocol });
+}
+
+function fingerprintScopes(scope: SyncScope): string[] {
+  if (scope.kind === 'full') {
+    return [Replication.globalDomain];
+  }
+
+  const protocols = new Set(scope.protocols);
+  return [...protocols].flatMap((protocol: string): string[] => [
+    Replication.protocolDomain(protocol),
+    ...Replication.taggedCoreProtocolDomains(protocol, protocols),
+  ]);
+}

--- a/packages/agent/tests/sync-drain-coverage.spec.ts
+++ b/packages/agent/tests/sync-drain-coverage.spec.ts
@@ -1,0 +1,67 @@
+import sinon from 'sinon';
+
+import { Level } from 'level';
+import { describe, expect, it } from 'bun:test';
+
+import { SyncEngineLevel } from '../src/sync-engine-level.js';
+
+describe('SyncEngineLevel drain coverage', () => {
+  it('fails when one of two registered identities resolves no active projection', async () => {
+    const endpoint = 'https://dwn.example';
+    const coveredDid = 'did:example:covered';
+    const missingDid = 'did:example:missing';
+    const db = new Level<string, string>('__TESTDATA__/sync-drain-coverage');
+    const syncEngine = new SyncEngineLevel({ db });
+    await syncEngine.clear();
+    const registrations = db.sublevel('registeredIdentities');
+    await registrations.put(coveredDid, JSON.stringify({ protocols: 'all' }));
+    await registrations.put(missingDid, JSON.stringify({ protocols: 'all' }));
+
+    sinon.stub(syncEngine as any, 'buildSyncTargetsForEndpoint').callsFake(async (did: string): Promise<any[]> => {
+      if (did === missingDid) {
+        return [];
+      }
+      return [{
+        authorization      : { kind: 'owner' },
+        authorizationEpoch : 'owner-epoch',
+        did,
+        dwnUrl             : endpoint,
+        scope              : { kind: 'full' },
+      }];
+    });
+    sinon.stub(syncEngine as any, 'drainSyncTarget').callsFake(async (target: any): Promise<any> => ({
+      tenantDid      : target.did,
+      remoteEndpoint : target.dwnUrl,
+      scope          : target.scope,
+      completed      : true,
+      cancelled      : false,
+      converged      : true,
+    }));
+
+    const result = await syncEngine.drainTo(endpoint);
+
+    expect(result.completed).toBe(false);
+    expect(result.targets).toHaveLength(2);
+    expect(result.targets).toContainEqual({
+      tenantDid      : coveredDid,
+      remoteEndpoint : endpoint,
+      scope          : { kind: 'full' },
+      completed      : true,
+      cancelled      : false,
+      converged      : true,
+    });
+    expect(result.targets).toContainEqual({
+      tenantDid      : missingDid,
+      remoteEndpoint : endpoint,
+      scope          : { kind: 'full' },
+      completed      : false,
+      cancelled      : false,
+      converged      : false,
+      error          : 'registered identity resolved no active sync projections',
+    });
+
+    sinon.restore();
+    await syncEngine.clear();
+    await syncEngine.close();
+  });
+});

--- a/packages/agent/tests/sync-ejection-snapshot.spec.ts
+++ b/packages/agent/tests/sync-ejection-snapshot.spec.ts
@@ -1,0 +1,79 @@
+import { Level } from 'level';
+import { describe, expect, it } from 'bun:test';
+
+import { SyncEngineLevel } from '../src/sync-engine-level.js';
+
+describe('SyncEngineLevel ejection snapshots', () => {
+  it('preserves the replica ID across reopen and rotates it after a full clear', async () => {
+    const dataPath = '__TESTDATA__/sync-ejection-snapshot/reopen';
+    let engine = new SyncEngineLevel({ dataPath });
+    await engine.clear();
+
+    const initial = await engine.getEjectionSnapshot();
+    expect(await engine.getEjectionSnapshot()).toEqual(initial);
+    await engine.close();
+
+    engine = new SyncEngineLevel({ dataPath });
+    const reopened = await engine.getEjectionSnapshot();
+    expect(reopened).toEqual(initial);
+
+    await engine.clear();
+    const rotated = await engine.getEjectionSnapshot();
+    expect(rotated.replicaId).not.toBe(initial.replicaId);
+    expect(rotated.registrationFingerprint).toBe(initial.registrationFingerprint);
+
+    await engine.clear();
+    await engine.close();
+  });
+
+  it('uses a distinct replica ID for each sync-store path', async () => {
+    const first = new SyncEngineLevel({ dataPath: '__TESTDATA__/sync-ejection-snapshot/first' });
+    const second = new SyncEngineLevel({ dataPath: '__TESTDATA__/sync-ejection-snapshot/second' });
+    await Promise.all([first.clear(), second.clear()]);
+
+    const [firstSnapshot, secondSnapshot] = await Promise.all([
+      first.getEjectionSnapshot(),
+      second.getEjectionSnapshot(),
+    ]);
+
+    expect(firstSnapshot.replicaId).not.toBe(secondSnapshot.replicaId);
+    expect(firstSnapshot.registrationFingerprint).toBe(secondSnapshot.registrationFingerprint);
+
+    await Promise.all([first.clear(), second.clear()]);
+    await Promise.all([first.close(), second.close()]);
+  });
+
+  it('fingerprints sorted canonical identity options and changes with topology', async () => {
+    const db = new Level<string, string>('__TESTDATA__/sync-ejection-snapshot/topology');
+    const engine = new SyncEngineLevel({ db });
+    await engine.clear();
+    const registrations = db.sublevel('registeredIdentities');
+    const empty = await engine.getEjectionSnapshot();
+
+    await registrations.put('did:example:b', JSON.stringify({
+      protocols   : ['https://protocol.example/z', 'https://protocol.example/a', 'https://protocol.example/z'],
+      delegateDid : 'did:example:delegate',
+    }));
+    await registrations.put('did:example:a', JSON.stringify({ protocols: 'all' }));
+    const firstTopology = await engine.getEjectionSnapshot();
+    expect(firstTopology.replicaId).toBe(empty.replicaId);
+    expect(firstTopology.registrationFingerprint).not.toBe(empty.registrationFingerprint);
+
+    await registrations.clear();
+    await registrations.put('did:example:a', JSON.stringify({ protocols: 'all' }));
+    await registrations.put('did:example:b', JSON.stringify({
+      delegateDid : 'did:example:delegate',
+      protocols   : ['https://protocol.example/a', 'https://protocol.example/z'],
+    }));
+    const canonicalEquivalent = await engine.getEjectionSnapshot();
+    expect(canonicalEquivalent).toEqual(firstTopology);
+
+    await registrations.put('did:example:c', JSON.stringify({ protocols: 'all' }));
+    const changedTopology = await engine.getEjectionSnapshot();
+    expect(changedTopology.replicaId).toBe(firstTopology.replicaId);
+    expect(changedTopology.registrationFingerprint).not.toBe(firstTopology.registrationFingerprint);
+
+    await engine.clear();
+    await engine.close();
+  });
+});

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -15,7 +15,17 @@
  */
 
 import type { RecordsWriteMessage } from '@enbox/dwn-sdk-js';
-import type { AgentSessionIdentity, BearerIdentity, DwnDataEncodedRecordsWriteMessage, HdIdentityVault, PortableIdentity } from '@enbox/agent';
+import type {
+  AgentSessionIdentity,
+  BearerIdentity,
+  DwnDataEncodedRecordsWriteMessage,
+  HdIdentityVault,
+  LocalReplicaDrainProof,
+  LocalReplicaDrainTargetProof,
+  PortableIdentity,
+  SyncDrainResult,
+  SyncEjectionSnapshot,
+} from '@enbox/agent';
 
 import type { FlowContext } from './connect/lifecycle.js';
 import type { PasswordProvider } from './password-provider.js';
@@ -43,6 +53,7 @@ import type {
   WalletConnectOptions,
 } from './types.js';
 import type {
+  LocalDwnEjectionRecord,
   LocalDwnPairingRecord,
   LocalDwnPairingRequestResult,
   LocalDwnProbeResult,
@@ -174,6 +185,7 @@ export class AuthManager {
   static async create(options: AuthManagerOptions = {}): Promise<AuthManager> {
     const emitter = new AuthEventEmitter();
     const storage = options.storage ?? createDefaultStorage();
+    const dataPath = options.dataPath ?? 'DATA/AGENT';
 
     // Run local DWN discovery BEFORE creating the agent. Discovery has
     // zero vault/DWN dependencies — it reads the persisted pairing record
@@ -188,8 +200,28 @@ export class AuthManager {
     if (!options.agent && options.localDwnStrategy !== 'off') {
       localDwnPairing = await discoverLocalDwnPairing(storage);
       if (localDwnPairing !== undefined) {
-        const ejection = await readLocalDwnEjectionRecordForPairing(storage, localDwnPairing);
-        localDwnEndpoint = ejection === undefined ? undefined : localDwnPairing.endpoint;
+        const localDwnEjection = await readLocalDwnEjectionRecordForPairing(storage, localDwnPairing);
+        if (localDwnEjection?.version === 2) {
+          let proofIsValid = false;
+          try {
+            const inspection = await EnboxUserAgent.inspectLocalReplicaDrainProof({
+              dataPath,
+              proof: localDwnEjection.drainProof,
+            });
+            proofIsValid = inspection.valid;
+          } catch {
+            // Treat unreadable replica proof as invalid and boot locally.
+          }
+
+          if (proofIsValid) {
+            localDwnEndpoint = localDwnPairing.endpoint;
+          } else {
+            await clearLocalDwnEjection(storage);
+          }
+        } else if (localDwnEjection !== undefined) {
+          // Legacy endpoint-only markers are not proof of this replica.
+          await clearLocalDwnEjection(storage);
+        }
       }
       // NOTE: We intentionally do NOT emit 'local-dwn-available' here
       // because event listeners aren't attached yet. Consumers should
@@ -198,7 +230,7 @@ export class AuthManager {
 
     // Use a pre-built agent or create one with the given options.
     const userAgent = options.agent ?? await EnboxUserAgent.create({
-      dataPath         : options.dataPath,
+      dataPath,
       agentVault       : options.agentVault,
       localDwnStrategy : options.localDwnStrategy,
       localDwnEndpoint,
@@ -1131,22 +1163,54 @@ export class AuthManager {
     }
 
     this._userAgent.rpc = createLocalDwnRpcClient(pairing, this._userAgent.rpc);
+    const beforeDrain = await this._userAgent.sync.getEjectionSnapshot();
     const drain = await this._userAgent.sync.drainTo(pairing.endpoint, options);
-    if (!drain.completed) {
+    let afterDrain: SyncEjectionSnapshot;
+    try {
+      afterDrain = await this._userAgent.sync.getEjectionSnapshot();
+    } catch {
       await clearLocalDwnEjection(this._storage);
       return {
-        drain,
+        drain: {
+          ...drain,
+          completed       : false,
+          error           : 'unable to verify the local replica snapshot after drain',
+          topologyChanged : true,
+        },
         endpoint              : drain.endpoint,
         nextSessionRemoteMode : false,
         status                : 'incomplete',
       };
     }
 
-    await persistLocalDwnEjectionRecord(this._storage, {
+    const drainProof = drain.endpoint === pairing.endpoint
+      ? AuthManager._createLocalReplicaDrainProof(beforeDrain, afterDrain, drain)
+      : undefined;
+    if (drainProof === undefined) {
+      await clearLocalDwnEjection(this._storage);
+      const incompleteDrain: SyncDrainResult = drain.completed
+        ? {
+          ...drain,
+          completed       : false,
+          error           : 'local replica drain proof validation failed after drain completion',
+          topologyChanged : true,
+        }
+        : drain;
+      return {
+        drain                 : incompleteDrain,
+        endpoint              : incompleteDrain.endpoint,
+        nextSessionRemoteMode : false,
+        status                : 'incomplete',
+      };
+    }
+
+    const ejection: LocalDwnEjectionRecord = {
       completedAt : Date.now(),
+      drainProof,
       endpoint    : drain.endpoint,
-      version     : 1,
-    });
+      version     : 2,
+    };
+    await persistLocalDwnEjectionRecord(this._storage, ejection);
 
     return {
       drain,
@@ -1399,6 +1463,129 @@ export class AuthManager {
     }
 
     await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, narrowed);
+  }
+
+  private static _createLocalReplicaDrainProof(
+    beforeDrain: SyncEjectionSnapshot,
+    afterDrain: SyncEjectionSnapshot,
+    drain: SyncDrainResult,
+  ): LocalReplicaDrainProof | undefined {
+    if (
+      !drain.completed
+      || drain.cancelled
+      || drain.topologyChanged
+      || drain.error !== undefined
+      || !Array.isArray(drain.targets)
+      || typeof beforeDrain.replicaId !== 'string'
+      || beforeDrain.replicaId.length === 0
+      || !AuthManager._isCanonicalRegistrationFingerprint(beforeDrain.registrationFingerprint)
+      || beforeDrain.replicaId !== afterDrain.replicaId
+      || beforeDrain.registrationFingerprint !== afterDrain.registrationFingerprint
+    ) {
+      return undefined;
+    }
+
+    const targets: LocalReplicaDrainTargetProof[] = [];
+    const targetKeys = new Set<string>();
+    for (const target of drain.targets) {
+      if (
+        !target.completed
+        || target.cancelled
+        || !target.converged
+        || target.error !== undefined
+        || target.remoteEndpoint !== drain.endpoint
+        || typeof target.tenantDid !== 'string'
+        || !/^did:[a-z0-9]+:[^\s]+$/.test(target.tenantDid)
+        || !AuthManager._isValidSyncScope(target.scope)
+        || !AuthManager._isCanonicalFingerprint(target.localFingerprint)
+        || target.remoteFingerprint !== target.localFingerprint
+        || !AuthManager._isValidProgressToken(target.pushCheckpoint)
+      ) {
+        return undefined;
+      }
+
+      const proofTarget: LocalReplicaDrainTargetProof = {
+        tenantDid         : target.tenantDid,
+        scope             : target.scope,
+        localFingerprint  : target.localFingerprint,
+        remoteFingerprint : target.remoteFingerprint,
+        ...(target.pushCheckpoint === undefined ? {} : { pushCheckpoint: target.pushCheckpoint }),
+      };
+      const targetKey = AuthManager._localReplicaDrainTargetKey(proofTarget);
+      if (targetKeys.has(targetKey)) {
+        return undefined;
+      }
+      targetKeys.add(targetKey);
+      targets.push(proofTarget);
+    }
+
+    if (targets.length === 0) {
+      return undefined;
+    }
+
+    return {
+      replicaId               : beforeDrain.replicaId,
+      registrationFingerprint : beforeDrain.registrationFingerprint,
+      targets                 : targets as [LocalReplicaDrainTargetProof, ...LocalReplicaDrainTargetProof[]],
+    };
+  }
+
+  private static _isCanonicalFingerprint(value: unknown): value is string {
+    return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
+  }
+
+  private static _localReplicaDrainTargetKey(target: LocalReplicaDrainTargetProof): string {
+    return JSON.stringify([
+      target.tenantDid,
+      target.scope.kind,
+      target.scope.kind === 'protocolSet' ? target.scope.protocols : [],
+    ]);
+  }
+
+  private static _isCanonicalRegistrationFingerprint(value: unknown): value is string {
+    return typeof value === 'string' && /^[A-Za-z0-9_-]{43}$/.test(value);
+  }
+
+  private static _isValidProgressToken(token: unknown): boolean {
+    if (typeof token !== 'object' || token === null || Array.isArray(token)) {
+      return token === undefined;
+    }
+
+    const value = token as Record<string, unknown>;
+    return typeof value.streamId === 'string'
+      && value.streamId.length > 0
+      && typeof value.epoch === 'string'
+      && value.epoch.length > 0
+      && typeof value.position === 'string'
+      && /^(?:0|[1-9]\d*)$/.test(value.position)
+      && (value.messageCid === undefined || (typeof value.messageCid === 'string' && value.messageCid.length > 0));
+  }
+
+  private static _isValidSyncScope(scope: unknown): scope is LocalReplicaDrainTargetProof['scope'] {
+    if (typeof scope !== 'object' || scope === null || Array.isArray(scope)) {
+      return false;
+    }
+
+    const value = scope as Record<string, unknown>;
+    if (value.kind === 'full') {
+      return Object.keys(value).length === 1;
+    }
+    if (value.kind !== 'protocolSet' || !Array.isArray(value.protocols) || value.protocols.length === 0) {
+      return false;
+    }
+    const keys = Object.keys(value);
+    if (keys.length !== 2 || keys.some((key): boolean => key !== 'kind' && key !== 'protocols')) {
+      return false;
+    }
+
+    let previous: string | undefined;
+    for (const protocol of value.protocols) {
+      if (typeof protocol !== 'string' || protocol.length === 0 || (previous !== undefined && previous >= protocol)) {
+        return false;
+      }
+      previous = protocol;
+    }
+    return true;
   }
 
   private _setState(state: AuthState): void {

--- a/packages/auth/src/auth-manager.ts
+++ b/packages/auth/src/auth-manager.ts
@@ -187,46 +187,12 @@ export class AuthManager {
     const storage = options.storage ?? createDefaultStorage();
     const dataPath = options.dataPath ?? 'DATA/AGENT';
 
-    // Run local DWN discovery BEFORE creating the agent. Discovery has
-    // zero vault/DWN dependencies — it reads the persisted pairing record
-    // and validates it via GET /info plus authenticated /local/status.
-    //
-    // A stored pairing alone is not enough to change the agent's storage mode:
-    // pairing establishes trust, while the ejection marker proves the local
-    // in-process DWN has drained to the paired node. Only then does the next
-    // session boot in remote mode.
-    let localDwnEndpoint: string | undefined;
-    let localDwnPairing: LocalDwnPairingRecord | undefined;
-    if (!options.agent && options.localDwnStrategy !== 'off') {
-      localDwnPairing = await discoverLocalDwnPairing(storage);
-      if (localDwnPairing !== undefined) {
-        const localDwnEjection = await readLocalDwnEjectionRecordForPairing(storage, localDwnPairing);
-        if (localDwnEjection?.version === 2) {
-          let proofIsValid = false;
-          try {
-            const inspection = await EnboxUserAgent.inspectLocalReplicaDrainProof({
-              dataPath,
-              proof: localDwnEjection.drainProof,
-            });
-            proofIsValid = inspection.valid;
-          } catch {
-            // Treat unreadable replica proof as invalid and boot locally.
-          }
-
-          if (proofIsValid) {
-            localDwnEndpoint = localDwnPairing.endpoint;
-          } else {
-            await clearLocalDwnEjection(storage);
-          }
-        } else if (localDwnEjection !== undefined) {
-          // Legacy endpoint-only markers are not proof of this replica.
-          await clearLocalDwnEjection(storage);
-        }
-      }
-      // NOTE: We intentionally do NOT emit 'local-dwn-available' here
-      // because event listeners aren't attached yet. Consumers should
-      // check `authManager.localDwnEndpoint` after create() returns.
-    }
+    const { localDwnEndpoint, localDwnPairing } = await AuthManager._resolveLocalDwnBootState({
+      agent            : options.agent,
+      dataPath,
+      localDwnStrategy : options.localDwnStrategy,
+      storage,
+    });
 
     // Use a pre-built agent or create one with the given options.
     const userAgent = options.agent ?? await EnboxUserAgent.create({
@@ -1463,6 +1429,64 @@ export class AuthManager {
     }
 
     await this._registerOrUpdateSyncIdentity(connectedDid, delegateDid, narrowed);
+  }
+
+  /** Resolve whether a persisted local-node pairing can safely authorize remote-mode boot. */
+  private static async _resolveLocalDwnBootState({
+    agent,
+    dataPath,
+    localDwnStrategy,
+    storage,
+  }: {
+    agent: AuthManagerOptions['agent'];
+    dataPath: string;
+    localDwnStrategy: AuthManagerOptions['localDwnStrategy'];
+    storage: StorageAdapter;
+  }): Promise<{
+    localDwnEndpoint?: string;
+    localDwnPairing?: LocalDwnPairingRecord;
+  }> {
+    if (agent || localDwnStrategy === 'off') {
+      return {};
+    }
+
+    // Discovery has no vault/DWN dependency, so it must complete before the
+    // agent is created. Pairing establishes trust; only a valid v2 proof
+    // establishes that the exact in-process replica was safely drained.
+    const localDwnPairing = await discoverLocalDwnPairing(storage);
+    if (localDwnPairing === undefined) {
+      return {};
+    }
+
+    const ejection = await readLocalDwnEjectionRecordForPairing(storage, localDwnPairing);
+    if (
+      ejection?.version === 2
+      && await AuthManager._isLocalReplicaDrainProofValid(dataPath, ejection.drainProof)
+    ) {
+      return { localDwnEndpoint: localDwnPairing.endpoint, localDwnPairing };
+    }
+
+    if (ejection !== undefined) {
+      // Invalid/unreadable v2 proofs and legacy endpoint-only v1 markers can
+      // never authorize remote mode. Preserve the pairing for a future eject.
+      await clearLocalDwnEjection(storage);
+    }
+
+    // NOTE: We intentionally do NOT emit 'local-dwn-available' here because
+    // event listeners are not attached until after create() returns.
+    return { localDwnPairing };
+  }
+
+  private static async _isLocalReplicaDrainProofValid(
+    dataPath: string,
+    proof: LocalReplicaDrainProof,
+  ): Promise<boolean> {
+    try {
+      const inspection = await EnboxUserAgent.inspectLocalReplicaDrainProof({ dataPath, proof });
+      return inspection.valid;
+    } catch {
+      return false;
+    }
   }
 
   private static _createLocalReplicaDrainProof(

--- a/packages/auth/src/discovery.ts
+++ b/packages/auth/src/discovery.ts
@@ -9,7 +9,6 @@
  * @module
  */
 
-import type { EnboxUserAgent } from '@enbox/agent';
 import type { ReplicationApplyResult } from '@enbox/dwn-sdk-js';
 import type {
   DidRpcRequest,
@@ -21,6 +20,7 @@ import type {
   EnboxRpc,
   ServerInfo,
 } from '@enbox/dwn-clients';
+import type { EnboxUserAgent, LocalReplicaDrainProof } from '@enbox/agent';
 
 import type { AuthEventEmitter } from './events.js';
 import type { StorageAdapter } from './types.js';
@@ -41,11 +41,18 @@ export type LocalDwnPairingRecord = {
   createdAt: number;
 };
 
-export type LocalDwnEjectionRecord = {
-  version: 1;
-  endpoint: string;
-  completedAt: number;
-};
+export type LocalDwnEjectionRecord =
+  | {
+    version: 1;
+    endpoint: string;
+    completedAt: number;
+  }
+  | {
+    version: 2;
+    endpoint: string;
+    completedAt: number;
+    drainProof: LocalReplicaDrainProof;
+  };
 
 export type LocalDwnUnsupportedReason = 'no-fetch' | 'insecure-context' | 'safari';
 
@@ -110,7 +117,6 @@ export type LocalDwnPairingRequestResult =
   | { status: 'timeout'; endpoint: string; requestId: string; pollUrl: string };
 
 const localDwnPairingRecordVersion = 1;
-const localDwnEjectionRecordVersion = 1;
 const defaultPairingTimeoutMs = 5 * 60 * 1000;
 const defaultPairingPollIntervalMs = 1500;
 
@@ -267,7 +273,7 @@ export async function persistLocalDwnEjectionRecord(
   await storage.set(STORAGE_KEYS.LOCAL_DWN_EJECTION, JSON.stringify({
     ...record,
     endpoint : normalizeBaseUrl(record.endpoint),
-    version  : localDwnEjectionRecordVersion,
+    version  : record.version,
   }));
 }
 
@@ -672,24 +678,135 @@ function parseLocalDwnPairingRecord(raw: string): LocalDwnPairingRecord | undefi
 
 function parseLocalDwnEjectionRecord(raw: string): LocalDwnEjectionRecord | undefined {
   try {
-    const value = JSON.parse(raw) as Partial<LocalDwnEjectionRecord>;
+    const value = JSON.parse(raw) as unknown;
     if (
-      value.version !== localDwnEjectionRecordVersion
-      || typeof value.endpoint !== 'string'
+      !isRecord(value)
+      || !isNonEmptyString(value.endpoint)
       || typeof value.completedAt !== 'number'
       || !Number.isFinite(value.completedAt)
     ) {
       return undefined;
     }
 
-    return {
+    const common = {
       completedAt : value.completedAt,
       endpoint    : normalizeBaseUrl(value.endpoint),
-      version     : localDwnEjectionRecordVersion,
     };
+
+    if (value.version === 1) {
+      return { ...common, version: 1 };
+    }
+
+    if (value.version === 2 && isLocalReplicaDrainProof(value.drainProof)) {
+      return {
+        ...common,
+        drainProof : value.drainProof,
+        version    : 2,
+      };
+    }
+
+    return undefined;
   } catch {
     return undefined;
   }
+}
+
+function isLocalReplicaDrainProof(value: unknown): value is LocalReplicaDrainProof {
+  if (
+    !isRecord(value)
+    || !isNonEmptyString(value.replicaId)
+    || !isCanonicalRegistrationFingerprint(value.registrationFingerprint)
+    || !Array.isArray(value.targets)
+    || value.targets.length === 0
+  ) {
+    return false;
+  }
+
+  const targetKeys = new Set<string>();
+  for (const target of value.targets) {
+    if (!isLocalReplicaDrainTargetProof(target)) {
+      return false;
+    }
+
+    const targetKey = localReplicaDrainTargetKey(target);
+    if (targetKeys.has(targetKey)) {
+      return false;
+    }
+    targetKeys.add(targetKey);
+  }
+  return true;
+}
+
+function isLocalReplicaDrainTargetProof(
+  value: unknown,
+): value is LocalReplicaDrainProof['targets'][number] {
+  return isRecord(value)
+    && typeof value.tenantDid === 'string'
+    && /^did:[a-z0-9]+:[^\s]+$/.test(value.tenantDid)
+    && isValidSyncScope(value.scope)
+    && isCanonicalFingerprint(value.localFingerprint)
+    && value.remoteFingerprint === value.localFingerprint
+    && (value.pushCheckpoint === undefined || isValidProgressToken(value.pushCheckpoint));
+}
+
+function localReplicaDrainTargetKey(target: LocalReplicaDrainProof['targets'][number]): string {
+  return JSON.stringify([
+    target.tenantDid,
+    target.scope.kind,
+    target.scope.kind === 'protocolSet' ? target.scope.protocols : [],
+  ]);
+}
+
+function isValidSyncScope(value: unknown): value is LocalReplicaDrainProof['targets'][number]['scope'] {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.kind === 'full') {
+    return Object.keys(value).length === 1;
+  }
+
+  if (value.kind !== 'protocolSet' || !Array.isArray(value.protocols) || value.protocols.length === 0) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  if (keys.length !== 2 || keys.some((key): boolean => key !== 'kind' && key !== 'protocols')) {
+    return false;
+  }
+
+  let previous: string | undefined;
+  for (const protocol of value.protocols) {
+    if (!isNonEmptyString(protocol) || (previous !== undefined && previous >= protocol)) {
+      return false;
+    }
+    previous = protocol;
+  }
+  return true;
+}
+
+function isValidProgressToken(value: unknown): boolean {
+  return isRecord(value)
+    && isNonEmptyString(value.streamId)
+    && isNonEmptyString(value.epoch)
+    && typeof value.position === 'string'
+    && /^(?:0|[1-9]\d*)$/.test(value.position)
+    && (value.messageCid === undefined || isNonEmptyString(value.messageCid));
+}
+
+function isCanonicalFingerprint(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
+}
+
+function isCanonicalRegistrationFingerprint(value: unknown): value is string {
+  return typeof value === 'string' && /^[A-Za-z0-9_-]{43}$/.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
 }
 
 async function validateLocalDwnPairing(

--- a/packages/auth/tests/auth-manager-create.spec.ts
+++ b/packages/auth/tests/auth-manager-create.spec.ts
@@ -406,6 +406,54 @@ describe('AuthManager.create()', () => {
     expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
   });
 
+  test('falls back to local mode when late v2 proof inspection throws', async () => {
+    const storage = await createEjectedLocalNodeStorage();
+    stubPairedLocalNodeFetch();
+    inspectLocalReplicaDrainProofStub.rejects(new Error('proof store unavailable'));
+
+    let capturedOptions: any;
+    userAgentCreateStub.onFirstCall().callsFake((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    const manager = await AuthManager.create({ storage });
+
+    expect(capturedOptions.localDwnEndpoint).toBeUndefined();
+    expect(capturedOptions.rpcClient).toBeUndefined();
+    expect(manager.localDwnEndpoint).toBeUndefined();
+    expect(await readLocalDwnPairingRecord(storage)).toBeDefined();
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
+  });
+
+  test('bypasses local-node proof resolution for supplied agents and strategy off', async () => {
+    const customAgentStorage = await createEjectedLocalNodeStorage();
+    const customAgent = createMockAgent({ vaultIsInitialized: async () => false });
+
+    const customManager = await AuthManager.create({
+      agent   : customAgent as any,
+      storage : customAgentStorage,
+    });
+
+    expect(customManager.agent).toBe(customAgent);
+    expect(inspectLocalReplicaDrainProofStub.called).toBe(false);
+    expect(await readLocalDwnEjectionRecord(customAgentStorage)).toBeDefined();
+
+    const disabledStorage = await createEjectedLocalNodeStorage();
+    let capturedOptions: any;
+    userAgentCreateStub.onFirstCall().callsFake((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    await AuthManager.create({ localDwnStrategy: 'off', storage: disabledStorage });
+
+    expect(inspectLocalReplicaDrainProofStub.called).toBe(false);
+    expect(capturedOptions.localDwnEndpoint).toBeUndefined();
+    expect(capturedOptions.rpcClient).toBeUndefined();
+    expect(await readLocalDwnEjectionRecord(disabledStorage)).toBeDefined();
+  });
+
   test('falls back to an in-process agent without discarding an unavailable pairing', async () => {
     const storage = new MemoryStorage();
     const pairing = {

--- a/packages/auth/tests/auth-manager-create.spec.ts
+++ b/packages/auth/tests/auth-manager-create.spec.ts
@@ -1,6 +1,10 @@
 /**
  * Tests for AuthManager.create() and walletConnect() — the two uncovered methods.
  */
+import type { LocalReplicaDrainProof, SyncDrainResult, SyncDrainTargetResult } from '@enbox/agent';
+
+import type { LocalDwnEjectionRecord } from '../src/discovery.js';
+
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import sinon from 'sinon';
@@ -27,10 +31,12 @@ function createInitClientResult(): any {
 }
 
 let initClientStub: sinon.SinonStub;
+let inspectLocalReplicaDrainProofStub: sinon.SinonStub;
 let userAgentCreateStub: sinon.SinonStub;
 
 function setupStubs(): void {
   initClientStub = sinon.stub(WalletConnect, 'initClient').resolves(createInitClientResult());
+  inspectLocalReplicaDrainProofStub = sinon.stub(EnboxUserAgent, 'inspectLocalReplicaDrainProof').resolves({ valid: true });
   userAgentCreateStub = sinon.stub(EnboxUserAgent, 'create').resolves(createMockAgent() as any);
 }
 
@@ -56,6 +62,82 @@ function jsonResponse(body: unknown, status: number = 200): Response {
     headers: { 'content-type': 'application/json' },
     status,
   });
+}
+
+const localFingerprint = 'a'.repeat(64);
+const registrationFingerprint = 'A'.repeat(43);
+const validDrainProof: LocalReplicaDrainProof = {
+  registrationFingerprint,
+  replicaId : 'replica-id',
+  targets   : [{
+    tenantDid         : 'did:dht:alice',
+    scope             : { kind: 'full' },
+    pushCheckpoint    : { epoch: 'epoch-1', position: '1', streamId: 'stream-1' },
+    localFingerprint,
+    remoteFingerprint : localFingerprint,
+  }],
+};
+
+async function createPairedLocalNodeStorage(): Promise<MemoryStorage> {
+  const storage = new MemoryStorage();
+  await persistLocalDwnPairingRecord(storage, {
+    createdAt    : 123,
+    endpoint     : 'http://127.0.0.1:55500',
+    pairedOrigin : 'https://app.example',
+    token        : 'paired-token',
+    version      : 1,
+  });
+  return storage;
+}
+
+async function createEjectedLocalNodeStorage(
+  ejection: LocalDwnEjectionRecord = {
+    completedAt : 456,
+    drainProof  : validDrainProof,
+    endpoint    : 'http://127.0.0.1:55500',
+    version     : 2,
+  },
+): Promise<MemoryStorage> {
+  const storage = await createPairedLocalNodeStorage();
+  await persistLocalDwnEjectionRecord(storage, ejection);
+  return storage;
+}
+
+function stubPairedLocalNodeFetch(): sinon.SinonStub {
+  return sinon.stub(globalThis, 'fetch').callsFake(async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    if (url.toString().endsWith('/info')) {
+      return jsonResponse(localNodeInfo());
+    }
+
+    expect((init?.headers as Record<string, string>).authorization).toBe('Bearer paired-token');
+    return jsonResponse({ localNode: true, paired: true });
+  });
+}
+
+function completedDrainResult(
+  endpoint: string,
+  targetOverrides: Partial<SyncDrainTargetResult> = {},
+): SyncDrainResult {
+  return {
+    cancelled       : false,
+    completed       : true,
+    endpoint,
+    topologyChanged : false,
+    targets         : [{
+      cancelled         : false,
+      completed         : true,
+      converged         : true,
+      localFingerprint,
+      remoteEndpoint    : endpoint,
+      remoteFingerprint : localFingerprint,
+      scope             : { kind: 'full' },
+      tenantDid         : 'did:dht:alice',
+      ...targetOverrides,
+    }],
+  };
 }
 
 describe('AuthManager.create()', () => {
@@ -248,30 +330,39 @@ describe('AuthManager.create()', () => {
     });
   });
 
-  test('creates remote-mode agent with a stored local-node pairing after eject', async () => {
-    const storage = new MemoryStorage();
-    await persistLocalDwnPairingRecord(storage, {
-      createdAt    : 123,
+  test('creates a remote-mode agent only after the stored v2 drain proof passes late inspection', async () => {
+    const storage = await createEjectedLocalNodeStorage();
+    stubPairedLocalNodeFetch();
+
+    let capturedOptions: any;
+    userAgentCreateStub.onFirstCall().callsFake((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    const manager = await AuthManager.create({ dataPath: '/proof-data', storage });
+
+    expect(inspectLocalReplicaDrainProofStub.calledOnceWithExactly({
+      dataPath : '/proof-data',
+      proof    : validDrainProof,
+    })).toBe(true);
+    expect(capturedOptions.localDwnEndpoint).toBe('http://127.0.0.1:55500');
+    expect(capturedOptions.rpcClient).toBeDefined();
+    expect(manager.localDwnEndpoint).toBe('http://127.0.0.1:55500');
+    expect(manager.localDwnStatus).toEqual({
       endpoint     : 'http://127.0.0.1:55500',
       pairedOrigin : 'https://app.example',
-      token        : 'paired-token',
-      version      : 1,
+      status       : 'paired',
     });
-    await persistLocalDwnEjectionRecord(storage, {
+  });
+
+  test('falls back to local mode for a legacy v1 marker without discarding the pairing', async () => {
+    const storage = await createEjectedLocalNodeStorage({
       completedAt : 456,
       endpoint    : 'http://127.0.0.1:55500',
       version     : 1,
     });
-
-    sinon.stub(globalThis, 'fetch').callsFake(async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
-      const href = url.toString();
-      if (href.endsWith('/info')) {
-        return jsonResponse(localNodeInfo());
-      }
-
-      expect((init?.headers as Record<string, string>).authorization).toBe('Bearer paired-token');
-      return jsonResponse({ localNode: true, paired: true });
-    });
+    stubPairedLocalNodeFetch();
 
     let capturedOptions: any;
     userAgentCreateStub.onFirstCall().callsFake((...args: any[]): any => {
@@ -281,14 +372,38 @@ describe('AuthManager.create()', () => {
 
     const manager = await AuthManager.create({ storage });
 
-    expect(capturedOptions.localDwnEndpoint).toBe('http://127.0.0.1:55500');
-    expect(capturedOptions.rpcClient).toBeDefined();
-    expect(manager.localDwnEndpoint).toBe('http://127.0.0.1:55500');
-    expect(manager.localDwnStatus).toEqual({
+    expect(inspectLocalReplicaDrainProofStub.called).toBe(false);
+    expect(capturedOptions.localDwnEndpoint).toBeUndefined();
+    expect(capturedOptions.rpcClient).toBeUndefined();
+    expect(manager.localDwnEndpoint).toBeUndefined();
+    expect(await readLocalDwnPairingRecord(storage)).toEqual({
+      createdAt    : 123,
       endpoint     : 'http://127.0.0.1:55500',
       pairedOrigin : 'https://app.example',
-      status       : 'paired',
+      token        : 'paired-token',
+      version      : 1,
     });
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
+  });
+
+  test('falls back to local mode when late v2 proof inspection fails', async () => {
+    const storage = await createEjectedLocalNodeStorage();
+    stubPairedLocalNodeFetch();
+    inspectLocalReplicaDrainProofStub.resolves({ valid: false, reason: 'replica fingerprint changed' });
+
+    let capturedOptions: any;
+    userAgentCreateStub.onFirstCall().callsFake((...args: any[]): any => {
+      capturedOptions = args[0];
+      return Promise.resolve(createMockAgent());
+    });
+
+    const manager = await AuthManager.create({ storage });
+
+    expect(capturedOptions.localDwnEndpoint).toBeUndefined();
+    expect(capturedOptions.rpcClient).toBeUndefined();
+    expect(manager.localDwnEndpoint).toBeUndefined();
+    expect(await readLocalDwnPairingRecord(storage)).toBeDefined();
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
   });
 
   test('falls back to an in-process agent without discarding an unavailable pairing', async () => {
@@ -505,16 +620,7 @@ describe('AuthManager.create()', () => {
         targetDid : 'did:dht:alice',
       });
 
-      return {
-        completed : true,
-        endpoint,
-        targets   : [{
-          completed      : true,
-          converged      : true,
-          remoteEndpoint : endpoint,
-          tenantDid      : 'did:dht:alice',
-        }],
-      };
+      return completedDrainResult(endpoint);
     };
     userAgentCreateStub.onFirstCall().resolves(agent as any);
 
@@ -530,8 +636,18 @@ describe('AuthManager.create()', () => {
     expect(manager.localDwnEndpoint).toBeUndefined();
     expect(await readLocalDwnEjectionRecord(storage)).toEqual({
       completedAt : expect.any(Number),
-      endpoint    : 'http://127.0.0.1:55500',
-      version     : 1,
+      drainProof  : {
+        registrationFingerprint,
+        replicaId : 'replica-id',
+        targets   : [{
+          localFingerprint,
+          remoteFingerprint : localFingerprint,
+          scope             : { kind: 'full' },
+          tenantDid         : 'did:dht:alice',
+        }],
+      },
+      endpoint : 'http://127.0.0.1:55500',
+      version  : 2,
     });
 
     let capturedOptions: any;
@@ -545,6 +661,143 @@ describe('AuthManager.create()', () => {
     expect(capturedOptions.localDwnEndpoint).toBe('http://127.0.0.1:55500');
     expect(capturedOptions.rpcClient).toBeDefined();
     expect(nextManager.localDwnEndpoint).toBe('http://127.0.0.1:55500');
+    expect(inspectLocalReplicaDrainProofStub.calledOnce).toBe(true);
+  });
+
+  test('ejectToLocalNode rejects a completed drain when the replica snapshot changes', async () => {
+    const storage = await createPairedLocalNodeStorage();
+    stubPairedLocalNodeFetch();
+    let snapshotCalls = 0;
+    const agent = createMockAgent({
+      syncDrainTo             : async (endpoint): Promise<SyncDrainResult> => completedDrainResult(endpoint),
+      syncGetEjectionSnapshot : async () => ({
+        registrationFingerprint : snapshotCalls++ === 0 ? registrationFingerprint : 'B'.repeat(43),
+        replicaId               : 'replica-id',
+      }),
+    });
+    userAgentCreateStub.onFirstCall().resolves(agent as any);
+
+    const manager = await AuthManager.create({ storage });
+    const result = await manager.ejectToLocalNode();
+
+    expect(snapshotCalls).toBe(2);
+    expect(result).toMatchObject({
+      drain: {
+        completed       : false,
+        error           : 'local replica drain proof validation failed after drain completion',
+        topologyChanged : true,
+      },
+      nextSessionRemoteMode : false,
+      status                : 'incomplete',
+    });
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
+  });
+
+  test('ejectToLocalNode returns incomplete when the post-drain replica snapshot cannot be read', async () => {
+    const storage = await createPairedLocalNodeStorage();
+    stubPairedLocalNodeFetch();
+    let snapshotCalls = 0;
+    const agent = createMockAgent({
+      syncDrainTo             : async (endpoint): Promise<SyncDrainResult> => completedDrainResult(endpoint),
+      syncGetEjectionSnapshot : async () => {
+        if (snapshotCalls++ === 0) {
+          return { registrationFingerprint, replicaId: 'replica-id' };
+        }
+        throw new Error('snapshot unavailable');
+      },
+    });
+    userAgentCreateStub.onFirstCall().resolves(agent as any);
+
+    const manager = await AuthManager.create({ storage });
+    const result = await manager.ejectToLocalNode();
+
+    expect(result).toMatchObject({
+      drain: {
+        completed       : false,
+        error           : 'unable to verify the local replica snapshot after drain',
+        topologyChanged : true,
+      },
+      nextSessionRemoteMode : false,
+      status                : 'incomplete',
+    });
+    expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
+  });
+
+  test('ejectToLocalNode rejects completed drains whose targets cannot form a canonical proof', async () => {
+    const invalidDrains: Array<{ name: string; create: (endpoint: string) => SyncDrainResult }> = [
+      {
+        name   : 'missing scope',
+        create : (endpoint): SyncDrainResult => completedDrainResult(endpoint, { scope: undefined }),
+      },
+      {
+        name   : 'non-canonical fingerprint',
+        create : (endpoint): SyncDrainResult => completedDrainResult(endpoint, {
+          localFingerprint  : 'A'.repeat(64),
+          remoteFingerprint : 'A'.repeat(64),
+        }),
+      },
+      {
+        name   : 'mismatched fingerprints',
+        create : (endpoint): SyncDrainResult => completedDrainResult(endpoint, { remoteFingerprint: 'b'.repeat(64) }),
+      },
+      {
+        name   : 'malformed checkpoint',
+        create : (endpoint): SyncDrainResult => completedDrainResult(endpoint, {
+          pushCheckpoint: { epoch: 'epoch-1', position: '-1', streamId: 'stream-1' },
+        }),
+      },
+      {
+        name   : 'non-canonical full scope',
+        create : (endpoint): SyncDrainResult => completedDrainResult(endpoint, {
+          scope: { kind: 'full', protocols: [] } as any,
+        }),
+      },
+      {
+        name   : 'duplicate logical scope with reordered keys',
+        create : (endpoint): SyncDrainResult => {
+          const drain = completedDrainResult(endpoint, {
+            scope: { kind: 'protocolSet', protocols: ['https://a.example'] },
+          });
+          return {
+            ...drain,
+            targets: [
+              drain.targets[0],
+              {
+                ...drain.targets[0],
+                scope: { protocols: ['https://a.example'], kind: 'protocolSet' } as any,
+              },
+            ],
+          };
+        },
+      },
+      {
+        name   : 'empty target set',
+        create : (endpoint): SyncDrainResult => ({ ...completedDrainResult(endpoint), targets: [] }),
+      },
+      {
+        name   : 'contradictory topology flag',
+        create : (endpoint): SyncDrainResult => ({ ...completedDrainResult(endpoint), topologyChanged: true }),
+      },
+      {
+        name   : 'wrong target endpoint',
+        create : (endpoint): SyncDrainResult => completedDrainResult(endpoint, { remoteEndpoint: 'https://other.example' }),
+      },
+    ];
+    stubPairedLocalNodeFetch();
+
+    for (const [index, invalidDrain] of invalidDrains.entries()) {
+      const storage = await createPairedLocalNodeStorage();
+      userAgentCreateStub.onCall(index).resolves(createMockAgent({
+        syncDrainTo: async (endpoint): Promise<SyncDrainResult> => invalidDrain.create(endpoint),
+      }) as any);
+
+      const manager = await AuthManager.create({ storage });
+      const result = await manager.ejectToLocalNode();
+
+      expect({ name: invalidDrain.name, status: result.status }).toEqual({ name: invalidDrain.name, status: 'incomplete' });
+      expect(result).toMatchObject({ drain: { completed: false, topologyChanged: true } });
+      expect(await readLocalDwnEjectionRecord(storage)).toBeUndefined();
+    }
   });
 
   test('ejectToLocalNode does not persist remote-mode marker when drain is incomplete', async () => {

--- a/packages/auth/tests/dwn-discovery.spec.ts
+++ b/packages/auth/tests/dwn-discovery.spec.ts
@@ -1,3 +1,4 @@
+import type { LocalReplicaDrainProof } from '@enbox/agent';
 import type { ServerInfo } from '@enbox/dwn-clients';
 
 import { WebSocketDwnRpcClient } from '@enbox/dwn-clients';
@@ -48,6 +49,20 @@ const pairingRecord = {
   version      : 1 as const,
 };
 
+const localFingerprint = 'a'.repeat(64);
+const registrationFingerprint = 'A'.repeat(43);
+const drainProof: LocalReplicaDrainProof = {
+  registrationFingerprint,
+  replicaId : 'replica-id',
+  targets   : [{
+    localFingerprint,
+    pushCheckpoint    : { epoch: 'epoch-1', position: '42', streamId: 'stream-1' },
+    remoteFingerprint : localFingerprint,
+    scope             : { kind: 'full' },
+    tenantDid         : 'did:dht:alice',
+  }],
+};
+
 let originalLocation: Location | undefined;
 let originalNavigator: Navigator | undefined;
 let originalIsSecureContext: boolean | undefined;
@@ -85,6 +100,139 @@ describe('local-node pairing storage', () => {
     expect(raw).not.toBeNull();
     expect(JSON.parse(raw!)).toEqual(expected);
     expect(await readLocalDwnEjectionRecord(storage)).toEqual(expected);
+  });
+
+  test('persists and deeply reads a version 2 drain-proof record', async () => {
+    const storage = new MemoryStorage();
+
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      drainProof,
+      endpoint    : `${pairingRecord.endpoint}/`,
+      version     : 2,
+    });
+
+    expect(await readLocalDwnEjectionRecord(storage)).toEqual({
+      completedAt : 456,
+      drainProof,
+      endpoint    : pairingRecord.endpoint,
+      version     : 2,
+    });
+  });
+
+  test('accepts a canonical protocol-set proof with no push checkpoint', async () => {
+    const storage = new MemoryStorage();
+    const proofWithoutCheckpoint: LocalReplicaDrainProof = {
+      ...drainProof,
+      targets: [{
+        localFingerprint,
+        remoteFingerprint : localFingerprint,
+        scope             : { kind: 'protocolSet', protocols: ['https://a.example', 'https://b.example'] },
+        tenantDid         : 'did:dht:alice',
+      }],
+    };
+    await persistLocalDwnEjectionRecord(storage, {
+      completedAt : 456,
+      drainProof  : proofWithoutCheckpoint,
+      endpoint    : pairingRecord.endpoint,
+      version     : 2,
+    });
+
+    expect((await readLocalDwnEjectionRecord(storage))?.version).toBe(2);
+  });
+
+  test('clears version 2 records with malformed nested drain proofs', async () => {
+    const invalidProofs: Array<{ name: string; proof: unknown }> = [
+      { name: 'empty replica ID', proof: { ...drainProof, replicaId: '' } },
+      { name: 'empty registration fingerprint', proof: { ...drainProof, registrationFingerprint: '' } },
+      { name: 'non-canonical registration fingerprint', proof: { ...drainProof, registrationFingerprint: 'a'.repeat(42) } },
+      { name: 'empty targets', proof: { ...drainProof, targets: [] } },
+      {
+        name  : 'invalid tenant DID',
+        proof : { ...drainProof, targets: [{ ...drainProof.targets[0], tenantDid: 'alice' }] },
+      },
+      {
+        name  : 'duplicate tenant and scope target',
+        proof : { ...drainProof, targets: [drainProof.targets[0], { ...drainProof.targets[0] }] },
+      },
+      {
+        name  : 'duplicate logical scope with reordered keys',
+        proof : {
+          ...drainProof,
+          targets: [
+            {
+              ...drainProof.targets[0],
+              scope: { kind: 'protocolSet', protocols: ['https://a.example'] },
+            },
+            {
+              ...drainProof.targets[0],
+              scope: { protocols: ['https://a.example'], kind: 'protocolSet' },
+            },
+          ],
+        },
+      },
+      {
+        name  : 'non-canonical target fingerprint',
+        proof : {
+          ...drainProof,
+          targets: [{ ...drainProof.targets[0], localFingerprint: 'A'.repeat(64), remoteFingerprint: 'A'.repeat(64) }],
+        },
+      },
+      {
+        name  : 'mismatched fingerprints',
+        proof : { ...drainProof, targets: [{ ...drainProof.targets[0], remoteFingerprint: 'b'.repeat(64) }] },
+      },
+      {
+        name  : 'full scope with protocols',
+        proof : { ...drainProof, targets: [{ ...drainProof.targets[0], scope: { kind: 'full', protocols: [] } }] },
+      },
+      {
+        name  : 'unsorted protocol set',
+        proof : {
+          ...drainProof,
+          targets: [{
+            ...drainProof.targets[0],
+            scope: { kind: 'protocolSet', protocols: ['https://b.example', 'https://a.example'] },
+          }],
+        },
+      },
+      {
+        name  : 'non-decimal checkpoint',
+        proof : {
+          ...drainProof,
+          targets: [{
+            ...drainProof.targets[0],
+            pushCheckpoint: { epoch: 'epoch-1', position: '-1', streamId: 'stream-1' },
+          }],
+        },
+      },
+      {
+        name  : 'non-canonical checkpoint position',
+        proof : {
+          ...drainProof,
+          targets: [{
+            ...drainProof.targets[0],
+            pushCheckpoint: { epoch: 'epoch-1', position: '01', streamId: 'stream-1' },
+          }],
+        },
+      },
+    ];
+
+    for (const invalidProof of invalidProofs) {
+      const storage = new MemoryStorage();
+      await storage.set(STORAGE_KEYS.LOCAL_DWN_EJECTION, JSON.stringify({
+        completedAt : 456,
+        drainProof  : invalidProof.proof,
+        endpoint    : pairingRecord.endpoint,
+        version     : 2,
+      }));
+
+      expect({ name: invalidProof.name, record: await readLocalDwnEjectionRecord(storage) }).toEqual({
+        name   : invalidProof.name,
+        record : undefined,
+      });
+      expect(await storage.get(STORAGE_KEYS.LOCAL_DWN_EJECTION)).toBeNull();
+    }
   });
 
   test('clears malformed ejection records', async () => {

--- a/packages/auth/tests/helpers/mock-agent.ts
+++ b/packages/auth/tests/helpers/mock-agent.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-import type { EnboxUserAgent } from '@enbox/agent';
+import type { EnboxUserAgent, SyncEjectionSnapshot } from '@enbox/agent';
 
 import { PermissionsProtocol } from '@enbox/dwn-sdk-js';
 import { DwnPermissionGrant, InMemorySecretStore } from '@enbox/agent';
@@ -80,6 +80,7 @@ export interface MockAgentOverrides {
   syncStopSync?: (timeout: number) => Promise<void>;
   syncSync?: (direction: string) => Promise<void>;
   syncDrainTo?: (endpoint: string, options?: any) => Promise<any>;
+  syncGetEjectionSnapshot?: () => Promise<SyncEjectionSnapshot>;
   syncClose?: () => Promise<void>;
   syncHasActiveSubscriptions?: boolean;
   processDwnRequest?: (params: any) => Promise<any>;
@@ -176,13 +177,17 @@ export function createMockAgent(overrides: MockAgentOverrides = {}): EnboxUserAg
     },
 
     sync: {
-      registerIdentity       : overrides.syncRegisterIdentity ?? (async (): Promise<void> => {}),
-      unregisterIdentity     : overrides.syncUnregisterIdentity ?? (async (): Promise<void> => {}),
-      updateIdentityOptions  : overrides.syncUpdateIdentityOptions ?? (async (): Promise<void> => {}),
-      startSync              : overrides.syncStartSync ?? (async (): Promise<void> => {}),
-      stopSync               : overrides.syncStopSync ?? (async (): Promise<void> => {}),
-      sync                   : overrides.syncSync ?? (async (): Promise<void> => {}),
-      drainTo                : overrides.syncDrainTo ?? (async (endpoint: string): Promise<any> => ({ completed: true, endpoint, targets: [] })),
+      registerIdentity      : overrides.syncRegisterIdentity ?? (async (): Promise<void> => {}),
+      unregisterIdentity    : overrides.syncUnregisterIdentity ?? (async (): Promise<void> => {}),
+      updateIdentityOptions : overrides.syncUpdateIdentityOptions ?? (async (): Promise<void> => {}),
+      startSync             : overrides.syncStartSync ?? (async (): Promise<void> => {}),
+      stopSync              : overrides.syncStopSync ?? (async (): Promise<void> => {}),
+      sync                  : overrides.syncSync ?? (async (): Promise<void> => {}),
+      drainTo               : overrides.syncDrainTo ?? (async (endpoint: string): Promise<any> => ({ completed: true, endpoint, targets: [] })),
+      getEjectionSnapshot   : overrides.syncGetEjectionSnapshot ?? (async (): Promise<SyncEjectionSnapshot> => ({
+        registrationFingerprint : 'A'.repeat(43),
+        replicaId               : 'replica-id',
+      })),
       close                  : overrides.syncClose ?? (async (): Promise<void> => {}),
       hasActiveSubscriptions : overrides.syncHasActiveSubscriptions ?? false,
     },


### PR DESCRIPTION
## Summary

- persist v2 ejection markers bound to a stable source-replica ID, canonical registration topology, and converged drain manifest
- inspect retired message and task stores before remote-mode boot; legacy, changed, or unreadable proofs fall back locally while preserving pairing
- fail drains when any registered DID resolves no active sync projection

This intentionally does not delete local stores. It establishes the fail-closed source-replica proof needed before destination storage-generation binding and cross-context write fencing can make deletion safe in #1166.

## Test plan

- [x] bun run lint
- [x] bun run build
- [x] packages/auth: bun run test:node (536 pass)
- [x] packages/agent: bun run test:node (1327 pass)
- [x] bunx changeset status
