### PR TITLE
feat(browser): update default wallet catalog

### DIFF
--- a/.changeset/four-default-wallets.md
+++ b/.changeset/four-default-wallets.md
@@ -1,0 +1,5 @@
+---
+"@enbox/browser": patch
+---
+
+feat: update the default browser wallet selector to Enbox, Prism, Matcha, and Onyx

--- a/packages/browser/src/browser-connect-handler.ts
+++ b/packages/browser/src/browser-connect-handler.ts
@@ -38,7 +38,7 @@ export const DEFAULT_WALLETS: WalletOption[] = [
   {
     name        : 'Prism',
     url         : 'https://prism-wallet.pages.dev',
-    description : 'See your digital identity from every angle',
+    description : 'A clear view into your digital identity',
   },
   {
     name        : 'Matcha',

--- a/packages/browser/src/browser-connect-handler.ts
+++ b/packages/browser/src/browser-connect-handler.ts
@@ -15,7 +15,7 @@ import { showWalletSelector } from './ui/wallet-selector.js';
 
 /** A wallet entry shown in the wallet selector modal. */
 export interface WalletOption {
-  /** Display name (e.g. "Enbox Wallet"). */
+  /** Display name (e.g. "Enbox"). */
   name: string;
 
   /** Base URL of the wallet app (e.g. "https://enbox-wallet.pages.dev"). */
@@ -31,14 +31,24 @@ export interface WalletOption {
 /** Default wallets shown in the selector when no overrides are provided. */
 export const DEFAULT_WALLETS: WalletOption[] = [
   {
-    name        : 'Enbox Wallet',
+    name        : 'Enbox',
     url         : 'https://enbox-wallet.pages.dev',
-    description : 'Your digital identity wallet',
+    description : 'Manage your digital identity and data',
   },
   {
-    name        : 'Blue Enbox Wallet',
-    url         : 'https://blue-enbox-wallet.pages.dev',
-    description : 'Your digital identity wallet',
+    name        : 'Prism',
+    url         : 'https://prism-wallet.pages.dev',
+    description : 'See your digital identity from every angle',
+  },
+  {
+    name        : 'Matcha',
+    url         : 'https://matcha-wallet.pages.dev',
+    description : 'A fresh approach to digital identity',
+  },
+  {
+    name        : 'Onyx',
+    url         : 'https://onyx-wallet.pages.dev',
+    description : 'A refined home for your digital identity',
   },
 ];
 

--- a/packages/browser/tests/exports.spec.ts
+++ b/packages/browser/tests/exports.spec.ts
@@ -88,7 +88,7 @@ describe('@enbox/browser exports', () => {
       {
         name        : 'Prism',
         url         : 'https://prism-wallet.pages.dev',
-        description : 'See your digital identity from every angle',
+        description : 'A clear view into your digital identity',
       },
       {
         name        : 'Matcha',

--- a/packages/browser/tests/exports.spec.ts
+++ b/packages/browser/tests/exports.spec.ts
@@ -76,15 +76,31 @@ describe('@enbox/browser exports', () => {
     expect(typeof mod.BrowserConnectHandler).toBe('function');
   });
 
-  it('exports DEFAULT_WALLETS with correct pages.dev URLs', async () => {
+  it('exports the ordered default wallet catalog', async () => {
     const mod = await getBrowserExports();
     const wallets = mod.DEFAULT_WALLETS as Array<{ name: string; url: string; description?: string }>;
-    expect(Array.isArray(wallets)).toBe(true);
-    expect(wallets).toHaveLength(2);
-    expect(wallets[0].url).toBe('https://enbox-wallet.pages.dev');
-    expect(wallets[1].url).toBe('https://blue-enbox-wallet.pages.dev');
-    expect(wallets[0].description).toBeDefined();
-    expect(wallets[1].description).toBeDefined();
+    expect(wallets).toEqual([
+      {
+        name        : 'Enbox',
+        url         : 'https://enbox-wallet.pages.dev',
+        description : 'Manage your digital identity and data',
+      },
+      {
+        name        : 'Prism',
+        url         : 'https://prism-wallet.pages.dev',
+        description : 'See your digital identity from every angle',
+      },
+      {
+        name        : 'Matcha',
+        url         : 'https://matcha-wallet.pages.dev',
+        description : 'A fresh approach to digital identity',
+      },
+      {
+        name        : 'Onyx',
+        url         : 'https://onyx-wallet.pages.dev',
+        description : 'A refined home for your digital identity',
+      },
+    ]);
   });
 
   it('exports the popup connect flow and transports', async () => {


### PR DESCRIPTION
## Summary

- replace the Enbox/Blue Enbox browser defaults with Enbox, Prism, Matcha, and Onyx in the requested order
- use one-word display names and distinct product descriptions
- pin the complete ordered catalog in the browser export test
- add a patch changeset for `@enbox/browser`

## Rollout note

Do not merge/release this change until Prism, Matcha, and Onyx have migrated to the unified connect kernel and been redeployed.

Live verification on 2026-07-10 found that Enbox emits the current `enbox-connect-loaded/request/response` protocol, while Prism, Matcha, and Onyx still emit the removed legacy `dweb-connect-*` protocol. Those three are direct Cloudflare uploads without a published source branch, so their migration PRs cannot be opened yet. After their source is published, port the web-wallet #160 kernel migration, redeploy, and verify a complete popup handshake before making this PR ready for review.

## Test plan

- [x] `bun run lint`
- [x] `bun run build --filter=@enbox/browser`
- [x] `bun run --filter @enbox/agent build`
- [x] `bun run --filter @enbox/browser test:node` (10 passed)
- [x] `bun run --filter @enbox/browser test:browser` (198 passed across Chromium and Firefox)
- [x] `bun run test:node` from `packages/agent` (1,194 passed, 4 skipped)
- [x] `bunx changeset status`
