### PR TITLE
fix(connect): order composed-protocol install by `uses` deps + add @enbox/browser convenience re-exports

### DIFF
--- a/.changeset/browser-convenience-exports.md
+++ b/.changeset/browser-convenience-exports.md
@@ -1,0 +1,18 @@
+---
+"@enbox/browser": patch
+---
+
+feat(browser): re-export common symbols so dapps need fewer packages
+
+`@enbox/browser` now re-exports the handful of symbols dapps most commonly
+reached into sibling packages for, so that in most cases a dapp only needs
+`@enbox/browser` (plus `@enbox/protocols` for shared protocol definitions):
+
+- `TypedRecord` (from `@enbox/api`)
+- `BrowserStorage`, `ProviderAuthParams`, `ProviderAuthResult` (from `@enbox/auth`)
+- `DwnInterface` (from `@enbox/agent`)
+- `DateSort`, `DwnInterfaceName`, `DwnMethodName`, `ProtocolDefinition`,
+  `ProtocolActionRule` (from `@enbox/dwn-sdk-js`)
+
+These are additive re-exports; anything more specialized is still available by
+importing the underlying package directly.

--- a/.changeset/connect-uses-ordering.md
+++ b/.changeset/connect-uses-ordering.md
@@ -1,0 +1,20 @@
+---
+"@enbox/agent": patch
+---
+
+fix(connect): install composed protocols in `uses`-dependency order
+
+The connect approval ceremony prepared every requested protocol in one flat
+concurrent fan-out. The DWN's `ProtocolsConfigure` handler rejects a configure
+whose `uses` targets are not yet installed for the tenant, so a composing
+protocol (e.g. one that `uses` a social-graph protocol for a role) could race
+its dependency and land first — getting rejected and failing the fail-closed
+remote convergence check. On a fresh identity, where nothing is pre-installed,
+this reliably aborted the whole connect with "Could not verify the latest
+protocol definition on every reachable DWN endpoint".
+
+`prepareProtocol` is now fanned out in `uses`-dependency order: each protocol's
+in-batch dependencies fully converge across all endpoints before its dependents
+are prepared. Independent protocols within a dependency level are still prepared
+concurrently, and dependency cycles fall back to the previous best-effort
+concurrent behavior.

--- a/bun.lock
+++ b/bun.lock
@@ -139,6 +139,7 @@
         "@enbox/connect": "workspace:*",
         "@enbox/crypto": "workspace:*",
         "@enbox/dids": "workspace:*",
+        "@enbox/dwn-sdk-js": "workspace:*",
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/packages/agent/src/connect-approval.ts
+++ b/packages/agent/src/connect-approval.ts
@@ -278,6 +278,73 @@ function validatePermissionRequestProtocolUris(permissionRequests: ConnectPermis
   }
 }
 
