### PR TITLE
feat(browser): dedupe the expanded wallet grid, unify tile sizing, cap grid height; add Taffy + Astoria

### DIFF
--- a/.changeset/connect-modal-grid-dedupe.md
+++ b/.changeset/connect-modal-grid-dedupe.md
@@ -1,0 +1,13 @@
+---
+"@enbox/browser": patch
+---
+
+feat(browser): dedupe the expanded wallet grid, unify tile sizing, cap grid height; add Taffy + Astoria
+
+The connect modal's expanded panel now lists only the wallets not already
+visible in the identity row, so a wallet is never shown twice and the More
+tile's +N count equals the grid size exactly. Grid tiles share the identity
+row's tile recipe on a matching four-column grid, the grid caps at three rows
+and scrolls in place with a bottom-fade hint that clears at the end of the
+list, and the search threshold applies to the grid subset. Taffy and Astoria
+join the default wallet catalog.

--- a/packages/browser/src/browser-connect-handler.ts
+++ b/packages/browser/src/browser-connect-handler.ts
@@ -51,6 +51,16 @@ export const DEFAULT_WALLETS: WalletOption[] = [
     url         : 'https://onyx-wallet.pages.dev',
     description : 'A refined home for your digital identity',
   },
+  {
+    name        : 'Taffy',
+    url         : 'https://taffy-wallet.pages.dev',
+    description : 'A playful take on your digital identity',
+  },
+  {
+    name        : 'Astoria',
+    url         : 'https://astoria-wallet.pages.dev',
+    description : 'A grand home for your digital identity',
+  },
 ];
 
 /** Options for creating a BrowserConnectHandler. */

--- a/packages/browser/src/ui/connect-modal.ts
+++ b/packages/browser/src/ui/connect-modal.ts
@@ -14,9 +14,9 @@
  *    (or deep link on phones), the pairing-code input, progress, success,
  *    and error states.
  * 3. **Footer** — the wallet identity row ("Connecting with" + the selected
- *    wallet and the next catalog wallets as tiles, capped so the same wallet
- *    never appears twice), a More tile that expands the full catalog grid
- *    with search + custom URL in place, and the alternate-method link.
+ *    wallet and the next catalog wallets as tiles), a More tile that expands
+ *    the remaining wallets as a matching grid (search + custom URL) in
+ *    place — a wallet is never shown twice — and the alternate-method link.
  *
  * Theming: the stylesheet is static and reads `--ec-*` design tokens.
  * Light/dark follows the visitor's system via `prefers-color-scheme` and
@@ -927,29 +927,35 @@ export function runConnectModal(options: ConnectModalOptions): Promise<ConnectRe
       panel.className = 'wallet-panel';
       panel.hidden = true;
 
-      const hiddenCount = wallets.filter((wallet) => !rowWallets.some((shown) => shown.url === wallet.url)).length;
+      // The panel grid holds only the wallets NOT already visible in the
+      // row, so expanding never shows the same wallet twice.
+      const gridWallets = wallets.filter((wallet) => !rowWallets.some((shown) => shown.url === wallet.url));
+
       const more = document.createElement('button');
       more.className = 'row-tile more-tile';
       more.title = 'All wallets';
       more.setAttribute('aria-expanded', 'false');
-      more.appendChild(el('span', 'more-count', hiddenCount > 0 ? `+${hiddenCount}` : '⋯'));
+      more.appendChild(el('span', 'more-count', gridWallets.length > 0 ? `+${gridWallets.length}` : '⋯'));
       more.appendChild(el('span', 'row-tile-name', 'More'));
       more.addEventListener('click', () => {
         panel.hidden = !panel.hidden;
         more.setAttribute('aria-expanded', panel.hidden ? 'false' : 'true');
+        if (!panel.hidden) {
+          updateScrollHint();
+        }
       });
       row.appendChild(more);
 
       const label = rowWallets.length > 0 ? el('div', 'wallet-row-label', 'Connecting with') : undefined;
 
-      // Search filter — appears once the catalog outgrows one grid row.
+      // Search filter — appears once the grid outgrows one row of tiles.
       const tiles: Array<{ wallet: (typeof wallets)[number]; el: HTMLButtonElement }> = [];
       const empty = document.createElement('div');
       empty.className = 'wallet-empty';
-      empty.textContent = 'No wallets match your search.';
+      empty.textContent = 'No other wallets match your search.';
       empty.hidden = true;
 
-      if (wallets.length > WALLET_SEARCH_THRESHOLD) {
+      if (gridWallets.length > WALLET_SEARCH_THRESHOLD) {
         const search = document.createElement('input');
         search.type = 'search';
         search.className = 'wallet-search';
@@ -966,30 +972,37 @@ export function runConnectModal(options: ConnectModalOptions): Promise<ConnectRe
             if (match) { visible += 1; }
           }
           empty.hidden = visible > 0;
+          updateScrollHint();
         });
         panel.appendChild(search);
       }
 
