### PR TITLE
fix(dwn-server): copy local-node workspace manifest in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY packages/cli/package.json               packages/cli/
 COPY packages/electrobun-dwn/package.json    packages/electrobun-dwn/
 COPY packages/protocols/package.json         packages/protocols/
 COPY packages/protocol-codegen/package.json  packages/protocol-codegen/
+COPY packages/local-node/package.json        packages/local-node/
 COPY apps/docs/package.json                  apps/docs/
 
 RUN bun install --frozen-lockfile --ignore-scripts
@@ -87,6 +88,7 @@ COPY packages/cli/package.json               packages/cli/
 COPY packages/electrobun-dwn/package.json    packages/electrobun-dwn/
 COPY packages/protocols/package.json         packages/protocols/
 COPY packages/protocol-codegen/package.json  packages/protocol-codegen/
+COPY packages/local-node/package.json        packages/local-node/
 COPY apps/docs/package.json                  apps/docs/
 
 # Build packages in dependency order.


### PR DESCRIPTION
## Summary

The production `Dockerfile` copies each workspace `package.json` individually (for Docker layer caching), but `packages/local-node` was added to the root `workspaces` without a matching `COPY` line. `bun install --frozen-lockfile` then aborts the image build:

```
error: Workspace not found "packages/local-node" at /app/package.json:21:5
ERROR: process "/bin/sh -c bun install --frozen-lockfile --ignore-scripts" did not complete successfully: exit code: 1
```

This breaks the **AWS/ECS** image build (which uses the root `Dockerfile`). The **Fly** image is unaffected because `packages/dwn-server/Dockerfile` copies `packages/` wholesale.

## Fix

Add the missing `COPY packages/local-node/package.json packages/local-node/` in **both** the `deps` and `build` stages — the same pattern already used for the other excluded workspaces (`agent`, `browser`, `cli`, …). Only the manifest is copied; `local-node`'s source stays excluded via `.dockerignore` since `dwn-server` does not depend on it. This is exactly the maintenance step called out in `enbox-internal`'s `infra/DEPLOYMENT.md` ("when adding a new workspace package, add a `COPY packages/<name>/package.json` line in both stages").

Follows the same shape as #1203.

## Verification

Building the root `Dockerfile` from this branch now passes the `bun install --frozen-lockfile` step that previously failed, and produces the `dwn-server` 0.1.20 image deployed to AWS dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)