+/**
+ * Orders protocol preparation so that a protocol's in-batch composition
+ * dependencies are prepared before it.
+ *
+ * A composing protocol declares its dependencies via `uses` (e.g. focus-board
+ * `uses` social-graph for a `social:friend` role). The DWN `ProtocolsConfigure`
+ * handler rejects a configure whose `uses` targets are not yet installed for
+ * the tenant, so preparing every requested protocol in a single flat
+ * concurrent fan-out races a composing protocol against its dependency: on a
+ * fresh identity the dependent's configure can land before its `uses` target
+ * is installed, get rejected, and fail the fail-closed remote convergence
+ * check — aborting the whole connect.
+ *
+ * This returns dependency "levels": every request in a level has all of its
+ * in-batch `uses` targets in an earlier level, and requests within a level are
+ * independent and may be prepared concurrently. Callers prepare one level at a
+ * time, awaiting each before starting the next.
+ *
+ * `uses` targets that are not part of this batch are ignored — installing them
+ * is the caller's responsibility and they must already exist on the owner's
+ * DWNs. Cycles (which the DWN would reject anyway) are broken by emitting the
+ * remaining requests as a final level rather than looping forever, preserving
+ * the previous best-effort behavior for that degenerate case.
+ */
+export function orderPermissionRequestsByUsesDependencies(
+  permissionRequests: ConnectPermissionRequest[],
+): ConnectPermissionRequest[][] {
+  const inBatchProtocolUris = new Set(
+    permissionRequests.map((request) => request.protocolDefinition.protocol),
+  );
+
+  const inBatchDependenciesOf = (request: ConnectPermissionRequest): string[] => {
+    const uses = request.protocolDefinition.uses ?? {};
+    return Object.values(uses).filter(
+      (targetUri): targetUri is string =>
+        typeof targetUri === 'string'
+        && targetUri !== request.protocolDefinition.protocol
+        && inBatchProtocolUris.has(targetUri),
+    );
+  };
+
+  const remaining = new Set(permissionRequests);
+  const preparedProtocolUris = new Set<string>();
+  const levels: ConnectPermissionRequest[][] = [];
+
+  while (remaining.size > 0) {
+    const level = [...remaining].filter((request) =>
+      inBatchDependenciesOf(request).every((targetUri) => preparedProtocolUris.has(targetUri)),
+    );
+
+    if (level.length === 0) {
+      // Unsatisfiable dependency or cycle: emit the rest together and let the
+      // downstream fail-closed verification surface the real conflict.
+      levels.push([...remaining]);
+      break;
+    }
+
+    for (const request of level) {
+      remaining.delete(request);
+      preparedProtocolUris.add(request.protocolDefinition.protocol);
+    }
+    levels.push(level);
+  }
+
+  return levels;
+}
+
 function resolvePreSuppliedDelegateDid(delegateDid: string | undefined): string | undefined {
   if (delegateDid === undefined) {
     return undefined;
@@ -668,9 +735,16 @@ export async function executeConnectApproval(params: ExecuteConnectApprovalParam
     const grantSetup = await timed(
       `${CONNECT_PERF_LOG_PREFIX} permissionGrants.fanout (protocols=${numProtocols})`,
       async () => {
-        await Promise.all(request.permissionRequests.map(
-          ({ protocolDefinition }) => prepareProtocol(providerDid, agent, protocolDefinition)
-        ));
+        // Prepare in `uses`-dependency order: a composing protocol's configure
+        // is rejected by the DWN unless its `uses` targets are already
+        // installed, so dependencies must fully converge (across all endpoints)
+        // before their dependents fan out. Independent protocols within a level
+        // are still prepared concurrently.
+        for (const level of orderPermissionRequestsByUsesDependencies(request.permissionRequests)) {
+          await Promise.all(level.map(
+            ({ protocolDefinition }) => prepareProtocol(providerDid, agent, protocolDefinition)
+          ));
+        }
 
         const permissionScopes = request.permissionRequests.flatMap((permissionRequest) => permissionRequest.permissionScopes);
         const createdGrants = await ConnectCeremony.createPermissionGrants(

--- a/packages/agent/tests/connect-uses-ordering.spec.ts
+++ b/packages/agent/tests/connect-uses-ordering.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { ConnectPermissionRequest } from '@enbox/connect';
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+
+import { orderPermissionRequestsByUsesDependencies } from '../src/connect-approval.js';
+
+/** Minimal permission request builder for pure ordering tests. */
+function request(protocol: string, uses?: Record<string, string>): ConnectPermissionRequest {
+  const definition = {
+    protocol,
+    published : false,
+    types     : {},
+    structure : {},
+    ...(uses !== undefined && { uses }),
+  } as unknown as ProtocolDefinition;
+  return { protocolDefinition: definition, permissionScopes: [] };
+}
+
+/** Project ordering levels down to protocol URIs for readable assertions. */
+function levelUris(levels: ConnectPermissionRequest[][]): string[][] {
+  return levels.map((level) => level.map((request) => request.protocolDefinition.protocol));
+}
+
+describe('orderPermissionRequestsByUsesDependencies', () => {
+  it('keeps independent protocols in a single concurrent level', () => {
+    const levels = orderPermissionRequestsByUsesDependencies([
+      request('https://example.org/a'),
+      request('https://example.org/b'),
+    ]);
+
+    expect(levelUris(levels)).toEqual([['https://example.org/a', 'https://example.org/b']]);
+  });
+
+  it('places a composing protocol after its in-batch `uses` dependency', () => {
+    const board = request('https://app.example/board', { social: 'https://id.example/social' });
+    const social = request('https://id.example/social');
+
+    // Dependent is listed first — ordering must still prepare the dependency first.
+    const levels = orderPermissionRequestsByUsesDependencies([board, social]);
+
+    expect(levelUris(levels)).toEqual([
+      ['https://id.example/social'],
+      ['https://app.example/board'],
+    ]);
+  });
+
+  it('ignores `uses` targets that are not part of the batch', () => {
+    // social-graph is not requested in this batch, so `board` has no in-batch
+    // dependency and stays in the first level.
+    const levels = orderPermissionRequestsByUsesDependencies([
+      request('https://app.example/board', { social: 'https://id.example/social' }),
+    ]);
+
+    expect(levelUris(levels)).toEqual([['https://app.example/board']]);
+  });
+
+  it('orders a multi-level dependency chain', () => {
+    const levels = orderPermissionRequestsByUsesDependencies([
+      request('https://x/c', { b: 'https://x/b' }),
+      request('https://x/b', { a: 'https://x/a' }),
+      request('https://x/a'),
+    ]);
+
+    expect(levelUris(levels)).toEqual([['https://x/a'], ['https://x/b'], ['https://x/c']]);
+  });
+
+  it('breaks a dependency cycle by emitting the remaining requests as a final level', () => {
+    const levels = orderPermissionRequestsByUsesDependencies([
+      request('https://x/a', { b: 'https://x/b' }),
+      request('https://x/b', { a: 'https://x/a' }),
+    ]);
+
+    // No progress is possible, so both are emitted together (best-effort — the
+    // DWN's fail-closed verification surfaces the real conflict downstream).
+    expect(levels).toHaveLength(1);
+    expect(levels[0]).toHaveLength(2);
+  });
+
+  it('returns no levels for an empty batch', () => {
+    expect(orderPermissionRequestsByUsesDependencies([])).toEqual([]);
+  });
+});

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build:esm": "rm -rf dist/esm dist/types && bun tsc -p tsconfig.json",
-    "build:browser": "rm -rf dist/browser.mjs && bun ../../build/browser-bundle.js --metafile --external @enbox/agent --external @enbox/api --external @enbox/auth --external @enbox/auth/browser --external @enbox/common --external @enbox/connect --external @enbox/crypto --external @enbox/dids",
+    "build:browser": "rm -rf dist/browser.mjs && bun ../../build/browser-bundle.js --metafile --external @enbox/agent --external @enbox/api --external @enbox/auth --external @enbox/auth/browser --external @enbox/common --external @enbox/connect --external @enbox/crypto --external @enbox/dids --external @enbox/dwn-sdk-js",
     "build": "bun run clean && bun run build:esm && bun run build:browser",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -72,7 +72,8 @@
     "@enbox/common": "workspace:*",
     "@enbox/connect": "workspace:*",
     "@enbox/crypto": "workspace:*",
-    "@enbox/dids": "workspace:*"
+    "@enbox/dids": "workspace:*",
+    "@enbox/dwn-sdk-js": "workspace:*"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -106,3 +106,27 @@ export type {
 } from './dweb-connect-messages.js';
 export type { WalletSelectorOptions } from './ui/wallet-selector.js';
 export { probeWalletWellKnown, showWalletSelector, WALLET_WELL_KNOWN_PATH } from './ui/wallet-selector.js';
+
+// ─── Convenience re-exports for dapps ───────────────────────────
+//
+// So that most browser dapps only need `@enbox/browser` (plus
+// `@enbox/protocols` for shared protocol definitions). These surface the
+// symbols dapps most commonly reached into sibling packages for; anything
+// more specialized is still available by importing the underlying package
+// directly.
+
+// Typed record wrapper (from @enbox/api).
+export { TypedRecord } from '@enbox/api';
+
+// Custom storage adapter + DWN registration provider-auth callback shapes
+// (from @enbox/auth).
+export { BrowserStorage } from '@enbox/auth/browser';
+export type { ProviderAuthParams, ProviderAuthResult } from '@enbox/auth/browser';
+
+// DWN interface enum for typing agent requests (from @enbox/agent).
+export { DwnInterface } from '@enbox/agent';
+
+// Common DWN primitives for record queries, permission scopes, and protocol
+// typing (from @enbox/dwn-sdk-js).
+export { DateSort, DwnInterfaceName, DwnMethodName } from '@enbox/dwn-sdk-js';
+export type { ProtocolActionRule, ProtocolDefinition } from '@enbox/dwn-sdk-js';


### PR DESCRIPTION
Two related changes in one PR: fix a connect failure for protocols that compose others, and slim down the package surface dapps need to import.

## 1. `@enbox/agent` — install composed protocols in `uses`-dependency order

**Bug:** connecting a dapp whose protocol composes another (via `uses`) to a **fresh** identity failed with:

> Could not verify the latest protocol definition on every reachable DWN endpoint for `…/focus-board`.

**Root cause:** the connect approval ceremony prepared every requested protocol in one flat concurrent fan-out (`connect-approval.ts`):

```js
await Promise.all(request.permissionRequests.map(
  ({ protocolDefinition }) => prepareProtocol(providerDid, agent, protocolDefinition)
));
```

The DWN's `ProtocolsConfigure` handler rejects a configure whose `uses` targets are not yet installed for the tenant (`protocols-configure.js`: *"All `uses` protocols must already be installed for the tenant"*). So a composing protocol (e.g. `focus-board` → `uses` → `social-graph`) races its dependency; on a fresh identity where nothing is pre-installed, the dependent's configure can land before the dependency is installed, get rejected, and fail `prepareProtocol`'s fail-closed remote-convergence check — aborting the whole connect. (Verified it is *not* a definition-normalization mismatch: every focus-board URL round-trips cleanly through the DWN's `normalizeProtocolUrl`/`normalizeSchemaUrl`.)

**Fix:** `prepareProtocol` is now fanned out in `uses`-dependency order via `orderPermissionRequestsByUsesDependencies`. Each protocol's in-batch dependencies fully converge across all endpoints before its dependents are prepared; independent protocols within a level still run concurrently; dependency cycles fall back to the previous best-effort concurrent behavior.

## 2. `@enbox/browser` — convenience re-exports

So most dapps only need `@enbox/browser` (plus `@enbox/protocols` for shared protocol definitions). Additive re-exports of the symbols dapps most commonly reached into sibling packages for:

- `TypedRecord` (from `@enbox/api`)
- `BrowserStorage`, `ProviderAuthParams`, `ProviderAuthResult` (from `@enbox/auth`)
- `DwnInterface` (from `@enbox/agent`)
- `DateSort`, `DwnInterfaceName`, `DwnMethodName`, `ProtocolDefinition`, `ProtocolActionRule` (from `@enbox/dwn-sdk-js`)

Adds `@enbox/dwn-sdk-js` as a direct `@enbox/browser` dependency and externalizes it in the browser bundle (consistent with the other `@enbox/*` externals).

## Verification

- `turbo run build --filter=@enbox/browser` — 10/10 packages build (tsc + browser bundle).
- New unit test `packages/agent/tests/connect-uses-ordering.spec.ts` — 6/6 pass (independent → single level, dependent-after-dependency, out-of-order input, multi-level chain, cycle fallback, empty batch).
- `eslint --max-warnings 0` clean on both `@enbox/agent` and `@enbox/browser`.
- Re-exports confirmed present in `packages/browser/dist/types/index.d.ts`.

Two changesets included (`@enbox/agent` patch, `@enbox/browser` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)