### PR TITLE
fix(dwn-server): copy connect workspace manifest in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY packages/api/package.json               packages/api/
 COPY packages/auth/package.json              packages/auth/
 COPY packages/browser/package.json           packages/browser/
 COPY packages/cli/package.json               packages/cli/
+COPY packages/connect/package.json           packages/connect/
 COPY packages/electrobun-dwn/package.json    packages/electrobun-dwn/
 COPY packages/protocols/package.json         packages/protocols/
 COPY packages/protocol-codegen/package.json  packages/protocol-codegen/
@@ -85,6 +86,7 @@ COPY packages/api/package.json               packages/api/
 COPY packages/auth/package.json              packages/auth/
 COPY packages/browser/package.json           packages/browser/
 COPY packages/cli/package.json               packages/cli/
+COPY packages/connect/package.json           packages/connect/
 COPY packages/electrobun-dwn/package.json    packages/electrobun-dwn/
 COPY packages/protocols/package.json         packages/protocols/
 COPY packages/protocol-codegen/package.json  packages/protocol-codegen/


### PR DESCRIPTION
## Summary

- copy the new `packages/connect` workspace manifest into both production Docker build stages
- restore frozen workspace installation for the root AWS/ECS image build

## Test plan

- [x] `docker build -t enbox-dwn-server:a2f2ad7 .`
- [x] run the image and verify `/health` plus `/info` (`0.1.21`, SDK `0.4.10`)
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run --filter @enbox/agent build`
