### PR TITLE
chore(changeset): make the connect-dialog bump a patch

### DIFF
--- a/.changeset/standardized-connect-dialog.md
+++ b/.changeset/standardized-connect-dialog.md
@@ -1,5 +1,5 @@
 ---
-"@enbox/browser": minor
+"@enbox/browser": patch
 ---
 
 feat(browser): redesign the wallet connect dialog


### PR DESCRIPTION
Downgrades the changeset from #1246 from **minor** to **patch** for `@enbox/browser`.

The connect-dialog redesign landed with a `minor` changeset; per the project's patch-first cadence this should be a patch. `@enbox/browser` has not been released yet (still 0.3.41 on npm), so the open **"Version Packages" PR #1247** will regenerate to a patch bump (0.3.42) once this merges.

No code change — changeset metadata only.