-      // Square tiles, three per row; past two rows the grid scrolls in
-      // place so a large catalog never stretches the modal.
+      // Tiles matching the identity row, four per row; past three rows the
+      // grid scrolls in place, with a bottom fade hinting at more below.
+      const scrollWrap = document.createElement('div');
+      scrollWrap.className = 'wallet-scroll-wrap';
+      scrollWrap.hidden = gridWallets.length === 0;
       const scroll = document.createElement('div');
       scroll.className = 'wallet-scroll';
       const grid = document.createElement('div');
       grid.className = 'wallet-grid';
 
-      for (const wallet of wallets) {
+      const updateScrollHint = (): void => {
+        const overflowing = scroll.scrollHeight - scroll.clientHeight > 1;
+        const atEnd = scroll.scrollTop + scroll.clientHeight >= scroll.scrollHeight - 1;
+        scrollWrap.classList.toggle('scroll-hint', overflowing && !atEnd);
+      };
+      scroll.addEventListener('scroll', updateScrollHint);
+
+      for (const wallet of gridWallets) {
         const tile = document.createElement('button');
         tile.className = 'wallet-tile';
-        tile.title = wallet.name;
+        tile.title = wallet.description ?? wallet.name;
         tile.appendChild(buildWalletIcon(wallet));
         const tileName = document.createElement('span');
         tileName.className = 'wallet-tile-name';
         tileName.textContent = wallet.name;
         tile.appendChild(tileName);
-        if (wallet.url === walletUrl) {
-          tile.classList.add('selected');
-          tile.setAttribute('aria-pressed', 'true');
-        }
         tile.addEventListener('click', () => {
           selectWallet(wallet.url);
         });
@@ -998,7 +1011,8 @@ export function runConnectModal(options: ConnectModalOptions): Promise<ConnectRe
       }
       scroll.appendChild(grid);
       scroll.appendChild(empty);
-      panel.appendChild(scroll);
+      scrollWrap.appendChild(scroll);
+      panel.appendChild(scrollWrap);
 
       // Custom wallet URL (the power-user path, demoted to the disclosure).
       const custom = document.createElement('div');
@@ -1465,7 +1479,7 @@ const MODAL_STYLES = `
       grid-template-columns: repeat(4, 1fr);
       gap: 8px;
     }
-    .row-tile {
+    .row-tile, .wallet-tile {
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -1480,15 +1494,15 @@ const MODAL_STYLES = `
       font-size: 11px;
       cursor: pointer;
     }
-    .row-tile:hover { border-color: var(--ec-accent); }
+    .row-tile:hover, .wallet-tile:hover { border-color: var(--ec-accent); }
     .row-tile.selected {
       border-color: var(--ec-accent);
       background: var(--ec-accent-soft);
       box-shadow: inset 0 0 0 1px var(--ec-accent);
     }
     .row-tile.selected .row-tile-name { font-weight: 600; }
-    .row-tile .wallet-icon { width: 28px; height: 28px; }
-    .row-tile-name { max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .row-tile .wallet-icon, .wallet-tile .wallet-icon { width: 28px; height: 28px; }
+    .row-tile-name, .wallet-tile-name { max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
     .more-tile { color: var(--ec-muted); }
     .more-tile:hover { color: var(--ec-text); }
@@ -1514,46 +1528,33 @@ const MODAL_STYLES = `
     }
     .wallet-search:focus { outline: none; border-color: var(--ec-accent); }
 
-    .wallet-scroll { max-height: 260px; overflow-y: auto; }
+    /* Cap the grid at three rows of tiles; past that it scrolls in place,
+       and the wrapper's bottom fade hints that more wallets are below. */
+    .wallet-scroll-wrap { position: relative; }
+    .wallet-scroll { max-height: 220px; overflow-y: auto; }
+    .wallet-scroll-wrap.scroll-hint::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 28px;
+      background: linear-gradient(to bottom, transparent, var(--ec-bg));
+      pointer-events: none;
+    }
     .wallet-grid {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(4, 1fr);
       gap: 8px;
     }
-    .wallet-tile {
-      aspect-ratio: 1;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      gap: 8px;
-      padding: 8px;
-      min-width: 0;
-      background: var(--ec-surface);
-      border: 1px solid var(--ec-border);
-      border-radius: 12px;
-      color: var(--ec-text);
-      font-size: 12px;
-      cursor: pointer;
-    }
-    .wallet-tile:hover { border-color: var(--ec-accent); }
-    .wallet-tile.selected {
-      border-color: var(--ec-accent);
-      background: var(--ec-accent-soft);
-      box-shadow: inset 0 0 0 1px var(--ec-accent);
-    }
-    .wallet-tile-name { max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
     .wallet-icon { position: relative; width: 28px; height: 28px; flex-shrink: 0; display: inline-flex; }
-    .wallet-tile .wallet-icon { width: 40px; height: 40px; }
     .wallet-badge {
       width: 100%; height: 100%; border-radius: 8px; display: inline-flex;
       align-items: center; justify-content: center; font-size: 13px;
       font-weight: 600; background: var(--ec-accent-soft); color: var(--ec-accent);
     }
-    .wallet-tile .wallet-badge { border-radius: 10px; font-size: 17px; }
     .wallet-img { position: absolute; inset: 0; width: 100%; height: 100%; border-radius: 8px; object-fit: cover; }
-    .wallet-tile .wallet-img { border-radius: 10px; }
 
     .wallet-empty { padding: 10px 4px; font-size: 12px; color: var(--ec-muted); text-align: center; }
 

--- a/packages/browser/tests/connect-modal.spec.ts
+++ b/packages/browser/tests/connect-modal.spec.ts
@@ -366,7 +366,14 @@ describe('runConnectModal', () => {
     expect(rowNames()).toEqual(['Aurora', 'Basalt', 'Cinder']);
     expect(shadowRoot().querySelector('.more-count')?.textContent).toBe('+3');
 
+    const gridNames = (): Array<string | null> => Array.from(
+      shadowRoot().querySelectorAll('.wallet-tile .wallet-tile-name'),
+    ).map((name) => name.textContent);
+
+    // The expanded grid holds only the wallets not already in the row.
     shadowRoot().querySelector<HTMLButtonElement>('.more-tile')?.click();
+    expect(gridNames()).toEqual(['Dune', 'Ember', 'Fjord']);
+
     const tiles = Array.from(shadowRoot().querySelectorAll<HTMLButtonElement>('.wallet-tile'));
     tiles.find((tile) => tile.querySelector('.wallet-tile-name')?.textContent === 'Fjord')?.click();
     await flush();
@@ -378,6 +385,10 @@ describe('runConnectModal', () => {
     expect(shadowRoot().querySelector<HTMLElement>('.wallet-panel')?.hidden).toBe(true);
     expect(relay.calls).toHaveLength(2);
     expect(relay.calls[1].walletUri).toBe('https://fjord.example.com/connect/app');
+
+    // Re-expanding still shows only the wallets outside the recomposed row.
+    shadowRoot().querySelector<HTMLButtonElement>('.more-tile')?.click();
+    expect(gridNames()).toEqual(['Cinder', 'Dune', 'Ember']);
   });
 
   it('adopts a validated custom wallet URL into the row and re-mints', async () => {
@@ -453,22 +464,19 @@ describe('runConnectModal', () => {
     more?.click();
     expect(more?.getAttribute('aria-expanded')).toBe('true');
     expect(panel === null ? '' : getComputedStyle(panel).display).not.toBe('none');
-    const grid = shadowRoot().querySelector('.wallet-grid');
-    expect(grid).not.toBeNull();
-    expect(grid?.querySelectorAll('.wallet-tile')).toHaveLength(2);
-    // No search bar for a catalog that fits one row.
+    // Both wallets already sit in the row, so the panel repeats neither —
+    // it offers only the custom URL entry.
+    expect(shadowRoot().querySelectorAll('.wallet-tile')).toHaveLength(0);
+    expect(shadowRoot().querySelector<HTMLElement>('.wallet-scroll-wrap')?.hidden).toBe(true);
     expect(shadowRoot().querySelector('.wallet-search')).toBeNull();
-    // The active wallet reads as selected in the grid too.
-    const selected = grid?.querySelector('.wallet-tile.selected');
-    expect(selected?.querySelector('.wallet-tile-name')?.textContent).toBe('Enbox');
-    expect(selected?.getAttribute('aria-pressed')).toBe('true');
+    expect(shadowRoot().querySelector('.url-input')).not.toBeNull();
     // The method link keeps its own row beneath the switcher.
     expect(shadowRoot().querySelector('.footer-row .method-link')).not.toBeNull();
   });
 
-  it('shows the search bar past one row of tiles and filters the catalog', async () => {
+  it('shows the search bar past one row of grid tiles and filters the remainder', async () => {
     const relay = createFakeRelay();
-    const many: WalletOption[] = ['Aurora', 'Basalt', 'Cinder', 'Dune', 'Ember', 'Fjord']
+    const many: WalletOption[] = ['Aurora', 'Basalt', 'Cinder', 'Dune', 'Ember', 'Fjord', 'Grove', 'Hazel', 'Iris']
       .map((name) => ({ name, url: `https://${name.toLowerCase()}.example.com` }));
     const promise = runConnectModal({
       wallets            : many,
@@ -483,9 +491,12 @@ describe('runConnectModal', () => {
     expect(search).not.toBeNull();
     if (search == null) { return; }
 
+    // The grid holds only the six wallets not shown in the row.
+    const tiles = Array.from(shadowRoot().querySelectorAll<HTMLButtonElement>('.wallet-tile'));
+    expect(tiles).toHaveLength(6);
+
     search.value = 'fjord';
     search.dispatchEvent(new Event('input', { bubbles: true }));
-    const tiles = Array.from(shadowRoot().querySelectorAll<HTMLButtonElement>('.wallet-tile'));
     expect(tiles.filter((tile) => !tile.hidden)).toHaveLength(1);
     expect(tiles.find((tile) => !tile.hidden)?.textContent).toContain('Fjord');
     expect(shadowRoot().querySelector<HTMLElement>('.wallet-empty')?.hidden).toBe(true);
@@ -498,6 +509,35 @@ describe('runConnectModal', () => {
     search.value = '';
     search.dispatchEvent(new Event('input', { bubbles: true }));
     expect(tiles.filter((tile) => !tile.hidden)).toHaveLength(6);
+  });
+
+  it('caps the grid height and fades its bottom edge until the user scrolls to the end', async () => {
+    const relay = createFakeRelay();
+    const many: WalletOption[] = Array.from({ length: 19 }, (_, i) => ({
+      name : `Wallet ${String(i + 1).padStart(2, '0')}`,
+      url  : `https://wallet-${i + 1}.example.com`,
+    }));
+    const promise = runConnectModal({
+      wallets            : many,
+      permissionRequests : PERMISSIONS,
+      deps               : deps({ runRelay: relay.runRelay }),
+    });
+    promise.catch((): undefined => undefined);
+    await flush();
+
+    shadowRoot().querySelector<HTMLButtonElement>('.more-tile')?.click();
+
+    // 16 grid tiles at 4 per row overflow the three-row cap, so the fade
+    // hint shows; scrolling to the end clears it.
+    const wrap = shadowRoot().querySelector<HTMLElement>('.wallet-scroll-wrap');
+    const scroll = shadowRoot().querySelector<HTMLElement>('.wallet-scroll');
+    if (wrap == null || scroll == null) { throw new Error('expected the wallet grid scroller'); }
+    expect(scroll.scrollHeight).toBeGreaterThan(scroll.clientHeight);
+    expect(wrap.classList.contains('scroll-hint')).toBe(true);
+
+    scroll.scrollTop = scroll.scrollHeight;
+    scroll.dispatchEvent(new Event('scroll'));
+    expect(wrap.classList.contains('scroll-hint')).toBe(false);
   });
 
   it('forces an appearance and applies the dapp palette as inline tokens', async () => {

--- a/packages/browser/tests/exports.spec.ts
+++ b/packages/browser/tests/exports.spec.ts
@@ -100,6 +100,16 @@ describe('@enbox/browser exports', () => {
         url         : 'https://onyx-wallet.pages.dev',
         description : 'A refined home for your digital identity',
       },
+      {
+        name        : 'Taffy',
+        url         : 'https://taffy-wallet.pages.dev',
+        description : 'A playful take on your digital identity',
+      },
+      {
+        name        : 'Astoria',
+        url         : 'https://astoria-wallet.pages.dev',
+        description : 'A grand home for your digital identity',
+      },
     ]);
   });
 


### PR DESCRIPTION
## Summary

Re-lands the follow-up that missed #1257: that PR was squash-merged at 15:24 EDT with only the first commit, and the follow-up commit was pushed to the branch 39 minutes later, so it never reached `main`. This PR cherry-picks that commit (`828b0d9f`) onto current `main` — the first pass (identity row + QR logo) is already on `main` and intact.

- **No duplicates on expand** — the panel grid lists only the wallets not already visible in the identity row, so a wallet is never shown twice and the More tile's `+N` equals the grid size exactly. With a catalog of ≤3 (all in the row), the panel offers just the custom-URL entry.
- **Uniform tiles** — grid tiles share the identity row's tile recipe on a matching four-column grid.
- **Capped height + scroll hint** — the grid caps at three rows and scrolls in place, with a bottom-fade hint that clears at the end of the list; the search threshold now applies to the grid subset.
- **Catalog** — Taffy (`taffy-wallet.pages.dev`) and Astoria (`astoria-wallet.pages.dev`) join `DEFAULT_WALLETS`.

## Test plan

- [x] `bun run test:browser` — 258 tests pass (chromium + firefox) on top of current `main`, including specs for row/grid disjointness before and after recompose, the empty-grid small-catalog case, and the three-row cap + scroll fade hint
- [x] `bun run build` (root, Turbo) — clean
- [x] `bun run lint` — clean
- [x] Previously verified visually in a Playwright harness (16-wallet catalog): uniform tiles, deduped grid, search, fade hint
